### PR TITLE
Simplify a few pattern-matches.

### DIFF
--- a/crates/acir/src/native_types/arithmetic.rs
+++ b/crates/acir/src/native_types/arithmetic.rs
@@ -44,14 +44,14 @@ impl Mul<&FieldElement> for &Arithmetic {
         let mul_terms: Vec<_> = self
             .mul_terms
             .iter()
-            .map(|(q_m, w_l, w_r)| (*q_m * *rhs, w_l.clone(), w_r.clone()))
+            .map(|(q_m, w_l, w_r)| (*q_m * *rhs, *w_l, *w_r))
             .collect();
 
         // Scale the linear combinations terms
         let lin_combinations: Vec<_> = self
             .linear_combinations
             .iter()
-            .map(|(q_l, w_l)| (*q_l * *rhs, w_l.clone()))
+            .map(|(q_l, w_l)| (*q_l * *rhs, *w_l))
             .collect();
 
         // Scale the constant
@@ -127,13 +127,13 @@ impl Neg for &Arithmetic {
         let mul_terms: Vec<_> = self
             .mul_terms
             .iter()
-            .map(|(q_m, w_l, w_r)| (-*q_m, w_l.clone(), w_r.clone()))
+            .map(|(q_m, w_l, w_r)| (-*q_m, *w_l, *w_r))
             .collect();
 
         let linear_combinations: Vec<_> = self
             .linear_combinations
             .iter()
-            .map(|(q_k, w_k)| (-*q_k, w_k.clone()))
+            .map(|(q_k, w_k)| (-*q_k, *w_k))
             .collect();
         let q_c = -self.q_c;
 
@@ -213,7 +213,7 @@ impl Arithmetic {
         }
 
         // A polynomial with no mul term and a fan-in that fits inside of the width can fit into a single gate
-        if self.mul_terms.len() == 0 {
+        if self.mul_terms.is_empty() {
             return true;
         }
 
@@ -253,6 +253,6 @@ impl Arithmetic {
             }
         }
 
-        return found_x & found_y;
+        found_x & found_y
     }
 }

--- a/crates/acir/src/optimiser/csat_optimiser.rs
+++ b/crates/acir/src/optimiser/csat_optimiser.rs
@@ -86,7 +86,7 @@ impl Optimiser {
             pair.sort();
 
             *hash_map
-                .entry((pair[0].clone(), pair[1].clone()))
+                .entry((pair[0], pair[1]))
                 .or_insert(FieldElement::zero()) += scale;
         }
 
