### PR TITLE
Further simplify field element implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9c256a93a10ed9708c16a517d6dcfaba3d215c0d7fab44d29a9affefb5eeb8"
 dependencies = [
- "num-bigint 0.4.0",
+ "num-bigint",
  "num-traits",
  "quote",
  "syn",
@@ -1443,7 +1443,6 @@ dependencies = [
  "ark-ff",
  "blake2",
  "hex",
- "num-bigint 0.3.1",
 ]
 
 [[package]]
@@ -1520,17 +1519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]

--- a/crates/acvm/src/backends/csat_3_plonk_aztec/pwg/gadget_call.rs
+++ b/crates/acvm/src/backends/csat_3_plonk_aztec/pwg/gadget_call.rs
@@ -129,7 +129,7 @@ impl GadgetCaller {
                 }
                 let result = hasher.finalize();
 
-                let reduced_res = FieldElement::from_bytes_reduce(&result);
+                let reduced_res = FieldElement::from_be_bytes_reduce(&result);
 
                 assert_eq!(gadget_call.outputs.len(), 1);
 

--- a/crates/acvm/src/backends/csat_3_plonk_aztec/pwg/merkle.rs
+++ b/crates/acvm/src/backends/csat_3_plonk_aztec/pwg/merkle.rs
@@ -153,7 +153,7 @@ fn hash(message: &[u8]) -> FieldElement {
     let mut hasher = blake2::Blake2s::new();
     hasher.update(message);
     let res = hasher.finalize();
-    FieldElement::from_bytes_reduce(&res[..])
+    FieldElement::from_be_bytes_reduce(&res[..])
 }
 // XXX(FIXME) : Currently, this is very aztec specific, because this PWG does not have
 // a way to deal with generic ECC operations

--- a/crates/acvm/src/pwg/hash/mod.rs
+++ b/crates/acvm/src/pwg/hash/mod.rs
@@ -37,7 +37,7 @@ fn generic_hash_256<D: Digest>(
     for i in 0..32 {
         initial_witness.insert(
             gadget_call.outputs[i],
-            FieldElement::from_bytes(&[result[i]]),
+            FieldElement::from_be_bytes_reduce(&[result[i]]),
         );
     }
 }

--- a/crates/aztec_backend/src/barretenberg_rs/blake2s.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/blake2s.rs
@@ -19,7 +19,7 @@ impl Barretenberg {
         self.free(input_ptr);
 
         let result_bytes = self.slice_memory(0, 32);
-        FieldElement::from_bytes(&result_bytes)
+        FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 }
 

--- a/crates/aztec_backend/src/barretenberg_rs/pedersen.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/pedersen.rs
@@ -14,7 +14,7 @@ impl Barretenberg {
         );
 
         let result_bytes = self.slice_memory(64, 96);
-        FieldElement::from_bytes(&result_bytes)
+        FieldElement::from_be_bytes_reduce(&result_bytes)
     }
     pub fn compress_many(&mut self, inputs: Vec<FieldElement>) -> FieldElement {
         let input_buf = Assignments(inputs).to_bytes();
@@ -23,7 +23,7 @@ impl Barretenberg {
         self.call_multiple("pedersen_compress", vec![&input_ptr, &Value::I32(0)]);
 
         let result_bytes = self.slice_memory(0, 32);
-        FieldElement::from_bytes(&result_bytes)
+        FieldElement::from_be_bytes_reduce(&result_bytes)
     }
 }
 

--- a/crates/aztec_backend/src/barretenberg_rs/scalar_mul.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/scalar_mul.rs
@@ -14,8 +14,8 @@ impl Barretenberg {
         assert!(pubkey_x_bytes.len() == 32);
         assert!(pubkey_y_bytes.len() == 32);
 
-        let pubkey_x = FieldElement::from_bytes(pubkey_x_bytes);
-        let pubkey_y = FieldElement::from_bytes(pubkey_y_bytes);
+        let pubkey_x = FieldElement::from_be_bytes_reduce(pubkey_x_bytes);
+        let pubkey_y = FieldElement::from_be_bytes_reduce(pubkey_y_bytes);
         (pubkey_x, pubkey_y)
     }
 }

--- a/crates/noir_field/Cargo.toml
+++ b/crates/noir_field/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 hex = "0.4.2"
 
-ark-bn254 = { version = "^0.2.0", default-features = false, features = [ "curve" ] }
+ark-bn254 = { version = "^0.2.0", default-features = false, features = ["curve"] }
 ark-ff = { version = "^0.2.0", default-features = false }
 blake2 = "0.9.1"
-num-bigint = "0.3.1"

