### PR TITLE
Minor cleanup

### DIFF
--- a/crates/noirc_evaluator/src/environment.rs
+++ b/crates/noirc_evaluator/src/environment.rs
@@ -42,12 +42,12 @@ impl Environment {
         self.env.end_function()
     }
 
-    pub fn start_for_loop(&mut self) {
-        self.env.start_for_loop()
+    pub fn start_scope(&mut self) {
+        self.env.start_scope()
     }
 
-    pub fn end_for_loop(&mut self) {
-        self.env.end_for_loop();
+    pub fn end_scope(&mut self) {
+        self.env.end_scope();
     }
 
     pub fn store(&mut self, name: String, object: Object) {

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -621,7 +621,6 @@ impl<'a> Evaluator<'a> {
             HirExpression::For(for_expr) => self.handle_for_expr(env,for_expr).map_err(|kind|kind.add_span(span)),
             HirExpression::If(_) => todo!(),
             HirExpression::Prefix(_) => todo!(),
-            HirExpression::Predicate(_) => todo!(),
             HirExpression::Literal(_) => todo!(),
             HirExpression::Block(_) => todo!("currently block expressions not in for/if branches are not being evaluated. In the future, we should be able to unify the eval_block and all places which require block_expr here")
         }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -619,9 +619,10 @@ impl<'a> Evaluator<'a> {
                 }
             }
             HirExpression::For(for_expr) => self.handle_for_expr(env,for_expr).map_err(|kind|kind.add_span(span)),
-            HirExpression::If(_) => todo!(),
-            HirExpression::Prefix(_) => todo!(),
-            HirExpression::Literal(_) => todo!(),
+            HirExpression::If(_) => todo!("If expressions are currently unimplemented"),
+            HirExpression::Prefix(_) => todo!("Prefix expressions are currently unimplemented"),
+            HirExpression::Literal(HirLiteral::Str(_)) => todo!("string literals are currently unimplemented"),
+            HirExpression::Literal(HirLiteral::Bool(_)) => todo!("boolean literals are currently unimplemented"),
             HirExpression::Block(_) => todo!("currently block expressions not in for/if branches are not being evaluated. In the future, we should be able to unify the eval_block and all places which require block_expr here")
         }
     }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -514,7 +514,7 @@ impl<'a> Evaluator<'a> {
         let mut contents: Vec<Object> = Vec::new();
 
         for indice in ranged_object {
-            env.start_for_loop();
+            env.start_scope();
 
             // Add indice to environment
             let variable_name = self.context.def_interner.ident_name(&for_expr.identifier);
@@ -527,7 +527,7 @@ impl<'a> Evaluator<'a> {
                 .map_err(|err| err.remove_span())?;
             contents.push(return_typ);
 
-            env.end_for_loop();
+            env.end_scope();
         }
         let length = contents.len() as u128;
 

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -15,7 +15,6 @@ pub enum ExpressionKind {
     Call(Box<CallExpression>),
     Cast(Box<CastExpression>),
     Infix(Box<InfixExpression>),
-    Predicate(Box<InfixExpression>),
     For(Box<ForExpression>),
     If(Box<IfExpression>),
     Path(Path),
@@ -32,7 +31,6 @@ impl ExpressionKind {
     pub fn into_infix(self) -> Option<InfixExpression> {
         match self {
             ExpressionKind::Infix(infix) => Some(*infix),
-            ExpressionKind::Predicate(infix) => Some(*infix),
             _ => None,
         }
     }
@@ -363,7 +361,6 @@ impl Display for ExpressionKind {
             Call(call) => call.fmt(f),
             Cast(cast) => cast.fmt(f),
             Infix(infix) => infix.fmt(f),
-            Predicate(infix) => infix.fmt(f),
             For(for_loop) => for_loop.fmt(f),
             If(if_expr) => if_expr.fmt(f),
             Path(path) => path.fmt(f),

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use crate::token::{Attribute, Token};
+use crate::util::vecmap;
 use crate::{Ident, Path, Statement, Type};
 use acvm::FieldElement;
 use noirc_errors::{Span, Spanned};
@@ -372,7 +373,7 @@ impl Display for Literal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Literal::Array(array) => {
-                let contents: Vec<_> = array.contents.iter().map(ToString::to_string).collect();
+                let contents = vecmap(&array.contents, ToString::to_string);
                 write!(f, "[{}]", contents.join(", "))
             }
             Literal::Bool(boolean) => write!(f, "{}", if *boolean { "true" } else { "false" }),
@@ -418,7 +419,7 @@ impl Display for IndexExpression {
 
 impl Display for CallExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let args: Vec<_> = self.arguments.iter().map(ToString::to_string).collect();
+        let args = vecmap(&self.arguments, ToString::to_string);
         write!(f, "{}({})", self.func_name, args.join(", "))
     }
 }
@@ -482,11 +483,9 @@ impl Display for FunctionDefinition {
             writeln!(f, "{}", attribute)?;
         }
 
-        let parameters: Vec<_> = self
-            .parameters
-            .iter()
-            .map(|(name, r#type)| format!("{}: {}", name, r#type))
-            .collect();
+        let parameters = vecmap(&self.parameters, |(name, r#type)| {
+            format!("{}: {}", name, r#type)
+        });
 
         write!(
             f,

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -155,9 +155,7 @@ impl Type {
             (self, argument)
         {
             let is_super_type = param_type.is_super_type_of(arg_type);
-
             let arity_check = param_size.is_a_super_type_of(arg_size);
-
             return is_super_type && arity_check;
         }
 

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use crate::lexer::token::SpannedToken;
 use crate::token::Token;
+use crate::util::vecmap;
 use crate::{Expression, ExpressionKind, InfixExpression, Type};
 use noirc_errors::{Span, Spanned};
 
@@ -278,7 +279,7 @@ impl Display for AssignStatement {
 
 impl Display for Path {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let segments: Vec<_> = self.segments.iter().map(ToString::to_string).collect();
+        let segments = vecmap(&self.segments, ToString::to_string);
         write!(f, "{}::{}", self.kind, segments.join("::"))
     }
 }

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -3,6 +3,7 @@ use crate::hir::def_collector::dc_crate::DefCollector;
 use crate::hir::Context;
 use crate::node_interner::FuncId;
 use crate::parser::{parse_program, ParsedModule};
+use crate::util::vecmap;
 use arena::{Arena, Index};
 use fm::{FileId, FileManager};
 use noirc_errors::{CollectedErrors, DiagnosableError};
@@ -115,7 +116,7 @@ pub fn parse_file(
         Err(errs) => {
             let file_errs = CollectedErrors {
                 file_id,
-                errors: errs.into_iter().map(|err| err.to_diagnostic()).collect(),
+                errors: vecmap(errs, |err| err.to_diagnostic()),
             };
 
             Err(vec![file_errs])

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -119,11 +119,9 @@ impl<'a> Resolver<'a> {
             });
         }
     }
-    fn check_for_unused_variables_in_local_scope(decl_map: Scope, unused_vars: &mut Vec<IdentId>) {
-        let unused_variables = decl_map.predicate(|kv: &(&String, &ResolverMeta)| -> bool {
-            let variable_name = kv.0;
-            let metadata = kv.1;
 
+    fn check_for_unused_variables_in_local_scope(decl_map: Scope, unused_vars: &mut Vec<IdentId>) {
+        let unused_variables = decl_map.filter(|(variable_name, metadata)| {
             let has_underscore_prefix = variable_name.starts_with('_'); // XXX: This is used for development mode, and will be removed
 
             if metadata.num_times_used == 0 && !has_underscore_prefix {
@@ -332,7 +330,7 @@ impl<'a> Resolver<'a> {
                 let expr = HirPrefixExpression { operator, rhs };
                 self.interner.push_expr(HirExpression::Prefix(expr))
             }
-            ExpressionKind::Infix(infix) | ExpressionKind::Predicate(infix) => {
+            ExpressionKind::Infix(infix) => {
                 let lhs = self.intern_expr(infix.lhs);
                 let rhs = self.intern_expr(infix.rhs);
                 let expr = HirInfixExpression {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -22,6 +22,7 @@ use crate::graph::CrateId;
 use crate::hir_def::expr::HirIfExpression;
 use crate::hir_def::stmt::HirAssignStatement;
 use crate::node_interner::{ExprId, FuncId, IdentId, NodeInterner, StmtId};
+use crate::util::vecmap;
 use crate::{
     hir::{def_map::CrateDefMap, resolution::path_resolver::PathResolver},
     BlockExpression, Expression, ExpressionKind, FunctionKind, Ident, Literal, NoirFunction,
@@ -374,11 +375,7 @@ impl<'a> Resolver<'a> {
                     }
                 };
 
-                let arguments = call_expr
-                    .arguments
-                    .into_iter()
-                    .map(|arg| self.resolve_expression(arg))
-                    .collect();
+                let arguments = vecmap(call_expr.arguments, |arg| self.resolve_expression(arg));
 
                 HirExpression::Call(HirCallExpression { func_id, arguments })
             }
@@ -441,11 +438,7 @@ impl<'a> Resolver<'a> {
     fn resolve_block(&mut self, block_expr: BlockExpression) -> HirExpression {
         self.scopes.start_scope();
 
-        let stmts: Vec<_> = block_expr
-            .0
-            .into_iter()
-            .map(|stmt| self.intern_stmt(stmt))
-            .collect();
+        let stmts = vecmap(block_expr.0, |stmt| self.intern_stmt(stmt));
 
         self.scopes.end_scope();
         let hir_block = HirBlockExpression(stmts);

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -47,7 +47,8 @@ impl<K: std::hash::Hash + Eq + Clone, V> Scope<K, V> {
 
     /// Returns an iterator over all of the elements which satisfy the predicate
     pub fn filter<F>(&self, pred: F) -> impl Iterator<Item = (&K, &V)>
-        where F: FnMut(&(&K, &V)) -> bool
+    where
+        F: FnMut(&(&K, &V)) -> bool,
     {
         self.0.iter().filter(pred)
     }

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -165,13 +165,14 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
             .expect("ice: expected a scope tree, however none was found")
     }
 
-    /// Starting a for loop requires access to the outside scope.
-    /// Once the for loop has finished, we remove it from the scope tree
-    pub fn start_for_loop(&mut self) {
+    /// The beginning of a scope always correlates with the start of a block {}.
+    /// This can be in if expressions, for loops, or functions.
+    pub fn start_scope(&mut self) {
         self.extend_current_scope_tree()
     }
-    /// Ending a for loop requires removal of it's scope from the current scope tree
-    pub fn end_for_loop(&mut self) -> Scope<K, V> {
+
+    /// Ends the current scope - this should correspond with the end of a BlockExpression.
+    pub fn end_scope(&mut self) -> Scope<K, V> {
         self.remove_scope_tree_extension()
     }
 }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -154,9 +154,11 @@ pub(crate) fn type_check_expression(
             }
 
             // Type check arguments
-            let arg_types = call_expr.arguments.iter().map(|arg_expr| {
-                type_check_expression(interner, arg_expr)
-            }).collect::<Result<Vec<_>, _>>()?;
+            let arg_types = call_expr
+                .arguments
+                .iter()
+                .map(|arg_expr| type_check_expression(interner, arg_expr))
+                .collect::<Result<Vec<_>, _>>()?;
 
             // Check for argument param equality
             for (param, arg) in func_meta.parameters.iter().zip(arg_types) {
@@ -266,11 +268,15 @@ pub(crate) fn type_check_expression(
 
                         if then_type == Type::Unit {
                             err = err
-                                .add_context("Are you missing a semicolon at the end of your 'else' branch?")
+                                .add_context(
+                                    "Are you missing a semicolon at the end of your 'else' branch?",
+                                )
                                 .unwrap();
                         } else if else_type == Type::Unit {
                             err = err
-                                .add_context("Are you missing a semicolon at the end of your 'then' branch?")
+                                .add_context(
+                                    "Are you missing a semicolon at the end of your 'then' branch?",
+                                )
                                 .unwrap();
                         } else {
                             err = err
@@ -302,7 +308,7 @@ pub fn infix_operand_type_rules(
         return comparator_operand_type_rules(lhs_type, other);
     }
 
-    use { Type::*, FieldElementType::* };
+    use {FieldElementType::*, Type::*};
     match (lhs_type, other)  {
         (Integer(lhs_field_type,sign_x, bit_width_x), Integer(rhs_field_type,sign_y, bit_width_y)) => {
             let field_type = field_type_rules(lhs_field_type, rhs_field_type);
@@ -362,11 +368,8 @@ fn field_type_rules(lhs: &FieldElementType, rhs: &FieldElementType) -> FieldElem
     }
 }
 
-pub fn comparator_operand_type_rules(
-    lhs_type: &Type,
-    other: &Type,
-) -> Result<Type, String> {
-    use { Type::*, FieldElementType::* };
+pub fn comparator_operand_type_rules(lhs_type: &Type, other: &Type) -> Result<Type, String> {
+    use {FieldElementType::*, Type::*};
     match (lhs_type, other)  {
         (Integer(_, sign_x, bit_width_x), Integer(_, sign_y, bit_width_y)) => {
             if sign_x != sign_y {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -259,7 +259,7 @@ pub(crate) fn type_check_expression(
                         let mut err = TypeCheckError::TypeMismatch {
                             expected_typ: then_type.to_string(),
                             expr_typ: else_type.to_string(),
-                            expr_span: interner.expr_span(&alternative),
+                            expr_span: interner.expr_span(expr_id),
                         };
 
                         if then_type == Type::Unit {
@@ -271,7 +271,7 @@ pub(crate) fn type_check_expression(
                         } else if else_type == Type::Unit {
                             err = err
                                 .add_context(
-                                    "Are you missing a semicolon at the end of your 'then' branch?",
+                                    "Are you missing a semicolon at the end of the first block of this 'if'?",
                                 )
                                 .unwrap();
                         } else {

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -59,13 +59,6 @@ mod test {
 
     use noirc_errors::{Span, Spanned};
 
-    use crate::hir_def::{
-        expr::{
-            HirBinaryOp, HirBinaryOpKind, HirBlockExpression, HirExpression, HirInfixExpression,
-        },
-        function::{FuncMeta, HirFunction, Param},
-        stmt::{HirPrivateStatement, HirStatement},
-    };
     use crate::node_interner::{FuncId, NodeInterner};
     use crate::{graph::CrateId, Ident};
     use crate::{
@@ -74,6 +67,16 @@ mod test {
             resolution::{path_resolver::PathResolver, resolver::Resolver},
         },
         parse_program, FunctionKind, Path, Type,
+    };
+    use crate::{
+        hir_def::{
+            expr::{
+                HirBinaryOp, HirBinaryOpKind, HirBlockExpression, HirExpression, HirInfixExpression,
+            },
+            function::{FuncMeta, HirFunction, Param},
+            stmt::{HirPrivateStatement, HirStatement},
+        },
+        util::vecmap,
     };
 
     #[test]
@@ -245,14 +248,10 @@ mod test {
 
         let def_maps: HashMap<CrateId, CrateDefMap> = HashMap::new();
 
-        let func_meta: Vec<_> = program
-            .functions
-            .into_iter()
-            .map(|nf| {
-                let resolver = Resolver::new(&mut interner, &path_resolver, &def_maps);
-                resolver.resolve_function(nf).unwrap()
-            })
-            .collect();
+        let func_meta = vecmap(program.functions, |nf| {
+            let resolver = Resolver::new(&mut interner, &path_resolver, &def_maps);
+            resolver.resolve_function(nf).unwrap()
+        });
 
         for ((hir_func, meta), func_id) in func_meta.into_iter().zip(func_ids.clone()) {
             interner.update_fn(func_id, hir_func);

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -28,13 +28,9 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Result<(
     // Fetch the HirFunction and iterate all of it's statements
     let hir_func = interner.function(&func_id);
     let func_as_expr = hir_func.as_expr();
-
-    // Convert the function to a block expression and then type check the block expr
-    type_check_expression(interner, func_as_expr)?;
+    let function_last_type = type_check_expression(interner, func_as_expr)?;
 
     // Check declared return type and actual return type
-    let function_last_type = interner.id_type(func_as_expr);
-
     if !can_ignore_ret && (&function_last_type != declared_return_type) {
         let func_span = interner.id_span(func_as_expr); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
         return Err(TypeCheckError::TypeMismatch {

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -13,7 +13,6 @@ pub enum HirExpression {
     Index(HirIndexExpression),
     Call(HirCallExpression),
     Cast(HirCastExpression),
-    Predicate(HirInfixExpression),
     For(HirForExpression),
     If(HirIfExpression),
 }

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -3,6 +3,7 @@ use noirc_errors::Span;
 
 use crate::node_interner::{ExprId, FuncId, IdentId, StmtId};
 use crate::{BinaryOp, BinaryOpKind, Type, UnaryOp};
+
 #[derive(Debug, Clone)]
 pub enum HirExpression {
     Ident(IdentId),

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -15,7 +15,7 @@ pub enum HirExpression {
     Cast(HirCastExpression),
     Predicate(HirInfixExpression),
     For(HirForExpression),
-    If(IfExpression),
+    If(HirIfExpression),
 }
 
 impl HirExpression {
@@ -142,7 +142,7 @@ pub struct HirInfixExpression {
 }
 
 #[derive(Debug, Clone)]
-pub struct IfExpression {
+pub struct HirIfExpression {
     pub condition: ExprId,
     pub consequence: ExprId,
     pub alternative: Option<ExprId>,

--- a/crates/noirc_frontend/src/lib.rs
+++ b/crates/noirc_frontend/src/lib.rs
@@ -3,6 +3,7 @@ pub mod graph;
 pub mod lexer;
 pub mod node_interner;
 pub mod parser;
+pub mod util;
 
 pub mod hir;
 pub mod hir_def;

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 
 use crate::lexer::errors::LexerErrorKind;
 use crate::lexer::token::Token;
+use crate::util::vecmap;
 use crate::BinaryOp;
 
 use noirc_errors::CustomDiagnostic as Diagnostic;
@@ -64,12 +65,8 @@ impl DiagnosableError for ParserError {
         match &self.reason {
             Some(reason) => Diagnostic::simple_error(reason.clone(), String::new(), self.span),
             None => {
-                let mut expected = self
-                    .expected_tokens
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>();
-                expected.append(&mut self.expected_labels.iter().cloned().collect());
+                let mut expected = vecmap(&self.expected_tokens, ToString::to_string);
+                expected.append(&mut vecmap(&self.expected_labels, Clone::clone));
 
                 let primary = if expected.is_empty() {
                     format!("Unexpected {} in input", self.found)

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -174,17 +174,15 @@ fn tokenkind(tokenkind: TokenKind) -> impl NoirParser<Token> {
 }
 
 fn path() -> impl NoirParser<Path> {
-    let prefix = |key| keyword(key).ignore_then(just(Token::DoubleColon));
     let idents = || ident().separated_by(just(Token::DoubleColon)).at_least(1);
     let make_path = |kind| move |segments| Path { segments, kind };
 
+    let prefix = |key| keyword(key).ignore_then(just(Token::DoubleColon));
+    let path_kind = |key, kind| prefix(key).ignore_then(idents()).map(make_path(kind));
+
     choice((
-        prefix(Keyword::Crate)
-            .ignore_then(idents())
-            .map(make_path(PathKind::Crate)),
-        prefix(Keyword::Dep)
-            .ignore_then(idents())
-            .map(make_path(PathKind::Dep)),
+        path_kind(Keyword::Crate, PathKind::Crate),
+        path_kind(Keyword::Dep, PathKind::Dep),
         idents().map(make_path(PathKind::Plain)),
     ))
 }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -390,19 +390,11 @@ where
 
 fn create_infix_expression(lhs: Expression, (operator, rhs): (BinaryOp, Expression)) -> Expression {
     let span = lhs.span.merge(rhs.span);
-    let is_comparator = operator.contents.is_comparator();
     let infix = Box::new(InfixExpression { lhs, operator, rhs });
 
-    if is_comparator {
-        Expression {
-            span,
-            kind: ExpressionKind::Predicate(infix),
-        }
-    } else {
-        Expression {
-            span,
-            kind: ExpressionKind::Infix(infix),
-        }
+    Expression {
+        span,
+        kind: ExpressionKind::Infix(infix),
     }
 }
 

--- a/crates/noirc_frontend/src/util/mod.rs
+++ b/crates/noirc_frontend/src/util/mod.rs
@@ -1,4 +1,4 @@
-/// Equivalent to .iter().map(f).collect::<Vec<_>>()
+/// Equivalent to .into_iter().map(f).collect::<Vec<_>>()
 pub fn vecmap<T, U, F>(iterable: T, f: F) -> Vec<U>
 where
     T: IntoIterator,

--- a/crates/noirc_frontend/src/util/mod.rs
+++ b/crates/noirc_frontend/src/util/mod.rs
@@ -1,0 +1,8 @@
+/// Equivalent to .iter().map(f).collect::<Vec<_>>()
+pub fn vecmap<T, U, F>(iterable: T, f: F) -> Vec<U>
+where
+    T: IntoIterator,
+    F: FnMut(T::Item) -> U,
+{
+    iterable.into_iter().map(f).collect()
+}


### PR DESCRIPTION
This PR is mostly minor cleanup in the frontend, though also implements type checking and name resolution for if expressions, and type checking for predicate expressions. Predicate expressions also seem not to have been used before, so I merged them with the `InfixExpression` node. 
Part of the cleanup is the addition of a `vecmap` utility function for `xs.into_iter().map(...).collect::<Vec<_>>()` which was a common pattern throughout the codebase. This function would be useful for more than just the frontend, though I saw no better package to put it in, so for now it lives in `noirc_frontend/src/util/mod.rs`. If we ever want to expand these utility functions it may be helpful to create a new package to isolate them in the future.