### PR TITLE
Implement struct, tuple, and mut patterns in the frontend

### DIFF
--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -16,15 +16,18 @@ use acvm::FieldElement;
 use acvm::Language;
 use environment::{Environment, FuncContext};
 use errors::{RuntimeError, RuntimeErrorKind};
-use noirc_frontend::{hir_def::{
-    expr::{
-        HirBinaryOp, HirBinaryOpKind, HirBlockExpression, HirCallExpression, HirExpression,
-        HirForExpression, HirLiteral,
-    },
-    stmt::{HirConstrainStatement, HirStatement, HirPattern},
-}, FieldElementType};
-use noirc_frontend::node_interner::{ExprId, FuncId, IdentId, StmtId};
 use noirc_frontend::hir::Context;
+use noirc_frontend::node_interner::{ExprId, FuncId, IdentId, StmtId};
+use noirc_frontend::{
+    hir_def::{
+        expr::{
+            HirBinaryOp, HirBinaryOpKind, HirBlockExpression, HirCallExpression, HirExpression,
+            HirForExpression, HirLiteral,
+        },
+        stmt::{HirConstrainStatement, HirPattern, HirStatement},
+    },
+    FieldElementType,
+};
 use noirc_frontend::{FunctionKind, Type};
 use object::{Array, Integer, Object, RangedObject};
 pub struct Evaluator<'a> {

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::token::{Attribute, Token};
 use crate::util::vecmap;
-use crate::{Ident, Path, Recoverable, Statement, Type};
+use crate::{Ident, Path, Pattern, Recoverable, Statement, Type};
 use acvm::FieldElement;
 use noirc_errors::{Span, Spanned};
 
@@ -335,7 +335,7 @@ pub struct IfExpression {
 pub struct FunctionDefinition {
     pub name: Ident,
     pub attribute: Option<Attribute>, // XXX: Currently we only have one attribute defined. If more attributes are needed per function, we can make this a vector and make attribute definition more expressive
-    pub parameters: Vec<(Ident, Type)>,
+    pub parameters: Vec<(Pattern, Type)>,
     pub body: BlockExpression,
     pub span: Span,
     pub return_type: Type,

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::{token::Attribute, Ident};
+use crate::{token::Attribute, Ident, Pattern};
 
 use super::{FunctionDefinition, Type};
 
@@ -54,7 +54,7 @@ impl NoirFunction {
     pub fn name_ident(&self) -> &Ident {
         &self.def.name
     }
-    pub fn parameters(&self) -> &Vec<(Ident, Type)> {
+    pub fn parameters(&self) -> &Vec<(Pattern, Type)> {
         &self.def.parameters
     }
     pub fn attribute(&self) -> Option<&Attribute> {

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -316,9 +316,9 @@ pub struct ConstrainStatement(pub InfixExpression);
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Pattern {
     Identifier(Ident),
-    Mutable(Ident),
-    Tuple(Vec<Pattern>),
-    Struct(Ident, Vec<(Ident, Pattern)>),
+    Mutable(Box<Pattern>, Span),
+    Tuple(Vec<Pattern>, Span),
+    Struct(Path, Vec<(Ident, Pattern)>, Span),
 }
 
 impl Recoverable for Pattern {
@@ -427,12 +427,12 @@ impl Display for Pattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Pattern::Identifier(name) => name.fmt(f),
-            Pattern::Mutable(name) => write!(f, "mut {}", name),
-            Pattern::Tuple(fields) => {
+            Pattern::Mutable(name, _) => write!(f, "mut {}", name),
+            Pattern::Tuple(fields, _) => {
                 let fields = vecmap(fields, ToString::to_string);
                 write!(f, "({})", fields.join(", "))
             }
-            Pattern::Struct(typename, fields) => {
+            Pattern::Struct(typename, fields, _) => {
                 let fields = vecmap(fields, |(name, pattern)| format!("{}: {}", name, pattern));
                 write!(f, "{} {{ {} }}", typename, fields.join(", "))
             }

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -45,6 +45,8 @@ pub enum ResolverError {
         missing_fields: Vec<String>,
         struct_definition: Ident,
     },
+    #[error("Unneeded 'mut', pattern is already marked as mutable")]
+    UnnecessaryMut { first_mut: Span, second_mut: Span }
 }
 
 impl ResolverError {
@@ -166,6 +168,11 @@ impl ResolverError {
                 );
                 error
             }
+            ResolverError::UnnecessaryMut { first_mut, second_mut } => {
+                let mut error = Diagnostic::simple_error("'mut' here is not necessary".to_owned(), "".to_owned(), second_mut);
+                error.add_secondary("Pattern was already made mutable from this 'mut'".to_owned(), first_mut);
+                error
+            },
         }
     }
 }

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -46,7 +46,7 @@ pub enum ResolverError {
         struct_definition: Ident,
     },
     #[error("Unneeded 'mut', pattern is already marked as mutable")]
-    UnnecessaryMut { first_mut: Span, second_mut: Span }
+    UnnecessaryMut { first_mut: Span, second_mut: Span },
 }
 
 impl ResolverError {
@@ -168,11 +168,21 @@ impl ResolverError {
                 );
                 error
             }
-            ResolverError::UnnecessaryMut { first_mut, second_mut } => {
-                let mut error = Diagnostic::simple_error("'mut' here is not necessary".to_owned(), "".to_owned(), second_mut);
-                error.add_secondary("Pattern was already made mutable from this 'mut'".to_owned(), first_mut);
+            ResolverError::UnnecessaryMut {
+                first_mut,
+                second_mut,
+            } => {
+                let mut error = Diagnostic::simple_error(
+                    "'mut' here is not necessary".to_owned(),
+                    "".to_owned(),
+                    second_mut,
+                );
+                error.add_secondary(
+                    "Pattern was already made mutable from this 'mut'".to_owned(),
+                    first_mut,
+                );
                 error
-            },
+            }
         }
     }
 }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 use crate::graph::CrateId;
 use crate::hir::def_map::{ModuleDefId, TryFromModuleDefId};
 use crate::hir_def::expr::HirExpression;
