### PR TITLE
Add support for assignment of fields and indices in frontend

### DIFF
--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -346,7 +346,7 @@ impl<'a> Evaluator<'a> {
                 self.handle_definition(env, &let_stmt.pattern, &let_stmt.expression)
             }
             HirStatement::Assign(assign_stmt) => {
-                let ident = HirPattern::Identifier(assign_stmt.identifier);
+                let ident = HirPattern::Identifier(assign_stmt.lvalue);
                 self.handle_definition(env, &ident, &assign_stmt.expression)
             }
             HirStatement::Error => unreachable!(

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -16,8 +16,8 @@ use acvm::FieldElement;
 use acvm::Language;
 use environment::{Environment, FuncContext};
 use errors::{RuntimeError, RuntimeErrorKind};
-use noirc_frontend::hir::Context;
 use noirc_frontend::node_interner::{ExprId, FuncId, IdentId, StmtId};
+use noirc_frontend::{hir::Context, hir_def::stmt::HirLValue};
 use noirc_frontend::{
     hir_def::{
         expr::{
@@ -346,7 +346,12 @@ impl<'a> Evaluator<'a> {
                 self.handle_definition(env, &let_stmt.pattern, &let_stmt.expression)
             }
             HirStatement::Assign(assign_stmt) => {
-                let ident = HirPattern::Identifier(assign_stmt.lvalue);
+                let ident = HirPattern::Identifier(match assign_stmt.lvalue {
+                    HirLValue::Ident(ident) => ident,
+                    HirLValue::MemberAccess { .. } => unimplemented!(),
+                    HirLValue::Index { .. } => unimplemented!(),
+                });
+
                 self.handle_definition(env, &ident, &assign_stmt.expression)
             }
             HirStatement::Error => unreachable!(

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -16,8 +16,11 @@ use acvm::FieldElement;
 use acvm::Language;
 use environment::{Environment, FuncContext};
 use errors::{RuntimeError, RuntimeErrorKind};
-use noirc_frontend::{node_interner::{ExprId, FuncId, StmtId}, hir_def::{expr::HirIdent, stmt::HirLValue}};
 use noirc_frontend::hir::Context;
+use noirc_frontend::{
+    hir_def::{expr::HirIdent, stmt::HirLValue},
+    node_interner::{ExprId, FuncId, StmtId},
+};
 use noirc_frontend::{
     hir_def::{
         expr::{

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -11,7 +11,7 @@ use acvm::FieldElement;
 use noirc_frontend::hir::Context;
 use noirc_frontend::hir_def::expr::{HirConstructorExpression, HirMemberAccess};
 use noirc_frontend::hir_def::function::HirFunction;
-use noirc_frontend::hir_def::stmt::HirPattern;
+use noirc_frontend::hir_def::stmt::{HirLValue, HirPattern};
 use noirc_frontend::hir_def::{
     expr::{HirBinaryOp, HirBinaryOpKind, HirExpression, HirForExpression, HirLiteral},
     stmt::{HirConstrainStatement, HirLetStatement, HirStatement},
@@ -191,9 +191,8 @@ impl<'a> IRGenerator<'a> {
                 self.handle_let_statement(env, let_stmt)
             }
             HirStatement::Assign(assign_stmt) => {
-                let ident_def = self.def_interner().ident_def(&assign_stmt.lvalue);
-                //////////////TODO temp this is needed because we don't parse main arguments
-                let ident_name = self.ident_name(&assign_stmt.lvalue);
+                //////////////TODO name is needed because we don't parse main arguments
+                let (ident_def, ident_name) = self.lvalue_ident_def_and_name(&assign_stmt.lvalue);
 
                 let rhs = self.expression_to_object(env, &assign_stmt.expression)?;
 
@@ -205,7 +204,7 @@ impl<'a> IRGenerator<'a> {
                 } else {
                     //var is not defined,
                     //let's do it here for now...TODO
-                    let typ = self.def_interner().id_type(&assign_stmt.lvalue);
+                    let typ = self.lvalue_type(&assign_stmt.lvalue);
                     self.bind_fresh_pattern(&ident_name, &typ, rhs);
                 }
 
@@ -214,6 +213,25 @@ impl<'a> IRGenerator<'a> {
             HirStatement::Error => unreachable!(
                 "ice: compiler did not exit before codegen when a statement failed to parse"
             ),
+        }
+    }
+
+    fn lvalue_type(&self, lvalue: &HirLValue) -> Type {
+        match lvalue {
+            HirLValue::Ident(id) => self.def_interner().id_type(id),
+            HirLValue::MemberAccess { .. } => unimplemented!(),
+            HirLValue::Index { .. } => unimplemented!(),
+        }
+    }
+
+    fn lvalue_ident_def_and_name(&self, lvalue: &HirLValue) -> (Option<IdentId>, String) {
+        match lvalue {
+            HirLValue::Ident(id) => {
+                let def = self.def_interner().ident_def(id);
+                (def, self.ident_name(id))
+            }
+            HirLValue::MemberAccess { .. } => unimplemented!(),
+            HirLValue::Index { .. } => unimplemented!(),
         }
     }
 

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -191,9 +191,9 @@ impl<'a> IRGenerator<'a> {
                 self.handle_let_statement(env, let_stmt)
             }
             HirStatement::Assign(assign_stmt) => {
-                let ident_def = self.def_interner().ident_def(&assign_stmt.identifier);
+                let ident_def = self.def_interner().ident_def(&assign_stmt.lvalue);
                 //////////////TODO temp this is needed because we don't parse main arguments
-                let ident_name = self.ident_name(&assign_stmt.identifier);
+                let ident_name = self.ident_name(&assign_stmt.lvalue);
 
                 let rhs = self.expression_to_object(env, &assign_stmt.expression)?;
 
@@ -205,7 +205,7 @@ impl<'a> IRGenerator<'a> {
                 } else {
                     //var is not defined,
                     //let's do it here for now...TODO
-                    let typ = self.def_interner().id_type(&assign_stmt.identifier);
+                    let typ = self.def_interner().id_type(&assign_stmt.lvalue);
                     self.bind_fresh_pattern(&ident_name, &typ, rhs);
                 }
 

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -289,8 +289,22 @@ pub struct LetStatement {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AssignStatement {
-    pub identifier: Ident,
+    pub lvalue: LValue,
     pub expression: Expression,
+}
+
+/// Represents an Ast form that can be assigned to
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LValue {
+    Ident(Ident),
+    MemberAccess {
+        object: Box<LValue>,
+        field_name: Ident,
+    },
+    Index {
+        array: Box<LValue>,
+        index: Expression,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -341,7 +355,17 @@ impl Display for ConstrainStatement {
 
 impl Display for AssignStatement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} = {}", self.identifier, self.expression)
+        write!(f, "{} = {}", self.lvalue, self.expression)
+    }
+}
+
+impl Display for LValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LValue::Ident(ident) => ident.fmt(f),
+            LValue::MemberAccess { object, field_name } => write!(f, "{}.{}", object, field_name),
+            LValue::Index { array, index } => write!(f, "{}[{}]", array, index),
+        }
     }
 }
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -302,7 +302,7 @@ impl<'a> Resolver<'a> {
                 self.interner.push_stmt(stmt)
             }
             Statement::Assign(assign_stmt) => {
-                let identifier = self.find_variable(&assign_stmt.identifier);
+                let identifier = self.find_variable(&assign_stmt.lvalue);
                 let expression = self.resolve_expression(assign_stmt.expression);
                 let stmt = HirAssignStatement {
                     identifier,

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -30,7 +30,7 @@ use std::rc::Rc;
 use crate::graph::CrateId;
 use crate::hir::def_map::{ModuleDefId, TryFromModuleDefId};
 use crate::hir_def::expr::HirExpression;
-use crate::hir_def::stmt::{HirAssignStatement, HirPattern, HirLValue};
+use crate::hir_def::stmt::{HirAssignStatement, HirLValue, HirPattern};
 use crate::node_interner::{ExprId, FuncId, IdentId, NodeInterner, StmtId, TypeId};
 use crate::util::vecmap;
 use crate::{
@@ -38,7 +38,7 @@ use crate::{
     BlockExpression, Expression, ExpressionKind, FunctionKind, Ident, Literal, NoirFunction,
     Statement,
 };
-use crate::{NoirStruct, Path, Pattern, StructType, Type, UnresolvedType, ERROR_IDENT, LValue};
+use crate::{LValue, NoirStruct, Path, Pattern, StructType, Type, UnresolvedType, ERROR_IDENT};
 use noirc_errors::{Span, Spanned};
 
 use crate::hir::scope::{
@@ -321,12 +321,12 @@ impl<'a> Resolver<'a> {
                 let object = Box::new(self.resolve_lvalue(*object));
                 let field_name = self.interner.push_ident(field_name);
                 HirLValue::MemberAccess { object, field_name }
-            },
+            }
             LValue::Index { array, index } => {
                 let array = Box::new(self.resolve_lvalue(*array));
                 let index = self.resolve_expression(index);
                 HirLValue::Index { array, index }
-            },
+            }
         }
     }
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -30,7 +30,7 @@ use std::rc::Rc;
 use crate::graph::CrateId;
 use crate::hir::def_map::{ModuleDefId, TryFromModuleDefId};
 use crate::hir_def::expr::HirExpression;
-use crate::hir_def::stmt::{HirAssignStatement, HirPattern};
+use crate::hir_def::stmt::{HirAssignStatement, HirPattern, HirLValue};
 use crate::node_interner::{ExprId, FuncId, IdentId, NodeInterner, StmtId, TypeId};
 use crate::util::vecmap;
 use crate::{
@@ -38,7 +38,7 @@ use crate::{
     BlockExpression, Expression, ExpressionKind, FunctionKind, Ident, Literal, NoirFunction,
     Statement,
 };
-use crate::{NoirStruct, Path, Pattern, StructType, Type, UnresolvedType, ERROR_IDENT};
+use crate::{NoirStruct, Path, Pattern, StructType, Type, UnresolvedType, ERROR_IDENT, LValue};
 use noirc_errors::{Span, Spanned};
 
 use crate::hir::scope::{
@@ -302,15 +302,31 @@ impl<'a> Resolver<'a> {
                 self.interner.push_stmt(stmt)
             }
             Statement::Assign(assign_stmt) => {
-                let identifier = self.find_variable(&assign_stmt.lvalue);
+                let identifier = self.resolve_lvalue(assign_stmt.lvalue);
                 let expression = self.resolve_expression(assign_stmt.expression);
                 let stmt = HirAssignStatement {
-                    identifier,
+                    lvalue: identifier,
                     expression,
                 };
                 self.interner.push_stmt(HirStatement::Assign(stmt))
             }
             Statement::Error => self.interner.push_stmt(HirStatement::Error),
+        }
+    }
+
+    fn resolve_lvalue(&mut self, lvalue: LValue) -> HirLValue {
+        match lvalue {
+            LValue::Ident(ident) => HirLValue::Ident(self.find_variable(&ident)),
+            LValue::MemberAccess { object, field_name } => {
+                let object = Box::new(self.resolve_lvalue(*object));
+                let field_name = self.interner.push_ident(field_name);
+                HirLValue::MemberAccess { object, field_name }
+            },
+            LValue::Index { array, index } => {
+                let array = Box::new(self.resolve_lvalue(*array));
+                let index = self.resolve_expression(index);
+                HirLValue::Index { array, index }
+            },
         }
     }
 

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -505,9 +505,9 @@ pub fn check_member_access(
 
     if let Type::Struct(_, s) = &lhs_type {
         let s = s.borrow();
-        if let Some(field) = s.fields.iter().find(|(name, _)| name == &access.rhs) {
+        if let Some(field) = s.get_field(&access.rhs.0.contents) {
             // TODO: Should the struct's visibility be applied to the field?
-            return field.1.clone();
+            return field.clone();
         }
     } else if let Type::Tuple(elements) = &lhs_type {
         if let Ok(index) = access.rhs.0.contents.parse::<usize>() {

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -15,7 +15,7 @@ pub struct HirLetStatement {
 
 #[derive(Debug, Clone)]
 pub struct HirAssignStatement {
-    pub identifier: IdentId,
+    pub lvalue: HirLValue,
     pub expression: ExprId,
 }
 
@@ -86,13 +86,13 @@ impl HirPattern {
 /// Represents an Ast form that can be assigned to
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum HirLValue {
-    Ident(Ident),
+    Ident(IdentId),
     MemberAccess {
-        object: Box<LValue>,
-        field_name: Ident,
+        object: Box<HirLValue>,
+        field_name: IdentId,
     },
     Index {
-        array: Box<LValue>,
-        index: Expression,
+        array: Box<HirLValue>,
+        index: ExprId,
     },
 }

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -82,3 +82,17 @@ impl HirPattern {
         }
     }
 }
+
+/// Represents an Ast form that can be assigned to
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum HirLValue {
+    Ident(Ident),
+    MemberAccess {
+        object: Box<LValue>,
+        field_name: Ident,
+    },
+    Index {
+        array: Box<LValue>,
+        index: Expression,
+    },
+}

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -36,7 +36,8 @@ impl StructType {
     }
 
     pub fn get_field(&self, field_name: &str) -> Option<&Type> {
-        self.fields.iter()
+        self.fields
+            .iter()
             .find(|(name, _)| name.0.contents == field_name)
             .map(|(_, typ)| typ)
     }

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -34,6 +34,12 @@ impl StructType {
             methods: HashMap::new(),
         }
     }
+
+    pub fn get_field(&self, field_name: &str) -> Option<&Type> {
+        self.fields.iter()
+            .find(|(name, _)| name.0.contents == field_name)
+            .map(|(_, typ)| typ)
+    }
 }
 
 impl std::fmt::Display for StructType {

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -237,7 +237,6 @@ impl Precedence {
     // XXX: Check the precedence is correct for operators
     fn token_precedence(tok: &Token) -> Option<Precedence> {
         let precedence = match tok {
-            Token::Assign => Precedence::Lowest,
             Token::Equal => Precedence::Lowest,
             Token::NotEqual => Precedence::Lowest,
             Token::Less => Precedence::LessGreater,

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -363,7 +363,7 @@ fn assignment<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a
 where
     P: ExprParser + 'a,
 {
-    let failable = lvalue()
+    let failable = lvalue(expr_parser.clone())
         .then_ignore(just(Token::Assign))
         .labelled("statement");
 
@@ -380,14 +380,17 @@ enum LValueRhs {
     Index(Expression),
 }
 
-fn lvalue() -> impl NoirParser<LValue> {
+fn lvalue<'a, P>(expr_parser: P) -> impl NoirParser<LValue>
+where
+    P: ExprParser + 'a,
+{
     let l_ident = ident().map(LValue::Ident);
 
     let l_member_rhs = just(Token::Dot)
         .ignore_then(ident())
         .map(LValueRhs::MemberAccess);
 
-    let l_index = expression()
+    let l_index = expr_parser
         .delimited_by(just(Token::LeftBracket), just(Token::RightBracket))
         .map(LValueRhs::Index);
 

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 use crate::{
     AssignStatement, BinaryOp, BinaryOpKind, BlockExpression, ConstrainStatement, ForExpression,
-    FunctionDefinition, Ident, IfExpression, ImportStatement, InfixExpression, NoirFunction,
-    NoirImpl, NoirStruct, Path, PathKind, Pattern, Recoverable, UnaryOp,
+    FunctionDefinition, Ident, IfExpression, ImportStatement, InfixExpression, LValue,
+    NoirFunction, NoirImpl, NoirStruct, Path, PathKind, Pattern, Recoverable, UnaryOp,
 };
 
 use chumsky::prelude::*;
@@ -363,15 +363,46 @@ fn assignment<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a
 where
     P: ExprParser + 'a,
 {
-    let failable = ident()
+    let failable = lvalue()
         .then_ignore(just(Token::Assign))
         .labelled("statement");
+
     then_commit(failable, expr_parser).map(|(identifier, expression)| {
         Statement::Assign(AssignStatement {
-            identifier,
+            lvalue: identifier,
             expression,
         })
     })
+}
+
+enum LValueRhs {
+    MemberAccess(Ident),
+    Index(Expression),
+}
+
+fn lvalue() -> impl NoirParser<LValue> {
+    let l_ident = ident().map(LValue::Ident);
+
+    let l_member_rhs = just(Token::Dot)
+        .ignore_then(ident())
+        .map(LValueRhs::MemberAccess);
+
+    let l_index = expression()
+        .delimited_by(just(Token::LeftBracket), just(Token::RightBracket))
+        .map(LValueRhs::Index);
+
+    l_ident
+        .then(l_member_rhs.or(l_index).repeated())
+        .foldl(|lvalue, rhs| match rhs {
+            LValueRhs::MemberAccess(field_name) => LValue::MemberAccess {
+                object: Box::new(lvalue),
+                field_name,
+            },
+            LValueRhs::Index(index) => LValue::Index {
+                array: Box::new(lvalue),
+                index,
+            },
+        })
 }
 
 fn parse_type() -> impl NoirParser<UnresolvedType> {


### PR DESCRIPTION
Currently for assignment expressions we only support `ident = expr;`. This PR adds support for field assignment (`lvalue.ident = expr`) and array index assignment (`lvalue[expr] = expr;`) to the frontend - as well as nested forms of each.
Further work is needed to get these lvalue expressions working in the backend.