### PR TITLE
Enforce variables must be 'mut' to be assigned to

### DIFF
--- a/crates/nargo/tests/test_data/1_mul/src/main.nr
+++ b/crates/nargo/tests/test_data/1_mul/src/main.nr
@@ -1,7 +1,7 @@
 // Test unsafe integer multiplication with overflow: 12^8 = 429 981 696
 // The circuit should handle properly the growth of the bit size
 
-fn main(x : u32, y : u32, z : u32) {
+fn main(mut x : u32, y : u32, z : u32) {
     x = x * y;
     x = x * x;  //144
     x = x * x;  //20736

--- a/crates/nargo/tests/test_data/2_div/src/main.nr
+++ b/crates/nargo/tests/test_data/2_div/src/main.nr
@@ -1,6 +1,6 @@
 // Testing integer division: 7/3 = 2
 
-fn main(x : u32, y : u32, z : u32) {
+fn main(mut x : u32, y : u32, z : u32) {
     x = x / y;
     constrain (x) == z;
 }

--- a/crates/nargo/tests/test_data/3_add/src/main.nr
+++ b/crates/nargo/tests/test_data/3_add/src/main.nr
@@ -1,6 +1,6 @@
 // Test integer addition: 3 + 4 = 7
 
-fn main(x : u32, y : u32, z : u32) {
+fn main(mut x : u32, y : u32, z : u32) {
     x = x + y;
     constrain (x) == z;
 }

--- a/crates/nargo/tests/test_data/4_sub/src/main.nr
+++ b/crates/nargo/tests/test_data/4_sub/src/main.nr
@@ -1,6 +1,6 @@
 // Test unsafe integer substraction with underflow: 12 - 2418266113 = 1876701195 modulo 2^32
 
-fn main(x : u32, y : u32, z : u32) {
+fn main(mut x : u32, y : u32, z : u32) {
     x = x - y;
     constrain (x) == z;
 }

--- a/crates/nargo/tests/test_data/5_over/src/main.nr
+++ b/crates/nargo/tests/test_data/5_over/src/main.nr
@@ -1,6 +1,6 @@
 // Test unsafe integer arithmetic
 
-fn main(x : u32, y : u32) {
+fn main(mut x : u32, y : u32) {
     x = x * x;
     constrain (y) == x;
 }

--- a/crates/noirc_evaluator/src/builtin/setpub.rs
+++ b/crates/noirc_evaluator/src/builtin/setpub.rs
@@ -25,8 +25,9 @@ impl BuiltInCaller for SetPub {
             let func_name = evaluator
                 .context
                 .def_interner
-                .function_meta(&call_expr.func_id)
-                .name;
+                .function_name(&call_expr.func_id)
+                .to_owned();
+
             return Err(RuntimeErrorKind::FunctionNonMainContext { func_name }.add_span(span));
         }
 

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -16,8 +16,8 @@ use acvm::FieldElement;
 use acvm::Language;
 use environment::{Environment, FuncContext};
 use errors::{RuntimeError, RuntimeErrorKind};
-use noirc_frontend::hir::Context;
-use noirc_frontend::node_interner::{ExprId, FuncId, IdentId, StmtId};
+use noirc_frontend::{hir::Context, hir_def::expr::HirIdent};
+use noirc_frontend::node_interner::{ExprId, FuncId, StmtId};
 use noirc_frontend::{
     hir_def::{
         expr::{
@@ -174,9 +174,9 @@ impl<'a> Evaluator<'a> {
     // This is because, we currently do not have support for optimisations with polynomials of higher degree or higher fan-ins
     // XXX: One way to configure this in the future, is to count the fan-in/out and check if it is lower than the configured width
     // Either it is 1 * x + 0 or it is ax+b
-    fn evaluate_identifier(&mut self, ident_id: &IdentId, env: &mut Environment) -> Object {
-        let ident_name = self.context.def_interner.ident_name(ident_id);
-        env.get(&ident_name)
+    fn evaluate_identifier(&mut self, ident: HirIdent, env: &mut Environment) -> Object {
+        let ident_name = self.context.def_interner.definition_name(ident.id);
+        env.get(ident_name)
     }
 
     /// Compiles the AST into the intermediate format by evaluating the main function
@@ -224,7 +224,7 @@ impl<'a> Evaluator<'a> {
         let func_meta = self.context.def_interner.function_meta(&self.main_function);
         // XXX: We make the span very general here, so an error will underline all of the parameters in the span
         // This maybe not be desireable in the long run, because we want to point to the exact place
-        let param_span = func_meta.parameters.span(&self.context.def_interner);
+        let param_span = func_meta.parameters.span();
 
         let abi = func_meta.parameters.into_abi(&self.context.def_interner);
 
@@ -321,7 +321,7 @@ impl<'a> Evaluator<'a> {
 
     fn pattern_name(&self, pattern: &HirPattern) -> String {
         match pattern {
-            HirPattern::Identifier(id) => self.context.def_interner.ident_name(id),
+            HirPattern::Identifier(ident) => self.context.def_interner.definition_name(ident.id).to_owned(),
             HirPattern::Mutable(pattern, _) => self.pattern_name(pattern),
             HirPattern::Tuple(_, _) => todo!("Implement tuples in the backend"),
             HirPattern::Struct(_, _, _) => todo!("Implement structs in the backend"),
@@ -532,7 +532,7 @@ impl<'a> Evaluator<'a> {
             env.start_scope();
 
             // Add indice to environment
-            let variable_name = self.context.def_interner.ident_name(&for_expr.identifier);
+            let variable_name = self.context.def_interner.definition_name(for_expr.identifier.id).to_owned();
             env.store(variable_name, Object::Constants(indice));
 
             let block = self.expression_to_block(&for_expr.block);
@@ -586,7 +586,7 @@ impl<'a> Evaluator<'a> {
             HirExpression::Literal(HirLiteral::Array(arr_lit)) => {
                 Ok(Object::Array(Array::from(self, env, arr_lit)?))
             }
-            HirExpression::Ident(x) => Ok(self.evaluate_identifier(&x, env)),
+            HirExpression::Ident(x) => Ok(self.evaluate_identifier(x, env)),
             HirExpression::Infix(infx) => {
                 let lhs = self.expression_to_object(env, &infx.lhs)?;
                 let rhs = self.expression_to_object(env, &infx.rhs)?;
@@ -598,8 +598,8 @@ impl<'a> Evaluator<'a> {
             }
             HirExpression::Index(indexed_expr) => {
                 // Currently these only happen for arrays
-                let arr_name = self.context.def_interner.ident_name(&indexed_expr.collection_name);
-                let ident_span = self.context.def_interner.ident_span(&indexed_expr.collection_name);
+                let arr_name = self.context.def_interner.definition_name(indexed_expr.collection_name.id);
+                let ident_span = indexed_expr.collection_name.span;
                 let arr = env.get_array(&arr_name).map_err(|kind|kind.add_span(ident_span))?;
                 //
                 // Evaluate the index expression

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -16,8 +16,8 @@ use acvm::FieldElement;
 use acvm::Language;
 use environment::{Environment, FuncContext};
 use errors::{RuntimeError, RuntimeErrorKind};
-use noirc_frontend::{hir::Context, hir_def::expr::HirIdent};
 use noirc_frontend::node_interner::{ExprId, FuncId, StmtId};
+use noirc_frontend::{hir::Context, hir_def::expr::HirIdent};
 use noirc_frontend::{
     hir_def::{
         expr::{
@@ -321,7 +321,11 @@ impl<'a> Evaluator<'a> {
 
     fn pattern_name(&self, pattern: &HirPattern) -> String {
         match pattern {
-            HirPattern::Identifier(ident) => self.context.def_interner.definition_name(ident.id).to_owned(),
+            HirPattern::Identifier(ident) => self
+                .context
+                .def_interner
+                .definition_name(ident.id)
+                .to_owned(),
             HirPattern::Mutable(pattern, _) => self.pattern_name(pattern),
             HirPattern::Tuple(_, _) => todo!("Implement tuples in the backend"),
             HirPattern::Struct(_, _, _) => todo!("Implement structs in the backend"),
@@ -532,7 +536,11 @@ impl<'a> Evaluator<'a> {
             env.start_scope();
 
             // Add indice to environment
-            let variable_name = self.context.def_interner.definition_name(for_expr.identifier.id).to_owned();
+            let variable_name = self
+                .context
+                .def_interner
+                .definition_name(for_expr.identifier.id)
+                .to_owned();
             env.store(variable_name, Object::Constants(indice));
 
             let block = self.expression_to_block(&for_expr.block);
@@ -600,7 +608,7 @@ impl<'a> Evaluator<'a> {
                 // Currently these only happen for arrays
                 let arr_name = self.context.def_interner.definition_name(indexed_expr.collection_name.id);
                 let ident_span = indexed_expr.collection_name.span;
-                let arr = env.get_array(&arr_name).map_err(|kind|kind.add_span(ident_span))?;
+                let arr = env.get_array(arr_name).map_err(|kind|kind.add_span(ident_span))?;
                 //
                 // Evaluate the index expression
                 let index_as_obj = self.expression_to_object(env, &indexed_expr.index)?;

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -9,14 +9,14 @@ use super::super::errors::{RuntimeError, RuntimeErrorKind};
 use crate::object::Object;
 use acvm::FieldElement;
 use noirc_frontend::hir::Context;
-use noirc_frontend::hir_def::expr::{HirConstructorExpression, HirMemberAccess};
+use noirc_frontend::hir_def::expr::{HirConstructorExpression, HirMemberAccess, HirIdent};
 use noirc_frontend::hir_def::function::HirFunction;
 use noirc_frontend::hir_def::stmt::HirPattern;
 use noirc_frontend::hir_def::{
     expr::{HirBinaryOp, HirBinaryOpKind, HirExpression, HirForExpression, HirLiteral},
     stmt::{HirConstrainStatement, HirLetStatement, HirStatement},
 };
-use noirc_frontend::node_interner::{ExprId, IdentId, NodeInterner, StmtId};
+use noirc_frontend::node_interner::{ExprId, NodeInterner, StmtId, DefinitionId};
 use noirc_frontend::util::vecmap;
 use noirc_frontend::{FunctionKind, Type};
 
@@ -26,7 +26,7 @@ struct IRGenerator<'a> {
 
     /// The current value of a variable. Used for flattening structs
     /// into multiple variables/values
-    variable_values: HashMap<IdentId, Value>,
+    variable_values: HashMap<DefinitionId, Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -69,8 +69,8 @@ impl<'a> IRGenerator<'a> {
         }
     }
 
-    fn find_variable(&self, variable_def: Option<IdentId>) -> Option<&Value> {
-        variable_def.and_then(|def| self.variable_values.get(&def))
+    fn find_variable(&self, variable_def: DefinitionId) -> Option<&Value> {
+        self.variable_values.get(&variable_def)
     }
 
     fn get_current_value(&mut self, value: &Value) -> Value {
@@ -83,20 +83,19 @@ impl<'a> IRGenerator<'a> {
         }
     }
 
-    fn evaluate_identifier(&mut self, env: &mut Environment, ident_id: &IdentId) -> Value {
-        let ident_def = self.ident_def(ident_id);
-        if let Some(value) = ident_def.and_then(|def| self.variable_values.get(&def)) {
+    fn evaluate_identifier(&mut self, env: &mut Environment, ident: HirIdent) -> Value {
+        if let Some(value) = self.variable_values.get(&ident.id) {
             let value = value.clone();
             return self.get_current_value(&value);
         }
 
-        let ident_name = dbg!(self.ident_name(ident_id));
+        let ident_name = self.ident_name(&ident);
         let obj = env.get(&ident_name);
         let o_type = self
             .context
             .context
             .def_interner
-            .id_type(ident_def.unwrap());
+            .id_type(ident.id);
 
         let var = match obj {
             Object::Array(a) => {
@@ -104,7 +103,7 @@ impl<'a> IRGenerator<'a> {
                 //We should create an array from 'a' witnesses
                 self.context.mem.create_array_from_object(
                     &a,
-                    ident_def.unwrap(),
+                    ident.id,
                     obj_type,
                     &ident_name,
                 );
@@ -114,7 +113,7 @@ impl<'a> IRGenerator<'a> {
                     name: ident_name.clone(),
                     obj_type: node::ObjectType::Pointer(array_index),
                     root: None,
-                    def: ident_def,
+                    def: Some(ident.id),
                     witness: None,
                     parent_block: self.context.current_block,
                 }
@@ -127,7 +126,7 @@ impl<'a> IRGenerator<'a> {
                     name: ident_name.clone(),
                     obj_type,
                     root: None,
-                    def: ident_def,
+                    def: Some(ident.id),
                     witness: node::get_witness_from_object(&obj),
                     parent_block: self.context.current_block,
                 }
@@ -191,7 +190,7 @@ impl<'a> IRGenerator<'a> {
                 self.handle_let_statement(env, let_stmt)
             }
             HirStatement::Assign(assign_stmt) => {
-                let ident_def = self.def_interner().ident_def(&assign_stmt.identifier);
+                let ident_def = assign_stmt.identifier.id;
                 //////////////TODO temp this is needed because we don't parse main arguments
                 let ident_name = self.ident_name(&assign_stmt.identifier);
 
@@ -205,7 +204,7 @@ impl<'a> IRGenerator<'a> {
                 } else {
                     //var is not defined,
                     //let's do it here for now...TODO
-                    let typ = self.def_interner().id_type(&assign_stmt.identifier);
+                    let typ = self.def_interner().id_type(assign_stmt.identifier.id);
                     self.bind_fresh_pattern(&ident_name, &typ, rhs);
                 }
 
@@ -220,7 +219,7 @@ impl<'a> IRGenerator<'a> {
     fn create_new_variable(
         &mut self,
         var_name: String,
-        def: Option<IdentId>,
+        def: DefinitionId,
         env: &mut Environment,
     ) -> NodeId {
         let obj = env.get(&var_name);
@@ -230,7 +229,7 @@ impl<'a> IRGenerator<'a> {
             obj_type,
             name: var_name,
             root: None,
-            def,
+            def: Some(def),
             witness: node::get_witness_from_object(&obj),
             parent_block: self.context.current_block,
         };
@@ -296,24 +295,23 @@ impl<'a> IRGenerator<'a> {
     /// let bindings of struct variables, declaring a new variable for each field.
     fn bind_pattern(&mut self, pattern: &HirPattern, value: Value) {
         match (pattern, value) {
-            (HirPattern::Identifier(ident_id), Value::Single(node_id)) => {
-                let typ = self.def_interner().id_type(ident_id);
-                let variable_name = self.ident_name(ident_id);
-                let ident_def = self.ident_def(ident_id);
-                let value = self.bind_variable(variable_name, ident_def, &typ, node_id);
-                self.variable_values.insert(*ident_id, value);
+            (HirPattern::Identifier(ident), Value::Single(node_id)) => {
+                let typ = self.def_interner().id_type(ident.id);
+                let variable_name = self.ident_name(ident);
+                let value = self.bind_variable(variable_name, Some(ident.id), &typ, node_id);
+                self.variable_values.insert(ident.id, value);
             }
-            (HirPattern::Identifier(ident_id), value @ Value::Struct(_)) => {
-                let typ = self.def_interner().id_type(ident_id);
-                let name = self.ident_name(ident_id);
+            (HirPattern::Identifier(ident), value @ Value::Struct(_)) => {
+                let typ = self.def_interner().id_type(ident.id);
+                let name = self.ident_name(ident);
                 let value = self.bind_fresh_pattern(&name, &typ, value);
-                self.variable_values.insert(*ident_id, value);
+                self.variable_values.insert(ident.id, value);
             }
             (HirPattern::Mutable(pattern, _), value) => self.bind_pattern(pattern, value),
             (pattern @ (HirPattern::Tuple(..) | HirPattern::Struct(..)), Value::Struct(exprs)) => {
                 assert_eq!(pattern.field_count(), exprs.len());
                 for ((pattern_name, pattern), (field_name, value)) in pattern
-                    .iter_fields(&self.context.context.def_interner)
+                    .iter_fields()
                     .zip(exprs)
                 {
                     assert_eq!(pattern_name, field_name);
@@ -351,7 +349,7 @@ impl<'a> IRGenerator<'a> {
     fn bind_variable(
         &mut self,
         variable_name: String,
-        ident_def: Option<IdentId>,
+        definition_id: Option<DefinitionId>,
         typ: &Type,
         value_id: NodeId,
     ) -> Value {
@@ -359,7 +357,7 @@ impl<'a> IRGenerator<'a> {
 
         if matches!(obj_type, node::ObjectType::Pointer(_)) {
             if let Ok(rhs_mut) = self.context.get_mut_variable(value_id) {
-                rhs_mut.def = ident_def;
+                rhs_mut.def = definition_id;
                 rhs_mut.name = variable_name;
                 return Value::Single(value_id);
             }
@@ -368,7 +366,7 @@ impl<'a> IRGenerator<'a> {
         let new_var = Variable::new(
             obj_type,
             variable_name,
-            ident_def,
+            definition_id,
             self.context.current_block,
         );
         let id = self.context.add_variable(new_var, None);
@@ -444,12 +442,8 @@ impl<'a> IRGenerator<'a> {
         }
     }
 
-    fn ident_name(&self, ident: &IdentId) -> String {
-        self.context.context.def_interner.ident_name(ident)
-    }
-
-    fn ident_def(&self, ident: &IdentId) -> Option<IdentId> {
-        self.context.context.def_interner.ident_def(ident)
+    fn ident_name(&self, ident: &HirIdent) -> String {
+        self.context.context.def_interner.definition_name(ident.id).to_owned()
     }
 
     // Let statements are used to declare higher level objects
@@ -504,7 +498,7 @@ impl<'a> IRGenerator<'a> {
                 Ok(Value::Single(self.context.add_variable(new_var, None)))
             },
             HirExpression::Ident(x) =>  {
-               Ok(self.evaluate_identifier(env, &x))
+               Ok(self.evaluate_identifier(env, x))
                 //n.b this creates a new variable if it does not exist, may be we should delegate this to explicit statements (let) - TODO
             },
             HirExpression::Infix(infx) => {
@@ -535,13 +529,13 @@ impl<'a> IRGenerator<'a> {
             },
             HirExpression::Index(indexed_expr) => {
                 // Currently these only happen for arrays
-                let arr_def = self.def_interner().ident_def(&indexed_expr.collection_name);
-                let arr_name = self.def_interner().ident_name(&indexed_expr.collection_name);
-                let ident_span = self.def_interner().ident_span(&indexed_expr.collection_name);
-                let arr_type = self.def_interner().id_type(arr_def.unwrap());
+                let arr_def = indexed_expr.collection_name.id;
+                let arr_name = self.def_interner().definition_name(indexed_expr.collection_name.id).to_owned();
+                let ident_span = indexed_expr.collection_name.span;
+                let arr_type = self.def_interner().id_type(arr_def);
                 let o_type = arr_type.into();
                 let mut array_index = self.context.mem.arrays.len() as u32;
-                let array = if let Some(moi) = self.context.mem.find_array(&arr_def) {
+                let array = if let Some(moi) = self.context.mem.find_array(&Some(arr_def)) {
                     array_index= self.context.mem.get_array_index(moi).unwrap();
                     moi
                 }
@@ -556,7 +550,7 @@ impl<'a> IRGenerator<'a> {
                  }
                 else {
                     let arr = env.get_array(&arr_name).map_err(|kind|kind.add_span(ident_span)).unwrap();
-                    self.context.mem.create_array_from_object(&arr, arr_def.unwrap(), o_type, &arr_name)
+                    self.context.mem.create_array_from_object(&arr, arr_def, o_type, &arr_name)
                 };
                 //let array = self.mem.get_or_create_array(&arr, arr_def.unwrap(), o_type, arr_name);
                 let address = array.adr;
@@ -612,7 +606,7 @@ impl<'a> IRGenerator<'a> {
             .fields
             .into_iter()
             .map(|(ident, field)| {
-                let field_name = self.ident_name(&ident);
+                let field_name = ident.0.contents;
                 Ok((field_name, self.expression_to_object(env, &field)?))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -698,9 +692,9 @@ impl<'a> IRGenerator<'a> {
         //We support only const range for now
         let start = self.context.get_as_constant(start_idx).unwrap();
         //TODO how should we handle scope (cf. start/end_for_loop)?
-        let iter_name = self.def_interner().ident_name(&for_expr.identifier);
-        let iter_def = self.def_interner().ident_def(&for_expr.identifier);
-        let int_type = self.def_interner().id_type(&for_expr.identifier);
+        let iter_name = self.def_interner().definition_name(for_expr.identifier.id).to_owned();
+        let iter_def = for_expr.identifier.id;
+        let int_type = self.def_interner().id_type(iter_def);
         env.store(iter_name.clone(), Object::Constants(start));
         let iter_id = self.create_new_variable(iter_name, iter_def, env);
         let iter_var = self.context.get_mut_variable(iter_id).unwrap();

--- a/crates/noirc_evaluator/src/ssa/mem.rs
+++ b/crates/noirc_evaluator/src/ssa/mem.rs
@@ -2,7 +2,7 @@ use super::context::SsaContext;
 use super::node::{self, Node, NodeId};
 use acvm::acir::native_types::Witness;
 use acvm::FieldElement;
-use noirc_frontend::node_interner::IdentId;
+use noirc_frontend::node_interner::DefinitionId;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use std::collections::HashMap;
@@ -23,7 +23,7 @@ pub struct MemArray {
     pub element_type: node::ObjectType, //type of elements
     pub witness: Vec<Witness>,
     pub name: String,
-    pub def: IdentId,
+    pub def: DefinitionId,
     pub len: u32,     //number of elements
     pub adr: u32,     //base address of the array
     pub max: BigUint, //Max possible value of array elements
@@ -39,7 +39,7 @@ impl MemArray {
         assert!(self.witness.is_empty() || self.witness.len() == self.len.try_into().unwrap());
     }
 
-    pub fn new(definition: IdentId, name: &str, of: node::ObjectType, len: u32) -> MemArray {
+    pub fn new(definition: DefinitionId, name: &str, of: node::ObjectType, len: u32) -> MemArray {
         assert!(len > 0);
         MemArray {
             element_type: of,
@@ -54,7 +54,7 @@ impl MemArray {
 }
 
 impl Memory {
-    pub fn find_array(&self, definition: &Option<IdentId>) -> Option<&MemArray> {
+    pub fn find_array(&self, definition: &Option<DefinitionId>) -> Option<&MemArray> {
         definition.and_then(|def| self.arrays.iter().find(|a| a.def == def))
     }
 
@@ -76,7 +76,7 @@ impl Memory {
     pub fn create_array_from_object(
         &mut self,
         array: &Array,
-        definition: IdentId,
+        definition: DefinitionId,
         el_type: node::ObjectType,
         arr_name: &str,
     ) -> &MemArray {
@@ -89,7 +89,7 @@ impl Memory {
     }
 
     pub fn create_new_array(&mut self, len: u32, el_type: node::ObjectType, arr_name: &str) -> u32 {
-        let mut new_array = MemArray::new(IdentId::dummy_id(), arr_name, el_type, len);
+        let mut new_array = MemArray::new(DefinitionId::dummy_id(), arr_name, el_type, len);
         new_array.adr = self.last_adr;
         self.arrays.push(new_array);
         self.last_adr += len;

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -6,7 +6,7 @@ use acvm::acir::OPCODE;
 use acvm::FieldElement;
 use arena;
 use noirc_frontend::hir_def::expr::HirBinaryOpKind;
-use noirc_frontend::node_interner::IdentId;
+use noirc_frontend::node_interner::DefinitionId;
 use noirc_frontend::{Signedness, Type};
 use num_bigint::BigUint;
 use num_traits::One;
@@ -139,7 +139,7 @@ pub struct Variable {
     pub name: String,
     //pub cur_value: arena::Index, //for generating the SSA form, current value of the object during parsing of the AST
     pub root: Option<NodeId>, //when generating SSA, assignment of an object creates a new one which is linked to the original one
-    pub def: Option<IdentId>, //TODO redundant with root - should it be an option?
+    pub def: Option<DefinitionId>, //TODO redundant with root - should it be an option?
     //TODO clarify where cur_value and root is stored, and also this:
     //  pub max_bits: u32,                  //max possible bit size of the expression
     //  pub max_value: Option<BigUInt>,     //maximum possible value of the expression, if less than max_bits
@@ -155,7 +155,7 @@ impl Variable {
     pub fn new(
         obj_type: ObjectType,
         name: String,
-        def: Option<IdentId>,
+        def: Option<DefinitionId>,
         parent_block: BlockId,
     ) -> Variable {
         Variable {

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -2,7 +2,7 @@ use fm::FileId;
 use noirc_errors::{CollectedErrors, CustomDiagnostic, DiagnosableError};
 
 use crate::{
-    graph::CrateId, hir::def_collector::dc_crate::UnresolvedStruct, node_interner::TypeId, Ident,
+    graph::CrateId, hir::def_collector::dc_crate::UnresolvedStruct, node_interner::StructId, Ident,
     NoirFunction, NoirImpl, NoirStruct, ParsedModule,
 };
 
@@ -149,7 +149,7 @@ impl<'a> ModCollector<'a> {
 
             // Create the corresponding module for the struct namespace
             let id = match self.push_child_module(&name, self.file_id, false) {
-                Ok(local_id) => TypeId(ModuleId { krate, local_id }),
+                Ok(local_id) => StructId(ModuleId { krate, local_id }),
                 Err(mut more_errors) => {
                     errors.append(&mut more_errors);
                     continue;

--- a/crates/noirc_frontend/src/hir/def_map/item_scope.rs
+++ b/crates/noirc_frontend/src/hir/def_map/item_scope.rs
@@ -1,6 +1,6 @@
 use super::{namespace::PerNs, ModuleDefId, ModuleId};
 use crate::{
-    node_interner::{FuncId, TypeId},
+    node_interner::{FuncId, StructId},
     Ident,
 };
 use std::collections::{hash_map::Entry, HashMap};
@@ -69,7 +69,7 @@ impl ItemScope {
     pub fn define_struct_def(
         &mut self,
         name: Ident,
-        local_id: TypeId,
+        local_id: StructId,
     ) -> Result<(), (Ident, Ident)> {
         self.add_definition(name, ModuleDefId::TypeId(local_id))
     }

--- a/crates/noirc_frontend/src/hir/def_map/module_def.rs
+++ b/crates/noirc_frontend/src/hir/def_map/module_def.rs
@@ -1,4 +1,4 @@
-use crate::node_interner::{FuncId, TypeId};
+use crate::node_interner::{FuncId, StructId};
 
 use super::ModuleId;
 
@@ -6,7 +6,7 @@ use super::ModuleId;
 pub enum ModuleDefId {
     ModuleId(ModuleId),
     FunctionId(FuncId),
-    TypeId(TypeId),
+    TypeId(StructId),
 }
 
 impl ModuleDefId {
@@ -17,7 +17,7 @@ impl ModuleDefId {
         }
     }
 
-    pub fn as_type(&self) -> Option<TypeId> {
+    pub fn as_type(&self) -> Option<StructId> {
         match self {
             ModuleDefId::TypeId(type_id) => Some(*type_id),
             _ => None,
@@ -67,13 +67,13 @@ impl TryFromModuleDefId for FuncId {
     }
 }
 
-impl TryFromModuleDefId for TypeId {
+impl TryFromModuleDefId for StructId {
     fn try_from(id: ModuleDefId) -> Option<Self> {
         id.as_type()
     }
 
     fn dummy_id() -> Self {
-        TypeId::dummy_id()
+        StructId::dummy_id()
     }
 
     fn description() -> String {

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -2,10 +2,7 @@ use noirc_errors::CustomDiagnostic as Diagnostic;
 pub use noirc_errors::Span;
 use thiserror::Error;
 
-use crate::{
-    node_interner::NodeInterner,
-    Ident, hir_def::expr::HirIdent,
-};
+use crate::{hir_def::expr::HirIdent, node_interner::NodeInterner, Ident};
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ResolverError {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -14,14 +14,14 @@
 #[derive(Debug, PartialEq, Eq)]
 struct ResolverMeta {
     num_times_used: usize,
-    id: IdentId,
+    ident: HirIdent,
 }
 
 use crate::hir_def::expr::{
     HirArrayLiteral, HirBinaryOp, HirBlockExpression, HirCallExpression, HirCastExpression,
     HirConstructorExpression, HirForExpression, HirIfExpression, HirIndexExpression,
     HirInfixExpression, HirLiteral, HirMemberAccess, HirMethodCallExpression, HirPrefixExpression,
-    HirUnaryOp,
+    HirUnaryOp, HirIdent,
 };
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -31,7 +31,7 @@ use crate::graph::CrateId;
 use crate::hir::def_map::{ModuleDefId, TryFromModuleDefId};
 use crate::hir_def::expr::HirExpression;
 use crate::hir_def::stmt::{HirAssignStatement, HirPattern};
-use crate::node_interner::{ExprId, FuncId, IdentId, NodeInterner, StmtId, TypeId};
+use crate::node_interner::{ExprId, FuncId, NodeInterner, StmtId, StructId, DefinitionId};
 use crate::util::vecmap;
 use crate::{
     hir::{def_map::CrateDefMap, resolution::path_resolver::PathResolver},
@@ -60,7 +60,7 @@ pub struct Resolver<'a> {
     path_resolver: &'a dyn PathResolver,
     def_maps: &'a HashMap<CrateId, CrateDefMap>,
     interner: &'a mut NodeInterner,
-    self_type: Option<TypeId>,
+    self_type: Option<StructId>,
     errors: Vec<ResolverError>,
 }
 
@@ -80,7 +80,7 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub fn set_self_type(&mut self, self_type: Option<TypeId>) {
+    pub fn set_self_type(&mut self, self_type: Option<StructId>) {
         self.self_type = self_type;
     }
 
@@ -113,15 +113,15 @@ impl<'a> Resolver<'a> {
         }
 
         for unused_var in unused_vars.iter() {
-            if self.interner.ident_name(unused_var) != ERROR_IDENT {
+            if self.interner.definition_name(unused_var.id) != ERROR_IDENT {
                 self.push_err(ResolverError::UnusedVariable {
-                    ident_id: *unused_var,
+                    ident: *unused_var,
                 });
             }
         }
     }
 
-    fn check_for_unused_variables_in_local_scope(decl_map: Scope, unused_vars: &mut Vec<IdentId>) {
+    fn check_for_unused_variables_in_local_scope(decl_map: Scope, unused_vars: &mut Vec<HirIdent>) {
         let unused_variables = decl_map.filter(|(variable_name, metadata)| {
             let has_underscore_prefix = variable_name.starts_with('_'); // XXX: This is used for development mode, and will be removed
 
@@ -130,7 +130,7 @@ impl<'a> Resolver<'a> {
             }
             false
         });
-        unused_vars.extend(unused_variables.map(|(_, meta)| meta.id));
+        unused_vars.extend(unused_variables.map(|(_, meta)| meta.ident));
     }
 
     /// Run the given function in a new scope.
@@ -142,30 +142,25 @@ impl<'a> Resolver<'a> {
         ret
     }
 
-    fn add_variable_decl(&mut self, name: Ident) -> IdentId {
-        let id = self.interner.push_ident(name.clone());
-        // Variable was defined here, so it's definition links to itself
-        self.interner.linked_ident_to_def(id, id);
+    fn add_variable_decl(&mut self, name: Ident, mutable: bool) -> HirIdent {
+        let id = self.interner.push_definition(name.0.contents.clone(), mutable);
+        let ident = HirIdent { span: name.span(), id };
 
         let scope = self.scopes.get_mut_scope();
         let resolver_meta = ResolverMeta {
             num_times_used: 0,
-            id,
+            ident,
         };
-        let old_value = scope.add_key_value(name.0.contents, resolver_meta);
 
-        match old_value {
-            None => {
-                // New value, do nothing
-            }
-            Some(old_value) => {
-                self.push_err(ResolverError::DuplicateDefinition {
-                    first_ident: old_value.id,
-                    second_ident: id,
-                });
-            }
+        let old_value = scope.add_key_value(name.0.contents, resolver_meta);
+        if let Some(old_value) = old_value {
+            self.push_err(ResolverError::DuplicateDefinition {
+                first_ident: old_value.ident,
+                second_ident: ident,
+            });
         }
-        id
+
+        ident
     }
 
     // Checks for a variable having been declared before
@@ -175,27 +170,25 @@ impl<'a> Resolver<'a> {
     //
     // If a variable is not found, then an error is logged and a dummy id
     // is returned, for better error reporting UX
-    fn find_variable(&mut self, name: &Ident) -> IdentId {
-        // Give variable an IdentId. This is not a definition
-        let id = self.interner.push_ident(name.clone());
-
+    fn find_variable(&mut self, name: &Ident) -> HirIdent {
         // Find the definition for this Ident
         let scope_tree = self.scopes.current_scope_tree();
         let variable = scope_tree.find(&name.0.contents);
 
-        if let Some(variable_found) = variable {
+        let id = if let Some(variable_found) = variable {
             variable_found.num_times_used += 1;
-            self.interner.linked_ident_to_def(id, variable_found.id);
-            return id;
-        }
+            variable_found.ident.id
+        } else {
+            self.push_err(ResolverError::VariableNotDeclared {
+                name: name.0.contents.clone(),
+                span: name.0.span(),
+            });
 
-        let err = ResolverError::VariableNotDeclared {
-            name: name.0.contents.clone(),
-            span: name.0.span(),
+            DefinitionId::dummy_id()
         };
-        self.push_err(err);
 
-        IdentId::dummy_id()
+        let span = name.span();
+        HirIdent { span, id }
     }
 
     pub fn intern_function(&mut self, func: NoirFunction) -> (HirFunction, FuncMeta) {
@@ -251,7 +244,11 @@ impl<'a> Resolver<'a> {
     /// to be used in analysis and intern the function parameters
     fn extract_meta(&mut self, func: &NoirFunction) -> FuncMeta {
         let name = func.name().to_owned();
-        let name_id = self.interner.push_ident(func.name_ident().clone());
+
+        let span = func.name_ident().span();
+        let id = self.interner.push_definition(name, false);
+        let name = HirIdent { id, span };
+
         let attributes = func.attribute().cloned();
 
         let mut parameters = Vec::new();
@@ -265,7 +262,6 @@ impl<'a> Resolver<'a> {
 
         FuncMeta {
             name,
-            name_id,
             kind: func.kind,
             attributes,
             parameters: parameters.into(),
@@ -371,8 +367,10 @@ impl<'a> Resolver<'a> {
                 let end_range = self.resolve_expression(for_expr.end_range);
                 let (identifier, block) = (for_expr.identifier, for_expr.block);
 
+                // TODO: For loop variables are currently mutable by default since we haven't
+                //       yet implemented syntax for them to be optionally mutable.
                 let (identifier, block_id) = self.in_new_scope(|this| {
-                    (this.add_variable_decl(identifier), this.intern_block(block))
+                    (this.add_variable_decl(identifier, true), this.intern_block(block))
                 });
 
                 HirExpression::For(HirForExpression {
@@ -395,16 +393,15 @@ impl<'a> Resolver<'a> {
                 // If the Path is being used as an Expression, then it is referring to an Identifier
                 //
                 // This is currently not supported : const x = foo::bar::SOME_CONST + 10;
-                let ident_id = match path.as_ident() {
+                HirExpression::Ident(match path.as_ident() {
+                    Some(identifier) => self.find_variable(identifier),
                     None => {
                         self.push_err(ResolverError::PathIsNotIdent { span: path.span() });
-
-                        IdentId::dummy_id()
+                        let id = DefinitionId::dummy_id();
+                        let span = path.span();
+                        HirIdent { id, span }
                     }
-                    Some(identifier) => self.find_variable(identifier),
-                };
-
-                HirExpression::Ident(ident_id)
+                })
             }
             ExpressionKind::Block(block_expr) => self.resolve_block(block_expr),
             ExpressionKind::Constructor(constructor) => {
@@ -454,7 +451,7 @@ impl<'a> Resolver<'a> {
     fn resolve_pattern_mutable(&mut self, pattern: Pattern, mutable: Option<Span>) -> HirPattern {
         match pattern {
             Pattern::Identifier(name) => {
-                let id = self.add_variable_decl(name);
+                let id = self.add_variable_decl(name, mutable.is_some());
                 HirPattern::Identifier(id)
             }
             Pattern::Mutable(pattern, span) => {
@@ -492,11 +489,11 @@ impl<'a> Resolver<'a> {
     /// and constructor patterns.
     fn resolve_constructor_fields<T, U, F>(
         &mut self,
-        type_id: TypeId,
+        type_id: StructId,
         fields: Vec<(Ident, T)>,
         span: Span,
         mut resolve_function: F,
-    ) -> Vec<(IdentId, U)>
+    ) -> Vec<(Ident, U)>
     where
         F: FnMut(&mut Self, T) -> U,
     {
@@ -523,8 +520,7 @@ impl<'a> Resolver<'a> {
                 });
             }
 
-            let name_id = self.interner.push_ident(field);
-            ret.push((name_id, resolved));
+            ret.push((field, resolved));
         }
 
         if !unseen_fields.is_empty() {
@@ -541,11 +537,11 @@ impl<'a> Resolver<'a> {
         ret
     }
 
-    pub fn get_struct(&self, type_id: TypeId) -> Rc<RefCell<StructType>> {
+    pub fn get_struct(&self, type_id: StructId) -> Rc<RefCell<StructType>> {
         self.interner.get_struct(type_id)
     }
 
-    fn get_field_names_of_type(&self, type_id: TypeId) -> HashSet<Ident> {
+    fn get_field_names_of_type(&self, type_id: StructId) -> HashSet<Ident> {
         let typ = self.get_struct(type_id);
         let typ = typ.borrow();
         typ.fields.iter().map(|(name, _)| name.clone()).collect()
@@ -571,7 +567,7 @@ impl<'a> Resolver<'a> {
         self.lookup(path)
     }
 
-    fn lookup_type(&mut self, path: Path) -> TypeId {
+    fn lookup_type(&mut self, path: Path) -> StructId {
         let ident = path.as_ident();
         if ident.map_or(false, |i| i == "Self") {
             if let Some(id) = &self.self_type {
@@ -584,10 +580,10 @@ impl<'a> Resolver<'a> {
 
     pub fn lookup_struct(&mut self, path: Path) -> Option<Rc<RefCell<StructType>>> {
         let id = self.lookup_type(path);
-        (id != TypeId::dummy_id()).then(|| self.get_struct(id))
+        (id != StructId::dummy_id()).then(|| self.get_struct(id))
     }
 
-    pub fn lookup_type_for_impl(mut self, path: Path) -> (TypeId, Vec<ResolverError>) {
+    pub fn lookup_type_for_impl(mut self, path: Path) -> (StructId, Vec<ResolverError>) {
         (self.lookup_type(path), self.errors)
     }
 
@@ -710,12 +706,13 @@ mod test {
         let err = errors.pop().unwrap();
         // It should be regarding the unused variable
         match err {
-            ResolverError::UnusedVariable { ident_id } => {
-                assert_eq!(interner.ident_name(&ident_id), "y".to_owned());
+            ResolverError::UnusedVariable { ident } => {
+                assert_eq!(interner.definition_name(ident.id), "y".to_owned());
             }
             _ => unimplemented!("we should only have an unused var error"),
         }
     }
+
     #[test]
     fn resolve_unresolved_var() {
         let src = r#"
@@ -785,8 +782,8 @@ mod test {
         // `foo::bar` does not exist
         for err in errors {
             match &err {
-                ResolverError::UnusedVariable { ident_id } => {
-                    let name = interner.ident_name(ident_id);
+                ResolverError::UnusedVariable { ident } => {
+                    let name = interner.definition_name(ident.id);
                     assert_eq!(name, "z");
                 }
                 ResolverError::VariableNotDeclared { name, .. } => {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -17,12 +17,9 @@ pub(crate) fn type_check_expression(
     errors: &mut Vec<TypeCheckError>,
 ) -> Type {
     let typ = match interner.expression(expr_id) {
-        HirExpression::Ident(ident_id) => {
+        HirExpression::Ident(ident) => {
             // If an Ident is used in an expression, it cannot be a declaration statement
-            match interner.ident_def(&ident_id) {
-                Some(ident_def_id) => interner.id_type(ident_def_id),
-                None => Type::Error,
-            }
+            interner.id_type(ident.id)
         }
         HirExpression::Literal(literal) => {
             match literal {
@@ -94,33 +91,30 @@ pub(crate) fn type_check_expression(
             }
         }
         HirExpression::Index(index_expr) => {
-            if let Some(ident_def) = interner.ident_def(&index_expr.collection_name) {
-                let index_type = type_check_expression(interner, &index_expr.index, errors);
-                if index_type != Type::CONSTANT && index_type != Type::Error {
-                    let span = interner.id_span(&index_expr.index);
-                    errors.push(TypeCheckError::TypeMismatch {
-                        expected_typ: "const Field".to_owned(),
-                        expr_typ: index_type.to_string(),
-                        expr_span: span,
-                    });
-                }
+            let ident_def = index_expr.collection_name.id;
+            let index_type = type_check_expression(interner, &index_expr.index, errors);
+            if index_type != Type::CONSTANT && index_type != Type::Error {
+                let span = interner.id_span(&index_expr.index);
+                errors.push(TypeCheckError::TypeMismatch {
+                    expected_typ: "const Field".to_owned(),
+                    expr_typ: index_type.to_string(),
+                    expr_span: span,
+                });
+            }
 
-                match interner.id_type(&ident_def) {
-                    // XXX: We can check the array bounds here also, but it may be better to constant fold first
-                    // and have ConstId instead of ExprId for constants
-                    Type::Array(_, _, base_type) => *base_type,
-                    typ => {
-                        let span = interner.id_span(&index_expr.collection_name);
-                        errors.push(TypeCheckError::TypeMismatch {
-                            expected_typ: "Array".to_owned(),
-                            expr_typ: typ.to_string(),
-                            expr_span: span,
-                        });
-                        Type::Error
-                    }
+            match interner.id_type(ident_def) {
+                // XXX: We can check the array bounds here also, but it may be better to constant fold first
+                // and have ConstId instead of ExprId for constants
+                Type::Array(_, _, base_type) => *base_type,
+                Type::Error => Type::Error,
+                typ => {
+                    errors.push(TypeCheckError::TypeMismatch {
+                        expected_typ: "Array".to_owned(),
+                        expr_typ: typ.to_string(),
+                        expr_span: index_expr.collection_name.span,
+                    });
+                    Type::Error
                 }
-            } else {
-                Type::Error
             }
         }
         HirExpression::Call(call_expr) => {
@@ -192,7 +186,7 @@ pub(crate) fn type_check_expression(
                 unimplemented!("start range and end range have different types.");
             }
             // The type of the identifier is equal to the type of the ranges
-            interner.push_ident_type(&for_expr.identifier, start_range_type);
+            interner.push_definition_type(for_expr.identifier.id, start_range_type);
 
             let last_type = type_check_expression(interner, &for_expr.block, errors);
 
@@ -449,11 +443,11 @@ fn check_constructor(
     // Note that we use a Vec to store the original arguments (rather than a BTreeMap) to
     // preserve the evaluation order of the source code.
     let mut args = constructor.fields.clone();
-    args.sort_by_key(|arg| interner.ident(&arg.0));
+    args.sort_by_key(|arg| arg.0.clone());
 
-    for ((param_name, param_type), (arg_id, arg)) in typ.borrow().fields.iter().zip(args) {
+    for ((param_name, param_type), (arg_ident, arg)) in typ.borrow().fields.iter().zip(args) {
         // Sanity check to ensure we're matching against the same field
-        assert_eq!(param_name, &interner.ident(&arg_id));
+        assert_eq!(param_name, &arg_ident);
 
         let arg_type = type_check_expression(interner, &arg, errors);
 

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -61,8 +61,9 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
 mod test {
     use std::collections::HashMap;
 
-    use noirc_errors::{Span, Spanned};
+    use noirc_errors::Span;
 
+    use crate::hir_def::expr::HirIdent;
     use crate::hir_def::stmt::HirLetStatement;
     use crate::hir_def::stmt::HirPattern::Identifier;
     use crate::hir_def::types::Type;
@@ -94,18 +95,29 @@ mod test {
         // let z = x + y;
         //
         // Push x variable
-        let x_id = interner.push_ident(Spanned::from(Span::default(), String::from("x")).into());
-        interner.linked_ident_to_def(x_id, x_id);
+        let x_id = interner.push_definition("x".into(), false);
+        let x = HirIdent {
+            id: x_id,
+            span: Span::default(),
+        };
+
         // Push y variable
-        let y_id = interner.push_ident(Spanned::from(Span::default(), String::from("y")).into());
-        interner.linked_ident_to_def(y_id, y_id);
+        let y_id = interner.push_definition("y".into(), false);
+        let y = HirIdent {
+            id: y_id,
+            span: Span::default(),
+        };
+
         // Push z variable
-        let z_id = interner.push_ident(Spanned::from(Span::default(), String::from("z")).into());
-        interner.linked_ident_to_def(z_id, z_id);
+        let z_id = interner.push_definition("z".into(), false);
+        let z = HirIdent {
+            id: z_id,
+            span: Span::default(),
+        };
 
         // Push x and y as expressions
-        let x_expr_id = interner.push_expr(HirExpression::Ident(x_id));
-        let y_expr_id = interner.push_expr(HirExpression::Ident(y_id));
+        let x_expr_id = interner.push_expr(HirExpression::Ident(x));
+        let y_expr_id = interner.push_expr(HirExpression::Ident(y));
 
         // Create Infix
         let operator = HirBinaryOp {
@@ -121,7 +133,7 @@ mod test {
 
         // Create let statement
         let let_stmt = HirLetStatement {
-            pattern: Identifier(z_id),
+            pattern: Identifier(z),
             r#type: Type::Unspecified,
             expression: expr_id,
         };
@@ -132,19 +144,19 @@ mod test {
         let func = HirFunction::unsafe_from_expr(expr_id);
         let func_id = interner.push_fn(func);
 
-        let name = "test_func".to_owned();
-        let fake_span = Span::single_char(0);
-        let name_id = interner.push_ident(Ident::from(Spanned::from(fake_span, name.clone())));
+        let name = HirIdent {
+            span: Span::default(),
+            id: interner.push_definition("test_func".into(), false),
+        };
 
         // Add function meta
         let func_meta = FuncMeta {
             name,
-            name_id,
             kind: FunctionKind::Normal,
             attributes: None,
             parameters: vec![
-                Param(Identifier(x_id), Type::WITNESS),
-                Param(Identifier(y_id), Type::WITNESS),
+                Param(Identifier(x), Type::WITNESS),
+                Param(Identifier(y), Type::WITNESS),
             ]
             .into(),
             return_type: Type::Unit,

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -101,7 +101,10 @@ fn type_check_assign_stmt(
     let definition = interner.definition(ident_def);
     if !definition.mutable {
         errors.push(TypeCheckError::Unstructured {
-            msg: format!("Variable {} must be mutable to be assigned to", definition.name),
+            msg: format!(
+                "Variable {} must be mutable to be assigned to",
+                definition.name
+            ),
             span: assign_stmt.identifier.span,
         });
     }

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use acvm::FieldElement;
 use noirc_errors::Span;
 
-use crate::node_interner::{ExprId, FuncId, StmtId, StructId, DefinitionId};
+use crate::node_interner::{DefinitionId, ExprId, FuncId, StmtId, StructId};
 use crate::{BinaryOp, BinaryOpKind, Ident, UnaryOp};
 
 use super::types::{StructType, Type};

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -4,14 +4,14 @@ use std::rc::Rc;
 use acvm::FieldElement;
 use noirc_errors::Span;
 
-use crate::node_interner::{ExprId, FuncId, IdentId, StmtId, TypeId};
+use crate::node_interner::{ExprId, FuncId, StmtId, StructId, DefinitionId};
 use crate::{BinaryOp, BinaryOpKind, Ident, UnaryOp};
 
 use super::types::{StructType, Type};
 
 #[derive(Debug, Clone)]
 pub enum HirExpression {
-    Ident(IdentId),
+    Ident(HirIdent),
     Literal(HirLiteral),
     Block(HirBlockExpression),
     Prefix(HirPrefixExpression),
@@ -35,9 +35,15 @@ impl HirExpression {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct HirIdent {
+    pub span: Span,
+    pub id: DefinitionId,
+}
+
 #[derive(Debug, Clone)]
 pub struct HirForExpression {
-    pub identifier: IdentId,
+    pub identifier: HirIdent,
     pub start_range: ExprId,
     pub end_range: ExprId,
     pub block: ExprId,
@@ -210,7 +216,7 @@ impl HirMethodCallExpression {
 
 #[derive(Debug, Clone)]
 pub struct HirConstructorExpression {
-    pub type_id: TypeId,
+    pub type_id: StructId,
     pub r#type: Rc<RefCell<StructType>>,
 
     // NOTE: It is tempting to make this a BTreeSet to force ordering of field
@@ -218,12 +224,12 @@ pub struct HirConstructorExpression {
     //       but doing so would force the order of evaluation of field
     //       arguments to be alphabetical rather than the ordering the user
     //       included in the source code.
-    pub fields: Vec<(IdentId, ExprId)>,
+    pub fields: Vec<(Ident, ExprId)>,
 }
 
 #[derive(Debug, Clone)]
 pub struct HirIndexExpression {
-    pub collection_name: IdentId,
+    pub collection_name: HirIdent,
     pub index: ExprId,
 }
 

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -1,9 +1,9 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::expr::{HirInfixExpression, HirIdent};
+use super::expr::{HirIdent, HirInfixExpression};
 use crate::node_interner::ExprId;
-use crate::{StructType, Type, Ident};
+use crate::{Ident, StructType, Type};
 use noirc_errors::Span;
 
 #[derive(Debug, Clone)]

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -1,9 +1,9 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::expr::HirInfixExpression;
-use crate::node_interner::{ExprId, IdentId, NodeInterner};
-use crate::{StructType, Type};
+use super::expr::{HirInfixExpression, HirIdent};
+use crate::node_interner::ExprId;
+use crate::{StructType, Type, Ident};
 use noirc_errors::Span;
 
 #[derive(Debug, Clone)]
@@ -15,7 +15,7 @@ pub struct HirLetStatement {
 
 #[derive(Debug, Clone)]
 pub struct HirAssignStatement {
-    pub identifier: IdentId,
+    pub identifier: HirIdent,
     pub expression: ExprId,
 }
 
@@ -41,10 +41,10 @@ pub enum HirStatement {
 
 #[derive(Debug, Clone)]
 pub enum HirPattern {
-    Identifier(IdentId),
+    Identifier(HirIdent),
     Mutable(Box<HirPattern>, Span),
     Tuple(Vec<HirPattern>, Span),
-    Struct(Rc<RefCell<StructType>>, Vec<(IdentId, HirPattern)>, Span),
+    Struct(Rc<RefCell<StructType>>, Vec<(Ident, HirPattern)>, Span),
 }
 
 impl HirPattern {
@@ -59,15 +59,12 @@ impl HirPattern {
 
     /// Iterate over the fields of this pattern.
     /// Panics if the type is not a struct or tuple.
-    pub fn iter_fields<'a>(
-        &'a self,
-        interner: &'a NodeInterner,
-    ) -> Box<dyn Iterator<Item = (String, &'a HirPattern)> + 'a> {
+    pub fn iter_fields<'a>(&'a self) -> Box<dyn Iterator<Item = (String, &'a HirPattern)> + 'a> {
         match self {
             HirPattern::Struct(_, fields, _) => Box::new(
                 fields
                     .iter()
-                    .map(move |(name_id, pattern)| (interner.ident_name(name_id), pattern)),
+                    .map(move |(name, pattern)| (name.0.contents.clone(), pattern)),
             ),
             HirPattern::Tuple(fields, _) => Box::new(
                 fields

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -4,14 +4,14 @@ use noirc_abi::{AbiFEType, AbiType};
 use noirc_errors::Span;
 
 use crate::{
-    node_interner::{FuncId, TypeId},
+    node_interner::{FuncId, StructId},
     util::vecmap,
     ArraySize, FieldElementType, Ident, Signedness,
 };
 
 #[derive(Debug, Eq)]
 pub struct StructType {
-    pub id: TypeId,
+    pub id: StructId,
     pub name: Ident,
     pub fields: Vec<(Ident, Type)>,
     pub methods: HashMap<String, FuncId>,
@@ -25,7 +25,7 @@ impl PartialEq for StructType {
 }
 
 impl StructType {
-    pub fn new(id: TypeId, name: Ident, span: Span, fields: Vec<(Ident, Type)>) -> StructType {
+    pub fn new(id: StructId, name: Ident, span: Span, fields: Vec<(Ident, Type)>) -> StructType {
         StructType {
             id,
             fields,

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -5,8 +5,6 @@ use std::rc::Rc;
 use arena::{Arena, Index};
 use noirc_errors::Span;
 
-use crate::Ident;
-
 use crate::graph::CrateId;
 use crate::hir::def_collector::dc_crate::UnresolvedStruct;
 use crate::hir::def_map::{LocalModuleId, ModuleId};
@@ -18,12 +16,18 @@ use crate::hir_def::{
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub struct IdentId(Index);
+pub struct DefinitionId(usize);
 
-impl IdentId {
+impl DefinitionId {
     //dummy id for error reporting
-    pub fn dummy_id() -> IdentId {
-        IdentId(Index::from_raw_parts(std::usize::MAX, 0))
+    pub fn dummy_id() -> DefinitionId {
+        DefinitionId(std::usize::MAX)
+    }
+}
+
+impl From<DefinitionId> for Index {
+    fn from(id: DefinitionId) -> Self {
+        Index::from_raw_parts(id.0, u64::MAX)
     }
 }
 
@@ -51,14 +55,14 @@ impl FuncId {
 }
 
 #[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
-pub struct TypeId(pub ModuleId);
+pub struct StructId(pub ModuleId);
 
-impl TypeId {
+impl StructId {
     //dummy id for error reporting
     // This can be anything, as the program will ultimately fail
     // after resolution
-    pub fn dummy_id() -> TypeId {
-        TypeId(ModuleId {
+    pub fn dummy_id() -> StructId {
+        StructId(ModuleId {
             krate: CrateId::dummy_id(),
             local_id: LocalModuleId::dummy_id(),
         })
@@ -94,10 +98,8 @@ macro_rules! partialeq {
 
 into_index!(ExprId);
 into_index!(StmtId);
-into_index!(IdentId);
 
 partialeq!(ExprId);
-partialeq!(IdentId);
 partialeq!(StmtId);
 
 /// A Definition enum specifies anything that we can intern in the NodeInterner
@@ -107,7 +109,6 @@ partialeq!(StmtId);
 #[derive(Debug, Clone)]
 enum Node {
     Function(HirFunction),
-    Ident(Ident),
     Statement(HirStatement),
     Expression(HirExpression),
 }
@@ -117,19 +118,11 @@ pub struct NodeInterner {
     nodes: Arena<Node>,
     func_meta: HashMap<FuncId, FuncMeta>,
 
-    // Maps for span
-    // Each encountered variable has it's own span
-    // We therefore give each variable, it's own IdentId
-    //
-    // Maps IdentId to it's definition
-    // For `let x = EXPR` x will point to itself as a definition
-    ident_to_defs: HashMap<IdentId, IdentId>,
     // Map each `Index` to it's own span
     id_to_span: HashMap<Index, Span>,
-    // Map each IdentId to it's name
-    // This is a string right now, but once Strings are interned
-    // In the lexer, this will be a SymbolId
-    ident_to_name: HashMap<IdentId, String>,
+
+    // Maps each DefinitionId to a DefinitionInfo.
+    definitions: Vec<DefinitionInfo>,
 
     // Type checking map
     //
@@ -145,7 +138,13 @@ pub struct NodeInterner {
     // Each struct definition is possibly shared across multiple type nodes.
     // It is also mutated through the RefCell during name resolution to append
     // methods from impls to the type.
-    structs: HashMap<TypeId, Rc<RefCell<StructType>>>,
+    structs: HashMap<StructId, Rc<RefCell<StructType>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DefinitionInfo {
+    pub name: String,
+    pub mutable: bool,
 }
 
 impl Default for NodeInterner {
@@ -153,9 +152,8 @@ impl Default for NodeInterner {
         let mut interner = NodeInterner {
             nodes: Arena::default(),
             func_meta: HashMap::new(),
-            ident_to_defs: HashMap::new(),
             id_to_span: HashMap::new(),
-            ident_to_name: HashMap::new(),
+            definitions: vec![],
             id_to_type: HashMap::new(),
             structs: HashMap::new(),
         };
@@ -193,7 +191,7 @@ impl NodeInterner {
         self.id_to_type.insert(expr_id.into(), typ);
     }
 
-    pub fn push_empty_struct(&mut self, type_id: TypeId, typ: &UnresolvedStruct) {
+    pub fn push_empty_struct(&mut self, type_id: StructId, typ: &UnresolvedStruct) {
         self.structs.insert(
             type_id,
             Rc::new(RefCell::new(StructType {
@@ -206,7 +204,7 @@ impl NodeInterner {
         );
     }
 
-    pub fn update_struct<F>(&mut self, type_id: TypeId, f: F)
+    pub fn update_struct<F>(&mut self, type_id: StructId, f: F)
     where
         F: FnOnce(&mut StructType),
     {
@@ -223,9 +221,10 @@ impl NodeInterner {
     pub fn make_expr_type_unit(&mut self, expr_id: &ExprId) {
         self.id_to_type.insert(expr_id.into(), Type::Unit);
     }
+
     /// Store the type for an interned Identifier
-    pub fn push_ident_type(&mut self, ident_id: &IdentId, typ: Type) {
-        self.id_to_type.insert(ident_id.into(), typ);
+    pub fn push_definition_type(&mut self, definition_id: DefinitionId, typ: Type) {
+        self.id_to_type.insert(definition_id.into(), typ);
     }
 
     /// Intern an empty function.
@@ -258,40 +257,14 @@ impl NodeInterner {
         self.func_meta.insert(func_id, func_data);
     }
 
-    /// Interns an Identifier
-    pub fn push_ident(&mut self, ident: Ident) -> IdentId {
-        let span = ident.0.span();
-        let name = ident.0.contents.clone();
+    pub fn push_definition(&mut self, name: String, mutable: bool) -> DefinitionId {
+        let id = self.definitions.len();
+        self.definitions.push(DefinitionInfo {
+            name,
+            mutable,
+        });
 
-        let id = IdentId(self.nodes.insert(Node::Ident(ident)));
-
-        self.id_to_span.insert(id.into(), span);
-
-        // XXX: Once Strings are interned name will also be an Id
-        self.ident_to_name.insert(id, name);
-
-        // Note: These three maps are not invariant under their length
-        // consider the case that we only ever inserted functions
-        // the last two maps would be empty, while the first would be non-empty.
-
-        id
-    }
-    /// Links the Identifier to the Identifier which defined it.
-    pub fn linked_ident_to_def(&mut self, ident: IdentId, def: IdentId) {
-        self.ident_to_defs.insert(ident, def);
-    }
-    /// Finds the IdentifierId which declared/defined this IdentifierId
-    ///
-    /// Example:
-    ///
-    /// priv z = x + a;
-    /// priv k = z + b;
-    ///
-    /// Notice z is used twice. Each `z` has a unique IdentId
-    /// However, the first `z` is the one that defines it.
-    /// This function would return the Identifier of the first `z`
-    pub fn ident_def(&self, ident: &IdentId) -> Option<IdentId> {
-        self.ident_to_defs.get(ident).copied()
+        DefinitionId(id)
     }
 
     /// Returns the interned HIR function corresponding to `func_id`
@@ -308,12 +281,18 @@ impl NodeInterner {
             _ => panic!("ice: all function ids should correspond to a function in the interner"),
         }
     }
+
     /// Returns the interned meta data corresponding to `func_id`
     pub fn function_meta(&self, func_id: &FuncId) -> FuncMeta {
         self.func_meta
             .get(func_id)
             .cloned()
             .expect("ice: all function ids should have metadata")
+    }
+
+    pub fn function_name(&self, func_id: &FuncId) -> &str {
+        let name_id = self.function_meta(func_id).name.id;
+        self.definition_name(name_id)
     }
 
     /// Returns the interned statement corresponding to `stmt_id`
@@ -342,53 +321,32 @@ impl NodeInterner {
             }
         }
     }
-    /// Returns the interned identifier corresponding to `ident_id`
-    pub fn ident(&self, ident_id: &IdentId) -> Ident {
-        let def = self
-            .nodes
-            .get(ident_id.0)
-            .expect("ice: all ident ids should have definitions");
 
-        match def {
-            Node::Ident(ident) => ident.clone(),
-            _ => panic!("ice: all expression ids should correspond to a statement in the interner"),
-        }
+    pub fn definition(&self, id: DefinitionId) -> &DefinitionInfo {
+        &self.definitions[id.0]
     }
 
-    /// Returns the Identifier as a String
+    /// Returns the name of the definition
     ///
     /// This is needed as the Environment needs to map variable names to witness indices
-    pub fn ident_name(&self, ident_id: &IdentId) -> String {
-        self.ident_to_name
-            .get(ident_id)
-            .expect("ice: all ident ids should have names. This indicates a bug in the Resolver.")
-            .clone()
+    pub fn definition_name(&self, id: DefinitionId) -> &str {
+        &self.definition(id).name
     }
 
-    /// Returns the span of an identifier
-    pub fn ident_span(&self, ident_id: &IdentId) -> Span {
-        self.id_span(ident_id)
-    }
     /// Returns the span of an expression
     pub fn expr_span(&self, expr_id: &ExprId) -> Span {
         self.id_span(expr_id)
     }
 
-    pub fn get_struct(&self, id: TypeId) -> Rc<RefCell<StructType>> {
+    pub fn get_struct(&self, id: StructId) -> Rc<RefCell<StructType>> {
         self.structs[&id].clone()
     }
 
-    /// Returns the type of an item stored in the Interner.
-    //
-    // Why can we unwrap here?
-    // If the compiler is correct, it will not ask for an Id of an object
-    // which does not have a type. This will cause a panic.
-    // Since type checking always comes after resolution.
-    // If resolution is correct, we will always assign types to Identifiers before we use them.
-    // The same would go for Expressions.
+    /// Returns the type of an item stored in the Interner or Error if it was not found.
     pub fn id_type(&self, index: impl Into<Index>) -> Type {
-        self.id_to_type.get(&index.into()).cloned().unwrap()
+        self.id_to_type.get(&index.into()).cloned().unwrap_or(Type::Error)
     }
+
     /// Returns the span of an item stored in the Interner
     pub fn id_span(&self, index: impl Into<Index>) -> Span {
         self.id_to_span.get(&index.into()).copied().unwrap()

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -259,10 +259,7 @@ impl NodeInterner {
 
     pub fn push_definition(&mut self, name: String, mutable: bool) -> DefinitionId {
         let id = self.definitions.len();
-        self.definitions.push(DefinitionInfo {
-            name,
-            mutable,
-        });
+        self.definitions.push(DefinitionInfo { name, mutable });
 
         DefinitionId(id)
     }
@@ -344,7 +341,10 @@ impl NodeInterner {
 
     /// Returns the type of an item stored in the Interner or Error if it was not found.
     pub fn id_type(&self, index: impl Into<Index>) -> Type {
-        self.id_to_type.get(&index.into()).cloned().unwrap_or(Type::Error)
+        self.id_to_type
+            .get(&index.into())
+            .cloned()
+            .unwrap_or(Type::Error)
     }
 
     /// Returns the span of an item stored in the Interner

--- a/examples/assign_ex/src/main.nr
+++ b/examples/assign_ex/src/main.nr
@@ -1,6 +1,6 @@
 
 fn main(x : Field, y : Field) {
-    let z = x + y;
+    let mut z = x + y;
     constrain z == 3;
     z = x * y;
     constrain z == 2;


### PR DESCRIPTION
This PR separates IdentIds from the new DefinitionIds, the former is removed entirely and all variables referencing the same definition will have the same DefinitionId. The names and types of definitions are still deduplicated in the interner. A new 'mutable' field was also added to track mutability.

This change was made purely to be more like rust, there were no runtime changes required/made for this to be made.

Example Error:
```
error: Variable z must be mutable to be assigned to
  ┌─ /Users/jakefecher/Code/Noir/noir/crates/nargo/../../examples/assign_ex/src/main.nr:5:5
  │
5 │     z = x * y;
  │     -
```