### PR TITLE
Remove windows as a release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,16 @@ jobs:
     strategy:
       matrix:
         name: [
-            linux,
+            # linux,
             # windows,
             macos
         ]
 
         include:
-          - name: linux
-            os: ubuntu-latest
-            artifact_name: nargo
-            asset_name: nargo-linux
+          # - name: linux
+          #   os: ubuntu-latest
+          #   artifact_name: nargo
+          #   asset_name: nargo-linux
           # - name: windows
           #   os: windows-latest
           #   artifact_name: nargo.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         name: [
             linux,
-            windows,
+            # windows,
             macos
         ]
 
@@ -25,10 +25,10 @@ jobs:
             os: ubuntu-latest
             artifact_name: nargo
             asset_name: nargo-linux
-          - name: windows
-            os: windows-latest
-            artifact_name: nargo.exe
-            asset_name: nargo-windows
+          # - name: windows
+          #   os: windows-latest
+          #   artifact_name: nargo.exe
+          #   asset_name: nargo-windows
           - name: macos
             os: macos-latest
             artifact_name: nargo


### PR DESCRIPTION
The aztec-backend does not work with windows, so we remove it as a target for now. Ideally Noir should not have to worry about whether backends compile to windows or not, and or have a way to mitigate this. For now, we just remove windows as barretenberg is the main backend.