### PR TITLE
Check consistency between Toml and Abi

### DIFF
--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -83,17 +83,20 @@ fn process_abi_with_input(
 ) -> BTreeMap<Witness, FieldElement> {
     let mut solved_witness = BTreeMap::new();
 
-    let param_names = abi.parameter_names();
     let mut index = 0;
 
-    for param in param_names.into_iter() {
+    for (param_name, param_type) in abi.parameters.into_iter() {
         let value = witness_map
-            .get(param)
+            .get(&param_name)
             .expect(&format!(
                 "ABI expects the parameter `{}`, but this was not found",
-                param
+                param_name
             ))
             .clone();
+
+        if !value.matches_abi(param_type) {
+            write_stderr(&format!("The parameters in the main do not match the parameters in the {}.toml file. \n Please check `{}` parameter ", PROVER_INPUT_FILE,param_name))
+        }
 
         match value {
             InputValue::Field(element) => {

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -4,6 +4,8 @@ use std::{collections::BTreeMap, path::Path};
 
 use noir_field::FieldElement;
 
+use crate::AbiType;
+
 /// This is what all formats eventually transform into
 /// For example, a toml file will parse into TomlTypes
 /// and those TomlTypes will be mapped to Value
@@ -11,6 +13,21 @@ use noir_field::FieldElement;
 pub enum InputValue {
     Field(FieldElement),
     Vec(Vec<FieldElement>),
+}
+
+impl InputValue {
+    /// Checks whether the ABI type matches the InputValue type
+    /// and also their arity
+    pub fn matches_abi(&self, abi_param: AbiType) -> bool {
+        match (self, abi_param) {
+            (InputValue::Field(_), AbiType::Field(_)) => true,
+            (InputValue::Field(_), AbiType::Array { .. }) => false,
+            (InputValue::Field(_), AbiType::Integer { .. }) => true,
+            (InputValue::Vec(_), AbiType::Field(_)) => false,
+            (InputValue::Vec(x), AbiType::Array { length, .. }) => x.len() == length as usize,
+            (InputValue::Vec(_), AbiType::Integer { .. }) => false,
+        }
+    }
 }
 
 /// Parses the initial Witness Values that are needed to seed the


### PR DESCRIPTION
This adds a helpful error if the user does not enter the right parameter types.

In another PR, write_stderr will be removed, as it uses exit() which prevents drops from happening. Furthermore, the red text is not appealing to the eyes.