### PR TITLE
Array code cleanup

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -314,12 +314,8 @@ impl<'a> Resolver<'a> {
             ExpressionKind::Literal(literal) => HirExpression::Literal(match literal {
                 Literal::Bool(b) => HirLiteral::Bool(b),
                 Literal::Array(arr) => {
-                    let mut interned_contents = Vec::new();
-                    for content in arr.contents {
-                        interned_contents.push(self.resolve_expression(content));
-                    }
                     HirLiteral::Array(HirArrayLiteral {
-                        contents: interned_contents,
+                        contents: vecmap(arr.contents, |elem| self.resolve_expression(elem)),
                         r#type: arr.r#type,
                         length: arr.length,
                     })

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -313,13 +313,11 @@ impl<'a> Resolver<'a> {
             }
             ExpressionKind::Literal(literal) => HirExpression::Literal(match literal {
                 Literal::Bool(b) => HirLiteral::Bool(b),
-                Literal::Array(arr) => {
-                    HirLiteral::Array(HirArrayLiteral {
-                        contents: vecmap(arr.contents, |elem| self.resolve_expression(elem)),
-                        r#type: arr.r#type,
-                        length: arr.length,
-                    })
-                }
+                Literal::Array(arr) => HirLiteral::Array(HirArrayLiteral {
+                    contents: vecmap(arr.contents, |elem| self.resolve_expression(elem)),
+                    r#type: arr.r#type,
+                    length: arr.length,
+                }),
                 Literal::Integer(integer) => HirLiteral::Integer(integer),
                 Literal::Str(str) => HirLiteral::Str(str),
             }),

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -530,7 +530,12 @@ where
 {
     expression_list(expr_parser)
         .delimited_by(just(Token::LeftBracket), just(Token::RightBracket))
-        .map(ExpressionKind::array)
+        .validate(|elems, span, emit| {
+            if elems.is_empty() {
+                emit(ParserError::with_reason("Arrays must have at least one element".to_owned(), span))
+            }
+            ExpressionKind::array(elems)
+        })
 }
 
 fn expression_list<P>(expr_parser: P) -> impl NoirParser<Vec<Expression>>

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -532,7 +532,10 @@ where
         .delimited_by(just(Token::LeftBracket), just(Token::RightBracket))
         .validate(|elems, span, emit| {
             if elems.is_empty() {
-                emit(ParserError::with_reason("Arrays must have at least one element".to_owned(), span))
+                emit(ParserError::with_reason(
+                    "Arrays must have at least one element".to_owned(),
+                    span,
+                ))
             }
             ExpressionKind::array(elems)
         })


### PR DESCRIPTION
I noticed we assumed in the type checker code that arrays always had at least one element. I added a better error message for this case and refactored some so we can continue type checking without hitting the assert.