-use crate::hir_def::stmt::HirAssignStatement;
+use crate::hir_def::stmt::{HirAssignStatement, HirPattern};
 use crate::node_interner::{ExprId, FuncId, IdentId, NodeInterner, StmtId, TypeId};
 use crate::util::vecmap;
 use crate::{
@@ -36,7 +36,7 @@ use crate::{
     BlockExpression, Expression, ExpressionKind, FunctionKind, Ident, Literal, NoirFunction,
     Statement,
 };
-use crate::{Path, StructType, ERROR_IDENT};
+use crate::{Path, StructType, ERROR_IDENT, Pattern};
 use noirc_errors::{Span, Spanned};
 
 use crate::hir::scope::{
@@ -221,10 +221,9 @@ impl<'a> Resolver<'a> {
         let attributes = func.attribute().cloned();
 
         let mut parameters = Vec::new();
-        for (ident, typ) in func.parameters().iter().cloned() {
-            let ident_id = self.add_variable_decl(ident.clone());
-
-            parameters.push(Param(ident_id, typ));
+        for (pattern, typ) in func.parameters().iter().cloned() {
+            let pattern = self.resolve_pattern(pattern);
+            parameters.push(Param(pattern, typ));
         }
 
         let return_type = func.return_type();
@@ -242,10 +241,8 @@ impl<'a> Resolver<'a> {
     pub fn intern_stmt(&mut self, stmt: Statement) -> StmtId {
         match stmt {
             Statement::Let(let_stmt) => {
-                let id = self.add_variable_decl(let_stmt.identifier);
-
                 let let_stmt = HirLetStatement {
-                    identifier: id,
+                    pattern: self.resolve_pattern(let_stmt.pattern),
                     r#type: let_stmt.r#type,
                     expression: self.intern_expr(let_stmt.expression),
                 };
@@ -253,10 +250,8 @@ impl<'a> Resolver<'a> {
                 self.interner.push_stmt(HirStatement::Let(let_stmt))
             }
             Statement::Const(const_stmt) => {
-                let id = self.add_variable_decl(const_stmt.identifier);
-
                 let const_stmt = HirConstStatement {
-                    identifier: id,
+                    pattern: self.resolve_pattern(const_stmt.pattern),
                     r#type: const_stmt.r#type,
                     expression: self.intern_expr(const_stmt.expression),
                 };
@@ -273,11 +268,9 @@ impl<'a> Resolver<'a> {
                 self.interner.push_stmt(HirStatement::Constrain(stmt))
             }
             Statement::Private(priv_stmt) => {
-                let identifier = self.add_variable_decl(priv_stmt.identifier);
-                let expression = self.resolve_expression(priv_stmt.expression);
                 let stmt = HirPrivateStatement {
-                    identifier,
-                    expression,
+                    pattern: self.resolve_pattern(priv_stmt.pattern),
+                    expression: self.resolve_expression(priv_stmt.expression),
                     r#type: priv_stmt.r#type,
                 };
                 self.interner.push_stmt(HirStatement::Private(stmt))
@@ -392,7 +385,7 @@ impl<'a> Resolver<'a> {
                 let type_id = self.lookup_type(constructor.type_name);
                 HirExpression::Constructor(HirConstructorExpression {
                     type_id,
-                    fields: self.resolve_constructor_fields(type_id, constructor.fields, span),
+                    fields: self.resolve_constructor_fields(type_id, constructor.fields, span, Resolver::resolve_expression),
                     r#type: self.get_struct(type_id),
                 })
             }
@@ -412,21 +405,62 @@ impl<'a> Resolver<'a> {
         expr_id
     }
 
+    fn resolve_pattern(&mut self, pattern: Pattern) -> HirPattern {
+        self.resolve_pattern_mutable(pattern, None)
+    }
+
+    fn resolve_pattern_mutable(&mut self, pattern: Pattern, mutable: Option<Span>) -> HirPattern {
+        match pattern {
+            Pattern::Identifier(name) => {
+                let id = self.interner.push_ident(name);
+                HirPattern::Identifier(id)
+            },
+            Pattern::Mutable(pattern, span) => {
+                if let Some(first_mut) = mutable {
+                    self.push_err(ResolverError::UnnecessaryMut {
+                        first_mut,
+                        second_mut: span,
+                    })
+                }
+
+                let pattern = self.resolve_pattern_mutable(*pattern, Some(span));
+                HirPattern::Mutable(Box::new(pattern), span)
+            }
+            Pattern::Tuple(fields, span) => {
+                let fields = vecmap(fields, |field| self.resolve_pattern_mutable(field, mutable));
+                HirPattern::Tuple(fields, span)
+            },
+            Pattern::Struct(name, fields, span) => {
+                let struct_id = self.lookup_type(name);
+                let struct_type = self.get_struct(struct_id);
+                let resolve_field = |this: &mut Self, pattern| this.resolve_pattern_mutable(pattern, mutable);
+                let fields = self.resolve_constructor_fields(struct_id, fields, span, resolve_field);
+                HirPattern::Struct(struct_type, fields, span)
+            },
+        }
+    }
+
     /// Resolve all the fields of a struct constructor expression.
     /// Ensures all fields are present, none are repeated, and all
     /// are part of the struct.
-    fn resolve_constructor_fields(
+    ///
+    /// This is generic to allow it to work for constructor expressions
+    /// and constructor patterns.
+    fn resolve_constructor_fields<T, U, F>(
         &mut self,
         type_id: TypeId,
-        fields: Vec<(Ident, Expression)>,
+        fields: Vec<(Ident, T)>,
         span: Span,
-    ) -> Vec<(IdentId, ExprId)> {
+        mut resolve_function: F,
+    ) -> Vec<(IdentId, U)>
+        where F: FnMut(&mut Self, T) -> U
+    {
         let mut ret = Vec::with_capacity(fields.len());
         let mut seen_fields = HashSet::new();
         let mut unseen_fields = self.get_field_names_of_type(type_id);
 
         for (field, expr) in fields {
-            let expr_id = self.resolve_expression(expr);
+            let resolved = resolve_function(self, expr);
 
             if unseen_fields.contains(&field) {
                 unseen_fields.remove(&field);
@@ -445,7 +479,7 @@ impl<'a> Resolver<'a> {
             }
 
             let name_id = self.interner.push_ident(field);
-            ret.push((name_id, expr_id));
+            ret.push((name_id, resolved));
         }
 
         if !unseen_fields.is_empty() {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -392,7 +392,7 @@ impl<'a> Resolver<'a> {
     fn resolve_pattern_mutable(&mut self, pattern: Pattern, mutable: Option<Span>) -> HirPattern {
         match pattern {
             Pattern::Identifier(name) => {
-                let id = self.interner.push_ident(name);
+                let id = self.add_variable_decl(name);
                 HirPattern::Identifier(id)
             },
             Pattern::Mutable(pattern, span) => {

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -137,7 +137,11 @@ mod test {
             name: String::from("test_func"),
             kind: FunctionKind::Normal,
             attributes: None,
-            parameters: vec![Param(Identifier(x_id), Type::WITNESS), Param(Identifier(y_id), Type::WITNESS)].into(),
+            parameters: vec![
+                Param(Identifier(x_id), Type::WITNESS),
+                Param(Identifier(y_id), Type::WITNESS),
+            ]
+            .into(),
             return_type: Type::Unit,
             has_body: true,
         };

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -57,7 +57,7 @@ pub fn bind_pattern(
 ) {
     match pattern {
         HirPattern::Identifier(id) => interner.push_ident_type(id, typ),
-        HirPattern::Mutable(pattern, _) => bind_pattern(interner, &pattern, typ, errors),
+        HirPattern::Mutable(pattern, _) => bind_pattern(interner, pattern, typ, errors),
         HirPattern::Tuple(_fields, _span) => {
             todo!("Implement tuple types")
         }

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -1,5 +1,5 @@
 use crate::hir_def::stmt::{
-    HirAssignStatement, HirConstrainStatement, HirLetStatement, HirStatement, HirPattern,
+    HirAssignStatement, HirConstrainStatement, HirLetStatement, HirPattern, HirStatement,
 };
 use crate::node_interner::{ExprId, NodeInterner, StmtId};
 use crate::Type;
@@ -60,31 +60,27 @@ pub fn bind_pattern(
         HirPattern::Mutable(pattern, _) => bind_pattern(interner, &pattern, typ, errors),
         HirPattern::Tuple(_fields, _span) => {
             todo!("Implement tuple types")
-        },
-        HirPattern::Struct(struct_type, fields, span) => {
-            match typ {
-                Type::Struct(inner) if inner.id == struct_type.id => {
-                    let mut pattern_fields = fields.clone();
-                    let mut type_fields = inner.fields.clone();
+        }
+        HirPattern::Struct(struct_type, fields, span) => match typ {
+            Type::Struct(inner) if inner.id == struct_type.id => {
+                let mut pattern_fields = fields.clone();
+                let mut type_fields = inner.fields.clone();
 
-                    pattern_fields.sort_by_key(|(id, _)| {
-                        interner.ident(id)
-                    });
-                    type_fields.sort_by_key(|(ident, _)| ident.clone());
+                pattern_fields.sort_by_key(|(id, _)| interner.ident(id));
+                type_fields.sort_by_key(|(ident, _)| ident.clone());
 
-                    for (pattern_field, type_field) in pattern_fields.into_iter().zip(type_fields) {
-                        assert_eq!(interner.ident(&pattern_field.0), type_field.0);
-                        bind_pattern(interner, &pattern_field.1, type_field.1, errors);
-                    }
-                },
-                Type::Error => (),
-                other => {
-                    errors.push(TypeCheckError::TypeMismatch {
-                        expected_typ: other.to_string(),
-                        expr_typ: other.to_string(),
-                        expr_span: *span,
-                    });
+                for (pattern_field, type_field) in pattern_fields.into_iter().zip(type_fields) {
+                    assert_eq!(interner.ident(&pattern_field.0), type_field.0);
+                    bind_pattern(interner, &pattern_field.1, type_field.1, errors);
                 }
+            }
+            Type::Error => (),
+            other => {
+                errors.push(TypeCheckError::TypeMismatch {
+                    expected_typ: other.to_string(),
+                    expr_typ: other.to_string(),
+                    expr_span: *span,
+                });
             }
         },
     }

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -58,7 +58,8 @@ pub struct Parameters(Vec<Param>);
 impl Parameters {
     pub fn into_abi(self, interner: &NodeInterner) -> Abi {
         let parameters = vecmap(self.0, |param| {
-            let param_name = get_param_name(&param.0, interner).expect("Abi for tuple and struct parameters is unimplemented");
+            let param_name = get_param_name(&param.0, interner)
+                .expect("Abi for tuple and struct parameters is unimplemented");
             (param_name, param.1.as_abi_type())
         });
         noirc_abi::Abi { parameters }

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -2,7 +2,8 @@ use noirc_abi::Abi;
 use noirc_errors::Span;
 
 use super::expr::{HirBlockExpression, HirExpression};
-use crate::node_interner::{ExprId, IdentId, NodeInterner};
+use super::stmt::HirPattern;
+use crate::node_interner::{ExprId, NodeInterner};
 use crate::util::vecmap;
 use crate::{token::Attribute, FunctionKind, Type};
 
@@ -38,7 +39,18 @@ impl HirFunction {
 
 /// An interned function parameter from a function definition
 #[derive(Debug, Clone)]
-pub struct Param(pub IdentId, pub Type);
+pub struct Param(pub HirPattern, pub Type);
+
+/// Attempts to retrieve the name of this parameter. Returns None
+/// if this parameter is a tuple or struct pattern.
+fn get_param_name(pattern: &HirPattern, interner: &NodeInterner) -> Option<String> {
+    match pattern {
+        HirPattern::Identifier(id) => Some(interner.ident_name(id)),
+        HirPattern::Mutable(pattern, _) => get_param_name(pattern, interner),
+        HirPattern::Tuple(_, _) => None,
+        HirPattern::Struct(_, _, _) => None,
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Parameters(Vec<Param>);
@@ -46,16 +58,20 @@ pub struct Parameters(Vec<Param>);
 impl Parameters {
     pub fn into_abi(self, interner: &NodeInterner) -> Abi {
         let parameters = vecmap(self.0, |param| {
-            let (param_id, param_type) = (param.0, param.1);
-            let param_name = interner.ident_name(&param_id);
-            (param_name, param_type.as_abi_type())
+            let param_name = get_param_name(&param.0, interner).expect("Abi for tuple and struct parameters is unimplemented");
+            (param_name, param.1.as_abi_type())
         });
         noirc_abi::Abi { parameters }
     }
 
     pub fn span(&self, interner: &NodeInterner) -> Span {
         assert!(!self.is_empty());
-        let mut spans = vecmap(&self.0, |param| interner.ident_span(&param.0));
+        let mut spans = vecmap(&self.0, |param| match &param.0 {
+            HirPattern::Identifier(id) => interner.ident_span(id),
+            HirPattern::Mutable(_, span) => *span,
+            HirPattern::Tuple(_, span) => *span,
+            HirPattern::Struct(_, _, span) => *span,
+        });
 
         let merged_span = spans.pop().unwrap();
         for span in spans {

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -4,7 +4,7 @@ use noirc_errors::Span;
 
 use super::expr::HirInfixExpression;
 use crate::node_interner::{ExprId, IdentId};
-use crate::{Type, StructType};
+use crate::{StructType, Type};
 
 #[derive(Debug, Clone)]
 pub struct HirLetStatement {
@@ -44,5 +44,5 @@ pub enum HirPattern {
     Identifier(IdentId),
     Mutable(Box<HirPattern>, Span),
     Tuple(Vec<HirPattern>, Span),
-    Struct(Rc<StructType>, Vec<(IdentId, HirPattern)>, Span)
+    Struct(Rc<StructType>, Vec<(IdentId, HirPattern)>, Span),
 }

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -1,17 +1,21 @@
-use crate::Type;
+use std::rc::Rc;
+
+use noirc_errors::Span;
+
+use crate::{Type, StructType};
 
 use super::expr::HirInfixExpression;
 use crate::node_interner::{ExprId, IdentId};
 #[derive(Debug, Clone)]
 pub struct HirLetStatement {
-    pub identifier: IdentId,
+    pub pattern: HirPattern,
     pub r#type: Type,
     pub expression: ExprId,
 }
 
 #[derive(Debug, Clone)]
 pub struct HirConstStatement {
-    pub identifier: IdentId,
+    pub pattern: HirPattern,
     pub r#type: Type,
     pub expression: ExprId,
 }
@@ -26,7 +30,7 @@ pub struct HirPublicStatement {
 
 #[derive(Debug, Clone)]
 pub struct HirPrivateStatement {
-    pub identifier: IdentId,
+    pub pattern: HirPattern,
     pub r#type: Type,
     pub expression: ExprId,
 }
@@ -38,12 +42,14 @@ pub struct HirAssignStatement {
 
 #[derive(Debug, Clone)]
 pub struct HirConstrainStatement(pub HirInfixExpression);
+
 #[derive(Debug, Clone)]
 pub struct BinaryStatement {
     pub lhs: ExprId,
     pub r#type: Type,
     pub expression: ExprId,
 }
+
 #[derive(Debug, Clone)]
 pub enum HirStatement {
     Let(HirLetStatement),
@@ -54,4 +60,12 @@ pub enum HirStatement {
     Expression(ExprId),
     Semi(ExprId),
     Error,
+}
+
+#[derive(Debug, Clone)]
+pub enum HirPattern {
+    Identifier(IdentId),
+    Mutable(Box<HirPattern>, Span),
+    Tuple(Vec<HirPattern>, Span),
+    Struct(Rc<StructType>, Vec<(IdentId, HirPattern)>, Span)
 }

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -417,6 +417,7 @@ pub enum Keyword {
     In,
     Use,
     Constrain,
+    Mut,
     // Field types
     Pub,
     Priv,
@@ -444,6 +445,7 @@ impl fmt::Display for Keyword {
             Keyword::Else => write!(f, "else"),
             Keyword::While => write!(f, "while"),
             Keyword::Constrain => write!(f, "constrain"),
+            Keyword::Mut => write!(f, "mut"),
             Keyword::Let => write!(f, "let"),
             Keyword::As => write!(f, "as"),
             Keyword::Use => write!(f, "use"),
@@ -473,6 +475,7 @@ impl Keyword {
             "else" => Some(Token::Keyword(Keyword::Else)),
             "while" => Some(Token::Keyword(Keyword::While)),
             "constrain" => Some(Token::Keyword(Keyword::Constrain)),
+            "mut" => Some(Token::Keyword(Keyword::Mut)),
             "let" => Some(Token::Keyword(Keyword::Let)),
             "as" => Some(Token::Keyword(Keyword::As)),
             "use" => Some(Token::Keyword(Keyword::Use)),

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -104,8 +104,7 @@ fn attribute() -> impl NoirParser<Attribute> {
 }
 
 fn struct_fields() -> impl NoirParser<Vec<(Ident, Type)>> {
-    let type_parser =
-        parse_type_with_visibility(optional_const(), parse_type_no_field_element());
+    let type_parser = parse_type_with_visibility(optional_const(), parse_type_no_field_element());
 
     ident()
         .then_ignore(just(Token::Colon))

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -13,7 +13,7 @@ use crate::{
 use crate::{
     AssignStatement, BinaryOp, BinaryOpKind, BlockExpression, ConstrainStatement, ForExpression,
     FunctionDefinition, Ident, IfExpression, ImportStatement, InfixExpression, NoirStruct, Path,
-    PathKind, UnaryOp,
+    PathKind, Pattern, UnaryOp,
 };
 
 use chumsky::prelude::*;
@@ -104,23 +104,20 @@ fn attribute() -> impl NoirParser<Attribute> {
 }
 
 fn struct_fields() -> impl NoirParser<Vec<(Ident, Type)>> {
-    parameters(parse_type_with_visibility(
-        optional_pri_or_const(),
-        parse_type_no_field_element(),
-    ))
-}
+    let type_parser =
+        parse_type_with_visibility(optional_pri_or_const(), parse_type_no_field_element());
 
-fn function_parameters() -> impl NoirParser<Vec<(Ident, Type)>> {
-    parameters(parse_type())
-}
-
-fn parameters<P>(type_parser: P) -> impl NoirParser<Vec<(Ident, Type)>>
-where
-    P: NoirParser<Type>,
-{
     ident()
         .then_ignore(just(Token::Colon))
         .then(type_parser)
+        .separated_by(just(Token::Comma))
+        .allow_trailing()
+}
+
+fn function_parameters() -> impl NoirParser<Vec<(Pattern, Type)>> {
+    pattern()
+        .then_ignore(just(Token::Colon))
+        .then(parse_type())
         .separated_by(just(Token::Comma))
         .allow_trailing()
 }
@@ -279,15 +276,46 @@ fn generic_declaration<'a, F, P>(
     f: F,
 ) -> impl NoirParser<Statement> + 'a
 where
-    F: 'a + Clone + Fn(((Ident, Type), Expression)) -> Statement,
+    F: 'a + Clone + Fn(((Pattern, Type), Expression)) -> Statement,
     P: ExprParser + 'a,
 {
-    let p = ignore_then_commit(keyword(key).labelled("statement"), ident());
+    let p = ignore_then_commit(keyword(key).labelled("statement"), pattern());
     let p = p.then(optional_type_annotation());
     let p = then_commit_ignore(p, just(Token::Assign));
     let p = then_commit(p, expr_parser);
 
     p.map(f)
+}
+
+fn pattern() -> impl NoirParser<Pattern> {
+    recursive(|pattern| {
+        let ident_pattern = ident().map(|name| Pattern::Identifier(name));
+
+        let mut_pattern = keyword(Keyword::Mut)
+            .ignore_then(ident())
+            .map(|name| Pattern::Mutable(name));
+
+        let shortfield = ident().map(|name| (name.clone(), Pattern::Identifier(name)));
+        let longfield = ident()
+            .then_ignore(just(Token::Colon))
+            .then(pattern.clone());
+
+        let struct_pattern_fields = longfield
+            .or(shortfield)
+            .separated_by(just(Token::Comma))
+            .delimited_by(just(Token::LeftBrace), just(Token::RightBrace));
+
+        let struct_pattern = ident()
+            .then(struct_pattern_fields)
+            .map(|(typename, fields)| Pattern::Struct(typename, fields));
+
+        let tuple_pattern = pattern
+            .separated_by(just(Token::Comma))
+            .delimited_by(just(Token::LeftParen), just(Token::RightParen))
+            .map(|fields| Pattern::Tuple(fields));
+
+        choice((mut_pattern, tuple_pattern, struct_pattern, ident_pattern))
+    })
 }
 
 fn assignment<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -270,7 +270,7 @@ where
 
 fn pattern() -> impl NoirParser<Pattern> {
     recursive(|pattern| {
-        let ident_pattern = ident().map(|name| Pattern::Identifier(name));
+        let ident_pattern = ident().map(Pattern::Identifier);
 
         let mut_pattern = keyword(Keyword::Mut)
             .ignore_then(pattern.clone())
@@ -293,7 +293,7 @@ fn pattern() -> impl NoirParser<Pattern> {
         let tuple_pattern = pattern
             .separated_by(just(Token::Comma))
             .delimited_by(just(Token::LeftParen), just(Token::RightParen))
-            .map_with_span(|fields, span| Pattern::Tuple(fields, span));
+            .map_with_span(Pattern::Tuple);
 
         choice((mut_pattern, tuple_pattern, struct_pattern, ident_pattern))
     })


### PR DESCRIPTION
This adds support for the above patterns which allows for:
- Destructuring structs:
```rs
let Foo { a, b: bar } = Foo { a: 0, b: 1 };
a + bar
```
- Destructuring tuples:
```rs
let (a, b, c) = (1, 2, (3, 4));
a + b
```
- Mut patterns:
```
let mut a = 32;
a = 5;
let mut (b, c) = (1, 2);
let (d, mut e) = (3, 4);
// ...etc
```
- And identifier patterns.

Note that some functionality to fully make use of these patterns is still unimplemented:
- Structs and tuples are not implemented in the backend
- Tuples are not implemented at all, this PR is their first inclusion in noir.
- Mutability of a variable isn't tracked yet. Ideally we track this and issue an error when attempting to mutate an immutable variable.