@@ -149,8 +149,8 @@ impl Optimiser {
         // subset of the terms that can be represented as full gates
         let mut new_gate = Arithmetic::default();
 
-        while gate.mul_terms.len() > 0 {
-            let pair = gate.mul_terms[0].clone();
+        while !gate.mul_terms.is_empty() {
+            let pair = gate.mul_terms[0];
 
             // Check if this pair is present in the simplified fan-in
             // We are assuming that the fan-in/fan-out has been simplified.
@@ -179,8 +179,8 @@ impl Optimiser {
                     // This means that we can form a full gate with this Qm term
 
                     // First fetch the left and right wires which match the mul term
-                    let left_wire_term = gate.linear_combinations[x].clone();
-                    let right_wire_term = gate.linear_combinations[y].clone();
+                    let left_wire_term = gate.linear_combinations[x];
+                    let right_wire_term = gate.linear_combinations[y];
 
                     // Lets create an intermediate gate to store this full gate
                     //
@@ -221,9 +221,9 @@ impl Optimiser {
                     // Constrain the gate to the intermediate variable
                     intermediate_gate
                         .linear_combinations
-                        .push((-FieldElement::one(), inter_var.clone()));
+                        .push((-FieldElement::one(), inter_var));
                     // Add intermediate gate to the map
-                    intermediate_variables.insert(inter_var.clone(), intermediate_gate);
+                    intermediate_variables.insert(inter_var, intermediate_gate);
 
                     // Add intermediate variable to the new gate instead of the full gate
                     new_gate
@@ -308,10 +308,10 @@ impl Optimiser {
             // Constrain it to be equal to the intermediate variable
             intermediate_gate
                 .linear_combinations
-                .push((-FieldElement::one(), inter_var.clone()));
+                .push((-FieldElement::one(), inter_var));
 
             // Add intermediate gate and variable to map
-            intermediate_variables.insert(inter_var.clone(), intermediate_gate);
+            intermediate_variables.insert(inter_var, intermediate_gate);
 
             // Add intermediate variable as a part of the fan-in for the original gate
             gate.linear_combinations
@@ -354,7 +354,7 @@ impl Optimiser {
 
             intermediate_gate
                 .linear_combinations
-                .push((-FieldElement::one(), inter_var.clone()));
+                .push((-FieldElement::one(), inter_var));
 
             // Add intermediate gate and variable to map
             intermediate_variables.insert(inter_var, intermediate_gate);

--- a/crates/aztec_backend/src/barretenberg_rs/composer.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/composer.rs
@@ -593,7 +593,7 @@ impl StandardComposer {
             now.elapsed().as_nanos(),
             now.elapsed().as_secs(),
         );
-        return remove_public_inputs(self.constraint_system.public_inputs.len(), proof);
+        remove_public_inputs(self.constraint_system.public_inputs.len(), proof)
     }
 
     pub fn verify(
@@ -642,7 +642,7 @@ impl StandardComposer {
                         ],
                     )
                     .value();
-                verified.clone()
+                verified
             }
             Some(pub_inputs) => {
                 let pub_inputs_buf = pub_inputs.to_bytes();
@@ -665,7 +665,7 @@ impl StandardComposer {
 
                 self.barretenberg.free(pub_inputs_ptr);
 
-                verified.clone()
+                verified
             }
         };
         // self.barretenberg.free(cs_ptr);
@@ -722,7 +722,7 @@ mod test {
             blake2s_constraints: vec![],
             pedersen_constraints: vec![],
             hash_to_field_constraints: vec![],
-            constraints: vec![constraint.clone()],
+            constraints: vec![constraint],
             ecdsa_secp256k1_constraints: vec![],
             fixed_base_scalar_mul_constraints: vec![],
         };
@@ -768,11 +768,11 @@ mod test {
         test_circuit(
             constraint_system,
             vec![
-                case_1.clone(),
-                case_2.clone(),
-                case_3.clone(),
-                case_4.clone(),
-                case_5.clone(),
+                case_1,
+                case_2,
+                case_3,
+                case_4,
+                case_5,
                 case_6a,
                 case_6b,
             ],

--- a/crates/aztec_backend/src/barretenberg_rs/crs.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/crs.rs
@@ -79,7 +79,7 @@ struct PartialRangeIter {
 impl PartialRangeIter {
     pub fn new(start: u64, end: u64, buffer_size: u32) -> Result<Self> {
         if buffer_size == 0 {
-            Err("invalid buffer_size, give a value greater than zero.")?;
+            return Err("invalid buffer_size, give a value greater than zero.".into());
         }
         Ok(PartialRangeIter {
             start,

--- a/crates/aztec_backend/src/barretenberg_rs/mod.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/mod.rs
@@ -1,5 +1,5 @@
 ///  Import the barretenberg WASM file
-pub static WASM: &'static [u8] = include_bytes!("barretenberg.wasm");
+pub static WASM: &[u8] = include_bytes!("barretenberg.wasm");
 
 pub mod blake2s;
 pub mod composer;
@@ -75,7 +75,7 @@ impl Barretenberg {
         // We take in a reference to values, since they do not implement Copy.
         // We then clone them inside of this function, so that the API does not have a bunch of Clones everywhere
 
-        let params: Vec<_> = params.into_iter().map(|p| p.clone()).collect();
+        let params: Vec<_> = params.into_iter().cloned().collect();
         let func = self.instance.exports.get_function(name).unwrap();
         let option_value = func.call(&params).unwrap().first().cloned();
 

--- a/crates/aztec_backend/src/barretenberg_rs/pedersen.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/pedersen.rs
@@ -61,7 +61,7 @@ fn basic_interop() {
 
         let got = barretenberg.compress_native(&test.input_left, &test.input_right);
         let got_many =
-            barretenberg.compress_many(vec![test.input_left.clone(), test.input_right.clone()]);
+            barretenberg.compress_many(vec![test.input_left, test.input_right]);
         assert_eq!(got, expected);
         assert_eq!(got, got_many);
     }

--- a/crates/aztec_backend/src/serialiser/mod.rs
+++ b/crates/aztec_backend/src/serialiser/mod.rs
@@ -71,10 +71,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         let mut outputs_iter = gadget_call.outputs.iter();
                         let mut result = [0i32; 32];
                         for i in 0..32 {
-                            let out_byte = outputs_iter.next().expect(&format!(
-                                "missing rest of output. tried to get byte {} but failed",
-                                i
-                            ));
+                            let out_byte = outputs_iter.next().unwrap_or_else(|| panic!("missing rest of output. tried to get byte {} but failed", i));
 
                             let out_byte_index = out_byte.witness_index() as i32;
                             result[i] = out_byte_index
@@ -99,10 +96,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         let mut outputs_iter = gadget_call.outputs.iter();
                         let mut result = [0i32; 32];
                         for i in 0..32 {
-                            let out_byte = outputs_iter.next().expect(&format!(
-                                "missing rest of output. tried to get byte {} but failed",
-                                i
-                            ));
+                            let out_byte = outputs_iter.next().unwrap_or_else(|| panic!("missing rest of output. tried to get byte {} but failed", i));
 
                             let out_byte_index = out_byte.witness_index() as i32;
                             result[i] = out_byte_index
@@ -185,10 +179,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         // signature
                         let mut signature = [0i32; 64];
                         for i in 0..64 {
-                            let sig_byte = inputs_iter.next().expect(&format!(
-                                "missing rest of signature. tried to get byte {} but failed",
-                                i
-                            ));
+                            let sig_byte = inputs_iter.next().unwrap_or_else(|| panic!("missing rest of signature. tried to get byte {} but failed", i));
                             let sig_byte_index = sig_byte.witness.witness_index() as i32;
                             signature[i] = sig_byte_index
                         }
@@ -254,20 +245,14 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         // public key x
                         let mut public_key_x = [0i32; 32];
                         for i in 0..32 {
-                            let x_byte = inputs_iter.next().expect(&format!(
-                                "missing rest of x component for public key. tried to get byte {} but failed",
-                                i
-                            ));
+                            let x_byte = inputs_iter.next().unwrap_or_else(|| panic!("missing rest of x component for public key. tried to get byte {} but failed", i));
                             let x_byte_index = x_byte.witness.witness_index() as i32;
                             public_key_x[i] = x_byte_index
                         }
                         // public key y
                         let mut public_key_y = [0i32; 32];
                         for i in 0..32 {
-                            let y_byte = inputs_iter.next().expect(&format!(
-                                          "missing rest of y component for public key. tried to get byte {} but failed",
-                                          i
-                                      ));
+                            let y_byte = inputs_iter.next().unwrap_or_else(|| panic!("missing rest of y component for public key. tried to get byte {} but failed", i));
                             let y_byte_index = y_byte.witness.witness_index() as i32;
                             public_key_y[i] = y_byte_index
                         }
@@ -275,10 +260,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         // signature
                         let mut signature = [0i32; 64];
                         for i in 0..64 {
-                            let sig_byte = inputs_iter.next().expect(&format!(
-                                "missing rest of signature. tried to get byte {} but failed",
-                                i
-                            ));
+                            let sig_byte = inputs_iter.next().unwrap_or_else(|| panic!("missing rest of signature. tried to get byte {} but failed", i));
                             let sig_byte_index = sig_byte.witness.witness_index() as i32;
                             signature[i] = sig_byte_index
                         }
@@ -361,7 +343,7 @@ fn serialise_arithmetic_gates(gate: &Arithmetic) -> Constraint {
     let qc: FieldElement;
 
     // check mul gate
-    if gate.mul_terms.len() != 0 {
+    if !gate.mul_terms.is_empty() {
         let mul_term = &gate.mul_terms[0];
         qm = mul_term.0;
 

--- a/crates/fm/src/file_map.rs
+++ b/crates/fm/src/file_map.rs
@@ -62,10 +62,7 @@ impl FileMap {
         FileId(file_id)
     }
     pub fn get_file(&self, file_id: FileId) -> Option<File> {
-        match self.0.get(file_id.0) {
-            Some(source) => Some(File(source)),
-            None => None,
-        }
+        self.0.get(file_id.0).map(|source| File(source))
     }
 }
 

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 };
 pub use util::*;
 
-pub const FILE_EXTENSION: &'static str = "nr";
+pub const FILE_EXTENSION: &str = "nr";
 
 // XXX: Create a trait for file io
 /// An enum to differentiate between the root file
@@ -44,7 +44,7 @@ impl FileManager {
         // We expect the caller to ensure that the file is a valid noir file
         let ext = path_to_file
             .extension()
-            .expect(&format!("{:?} does not have an extension", path_to_file));
+            .unwrap_or_else(|| panic!("{:?} does not have an extension", path_to_file));
         if ext != FILE_EXTENSION {
             return None;
         }
@@ -87,7 +87,7 @@ impl FileManager {
         let dir = self.path(anchor).to_path_buf();
 
         candidate_files.push(
-            dir.to_path_buf()
+            dir
                 .join(&format!("{}.{}", mod_name, FILE_EXTENSION)),
         );
 

--- a/crates/fm/src/util.rs
+++ b/crates/fm/src/util.rs
@@ -8,7 +8,7 @@ pub fn find_file<P: AsRef<Path>>(path: P, file_name: &str, extension: &str) -> O
     let entries = list_files_and_folders_in(path)?;
 
     let mut file_name = file_name.to_owned();
-    file_name.push_str(".");
+    file_name.push('.');
     file_name.push_str(extension);
 
     find_artifact(entries, &file_name)

--- a/crates/nargo/src/cli/new_cmd.rs
+++ b/crates/nargo/src/cli/new_cmd.rs
@@ -23,13 +23,13 @@ pub(crate) fn run(args: ArgMatches) {
     let src_dir = package_dir.join(Path::new(SRC_DIR));
     create_src_dir(&src_dir);
 
-    const EXAMPLE: &'static str = "
+    const EXAMPLE: &str = "
         fn main(x : Field, y : pub Field) {
             constrain x != y;
         }
     ";
 
-    const SETTINGS: &'static str = r#"
+    const SETTINGS: &str = r#"
         [package]
         authors = [""]
         compiler_version = "0.1"

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -88,10 +88,7 @@ fn process_abi_with_input(
     for (param_name, param_type) in abi.parameters.into_iter() {
         let value = witness_map
             .get(&param_name)
-            .expect(&format!(
-                "ABI expects the parameter `{}`, but this was not found",
-                param_name
-            ))
+            .unwrap_or_else(|| panic!("ABI expects the parameter `{}`, but this was not found", param_name))
             .clone();
 
         if !value.matches_abi(param_type) {

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -77,10 +77,7 @@ fn process_abi_with_verifier_input(
     for (param_name, param_type) in abi.parameters.into_iter() {
         let value = pi_map
             .get(&param_name)
-            .expect(&format!(
-                "ABI expects the parameter `{}`, but this was not found",
-                param_name
-            ))
+            .unwrap_or_else(|| panic!("ABI expects the parameter `{}`, but this was not found", param_name))
             .clone();
 
         if !value.matches_abi(param_type) && param_name != RESERVED_PUBLIC_ARR {

--- a/crates/noir_field/src/lib.rs
+++ b/crates/noir_field/src/lib.rs
@@ -28,7 +28,7 @@ impl From<i128> for FieldElement {
         if negative {
             result = -result;
         }
-        return FieldElement(result);
+        FieldElement(result)
     }
 }
 
@@ -54,10 +54,7 @@ impl FieldElement {
             return FieldElement::from_hex(input);
         }
 
-        let fr = match Fr::from_str(input) {
-            Err(_) => return None,
-            Ok(x) => x,
-        };
+        let fr = Fr::from_str(input).ok()?;
         Some(FieldElement(fr))
     }
     // This is the amount of bits that are always zero,
@@ -76,10 +73,10 @@ impl FieldElement {
     }
     /// This is the number of bits required to represent this specific field element
     pub fn num_bits(&self) -> u32 {
-        let non_zero_index = BitIteratorBE::new(self.0.into_repr()).position(|x| x != false);
+        let non_zero_index = BitIteratorBE::new(self.0.into_repr()).position(|x| x);
 
         match non_zero_index {
-            None => return 0,
+            None => 0,
             Some(index) => {
                 // The most significant bit was found at index.
                 // The index tells us how many elements came before the most significant bit
@@ -90,7 +87,7 @@ impl FieldElement {
                 // This is now the amount of significant elements that came before the most significant bit
                 let msb_index_offset = (index as u32) - offset;
 
-                return FieldElement::max_num_bits() - msb_index_offset;
+                FieldElement::max_num_bits() - msb_index_offset
             }
         }
     }
@@ -129,7 +126,7 @@ impl FieldElement {
     }
     pub fn from_hex(hex_str: &str) -> Option<FieldElement> {
         let dec_str = hex_to_decimal(hex_str);
-        return Fr::from_str(&dec_str).map(|fr| FieldElement(fr)).ok();
+        Fr::from_str(&dec_str).map(FieldElement).ok()
     }
 
     // XXX: This is not portable, if the underlying field changes!
@@ -170,9 +167,9 @@ impl FieldElement {
             .enumerate()
             .map(|(i, bit)| {
                 if i < (max_bits - num_bits) as usize {
-                    return false;
+                    false
                 } else {
-                    return bit;
+                    bit
                 }
             })
             .collect();

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -83,7 +83,7 @@ enum TomlTypes {
 
 fn parse_str(value: &str) -> FieldElement {
     if value.starts_with("0x") {
-        FieldElement::from_hex(value).expect(&format!("Could not parse hex value {}", value))
+        FieldElement::from_hex(value).unwrap_or_else(|| panic!("Could not parse hex value {}", value))
     } else {
         let val: i128 = value
             .parse()

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -47,7 +47,7 @@ impl Driver {
             }
             return false;
         }
-        return true;
+        true
     }
 
     /// Adds the File with the local crate root to the file system

--- a/crates/noirc_errors/src/position.rs
+++ b/crates/noirc_errors/src/position.rs
@@ -29,7 +29,7 @@ impl Position {
     }
 
     pub fn mark(&self) -> Position {
-        self.clone()
+        *self
     }
     pub fn forward(self) -> Position {
         self.forward_by(1)
@@ -99,7 +99,7 @@ impl<T> Spanned<T> {
     }
 
     pub fn span(&self) -> Span {
-        self.span.clone()
+        self.span
     }
 }
 

--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -63,7 +63,7 @@ impl Reporter {
     ) {
         // Convert each Custom Diagnostic into a diagnostic
         let diagnostics: Vec<_> = diagnostics
-            .into_iter()
+            .iter()
             .map(|cd| {
                 let secondary_labels: Vec<_> = cd
                     .secondaries
@@ -95,7 +95,7 @@ impl Reporter {
             .unwrap();
         }
 
-        if diagnostics.len() != 0 {
+        if !diagnostics.is_empty() {
             writer
                 .lock()
                 .set_color(ColorSpec::new().set_fg(Some(Color::Red)))

--- a/crates/noirc_evaluator/src/binary_op/bound_check.rs
+++ b/crates/noirc_evaluator/src/binary_op/bound_check.rs
@@ -39,7 +39,7 @@ fn bound_check(
                     .into_arithmetic()
                     .ok_or(RuntimeErrorKind::UnstructuredError {
                         span: Default::default(),
-                        message: format!("invalid lower bound being used in bound check"),
+                        message: "invalid lower bound being used in bound check".to_string(),
                     })?;
 
             let k = handle_sub_op(

--- a/crates/noirc_evaluator/src/binary_op/cast.rs
+++ b/crates/noirc_evaluator/src/binary_op/cast.rs
@@ -10,7 +10,7 @@ pub fn handle_cast_op(
         _ => {
             return Err(RuntimeErrorKind::UnstructuredError {
                 span: Default::default(),
-                message: format!("currently we do not support type casting to non integers"),
+                message: "currently we do not support type casting to non integers".to_string(),
             })
         }
     };
@@ -24,7 +24,7 @@ pub fn handle_cast_op(
         Object::Constants(_) => {
             return Err(RuntimeErrorKind::UnstructuredError {
                 span: Default::default(),
-                message: format!("currently we do not support casting constants to a type"),
+                message: "currently we do not support casting constants to a type".to_string(),
             })
         }
         Object::Linear(linear) => {

--- a/crates/noirc_evaluator/src/binary_op/equal.rs
+++ b/crates/noirc_evaluator/src/binary_op/equal.rs
@@ -17,13 +17,13 @@ pub fn handle_equal_op(
         Object::Null => {
             return Err(RuntimeErrorKind::UnstructuredError {
                 span: Default::default(),
-                message: format!("constrain statement cannot output a null polynomial"),
+                message: "constrain statement cannot output a null polynomial".to_string(),
             })
         } // XXX; This should be BUG  severity as sub should have caught it
         Object::Constants(_) => {
             return Err(RuntimeErrorKind::UnstructuredError {
                 span: Default::default(),
-                message: format!("cannot constrain two constants"),
+                message: "cannot constrain two constants".to_string(),
             })
         }
         Object::Linear(linear) => evaluator.gates.push(Gate::Arithmetic(linear.into())),

--- a/crates/noirc_evaluator/src/binary_op/mod.rs
+++ b/crates/noirc_evaluator/src/binary_op/mod.rs
@@ -75,12 +75,12 @@ pub fn maybe_equal(
     }));
 
     // y = 1 -uz
-    let uz: Arithmetic = (Linear::from_witness(u_wit) * Linear::from_witness(z)).into();
+    let uz: Arithmetic = Linear::from_witness(u_wit) * Linear::from_witness(z);
     let gate = uz.neg() + &FieldElement::one();
     let (_, y) = evaluator.create_intermediate_variable(gate);
 
     // yu = 0
-    let gate: Arithmetic = (Linear::from_witness(u_wit) * Linear::from_witness(y)).into();
+    let gate: Arithmetic = Linear::from_witness(u_wit) * Linear::from_witness(y);
     evaluator.gates.push(Gate::Arithmetic(gate));
 
     // We know that y is a boolean

--- a/crates/noirc_evaluator/src/binary_op/mul.rs
+++ b/crates/noirc_evaluator/src/binary_op/mul.rs
@@ -52,7 +52,7 @@ fn handle_arithmetic_mul(
     // Arriving here means that we do not have one of the operands as a constant
     // Create an intermediate variable for the arithmetic gate
     let (intermediate_var, _) = evaluator.create_intermediate_variable(arith);
-    return handle_mul_op(intermediate_var, polynomial, evaluator);
+    handle_mul_op(intermediate_var, polynomial, evaluator)
 }
 
 fn handle_linear_mul(
@@ -62,7 +62,7 @@ fn handle_linear_mul(
 ) -> Result<Object, RuntimeErrorKind> {
     match polynomial {
         Object::Arithmetic(arith) => {
-            return handle_arithmetic_mul(arith, Object::Linear(linear), evaluator);
+            handle_arithmetic_mul(arith, Object::Linear(linear), evaluator)
         }
         Object::Linear(linear_rhs) => Ok(Object::Arithmetic(&linear * &linear_rhs)),
         Object::Constants(constant) => Ok(Object::Linear(&linear * &constant)),

--- a/crates/noirc_evaluator/src/binary_op/sub.rs
+++ b/crates/noirc_evaluator/src/binary_op/sub.rs
@@ -12,11 +12,11 @@ pub fn handle_sub_op(
         Object::Null => {
             return Err(RuntimeErrorKind::UnstructuredError {
                 span: Default::default(),
-                message: format!("cannot do an operation with the null object"),
+                message: "cannot do an operation with the null object".to_string(),
             })
         }
         Object::Arithmetic(arith) => Object::Arithmetic(-&arith),
-        Object::Constants(c) => Object::Constants(-c.clone()),
+        Object::Constants(c) => Object::Constants(-c),
         Object::Linear(linear) => Object::Linear(-&linear),
         Object::Integer(_rhs_integer) => {
             let left_int = left.integer();
@@ -25,7 +25,7 @@ pub fn handle_sub_op(
                 None => {
                     return Err(RuntimeErrorKind::UnstructuredError {
                         span: Default::default(),
-                        message: format!("rhs is an integer, however the lhs is not"),
+                        message: "rhs is an integer, however the lhs is not".to_string(),
                     })
                 }
             }
@@ -39,7 +39,7 @@ pub fn handle_sub_op(
                 None => {
                     return Err(RuntimeErrorKind::UnstructuredError {
                         span: Default::default(),
-                        message: format!("rhs is an integer, however the lhs is not"),
+                        message: "rhs is an integer, however the lhs is not".to_string(),
                     })
                 }
             }

--- a/crates/noirc_evaluator/src/environment.rs
+++ b/crates/noirc_evaluator/src/environment.rs
@@ -52,7 +52,7 @@ impl Environment {
 
     pub fn store(&mut self, name: String, object: Object) {
         let scope = self.env.get_mut_scope();
-        scope.add_key_value(name.clone(), object);
+        scope.add_key_value(name, object);
     }
 
     pub fn get(&mut self, name: &String) -> Object {

--- a/crates/noirc_evaluator/src/errors.rs
+++ b/crates/noirc_evaluator/src/errors.rs
@@ -52,7 +52,7 @@ impl DiagnosableError for RuntimeErrorKind {
     fn to_diagnostic(&self) -> Diagnostic {
         match self {
             RuntimeErrorKind::ArrayOutOfBounds { index, bound, span } => Diagnostic::simple_error(
-                format!("index out of bounds"),
+                "index out of bounds".to_string(),
                 format!(
                     "out of bounds error, index is {} but length is {}",
                     index, bound

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -150,11 +150,11 @@ impl<'a> Evaluator<'a> {
                     "The Binary operation `=` can only be used in declaration statements"
                         .to_string(),
                 );
-                return Err(err);
+                Err(err)
             }
             HirBinaryOpKind::Or => {
                 let err = RuntimeErrorKind::Unimplemented("The Or operation is currently not implemented. First implement in Barretenberg.".to_owned());
-                return Err(err);
+                Err(err)
             }
         }
     }
@@ -347,7 +347,7 @@ impl<'a> Evaluator<'a> {
                 .extract_private_witness()
                 .ok_or(RuntimeErrorKind::UnstructuredError {
                     span: Default::default(),
-                    message: format!("only witnesses can be used in a private statement"),
+                    message: "only witnesses can be used in a private statement".to_string(),
                 })?;
         self.gates
             .push(Gate::Arithmetic(&rhs_as_witness - &witness));
@@ -447,7 +447,7 @@ impl<'a> Evaluator<'a> {
 
         match rhs_poly {
             Object::Array(arr) => {
-                env.store(variable_name.into(), Object::Array(arr));
+                env.store(variable_name, Object::Array(arr));
             }
             _ => unimplemented!(
                 "logic for types that are not arrays in a let statement, not implemented yet!"
@@ -523,7 +523,7 @@ impl<'a> Evaluator<'a> {
     ) -> Result<Object, RuntimeErrorKind> {
         let expr = self.context.def_interner.expression(expr_id);
         match expr {
-            HirExpression::Literal(HirLiteral::Integer(x)) => Ok(Object::Constants(x.into())),
+            HirExpression::Literal(HirLiteral::Integer(x)) => Ok(Object::Constants(x)),
             HirExpression::Literal(HirLiteral::Array(arr_lit)) => {
                 Ok(Object::Array(Array::from(self, env, arr_lit)?))
             }

--- a/crates/noirc_evaluator/src/low_level_function_impl/ecdsa_secp256k1.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/ecdsa_secp256k1.rs
@@ -75,7 +75,7 @@ impl EcdsaSecp256k1Gadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: 8,
             });
         }
@@ -93,7 +93,7 @@ impl EcdsaSecp256k1Gadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: 8,
             });
         }
@@ -111,7 +111,7 @@ impl EcdsaSecp256k1Gadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: 8,
             });
         }
@@ -128,7 +128,7 @@ impl EcdsaSecp256k1Gadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: 8,
             });
         }

--- a/crates/noirc_evaluator/src/low_level_function_impl/merkle_membership.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/merkle_membership.rs
@@ -60,7 +60,7 @@ impl MerkleMembershipGadget {
         let root_witness = root.witness().unwrap();
 
         // XXX: Instead of panics, return a user error here
-        if hash_path.contents.len() < 1 {
+        if hash_path.contents.is_empty() {
             panic!("the hash path must contain atleast two items")
         }
         // XXX: Instead of panics, return a user error here
@@ -98,7 +98,7 @@ impl MerkleMembershipGadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: noir_field::FieldElement::max_num_bits(),
             });
         }

--- a/crates/noirc_evaluator/src/low_level_function_impl/mod.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/mod.rs
@@ -67,10 +67,10 @@ pub fn call_low_level(
         OPCODE::FixedBaseScalarMul => FixedBaseScalarMulGadget::call(evaluator, env, call_expr),
         k => {
             let message = format!("The OPCODE {} exists, however, currently the compiler does not have a concrete implementation for it", k);
-            return Err(RuntimeErrorKind::UnstructuredError {
+            Err(RuntimeErrorKind::UnstructuredError {
                 span: Default::default(),
                 message,
-            });
+            })
         }
     }
 }

--- a/crates/noirc_evaluator/src/low_level_function_impl/pedersen.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/pedersen.rs
@@ -52,7 +52,7 @@ impl PedersenGadget {
         let arr = Array::from_expression(evaluator, env, &arr_expr)?;
 
         // XXX: Instead of panics, return a user error here
-        if arr.contents.len() < 1 {
+        if arr.contents.is_empty() {
             panic!("a pedersen hash requires at least one element to hash")
         }
 
@@ -73,7 +73,7 @@ impl PedersenGadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: noir_field::FieldElement::max_num_bits(),
             });
         }

--- a/crates/noirc_evaluator/src/low_level_function_impl/schnorr.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/schnorr.rs
@@ -89,7 +89,7 @@ impl SchnorrVerifyGadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: 8,
             });
         }
@@ -108,7 +108,7 @@ impl SchnorrVerifyGadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits: 8,
             });
         }

--- a/crates/noirc_evaluator/src/low_level_function_impl/sha256.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/sha256.rs
@@ -81,7 +81,7 @@ impl Sha256Gadget {
             };
 
             inputs.push(GadgetInput {
-                witness: witness,
+                witness,
                 num_bits,
             });
         }

--- a/crates/noirc_evaluator/src/object/array.rs
+++ b/crates/noirc_evaluator/src/object/array.rs
@@ -104,7 +104,7 @@ impl Array {
         if lhs_len == 0 {
             return Err(RuntimeErrorKind::UnstructuredError {
                 span: Span::default(),
-                message: format!("arrays must contain at least one element"),
+                message: "arrays must contain at least one element".to_string(),
             });
         }
 

--- a/crates/noirc_evaluator/src/object/integer.rs
+++ b/crates/noirc_evaluator/src/object/integer.rs
@@ -80,10 +80,10 @@ impl Integer {
                     "tried to convert a {} into an integer. This is not possible.",
                     k.r#type()
                 );
-                return Err(RuntimeErrorKind::UnstructuredError {
+                Err(RuntimeErrorKind::UnstructuredError {
                     span: Default::default(),
                     message,
-                });
+                })
             }
         }
     }
@@ -105,7 +105,7 @@ impl Integer {
         let res =
             binary_op::handle_add_op(Object::from_witness(self.witness), witness_rhs, evaluator)?;
 
-        Ok(Integer::from_object(res, self.num_bits, evaluator)?)
+        Integer::from_object(res, self.num_bits, evaluator)
     }
     pub fn sub(
         &self,
@@ -127,7 +127,7 @@ impl Integer {
             binary_op::handle_sub_op(Object::from_witness(self.witness), witness_rhs, evaluator)?;
 
         // Constrain the result to be equal to an integer in range of 2^num_bits
-        Ok(Integer::from_object(res, self.num_bits, evaluator)?)
+        Integer::from_object(res, self.num_bits, evaluator)
     }
 
     pub fn logic(
@@ -203,11 +203,11 @@ impl Integer {
         let res =
             binary_op::handle_mul_op(Object::from_witness(self.witness), witness_rhs, evaluator)?;
 
-        Ok(Integer::from_object(
+        Integer::from_object(
             res,
             self.num_bits + num_bits,
             evaluator,
-        )?)
+        )
     }
 }
 

--- a/crates/noirc_evaluator/src/object/mod.rs
+++ b/crates/noirc_evaluator/src/object/mod.rs
@@ -208,7 +208,7 @@ impl Object {
             Object::Constants(lhs) => Object::Constants(*lhs * constant),
             Object::Arithmetic(lhs) => Object::Arithmetic(lhs * &constant),
         };
-        return Some(obj);
+        Some(obj)
     }
 }
 
@@ -264,7 +264,7 @@ impl RangedObject {
 
         // We only allow ascending ranges
         if (end - start).num_bits() > 252 {
-            let message = format!("We currently only allow ranges to be ascending. For example `0..10` is  valid, however `10..0` is not");
+            let message = "We currently only allow ranges to be ascending. For example `0..10` is  valid, however `10..0` is not".to_string();
             return Err(RuntimeErrorKind::UnstructuredError {
                 span: Default::default(),
                 message,

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -93,7 +93,7 @@ impl Expression {
         };
 
         let ident = Ident(Spanned::from(self.span, identifier));
-        return Some(ident);
+        Some(ident)
     }
 }
 
@@ -180,7 +180,7 @@ impl From<&Token> for Option<BinaryOpKind> {
             Token::Assign => BinaryOpKind::Assign,
             _ => return None,
         };
-        return Some(op);
+        Some(op)
     }
 }
 

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -97,7 +97,7 @@ impl CrateGraph {
     }
 
     pub fn crate_type(&self, crate_id: CrateId) -> CrateType {
-        self.arena.get(&crate_id).unwrap().crate_type.clone()
+        self.arena.get(&crate_id).unwrap().crate_type
     }
 
     pub fn iter_keys(&self) -> impl Iterator<Item = CrateId> + '_ {

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -196,7 +196,7 @@ fn resolve_functions(
     if errors.is_empty() {
         return Ok(file_func_ids);
     }
-    return Err(errors);
+    Err(errors)
 }
 
 use crate::hir::type_check::type_check_func;

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -45,7 +45,7 @@ impl<'a> ModCollector<'a> {
         };
         for function in self.ast.functions.clone() {
             let name = function.name_ident().clone();
-            let nf: NoirFunction = function.into();
+            let nf: NoirFunction = function;
 
             // First create dummy function in the DefInterner
             // So that we can get a FuncId
@@ -152,8 +152,7 @@ impl<'a> ModCollector<'a> {
         let mod_id = ModuleId {
             krate: self.def_collector.def_map.krate,
             local_id: LocalModuleId(module_id),
-        }
-        .into();
+        };
         modules[self.module_id.0]
             .scope
             .define_module_def(mod_name.to_owned(), mod_id)

--- a/crates/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/errors.rs
@@ -31,10 +31,10 @@ impl DiagnosableError for DefCollectorErrorKind {
 
                 let mut diag = Diagnostic::simple_error(
                     format!("duplicate definitions of {} function found", func_name),
-                    format!("first definition found here"),
+                    "first definition found here".to_string(),
                     first_span,
                 );
-                diag.add_secondary(format!("second definition found here"), second_span);
+                diag.add_secondary("second definition found here".to_string(), second_span);
                 diag
             }
             DefCollectorErrorKind::DuplicateModuleDecl {
@@ -47,10 +47,10 @@ impl DiagnosableError for DefCollectorErrorKind {
 
                 let mut diag = Diagnostic::simple_error(
                     format!("module {} has been declared twice", mod_name),
-                    format!("first declaration found here"),
+                    "first declaration found here".to_string(),
                     first_span,
                 );
-                diag.add_secondary(format!("second declaration found here"), second_span);
+                diag.add_secondary("second declaration found here".to_string(), second_span);
                 diag
             }
             DefCollectorErrorKind::DuplicateImport {
@@ -63,10 +63,10 @@ impl DiagnosableError for DefCollectorErrorKind {
 
                 let mut diag = Diagnostic::simple_error(
                     format!("the name `{}` is defined multiple times", import_name),
-                    format!("first import found here"),
+                    "first import found here".to_string(),
                     first_span,
                 );
-                diag.add_secondary(format!("second import found here"), second_span);
+                diag.add_secondary("second import found here".to_string(), second_span);
                 diag
             }
             DefCollectorErrorKind::UnresolvedModuleDecl { mod_name } => {

--- a/crates/noirc_frontend/src/hir/def_map/item_scope.rs
+++ b/crates/noirc_frontend/src/hir/def_map/item_scope.rs
@@ -37,20 +37,20 @@ impl ItemScope {
             ModuleDefId::ModuleId(_) => {
                 if let Entry::Occupied(o) = self.types.entry(name.clone()) {
                     let old_ident = o.key();
-                    return Err((old_ident.clone(), name.clone()));
+                    return Err((old_ident.clone(), name));
                 }
 
                 self.types
-                    .insert(name.clone(), (mod_def, Visibility::Public))
+                    .insert(name, (mod_def, Visibility::Public))
             }
             ModuleDefId::FunctionId(_) => {
                 if let Entry::Occupied(o) = self.values.entry(name.clone()) {
                     let old_ident = o.key();
-                    return Err((old_ident.clone(), name.clone()));
+                    return Err((old_ident.clone(), name));
                 }
 
                 self.values
-                    .insert(name.clone(), (mod_def, Visibility::Public))
+                    .insert(name, (mod_def, Visibility::Public))
             }
         };
         Ok(())

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -116,7 +116,7 @@ pub fn parse_file(
         Err(errs) => {
             let file_errs = CollectedErrors {
                 file_id,
-                errors: errs.into_iter().map(|err| err.to_diagnostic()).collect(),
+                errors: errs.iter().map(|err| err.to_diagnostic()).collect(),
             };
 
             Err(vec![file_errs])

--- a/crates/noirc_frontend/src/hir/def_map/module_def.rs
+++ b/crates/noirc_frontend/src/hir/def_map/module_def.rs
@@ -13,7 +13,7 @@ impl ModuleDefId {
         if let ModuleDefId::FunctionId(func_id) = self {
             return Some(*func_id);
         }
-        return None;
+        None
     }
     // XXX: We are still allocating fro error reporting even though strings are stored in binary
     // It is a minor performance issue, which can be addressed by having the error reporting, not allocate

--- a/crates/noirc_frontend/src/hir/def_map/namespace.rs
+++ b/crates/noirc_frontend/src/hir/def_map/namespace.rs
@@ -32,9 +32,8 @@ impl PerNs {
 
     pub fn iter_items(self) -> impl Iterator<Item = (ModuleDefId, Visibility)> {
         self.types
-            .map(|it| it)
             .into_iter()
-            .chain(self.values.map(|it| it).into_iter())
+            .chain(self.values.into_iter())
     }
 
     pub fn is_none(&self) -> bool {

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -51,10 +51,10 @@ impl ResolverError {
 
                 let mut diag = Diagnostic::simple_error(
                     format!("duplicate definitions of {} found", name),
-                    format!("first definition found here"),
+                    "first definition found here".to_string(),
                     first_span,
                 );
-                diag.add_secondary(format!("second definition found here"), second_span);
+                diag.add_secondary("second definition found here".to_string(), second_span);
                 diag
             }
             ResolverError::UnusedVariable { ident_id } => {
@@ -63,7 +63,7 @@ impl ResolverError {
 
                 let mut diag = Diagnostic::simple_error(
                     format!("unused variable {}", name),
-                    format!("unused variable "),
+                    "unused variable ".to_string(),
                     span,
                 );
 
@@ -72,11 +72,11 @@ impl ResolverError {
             }
             ResolverError::VariableNotDeclared { name, span } => Diagnostic::simple_error(
                 format!("cannot find `{}` in this scope ", name),
-                format!("not found in this scope"),
+                "not found in this scope".to_string(),
                 span,
             ),
             ResolverError::PathIsNotIdent { span } => Diagnostic::simple_error(
-                format!("cannot use path as an identifier"),
+                "cannot use path as an identifier".to_string(),
                 String::new(),
                 span,
             ),

--- a/crates/noirc_frontend/src/hir/resolution/import.rs
+++ b/crates/noirc_frontend/src/hir/resolution/import.rs
@@ -109,7 +109,7 @@ fn resolve_name_in_module(
         return PathResolution::Resolved(PerNs::types(mod_id.into()));
     }
 
-    let mut import_path = import_path.into_iter();
+    let mut import_path = import_path.iter();
     let first_segment = import_path.next().expect("ice: could not fetch first segment");
     let mut current_ns = current_mod.scope.find_name(&first_segment);
     if current_ns.is_none() {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -76,7 +76,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn push_err(&mut self, err: ResolverError) {
-        self.errors.push(err.into())
+        self.errors.push(err)
     }
 
     /// Resolving a function involves interning the metadata
@@ -96,9 +96,9 @@ impl<'a> Resolver<'a> {
         self.check_for_unused_variables_in_scope_tree(func_scope_tree);
 
         if self.errors.is_empty() {
-            return Ok((hir_func, func_meta));
+            Ok((hir_func, func_meta))
         } else {
-            return Err(self.errors);
+            Err(self.errors)
         }
     }
     fn resolve_expression(&mut self, expr: Expression) -> ExprId {
@@ -144,7 +144,7 @@ impl<'a> Resolver<'a> {
             num_times_used: 0,
             id,
         };
-        let old_value = scope.add_key_value(name.0.contents.clone(), resolver_meta);
+        let old_value = scope.add_key_value(name.0.contents, resolver_meta);
 
         match old_value {
             None => {
@@ -187,7 +187,7 @@ impl<'a> Resolver<'a> {
         };
         self.push_err(err);
 
-        return IdentId::dummy_id();
+        IdentId::dummy_id()
     }
 
     pub fn intern_function(&mut self, func: NoirFunction) -> (HirFunction, FuncMeta) {
@@ -363,7 +363,7 @@ impl<'a> Resolver<'a> {
                             let err = ResolverError::Expected {
                                 expected: "function".to_owned(),
                                 got: def_id.as_str().to_owned(),
-                                span: span,
+                                span,
                             };
                             self.push_err(err);
                             FuncId::dummy_id()
@@ -505,7 +505,7 @@ mod test {
             }
         }
 
-        (interner.clone(), errors)
+        (interner, errors)
     }
 
     #[test]

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -45,10 +45,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> Scope<K, V> {
         self.0.get_mut(key)
     }
     pub fn occupied_key(&mut self, key: &K) -> Option<&K> {
-        match self.0.get_key_value(key) {
-            Some((k, _)) => Some(k),
-            None => None,
-        }
+        self.0.get_key_value(key).map(|(k, _)| k)
     }
 
     // From HashMap: If the map did not have this key present, None is returned.
@@ -88,7 +85,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeTree<K, V> {
             }
         }
 
-        return None;
+        None
     }
 
     pub fn push_scope(&mut self) {

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -70,8 +70,7 @@ impl TypeCheckError {
             }
             TypeCheckError::MultipleErrors(errors) => errors
                 .into_iter()
-                .map(|err| err.into_diagnostics(interner))
-                .flatten()
+                .flat_map(|err| err.into_diagnostics(interner))
                 .collect(),
             TypeCheckError::Context { err, ctx } => {
                 let mut diags = err.into_diagnostics(interner);
@@ -136,7 +135,7 @@ impl TypeCheckError {
             }
             TypeCheckError::PublicReturnType { typ, span } => {
                 vec![Diagnostic::simple_error(
-                    format!("functions cannot declare a public return type"),
+                    "functions cannot declare a public return type".to_string(),
                     format!("return type is {}", typ),
                     span,
                 )]

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -25,7 +25,7 @@ pub(crate) fn type_check_expression(
 
             // The type of this Ident expression is the type of the Identifier which defined it
             let typ = interner.id_type(ident_def_id);
-            interner.push_expr_type(expr_id, typ.clone());
+            interner.push_expr_type(expr_id, typ);
         }
         HirExpression::Literal(literal) => {
             match literal {
@@ -291,10 +291,10 @@ pub fn infix_operand_type_rules(
                 Ok(Type::Integer(field_type,*sign_x, *bit_width_x))
             }
             (Type::Integer(_,_, _), Type::FieldElement(FieldElementType::Private)) | ( Type::FieldElement(FieldElementType::Private), Type::Integer(_,_, _) ) => {
-                Err(format!("Cannot use an integer and a witness in a binary operation, try converting the witness into an integer"))
+                Err("Cannot use an integer and a witness in a binary operation, try converting the witness into an integer".to_string())
             }
             (Type::Integer(_,_, _), Type::FieldElement(FieldElementType::Public)) | ( Type::FieldElement(FieldElementType::Public), Type::Integer(_,_, _) ) => {
-                Err(format!("Cannot use an integer and a public variable in a binary operation, try converting the public into an integer"))
+                Err("Cannot use an integer and a public variable in a binary operation, try converting the public into an integer".to_string())
             }
             (Type::Integer(int_field_type,sign_x, bit_width_x), Type::FieldElement(FieldElementType::Constant))| (Type::FieldElement(FieldElementType::Constant),Type::Integer(int_field_type,sign_x, bit_width_x)) => {
                 
@@ -305,7 +305,7 @@ pub fn infix_operand_type_rules(
                 Err(format!("Integer cannot be used with type {}", typ))
             }
             // Currently, arrays are not supported in binary operations
-            (Type::Array(_,_,_), _) | (_,Type::Array(_,_, _)) => Err(format!("Arrays cannot be used in an infix operation")),
+            (Type::Array(_,_,_), _) | (_,Type::Array(_,_, _)) => Err("Arrays cannot be used in an infix operation".to_string()),
             //
             // An error type on either side will always return an error
             (Type::Error, _) | (_,Type::Error) => Ok(Type::Error),
@@ -381,10 +381,10 @@ fn type_check_list_expression(
     interner: &mut NodeInterner,
     exprs: &[ExprId],
 ) -> Result<(), TypeCheckError> {
-    assert!(exprs.len() > 0);
+    assert!(!exprs.is_empty());
 
     let (_, errors): (Vec<_>, Vec<_>) = exprs
-        .into_iter()
+        .iter()
         .map(|arg| type_check_expression(interner, arg))
         .partition(Result::is_ok);
 

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -80,9 +80,9 @@ fn type_check_let_stmt(
     if !resolved_type.can_be_used_in_let() {
         let span = interner.expr_span(&let_stmt.expression);
         return Err(TypeCheckError::TypeCannotBeUsed {
-            typ: resolved_type.clone(),
+            typ: resolved_type,
             place: "let statement",
-            span: span,
+            span,
         });
     }
 

--- a/crates/noirc_frontend/src/lexer/errors.rs
+++ b/crates/noirc_frontend/src/lexer/errors.rs
@@ -17,12 +17,12 @@ impl DiagnosableError for LexerErrorKind {
     fn to_diagnostic(&self) -> Diagnostic {
         match self {
             LexerErrorKind::UnexpectedCharacter { span, found } => Diagnostic::simple_error(
-                format!("an unexpected character was found"),
+                "an unexpected character was found".to_string(),
                 format!(" {:?} is unexpected", found),
                 *span,
             ),
             LexerErrorKind::CharacterNotInLanguage { span, found } => Diagnostic::simple_error(
-                format!("char is not in language"),
+                "char is not in language".to_string(),
                 format!(" {:?} is not in language", found),
                 *span,
             ),

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -63,14 +63,14 @@ impl<'a> Lexer<'a> {
         if let Some(peeked_ch) = self.peek_char() {
             return *peeked_ch == ch;
         };
-        return false;
+        false
     }
 
     pub fn next_token(&mut self) -> SpannedTokenResult {
         match self.next_char() {
             Some(x) if { x.is_whitespace() } => {
                 self.eat_whitespace();
-                return self.next_token();
+                self.next_token()
             }
             Some('<') => self.glue(Token::Less),
             Some('>') => self.glue(Token::Greater),
@@ -118,10 +118,10 @@ impl<'a> Lexer<'a> {
         let start = self.position.mark();
 
         match self.peek_char_is(character) {
-            false => return Ok(single.into_single_span(start)),
+            false => Ok(single.into_single_span(start)),
             true => {
                 self.next_char();
-                return Ok(double.into_span(start, start.forward()));
+                Ok(double.into_span(start, start.forward()))
             }
         }
     }
@@ -226,7 +226,7 @@ impl<'a> Lexer<'a> {
                 "Lexer expected a '[' character after the '#' character, instead got {}",
                 self.next_char().unwrap()
             );
-            let err = Token::Error(err_msg.to_string());
+            let err = Token::Error(err_msg);
             return err.into_single_span(self.position.mark());
         }
         self.next_char();
@@ -241,7 +241,7 @@ impl<'a> Lexer<'a> {
                 "Lexer expected a trailing ']' character instead got {}",
                 self.next_char().unwrap()
             );
-            return Token::Error(err_msg.to_string()).into_single_span(self.position.mark());
+            return Token::Error(err_msg).into_single_span(self.position.mark());
         }
         self.next_char();
 
@@ -260,15 +260,15 @@ impl<'a> Lexer<'a> {
         });
 
         // Check if word either an identifier or a keyword
-        if let Some(keyword_token) = Keyword::lookup_keyword(&word.to_string()) {
+        if let Some(keyword_token) = Keyword::lookup_keyword(&word) {
             return keyword_token.into_span(start_span, end_span);
         }
         // Check if word an int type
-        if let Some(int_type_token) = IntType::lookup_int_type(&word.to_string()) {
+        if let Some(int_type_token) = IntType::lookup_int_type(&word) {
             return int_type_token.into_span(start_span, end_span);
         }
         let ident_token = Token::Ident(word);
-        return ident_token.into_span(start_span, end_span);
+        ident_token.into_span(start_span, end_span)
     }
     fn eat_digit(&mut self, initial_char: char) -> SpannedToken {
         let (integer_str, start_span, end_span) = self.eat_while(Some(initial_char), |ch| {
@@ -280,7 +280,7 @@ impl<'a> Lexer<'a> {
             Some(integer) => integer,
         };
 
-        let integer_token = Token::Int(integer.into());
+        let integer_token = Token::Int(integer);
         integer_token.into_span(start_span, end_span)
     }
     fn eat_string_literal(&mut self) -> SpannedToken {

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -223,7 +223,7 @@ impl Token {
         };
 
         // If we arrive here, then the Token variants are the same and they are not the Keyword type
-        return same_token_variant;
+        same_token_variant
     }
     pub fn is_comment(&self) -> bool {
         match self {
@@ -274,19 +274,16 @@ impl IntType {
     pub(crate) fn lookup_int_type(word: &str) -> Option<Token> {
         // Check if the first string is a 'u' or 'i'
 
-        let is_signed = if word.starts_with("i") {
+        let is_signed = if word.starts_with('i') {
             true
-        } else if word.starts_with("u") {
+        } else if word.starts_with('u') {
             false
         } else {
             return None;
         };
 
         // Word start with 'u' or 'i'. Check if the latter is an integer
-        let str_as_u32 = match word[1..].parse::<u32>() {
-            Ok(str_as_u32) => str_as_u32,
-            Err(_) => return None,
-        };
+        let str_as_u32 = word[1..].parse::<u32>().ok()?;
 
         let max_bits = noir_field::FieldElement::max_num_bits();
 
@@ -301,9 +298,9 @@ impl IntType {
         }
 
         if is_signed {
-            return Some(Token::IntType(IntType::Signed(str_as_u32)));
+            Some(Token::IntType(IntType::Signed(str_as_u32)))
         } else {
-            return Some(Token::IntType(IntType::Unsigned(str_as_u32)));
+            Some(Token::IntType(IntType::Unsigned(str_as_u32)))
         }
     }
 }

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -253,7 +253,7 @@ impl NodeInterner {
             .expect("ice: all function ids should have definitions");
 
         match def {
-            Node::Function(func) => return func.clone(),
+            Node::Function(func) => func.clone(),
             _ => panic!("ice: all function ids should correspond to a function in the interner"),
         }
     }
@@ -273,7 +273,7 @@ impl NodeInterner {
             .expect("ice: all statement ids should have definitions");
 
         match def {
-            Node::Statement(stmt) => return stmt.clone(),
+            Node::Statement(stmt) => stmt.clone(),
             _ => panic!("ice: all statement ids should correspond to a statement in the interner"),
         }
     }
@@ -285,7 +285,7 @@ impl NodeInterner {
             .expect("ice: all expression ids should have definitions");
 
         match def {
-            Node::Expression(expr) => return expr.clone(),
+            Node::Expression(expr) => expr.clone(),
             _ => {
                 panic!("ice: all expression ids should correspond to a expression in the interner")
             }
@@ -299,7 +299,7 @@ impl NodeInterner {
             .expect("ice: all ident ids should have definitions");
 
         match def {
-            Node::Ident(ident) => return ident.clone(),
+            Node::Ident(ident) => ident.clone(),
             _ => panic!("ice: all expression ids should correspond to a statement in the interner"),
         }
     }

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -41,20 +41,20 @@ impl DiagnosableError for ParserErrorKind {
             ParserErrorKind::ExpectedExpression { span, lexeme } => {
                 let mut diag = Diagnostic::simple_error(
                     format!("Unexpected start of an expression {}", lexeme),
-                    format!("did not expect this token"),
+                    "did not expect this token".to_string(),
                     *span,
                 );
-                diag.add_note(format!("This error is commonly caused by either a previous error cascading or an unclosed delimiter."));
+                diag.add_note("This error is commonly caused by either a previous error cascading or an unclosed delimiter.".to_string());
                 diag
             }
             ParserErrorKind::TokenNotUnaryOp { spanned_token } => Diagnostic::simple_error(
                 format!("Unsupported unary operation {}", spanned_token.token()),
-                format!("cannot use as a unary operation."),
+                "cannot use as a unary operation.".to_string(),
                 spanned_token.into_span(),
             ),
             ParserErrorKind::TokenNotBinaryOp { spanned_token } => Diagnostic::simple_error(
                 format!("Unsupported binary operation {}", spanned_token.token()),
-                format!("cannot use as a binary operation."),
+                "cannot use as a binary operation.".to_string(),
                 spanned_token.into_span(),
             ),
             ParserErrorKind::UnexpectedToken {
@@ -86,8 +86,8 @@ impl DiagnosableError for ParserErrorKind {
                 };
 
                 let mut diag = Diagnostic::simple_error(
-                    format!("path is ambiguous"),
-                    format!("path contains a single keyword"),
+                    "path is ambiguous".to_string(),
+                    "path contains a single keyword".to_string(),
                     *span,
                 );
                 diag.add_note(note.to_owned());

--- a/crates/noirc_frontend/src/parser/infix_parser/binary.rs
+++ b/crates/noirc_frontend/src/parser/infix_parser/binary.rs
@@ -25,15 +25,15 @@ impl BinaryParser {
         let rhs = parser.parse_expression(curr_precedence)?;
 
         let infix_expression = Box::new(InfixExpression {
-            lhs: lhs,
+            lhs,
             operator,
-            rhs: rhs.clone(),
+            rhs,
         });
 
         if is_predicate_op {
             return Ok(ExpressionKind::Predicate(infix_expression));
         }
-        return Ok(ExpressionKind::Infix(infix_expression));
+        Ok(ExpressionKind::Infix(infix_expression))
     }
 }
 fn token_to_binary_op(spanned_tok: &SpannedToken) -> Result<BinaryOp, ParserErrorKind> {
@@ -63,7 +63,7 @@ mod test {
 
     #[test]
     fn start_end_cursor() {
-        const SRC: &'static str = " + 6";
+        const SRC: &str = " + 6";
 
         let mut parser = test_parse(SRC);
 
@@ -71,7 +71,7 @@ mod test {
 
         let _ = BinaryParser::parse(&mut parser, dummy_expr()).unwrap();
 
-        let end = parser.curr_token.clone();
+        let end = parser.curr_token;
 
         assert_eq!(start, crate::token::Token::Plus);
         assert_eq!(end, crate::token::Token::Int(6.into()));

--- a/crates/noirc_frontend/src/parser/infix_parser/call.rs
+++ b/crates/noirc_frontend/src/parser/infix_parser/call.rs
@@ -23,7 +23,7 @@ impl CallParser {
             ExpressionKind::Path(path) => path,
             _ => {
                 return Err(ParserErrorKind::UnstructuredError {
-                    message: format!("expected a path for the function name"),
+                    message: "expected a path for the function name".to_string(),
                     span: func_path.span,
                 })
             }
@@ -50,7 +50,7 @@ mod test {
     pub(crate) fn dummy_path_expr() -> Expression {
         use crate::parser::prefix_parser::PrefixParser;
 
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             std::hash
         "#;
 

--- a/crates/noirc_frontend/src/parser/infix_parser/index.rs
+++ b/crates/noirc_frontend/src/parser/infix_parser/index.rs
@@ -12,7 +12,7 @@ impl IndexParser {
     /// Cursor End : `]`
     pub fn parse(parser: &mut Parser, collection_name: Expression) -> ParserExprKindResult {
         // XXX: We will clean up these unnecessary format! allocations in the refactor after the next
-        let msg = format!("expected an identifier for the collection name. Arbitrary expressions are yet to arrive");
+        let msg = "expected an identifier for the collection name. Arbitrary expressions are yet to arrive".to_string();
         let err = ParserErrorKind::UnstructuredError {
             message: msg,
             span: collection_name.span,

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -94,7 +94,7 @@ pub(crate) fn test_parse(src: &str) -> Parser {
 #[cfg(test)]
 pub(crate) fn dummy_expr() -> crate::Expression {
     use crate::parser::prefix_parser::PrefixParser;
-    const SRC: &'static str = r#"
+    const SRC: &str = r#"
         foo;
     "#;
     let mut parser = test_parse(SRC);

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -86,7 +86,7 @@ impl<'a> Parser<'a> {
             });
         }
         self.advance_tokens();
-        return Ok(());
+        Ok(())
     }
 
     // peaks at the next token
@@ -108,7 +108,7 @@ impl<'a> Parser<'a> {
             });
         }
         self.advance_tokens();
-        return Ok(());
+        Ok(())
     }
 
     /// A Program corresponds to a single module
@@ -160,10 +160,10 @@ impl<'a> Parser<'a> {
             self.advance_tokens();
         }
 
-        if self.errors.len() > 0 {
-            return Err(&self.errors);
+        if !self.errors.is_empty() {
+            Err(&self.errors)
         } else {
-            return Ok(program);
+            Ok(program)
         }
     }
 
@@ -238,7 +238,7 @@ impl<'a> Parser<'a> {
                 }
             }
         };
-        return Ok(stmt);
+        Ok(stmt)
     }
 
     fn parse_expression_statement(&mut self) -> ParserExprResult {
@@ -264,7 +264,7 @@ impl<'a> Parser<'a> {
             match self.choose_infix_parser() {
                 None => {
                     dbg!("No infix function found for {}", self.curr_token.token());
-                    return Ok(left_exp.clone());
+                    return Ok(left_exp);
                 }
                 Some(infix_parser) => {
                     self.advance_tokens();
@@ -273,7 +273,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        return Ok(left_exp);
+        Ok(left_exp)
     }
     fn choose_prefix_parser(&self) -> Option<PrefixParser> {
         match self.curr_token.token() {
@@ -388,7 +388,7 @@ impl<'a> Parser<'a> {
                 self.advance_tokens();
             }
             (true, false) => {
-                let message = format!("unexpected field element type keyword found. \"pub, priv or const\" is not valid here");
+                let message = "unexpected field element type keyword found. \"pub, priv or const\" is not valid here".to_string();
                 return Err(ParserErrorKind::UnstructuredError {
                     message,
                     span: self.curr_token.into_span(),
@@ -413,10 +413,10 @@ impl<'a> Parser<'a> {
             Token::LeftBracket => self.parse_array_type(field_type),
             k => {
                 let message = format!("Expected a type, found {}", k);
-                return Err(ParserErrorKind::UnstructuredError {
+                Err(ParserErrorKind::UnstructuredError {
                     message,
                     span: self.curr_token.into_span(),
-                });
+                })
             }
         }
     }
@@ -433,10 +433,10 @@ impl<'a> Parser<'a> {
                     "unexpected keyword. Expected \"pub, const or priv\". found {}",
                     tok
                 );
-                return Err(ParserErrorKind::UnstructuredError {
+                Err(ParserErrorKind::UnstructuredError {
                     message,
                     span: self.curr_token.into_span(),
-                });
+                })
             }
         }
     }
@@ -450,7 +450,7 @@ impl<'a> Parser<'a> {
         let array_len = match self.peek_token.clone().into() {
             Token::Int(integer) => {
                 if !integer.fits_in_u128() {
-                    let message = format!("Array sizes must fit within a u128");
+                    let message = "Array sizes must fit within a u128".to_string();
                     return Err(ParserErrorKind::UnstructuredError {
                         message,
                         span: self.peek_token.into_span(),
@@ -461,7 +461,7 @@ impl<'a> Parser<'a> {
             }
             Token::RightBracket => ArraySize::Variable,
             _ => {
-                let message = format!("The array size is defined as [k] for fixed size or [] for variable length. k must be a literal");
+                let message = "The array size is defined as [k] for fixed size or [] for variable length. k must be a literal".to_string();
                 return Err(ParserErrorKind::UnstructuredError {
                     message,
                     span: self.peek_token.into_span(),
@@ -477,7 +477,7 @@ impl<'a> Parser<'a> {
         // Disallow [4][3]Witness ie Matrices
         if self.peek_token == Token::LeftBracket {
             return Err(ParserErrorKind::UnstructuredError {
-                message: format!("Currently Multi-dimensional arrays are not supported"),
+                message: "Currently Multi-dimensional arrays are not supported".to_string(),
                 span: self.peek_token.into_span(),
             });
         }
@@ -495,7 +495,7 @@ mod test {
 
     #[test]
     fn regression_skip_comment() {
-        const COMMENT_BETWEEN_FIELD: &'static str = r#"
+        const COMMENT_BETWEEN_FIELD: &str = r#"
             fn main(
                 // This comment should be skipped
                 x : Field, 
@@ -505,7 +505,7 @@ mod test {
 
             }
         "#;
-        const COMMENT_BETWEEN_CALL: &'static str = r#"
+        const COMMENT_BETWEEN_CALL: &str = r#"
             fn main(x : Field, y : Field,) {
                 foo::bar(
                     // Comment for x argument
@@ -516,8 +516,8 @@ mod test {
             }
         "#;
         let mut parser = Parser::from_src(COMMENT_BETWEEN_FIELD);
-        let program = parser.parse_program().unwrap();
+        let _program = parser.parse_program().unwrap();
         parser = Parser::from_src(COMMENT_BETWEEN_CALL);
-        let program = parser.parse_program().unwrap();
+        let _program = parser.parse_program().unwrap();
     }
 }

--- a/crates/noirc_frontend/src/parser/prefix_parser/array.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/array.rs
@@ -54,7 +54,7 @@ mod test {
     /// This is the standard way to declare an array
     #[test]
     fn valid_syntax() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             [0,1,2,3,4]
         "#;
 
@@ -64,7 +64,7 @@ mod test {
 
         let expr = ArrayParser::parse(&mut parser).unwrap();
 
-        let end = parser.curr_token.clone();
+        let end = parser.curr_token;
 
         // First check that the cursor was in the right position at
         // the start and at the end
@@ -86,7 +86,7 @@ mod test {
     fn valid_syntax_extra_comma() {
         // This is a valid user error. We return an unexpected token error.
         // We expect a `]` but instead we get an EOF
-        const MISSING_END: &'static str = r#"
+        const MISSING_END: &str = r#"
             [0,1,2,3,4,]
         "#;
 
@@ -98,21 +98,21 @@ mod test {
         // Since this is a prefix parser, this should be impossible to arrive at
         // unless there is an off-by-one error. The exact error here is not important,
         // since arriving here would signal an ICE
-        const MISSING_START: &'static str = r#"
+        const MISSING_START: &str = r#"
             0,1,2,3,4]
         "#;
         ArrayParser::parse(&mut test_parse(MISSING_START)).unwrap_err();
     }
     #[test]
     fn double_prefix() {
-        const DOUBLE_PREFIX: &'static str = r#"
+        const DOUBLE_PREFIX: &str = r#"
             [[0,1,2,3,4]
         "#;
         ArrayParser::parse(&mut test_parse(DOUBLE_PREFIX)).unwrap_err();
     }
     #[test]
     fn double_delimiter() {
-        const DOUBLE_DELIMITER: &'static str = r#"
+        const DOUBLE_DELIMITER: &str = r#"
             [0,1,2,,]
         "#;
         ArrayParser::parse(&mut test_parse(DOUBLE_DELIMITER)).unwrap_err();
@@ -123,7 +123,7 @@ mod test {
         /// Note that the ArrayParser parses the first array which is [0,1,2,3,4]
         /// Then whatever comes after that is no longer the responsibility of the
         /// Array Parser
-        const DOUBLE_POSTFIX: &'static str = r#"
+        const DOUBLE_POSTFIX: &str = r#"
             [0,1,2,3,4]]
         "#;
         ArrayParser::parse(&mut test_parse(DOUBLE_POSTFIX)).unwrap();
@@ -133,7 +133,7 @@ mod test {
     fn missing_closing_bracket() {
         // This is a valid user error. We return an unexpected token error.
         // We expect a `]` but instead we get an EOF
-        const MISSING_END: &'static str = r#"
+        const MISSING_END: &str = r#"
             [0,1,2,3,4
         "#;
 

--- a/crates/noirc_frontend/src/parser/prefix_parser/block.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/block.rs
@@ -26,7 +26,7 @@ impl BlockParser {
         // XXX: Check consistency with for parser, if parser and func parser
         if parser.curr_token != Token::LeftBrace {
             return Err(ParserErrorKind::UnstructuredError {
-                message: format!("Expected a {{ to start the block expression"),
+                message: "Expected a { to start the block expression".to_string(),
                 span: parser.curr_token.into_span(),
             });
         }
@@ -39,7 +39,7 @@ impl BlockParser {
 
         if parser.curr_token != Token::RightBrace {
             return Err(ParserErrorKind::UnstructuredError {
-                message: format!("Expected a }} to end the block expression"),
+                message: "Expected a } to end the block expression".to_string(),
                 span: parser.curr_token.into_span(),
             });
         }
@@ -65,7 +65,7 @@ mod test {
     /// This block expression has a single item in it, an array
     #[test]
     fn valid_syntax() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             {
                 [0,1,2,3,4]
             }
@@ -77,7 +77,7 @@ mod test {
 
         let expr = BlockParser::parse(&mut parser).unwrap();
 
-        let end = parser.curr_token.clone();
+        let end = parser.curr_token;
 
         // First check that the cursor was in the right position at
         // the start and at the end
@@ -93,7 +93,7 @@ mod test {
 
     #[test]
     fn missing_starting_brace() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             
                 [0,1,2,3,4]
             }
@@ -104,7 +104,7 @@ mod test {
     }
     #[test]
     fn missing_end_brace() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             {
                 [0,1,2,3,4]
             
@@ -119,19 +119,19 @@ mod test {
         /// Invalid contents is caught
         ///
         /// Array content is invalid
-        const INVALID_SRC: &'static str = r#"
+        const INVALID_SRC: &str = r#"
             {
                 [0,1,2,,]
             }
         "#;
         /// Array is missing it's ending bracket
-        const INVALID_SRC_2: &'static str = r#"
+        const INVALID_SRC_2: &str = r#"
             {
                 [0,1,2,3
             }
         "#;
         /// Array is missing it's starting bracket
-        const INVALID_SRC_3: &'static str = r#"
+        const INVALID_SRC_3: &str = r#"
             {
                 0,1,2,3]
             }
@@ -155,7 +155,7 @@ mod test {
         /// is not called unless there is a left brace.
         /// To be on the conservative side, it should be left in,
         /// incase there is a way to manipulate the syntax
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
                 [[0,1,2,3,4]
             }
         "#;

--- a/crates/noirc_frontend/src/parser/prefix_parser/constrain.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/constrain.rs
@@ -49,7 +49,7 @@ impl ConstrainParser {
         let infix = match expr.kind.into_infix() {
             Some(infix) => infix,
             None => {
-                let message = format!("Expected an infix expression since this is a constrain statement. You cannot assign values");
+                let message = "Expected an infix expression since this is a constrain statement. You cannot assign values".to_string();
                 return Err(ParserErrorKind::UnstructuredError {
                     message,
                     span: expr.span,
@@ -58,7 +58,7 @@ impl ConstrainParser {
         };
 
         if infix.operator.contents == BinaryOpKind::Assign {
-            let message = format!("Cannot use '=' with a constrain statement");
+            let message = "Cannot use '=' with a constrain statement".to_string();
             return Err(ParserErrorKind::UnstructuredError {
                 message,
                 span: infix.operator.span(),
@@ -92,7 +92,7 @@ mod test {
     /// This is the standard way to declare a constrain statement
     #[test]
     fn valid_syntax() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             constrain x == y;
         "#;
 
@@ -102,7 +102,7 @@ mod test {
 
         let _stmt = ConstrainParser::parse_statement(&mut parser).unwrap();
 
-        let end = parser.curr_token.clone();
+        let end = parser.curr_token;
 
         // First check that the cursor was in the right position at
         // the start and at the end
@@ -135,19 +135,19 @@ mod test {
         /// The first (inner) `==` is a predicate which returns 0/1
         /// The outer layer is an infix `==` which is
         /// associated with the Constrain statement
-        const VALID_1: &'static str = r#"
+        const VALID_1: &str = r#"
             constrain ((x + y) == k) + z == y;
         "#;
-        const VALID_2: &'static str = r#"
+        const VALID_2: &str = r#"
             constrain (x + !y) == y;
         "#;
-        const VALID_3: &'static str = r#"
+        const VALID_3: &str = r#"
             constrain (x ^ y) == y;
         "#;
-        const VALID_4: &'static str = r#"
+        const VALID_4: &str = r#"
             constrain (x ^ y) == (y + m);
         "#;
-        const VALID_5: &'static str = r#"
+        const VALID_5: &str = r#"
             constrain x + x ^ x == y | m;
         "#;
 
@@ -172,7 +172,7 @@ mod test {
         ///
         /// This is so that, you can have an expression as the last item in
         /// a block.
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
                 constrain x == y
             }
         "#;
@@ -185,7 +185,7 @@ mod test {
     fn invalid_assign() {
         /// The Assignment operator is different to the equals sign
         /// and cannot be used in a constrain statement.
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
                 constrain x = y;
             }
         "#;

--- a/crates/noirc_frontend/src/parser/prefix_parser/declaration.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/declaration.rs
@@ -25,10 +25,10 @@ impl DeclarationParser {
             Keyword::Priv => Ok(Statement::Private(parse_private_statement(parser)?)),
             kw => {
                 let msg = format!("the keyword {} cannot be used to declare a statement. Please use `let`, `const` or `priv`", kw);
-                return Err(ParserErrorKind::UnstructuredError {
+                Err(ParserErrorKind::UnstructuredError {
                     span: parser.curr_token.into_span(),
                     message: msg,
-                });
+                })
             }
         }
     }
@@ -148,7 +148,7 @@ mod test {
         /// Let statements are not type checked here, so the parser will accept as
         /// long as it is a type. Other statements such as Public are type checked
         /// Because for now, they can only have one type
-        const VALID: &'static [&str] = &[
+        const VALID: &[&str] = &[
             r#"
                 let x = y;
             "#,
@@ -175,7 +175,7 @@ mod test {
         /// as there are many private types.
         ///
         /// It is possible to check for basic types in the future.
-        const VALID: &'static [&str] = &[
+        const VALID: &[&str] = &[
             r#"
                 priv x = y;
             "#,
@@ -199,7 +199,7 @@ mod test {
     #[test]
     fn invalid_pub_syntax() {
         // pub cannot be used to declare a statement
-        const INVALID: &'static [&str] = &[
+        const INVALID: &[&str] = &[
             r#"
                 pub x = y;
             "#,
@@ -217,7 +217,7 @@ mod test {
     fn valid_const_syntax() {
         /// XXX: We have `Constant` because we may allow constants to
         /// be casted to integers. Maybe rename this to `Field` instead
-        const VALID: &'static [&str] = &[
+        const VALID: &[&str] = &[
             r#"
                 const x = y;
             "#,

--- a/crates/noirc_frontend/src/parser/prefix_parser/for_loop.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/for_loop.rs
@@ -87,12 +87,12 @@ mod test {
         /// The Parser does not check the types of the loops,
         /// it only checks for valid expressions in RANGE_START and
         /// RANGE_END
-        const SRC_EXPR_LOOP: &'static str = r#"
+        const SRC_EXPR_LOOP: &str = r#"
             for i in x+y..z {
 
             }
         "#;
-        const SRC_CONST_LOOP: &'static str = r#"
+        const SRC_CONST_LOOP: &str = r#"
             for i in 0..100 {
 
             }
@@ -112,19 +112,19 @@ mod test {
     #[test]
     fn invalid_syntax() {
         /// Cannot have a literal as the loop identifier
-        const SRC_LITERAL_IDENT: &'static str = r#"
+        const SRC_LITERAL_IDENT: &str = r#"
             for 1 in x+y..z {
 
             }
         "#;
         /// Currently only the DoubleDot is supported
-        const SRC_INCLUSIVE_LOOP: &'static str = r#"
+        const SRC_INCLUSIVE_LOOP: &str = r#"
             for i in 0...100 {
 
             }
         "#;
         /// Currently only the DoubleDot is supported
-        const SRC_INCLUSIVE_EQUAL_LOOP: &'static str = r#"
+        const SRC_INCLUSIVE_EQUAL_LOOP: &str = r#"
             for i in 0..=100 {
 
             }

--- a/crates/noirc_frontend/src/parser/prefix_parser/function.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/function.rs
@@ -69,7 +69,7 @@ impl FuncParser {
         // In the future, we can add a test attribute.
         // Arbitrary attributes will not be supported.
         let func_def = FunctionDefinition {
-            name: spanned_func_name.into(),
+            name: spanned_func_name,
             attribute,
             parameters,
             body,
@@ -191,7 +191,7 @@ mod test {
     }
     #[test]
     fn double_comma() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             fn x2( f: []Field,,) {
 
             }

--- a/crates/noirc_frontend/src/parser/prefix_parser/group.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/group.rs
@@ -37,12 +37,12 @@ mod test {
 
     #[test]
     fn valid_syntax() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             (x+a)
         "#;
         /// Remember that although this may fail overall
         /// for the GroupParser, it is locally correct
-        const SRC_DOUBLE_RPAREN: &'static str = r#"
+        const SRC_DOUBLE_RPAREN: &str = r#"
             (x+a))
         "#;
 
@@ -51,14 +51,14 @@ mod test {
     }
     #[test]
     fn invalid_syntax() {
-        const SRC_MISSING_RPAREN: &'static str = r#"
+        const SRC_MISSING_RPAREN: &str = r#"
             (x+a
         "#;
-        const SRC_DOUBLE_LPAREN: &'static str = r#"
+        const SRC_DOUBLE_LPAREN: &str = r#"
             ((x+a)
         "#;
 
-        const SRC_EMPTY_EXPR: &'static str = r#"
+        const SRC_EMPTY_EXPR: &str = r#"
             ()
         "#;
 

--- a/crates/noirc_frontend/src/parser/prefix_parser/if_expr.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/if_expr.rs
@@ -67,14 +67,14 @@ mod test {
 
     #[test]
     fn valid_syntax() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             if x + a {
 
             } else {
 
             }
         "#;
-        const SRC_NO_ELSE: &'static str = r#"
+        const SRC_NO_ELSE: &str = r#"
             if x {
 
             }
@@ -85,7 +85,7 @@ mod test {
     }
     #[test]
     fn no_else_brace() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             if (x / a) + 1 {
 
             } else

--- a/crates/noirc_frontend/src/parser/prefix_parser/literal.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/literal.rs
@@ -38,10 +38,10 @@ mod test {
     }
     #[test]
     fn valid_syntax_int() {
-        const SRC_INT: &'static str = r#"
+        const SRC_INT: &str = r#"
             5
         "#;
-        const SRC_HEX: &'static str = r#"
+        const SRC_HEX: &str = r#"
             0x05
         "#;
 
@@ -61,7 +61,7 @@ mod test {
 
     #[test]
     fn valid_syntax_str() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             "hello"
         "#;
 
@@ -74,10 +74,10 @@ mod test {
     }
     #[test]
     fn valid_syntax_bool() {
-        const SRC_TRUE: &'static str = r#"
+        const SRC_TRUE: &str = r#"
             true
         "#;
-        const SRC_FALSE: &'static str = r#"
+        const SRC_FALSE: &str = r#"
             false
         "#;
 

--- a/crates/noirc_frontend/src/parser/prefix_parser/module.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/module.rs
@@ -38,7 +38,7 @@ mod test {
 
     #[test]
     fn valid_syntax() {
-        const SRC: &'static str = r#"
+        const SRC: &str = r#"
             mod foo;
         "#;
 
@@ -48,7 +48,7 @@ mod test {
 
         ModuleParser::parse_decl(&mut parser).unwrap();
 
-        let end = parser.curr_token.clone();
+        let end = parser.curr_token;
 
         // First check that the cursor was in the right position at
         // the start and at the end
@@ -57,10 +57,10 @@ mod test {
     }
     #[test]
     fn invalid_syntax() {
-        const SRC_MISSING_SEMI_COLON: &'static str = r#"
+        const SRC_MISSING_SEMI_COLON: &str = r#"
             mod foo
         "#;
-        const SRC_INT: &'static str = r#"
+        const SRC_INT: &str = r#"
             mod 1;
         "#;
 

--- a/crates/noirc_frontend/src/parser/prefix_parser/name.rs
+++ b/crates/noirc_frontend/src/parser/prefix_parser/name.rs
@@ -14,10 +14,10 @@ impl NameParser {
             return Ok(ExpressionKind::Ident(x.clone()));
         }
 
-        return Err(ParserErrorKind::UnexpectedTokenKind {
+        Err(ParserErrorKind::UnexpectedTokenKind {
             span: parser.curr_token.into_span(),
             expected: TokenKind::Ident,
             found: parser.curr_token.kind(),
-        });
+        })
     }
 }


### PR DESCRIPTION
When those have an exact Option / Result equivalent.

Bonus:
- remove a few unneeded `.clone()`s, `return`s and `static`s
- when applicable (i.e. no interpolation), `"Hello, World".to_string()` brings less overhead than `format!("Hello, World")`
 

Tool-aided by [comby-rust](https://github.com/huitseeker/comby-rust).