### PR TITLE
Loosen type checking rules when the parameter type is Field

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -349,15 +349,8 @@ fn check_param_argument(
     if arg_type.is_variable_sized_array() {
         unreachable!("arg type type cannot be a variable sized array. This is not supported.")
     }
-
-    // Variable sized arrays (vectors) can be linked to fixed size arrays
-    // If the parameter specifies a variable sized array, then we can pass a
-    // fixed size array as an argument
-    if param_type.is_variable_sized_array() && arg_type.is_fixed_sized_array() {
-        return Ok(());
-    }
-
-    if param_type != arg_type {
+    
+    if !param_type.is_super_type_of(arg_type) {
         let span = interner.ident_span(&param_id);
         return Err(TypeCheckError::TypeMismatch {
             expected_typ: param_type.to_string(),


### PR DESCRIPTION
- Loosens the restrictions on the arguments when the parameter is a Field. Eg. a u8 can be passed to a function that requests a Field. This should allow for less casting 

- Moves more of the type checking code to the ast module section as methods on Type