### PR TITLE
Add 1in-1out example

### DIFF
--- a/crates/nargo/examples/simple_shield/Nargo.toml
+++ b/crates/nargo/examples/simple_shield/Nargo.toml
@@ -1,0 +1,6 @@
+
+[package]
+authors = [""]
+compiler_version = "0.1"
+
+[dependencies]

--- a/crates/nargo/examples/simple_shield/Prover.toml
+++ b/crates/nargo/examples/simple_shield/Prover.toml
@@ -1,0 +1,7 @@
+value = 0
+priv_key = 0
+note_root = 0
+index = 0
+note_hash_path = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+to_pubkey_x = 0
+to_pubkey_y = 0

--- a/crates/nargo/examples/simple_shield/Verifier.toml
+++ b/crates/nargo/examples/simple_shield/Verifier.toml
@@ -1,0 +1,2 @@
+note_root = 0
+setpub = [0, 0]

--- a/crates/nargo/examples/simple_shield/src/main.nr
+++ b/crates/nargo/examples/simple_shield/src/main.nr
@@ -1,0 +1,41 @@
+
+
+use dep::std;
+
+fn main(
+  // Public key of note
+  // all notes have the same denomination
+  priv_key : Field, 
+
+  // Merkle membership proof
+  note_root : pub Field, 
+  index : Field,
+  note_hash_path : [32]Field,
+
+  // Receiver public key
+  to_pubkey_x : Field, 
+  to_pubkey_y : Field, 
+) {
+
+    // Compute public key from private key to show ownership
+    //
+    let pubkey = std::scalar_mul::fixed_base(priv_key);
+    priv pubkey_x = pubkey[0];
+    priv pubkey_y = pubkey[1];
+
+    // Compute input note commitment
+    priv note_commitment = std::hash::pedersen([pubkey_x, pubkey_y]);
+    
+    // Compute input note nullifier
+    priv nullifier = std::hash::pedersen([note_commitment, index, priv_key]);
+
+    // Compute output note nullifier
+    priv receiver_note_commitment = std::hash::pedersen([to_pubkey_x, to_pubkey_y]);
+
+    // Check that the input note nullifier is in the root
+    priv is_member = std::merkle::check_membership(note_root, note_commitment, index, note_hash_path);
+    constrain is_member == 1;
+
+    std::set_as_public(receiver_note_commitment);
+    std::set_as_public(nullifier);
+}


### PR DESCRIPTION
Example shows how one may create a circuit for a 1input 1output transaction, where:

- Note denominations are the same
- Notes are stored in a merkle tree
- Instead of a signature, ownership of a note is proven by computing the corresponding public key from a private for that note.