### PR TITLE
Enforce Partial Witness Generator expects an ordered IR

### DIFF
--- a/crates/acvm/src/pwg/arithmetic.rs
+++ b/crates/acvm/src/pwg/arithmetic.rs
@@ -24,16 +24,18 @@ impl ArithmeticSolver {
     pub fn solve<'a>(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gate: &'a Arithmetic,
-    ) -> Option<&'a Arithmetic> {
+    ) {
         // Evaluate multiplication term
         let mul_result = ArithmeticSolver::solve_mul_term(gate, initial_witness);
         // Evaluate the fan-in terms
         let gate_status = ArithmeticSolver::solve_fan_in_term(gate, initial_witness);
 
         match (mul_result, gate_status) {
-            (MulTerm::TooManyUnknowns, _) => Some(gate),
-            (_, GateStatus::GateUnsolvable) => Some(gate),
-            (MulTerm::OneUnknown(_, _), GateStatus::GateSolvable(_, _)) => Some(gate),
+            (MulTerm::TooManyUnknowns, _)
+            | (_, GateStatus::GateUnsolvable)
+            | (MulTerm::OneUnknown(_, _), GateStatus::GateSolvable(_, _)) => {
+                unreachable!("ArithmeticSolver failed to solve {:?}", gate);
+            }
             (MulTerm::OneUnknown(partial_prod, unknown_var), GateStatus::GateSatisfied(sum)) => {
                 // We have one unknown in the mul term and the fan-in terms are solved.
                 // Hence the equation is solvable, since there is a single unknown
@@ -43,12 +45,10 @@ impl ArithmeticSolver {
                 let assignment = -(total_sum / partial_prod);
                 // Add this into the witness assignments
                 initial_witness.insert(unknown_var, assignment);
-                None
             }
             (MulTerm::Solved(_), GateStatus::GateSatisfied(_)) => {
                 // All the variables in the MulTerm are solved and the Fan-in is also solved
                 // There is nothing to solve
-                None
             }
             (
                 MulTerm::Solved(total_prod),
@@ -62,7 +62,6 @@ impl ArithmeticSolver {
                 let assignment = -(total_sum / coeff);
                 // Add this into the witness assignments
                 initial_witness.insert(unknown_var, assignment);
-                None
             }
         }
     }
@@ -178,8 +177,8 @@ fn arithmetic_smoke_test() {
     values.insert(c, FieldElement::from(1_i128));
     values.insert(d, FieldElement::from(1_i128));
 
-    assert!(ArithmeticSolver::solve(&mut values, &gate_a).is_none());
-    assert!(ArithmeticSolver::solve(&mut values, &gate_b).is_none());
+    ArithmeticSolver::solve(&mut values, &gate_a);
+    ArithmeticSolver::solve(&mut values, &gate_b);
 
     assert_eq!(values.get(&a).unwrap(), &FieldElement::from(4_i128));
 }

--- a/crates/acvm/src/pwg/arithmetic.rs
+++ b/crates/acvm/src/pwg/arithmetic.rs
@@ -21,10 +21,7 @@ enum MulTerm {
 
 impl ArithmeticSolver {
     /// Derives the rest of the witness based on the initial low level variables
-    pub fn solve<'a>(
-        initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        gate: &'a Arithmetic,
-    ) {
+    pub fn solve(initial_witness: &mut BTreeMap<Witness, FieldElement>, gate: &Arithmetic) {
         // Evaluate multiplication term
         let mul_result = ArithmeticSolver::solve_mul_term(gate, initial_witness);
         // Evaluate the fan-in terms

--- a/crates/aztec_backend/src/acvm_interop/pwg.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg.rs
@@ -20,118 +20,88 @@ impl PartialWitnessGenerator for Plonk {
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gates: Vec<acir::circuit::Gate>,
     ) -> Result<(), acir::OPCODE> {
-        if gates.is_empty() {
-            return Ok(());
-        }
-
-        let mut unsolved_gates: Vec<Gate> = Vec::new();
-
         for gate in gates.into_iter() {
-            let unsolved = match &gate {
+            match &gate {
                 Gate::Arithmetic(arith) => {
-                    ArithmeticSolver::solve(initial_witness, arith).is_some()
+                    ArithmeticSolver::solve(initial_witness, arith);
                 }
                 Gate::Range(_, _) => {
                     // We do not need to solve for this gate, we have passed responsibility to the underlying
                     // proof system for intermediate witness generation
-                    false
+                    ()
                 }
                 Gate::And(and_gate) => {
                     LogicSolver::solve_and_gate(initial_witness, and_gate);
-
-                    // We compute the result because the other gates may want to use the assignment to generate their assignments
-                    false
                 }
                 Gate::Xor(xor_gate) => {
                     LogicSolver::solve_xor_gate(initial_witness, xor_gate);
-
-                    // We compute the result because the other gates may want to use the assignment to generate their assignments
-                    false
                 }
                 Gate::GadgetCall(gc) => {
                     GadgetCaller::solve_gadget_call(initial_witness, gc)?;
-
-                    false
                 }
                 Gate::Directive(directive) => match directive {
-                    Directive::Invert { x, result } => match initial_witness.get(x) {
-                        None => true,
-                        Some(val) => {
-                            let inverse = val.inverse();
-                            initial_witness.insert(*result, inverse);
-                            false
-                        }
+                    Directive::Invert { x, result } => {
+                        let val = initial_witness[x];
+                        let inverse = val.inverse();
+                        initial_witness.insert(*result, inverse);
                     },
                     Directive::Quotient { a, b, q, r } => {
-                        match (initial_witness.get(a), initial_witness.get(b)) {
-                            (Some(val_a), Some(val_b)) => {
-                                let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
-                                let int_b = BigUint::from_bytes_be(&val_b.to_bytes());
+                        let val_a = initial_witness[a];
+                        let val_b = initial_witness[b];
+                        let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
+                        let int_b = BigUint::from_bytes_be(&val_b.to_bytes());
 
-                                let int_r = &int_a % &int_b;
-                                let int_q = &int_a / &int_b;
+                        let int_r = &int_a % &int_b;
+                        let int_q = &int_a / &int_b;
 
-                                initial_witness.insert(
-                                    *q,
-                                    FieldElement::from_be_bytes_reduce(&int_q.to_bytes_be()),
-                                );
-                                initial_witness.insert(
-                                    *r,
-                                    FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
-                                );
-                                false
-                            }
-                            _ => true,
-                        }
+                        initial_witness.insert(
+                            *q,
+                            FieldElement::from_be_bytes_reduce(&int_q.to_bytes_be()),
+                        );
+                        initial_witness.insert(
+                            *r,
+                            FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
+                        );
                     }
-                    Directive::Truncate { a, b, c, bit_size } => match initial_witness.get(a) {
-                        Some(val_a) => {
-                            let pow: BigUint = BigUint::one() << bit_size;
+                    Directive::Truncate { a, b, c, bit_size } => {
+                        let val_a = initial_witness[a];
+                        let pow: BigUint = BigUint::one() << bit_size;
 
-                            let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
-                            let int_b: BigUint = &int_a % &pow;
-                            let int_c: BigUint = (&int_a - &int_b) / &pow;
+                        let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
+                        let int_b: BigUint = &int_a % &pow;
+                        let int_c: BigUint = (&int_a - &int_b) / &pow;
 
-                            initial_witness.insert(
-                                *b,
-                                FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
-                            );
-                            initial_witness.insert(
-                                *c,
-                                FieldElement::from_be_bytes_reduce(&int_c.to_bytes_be()),
-                            );
-                            false
-                        }
-                        _ => true,
+                        initial_witness.insert(
+                            *b,
+                            FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
+                        );
+                        initial_witness.insert(
+                            *c,
+                            FieldElement::from_be_bytes_reduce(&int_c.to_bytes_be()),
+                        );
                     },
-                    Directive::Oddrange { a, b, r, bit_size } => match initial_witness.get(a) {
-                        Some(val_a) => {
-                            let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
-                            let pow: BigUint = BigUint::one() << (bit_size - 1);
+                    Directive::Oddrange { a, b, r, bit_size } => {
+                        let val_a = initial_witness[a];
+                        let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
+                        let pow: BigUint = BigUint::one() << (bit_size - 1);
 
-                            let bb = &int_a & &pow;
-                            let int_r = &int_a - &bb;
-                            let int_b = &bb >> (bit_size - 1);
+                        let bb = &int_a & &pow;
+                        let int_r = &int_a - &bb;
+                        let int_b = &bb >> (bit_size - 1);
 
-                            initial_witness.insert(
-                                *b,
-                                FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
-                            );
-                            initial_witness.insert(
-                                *r,
-                                FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
-                            );
-                            false
-                        }
-                        _ => true,
+                        initial_witness.insert(
+                            *b,
+                            FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
+                        );
+                        initial_witness.insert(
+                            *r,
+                            FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
+                        );
                     },
                 },
-            };
-            if unsolved {
-                unsolved_gates.push(gate);
             }
         }
 
-        self.solve(initial_witness, unsolved_gates)
+        Ok(())
     }
 }

--- a/crates/aztec_backend/src/acvm_interop/pwg.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg.rs
@@ -25,11 +25,9 @@ impl PartialWitnessGenerator for Plonk {
                 Gate::Arithmetic(arith) => {
                     ArithmeticSolver::solve(initial_witness, arith);
                 }
-                Gate::Range(_, _) => {
-                    // We do not need to solve for this gate, we have passed responsibility to the underlying
-                    // proof system for intermediate witness generation
-                    ()
-                }
+                // We do not need to solve for this gate, we have passed responsibility to the underlying
+                // proof system for intermediate witness generation
+                Gate::Range(_, _) => (),
                 Gate::And(and_gate) => {
                     LogicSolver::solve_and_gate(initial_witness, and_gate);
                 }
@@ -44,7 +42,7 @@ impl PartialWitnessGenerator for Plonk {
                         let val = initial_witness[x];
                         let inverse = val.inverse();
                         initial_witness.insert(*result, inverse);
-                    },
+                    }
                     Directive::Quotient { a, b, q, r } => {
                         let val_a = initial_witness[a];
                         let val_b = initial_witness[b];
@@ -54,14 +52,10 @@ impl PartialWitnessGenerator for Plonk {
                         let int_r = &int_a % &int_b;
                         let int_q = &int_a / &int_b;
 
-                        initial_witness.insert(
-                            *q,
-                            FieldElement::from_be_bytes_reduce(&int_q.to_bytes_be()),
-                        );
-                        initial_witness.insert(
-                            *r,
-                            FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
-                        );
+                        initial_witness
+                            .insert(*q, FieldElement::from_be_bytes_reduce(&int_q.to_bytes_be()));
+                        initial_witness
+                            .insert(*r, FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()));
                     }
                     Directive::Truncate { a, b, c, bit_size } => {
                         let val_a = initial_witness[a];
@@ -71,15 +65,11 @@ impl PartialWitnessGenerator for Plonk {
                         let int_b: BigUint = &int_a % &pow;
                         let int_c: BigUint = (&int_a - &int_b) / &pow;
 
-                        initial_witness.insert(
-                            *b,
-                            FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
-                        );
-                        initial_witness.insert(
-                            *c,
-                            FieldElement::from_be_bytes_reduce(&int_c.to_bytes_be()),
-                        );
-                    },
+                        initial_witness
+                            .insert(*b, FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()));
+                        initial_witness
+                            .insert(*c, FieldElement::from_be_bytes_reduce(&int_c.to_bytes_be()));
+                    }
                     Directive::Oddrange { a, b, r, bit_size } => {
                         let val_a = initial_witness[a];
                         let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
@@ -89,15 +79,11 @@ impl PartialWitnessGenerator for Plonk {
                         let int_r = &int_a - &bb;
                         let int_b = &bb >> (bit_size - 1);
 
-                        initial_witness.insert(
-                            *b,
-                            FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
-                        );
-                        initial_witness.insert(
-                            *r,
-                            FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
-                        );
-                    },
+                        initial_witness
+                            .insert(*b, FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()));
+                        initial_witness
+                            .insert(*r, FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()));
+                    }
                 },
             }
         }


### PR DESCRIPTION
Before the partial witness generator would retry instructions that failed in case they were generated out of order. This was potentially problematic as it could lead to e.g. assignment instructions being performed in different orders changing the final results of variables.