### PR TITLE
Hide error type from being shown in error messages

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -1,3 +1,5 @@
+use noirc_errors::Span;
+
 use crate::{
     hir_def::{
         expr::{self, HirBinaryOp, HirExpression, HirLiteral},
@@ -45,21 +47,19 @@ pub(crate) fn type_check_expression(
                     );
 
                     // Check if the array is homogeneous
-                    if first_elem_type != Type::Error {
-                        for (index, elem_type) in elem_types.iter().enumerate().skip(1) {
-                            if *elem_type != first_elem_type && elem_type != &Type::Error {
-                                errors.push(
-                                    TypeCheckError::NonHomogeneousArray {
-                                        first_span: interner.expr_span(&arr.contents[0]),
-                                        first_type: first_elem_type.to_string(),
-                                        first_index: index,
-                                        second_span: interner.expr_span(&arr.contents[index]),
-                                        second_type: elem_type.to_string(),
-                                        second_index: index + 1,
-                                    }
-                                    .add_context("elements in an array must have the same type"),
-                                );
-                            }
+                    for (index, elem_type) in elem_types.iter().enumerate().skip(1) {
+                        if !elem_type.matches(&first_elem_type) {
+                            errors.push(
+                                TypeCheckError::NonHomogeneousArray {
+                                    first_span: interner.expr_span(&arr.contents[0]),
+                                    first_type: first_elem_type.to_string(),
+                                    first_index: index,
+                                    second_span: interner.expr_span(&arr.contents[index]),
+                                    second_type: elem_type.to_string(),
+                                    second_index: index + 1,
+                                }
+                                .add_context("elements in an array must have the same type"),
+                            );
                         }
                     }
 
@@ -96,7 +96,7 @@ pub(crate) fn type_check_expression(
         HirExpression::Index(index_expr) => {
             if let Some(ident_def) = interner.ident_def(&index_expr.collection_name) {
                 let index_type = type_check_expression(interner, &index_expr.index, errors);
-                if index_type != Type::CONSTANT && index_type != Type::Error {
+                if !index_type.matches(&Type::CONSTANT) {
                     let span = interner.id_span(&index_expr.index);
                     errors.push(TypeCheckError::TypeMismatch {
                         expected_typ: "const Field".to_owned(),
@@ -109,6 +109,7 @@ pub(crate) fn type_check_expression(
                     // XXX: We can check the array bounds here also, but it may be better to constant fold first
                     // and have ConstId instead of ExprId for constants
                     Type::Array(_, _, base_type) => *base_type,
+                    Type::Error => Type::Error,
                     typ => {
                         let span = interner.id_span(&index_expr.collection_name);
                         errors.push(TypeCheckError::TypeMismatch {
@@ -152,20 +153,15 @@ pub(crate) fn type_check_expression(
         }
         HirExpression::Cast(cast_expr) => {
             // Evaluate the LHS
-            let _lhs_type = type_check_expression(interner, &cast_expr.lhs, errors);
-
-            // Then check that the type_of(LHS) can be casted to the RHS
-            // This is currently being done in the evaluator, we should move it all to here
-            // XXX(^) : Move checks for casting from runtime to here
-
-            // type_of(cast_expr) == type_of(cast_type)
-            cast_expr.r#type
+            let lhs_type = type_check_expression(interner, &cast_expr.lhs, errors);
+            let span = interner.expr_span(expr_id);
+            check_cast(lhs_type, cast_expr.r#type, span, errors)
         }
         HirExpression::For(for_expr) => {
             let start_range_type = type_check_expression(interner, &for_expr.start_range, errors);
             let end_range_type = type_check_expression(interner, &for_expr.end_range, errors);
 
-            if start_range_type != Type::FieldElement(FieldElementType::Constant) {
+            if !start_range_type.matches(&Type::CONSTANT) {
                 errors.push(
                     TypeCheckError::TypeCannotBeUsed {
                         typ: start_range_type.clone(),
@@ -176,7 +172,7 @@ pub(crate) fn type_check_expression(
                 );
             }
 
-            if end_range_type != Type::FieldElement(FieldElementType::Constant) {
+            if !end_range_type.matches(&Type::CONSTANT) {
                 errors.push(
                     TypeCheckError::TypeCannotBeUsed {
                         typ: end_range_type.clone(),
@@ -187,18 +183,21 @@ pub(crate) fn type_check_expression(
                 );
             }
 
-            // This check is only needed, if we decide to not have constant range bounds.
-            if start_range_type != end_range_type {
-                unimplemented!("start range and end range have different types.");
-            }
-            // The type of the identifier is equal to the type of the ranges
-            interner.push_ident_type(&for_expr.identifier, start_range_type);
+            let var_type = if start_range_type.matches(&end_range_type) {
+                start_range_type
+            } else {
+                let msg = format!(
+                    "start range type '{}' does not match the end range type '{}'",
+                    start_range_type, end_range_type
+                );
+                let span = interner.expr_span(&for_expr.end_range);
+                errors.push(TypeCheckError::Unstructured { msg, span });
+                Type::Error
+            };
+
+            interner.push_ident_type(&for_expr.identifier, var_type);
 
             let last_type = type_check_expression(interner, &for_expr.block, errors);
-
-            // XXX: In the release before this, we were using the start and end range to determine the number
-            // of iterations and marking the type as Fixed. Is this still necessary?
-            // It may be possible to do this properly again, once we do constant folding. Since the range will always be const expr
             Type::Array(
                 // The type is assumed to be private unless the user specifies
                 // that they want to make it public on the LHS with type annotations
@@ -215,7 +214,7 @@ pub(crate) fn type_check_expression(
                 let expr_type = super::stmt::type_check(interner, stmt, errors);
 
                 if i + 1 < statements.len() {
-                    if expr_type != Type::Unit && expr_type != Type::Error {
+                    if !expr_type.matches(&Type::Unit) {
                         let id = match interner.statement(stmt) {
                             crate::hir_def::stmt::HirStatement::Expression(expr) => expr,
                             _ => *expr_id,
@@ -251,6 +250,32 @@ pub(crate) fn type_check_expression(
 
     interner.push_expr_type(expr_id, typ.clone());
     typ
+}
+
+fn check_cast(from: Type, to: Type, span: Span, errors: &mut Vec<TypeCheckError>) -> Type {
+    match to {
+        Type::Integer(..) => (), // valid cast
+        Type::FieldElement(_) => (),
+        Type::Error => return Type::Error,
+        _ => {
+            let msg = "Only integer and Field types may be casted to".into();
+            errors.push(TypeCheckError::Unstructured { msg, span });
+            return Type::Error;
+        }
+    }
+
+    match from {
+        Type::Integer(..) => (),
+        Type::FieldElement(_) => (),
+        Type::Error => return Type::Error,
+        from => {
+            let msg = format!("Cannot cast type {} to a(n) {}", from, to);
+            errors.push(TypeCheckError::Unstructured { msg, span });
+            return Type::Error;
+        }
+    }
+
+    to
 }
 
 fn lookup_method(
@@ -397,7 +422,7 @@ fn check_if_expr(
     let cond_type = type_check_expression(interner, &if_expr.condition, errors);
     let then_type = type_check_expression(interner, &if_expr.consequence, errors);
 
-    if cond_type != Type::Bool {
+    if !cond_type.matches(&Type::Bool) {
         errors.push(TypeCheckError::TypeMismatch {
             expected_typ: Type::Bool.to_string(),
             expr_typ: cond_type.to_string(),
@@ -410,7 +435,7 @@ fn check_if_expr(
         Some(alternative) => {
             let else_type = type_check_expression(interner, &alternative, errors);
 
-            if then_type != else_type {
+            if !then_type.matches(&else_type) {
                 let mut err = TypeCheckError::TypeMismatch {
                     expected_typ: then_type.to_string(),
                     expr_typ: else_type.to_string(),

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -9,10 +9,7 @@ mod stmt;
 use errors::TypeCheckError;
 use expr::type_check_expression;
 
-use crate::{
-    hir_def::types::Type,
-    node_interner::{FuncId, NodeInterner},
-};
+use crate::node_interner::{FuncId, NodeInterner};
 
 use self::stmt::bind_pattern;
 
@@ -38,10 +35,7 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     let function_last_type = type_check_expression(interner, func_as_expr, &mut errors);
 
     // Check declared return type and actual return type
-    if !can_ignore_ret
-        && (&function_last_type != declared_return_type)
-        && function_last_type != Type::Error
-    {
+    if !can_ignore_ret && !function_last_type.matches(declared_return_type) {
         let func_span = interner.id_span(func_as_expr); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
         errors.push(TypeCheckError::TypeMismatch {
             expected_typ: declared_return_type.to_string(),

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -98,7 +98,7 @@ fn type_check_assign_stmt(
     if let Some(ident_def) = interner.ident_def(&assign_stmt.identifier) {
         let identifier_type = interner.id_type(&ident_def);
 
-        if expr_type != identifier_type {
+        if !expr_type.matches(&identifier_type) {
             errors.push(TypeCheckError::TypeMismatch {
                 expected_typ: identifier_type.to_string(),
                 expr_typ: expr_type.to_string(),
@@ -177,7 +177,7 @@ fn type_check_declaration(
 
     // Now check if LHS is the same type as the RHS
     // Importantly, we do not co-erce any types implicitly
-    if annotated_type != expr_type {
+    if !annotated_type.matches(&expr_type) {
         let expr_span = interner.expr_span(&rhs_expr);
         errors.push(TypeCheckError::TypeMismatch {
             expected_typ: annotated_type.to_string(),
@@ -186,7 +186,5 @@ fn type_check_declaration(
         });
     }
 
-    // At this point annotated type and user specified type are the same
-    // so we can return either. Cloning a Type is Cheap and may eventually be Copy
     expr_type
 }

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -109,6 +109,14 @@ impl Type {
         }
     }
 
+    /// True if this type 'matches' another. Matching is more strict
+    /// than subtyping but less strict than Eq. In particular, a type
+    /// matches another iff it is exactly equal to the other type or
+    /// either type is the Error type.
+    pub fn matches(&self, other: &Type) -> bool {
+        self == other || self == &Type::Error || other == &Type::Error
+    }
+
     // A feature of the language is that `Field` is like an
     // `Any` type which allows you to pass in any type which
     // is fundamentally a field element. E.g all integer types


### PR DESCRIPTION
I noticed there were still some times we check if a type is exactly equal to another, without checking if either is the error type. This PR adds `Type::matches` for checking `==` or `is_error` and goes through every use of `Type::eq` to ensure we no longer expose the Error type to users in error messages. This ensures that if a particular expression fails to typecheck the user doesn't get an error in every spot that uses that expression saying `expected xxx but found type Error`.

This PR also fills in a TODO to check that type casting is valid in the type checker rather than the evaluator.