### PR TITLE
Remove 'priv' and 'const' statements

### DIFF
--- a/crates/noirc_driver/tests/pass/basic_import.nr
+++ b/crates/noirc_driver/tests/pass/basic_import.nr
@@ -5,7 +5,7 @@ use crate::import::hello;
 
 fn main(x : Field, y : Field) {
     let _k = std::hash::pedersen([x]);
-    priv _l = hello(x);
+    let _l = hello(x);
 
     constrain x != import::hello(y);
 }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -16,15 +16,15 @@ use acvm::FieldElement;
 use acvm::Language;
 use environment::{Environment, FuncContext};
 use errors::{RuntimeError, RuntimeErrorKind};
-use noirc_frontend::hir::Context;
 use noirc_frontend::hir_def::{
     expr::{
         HirBinaryOp, HirBinaryOpKind, HirBlockExpression, HirCallExpression, HirExpression,
         HirForExpression, HirLiteral,
     },
-    stmt::{HirConstrainStatement, HirLetStatement, HirPrivateStatement, HirStatement},
+    stmt::{HirConstrainStatement, HirStatement},
 };
 use noirc_frontend::node_interner::{ExprId, FuncId, IdentId, StmtId};
+use noirc_frontend::{hir::Context, FieldElementType};
 use noirc_frontend::{FunctionKind, Type};
 use object::{Array, Integer, Object, RangedObject};
 pub struct Evaluator<'a> {