--- a/crates/noir_field/src/lib.rs
+++ b/crates/noir_field/src/lib.rs
@@ -115,18 +115,9 @@ impl FieldElement {
         hex::encode(bytes)
     }
     pub fn from_hex(hex_str: &str) -> Option<FieldElement> {
-        // This is needed because arkworks only accepts arbitrary sized
-        // decimal strings and not hex strings
-        fn hex_to_decimal(value: &str) -> String {
-            let value = value.strip_prefix("0x").unwrap_or(value);
-
-            use num_bigint::BigInt;
-            BigInt::parse_bytes(value.as_bytes(), 16)
-                .unwrap()
-                .to_str_radix(10)
-        }
-        let dec_str = hex_to_decimal(hex_str);
-        Fr::from_str(&dec_str).map(FieldElement).ok()
+        let value = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+        let hex_as_bytes = hex::decode(value).ok()?;
+        Some(FieldElement::from_be_bytes_reduce(&hex_as_bytes))
     }
 
     pub fn to_bytes(self) -> Vec<u8> {

--- a/crates/noir_field/src/lib.rs
+++ b/crates/noir_field/src/lib.rs
@@ -78,7 +78,7 @@ impl FieldElement {
     pub fn num_bits(&self) -> u32 {
         let bits = self.bits();
         // Iterate the number of bits and pop off all leading zeroes
-        let iter = bits.iter().skip_while(|x| **x == false);
+        let iter = bits.iter().skip_while(|x| !(**x));
         // Note: count will panic if it goes over usize::MAX.
         // This may not be suitable for devices whose usize < u16
         iter.count() as u32

--- a/crates/noir_field/src/lib.rs
+++ b/crates/noir_field/src/lib.rs
@@ -1,6 +1,6 @@
 use ark_bn254::Fr;
+use ark_ff::PrimeField;
 use ark_ff::{to_bytes, Field};
-use ark_ff::{BitIteratorBE, PrimeField};
 use ark_ff::{One, Zero};
 use std::str::FromStr;
 // XXX: Switch out for a trait and proper implementations
@@ -74,37 +74,14 @@ impl FieldElement {
         Some(FieldElement(fr))
     }
 
-    // This is the amount of bits that are always zero,
-    // In BN256, every element can be represented with 254 bits.
-    // However this representation uses 256 bits, hence 2 wasted bits
-    // Note: This has nothing to do with saturated field elements.
-    fn wasted_bits() -> u32 {
-        let vec: Vec<_> = BitIteratorBE::new(Fr::one().into_repr()).collect();
-
-        let num_bits_used = vec.len() as u32;
-        let num_bits_needed = FieldElement::max_num_bits();
-        num_bits_used - num_bits_needed
-    }
-
     /// This is the number of bits required to represent this specific field element
     pub fn num_bits(&self) -> u32 {
-        let non_zero_index = BitIteratorBE::new(self.0.into_repr()).position(|x| x);
-
-        match non_zero_index {
-            None => 0,
-            Some(index) => {
-                // The most significant bit was found at index.
-                // The index tells us how many elements came before the most significant bit
-
-                // We need to compute the offset as the representation may have wasted bits
-                let offset = FieldElement::wasted_bits();
-
-                // This is now the amount of significant elements that came before the most significant bit
-                let msb_index_offset = (index as u32) - offset;
-
-                FieldElement::max_num_bits() - msb_index_offset
-            }
-        }
+        let bits = self.bits();
+        // Iterate the number of bits and pop off all leading zeroes
+        let iter = bits.iter().skip_while(|x| **x == false);
+        // Note: count will panic if it goes over usize::MAX.
+        // This may not be suitable for devices whose usize < u16
+        iter.count() as u32
     }
 
     pub fn fits_in_u128(&self) -> bool {
@@ -158,27 +135,28 @@ impl FieldElement {
         bytes
     }
 
-    /// Converts bytes into a FieldElement. Does not reduce.
-    pub fn from_bytes(bytes: &[u8]) -> FieldElement {
-        let hex_str = hex::encode(bytes);
-        FieldElement::from_hex(&hex_str).unwrap()
-    }
     /// Converts bytes into a FieldElement and applies a
     /// reduction if needed.
-    pub fn from_bytes_reduce(bytes: &[u8]) -> FieldElement {
+    pub fn from_be_bytes_reduce(bytes: &[u8]) -> FieldElement {
         FieldElement(Fr::from_be_bytes_mod_order(bytes))
     }
 
-    // mask_to methods will not remove any bytes from the field
-    // they are simply zeroed out
-    // Whereas truncate_to will remove those bits and make the byte array smaller
-    fn mask_to_bytes(&self, num_bits: u32) -> Vec<u8> {
-        let mut bytes = self.to_bytes();
-        mask_vector_le(&mut bytes, num_bits as usize);
-        bytes.to_vec()
-    }
     pub fn bits(&self) -> Vec<bool> {
-        BitIteratorBE::new(self.0.into_repr()).collect()
+        let bytes = self.to_bytes();
+        let mut bits = Vec::with_capacity(bytes.len() * 8);
+        for byte in bytes {
+            let _bits = FieldElement::byte_to_bit(byte);
+            bits.extend(_bits);
+        }
+        bits
+    }
+
+    fn byte_to_bit(byte: u8) -> Vec<bool> {
+        let mut bits = Vec::with_capacity(8);
+        for index in (0..=7).rev() {
+            bits.push((byte & (1 << index)) >> index == 1)
+        }
+        bits
     }
 
     /// Returns the closest number of bytes to the bits specified
@@ -195,6 +173,15 @@ impl FieldElement {
         bytes.reverse(); // put it in big endian format. XXX(next refactor): we should be explicit about endianess.
 
         bytes[0..num_elements].to_vec()
+    }
+
+    // mask_to methods will not remove any bytes from the field
+    // they are simply zeroed out
+    // Whereas truncate_to will remove those bits and make the byte array smaller
+    fn mask_to_bytes(&self, num_bits: u32) -> Vec<u8> {
+        let mut bytes = self.to_bytes();
+        mask_vector_le(&mut bytes, num_bits as usize);
+        bytes.to_vec()
     }
 
     fn and_xor(&self, rhs: &FieldElement, num_bits: u32, is_xor: bool) -> FieldElement {
@@ -217,7 +204,7 @@ impl FieldElement {
             .map(|(lhs, rhs)| if is_xor { lhs ^ rhs } else { lhs & rhs })
             .collect();
 
-        FieldElement::from_bytes(&and_byte_arr)
+        FieldElement::from_be_bytes_reduce(&and_byte_arr)
     }
     pub fn and(&self, rhs: &FieldElement, num_bits: u32) -> FieldElement {
         self.and_xor(rhs, num_bits, false)


### PR DESCRIPTION
This further removes arkwork specific code in the implementation, and also removes from_bytes method which was also doing a reduction.

closes #64 