### PR TITLE
Use typed IDs over arena::Index in ssa pass

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -1,7 +1,6 @@
 use super::node::NodeId;
 use super::node::{Instruction, Operation};
 use acvm::FieldElement;
-use arena::Index;
 use num_traits::One;
 use num_traits::Zero;
 use std::cmp::Ordering;
@@ -57,7 +56,7 @@ impl Acir {
         if self.arith_cache.contains_key(&id) {
             return self.arith_cache[&id].clone();
         }
-        let var = match irgen.rename_me_get_object(id) {
+        let var = match irgen.try_get_node(id) {
             Some(node::NodeObj::Const(c)) => {
                 let f_value = FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be()); //TODO const should be a field
                 let expr = Arithmetic {

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -1,5 +1,7 @@
-use super::{code_gen::IRGenerator, node};
-use arena::Index;
+use super::{
+    code_gen::IRGenerator,
+    node::{self, NodeId},
+};
 use std::collections::{HashMap, VecDeque};
 
 #[derive(PartialEq, Debug)]
@@ -8,23 +10,32 @@ pub enum BlockType {
     ForJoin,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct BlockId(pub arena::Index);
+
+impl BlockId {
+    pub fn dummy() -> BlockId {
+        BlockId(IRGenerator::dummy_id())
+    }
+}
+
 #[derive(Debug)]
 pub struct BasicBlock {
-    pub idx: arena::Index,
+    pub id: BlockId,
     pub kind: BlockType,
-    pub dominator: Option<arena::Index>, //direct dominator
-    pub dominated: Vec<arena::Index>,    //dominated sons
-    pub predecessor: Vec<arena::Index>,  //for computing the dominator tree
-    pub left: Option<arena::Index>,      //sequential successor
-    pub right: Option<arena::Index>,     //jump successor
-    pub instructions: Vec<arena::Index>,
-    pub value_map: HashMap<arena::Index, arena::Index>, //for generating the ssa form
+    pub dominator: Option<BlockId>, //direct dominator
+    pub dominated: Vec<BlockId>,    //dominated sons
+    pub predecessor: Vec<BlockId>,  //for computing the dominator tree
+    pub left: Option<BlockId>,      //sequential successor
+    pub right: Option<BlockId>,     //jump successor
+    pub instructions: Vec<NodeId>,
+    pub value_map: HashMap<NodeId, NodeId>, //for generating the ssa form
 }
 
 impl BasicBlock {
-    pub fn new(prev: arena::Index, kind: BlockType) -> BasicBlock {
+    pub fn new(prev: BlockId, kind: BlockType) -> BasicBlock {
         BasicBlock {
-            idx: crate::ssa::code_gen::IRGenerator::dummy_id(),
+            id: BlockId(IRGenerator::dummy_id()),
             predecessor: vec![prev],
             left: None,
             right: None,
@@ -36,17 +47,17 @@ impl BasicBlock {
         }
     }
 
-    pub fn get_current_value(&self, idx: arena::Index) -> Option<arena::Index> {
-        self.value_map.get(&idx).copied()
+    pub fn get_current_value(&self, id: NodeId) -> Option<NodeId> {
+        self.value_map.get(&id).copied()
     }
 
     //When generating a new instance of a variable because of ssa, we update the value array
     //to link the two variables
-    pub fn update_variable(&mut self, old_value: arena::Index, new_value: arena::Index) {
+    pub fn update_variable(&mut self, old_value: NodeId, new_value: NodeId) {
         self.value_map.insert(old_value, new_value);
     }
 
-    pub fn get_first_instruction(&self) -> arena::Index {
+    pub fn get_first_instruction(&self) -> NodeId {
         self.instructions[0]
     }
 
@@ -55,18 +66,14 @@ impl BasicBlock {
     }
 }
 
-///////////
-
 pub fn create_first_block(igen: &mut IRGenerator) {
-    let first_block = BasicBlock::new(igen.dummy(), BlockType::Normal);
-    let new_idx = igen.blocks.insert(first_block);
-    let block2 = igen.blocks.get_mut(new_idx).unwrap(); //RIA..
-    block2.idx = new_idx;
-    igen.first_block = new_idx;
-    igen.current_block = new_idx;
+    let first_block = BasicBlock::new(BlockId::dummy(), BlockType::Normal);
+    let first_block = igen.insert_block(first_block);
+    igen.first_block = first_block.id;
+    igen.current_block = first_block.id;
     igen.new_instruction(
-        igen.dummy(),
-        igen.dummy(),
+        NodeId::dummy(),
+        NodeId::dummy(),
         node::Operation::Nop,
         node::ObjectType::NotAnObject,
     );
@@ -74,42 +81,43 @@ pub fn create_first_block(igen: &mut IRGenerator) {
 
 //Creates a new sealed block (i.e whose predecessors are known)
 //It is not suitable for the first block because it uses the current block.
-pub fn new_sealed_block(igen: &mut IRGenerator, kind: BlockType) -> arena::Index {
+pub fn new_sealed_block(igen: &mut IRGenerator, kind: BlockType) -> BlockId {
     let new_block = BasicBlock::new(igen.current_block, kind);
-    let new_idx = igen.blocks.insert(new_block);
-    let block2 = igen.blocks.get_mut(new_idx).unwrap(); //RIA..
-    block2.idx = new_idx;
-    block2.dominator = Some(igen.current_block);
-    igen.sealed_blocks.insert(new_idx);
+    let new_block = igen.insert_block(new_block);
+    new_block.dominator = Some(igen.current_block);
+    igen.sealed_blocks.insert(new_block.id);
+
     //update current block
-    let cb = igen.get_block_mut(igen.current_block).unwrap();
-    cb.left = Some(new_idx);
-    igen.current_block = new_idx;
+    let cb = igen.get_current_block_mut();
+    cb.left = Some(new_block.id);
+    igen.current_block = new_block.id;
     igen.new_instruction(
-        igen.dummy(),
-        igen.dummy(),
+        NodeId::dummy(),
+        NodeId::dummy(),
         node::Operation::Nop,
         node::ObjectType::NotAnObject,
     );
-    new_idx
+    new_block.id
 }
 
 //if left is true, the new block is left to the current block
-pub fn new_unsealed_block(igen: &mut IRGenerator, kind: BlockType, left: bool) -> arena::Index {
-    let new_idx = create_block(igen, kind);
-    let block2 = igen.blocks.get_mut(new_idx).unwrap(); //RIA..
-    block2.dominator = Some(igen.current_block);
+pub fn new_unsealed_block(igen: &mut IRGenerator, kind: BlockType, left: bool) -> BlockId {
+    let new_block = create_block(igen, kind);
+    new_block.dominator = Some(igen.current_block);
+    let new_idx = new_block.id;
+
     //update current block
-    let cb = igen.get_block_mut(igen.current_block).unwrap();
+    let cb = igen.get_current_block_mut();
     if left {
         cb.left = Some(new_idx);
     } else {
         cb.right = Some(new_idx);
     }
+
     igen.current_block = new_idx;
     igen.new_instruction(
-        igen.dummy(),
-        igen.dummy(),
+        NodeId::dummy(),
+        NodeId::dummy(),
         node::Operation::Nop,
         node::ObjectType::NotAnObject,
     );
@@ -117,53 +125,43 @@ pub fn new_unsealed_block(igen: &mut IRGenerator, kind: BlockType, left: bool) -
 }
 
 //create a block and sets its id, but do not update current block, and do not add dummy instruction!
-pub fn create_block(igen: &mut IRGenerator, kind: BlockType) -> arena::Index {
+pub fn create_block<'a>(igen: &'a mut IRGenerator, kind: BlockType) -> &'a mut BasicBlock {
     let new_block = BasicBlock::new(igen.current_block, kind);
-    let new_idx = igen.blocks.insert(new_block);
-    let block2 = igen.blocks.get_mut(new_idx).unwrap(); //RIA..
-    block2.idx = new_idx;
-    new_idx
+    igen.insert_block(new_block)
 }
 
 //link the current block to the target block so that current block becomes its target
 pub fn link_with_target(
     igen: &mut IRGenerator,
-    target: arena::Index,
-    left: Option<arena::Index>,
-    right: Option<arena::Index>,
+    target: BlockId,
+    left: Option<BlockId>,
+    right: Option<BlockId>,
 ) {
-    if let Some(target_block) = igen.get_block_mut(target) {
+    if let Some(target_block) = igen.rename_me_get_block_mut(target) {
         target_block.right = right;
         target_block.left = left;
         //TODO should also update the last instruction rhs to the first instruction of the current block  -- TODOshoud we do it here??
         if let Some(right_uw) = right {
-            let rb = igen.get_block_mut(right_uw);
-            rb.unwrap().dominator = Some(target);
+            igen[right_uw].dominator = Some(target);
         }
         if let Some(left_uw) = left {
-            let lb = igen.get_block_mut(left_uw);
-            lb.unwrap().dominator = Some(target);
+            igen[left_uw].dominator = Some(target);
         }
     }
 }
 
 pub fn compute_dom(igen: &mut IRGenerator) {
-    let mut dominator_link: HashMap<arena::Index, Vec<arena::Index>> = HashMap::new();
-    for (idx, block) in &igen.blocks {
+    let mut dominator_link = HashMap::new();
+
+    for block in igen.iter_blocks() {
         if let Some(dom) = block.dominator {
-            if dominator_link.contains_key(&dom) {
-                let mut v = dominator_link[&dom].clone(); //TODO can we avoid it?
-                v.push(idx);
-                dominator_link.insert(dom, v);
-            } else {
-                dominator_link.insert(dom, [idx].to_vec());
-            }
+            dominator_link.entry(dom).or_insert(vec![]).push(block.id);
             // dom_block.dominated.push(idx);
         }
     }
     //RIA
     for (master, svec) in dominator_link {
-        let dom_b = igen.get_block_mut(master).unwrap();
+        let dom_b = &mut igen[master];
         for slave in svec {
             dom_b.dominated.push(slave);
         }
@@ -171,26 +169,26 @@ pub fn compute_dom(igen: &mut IRGenerator) {
 }
 
 //breadth-first traversal of the CFG, from start, until we reach stop
-pub fn bfs(start: Index, stop: Index, eval: &IRGenerator) -> Vec<Index> {
+pub fn bfs(start: BlockId, stop: BlockId, igen: &IRGenerator) -> Vec<BlockId> {
     let mut result = vec![start]; //list of blocks in the visited subgraph
-    let mut queue: VecDeque<Index> = VecDeque::new(); //Queue of elements to visit
+    let mut queue = VecDeque::new(); //Queue of elements to visit
     queue.push_back(start);
+
     while !queue.is_empty() {
-        let b = queue.pop_front().unwrap();
-        if let Some(block) = eval.try_get_block(b) {
-            if let Some(left) = block.left {
-                if left != stop && !result.contains(&left) {
-                    result.push(left);
-                    queue.push_back(left);
+        // TODO: Change back to if let if this fails
+        let test_and_push = |block_opt| {
+            if let Some(block_id) = block_opt {
+                if block_id != stop && !result.contains(&block_id) {
+                    result.push(block_id);
+                    queue.push_back(block_id);
                 }
             }
-            if let Some(right) = block.right {
-                if right != stop && !result.contains(&right) {
-                    result.push(right);
-                    queue.push_back(right);
-                }
-            }
-        }
+        };
+
+        let block = &igen[queue.pop_front().unwrap()];
+        test_and_push(block.left);
+        test_and_push(block.right);
     }
+
     result
 }

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -142,7 +142,7 @@ pub fn link_with_target(
     left: Option<BlockId>,
     right: Option<BlockId>,
 ) {
-    if let Some(target_block) = igen.rename_me_get_block_mut(target) {
+    if let Some(target_block) = igen.try_get_block_mut(target) {
         target_block.right = right;
         target_block.left = left;
         //TODO should also update the last instruction rhs to the first instruction of the current block  -- TODOshoud we do it here??

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -1,3 +1,5 @@
+use super::block::{BasicBlock, BlockId};
+use super::node::{Instruction, NodeId, NodeObj, Operation};
 use super::{block, flatten, integer, node, optim, ssa_form};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -29,13 +31,13 @@ use num_bigint::BigUint;
 pub struct IRGenerator<'a> {
     pub context: Option<&'a Context>,
 
-    pub first_block: arena::Index,
-    pub current_block: arena::Index,
-    pub blocks: arena::Arena<block::BasicBlock>,
+    pub first_block: BlockId,
+    pub current_block: BlockId,
+    blocks: arena::Arena<block::BasicBlock>,
     pub nodes: arena::Arena<node::NodeObj>,
     pub id0: arena::Index, //dummy index.. should we put a dummy object somewhere?
-    pub value_name: HashMap<arena::Index, u32>,
-    pub sealed_blocks: HashSet<arena::Index>,
+    pub value_name: HashMap<NodeId, u32>,
+    pub sealed_blocks: HashSet<BlockId>,
 }
 
 impl<'a> IRGenerator<'a> {
@@ -43,40 +45,47 @@ impl<'a> IRGenerator<'a> {
         let mut pc = IRGenerator {
             context: Some(context),
             id0: IRGenerator::dummy_id(),
-            first_block: IRGenerator::dummy_id(),
-            current_block: IRGenerator::dummy_id(),
+            first_block: BlockId::dummy(),
+            current_block: BlockId::dummy(),
             blocks: arena::Arena::new(),
             nodes: arena::Arena::new(),
             // dummy_instruction: ParsingContext::dummy_id(),
             value_name: HashMap::new(),
             sealed_blocks: HashSet::new(),
-        }; //, objects: arena::Arena::new()
+        };
         block::create_first_block(&mut pc);
         pc
     }
 
+    pub fn insert_block(&mut self, block: BasicBlock) -> &mut BasicBlock {
+        let id = self.blocks.insert(block);
+        let block = &mut self.blocks[id];
+        block.id = BlockId(id);
+        block
+    }
+
     //Display an object for debugging puposes
-    fn to_string(&self, idx: arena::Index) -> String {
-        if let Some(var) = self.get_object(idx) {
+    fn node_to_string(&self, id: NodeId) -> String {
+        if let Some(var) = self.rename_me_get_object(id) {
             return format!("{}", var);
         } else {
-            return format!("unknown {:?}", idx.into_raw_parts().0);
+            return format!("unknown {:?}", id.0.into_raw_parts().0);
         }
     }
 
     pub fn print_block(&self, b: &block::BasicBlock) {
-        for idx in &b.instructions {
-            let ins = self.get_instruction(*idx);
+        for id in &b.instructions {
+            let ins = self.get_instruction(*id);
             let mut str_res = if ins.res_name.is_empty() {
-                format!("{:?}", idx.into_raw_parts().0)
+                format!("{:?}", id.0.into_raw_parts().0)
             } else {
                 ins.res_name.clone()
             };
             if ins.is_deleted {
                 str_res += " -DELETED";
             }
-            let lhs_str = self.to_string(ins.lhs);
-            let rhs_str = self.to_string(ins.rhs);
+            let lhs_str = self.node_to_string(ins.lhs);
+            let rhs_str = self.node_to_string(ins.rhs);
             let mut ins_str = format!("{} op:{:?} {}", lhs_str, ins.operator, rhs_str);
 
             if ins.operator == node::Operation::Phi {
@@ -101,21 +110,38 @@ impl<'a> IRGenerator<'a> {
         self.context.unwrap()
     }
 
-    //Add an object to the nodes arena and set its id
-    pub fn add_object(&mut self, obj: node::NodeObj) -> arena::Index {
-        let idx = self.nodes.insert(obj);
-        let obj2 = self.nodes.get_mut(idx).unwrap(); //TODO-RIA can we avoid this? and simply modify obj?
-        match obj2 {
-            node::NodeObj::Obj(o) => o.id = idx,
-            node::NodeObj::Instr(i) => {
-                i.idx = idx;
-                let cb = self.get_current_block_mut();
-                cb.instructions.push(idx);
-            }
-            node::NodeObj::Const(c) => c.id = idx,
+    /// Add an instruction to self.nodes and sets its id.
+    /// This function does NOT push the instruction to the current block.
+    /// See push_instruction for that.
+    pub fn add_instruction(&mut self, instruction: node::Instruction) -> NodeId {
+        let obj = NodeObj::Instr(instruction);
+        let id = NodeId(self.nodes.insert(obj));
+        match &mut self[id] {
+            NodeObj::Instr(i) => i.id = id,
+            _ => unreachable!(),
         }
 
-        idx
+        id
+    }
+
+    /// Adds the instruction to self.nodes and pushes it to the current block
+    pub fn push_instruction(&mut self, instruction: node::Instruction) -> NodeId {
+        let id = self.add_instruction(instruction);
+        if let NodeObj::Instr(i) = &self[id] {
+            self.get_current_block_mut().instructions.push(id);
+        }
+        id
+    }
+
+    pub fn add_const(&mut self, constant: node::Constant) -> NodeId {
+        let obj = NodeObj::Const(constant);
+        let id = NodeId(self.nodes.insert(obj));
+        match &mut self[id] {
+            node::NodeObj::Const(c) => c.id = id,
+            _ => unreachable!(),
+        }
+
+        id
     }
 
     pub fn find_variable(&self, definition: &Option<IdentId>) -> Option<&node::Variable> {
@@ -132,12 +158,12 @@ impl<'a> IRGenerator<'a> {
         None
     }
 
-    pub fn find_const(&self, value: &BigUint) -> Option<arena::Index> {
+    pub fn find_const(&self, value: &BigUint) -> Option<NodeId> {
         //TODO We should map constant values to id
         for (idx, o) in &self.nodes {
             if let node::NodeObj::Const(c) = o {
                 if c.value == *value {
-                    return Some(idx);
+                    return Some(NodeId(idx));
                 }
             }
         }
@@ -148,58 +174,54 @@ impl<'a> IRGenerator<'a> {
         arena::Index::from_raw_parts(std::usize::MAX, 0)
     }
 
-    pub fn dummy(&self) -> arena::Index {
-        IRGenerator::dummy_id()
+    pub fn rename_me_get_object(&self, id: NodeId) -> Option<&node::NodeObj> {
+        self.nodes.get(id.0)
     }
 
-    pub fn get_object(&self, idx: arena::Index) -> Option<&node::NodeObj> {
-        self.nodes.get(idx)
+    pub fn rename_me_get_mut_object(&mut self, id: NodeId) -> Option<&mut node::NodeObj> {
+        self.nodes.get_mut(id.0)
     }
 
-    pub fn get_mut_object(&mut self, idx: arena::Index) -> Option<&mut node::NodeObj> {
-        self.nodes.get_mut(idx)
-    }
-
-    fn get_object_type(&self, idx: arena::Index) -> node::ObjectType {
-        self.get_object(idx).unwrap().get_type()
+    fn get_object_type(&self, id: NodeId) -> node::ObjectType {
+        self[id].get_type()
     }
 
     //Returns the object value if it is a constant, None if not. TODO: handle types
-    pub fn get_as_constant(&self, idx: arena::Index) -> Option<FieldElement> {
-        if let Some(node::NodeObj::Const(c)) = self.get_object(idx) {
+    pub fn get_as_constant(&self, id: NodeId) -> Option<FieldElement> {
+        if let Some(node::NodeObj::Const(c)) = self.rename_me_get_object(id) {
             return Some(FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be()));
         }
         None
     }
 
     //todo handle errors
-    fn get_instruction(&self, idx: arena::Index) -> &node::Instruction {
-        self.try_get_instruction(idx)
+    fn get_instruction(&self, id: NodeId) -> &node::Instruction {
+        self.try_get_instruction(id)
             .expect("Index not found or not an instruction")
     }
 
-    pub fn get_mut_instruction(&mut self, idx: arena::Index) -> &mut node::Instruction {
-        self.try_get_mut_instruction(idx)
+    pub fn get_mut_instruction(&mut self, id: NodeId) -> &mut node::Instruction {
+        self.try_get_mut_instruction(id)
             .expect("Index not found or not an instruction")
     }
 
-    pub fn try_get_instruction(&self, idx: arena::Index) -> Option<&node::Instruction> {
-        if let Some(node::NodeObj::Instr(i)) = self.get_object(idx) {
+    pub fn try_get_instruction(&self, id: NodeId) -> Option<&node::Instruction> {
+        if let Some(NodeObj::Instr(i)) = self.rename_me_get_object(id) {
             return Some(i);
         }
         None
     }
 
-    pub fn try_get_mut_instruction(&mut self, idx: arena::Index) -> Option<&mut node::Instruction> {
-        if let Some(node::NodeObj::Instr(i)) = self.get_mut_object(idx) {
+    pub fn try_get_mut_instruction(&mut self, id: NodeId) -> Option<&mut node::Instruction> {
+        if let Some(NodeObj::Instr(i)) = self.rename_me_get_mut_object(id) {
             return Some(i);
         }
         None
     }
 
-    pub fn get_variable(&self, idx: arena::Index) -> Result<&node::Variable, &str> {
+    pub fn get_variable(&self, id: NodeId) -> Result<&node::Variable, &str> {
         //TODO proper error handling
-        match self.nodes.get(idx) {
+        match self.nodes.get(id.0) {
             Some(t) => match t {
                 node::NodeObj::Obj(o) => Ok(o),
                 _ => Err("Not an object"),
@@ -208,9 +230,9 @@ impl<'a> IRGenerator<'a> {
         }
     }
 
-    pub fn get_mut_variable(&mut self, idx: arena::Index) -> Result<&mut node::Variable, &str> {
+    pub fn get_mut_variable(&mut self, id: NodeId) -> Result<&mut node::Variable, &str> {
         //TODO proper error handling
-        match self.nodes.get_mut(idx) {
+        match self.nodes.get_mut(id.0) {
             Some(t) => match t {
                 node::NodeObj::Obj(o) => Ok(o),
                 _ => Err("Not an object"),
@@ -219,69 +241,62 @@ impl<'a> IRGenerator<'a> {
         }
     }
 
-    pub fn get_root_id(&self, var_id: arena::Index) -> arena::Index {
-        let var = self.get_variable(var_id).unwrap();
-        var.get_root()
+    pub fn get_root_value(&self, id: NodeId) -> NodeId {
+        self.get_variable(id).map(|v| v.get_root()).unwrap_or(id)
     }
 
-    pub fn add_variable(
-        &mut self,
-        obj: node::Variable,
-        root: Option<arena::Index>,
-    ) -> arena::Index {
-        let idx = self.nodes.insert(node::NodeObj::Obj(obj));
-        let obj2 = self.nodes.get_mut(idx).unwrap();
-        match obj2 {
+    pub fn add_variable(&mut self, obj: node::Variable, root: Option<NodeId>) -> NodeId {
+        let id = NodeId(self.nodes.insert(NodeObj::Obj(obj)));
+        match &mut self[id] {
             node::NodeObj::Obj(v) => {
-                v.id = idx;
+                v.id = id;
                 v.root = root;
             }
             _ => unreachable!(),
         }
-        idx
+        id
     }
 
     pub fn new_instruction(
         &mut self,
-        lhs: arena::Index,
-        rhs: arena::Index,
+        lhs: NodeId,
+        rhs: NodeId,
         opcode: node::Operation,
         optype: node::ObjectType,
-    ) -> arena::Index {
+    ) -> NodeId {
         //Add a new instruction to the nodes arena
         let cb = self.get_current_block();
 
-        let mut i = node::Instruction::new(opcode, lhs, rhs, optype, Some(cb.idx));
+        let mut i = node::Instruction::new(opcode, lhs, rhs, optype, Some(cb.id));
         //Basic simplification
         optim::simplify(self, &mut i);
         if i.is_deleted {
             return i.rhs;
         }
-        self.add_object(node::NodeObj::Instr(i))
+        self.push_instruction(i)
     }
 
     //Retrieve the object conresponding to the const value given in argument
     // If such object does not exist, we create one
     //TODO: handle type
-    pub fn get_const(&mut self, x: FieldElement, t: node::ObjectType) -> arena::Index {
+    pub fn get_or_create_const(&mut self, x: FieldElement, t: node::ObjectType) -> NodeId {
         let value = BigUint::from_bytes_be(&x.to_bytes()); //TODO a const should be a field element
         if let Some(obj) = self.find_const(&value)
         //todo type
         {
             return obj;
         }
-        let obj_cst = node::Constant {
-            id: self.dummy(),
+
+        self.add_const(node::Constant {
+            id: NodeId::dummy(),
             value,
             value_str: String::new(),
             value_type: t,
-        };
-        let obj = node::NodeObj::Const(obj_cst);
-        self.add_object(obj)
+        })
     }
 
     //TODO the type should be provided by previous step so we can use get_const() instead
-    pub fn new_constant(&mut self, x: FieldElement) -> arena::Index {
+    pub fn new_constant(&mut self, x: FieldElement) -> NodeId {
         //we try to convert it to a supported integer type
         //if it does not work, we use the field type
         //n.b we cannot support custom fields bigger than the native field, we would need to support bigint and
@@ -297,14 +312,12 @@ impl<'a> IRGenerator<'a> {
         //TODO default should be FieldElement, not i32
         let num_bits = x.num_bits();
         if num_bits < 32 {
-            let obj_cst = node::Constant {
-                id: self.id0,
+            self.add_const(node::Constant {
+                id: NodeId::dummy(),
                 value,
                 value_type: node::ObjectType::Signed(32),
                 value_str: String::new(),
-            };
-            let obj = node::NodeObj::Const(obj_cst);
-            self.add_object(obj)
+            })
         } else {
             //idx = self.id0;
             todo!();
@@ -314,49 +327,39 @@ impl<'a> IRGenerator<'a> {
     }
 
     //same as update_variable but using the var index instead of var
-    pub fn update_variable_id(
-        &mut self,
-        var_id: arena::Index,
-        new_var: arena::Index,
-        new_value: arena::Index,
-    ) {
-        let root_id = self.get_root_id(var_id);
+    pub fn update_variable_id(&mut self, var_id: NodeId, new_var: NodeId, new_value: NodeId) {
+        let root_id = self.get_root_value(var_id);
         let root = self.get_variable(root_id).unwrap();
         let root_name = root.name.clone();
         let cb = self.get_current_block_mut();
         cb.update_variable(var_id, new_value);
-        self.value_name.entry(var_id).or_insert(1);
-        self.value_name.insert(var_id, self.value_name[&var_id] + 1);
-        //  let vname = cb.get_value_name(var_id).to_string();
-        let vname = if self.value_name.contains_key(&var_id) {
-            self.value_name[&var_id]
-        } else {
-            0
-        }
-        .to_string();
+        let vname = self.value_name.entry(var_id).or_insert(0);
+        *vname += 1;
+
         if let Ok(nvar) = self.get_mut_variable(new_var) {
-            nvar.name = root_name + &vname;
+            nvar.name = format!("{root_name}{vname}");
         }
     }
+
     //blocks/////////////////////////
-
-    pub fn get_block_mut(&mut self, idx: arena::Index) -> Option<&mut block::BasicBlock> {
-        self.blocks.get_mut(idx)
+    pub fn rename_me_get_block(&self, id: BlockId) -> Option<&block::BasicBlock> {
+        self.blocks.get(id.0)
     }
 
-    pub fn get_current_block_mut(&mut self) -> &mut block::BasicBlock {
-        self.blocks.get_mut(self.current_block).unwrap()
-    }
-
-    pub fn try_get_block(&self, idx: arena::Index) -> Option<&block::BasicBlock> {
-        self.blocks.get(idx)
-    }
-    pub fn get_block(&self, idx: arena::Index) -> &block::BasicBlock {
-        self.blocks.get(idx).unwrap()
+    pub fn rename_me_get_block_mut(&mut self, id: BlockId) -> Option<&mut block::BasicBlock> {
+        self.blocks.get_mut(id.0)
     }
 
     pub fn get_current_block(&self) -> &block::BasicBlock {
-        self.blocks.get(self.current_block).unwrap()
+        &self[self.current_block]
+    }
+
+    pub fn get_current_block_mut(&mut self) -> &mut block::BasicBlock {
+        &mut self[self.current_block]
+    }
+
+    pub fn iter_blocks(&self) -> impl Iterator<Item = &BasicBlock> {
+        self.blocks.iter().map(|(_id, block)| block)
     }
 
     ////////////////PARSING THE AST//////////////////////////////////////////////
@@ -405,7 +408,7 @@ impl<'a> IRGenerator<'a> {
         Ok(())
     }
 
-    fn evaluate_identifier(&mut self, env: &mut Environment, ident_id: &IdentId) -> arena::Index {
+    fn evaluate_identifier(&mut self, env: &mut Environment, ident_id: &IdentId) -> NodeId {
         let ident_name = self.context.unwrap().def_interner.ident_name(ident_id);
         let ident_def = self.context.unwrap().def_interner.ident_def(ident_id);
         // let var = self.find_variable(&ident_def); //TODO by name or by id?
@@ -419,7 +422,7 @@ impl<'a> IRGenerator<'a> {
 
         //new variable - should be in a let statement? The let statement should set the type
         let obj = node::Variable {
-            id: self.id0,
+            id: NodeId::dummy(),
             name: ident_name.clone(),
             obj_type,
             root: None,
@@ -429,31 +432,28 @@ impl<'a> IRGenerator<'a> {
         };
 
         let v_id = self.add_variable(obj, None);
-        self.get_block_mut(self.current_block)
-            .unwrap()
-            .update_variable(v_id, v_id);
+        self.get_current_block_mut().update_variable(v_id, v_id);
         v_id
     }
 
     //Cast lhs into type rtype. a cast b means (a) b
-    fn new_cast_expression(&mut self, lhs: arena::Index, rtype: node::ObjectType) -> arena::Index {
+    fn new_cast_expression(&mut self, lhs: NodeId, rtype: node::ObjectType) -> NodeId {
         //generate instruction 'a cast a', with result type rtype
-        let i = node::Instruction::new(
+        self.push_instruction(Instruction::new(
             node::Operation::Cast,
             lhs,
             lhs,
             rtype,
             Some(self.current_block),
-        );
-        self.add_object(node::NodeObj::Instr(i))
+        ))
     }
 
     fn evaluate_infix_expression(
         &mut self,
-        lhs: arena::Index,
-        rhs: arena::Index,
+        lhs: NodeId,
+        rhs: NodeId,
         op: HirBinaryOp,
-    ) -> Result<arena::Index, RuntimeError> {
+    ) -> Result<NodeId, RuntimeError> {
         let ltype = self.get_object_type(lhs);
 
         let optype = ltype; //n.b. we do not verify rhs type as it should have been handled by the typechecker.
@@ -467,7 +467,7 @@ impl<'a> IRGenerator<'a> {
         &mut self,
         env: &mut Environment,
         stmt_id: &StmtId,
-    ) -> Result<arena::Index, RuntimeError> {
+    ) -> Result<NodeId, RuntimeError> {
         let statement = self.context().def_interner.statement(stmt_id);
         match statement {
             HirStatement::Constrain(constrain_stmt) => {
@@ -490,16 +490,14 @@ impl<'a> IRGenerator<'a> {
                     .context()
                     .def_interner
                     .ident_name(&assign_stmt.identifier);
-                let lhs = //self.find_variable(&ident_def).unwrap(); //left hand must be already declared
-                if  let Some(var) = self.find_variable(&ident_def) {
-                    var
-                } else {
+
+                let lhs = self.find_variable(&ident_def).unwrap_or_else(|| {
                     //var is not defined,
                     //let's do it here for now...TODO
                     let obj = env.get(&ident_name);
                     let obj_type = node::ObjectType::get_type_from_object(&obj);
                     let new_var2 = node::Variable {
-                        id: self.dummy(),
+                        id: NodeId::dummy(),
                         obj_type,
                         name: ident_name.clone(),
                         root: None,
@@ -508,11 +506,11 @@ impl<'a> IRGenerator<'a> {
                         parent_block: self.current_block,
                     };
                     let new_var2_id = self.add_variable(new_var2, None);
-                    self.get_block_mut(self.current_block)
-                        .unwrap()
+                    self.get_current_block_mut()
                         .update_variable(new_var2_id, new_var2_id); //DE MEME
                     self.get_variable(new_var2_id).unwrap()
-                };
+                });
+
                 //////////////////////////////----******************************************
                 let new_var = node::Variable {
                     id: lhs.id,
@@ -529,7 +527,7 @@ impl<'a> IRGenerator<'a> {
                 let new_var_id = self.add_variable(new_var, Some(ls_root));
 
                 let rhs_id = self.expression_to_object(env, &assign_stmt.expression)?;
-                let rhs = self.get_object(rhs_id).unwrap();
+                let rhs = &self[rhs_id];
                 let r_type = rhs.get_type();
                 let r_id = rhs.get_id();
                 let result = self.new_instruction(new_var_id, r_id, node::Operation::Ass, r_type);
@@ -547,11 +545,11 @@ impl<'a> IRGenerator<'a> {
         var_name: String,
         def: Option<IdentId>,
         env: &mut Environment,
-    ) -> arena::Index {
+    ) -> NodeId {
         let obj = env.get(&var_name);
         let obj_type = node::ObjectType::get_type_from_object(&obj);
         let new_var = node::Variable {
-            id: self.dummy(),
+            id: NodeId::dummy(),
             obj_type,
             name: var_name,
             root: None,
@@ -567,7 +565,7 @@ impl<'a> IRGenerator<'a> {
         &mut self,
         env: &mut Environment,
         constrain_stmt: HirConstrainStatement,
-    ) -> Result<arena::Index, RuntimeError> {
+    ) -> Result<NodeId, RuntimeError> {
         let lhs = self.expression_to_object(env, &constrain_stmt.0.lhs)?;
         let rhs = self.expression_to_object(env, &constrain_stmt.0.rhs)?;
 
@@ -618,14 +616,13 @@ impl<'a> IRGenerator<'a> {
         &mut self,
         env: &mut Environment,
         let_stmt: HirLetStatement,
-    ) -> Result<arena::Index, RuntimeError> {
+    ) -> Result<NodeId, RuntimeError> {
         //create a variable from the left side of the statement, evaluate the right and generate an assign instruction.
 
         // Extract the expression
         let rhs_id = self.expression_to_object(env, &let_stmt.expression)?;
         //TODO: is there always an expression? if not, how can we get the type of the variable?
-        let rhs = self.get_object(rhs_id).unwrap();
-        let rtype = rhs.get_type();
+        let rtype = self[rhs_id].get_type();
 
         // Convert the LHS into an identifier
         let variable_name = self.context().def_interner.ident_name(&let_stmt.identifier);
@@ -634,7 +631,7 @@ impl<'a> IRGenerator<'a> {
         //TODO in the name already exists, we should use something else (from env) to find a variable (identid?)
 
         let new_var = node::Variable {
-            id: self.dummy(),
+            id: NodeId::dummy(),
             obj_type: rtype, //TODO - what if type is defined on lhs only?
             name: variable_name,
             root: None,
@@ -657,7 +654,7 @@ impl<'a> IRGenerator<'a> {
         &mut self,
         env: &mut Environment,
         expr_id: &ExprId,
-    ) -> Result<arena::Index, RuntimeError> {
+    ) -> Result<NodeId, RuntimeError> {
         let expr = self.context().def_interner.expression(expr_id);
         let span = self.context().def_interner.expr_span(expr_id);
         match expr {
@@ -748,7 +745,7 @@ impl<'a> IRGenerator<'a> {
         &mut self,
         env: &mut Environment,
         for_expr: HirForExpression,
-    ) -> Result<arena::Index, RuntimeErrorKind> {
+    ) -> Result<NodeId, RuntimeErrorKind> {
         //we add the ' i = start' instruction (in the block before the join)
         let start_idx = self
             .expression_to_object(env, &for_expr.start_range)
@@ -801,27 +798,21 @@ impl<'a> IRGenerator<'a> {
                                                           //we generate the phi for the iterator because the iterator is manually created
         let phi = self.generate_empty_phi(join_idx, iter_id);
         self.update_variable_id(iter_id, i1_id, phi); //j'imagine que y'a plus besoin
-        let cond =
-            self.new_instruction(phi, end_idx, node::Operation::Ne, node::ObjectType::Boolean);
+        let cond = self.new_instruction(phi, end_idx, Operation::Ne, node::ObjectType::Boolean);
         let to_fix = self.new_instruction(
             cond,
-            self.dummy(),
+            NodeId::dummy(),
             node::Operation::Jeq,
             node::ObjectType::NotAnObject,
         );
 
         //Body
-        let body_idx = block::new_sealed_block(self, block::BlockType::Normal);
-        let block = match self
-            .context
-            .unwrap()
-            .def_interner
-            .expression(&for_expr.block)
-        {
+        let body_id = block::new_sealed_block(self, block::BlockType::Normal);
+        let block = match self.context().def_interner.expression(&for_expr.block) {
             HirExpression::Block(block_expr) => block_expr,
             _ => panic!("ice: expected a block expression"),
         };
-        let body_block1 = self.get_block_mut(body_idx).unwrap();
+        let body_block1 = &mut self[body_id];
         body_block1.update_variable(iter_id, phi); //TODO try with just a get_current_value(iter)
         let statements = block.statements();
         for stmt in statements {
@@ -829,20 +820,20 @@ impl<'a> IRGenerator<'a> {
         }
 
         //increment iter
-        let one = self.get_const(FieldElement::one(), iter_type);
+        let one = self.get_or_create_const(FieldElement::one(), iter_type);
         let incr = self.new_instruction(phi, one, node::Operation::Add, iter_type);
         let cur_block_id = self.current_block; //It should be the body block, except if the body has CFG statements
-        let cur_block = self.get_block_mut(cur_block_id).unwrap();
+        let cur_block = &mut self[cur_block_id];
         cur_block.update_variable(iter_id, incr);
 
         //body.left = join
         cur_block.left = Some(join_idx);
-        let join_mut = self.get_block_mut(join_idx).unwrap();
+        let join_mut = &mut self[join_idx];
         join_mut.predecessor.push(cur_block_id);
         //jump back to join
         self.new_instruction(
-            self.dummy(),
-            self.get_block(join_idx).get_first_instruction(),
+            NodeId::dummy(),
+            self[join_idx].get_first_instruction(),
             node::Operation::Jmp,
             node::ObjectType::NotAnObject,
         );
@@ -852,54 +843,69 @@ impl<'a> IRGenerator<'a> {
         //exit block
         self.current_block = exit_id;
         let exit_first = self.get_current_block().get_first_instruction();
-        block::link_with_target(self, join_idx, Some(exit_id), Some(body_idx));
+        block::link_with_target(self, join_idx, Some(exit_id), Some(body_id));
         let to_fix_ins = self.try_get_mut_instruction(to_fix);
-        to_fix_ins.unwrap().rhs = body_idx;
+        to_fix_ins.unwrap().rhs = self[body_id].get_first_instruction();
 
         Ok(exit_first) //TODO what should we return???
     }
 
     pub fn acir(&self, evaluator: &mut Evaluator) {
         let mut acir = Acir::new();
-        let mut fb = self.try_get_block(self.first_block);
-        while fb.is_some() {
-            for iter in &fb.unwrap().instructions {
+        let mut fb = Some(&self[self.first_block]);
+        while let Some(block) = fb {
+            for iter in &block.instructions {
                 let ins = self.get_instruction(*iter);
                 acir.evaluate_instruction(ins, evaluator, self);
             }
             //TODO we should rather follow the jumps
-            if fb.unwrap().left.is_some() {
-                fb = self.try_get_block(fb.unwrap().left.unwrap());
-            } else {
-                fb = None;
-            }
+            fb = block.left.map(|block_id| &self[block_id]);
         }
         //   dbg!(acir.arith_cache);
     }
 
-    pub fn generate_empty_phi(
-        &mut self,
-        target_block: arena::Index,
-        root: arena::Index,
-    ) -> arena::Index {
+    pub fn generate_empty_phi(&mut self, target_block: BlockId, root: NodeId) -> NodeId {
         //Ensure there is not already a phi for the variable (n.b. probably not usefull)
-        let block = self.get_block(target_block);
-        for i in &block.instructions {
+        for i in &self[target_block].instructions {
             if let Some(ins) = self.try_get_instruction(*i) {
                 if ins.operator == node::Operation::Phi && ins.rhs == root {
                     return *i;
                 }
             }
         }
+
         let v_type = self.get_object_type(root);
-        let new_phi =
-            node::Instruction::new(node::Operation::Phi, root, root, v_type, Some(target_block));
-        let phi_id = self.nodes.insert(node::NodeObj::Instr(new_phi));
-        //ria
-        let mut phi_ins = self.try_get_mut_instruction(phi_id).unwrap();
-        phi_ins.idx = phi_id;
-        let block = self.get_block_mut(target_block).unwrap();
-        block.instructions.insert(1, phi_id);
+        let new_phi = Instruction::new(Operation::Phi, root, root, v_type, Some(target_block));
+        let phi_id = self.add_instruction(new_phi);
+        self[target_block].instructions.insert(1, phi_id);
         phi_id
+    }
+}
+
+impl std::ops::Index<BlockId> for IRGenerator<'_> {
+    type Output = BasicBlock;
+
+    fn index(&self, index: BlockId) -> &Self::Output {
+        &self.blocks[index.0]
+    }
+}
+
+impl std::ops::IndexMut<BlockId> for IRGenerator<'_> {
+    fn index_mut(&mut self, index: BlockId) -> &mut Self::Output {
+        &mut self.blocks[index.0]
+    }
+}
+
+impl std::ops::Index<NodeId> for IRGenerator<'_> {
+    type Output = NodeObj;
+
+    fn index(&self, index: NodeId) -> &Self::Output {
+        &self.nodes[index.0]
+    }
+}
+
+impl std::ops::IndexMut<NodeId> for IRGenerator<'_> {
+    fn index_mut(&mut self, index: NodeId) -> &mut Self::Output {
+        &mut self.nodes[index.0]
     }
 }

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -66,7 +66,7 @@ impl<'a> IRGenerator<'a> {
 
     //Display an object for debugging puposes
     fn node_to_string(&self, id: NodeId) -> String {
-        if let Some(var) = self.rename_me_get_object(id) {
+        if let Some(var) = self.try_get_node(id) {
             return format!("{}", var);
         } else {
             return format!("unknown {:?}", id.0.into_raw_parts().0);
@@ -135,7 +135,7 @@ impl<'a> IRGenerator<'a> {
     /// Adds the instruction to self.nodes and pushes it to the current block
     pub fn push_instruction(&mut self, instruction: node::Instruction) -> NodeId {
         let id = self.add_instruction(instruction);
-        if let NodeObj::Instr(i) = &self[id] {
+        if let NodeObj::Instr(_) = &self[id] {
             self.get_current_block_mut().instructions.push(id);
         }
         id
@@ -182,11 +182,11 @@ impl<'a> IRGenerator<'a> {
         arena::Index::from_raw_parts(std::usize::MAX, 0)
     }
 
-    pub fn rename_me_get_object(&self, id: NodeId) -> Option<&node::NodeObj> {
+    pub fn try_get_node(&self, id: NodeId) -> Option<&node::NodeObj> {
         self.nodes.get(id.0)
     }
 
-    pub fn rename_me_get_mut_object(&mut self, id: NodeId) -> Option<&mut node::NodeObj> {
+    pub fn try_get_node_mut(&mut self, id: NodeId) -> Option<&mut node::NodeObj> {
         self.nodes.get_mut(id.0)
     }
 
@@ -196,7 +196,7 @@ impl<'a> IRGenerator<'a> {
 
     //Returns the object value if it is a constant, None if not. TODO: handle types
     pub fn get_as_constant(&self, id: NodeId) -> Option<FieldElement> {
-        if let Some(node::NodeObj::Const(c)) = self.rename_me_get_object(id) {
+        if let Some(node::NodeObj::Const(c)) = self.try_get_node(id) {
             return Some(FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be()));
         }
         None
@@ -214,14 +214,14 @@ impl<'a> IRGenerator<'a> {
     }
 
     pub fn try_get_instruction(&self, id: NodeId) -> Option<&node::Instruction> {
-        if let Some(NodeObj::Instr(i)) = self.rename_me_get_object(id) {
+        if let Some(NodeObj::Instr(i)) = self.try_get_node(id) {
             return Some(i);
         }
         None
     }
 
     pub fn try_get_mut_instruction(&mut self, id: NodeId) -> Option<&mut node::Instruction> {
-        if let Some(NodeObj::Instr(i)) = self.rename_me_get_mut_object(id) {
+        if let Some(NodeObj::Instr(i)) = self.try_get_node_mut(id) {
             return Some(i);
         }
         None
@@ -351,11 +351,7 @@ impl<'a> IRGenerator<'a> {
     }
 
     //blocks/////////////////////////
-    pub fn rename_me_get_block(&self, id: BlockId) -> Option<&block::BasicBlock> {
-        self.blocks.get(id.0)
-    }
-
-    pub fn rename_me_get_block_mut(&mut self, id: BlockId) -> Option<&mut block::BasicBlock> {
+    pub fn try_get_block_mut(&mut self, id: BlockId) -> Option<&mut block::BasicBlock> {
         self.blocks.get_mut(id.0)
     }
 

--- a/crates/noirc_evaluator/src/ssa/flatten.rs
+++ b/crates/noirc_evaluator/src/ssa/flatten.rs
@@ -297,7 +297,7 @@ fn evaluate_one(
     match get_current_value_for_node_eval(obj, value_array) {
         node::NodeEval::Const(_, _) => obj,
         node::NodeEval::Instruction(obj_id) => {
-            if igen.rename_me_get_object(obj_id).is_none() {
+            if igen.try_get_node(obj_id).is_none() {
                 return obj;
             }
 
@@ -313,7 +313,7 @@ fn evaluate_one(
                     let lhr = get_current_value(i.rhs, value_array);
                     let result = i.evaluate(&lhs, &lhr);
                     if let node::NodeEval::Instruction(idx) = result {
-                        if igen.rename_me_get_object(idx).is_none() {
+                        if igen.try_get_node(idx).is_none() {
                             return NodeEval::Instruction(obj_id);
                         }
                     }
@@ -338,7 +338,7 @@ fn evaluate_object(
     match get_current_value_for_node_eval(obj, value_array) {
         node::NodeEval::Const(_, _) => obj,
         node::NodeEval::Instruction(obj_id) => {
-            if igen.rename_me_get_object(obj_id).is_none() {
+            if igen.try_get_node(obj_id).is_none() {
                 dbg!(obj_id);
                 return obj;
             }
@@ -356,7 +356,7 @@ fn evaluate_object(
                         evaluate_object(get_current_value(i.rhs, value_array), value_array, igen);
                     let result = i.evaluate(&lhs, &lhr);
                     if let NodeEval::Instruction(idx) = result {
-                        if igen.rename_me_get_object(idx).is_none() {
+                        if igen.try_get_node(idx).is_none() {
                             return NodeEval::Instruction(obj_id);
                         }
                     }

--- a/crates/noirc_evaluator/src/ssa/flatten.rs
+++ b/crates/noirc_evaluator/src/ssa/flatten.rs
@@ -1,7 +1,7 @@
 use super::{
-    block,
+    block::{self, BlockId},
     code_gen::IRGenerator,
-    node::{self, Node, NodeEval, Operation},
+    node::{self, Node, NodeEval, NodeId, Operation},
     optim,
 };
 use acvm::FieldElement;
@@ -12,8 +12,8 @@ use std::collections::HashMap;
 pub fn unroll_tree(eval: &mut IRGenerator) {
     //Calls outer_unroll() from the root node
     let mut id = eval.first_block;
-    let mut unroll_ins: Vec<Index> = Vec::new();
-    let mut eval_map: HashMap<Index, node::NodeEval> = HashMap::new();
+    let mut unroll_ins = Vec::new();
+    let mut eval_map = HashMap::new();
     let mut from = id;
     while let Some(next) = outer_unroll(&mut unroll_ins, &mut eval_map, id, from, eval) {
         from = id;
@@ -28,10 +28,10 @@ fn eval_block(block_id: Index, eval_map: &HashMap<Index, NodeEval>, eval: &mut I
         //RIA
         if let Some(ins) = eval.try_get_mut_instruction(*i) {
             if let Some(value) = eval_map.get(&ins.rhs) {
-                ins.rhs = value.to_index().unwrap();
+                ins.rhs = value.into_node_id().unwrap();
             }
             if let Some(value) = eval_map.get(&ins.lhs) {
-                ins.lhs = value.to_index().unwrap();
+                ins.lhs = value.into_node_id().unwrap();
             }
             if ins.operator == Operation::EqGate {}
             //TODO simplify(eval, ins);
@@ -80,8 +80,8 @@ pub fn unroll_std_block(
         let ins = eval.get_object(*i_id).unwrap();
         match ins {
             node::NodeObj::Instr(i) => {
-                let new_left = get_current_value(i.lhs, eval_map).to_index().unwrap();
-                let new_right = get_current_value(i.rhs, eval_map).to_index().unwrap();
+                let new_left = get_current_value(i.lhs, eval_map).into_node_id().unwrap();
+                let new_right = get_current_value(i.rhs, eval_map).into_node_id().unwrap();
                 let mut new_ins = node::Instruction::new(
                     i.operator, new_left, new_right, i.res_type, None, //TODO to fix later
                 );
@@ -101,7 +101,7 @@ pub fn unroll_std_block(
                         let mut to_delete = false;
                         if new_ins.is_deleted {
                             result_id = new_ins.rhs;
-                            if new_ins.rhs == new_ins.idx {
+                            if new_ins.rhs == new_ins.id {
                                 to_delete = true;
                             }
                         } else {
@@ -110,7 +110,7 @@ pub fn unroll_std_block(
                         }
                         //ignore self-deleted instructions
                         if !to_delete {
-                            eval_map.insert(*i_id, node::NodeEval::Idx(result_id));
+                            eval_map.insert(*i_id, node::NodeEval::Instruction(result_id));
                         }
                     }
                 }
@@ -127,14 +127,13 @@ pub fn unroll_std_block(
 //If the body does not ends with a jump back to the join block, we continue to unroll the next block, until we reach the join.
 //If there is a nested loop, unroll_block will call recursively unroll_join, keeping unroll list and eval map from the previous one
 pub fn unroll_join(
-    unroll_ins: &mut Vec<Index>, //unrolled instructions
+    unrolled_instructions: &mut Vec<NodeId>,
     eval_map: &mut HashMap<Index, node::NodeEval>,
-    block_id: Index, //block to unroll
-    _caller: Index,  //previous block TODO is it needed?
-    eval: &mut IRGenerator,
-) -> Option<Index> {
+    block_to_unroll: BlockId,
+    igen: &mut IRGenerator,
+) -> Option<BlockId> {
     //Returns the exit block of the loop
-    let join = eval.get_block(block_id);
+    let join = &igen[block_to_unroll];
     let join_instructions = join.instructions.clone();
     let join_left = join.left; //XXX.clone();
     let prev = *join.predecessor.first().unwrap(); //todo predecessor.first or .last?
@@ -142,27 +141,27 @@ pub fn unroll_join(
     let mut from = prev; //todo caller?
     assert!(join.is_join());
     let body_id = join.right.unwrap();
-    if unroll_ins.is_empty() {
-        unroll_ins.push(*join_instructions.first().unwrap()); //TODO is it needed? we also should assert it is a nop instruction.
+    if unrolled_instructions.is_empty() {
+        unrolled_instructions.push(*join_instructions.first().unwrap()); //TODO is it needed? we also should assert it is a nop instruction.
     }
     let mut processed: Vec<Index> = Vec::new();
     while {
         //evaluate the join  block:
-        evaluate_phi(&join_instructions, from, eval_map, eval);
-        evaluate_conditional_jump(*join_instructions.last().unwrap(), eval_map, eval)
+        evaluate_phi(&join_instructions, from, eval_map, igen);
+        evaluate_conditional_jump(*join_instructions.last().unwrap(), eval_map, igen)
     } {
-        from = block_id;
+        from = block_to_unroll;
         let mut b_id = body_id;
         let mut next;
         while {
-            next = unroll_block(unroll_ins, eval_map, b_id, from, eval);
+            next = unroll_block(unrolled_instructions, eval_map, b_id, from, igen);
             processed.push(b_id);
             next.is_some()
         } {
             //process next block:
             from = b_id;
             b_id = next.unwrap();
-            if b_id == block_id {
+            if b_id == block_to_unroll {
                 //looping back to the join block; we are done
                 break;
             }
@@ -173,31 +172,31 @@ pub fn unroll_join(
 
 // Unrolling outer loops, i.e non-nested loops
 pub fn outer_unroll(
-    unroll_ins: &mut Vec<Index>, //unrolled instructions
-    eval_map: &mut HashMap<Index, node::NodeEval>,
-    block_id: Index, //block to unroll
-    caller: Index,   //previous block
-    eval: &mut IRGenerator,
-) -> Option<Index> //next block
+    unroll_ins: &mut Vec<NodeId>, //unrolled instructions
+    eval_map: &mut HashMap<NodeId, node::NodeEval>,
+    block_id: BlockId, //block to unroll
+    caller: BlockId,   //previous block
+    igen: &mut IRGenerator,
+) -> Option<BlockId> //next block
 {
     assert!(unroll_ins.is_empty());
-    let block = eval.get_block(block_id);
+    let block = &igen[block_id];
     let b_right = block.right;
     let b_left = block.left;
     let block_instructions = block.instructions.clone();
     if block.is_join() {
         //1. unroll the block into the unroll_ins
-        unroll_join(unroll_ins, eval_map, block_id, caller, eval);
+        unroll_join(unroll_ins, eval_map, block_id, caller, igen);
         //2. map the Phis variables to their unrolled values:
         for ins in &block_instructions {
-            if let Some(ins_obj) = eval.try_get_instruction(*ins) {
+            if let Some(ins_obj) = igen.try_get_instruction(*ins) {
                 if ins_obj.operator == node::Operation::Phi {
                     if eval_map.contains_key(&ins_obj.rhs) {
                         eval_map.insert(ins_obj.lhs, eval_map[&ins_obj.rhs]);
                         //todo test with constants
-                    } else if eval_map.contains_key(&ins_obj.idx) {
+                    } else if eval_map.contains_key(&ins_obj.id) {
                         //   unroll_map.insert(ins_obj.lhs, eval_map[&ins_obj.idx].to_index().unwrap());
-                        eval_map.insert(ins_obj.lhs, eval_map[&ins_obj.idx]);
+                        eval_map.insert(ins_obj.lhs, eval_map[&ins_obj.id]);
                         //todo test with constants
                     }
                 } else if ins_obj.operator != node::Operation::Nop {
@@ -206,12 +205,10 @@ pub fn outer_unroll(
             }
         }
         //3. Merge the unrolled blocks into the join
-        for ins in &unroll_ins.clone() {
-            //TODO this clone should not be needed...
-            let ins_obj = eval.try_get_mut_instruction(*ins);
-            ins_obj.unwrap().idx = *ins;
+        for ins in unroll_ins {
+            igen[*ins].set_id(*ins);
         }
-        let join_mut = eval.get_block_mut(block_id).unwrap();
+        let join_mut = &mut igen[block_id];
         join_mut.instructions = unroll_ins.clone();
         join_mut.right = None;
         join_mut.kind = block::BlockType::Normal;
@@ -225,9 +222,9 @@ pub fn outer_unroll(
         }
         //we get the subgraph, however we could retrieve the list of processed blocks directly in unroll_join (cf. processed)
         if let Some(body_id) = b_right {
-            let sub_graph = block::bfs(body_id, block_id, eval);
+            let sub_graph = block::bfs(body_id, block_id, igen);
             for b in sub_graph {
-                eval.blocks.remove(b);
+                igen.blocks.remove(b);
             }
         }
 
@@ -235,34 +232,37 @@ pub fn outer_unroll(
         unroll_ins.clear();
     } else {
         //We update block instructions from the eval_map
-        eval_block(block_id, eval_map, eval);
+        eval_block(block_id, eval_map, igen);
     }
     b_left //returns the next block to process
 }
 
 //evaluate phi instruction, coming from 'from' block; retrieve the argument corresponding to the block, evaluates it and update the evaluation map
 fn evaluate_phi(
-    instructions: &[arena::Index],
-    from: Index,
-    to: &mut HashMap<Index, node::NodeEval>,
-    eval: &mut IRGenerator,
+    instructions: &[NodeId],
+    from: NodeId,
+    to: &mut HashMap<NodeId, NodeEval>,
+    igen: &mut IRGenerator,
 ) {
     for i in instructions {
-        let mut to_process: Vec<(Index, node::NodeEval)> = Vec::new();
-        if let Some(ins) = eval.try_get_instruction(*i) {
+        let mut to_process = Vec::new();
+        if let Some(ins) = igen.try_get_instruction(*i) {
             for phi in &ins.phi_arguments {
                 if phi.1 == from {
                     //we evaluate the phi instruction value
-                    to_process.push((ins.idx, evaluate_one(node::NodeEval::Idx(phi.0), to, eval)));
+                    to_process.push((ins.id, evaluate_one(NodeEval::Instruction(phi.0), to, igen)));
                 }
             }
-            if ins.operator != node::Operation::Phi && ins.operator != node::Operation::Nop {
+            if ins.operator != Operation::Phi && ins.operator != Operation::Nop {
                 break; //phi instructions are placed at the beginning (and after the first dummy instruction)
             }
         }
         //Update the evaluation map.
         for obj in to_process {
-            to.insert(obj.0, node::NodeEval::Idx(optim::to_index(eval, obj.1)));
+            to.insert(
+                obj.0,
+                node::NodeEval::Instruction(optim::to_index(igen, obj.1)),
+            );
         }
     }
 }
@@ -276,7 +276,7 @@ fn evaluate_conditional_jump(
     let jump_ins = eval.try_get_instruction(jump).unwrap();
     let lhs = get_current_value(jump_ins.lhs, value_array);
     let cond = evaluate_object(lhs, value_array, eval);
-    if let Some(cond_const) = cond.to_const_value() {
+    if let Some(cond_const) = cond.into_const_value() {
         let result = !cond_const.is_zero();
         match jump_ins.operator {
             node::Operation::Jeq => return result,
@@ -290,51 +290,48 @@ fn evaluate_conditional_jump(
 }
 
 //Retrieve the NodeEval value of the index in the evaluation map
-fn get_current_value(idx: Index, value_array: &HashMap<arena::Index, NodeEval>) -> NodeEval {
-    if value_array.contains_key(&idx) {
-        return value_array[&idx];
-    }
-    node::NodeEval::Idx(idx)
+fn get_current_value(id: NodeId, value_array: &HashMap<NodeId, NodeEval>) -> NodeEval {
+    *value_array.get(&id).unwrap_or(&NodeEval::Instruction(id))
 }
 
 //Same as get_current_value but for a NodeEval object instead of a NodeObj
 fn get_current_value_for_node_eval(
     obj: NodeEval,
-    value_array: &HashMap<arena::Index, NodeEval>,
+    value_array: &HashMap<NodeId, NodeEval>,
 ) -> NodeEval {
     match obj {
         node::NodeEval::Const(_, _) => obj,
-        node::NodeEval::Idx(obj_id) => get_current_value(obj_id, value_array),
+        node::NodeEval::Instruction(obj_id) => get_current_value(obj_id, value_array),
     }
 }
 
 //evaluate the object without recursion, doing only one step of evaluation
 fn evaluate_one(
-    obj: node::NodeEval,
-    value_array: &HashMap<arena::Index, NodeEval>,
-    eval: &IRGenerator,
-) -> node::NodeEval {
+    obj: NodeEval,
+    value_array: &HashMap<NodeId, NodeEval>,
+    igen: &IRGenerator,
+) -> NodeEval {
     match get_current_value_for_node_eval(obj, value_array) {
         node::NodeEval::Const(_, _) => obj,
-        node::NodeEval::Idx(obj_id) => {
-            if eval.get_object(obj_id).is_none() {
+        node::NodeEval::Instruction(obj_id) => {
+            if igen.get_object(obj_id).is_none() {
                 return obj;
             }
-            let value = eval.get_object(obj_id).unwrap();
+            let value = igen.get_object(obj_id).unwrap();
             match value {
                 node::NodeObj::Instr(i) => {
                     if i.operator == node::Operation::Phi {
                         //n.b phi are handled before, else we should know which block we come from
-                        dbg!(i.idx);
-                        return node::NodeEval::Idx(i.idx);
+                        dbg!(i.id);
+                        return node::NodeEval::Instruction(i.id);
                     }
 
                     let lhs = get_current_value(i.lhs, value_array);
                     let lhr = get_current_value(i.rhs, value_array);
                     let result = i.evaluate(&lhs, &lhr);
-                    if let node::NodeEval::Idx(idx) = result {
-                        if eval.get_object(idx).is_none() {
-                            return node::NodeEval::Idx(obj_id);
+                    if let node::NodeEval::Instruction(idx) = result {
+                        if igen.get_object(idx).is_none() {
+                            return node::NodeEval::Instruction(obj_id);
                         }
                     }
                     result
@@ -343,7 +340,7 @@ fn evaluate_one(
                     let value = FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be());
                     node::NodeEval::Const(value, c.get_type())
                 }
-                _ => node::NodeEval::Idx(obj_id),
+                _ => node::NodeEval::Instruction(obj_id),
             }
         }
     }
@@ -357,7 +354,7 @@ fn evaluate_object(
 ) -> node::NodeEval {
     match get_current_value_for_node_eval(obj, value_array) {
         node::NodeEval::Const(_, _) => obj,
-        node::NodeEval::Idx(obj_id) => {
+        node::NodeEval::Instruction(obj_id) => {
             if eval.get_object(obj_id).is_none() {
                 dbg!(obj_id);
                 return obj;
@@ -367,8 +364,8 @@ fn evaluate_object(
             match value {
                 node::NodeObj::Instr(i) => {
                     if i.operator == node::Operation::Phi {
-                        dbg!(i.idx);
-                        return node::NodeEval::Idx(i.idx);
+                        dbg!(i.id);
+                        return node::NodeEval::Instruction(i.id);
                     }
                     //n.b phi are handled before, else we should know which block we come from
                     let lhs =
@@ -376,9 +373,9 @@ fn evaluate_object(
                     let lhr =
                         evaluate_object(get_current_value(i.rhs, value_array), value_array, eval);
                     let result = i.evaluate(&lhs, &lhr);
-                    if let node::NodeEval::Idx(idx) = result {
+                    if let node::NodeEval::Instruction(idx) = result {
                         if eval.get_object(idx).is_none() {
-                            return node::NodeEval::Idx(obj_id);
+                            return node::NodeEval::Instruction(obj_id);
                         }
                     }
                     result
@@ -387,7 +384,7 @@ fn evaluate_object(
                     let value = FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be());
                     node::NodeEval::Const(value, c.get_type())
                 }
-                _ => node::NodeEval::Idx(obj_id),
+                _ => node::NodeEval::Instruction(obj_id),
             }
         }
     }

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -3,12 +3,11 @@ use super::{
     //block,
     code_gen::IRGenerator,
     node::{self, Instruction, Node, NodeId, NodeObj, Operation},
-    optim,
 };
 use acvm::FieldElement;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::convert::TryInto;
 
 //Returns the maximum bit size of short integers
@@ -123,7 +122,7 @@ fn add_to_truncate(
 ) -> BigUint {
     let v_max = &max_map[&obj_id];
     if *v_max >= BigUint::one() << bit_size {
-        if let Some(node::NodeObj::Const(_)) = &igen.rename_me_get_object(obj_id) {
+        if let Some(node::NodeObj::Const(_)) = &igen.try_get_node(obj_id) {
             return v_max.clone(); //a constant cannot be truncated, so we exit the function gracefully
         }
         let truncate_bits;

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -3,6 +3,7 @@ use super::{
     //block,
     code_gen::IRGenerator,
     node::{self, Instruction, Node, NodeId, NodeObj, Operation},
+    optim,
 };
 use acvm::FieldElement;
 use num_bigint::BigUint;
@@ -329,12 +330,12 @@ pub fn block_overflow(
             update_ins_parameters(igen, ins.id, l_new, r_new, max_r_value);
         }
     }
+
     update_value_array(igen, block_id, &value_map);
-    // let mut anchor = HashMap::new();
 
     //We run another round of CSE for the block in order to remove possible duplicated truncates, this will assign 'new_list' to the block instructions
-    // TODO: Type error, new_list: Vec<NodeId>, but block_cse expects blocks: Vec<BlockId>
-    // optim::block_cse(igen, block_id, &mut anchor, &mut new_list);
+    let mut anchor = HashMap::new();
+    optim::block_cse(igen, block_id, &mut anchor, &mut new_list);
 }
 
 fn update_value_array(igen: &mut IRGenerator, block_id: BlockId, vmap: &HashMap<NodeId, NodeId>) {

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -1,7 +1,8 @@
 use super::{
+    block::BlockId,
     //block,
     code_gen::IRGenerator,
-    node::{self, Instruction, Node, Operation},
+    node::{self, Instruction, Node, NodeId, NodeObj, Operation},
     optim,
 };
 use acvm::FieldElement;
@@ -19,13 +20,13 @@ pub fn short_integer_max_bit_size() -> u32 {
 
 //Gets the maximum value of the instruction result
 pub fn get_instruction_max(
-    eval: &IRGenerator,
+    igen: &IRGenerator,
     ins: &node::Instruction,
-    max_map: &mut HashMap<arena::Index, BigUint>,
-    vmap: &HashMap<arena::Index, arena::Index>,
+    max_map: &mut HashMap<NodeId, BigUint>,
+    vmap: &HashMap<NodeId, NodeId>,
 ) -> BigUint {
-    let r_max = get_obj_max_value(eval, None, ins.rhs, max_map, vmap);
-    let l_max = get_obj_max_value(eval, None, ins.lhs, max_map, vmap);
+    let r_max = get_obj_max_value(igen, None, ins.rhs, max_map, vmap);
+    let l_max = get_obj_max_value(igen, None, ins.lhs, max_map, vmap);
     get_max_value(ins, l_max, r_max)
 }
 
@@ -34,29 +35,29 @@ pub fn get_instruction_max(
 // we use the value array (get_current_value2) in order to handle truncate instructions
 // we need to do it because rust did not allow to modify the instruction in block_overflow..
 pub fn get_obj_max_value(
-    eval: &IRGenerator,
-    obj: Option<&node::NodeObj>,
-    idx: arena::Index,
-    max_map: &mut HashMap<arena::Index, BigUint>,
-    vmap: &HashMap<arena::Index, arena::Index>,
+    igen: &IRGenerator,
+    obj: Option<&NodeObj>,
+    id: NodeId,
+    max_map: &mut HashMap<NodeId, BigUint>,
+    vmap: &HashMap<NodeId, NodeId>,
 ) -> BigUint {
-    let id = get_value_from_map(idx, vmap); //block.get_current_value(idx);
+    let id = get_value_from_map(id, vmap);
     if max_map.contains_key(&id) {
         return max_map[&id].clone();
     }
 
-    let obj_ = obj.unwrap_or_else(|| eval.get_object(id).unwrap());
+    let obj_ = obj.unwrap_or_else(|| &igen[id]);
 
     let result = match obj_ {
-        node::NodeObj::Obj(v) => {
+        NodeObj::Obj(v) => {
             dbg!(v.size_in_bits());
             if v.size_in_bits() > 100 {
                 dbg!(&v);
             }
             (BigUint::one() << v.size_in_bits()) - BigUint::one()
         } //TODO check for signed type
-        node::NodeObj::Instr(i) => get_instruction_max(eval, i, max_map, vmap),
-        node::NodeObj::Const(c) => c.value.clone(), //TODO panic for string constants
+        NodeObj::Instr(i) => get_instruction_max(igen, i, max_map, vmap),
+        NodeObj::Const(c) => c.value.clone(), //TODO panic for string constants
     };
     max_map.insert(id, result.clone());
     result
@@ -64,35 +65,36 @@ pub fn get_obj_max_value(
 
 //Creates a truncate instruction for obj_id
 pub fn truncate(
-    eval: &mut IRGenerator,
-    obj_id: arena::Index,
+    igen: &mut IRGenerator,
+    obj_id: NodeId,
     bit_size: u32,
-    max_map: &mut HashMap<arena::Index, BigUint>,
-) -> Option<arena::Index> {
+    max_map: &mut HashMap<NodeId, BigUint>,
+) -> Option<NodeId> {
     // get type
-    let obj = eval.get_object(obj_id).unwrap();
+    let obj = &igen[obj_id];
     let obj_type = obj.get_type();
     let obj_name = format!("{}", obj);
     //ensure truncate is needed:
     let v_max = &max_map[&obj_id];
+
     if *v_max >= BigUint::one() << bit_size {
         //TODO is this leaking some info????
-        let rhs_bitsize = eval.new_constant(FieldElement::from(bit_size as i128));
+        let rhs_bitsize = igen.new_constant(FieldElement::from(bit_size as i128));
         //Create a new truncate instruction '(idx): obj trunc bit_size'
         //set current value of obj to idx
-        let mut i =
-            node::Instruction::new(node::Operation::Trunc, obj_id, rhs_bitsize, obj_type, None);
+        let mut i = Instruction::new(Operation::Trunc, obj_id, rhs_bitsize, obj_type, None);
         if i.res_name.ends_with("_t") {
             //TODO we should use %t so that we can check for this substring (% is not a valid char for a variable name) in the name and then write name%t[number+1]
         }
         i.res_name = obj_name + "_t";
         i.bit_size = v_max.bits() as u32;
-        let i_id = eval.nodes.insert(node::NodeObj::Instr(i));
+        let i_id = igen.add_instruction(i);
         max_map.insert(i_id, BigUint::from((1_u128 << bit_size) - 1));
-        return Some(i_id);
+        Some(i_id)
         //we now need to call fix_truncate(), it is done in a separate function in order to not overwhelm the arguments list.
+    } else {
+        None
     }
-    None
 }
 
 //Set the id and parent block of the truncate instruction
@@ -100,29 +102,28 @@ pub fn truncate(
 //We also update the value array
 pub fn fix_truncate(
     eval: &mut IRGenerator,
-    idx: arena::Index,
-    prev_id: arena::Index,
-    block_idx: arena::Index,
-    vmap: &mut HashMap<arena::Index, arena::Index>,
+    id: NodeId,
+    prev_id: NodeId,
+    block_idx: BlockId,
+    vmap: &mut HashMap<NodeId, NodeId>,
 ) {
-    if let Some(ins) = eval.try_get_mut_instruction(idx) {
-        ins.id = idx;
+    if let Some(ins) = eval.try_get_mut_instruction(id) {
         ins.parent_block = block_idx;
-        vmap.insert(prev_id, idx);
+        vmap.insert(prev_id, id);
     }
 }
 
 //Adds the variable to the list of variables that need to be truncated
 fn add_to_truncate(
-    eval: &IRGenerator,
-    obj_id: arena::Index,
+    igen: &IRGenerator,
+    obj_id: NodeId,
     bit_size: u32,
-    to_truncate: &mut HashMap<arena::Index, u32>,
-    max_map: &HashMap<arena::Index, BigUint>,
+    to_truncate: &mut HashMap<NodeId, u32>,
+    max_map: &HashMap<NodeId, BigUint>,
 ) -> BigUint {
     let v_max = &max_map[&obj_id];
     if *v_max >= BigUint::one() << bit_size {
-        if let Some(node::NodeObj::Const(_)) = eval.get_object(obj_id) {
+        if let Some(node::NodeObj::Const(_)) = &igen.rename_me_get_object(obj_id) {
             return v_max.clone(); //a constant cannot be truncated, so we exit the function gracefully
         }
         let truncate_bits;
@@ -140,17 +141,17 @@ fn add_to_truncate(
 
 //Truncate the 'to_truncate' list
 fn process_to_truncate(
-    eval: &mut IRGenerator,
-    new_list: &mut Vec<arena::Index>,
-    to_truncate: &mut HashMap<arena::Index, u32>,
-    max_map: &mut HashMap<arena::Index, BigUint>,
-    block_idx: arena::Index,
-    vmap: &mut HashMap<arena::Index, arena::Index>,
+    igen: &mut IRGenerator,
+    new_list: &mut Vec<NodeId>,
+    to_truncate: &mut HashMap<NodeId, u32>,
+    max_map: &mut HashMap<NodeId, BigUint>,
+    block_idx: BlockId,
+    vmap: &mut HashMap<NodeId, NodeId>,
 ) {
     for (id, bit_size) in to_truncate.iter() {
-        if let Some(truncate_idx) = truncate(eval, *id, *bit_size, max_map) {
+        if let Some(truncate_idx) = truncate(igen, *id, *bit_size, max_map) {
             //TODO properly handle signed arithmetic...
-            fix_truncate(eval, truncate_idx, *id, block_idx, vmap);
+            fix_truncate(igen, truncate_idx, *id, block_idx, vmap);
             new_list.push(truncate_idx);
         }
     }
@@ -159,13 +160,13 @@ fn process_to_truncate(
 
 //Update right and left operands of the provided instruction
 fn update_ins_parameters(
-    eval: &mut IRGenerator,
-    idx: arena::Index,
-    lhs: arena::Index,
-    rhs: arena::Index,
+    igen: &mut IRGenerator,
+    id: NodeId,
+    lhs: NodeId,
+    rhs: NodeId,
     max_value: Option<BigUint>,
 ) {
-    let mut ins = eval.try_get_mut_instruction(idx).unwrap();
+    let mut ins = igen.try_get_mut_instruction(id).unwrap();
     ins.lhs = lhs;
     ins.rhs = rhs;
     if let Some(max_v) = max_value {
@@ -174,52 +175,48 @@ fn update_ins_parameters(
 }
 
 //Add required truncate instructions on all blocks
-pub fn overflow_strategy(eval: &mut IRGenerator) {
-    let mut max_map: HashMap<arena::Index, BigUint> = HashMap::new();
-    tree_overflow(eval, eval.first_block, &mut max_map);
+pub fn overflow_strategy(igen: &mut IRGenerator) {
+    let mut max_map = HashMap::new();
+    tree_overflow(igen, igen.first_block, &mut max_map);
 }
 
 //implement overflow strategy following the dominator tree
 pub fn tree_overflow(
-    eval: &mut IRGenerator,
-    b_idx: arena::Index,
-    max_map: &mut HashMap<arena::Index, BigUint>,
+    igen: &mut IRGenerator,
+    b_idx: BlockId,
+    max_map: &mut HashMap<NodeId, BigUint>,
 ) {
-    block_overflow(eval, b_idx, max_map);
-    let block = eval.get_block(b_idx);
-    let bd = block.dominated.clone();
+    block_overflow(igen, b_idx, max_map);
     //TODO: Handle IF statements in there:
-    for b in bd {
-        tree_overflow(eval, b, &mut max_map.clone());
+    for b in igen[b_idx].dominated.clone() {
+        tree_overflow(igen, b, &mut max_map.clone());
     }
 }
 
 //overflow strategy for one block
 //TODO - check the type; we MUST NOT truncate or overflow field elements!!
 pub fn block_overflow(
-    eval: &mut IRGenerator,
-    b_idx: arena::Index,
-    //block: &mut node::BasicBlock,
-    max_map: &mut HashMap<arena::Index, BigUint>,
+    igen: &mut IRGenerator,
+    block_id: BlockId,
+    max_map: &mut HashMap<NodeId, BigUint>,
 ) {
     //for each instruction, we compute the resulting max possible value (in term of the field representation of the operation)
     //when it is over the field charac, or if the instruction requires it, then we insert truncate instructions
     // The instructions are insterted in a duplicate list( because of rust ownership..), which we use for
     // processing another cse round for the block because the truncates may be duplicated.
-    let block = eval.blocks.get(b_idx).unwrap();
-    let mut b: Vec<node::Instruction> = Vec::new();
-    let mut new_list: Vec<arena::Index> = Vec::new();
-    let mut truncate_map: HashMap<arena::Index, u32> = HashMap::new();
-    let mut modify_ins: Option<Instruction> = None;
+    let mut instructions = Vec::new();
+    let mut new_list = Vec::new();
+    let mut truncate_map = HashMap::new();
+    let mut modify_ins = None;
     let mut trunc_size = FieldElement::zero();
     //RIA...
-    for iter in &block.instructions {
-        b.push((*eval.try_get_instruction(*iter).unwrap()).clone());
+    for iter in &igen[block_id].instructions {
+        instructions.push((*igen.try_get_instruction(*iter).unwrap()).clone());
     }
     //since we process the block from the start, the block value map is not relevant
-    let mut value_map: HashMap<arena::Index, arena::Index> = HashMap::new();
-    for mut ins in b {
-        if ins.operator == node::Operation::Nop {
+    let mut value_map = HashMap::new();
+    for mut ins in instructions {
+        if ins.operator == Operation::Nop {
             continue;
         }
         //We retrieve get_current_value() in case a previous truncate has updated the value map
@@ -235,21 +232,21 @@ pub fn block_overflow(
             update_instruction = true;
         }
 
-        let r_obj = eval.get_object(r_id).unwrap();
-        let l_obj = eval.get_object(l_id).unwrap();
-        let r_max = get_obj_max_value(eval, Some(r_obj), r_id, max_map, &value_map);
-        get_obj_max_value(eval, Some(l_obj), l_id, max_map, &value_map);
+        let r_obj = &igen[r_id];
+        let l_obj = &igen[l_id];
+        let r_max = get_obj_max_value(igen, Some(r_obj), r_id, max_map, &value_map);
+        get_obj_max_value(igen, Some(l_obj), l_id, max_map, &value_map);
         //insert required truncates
         let to_truncate = ins.truncate_required(l_obj.size_in_bits(), r_obj.size_in_bits());
         if to_truncate.0 {
             //adds a new truncate(lhs) instruction
-            add_to_truncate(eval, l_id, l_obj.size_in_bits(), &mut truncate_map, max_map);
+            add_to_truncate(igen, l_id, l_obj.size_in_bits(), &mut truncate_map, max_map);
         }
         if to_truncate.1 {
             //adds a new truncate(rhs) instruction
-            add_to_truncate(eval, r_id, r_obj.size_in_bits(), &mut truncate_map, max_map);
+            add_to_truncate(igen, r_id, r_obj.size_in_bits(), &mut truncate_map, max_map);
         }
-        if ins.operator == node::Operation::Cast {
+        if ins.operator == Operation::Cast {
             //TODO for now the types we support here are only all integer types (field, signed, unsigned, bool)
             //so a cast would normally translate to a truncate.
             //if res_type and lhs have the same bit size (in a large sens, which include field elements)
@@ -283,7 +280,7 @@ pub fn block_overflow(
                 //n.b. we do not update value map because we re-use the cast instruction
             }
         }
-        let mut ins_max = get_instruction_max(eval, &ins, max_map, &value_map);
+        let mut ins_max = get_instruction_max(igen, &ins, max_map, &value_map);
         if ins_max.bits() >= (FieldElement::max_num_bits() as u64) {
             //let's truncate a and b:
             //- insert truncate(lhs) dans la list des instructions
@@ -291,9 +288,9 @@ pub fn block_overflow(
             //- update r_max et l_max
             //n.b we could try to truncate only one of them, but then we should check if rhs==lhs.
             let l_trunc_max =
-                add_to_truncate(eval, l_id, l_obj.size_in_bits(), &mut truncate_map, max_map);
+                add_to_truncate(igen, l_id, l_obj.size_in_bits(), &mut truncate_map, max_map);
             let r_trunc_max =
-                add_to_truncate(eval, r_id, r_obj.size_in_bits(), &mut truncate_map, max_map);
+                add_to_truncate(igen, r_id, r_obj.size_in_bits(), &mut truncate_map, max_map);
             ins_max = get_max_value(&ins, l_trunc_max.clone(), r_trunc_max.clone());
             if ins_max.bits() >= FieldElement::max_num_bits().into() {
                 let message = format!(
@@ -305,11 +302,11 @@ pub fn block_overflow(
             }
         }
         process_to_truncate(
-            eval,
+            igen,
             &mut new_list,
             &mut truncate_map,
             max_map,
-            b_idx,
+            block_id,
             &mut value_map,
         );
         new_list.push(ins.id);
@@ -328,37 +325,29 @@ pub fn block_overflow(
             }
             if let Some(modified_ins) = &modify_ins {
                 ins.operator = modified_ins.operator;
-                ins.rhs = eval.get_or_create_const(trunc_size, node::ObjectType::Unsigned(32));
+                ins.rhs = igen.get_or_create_const(trunc_size, node::ObjectType::Unsigned(32));
             }
-            update_ins_parameters(eval, ins.id, l_new, r_new, max_r_value);
+            update_ins_parameters(igen, ins.id, l_new, r_new, max_r_value);
         }
     }
-    update_value_array(eval, b_idx, &value_map);
-    let mut anchor: HashMap<node::Operation, VecDeque<arena::Index>> = HashMap::new();
+    update_value_array(igen, block_id, &value_map);
+    // let mut anchor = HashMap::new();
+
     //We run another round of CSE for the block in order to remove possible duplicated truncates, this will assign 'new_list' to the block instructions
-    optim::block_cse(eval, b_idx, &mut anchor, &mut new_list);
+    // TODO: Type error, new_list: Vec<NodeId>, but block_cse expects blocks: Vec<BlockId>
+    // optim::block_cse(igen, block_id, &mut anchor, &mut new_list);
 }
 
-fn update_value_array(
-    eval: &mut IRGenerator,
-    b_id: arena::Index,
-    vmap: &HashMap<arena::Index, arena::Index>,
-) {
-    let block = eval.get_block_mut(b_id).unwrap();
+fn update_value_array(igen: &mut IRGenerator, block_id: BlockId, vmap: &HashMap<NodeId, NodeId>) {
+    let block = &mut igen[block_id];
     for (old, new) in vmap {
         block.value_map.insert(*old, *new); //TODO we must merge rather than update
     }
 }
 
 //Get current value using the provided vmap
-pub fn get_value_from_map(
-    idx: arena::Index,
-    vmap: &HashMap<arena::Index, arena::Index>,
-) -> arena::Index {
-    match vmap.get(&idx) {
-        Some(cur_idx) => *cur_idx,
-        None => idx,
-    }
+pub fn get_value_from_map(id: NodeId, vmap: &HashMap<NodeId, NodeId>) -> NodeId {
+    *vmap.get(&id).unwrap_or(&id)
 }
 
 //Returns the max value of an operation from an upper bound of left and right hand sides

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -279,7 +279,7 @@ impl std::fmt::Display for Instruction {
 #[derive(Debug, Clone, Copy)]
 pub enum NodeEval {
     Const(FieldElement, ObjectType),
-    Instruction(NodeId),
+    VarOrInstruction(NodeId),
 }
 
 impl NodeEval {
@@ -292,7 +292,7 @@ impl NodeEval {
 
     pub fn into_node_id(self) -> Option<NodeId> {
         match self {
-            NodeEval::Instruction(i) => Some(i),
+            NodeEval::VarOrInstruction(i) => Some(i),
             NodeEval::Const(_, _) => None,
         }
     }
@@ -655,7 +655,7 @@ impl Instruction {
             Operation::Phi => (), //Phi are simplified by simply_phi() later on; they must not be simplified here
             _ => (),
         }
-        NodeEval::Instruction(self.id)
+        NodeEval::VarOrInstruction(self.id)
     }
 
     // Simplifies trivial Phi instructions by returning:

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -263,7 +263,7 @@ pub struct Instruction {
     pub max_value: BigUint, //TODO only for sub instruction: max value of the rhs
 
     //temp: todo phi subtype
-    pub phi_arguments: Vec<(NodeId, NodeId)>,
+    pub phi_arguments: Vec<(NodeId, BlockId)>,
 }
 
 impl std::fmt::Display for Instruction {
@@ -662,7 +662,7 @@ impl Instruction {
     // None, if the instruction is unreachable or in the root block and can be safely deleted
     // Some(id), if the instruction can be replaced by the node id
     // Some(ins_id), if the instruction is not trivial
-    pub fn simplify_phi(ins_id: NodeId, phi_arguments: &[(NodeId, NodeId)]) -> Option<NodeId> {
+    pub fn simplify_phi(ins_id: NodeId, phi_arguments: &[(NodeId, BlockId)]) -> Option<NodeId> {
         let mut same = None;
         for op in phi_arguments {
             if Some(op.0) == same || op.0 == ins_id {

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -306,7 +306,7 @@ impl Instruction {
         r_type: ObjectType,
         parent_block: Option<BlockId>,
     ) -> Instruction {
-        let id = NodeId(IRGenerator::dummy_id());
+        let id = NodeId::dummy();
         let p_block = parent_block.unwrap_or_else(BlockId::dummy);
 
         Instruction {

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -307,7 +307,7 @@ impl Instruction {
         parent_block: Option<BlockId>,
     ) -> Instruction {
         let id = NodeId(IRGenerator::dummy_id());
-        let p_block = parent_block.unwrap_or(BlockId::dummy());
+        let p_block = parent_block.unwrap_or_else(BlockId::dummy);
 
         Instruction {
             id,

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -20,7 +20,7 @@ pub fn to_const(eval: &IRGenerator, obj: NodeEval) -> NodeEval {
     match obj {
         node::NodeEval::Const(_, _) => obj,
         node::NodeEval::Instruction(i) => {
-            if let Some(NodeObj::Const(c)) = eval.rename_me_get_object(i) {
+            if let Some(NodeObj::Const(c)) = eval.try_get_node(i) {
                 return NodeEval::Const(
                     FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be()),
                     c.get_type(),
@@ -49,7 +49,7 @@ pub fn simplify(eval: &mut IRGenerator, ins: &mut node::Instruction) {
     //2. standard form
     ins.standard_form();
     if ins.operator == node::Operation::Cast {
-        if let Some(lhs_obj) = eval.rename_me_get_object(ins.lhs) {
+        if let Some(lhs_obj) = eval.try_get_node(ins.lhs) {
             if lhs_obj.get_type() == ins.res_type {
                 ins.is_deleted = true;
                 ins.rhs = ins.lhs;

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -1,14 +1,14 @@
 use super::{
+    block::BlockId,
     code_gen::IRGenerator,
-    node::{self, Node, NodeEval},
+    node::{self, Instruction, Node, NodeEval, NodeId, NodeObj, Operation},
 };
 use acvm::FieldElement;
-use arena::Index;
 use std::collections::{HashMap, VecDeque};
 
 //returns the NodeObj index of a NodeEval object
 //if NodeEval is a constant, it may creates a new NodeObj corresponding to the constant value
-pub fn to_index(eval: &mut IRGenerator, obj: node::NodeEval) -> Index {
+pub fn to_index(eval: &mut IRGenerator, obj: NodeEval) -> NodeId {
     match obj {
         node::NodeEval::Const(c, t) => eval.get_or_create_const(c, t),
         node::NodeEval::Instruction(i) => i,
@@ -16,12 +16,12 @@ pub fn to_index(eval: &mut IRGenerator, obj: node::NodeEval) -> Index {
 }
 
 // If NodeEval refers to a constant NodeObj, we return a constant NodeEval
-pub fn to_const(eval: &IRGenerator, obj: node::NodeEval) -> node::NodeEval {
+pub fn to_const(eval: &IRGenerator, obj: NodeEval) -> NodeEval {
     match obj {
         node::NodeEval::Const(_, _) => obj,
         node::NodeEval::Instruction(i) => {
-            if let Some(node::NodeObj::Const(c)) = eval.get_object(i) {
-                return node::NodeEval::Const(
+            if let Some(NodeObj::Const(c)) = eval.rename_me_get_object(i) {
+                return NodeEval::Const(
                     FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be()),
                     c.get_type(),
                 );
@@ -49,7 +49,7 @@ pub fn simplify(eval: &mut IRGenerator, ins: &mut node::Instruction) {
     //2. standard form
     ins.standard_form();
     if ins.operator == node::Operation::Cast {
-        if let Some(lhs_obj) = eval.get_object(ins.lhs) {
+        if let Some(lhs_obj) = eval.rename_me_get_object(ins.lhs) {
             if lhs_obj.get_type() == ins.res_type {
                 ins.is_deleted = true;
                 ins.rhs = ins.lhs;
@@ -101,13 +101,13 @@ pub fn simplify(eval: &mut IRGenerator, ins: &mut node::Instruction) {
 ////////////////////CSE////////////////////////////////////////
 
 pub fn find_similar_instruction(
-    eval: &IRGenerator,
-    lhs: arena::Index,
-    rhs: arena::Index,
-    prev_ins: &VecDeque<arena::Index>,
-) -> Option<arena::Index> {
+    igen: &IRGenerator,
+    lhs: NodeId,
+    rhs: NodeId,
+    prev_ins: &VecDeque<NodeId>,
+) -> Option<NodeId> {
     for iter in prev_ins {
-        if let Some(ins) = eval.try_get_instruction(*iter) {
+        if let Some(ins) = igen.try_get_instruction(*iter) {
             if ins.lhs == lhs && ins.rhs == rhs {
                 return Some(*iter);
             }
@@ -116,9 +116,9 @@ pub fn find_similar_instruction(
     None
 }
 
-pub fn propagate(eval: &IRGenerator, idx: arena::Index) -> arena::Index {
-    let mut result = idx;
-    if let Some(obj) = eval.try_get_instruction(idx) {
+pub fn propagate(igen: &IRGenerator, id: NodeId) -> NodeId {
+    let mut result = id;
+    if let Some(obj) = igen.try_get_instruction(id) {
         if obj.operator == node::Operation::Ass || obj.is_deleted {
             result = obj.rhs;
         }
@@ -127,49 +127,44 @@ pub fn propagate(eval: &IRGenerator, idx: arena::Index) -> arena::Index {
 }
 
 //common subexpression elimination, starting from the root
-pub fn cse(eval: &mut IRGenerator) {
-    let mut anchor: HashMap<node::Operation, VecDeque<arena::Index>> = HashMap::new();
-    cse_tree(eval, eval.first_block, &mut anchor);
+pub fn cse(igen: &mut IRGenerator) {
+    let mut anchor = HashMap::new();
+    cse_tree(igen, igen.first_block, &mut anchor);
 }
 
 //Perform CSE for the provided block and then process its children following the dominator tree, passing around the anchor list.
 pub fn cse_tree(
-    eval: &mut IRGenerator,
-    b_idx: arena::Index,
-    anchor: &mut HashMap<node::Operation, VecDeque<arena::Index>>,
+    igen: &mut IRGenerator,
+    block_id: BlockId,
+    anchor: &mut HashMap<Operation, VecDeque<NodeId>>,
 ) {
-    let mut i_list: Vec<arena::Index> = Vec::new();
-    block_cse(eval, b_idx, anchor, &mut i_list);
-    let block = eval.get_block(b_idx);
-    let bd = block.dominated.clone();
-    for b in bd {
-        cse_tree(eval, b, &mut anchor.clone());
+    let mut instructions = Vec::new();
+    block_cse(igen, block_id, anchor, &mut instructions);
+    for b in igen[block_id].dominated.clone() {
+        cse_tree(igen, b, &mut anchor.clone());
     }
 }
 
 //Performs common subexpression elimination and copy propagation on a block
 pub fn block_cse(
-    eval: &mut IRGenerator,
-    b_idx: arena::Index,
-    anchor: &mut HashMap<node::Operation, VecDeque<arena::Index>>,
-    block_list: &mut Vec<arena::Index>,
+    igen: &mut IRGenerator,
+    block_id: BlockId,
+    anchor: &mut HashMap<Operation, VecDeque<NodeId>>,
+    instructions: &mut Vec<NodeId>,
 ) {
-    let mut new_list: Vec<arena::Index> = Vec::new();
-    let bb = eval.blocks.get(b_idx).unwrap();
+    let mut new_list = Vec::new();
+    let bb = &igen[block_id];
 
-    if block_list.is_empty() {
-        //RIA...
-        for iter in &bb.instructions {
-            block_list.push(*iter);
-        }
+    if instructions.is_empty() {
+        instructions.append(&mut bb.instructions.clone());
     }
 
-    for iter in block_list {
-        if let Some(ins) = eval.try_get_instruction(*iter) {
+    for iter in instructions {
+        if let Some(ins) = igen.try_get_instruction(*iter) {
             let mut to_delete = false;
             let mut i_lhs = ins.lhs;
             let mut i_rhs = ins.rhs;
-            let mut phi_args: Vec<(arena::Index, arena::Index)> = Vec::new();
+            let mut phi_args = Vec::new();
             let mut to_update_phi = false;
             anchor.entry(ins.operator).or_insert_with(VecDeque::new);
             if ins.is_deleted {
@@ -177,10 +172,10 @@ pub fn block_cse(
             }
             if node::is_binary(ins.operator) {
                 //binary operation:
-                i_lhs = propagate(eval, ins.lhs);
-                i_rhs = propagate(eval, ins.rhs);
+                i_lhs = propagate(igen, ins.lhs);
+                i_rhs = propagate(igen, ins.rhs);
                 if let Some(j) =
-                    find_similar_instruction(eval, i_lhs, i_rhs, &anchor[&ins.operator])
+                    find_similar_instruction(igen, i_lhs, i_rhs, &anchor[&ins.operator])
                 {
                     to_delete = true; //we want to delete ins but ins is immutable so we use the new_list instead
                     i_rhs = j;
@@ -191,15 +186,15 @@ pub fn block_cse(
                 }
             } else if ins.operator == node::Operation::Ass {
                 //assignement
-                i_rhs = propagate(eval, ins.rhs);
+                i_rhs = propagate(igen, ins.rhs);
                 to_delete = true;
             } else if ins.operator == node::Operation::Cast {
-                i_lhs = propagate(eval, ins.lhs);
-                i_rhs = propagate(eval, ins.rhs);
+                i_lhs = propagate(igen, ins.lhs);
+                i_rhs = propagate(igen, ins.rhs);
             } else if ins.operator == node::Operation::Phi {
                 // propagate phi arguments
                 for a in &ins.phi_arguments {
-                    phi_args.push((propagate(eval, a.0), a.1));
+                    phi_args.push((propagate(igen, a.0), a.1));
                     if phi_args.last().unwrap().0 != a.0 {
                         to_update_phi = true;
                     }
@@ -219,41 +214,41 @@ pub fn block_cse(
                 new_list.push(*iter);
             }
             if to_update_phi {
-                let update = eval.get_mut_instruction(*iter);
+                let update = igen.get_mut_instruction(*iter);
                 update.phi_arguments = phi_args;
             } else if to_delete || ins.lhs != i_lhs || ins.rhs != i_rhs {
                 //update i:
                 let ii_l = ins.lhs;
                 let ii_r = ins.rhs;
-                let update = eval.get_mut_instruction(*iter);
+                let update = igen.get_mut_instruction(*iter);
                 update.lhs = i_lhs;
                 update.rhs = i_rhs;
                 update.is_deleted = to_delete;
                 //update instruction name - for debug/pretty print purposes only /////////////////////
-                if let Some(node::Instruction {
-                    operator: node::Operation::Ass,
+                if let Some(Instruction {
+                    operator: Operation::Ass,
                     lhs,
                     ..
-                }) = eval.try_get_instruction(ii_l)
+                }) = igen.try_get_instruction(ii_l)
                 {
-                    if let Ok(lv) = eval.get_variable(*lhs) {
+                    if let Ok(lv) = igen.get_variable(*lhs) {
                         let i_name = lv.name.clone();
-                        if let Some(p_ins) = eval.try_get_mut_instruction(i_lhs) {
+                        if let Some(p_ins) = igen.try_get_mut_instruction(i_lhs) {
                             if p_ins.res_name.is_empty() {
                                 p_ins.res_name = i_name;
                             }
                         }
                     }
                 }
-                if let Some(node::Instruction {
-                    operator: node::Operation::Ass,
+                if let Some(Instruction {
+                    operator: Operation::Ass,
                     lhs,
                     ..
-                }) = eval.try_get_instruction(ii_r)
+                }) = igen.try_get_instruction(ii_r)
                 {
-                    if let Ok(lv) = eval.get_variable(*lhs) {
+                    if let Ok(lv) = igen.get_variable(*lhs) {
                         let i_name = lv.name.clone();
-                        if let Some(p_ins) = eval.try_get_mut_instruction(i_rhs) {
+                        if let Some(p_ins) = igen.try_get_mut_instruction(i_rhs) {
                             if p_ins.res_name.is_empty() {
                                 p_ins.res_name = i_name;
                             }
@@ -264,6 +259,6 @@ pub fn block_cse(
             }
         }
     }
-    let bb = eval.blocks.get_mut(b_idx).unwrap();
-    bb.instructions = new_list;
+
+    igen[block_id].instructions = new_list;
 }

--- a/crates/noirc_evaluator/src/ssa/ssa_form.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_form.rs
@@ -84,8 +84,8 @@ pub fn get_current_value_in_block(
     let root = igen.get_root_value(var_id);
 
     igen[block_id]
-        .get_current_value(root)
-        .unwrap_or_else(|| get_block_value(igen, root, block_id))
+        .get_current_value(root) //Local value numbering
+        .unwrap_or_else(|| get_block_value(igen, root, block_id)) //Global value numbering
 }
 
 //Returns the current SSA value of a variable, recursively

--- a/crates/noirc_evaluator/src/ssa/ssa_form.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_form.rs
@@ -3,7 +3,6 @@ use super::{
     code_gen::IRGenerator,
     node::{self, NodeId},
 };
-use arena;
 
 // create phi arguments from the predecessors of the block (containing phi)
 pub fn write_phi(igen: &mut IRGenerator, predecessors: &[BlockId], var: NodeId, phi: NodeId) {
@@ -53,7 +52,7 @@ pub fn seal_block(igen: &mut IRGenerator, block_id: BlockId) {
 pub fn get_block_value(igen: &mut IRGenerator, root: NodeId, block_id: BlockId) -> NodeId {
     let result = if !igen.sealed_blocks.contains(&block_id) {
         //incomplete CFG
-        igen.generate_empty_phi(block_id, root);
+        igen.generate_empty_phi(block_id, root)
     } else {
         let block = &igen[block_id];
         if let Some(idx) = block.get_current_value(root) {
@@ -64,15 +63,15 @@ pub fn get_block_value(igen: &mut IRGenerator, root: NodeId, block_id: BlockId) 
             return root;
         }
         if pred.len() == 1 {
-            get_block_value(igen, root, pred[0]);
+            get_block_value(igen, root, pred[0])
         } else {
             let result = igen.generate_empty_phi(block_id, root);
             write_phi(igen, &pred, root, result);
             result
         }
     };
-    let block = igen.get_block_mut(block_id).unwrap();
-    block.update_variable(root, result);
+
+    igen[block_id].update_variable(root, result);
     result
 }
 


### PR DESCRIPTION
This PR is meant as a cleanup with no intended behavior changes*.

It:
- Replaces `arena::Index` in favor of `BlockId` and `NodeId` which gives us more type safety. Since we are effectively using indices as pointer, it is similar to replacing `void*` in favor of `BasicBlock*` and `NodeObj*`.
- Renames some parameters. I had no formal way of doing this change, I only changed some parameter names to be more descriptive as I saw them rather than attempting to go through every function. I tried to name all uses of `IRGenerator` as `igen` where before it was split between `igen`, `cfg` and `eval`.

*Refactoring to using stronger types via BlockId and InstructionId did reveal a bug in unrolling for loops where a node index was being passed as a block index.