@@ -313,58 +313,18 @@ impl<'a> Evaluator<'a> {
     ) -> Result<Object, RuntimeError> {
         let statement = self.context.def_interner.statement(stmt_id);
         match statement {
-            HirStatement::Private(x) => self.handle_private_statement(env, x),
             HirStatement::Constrain(constrain_stmt) => {
                 self.handle_constrain_statement(env, constrain_stmt)
-            }
-            HirStatement::Const(x) => {
-                let variable_name: String = self.context.def_interner.ident_name(&x.identifier);
-                // const can only be integers/Field elements, cannot involve the witness, so we can possibly move this to
-                // analysis. Right now it would not make a difference, since we are not compiling to an intermediate Noir format
-                let span = self.context.def_interner.expr_span(&x.expression);
-                let value = self
-                    .evaluate_integer(env, &x.expression)
-                    .map_err(|kind| kind.add_span(span))?;
-
-                env.store(variable_name, value);
-                Ok(Object::Null)
             }
             HirStatement::Expression(expr) | HirStatement::Semi(expr) => {
                 self.expression_to_object(env, &expr)
             }
             HirStatement::Let(let_stmt) => {
                 // let statements are used to declare a higher level object
-                self.handle_let_statement(env, let_stmt)?;
-
-                Ok(Object::Null)
+                self.handle_definition(env, &let_stmt.identifier, &let_stmt.expression)
             }
             HirStatement::Assign(assign_stmt) => {
-                // It's possible to desugar the assign statement in the type checker.
-                // However for clarity, we just match on the type and call the corresponding function.
-                // eg if  we are assigning a witness, we call handle_private_statement
-                let ident_def = self
-                    .context
-                    .def_interner
-                    .ident_def(&assign_stmt.identifier)
-                    .unwrap();
-                let typ = dbg!(self.context.def_interner.id_type(ident_def));
-                if typ.can_be_used_in_priv() {
-                    let stmt = HirPrivateStatement {
-                        identifier: assign_stmt.identifier,
-                        r#type: typ,
-                        expression: assign_stmt.expression,
-                    };
-                    self.handle_private_statement(env, stmt)
-                } else if typ.can_be_used_in_let() {
-                    let stmt = HirLetStatement {
-                        identifier: assign_stmt.identifier,
-                        r#type: typ,
-                        expression: assign_stmt.expression,
-                    };
-                    self.handle_let_statement(env, stmt)
-                } else {
-                    todo!("compiler currently cannot reassign types {:?}", typ)
-                }
+                self.handle_definition(env, &assign_stmt.identifier, &assign_stmt.expression)
             }
             HirStatement::Error => unreachable!(
                 "ice: compiler did not exit before codegen when a statement failed to parse"
@@ -378,12 +338,13 @@ impl<'a> Evaluator<'a> {
     fn handle_private_statement(
         &mut self,
         env: &mut Environment,
-        x: HirPrivateStatement,
+        identifier: &IdentId,
+        rhs: &ExprId,
     ) -> Result<Object, RuntimeError> {
-        let rhs_span = self.context.def_interner.expr_span(&x.expression);
-        let rhs_poly = self.expression_to_object(env, &x.expression)?;
+        let rhs_span = self.context.def_interner.expr_span(rhs);
+        let rhs_poly = self.expression_to_object(env, rhs)?;
 
-        let variable_name = self.context.def_interner.ident_name(&x.identifier);
+        let variable_name = self.context.def_interner.ident_name(identifier);
         // We do not store it in the environment yet, because it may need to be casted to an integer
         let witness = self.add_witness_to_cs();
 
@@ -484,32 +445,44 @@ impl<'a> Evaluator<'a> {
         };
         Ok(Object::Null)
     }
-    // Let statements are used to declare higher level objects
-    fn handle_let_statement(
+
+    fn handle_definition(
         &mut self,
         env: &mut Environment,
-        let_stmt: HirLetStatement,
+        identifier: &IdentId,
+        rhs: &ExprId,
     ) -> Result<Object, RuntimeError> {
         // Convert the LHS into an identifier
-        let variable_name = self.context.def_interner.ident_name(&let_stmt.identifier);
+        let variable_name = self.context.def_interner.ident_name(identifier);
 
-        // XXX: Currently we only support arrays using this, when other types are introduced
-        // we can extend into a separate (generic) module
+        match self.context.def_interner.id_type(rhs) {
+            Type::FieldElement(FieldElementType::Constant) => {
+                // const can only be integers/Field elements, cannot involve the witness, so we can possibly move this to
+                // analysis. Right now it would not make a difference, since we are not compiling to an intermediate Noir format
+                let span = self.context.def_interner.expr_span(rhs);
+                let value = self
+                    .evaluate_integer(env, rhs)
+                    .map_err(|kind| kind.add_span(span))?;
 
-        // Extract the array
-        let rhs_poly = self.expression_to_object(env, &let_stmt.expression)?;
-
-        match rhs_poly {
-            Object::Array(arr) => {
-                env.store(variable_name, Object::Array(arr));
+                env.store(variable_name, value);
             }
-            _ => unimplemented!(
-                "logic for types that are not arrays in a let statement, not implemented yet!"
-            ),
-        };
+            Type::Array(..) => {
+                let rhs_poly = self.expression_to_object(env, rhs)?;
+                match rhs_poly {
+                    Object::Array(arr) => {
+                        env.store(variable_name, Object::Array(arr));
+                    }
+                    _ => unimplemented!(
+                        "The evaluator currently only supports arrays and constant integers!"
+                    ),
+                };
+            }
+            _ => return self.handle_private_statement(env, identifier, rhs),
+        }
 
         Ok(Object::Null)
     }
+
     fn handle_for_expr(
         &mut self,
         env: &mut Environment,

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -16,7 +16,7 @@ use noirc_frontend::hir::Context;
 use noirc_frontend::hir_def::function::HirFunction;
 use noirc_frontend::hir_def::{
     expr::{HirBinaryOp, HirBinaryOpKind, HirExpression, HirForExpression, HirLiteral},
-    stmt::{HirConstrainStatement, HirLetStatement, HirPrivateStatement, HirStatement},
+    stmt::{HirConstrainStatement, HirLetStatement, HirStatement},
 };
 use noirc_frontend::node_interner::{ExprId, IdentId, StmtId};
 //use noirc_frontend::{FunctionKind, Type};
@@ -470,18 +470,8 @@ impl<'a> IRGenerator<'a> {
     ) -> Result<arena::Index, RuntimeError> {
         let statement = self.context().def_interner.statement(stmt_id);
         match statement {
-            HirStatement::Private(x) => self.handle_private_statement(env, x),
             HirStatement::Constrain(constrain_stmt) => {
                 self.handle_constrain_statement(env, constrain_stmt)
-            }
-            HirStatement::Const(x) => {
-                //let variable_name: String = self.context().def_interner.ident_name(&x.identifier);
-                // const can only be integers/Field elements, cannot involve the witness, so we can possibly move this to
-                // analysis. Right now it would not make a difference, since we are not compiling to an intermediate Noir format
-                //let span = self.context().def_interner.expr_span(&x.expression);
-                //TODO the result of expression_to_object should be an assignement, we should modify the lhs to specify it is a const
-                // and then forbid any other assignement with the same variable during the SSA phase (and instead of applying the SSA form of it).
-                self.expression_to_object(env, &x.expression)
             }
             HirStatement::Expression(expr) | HirStatement::Semi(expr) => {
                 self.expression_to_object(env, &expr)
@@ -621,39 +611,6 @@ impl<'a> IRGenerator<'a> {
             // we should merge their property; min(max), min(bitsize),etc..
         };
         result
-    }
-
-    //TODO: refactor properly so that one function handle the creation of a new variable and generates the ass opcode, and use it in priv,let,assign
-    //then add the priv feature: a priv variable should never be assigned to a const value (n.b. because apparently this would indicate a bug in a user program)
-    //so handle_private_statement should add the 'priv' attribute to the variable, and the handle_assign should check for it when assigning a const to a 'priv'var.
-    fn handle_private_statement(
-        &mut self,
-        env: &mut Environment,
-        priv_stmt: HirPrivateStatement,
-    ) -> Result<arena::Index, RuntimeError> {
-        // Create a new variable
-        let variable_name = self
-            .context()
-            .def_interner
-            .ident_name(&priv_stmt.identifier);
-        let ident_def = self.context().def_interner.ident_def(&priv_stmt.identifier);
-        let new_var = node::Variable {
-            id: self.dummy(),
-            obj_type: node::ObjectType::NativeField, //TODO
-            name: variable_name,
-            root: None,
-            def: ident_def,
-            witness: None, //TODO
-            parent_block: self.current_block,
-        };
-        let new_var_id = self.add_variable(new_var, None);
-        // Create assign instruction
-        let rhs_id = self.expression_to_object(env, &priv_stmt.expression)?;
-        let rhs = self.get_object(rhs_id).unwrap();
-        let r_type = rhs.get_type();
-        let result = self.new_instruction(new_var_id, rhs_id, node::Operation::Ass, r_type);
-        //self.update_variable_id(lhs_id, new_var_id); //update the name and the value array
-        Ok(result)
     }
 
     // Let statements are used to declare higher level objects

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -87,7 +87,7 @@ impl FieldElementType {
     /// Return the corresponding keyword for this field type
     pub fn as_keyword(self) -> Keyword {
         match self {
-            FieldElementType::Private => Keyword::Priv,
+            FieldElementType::Private => panic!("No Keyword for a Private FieldElementType"),
             FieldElementType::Public => Keyword::Pub,
             FieldElementType::Constant => Keyword::Const,
         }
@@ -170,12 +170,18 @@ impl Recoverable for Type {
 
 impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vis_str = |vis| match vis {
+            FieldElementType::Private => "",
+            FieldElementType::Public => "pub ",
+            FieldElementType::Constant => "const ",
+        };
+
         match self {
-            Type::FieldElement(fe_type) => write!(f, "{} Field", fe_type),
-            Type::Array(fe_type, size, typ) => write!(f, "{} {}{}", fe_type, size, typ),
+            Type::FieldElement(fe_type) => write!(f, "{}Field", vis_str(*fe_type)),
+            Type::Array(fe_type, size, typ) => write!(f, "{}{}{}", vis_str(*fe_type), size, typ),
             Type::Integer(fe_type, sign, num_bits) => match sign {
-                Signedness::Signed => write!(f, "{} i{}", fe_type, num_bits),
-                Signedness::Unsigned => write!(f, "{} u{}", fe_type, num_bits),
+                Signedness::Signed => write!(f, "{}i{}", vis_str(*fe_type), num_bits),
+                Signedness::Unsigned => write!(f, "{}u{}", vis_str(*fe_type), num_bits),
             },
             Type::Struct(s) => s.fmt(f),
             Type::Bool => write!(f, "bool"),
@@ -269,11 +275,6 @@ impl Type {
             Type::Array(_, sized, typ) => Some((sized, typ)),
             _ => None,
         }
-    }
-
-    // Returns true if the Type can be used in a Let statement
-    pub fn can_be_used_in_let(&self) -> bool {
-        self.is_fixed_sized_array() || self.is_variable_sized_array() || self == &Type::Error
     }
 
     // Returns true if the Type can be used in a Constrain statement

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -106,9 +106,7 @@ pub trait Recoverable {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Statement {
     Let(LetStatement),
-    Const(ConstStatement),
     Constrain(ConstrainStatement),
-    Private(PrivateStatement),
     Expression(Expression),
     Assign(AssignStatement),
     // This is an expression with a trailing semi-colon
@@ -136,22 +134,6 @@ impl Statement {
         })
     }
 
-    pub fn new_const(((identifier, r#type), expression): ((Ident, Type), Expression)) -> Statement {
-        Statement::Const(ConstStatement {
-            identifier,
-            r#type,
-            expression,
-        })
-    }
-
-    pub fn new_priv(((identifier, r#type), expression): ((Ident, Type), Expression)) -> Statement {
-        Statement::Private(PrivateStatement {
-            identifier,
-            r#type,
-            expression,
-        })
-    }
-
     pub fn add_semicolon(
         self,
         semi: Option<Token>,
@@ -161,15 +143,13 @@ impl Statement {
     ) -> Statement {
         match self {
             Statement::Let(_)
-            | Statement::Const(_)
             | Statement::Constrain(_)
-            | Statement::Private(_)
             | Statement::Assign(_)
             | Statement::Semi(_)
             | Statement::Error => {
                 // To match rust, statements always require a semicolon, even at the end of a block
                 if semi.is_none() {
-                    let reason = "Expected a ; after this statement".to_string();
+                    let reason = "Expected a ; separating these two statements".to_string();
                     emit_error(ParserError::with_reason(reason, span));
                 }
                 self
@@ -193,7 +173,7 @@ impl Statement {
                     // for unneeded expressions like { 1 + 2; 3 }
                     (_, Some(_), false) => Statement::Expression(expr),
                     (_, None, false) => {
-                        let reason = "Expected a ; after this expression".to_string();
+                        let reason = "Expected a ; separating these two statements".to_string();
                         emit_error(ParserError::with_reason(reason, span));
                         Statement::Expression(expr)
                     }
@@ -292,20 +272,6 @@ pub struct LetStatement {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ConstStatement {
-    pub identifier: Ident,
-    pub r#type: Type, // This will always be a Literal FieldElement
-    pub expression: Expression,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct PrivateStatement {
-    pub identifier: Ident,
-    pub r#type: Type,
-    pub expression: Expression,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AssignStatement {
     pub identifier: Ident,
     pub expression: Expression,
@@ -318,9 +284,7 @@ impl Display for Statement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Statement::Let(let_statement) => let_statement.fmt(f),
-            Statement::Const(const_statement) => const_statement.fmt(f),
             Statement::Constrain(constrain) => constrain.fmt(f),
-            Statement::Private(private) => private.fmt(f),
             Statement::Expression(expression) => expression.fmt(f),
             Statement::Assign(assign) => assign.fmt(f),
             Statement::Semi(semi) => write!(f, "{};", semi),
@@ -334,26 +298,6 @@ impl Display for LetStatement {
         write!(
             f,
             "let {}: {} = {}",
-            self.identifier, self.r#type, self.expression
-        )
-    }
-}
-
-impl Display for ConstStatement {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "const {}: {} = {}",
-            self.identifier, self.r#type, self.expression
-        )
-    }
-}
-
-impl Display for PrivateStatement {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "priv {}: {} = {}",
             self.identifier, self.r#type, self.expression
         )
     }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -44,10 +44,7 @@ use crate::hir::scope::{
 };
 use crate::hir_def::{
     function::{FuncMeta, HirFunction, Param},
-    stmt::{
-        HirConstStatement, HirConstrainStatement, HirLetStatement, HirPrivateStatement,
-        HirStatement,
-    },
+    stmt::{HirConstrainStatement, HirLetStatement, HirStatement},
 };
 
 use super::errors::ResolverError;
@@ -252,17 +249,6 @@ impl<'a> Resolver<'a> {
 
                 self.interner.push_stmt(HirStatement::Let(let_stmt))
             }
-            Statement::Const(const_stmt) => {
-                let id = self.add_variable_decl(const_stmt.identifier);
-
-                let const_stmt = HirConstStatement {
-                    identifier: id,
-                    r#type: const_stmt.r#type,
-                    expression: self.intern_expr(const_stmt.expression),
-                };
-
-                self.interner.push_stmt(HirStatement::Const(const_stmt))
-            }
             Statement::Constrain(constrain_stmt) => {
                 let lhs = self.resolve_expression(constrain_stmt.0.lhs);
                 let operator: HirBinaryOp = constrain_stmt.0.operator.into();
@@ -271,16 +257,6 @@ impl<'a> Resolver<'a> {
                 let stmt = HirConstrainStatement(HirInfixExpression { lhs, operator, rhs });
 
                 self.interner.push_stmt(HirStatement::Constrain(stmt))
-            }
-            Statement::Private(priv_stmt) => {
-                let identifier = self.add_variable_decl(priv_stmt.identifier);
-                let expression = self.resolve_expression(priv_stmt.expression);
-                let stmt = HirPrivateStatement {
-                    identifier,
-                    expression,
-                    r#type: priv_stmt.r#type,
-                };
-                self.interner.push_stmt(HirStatement::Private(stmt))
             }
             Statement::Expression(expr) => {
                 let stmt = HirStatement::Expression(self.resolve_expression(expr));
@@ -722,7 +698,7 @@ mod test {
         let src = r#"
             fn main(x : Field) {
                 for i in 1..20 {
-                    priv _z = x + i;
+                    let _z = x + i;
                 };
             }
         "#;

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -1,6 +1,5 @@
 use crate::hir_def::stmt::{
-    HirAssignStatement, HirConstStatement, HirConstrainStatement, HirLetStatement,
-    HirPrivateStatement, HirStatement,
+    HirAssignStatement, HirConstrainStatement, HirLetStatement, HirStatement,
 };
 use crate::node_interner::{ExprId, NodeInterner, StmtId};
 use crate::Type;
@@ -40,9 +39,7 @@ pub(crate) fn type_check(
             type_check_expression(interner, &expr_id, errors);
             interner.make_expr_type_unit(&expr_id);
         }
-        HirStatement::Private(priv_stmt) => type_check_priv_stmt(interner, priv_stmt, errors),
         HirStatement::Let(let_stmt) => type_check_let_stmt(interner, let_stmt, errors),
-        HirStatement::Const(const_stmt) => type_check_const_stmt(interner, const_stmt, errors),
         HirStatement::Constrain(constrain_stmt) => {
             type_check_constrain_stmt(interner, constrain_stmt, errors)
         }
@@ -74,27 +71,6 @@ fn type_check_assign_stmt(
     }
 }
 
-fn type_check_priv_stmt(
-    interner: &mut NodeInterner,
-    priv_stmt: HirPrivateStatement,
-    errors: &mut Vec<TypeCheckError>,
-) {
-    let resolved_type =
-        type_check_declaration(interner, priv_stmt.expression, priv_stmt.r#type, errors);
-
-    // Check if this type can be used in a Private statement
-    if !resolved_type.can_be_used_in_priv() {
-        errors.push(TypeCheckError::TypeCannotBeUsed {
-            typ: resolved_type.clone(),
-            place: "private statement",
-            span: interner.expr_span(&priv_stmt.expression),
-        });
-    }
-
-    // Set the type of the identifier to be equal to the annotated type
-    interner.push_ident_type(&priv_stmt.identifier, resolved_type);
-}
-
 fn type_check_let_stmt(
     interner: &mut NodeInterner,
     let_stmt: HirLetStatement,
@@ -103,41 +79,8 @@ fn type_check_let_stmt(
     let resolved_type =
         type_check_declaration(interner, let_stmt.expression, let_stmt.r#type, errors);
 
-    // Check if this type can be used in a Let statement
-    if !resolved_type.can_be_used_in_let() {
-        errors.push(TypeCheckError::TypeCannotBeUsed {
-            typ: resolved_type.clone(),
-            place: "let statement",
-            span: interner.expr_span(&let_stmt.expression),
-        });
-    }
-
     // Set the type of the identifier to be equal to the annotated type
     interner.push_ident_type(&let_stmt.identifier, resolved_type);
-}
-
-fn type_check_const_stmt(
-    interner: &mut NodeInterner,
-    const_stmt: HirConstStatement,
-    errors: &mut Vec<TypeCheckError>,
-) {
-    // XXX: It may not make sense to have annotations for const statements, since they can only have one type
-    // Unless we later want to have u32 constants and check those at compile time.
-    let resolved_type =
-        type_check_declaration(interner, const_stmt.expression, const_stmt.r#type, errors);
-
-    if resolved_type != Type::CONSTANT && resolved_type != Type::Error {
-        errors.push(
-            TypeCheckError::TypeCannotBeUsed {
-                typ: resolved_type.clone(),
-                place: "constant statement",
-                span: interner.expr_span(&const_stmt.expression),
-            }
-            .add_context("constant statements can only contain constant types"),
-        );
-    }
-
-    interner.push_ident_type(&const_stmt.identifier, resolved_type);
 }
 
 fn type_check_constrain_stmt(

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -1,7 +1,7 @@
-use crate::Type;
-
 use super::expr::HirInfixExpression;
 use crate::node_interner::{ExprId, IdentId};
+use crate::Type;
+
 #[derive(Debug, Clone)]
 pub struct HirLetStatement {
     pub identifier: IdentId,
@@ -10,27 +10,6 @@ pub struct HirLetStatement {
 }
 
 #[derive(Debug, Clone)]
-pub struct HirConstStatement {
-    pub identifier: IdentId,
-    pub r#type: Type,
-    pub expression: ExprId,
-}
-
-#[derive(Debug, Clone)]
-#[deprecated = "we will no longer support declaration of public variables"]
-pub struct HirPublicStatement {
-    pub identifier: IdentId,
-    pub r#type: Type,
-    pub expression: ExprId,
-}
-
-#[derive(Debug, Clone)]
-pub struct HirPrivateStatement {
-    pub identifier: IdentId,
-    pub r#type: Type,
-    pub expression: ExprId,
-}
-#[derive(Debug, Clone)]
 pub struct HirAssignStatement {
     pub identifier: IdentId,
     pub expression: ExprId,
@@ -38,18 +17,18 @@ pub struct HirAssignStatement {
 
 #[derive(Debug, Clone)]
 pub struct HirConstrainStatement(pub HirInfixExpression);
+
 #[derive(Debug, Clone)]
 pub struct BinaryStatement {
     pub lhs: ExprId,
     pub r#type: Type,
     pub expression: ExprId,
 }
+
 #[derive(Debug, Clone)]
 pub enum HirStatement {
     Let(HirLetStatement),
-    Const(HirConstStatement),
     Constrain(HirConstrainStatement),
-    Private(HirPrivateStatement),
     Assign(HirAssignStatement),
     Expression(ExprId),
     Semi(ExprId),

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -514,23 +514,21 @@ fn test_span() {
 #[test]
 fn test_basic_language_syntax() {
     let input = "
-
-    const five = 5;
-    pub ten : Field = 10;
-    let mul = fn(x, y) {
-         x * y;
-    };
-    priv result = mul(five, ten);
-
+        let five = 5;
+        let ten : Field = 10;
+        let mul = fn(x, y) {
+            x * y;
+        };
+        constrain mul(five, ten) == 50;
     ";
 
     let expected = vec![
-        Token::Keyword(Keyword::Const),
+        Token::Keyword(Keyword::Let),
         Token::Ident("five".to_string()),
         Token::Assign,
         Token::Int(5_i128.into()),
         Token::Semicolon,
-        Token::Keyword(Keyword::Pub),
+        Token::Keyword(Keyword::Let),
         Token::Ident("ten".to_string()),
         Token::Colon,
         Token::Keyword(Keyword::Field),
@@ -553,15 +551,15 @@ fn test_basic_language_syntax() {
         Token::Semicolon,
         Token::RightBrace,
         Token::Semicolon,
-        Token::Keyword(Keyword::Priv),
-        Token::Ident("result".to_string()),
-        Token::Assign,
+        Token::Keyword(Keyword::Constrain),
         Token::Ident("mul".to_string()),
         Token::LeftParen,
         Token::Ident("five".to_string()),
         Token::Comma,
         Token::Ident("ten".to_string()),
         Token::RightParen,
+        Token::Equal,
+        Token::Int(50_i128.into()),
         Token::Semicolon,
         Token::EOF,
     ];

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -40,12 +40,6 @@ impl SpannedToken {
     pub fn kind(&self) -> TokenKind {
         self.token().kind()
     }
-    pub fn is_variant(&self, tok: &Token) -> bool {
-        self.token().is_variant(tok)
-    }
-    pub fn can_start_declaration(&self) -> bool {
-        self.token().can_start_declaration()
-    }
 }
 
 impl std::fmt::Display for SpannedToken {
@@ -220,46 +214,11 @@ impl Token {
         matches!(self, Token::Ident(_))
     }
 
-    // Does not work for Keyword or whatever is inside of variant
-    pub fn is_variant(&self, tok: &Token) -> bool {
-        let got_variant = core::mem::discriminant(self);
-        let expected_variant = core::mem::discriminant(tok);
-        let same_token_variant = got_variant == expected_variant;
-        if !same_token_variant {
-            return false;
-        }
-
-        // Check if the keywords are the same
-        // Two tokens can be the same variant, but have different inner values
-        // We especially care about the Keyword value however
-        if let (Token::Keyword(x), Token::Keyword(y)) = (&self, tok) {
-            return x == y;
-        }
-
-        // If we arrive here, then the Token variants are the same and they are not the Keyword type
-        true
-    }
-
     pub(super) fn into_single_span(self, position: Position) -> SpannedToken {
         self.into_span(position, position)
     }
     pub(super) fn into_span(self, start: Position, end: Position) -> SpannedToken {
         SpannedToken(Spanned::from_position(start, end, self))
-    }
-
-    pub fn can_start_type(&self) -> bool {
-        matches!(
-            self,
-            Token::Keyword(Keyword::Field) | Token::IntType(_) | Token::LeftBracket
-        )
-    }
-    pub fn can_be_field_element_type(&self) -> bool {
-        matches!(
-            self,
-            Token::Keyword(Keyword::Pub)
-                | Token::Keyword(Keyword::Const)
-                | Token::Keyword(Keyword::Priv)
-        )
     }
 }
 
@@ -419,7 +378,6 @@ pub enum Keyword {
     Constrain,
     // Field types
     Pub,
-    Priv,
     Const,
     //
     SetPub,
@@ -449,7 +407,6 @@ impl fmt::Display for Keyword {
             Keyword::Use => write!(f, "use"),
             Keyword::SetPub => write!(f, "setpub"),
             Keyword::Pub => write!(f, "pub"),
-            Keyword::Priv => write!(f, "priv"),
             Keyword::Field => write!(f, "Field"),
             Keyword::Const => write!(f, "const"),
         }
@@ -481,7 +438,6 @@ impl Keyword {
 
             "setpub" => Some(Token::Keyword(Keyword::SetPub)),
 
-            "priv" => Some(Token::Keyword(Keyword::Priv)),
             "pub" => Some(Token::Keyword(Keyword::Pub)),
             "const" => Some(Token::Keyword(Keyword::Const)),
             // Native Types
@@ -491,51 +447,6 @@ impl Keyword {
             _ => None,
         }
     }
-}
-
-// The list of keyword tokens which can start "variable" declarations. "fn" is for function declarations
-// XXX(low) : It might make sense to create a Keyword::Declarations Variant
-const fn declaration_keywords() -> [Keyword; 4] {
-    [Keyword::Let, Keyword::Const, Keyword::Pub, Keyword::Priv]
-}
-
-impl Token {
-    /// Converts Token into a declaration keyword
-    /// Panics if the token cannot start a declaration
-    /// XXX: There should be a cleaner way of doing this.
-    pub fn to_declaration_keyword(&self) -> Keyword {
-        assert!(self.can_start_declaration());
-        match self {
-            Token::Keyword(kw) => *kw,
-            _ => unreachable!("All tokens which can start declarations, must be keyword"),
-        }
-    }
-    // The set of keyword which can declare variables
-    pub fn can_start_declaration(&self) -> bool {
-        // First check it is a keyword
-        let is_keyword = self.kind() == TokenKind::Keyword;
-        if !is_keyword {
-            return false;
-        }
-
-        match self {
-            Token::Keyword(kw) => declaration_keywords().contains(kw),
-            _ => false,
-        }
-    }
-}
-
-#[test]
-fn test_variant_equality() {
-    let tok = Token::Keyword(Keyword::Let);
-    let tok2 = Token::Keyword(Keyword::Let);
-    assert!(tok.is_variant(&tok2));
-
-    let tok3 = Token::Keyword(Keyword::Const);
-    assert!(!tok.is_variant(&tok3));
-
-    let tok4 = Token::LeftBrace;
-    assert!(!tok.is_variant(&tok4));
 }
 
 pub struct Tokens(pub Vec<SpannedToken>);

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -132,8 +132,6 @@ where
         Token::Semicolon,
         Token::RightBrace,
         Token::Keyword(Keyword::Let),
-        Token::Keyword(Keyword::Priv),
-        Token::Keyword(Keyword::Const),
         Token::Keyword(Keyword::Constrain),
     ];
     force(parser.recover_with(chumsky::prelude::skip_then_retry_until(terminators)))

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -105,7 +105,7 @@ fn attribute() -> impl NoirParser<Attribute> {
 
 fn struct_fields() -> impl NoirParser<Vec<(Ident, Type)>> {
     parameters(parse_type_with_visibility(
-        optional_pri_or_const(),
+        optional_const(),
         parse_type_no_field_element(),
     ))
 }
@@ -265,29 +265,11 @@ fn declaration<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a
 where
     P: ExprParser + 'a,
 {
-    let let_statement = generic_declaration(Keyword::Let, expr_parser.clone(), Statement::new_let);
-    let priv_statement =
-        generic_declaration(Keyword::Priv, expr_parser.clone(), Statement::new_priv);
-    let const_statement = generic_declaration(Keyword::Const, expr_parser, Statement::new_const);
-
-    choice((let_statement, priv_statement, const_statement))
-}
-
-fn generic_declaration<'a, F, P>(
-    key: Keyword,
-    expr_parser: P,
-    f: F,
-) -> impl NoirParser<Statement> + 'a
-where
-    F: 'a + Clone + Fn(((Ident, Type), Expression)) -> Statement,
-    P: ExprParser + 'a,
-{
-    let p = ignore_then_commit(keyword(key).labelled("statement"), ident());
+    let p = ignore_then_commit(keyword(Keyword::Let).labelled("statement"), ident());
     let p = p.then(optional_type_annotation());
     let p = then_commit_ignore(p, just(Token::Assign));
     let p = then_commit(p, expr_parser);
-
-    p.map(f)
+    p.map(Statement::new_let)
 }
 
 fn assignment<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a
@@ -334,7 +316,7 @@ where
 
 // Parse nothing, just return a FieldElementType::Private
 fn no_visibility() -> impl NoirParser<FieldElementType> {
-    just([]).or_not().map(|_| FieldElementType::Private)
+    empty().map(|_| FieldElementType::Private)
 }
 
 // Returns a parser that parses any FieldElementType that satisfies
@@ -346,19 +328,14 @@ fn visibility(field: FieldElementType) -> impl NoirParser<FieldElementType> {
 fn optional_visibility() -> impl NoirParser<FieldElementType> {
     choice((
         visibility(FieldElementType::Public),
-        visibility(FieldElementType::Private),
         visibility(FieldElementType::Constant),
         no_visibility(),
     ))
 }
 
 // This is primarily for struct fields which cannot be public
-fn optional_pri_or_const() -> impl NoirParser<FieldElementType> {
-    choice((
-        visibility(FieldElementType::Private),
-        visibility(FieldElementType::Constant),
-        no_visibility(),
-    ))
+fn optional_const() -> impl NoirParser<FieldElementType> {
+    visibility(FieldElementType::Constant).or(no_visibility())
 }
 
 fn field_type<P>(visibility_parser: P) -> impl NoirParser<Type>
@@ -901,13 +878,6 @@ mod test {
             vec!["let x = y", "let x : u8 = y"],
         );
     }
-    #[test]
-    fn parse_priv() {
-        parse_all(
-            declaration(expression()),
-            vec!["priv x = y", "priv x : pub Field = y"],
-        );
-    }
 
     #[test]
     fn parse_invalid_pub() {
@@ -915,16 +885,6 @@ mod test {
         parse_all_failing(
             statement(expression()),
             vec!["pub x = y", "pub x : pub Field = y"],
-        );
-    }
-
-    #[test]
-    fn parse_const() {
-        // XXX: We have `Constant` because we may allow constants to
-        // be casted to integers. Maybe rename this to `Field` instead
-        parse_all(
-            declaration(expression()),
-            vec!["const x = y", "const x : const Field = y"],
         );
     }
 
@@ -1185,7 +1145,6 @@ mod test {
             ("let = 4 + 3", 1, "let $error: unspecified = (4 + 3)"),
             ("let = ", 2, "let $error: unspecified = Error"),
             ("let", 3, "let $error: unspecified = Error"),
-            ("priv = ", 2, "priv $error: unspecified = Error"),
             ("foo = one two three", 1, "foo = one"),
             ("constrain", 2, "Error"), // We don't recover 'constrain Error' since constrain needs a binary operator
             ("constrain x ==", 2, "constrain (x == Error)"), // This gives a duplicate 'end of input' error currently

--- a/examples/10/src/main.nr
+++ b/examples/10/src/main.nr
@@ -1,16 +1,10 @@
-
-
-
 use dep::std;
 
 // Note: If main has any unsized types, then the verifier will never be able
 // to figure out the circuit instance
-//
 fn main(message : [10]u8, pub_key_x : Field, pub_key_y : Field, signature : [64]u8) {
-
      // Is there ever a situation where someone would want 
      // to ensure that a signature was invalid?
-     priv x = std::schnorr::verify_signature(signature, message,pub_key_x,pub_key_y);
-     
+     let x = std::schnorr::verify_signature(signature, message,pub_key_x,pub_key_y);
      constrain x == 1;
 }

--- a/examples/13/src/main.nr
+++ b/examples/13/src/main.nr
@@ -1,6 +1,3 @@
-
-
-
 use dep::std;
 
 // This is not fully supported by any backend
@@ -13,10 +10,8 @@ use dep::std;
 // the only backend implemented does not work properly for this,
 // we can still implement it on the frontend.
 fn main(hashed_message : [32]u8, pub_key_x : [32]u8, pub_key_y : [32]u8, signature : [64]u8) {
-
      // Is there ever a situation where someone would want 
      // to ensure that a signature was invalid?
-     priv x = std::ecdsa_secp256k1::verify_signature(signature, hashed_message,pub_key_x,pub_key_y);
-     
+     let x = std::ecdsa_secp256k1::verify_signature(signature, hashed_message,pub_key_x,pub_key_y);
      constrain x == 1;
 }

--- a/examples/2/src/main.nr
+++ b/examples/2/src/main.nr
@@ -3,8 +3,8 @@
 //
 //
 fn main(x : Field, y : Field) {
-    priv x_as_u8 = x as u8;
-    priv y_as_u8 = y as u8;
+    let x_as_u8 = x as u8;
+    let y_as_u8 = y as u8;
     
     constrain (x_as_u8 & y_as_u8) == y;
 }

--- a/examples/3/src/main.nr
+++ b/examples/3/src/main.nr
@@ -3,6 +3,6 @@
 // There is currently no range optimiser currently in ACIR :(
 //    
 fn main(x : u8, y : Field) {
-    priv _z = x + (y as u8);
+    let _z = x + (y as u8);
 }
     

--- a/examples/4/src/main.nr
+++ b/examples/4/src/main.nr
@@ -4,11 +4,11 @@
 //
 // XXX(Dankrad): For loop is not clear
 fn main(x : Field, y : Field) {
-    const _a = 1;
-    priv k = x + y;
+    let a = 1;
+    let k = x + y;
 
-    let j = for _k in _a..100 {
-       priv z = x + k;
+    let j = for _k in a..100 {
+       let z = x + k;
        z
     };
 

--- a/examples/assign_ex/src/main.nr
+++ b/examples/assign_ex/src/main.nr
@@ -1,6 +1,6 @@
 
 fn main(x : Field, y : Field) {
-    priv z = x + y;
+    let z = x + y;
     constrain z == 3;
     z = x * y;
     constrain z == 2;

--- a/examples/pred_eq/src/main.nr
+++ b/examples/pred_eq/src/main.nr
@@ -1,6 +1,6 @@
 use dep::std;
+
 fn main(x : Field, y : Field) {
-    priv p = std::predicate_eq(x, y);
+    let p = std::predicate_eq(x, y);
     constrain p == 1;
 }
-    

--- a/examples/simple_shield/src/main.nr
+++ b/examples/simple_shield/src/main.nr
@@ -17,8 +17,8 @@ fn main(
     // Compute public key from private key to show ownership
     //
     let pubkey = std::scalar_mul::fixed_base(priv_key);
-    priv pubkey_x = pubkey[0];
-    priv pubkey_y = pubkey[1];
+    let pubkey_x = pubkey[0];
+    let pubkey_y = pubkey[1];
 
     // Compute input note commitment
     let note_commitment = std::hash::pedersen([pubkey_x, pubkey_y]);
@@ -30,7 +30,7 @@ fn main(
     let receiver_note_commitment = std::hash::pedersen([to_pubkey_x, to_pubkey_y]);
 
     // Check that the input note nullifier is in the root
-    priv is_member = std::merkle::check_membership(note_root, note_commitment[0], index);
+    let is_member = std::merkle::check_membership(note_root, note_commitment[0], index);
     constrain is_member == 1;
 
     std::set_as_public(receiver_note_commitment[0]);


### PR DESCRIPTION
This PR is more minimalist than the previous PR. It:
- Merges 'priv' and 'const' statements into 'let' statements.
- Removes the 'priv' modifier (it remains the default modifier - no need to explicitly state priv)

It is worth noting there should be no loss of functionality with the removal of `const` statements since users can already specify `const` types. The following is valid:
```rs
let x: const Field = 2;
```