### PR TITLE
Change semantics of multiplying Integers

### DIFF
--- a/crates/noirc_evaluator/src/object/integer.rs
+++ b/crates/noirc_evaluator/src/object/integer.rs
@@ -196,7 +196,7 @@ impl Integer {
         let res =
             binary_op::handle_mul_op(Object::from_witness(self.witness), witness_rhs, evaluator)?;
 
-        Integer::from_object(res, self.num_bits + num_bits, evaluator)
+        Integer::from_object(res, self.num_bits, evaluator)
     }
 }
 


### PR DESCRIPTION
When multiplying integers, we result is constrained to be the same number of bits.

closes #80 