### PR TITLE
Remove ArrayLiteral r#type field in Ast and Hir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/AztecProtocol/barretenberg?branch=kw/noir-dsl-mac#2d845971147ae9e9aae49ae0be882a20d2f45f56"
+source = "git+https://github.com/AztecProtocol/barretenberg?rev=dde4b03196cc4eb881a4f5f0b2ab32703cd9f395#dde4b03196cc4eb881a4f5f0b2ab32703cd9f395"
 dependencies = [
  "cmake",
  "hex",
@@ -1161,9 +1161,13 @@ name = "noirc_evaluator"
 version = "0.1.0"
 dependencies = [
  "acvm",
+ "arena",
+ "lazy_static",
  "noirc_abi",
  "noirc_errors",
  "noirc_frontend",
+ "num-bigint",
+ "num-traits",
  "thiserror",
 ]
 

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -46,7 +46,6 @@ impl ExpressionKind {
     pub fn array(contents: Vec<Expression>) -> ExpressionKind {
         ExpressionKind::Literal(Literal::Array(ArrayLiteral {
             length: contents.len() as u128,
-            r#type: Type::Unknown,
             contents,
         }))
     }
@@ -345,7 +344,6 @@ pub struct FunctionDefinition {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ArrayLiteral {
     pub length: u128, // XXX: Maybe allow field element, so that the user can define the length using a constant
-    pub r#type: Type,
     pub contents: Vec<Expression>,
 }
 

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -146,7 +146,6 @@ pub enum Type {
 
     Error,
     Unspecified, // This is for when the user declares a variable without specifying it's type
-    Unknown, // This is mainly used for array literals, where the parser cannot figure out the type for the literal
 }
 
 impl Type {
@@ -183,7 +182,6 @@ impl std::fmt::Display for Type {
             Type::Unit => write!(f, "()"),
             Type::Error => write!(f, "error"),
             Type::Unspecified => write!(f, "unspecified"),
-            Type::Unknown => write!(f, "unknown"),
         }
     }
 }
@@ -247,7 +245,6 @@ impl Type {
             | Type::Bool
             | Type::Error
             | Type::Unspecified
-            | Type::Unknown
             | Type::Unit => 1,
         }
     }
@@ -361,7 +358,6 @@ impl Type {
             Type::Bool => panic!("currently, cannot have a bool in the entry point function"),
             Type::Error => unreachable!(),
             Type::Unspecified => unreachable!(),
-            Type::Unknown => unreachable!(),
             Type::Unit => unreachable!(),
             Type::Struct(_) => todo!(),
         }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -315,7 +315,6 @@ impl<'a> Resolver<'a> {
                 Literal::Bool(b) => HirLiteral::Bool(b),
                 Literal::Array(arr) => HirLiteral::Array(HirArrayLiteral {
                     contents: vecmap(arr.contents, |elem| self.resolve_expression(elem)),
-                    r#type: arr.r#type,
                     length: arr.length,
                 }),
                 Literal::Integer(integer) => HirLiteral::Integer(integer),

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -286,7 +286,6 @@ pub fn infix_operand_type_rules(
         // An error type on either side will always return an error
         (Error, _) | (_,Error) => Ok(Error),
         (Unspecified, _) | (_,Unspecified) => Ok(Unspecified),
-        (Unknown, _) | (_,Unknown) => Ok(Unknown),
         (Unit, _) | (_,Unit) => Ok(Unit),
         //
         // If no side contains an integer. Then we check if either side contains a witness
@@ -455,7 +454,6 @@ pub fn comparator_operand_type_rules(lhs_type: &Type, other: &Type) -> Result<Ty
         // Avoid reporting errors multiple times
         (Error, _) | (_,Error) => Ok(Error),
         (Unspecified, _) | (_,Unspecified) => Ok(Unspecified),
-        (Unknown, _) | (_,Unknown) => Ok(Unknown),
         (lhs, rhs) => Err(format!("Unsupported types for comparison: {} and {}", lhs, rhs)),
     }
 }

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -167,10 +167,10 @@ pub struct HirCastExpression {
     pub lhs: ExprId,
     pub r#type: Type,
 }
+
 #[derive(Debug, Clone)]
 pub struct HirArrayLiteral {
     pub length: u128,
-    pub r#type: Type,
     pub contents: Vec<ExprId>,
 }
 

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -821,12 +821,6 @@ mod test {
         for expr in parse_all(array_expr(expression()), valid) {
             let arr_lit = expr_to_array(expr);
             assert_eq!(arr_lit.length, 5);
-
-            // All array types are unknown at parse time
-            // This makes parsing simpler. The type checker
-            // needs to iterate the whole array to ensure homogeneity
-            // so there is no advantage to deducing the type here.
-            assert_eq!(arr_lit.r#type, Type::Unknown);
         }
 
         parse_all_failing(


### PR DESCRIPTION
Turns out this field was never actually used. `Type::Unknown` has also been removed since it was only used for this unused field.