### PR TITLE
Update semicolon handling to be more like rust's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,8 +284,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chumsky"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091823bc52a25302827bc0d34813ecf770b84d663a3aaac396b5d0dbd4ef1dcb"
+source = "git+https://github.com/zesterer/chumsky#75ed13caea4e1f4842cc5197e4724588e5f4b982"
 dependencies = [
  "ahash",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chumsky"
 version = "0.7.0"
-source = "git+https://github.com/zesterer/chumsky#75ed13caea4e1f4842cc5197e4724588e5f4b982"
+source = "git+https://github.com/zesterer/chumsky?rev=75ed13c#75ed13caea4e1f4842cc5197e4724588e5f4b982"
 dependencies = [
  "ahash",
 ]

--- a/crates/noirc_errors/Cargo.toml
+++ b/crates/noirc_errors/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 codespan-reporting = "0.9.5"
 codespan = "0.9.5"
 fm = {path = "../fm"}
-chumsky = { git = "https://github.com/zesterer/chumsky" }
+chumsky = { git = "https://github.com/zesterer/chumsky", rev="75ed13c" }

--- a/crates/noirc_errors/Cargo.toml
+++ b/crates/noirc_errors/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 codespan-reporting = "0.9.5"
 codespan = "0.9.5"
 fm = {path = "../fm"}
-chumsky = "0.7.0"
+chumsky = { git = "https://github.com/zesterer/chumsky" }

--- a/crates/noirc_errors/src/position.rs
+++ b/crates/noirc_errors/src/position.rs
@@ -66,7 +66,6 @@ impl Span {
     }
 
     pub fn exclusive(start: u32, end: u32) -> Span {
-        println!("range at {} .. {}", start, end);
         Span::new(start..end)
     }
 

--- a/crates/noirc_errors/src/position.rs
+++ b/crates/noirc_errors/src/position.rs
@@ -60,7 +60,7 @@ pub struct Span(ByteSpan);
 impl Span {
     pub fn new(mut range: Range<u32>) -> Span {
         if range.start >= range.end {
-            range = range.end .. range.start;
+            range = range.end..range.start;
 
             if range.end == range.start {
                 range.end += 1;

--- a/crates/noirc_errors/src/position.rs
+++ b/crates/noirc_errors/src/position.rs
@@ -58,7 +58,14 @@ impl<T> std::borrow::Borrow<T> for Spanned<T> {
 pub struct Span(ByteSpan);
 
 impl Span {
-    pub fn new(range: Range<u32>) -> Span {
+    pub fn new(mut range: Range<u32>) -> Span {
+        if range.start >= range.end {
+            range = range.end .. range.start;
+
+            if range.end == range.start {
+                range.end += 1;
+            }
+        }
         Span(ByteSpan::from(range))
     }
 

--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -13,7 +13,7 @@ noirc_errors = { path = "../noirc_errors" }
 std_lib = { path = "../std_lib" }
 fm = { path = "../fm" }
 arena = { path = "../arena" }
-chumsky = { git = "https://github.com/zesterer/chumsky" }
+chumsky = { git = "https://github.com/zesterer/chumsky", rev="75ed13c" }
 thiserror = "1.0.21"
 pathdiff = "0.2"
 smol_str = "0.1.17"

--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -13,7 +13,7 @@ noirc_errors = { path = "../noirc_errors" }
 std_lib = { path = "../std_lib" }
 fm = { path = "../fm" }
 arena = { path = "../arena" }
-chumsky = "0.7.0"
+chumsky = { git = "https://github.com/zesterer/chumsky" }
 thiserror = "1.0.21"
 pathdiff = "0.2"
 smol_str = "0.1.17"

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -120,7 +120,13 @@ impl Statement {
         })
     }
 
-    pub fn add_semicolon(self, semi: Option<Token>, span: Span, last_statement_in_block: bool, emit_error: &mut dyn FnMut(ParserError)) -> Statement {
+    pub fn add_semicolon(
+        self,
+        semi: Option<Token>,
+        span: Span,
+        last_statement_in_block: bool,
+        emit_error: &mut dyn FnMut(ParserError),
+    ) -> Statement {
         match self {
             Statement::Let(_)
             | Statement::Const(_)
@@ -135,7 +141,7 @@ impl Statement {
                     emit_error(ParserError::with_reason(reason, span));
                 }
                 self
-            },
+            }
 
             Statement::Expression(expr) => {
                 match (&expr.kind, semi, last_statement_in_block) {
@@ -148,7 +154,7 @@ impl Statement {
                         } else {
                             Statement::Expression(expr)
                         }
-                    },
+                    }
 
                     // Don't wrap expressions that are not the last expression in
                     // a block in a Semi so that we can report errors in the type checker
@@ -163,7 +169,7 @@ impl Statement {
                     (_, Some(_), true) => Statement::Semi(expr),
                     (_, None, true) => Statement::Expression(expr),
                 }
-            },
+            }
         }
     }
 }

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use crate::lexer::token::SpannedToken;
+use crate::parser::ParserError;
 use crate::token::Token;
 use crate::util::vecmap;
 use crate::{Expression, ExpressionKind, InfixExpression, NoirStruct, Type};
@@ -117,6 +118,53 @@ impl Statement {
             r#type,
             expression,
         })
+    }
+
+    pub fn add_semicolon(self, semi: Option<Token>, span: Span, last_statement_in_block: bool, emit_error: &mut dyn FnMut(ParserError)) -> Statement {
+        match self {
+            Statement::Let(_)
+            | Statement::Const(_)
+            | Statement::Constrain(_)
+            | Statement::Private(_)
+            | Statement::Assign(_)
+            | Statement::Semi(_)
+            | Statement::Error => {
+                // To match rust, statements always require a semicolon, even at the end of a block
+                if semi.is_none() {
+                    let reason = "Expected a ; after this statement".to_string();
+                    emit_error(ParserError::with_reason(reason, span));
+                }
+                self
+            },
+
+            Statement::Expression(expr) => {
+                match (&expr.kind, semi, last_statement_in_block) {
+                    // Semicolons are optional for these expressions
+                    (ExpressionKind::Block(_), semi, _)
+                    | (ExpressionKind::For(_), semi, _)
+                    | (ExpressionKind::If(_), semi, _) => {
+                        if semi.is_some() {
+                            Statement::Semi(expr)
+                        } else {
+                            Statement::Expression(expr)
+                        }
+                    },
+
+                    // Don't wrap expressions that are not the last expression in
+                    // a block in a Semi so that we can report errors in the type checker
+                    // for unneeded expressions like { 1 + 2; 3 }
+                    (_, Some(_), false) => Statement::Expression(expr),
+                    (_, None, false) => {
+                        let reason = "Expected a ; after this expression".to_string();
+                        emit_error(ParserError::with_reason(reason, span));
+                        Statement::Expression(expr)
+                    }
+
+                    (_, Some(_), true) => Statement::Semi(expr),
+                    (_, None, true) => Statement::Expression(expr),
+                }
+            },
+        }
     }
 }
 

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -221,7 +221,7 @@ pub(crate) fn type_check_expression(
             )
         }
         HirExpression::Block(block_expr) => {
-            let mut last = None;
+            let mut block_type = Type::Unit;
 
             let statements = block_expr.statements();
             for (i, stmt) in statements.iter().enumerate() {
@@ -236,11 +236,11 @@ pub(crate) fn type_check_expression(
                         });
                     }
                 } else {
-                    last = Some(expr_type);
+                    block_type = expr_type;
                 }
             }
 
-            last.unwrap_or(Type::Unit)
+            block_type
         }
         HirExpression::Prefix(_) => {
             // type_of(prefix_expr) == type_of(rhs_expression)

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -253,7 +253,7 @@ impl<'a> Lexer<'a> {
         }
         self.next_char();
 
-        let attribute = Attribute::lookup_attribute(&word, Span::exclusive(start, end))?;
+        let attribute = Attribute::lookup_attribute(&word, Span::inclusive(start, end))?;
 
         // Move start position backwards to cover the left bracket
         // Move end position forwards to cover the right bracket
@@ -274,7 +274,7 @@ impl<'a> Lexer<'a> {
 
         // Check if word an int type
         // if no error occurred, then it is either a valid integer type or it is not an int type
-        let parsed_token = IntType::lookup_int_type(&word, Span::exclusive(start, end))?;
+        let parsed_token = IntType::lookup_int_type(&word, Span::inclusive(start, end))?;
 
         // Check if it is an int type
         if let Some(int_type_token) = parsed_token {
@@ -293,7 +293,7 @@ impl<'a> Lexer<'a> {
         let integer = match FieldElement::try_from_str(&integer_str) {
             None => {
                 return Err(LexerErrorKind::InvalidIntegerLiteral {
-                    span: Span::exclusive(start, end),
+                    span: Span::inclusive(start, end),
                     found: integer_str,
                 })
             }

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -128,6 +128,8 @@ impl chumsky::Error<Token> for ParserError {
     }
 
     fn with_label(mut self, label: Self::Label) -> Self {
+        self.expected_tokens.clear();
+        self.expected_labels.clear();
         self.expected_labels.insert(label);
         self
     }

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -35,7 +35,7 @@ where
 {
     use Token::*;
     parser
-        .delimited_by(LeftParen, RightParen)
+        .delimited_by(just(LeftParen), just(RightParen))
         .recover_with(nested_delimiters(
             LeftParen,
             RightParen,

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -149,21 +149,15 @@ where
 }
 
 fn check_statements_require_semicolon(
-    mut statements: Vec<(Statement, (Option<Token>, Span))>,
+    statements: Vec<(Statement, (Option<Token>, Span))>,
     _span: Span,
     emit: &mut dyn FnMut(ParserError),
 ) -> Vec<Statement> {
-    let last = statements.pop();
-
-    let mut ret = vecmap(statements, |(statement, (semicolon, span))| {
-        statement.add_semicolon(semicolon, span, false, emit)
-    });
-
-    if let Some((last, (semicolon, span))) = last {
-        ret.push(last.add_semicolon(semicolon, span, true, emit));
-    }
-
-    ret
+    let last = statements.len().saturating_sub(1);
+    let iter = statements.into_iter().enumerate();
+    vecmap(iter, |(i, (statement, (semicolon, span)))| {
+        statement.add_semicolon(semicolon, span, i == last, emit)
+    })
 }
 
 fn optional_type_annotation() -> impl NoirParser<Type> {


### PR DESCRIPTION
Currently, the parser expects semicolons separating each statement in a block, with an optional final semicolon at the end of a block. This is incorrect if we want to strictly follow rust's grammar however. The proper rules should be:
- Semicolons are always required after non-expression statements - even at the end of a block.
- Semicolons are optional for `if`, `for`, and `block` expressions.
- Semicolons are optional for other expressions only at the end of a block. They are required otherwise.


This PR updates chumsky so that we can use the `validate` parser to map our input from `A -> B` rather than just `A -> A`, while also emitting non-fatal errors along the way. This is used to emit semicolon errors and recover from them.

Edit: This PR now also adds the check we discussed for checking intermediate expressions in a block have the unit type. So code like `{ 1 + 2; 3 }` is now expected to fail in the type checker. I have verified all our tests and examples still build with this change.