### PR TITLE
Support multi-dimensional arrays in the frontend

### DIFF
--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -598,9 +598,15 @@ impl<'a> Evaluator<'a> {
             }
             HirExpression::Index(indexed_expr) => {
                 // Currently these only happen for arrays
-                let arr_name = self.context.def_interner.ident_name(&indexed_expr.collection_name);
-                let ident_span = self.context.def_interner.ident_span(&indexed_expr.collection_name);
+                let collection_name = match self.context.def_interner.expression(&indexed_expr.collection) {
+                    HirExpression::Ident(id) => id,
+                    other => unimplemented!("Array indexing with an lhs of '{:?}' is unimplemented in the interpreter, you must use an expression in the form `identifier[expression]` for now.", other)
+                };
+
+                let arr_name = self.context.def_interner.ident_name(&collection_name);
+                let ident_span = self.context.def_interner.ident_span(&collection_name);
                 let arr = env.get_array(&arr_name).map_err(|kind|kind.add_span(ident_span))?;
+
                 //
                 // Evaluate the index expression
                 let index_as_obj = self.expression_to_object(env, &indexed_expr.index)?;

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -613,7 +613,7 @@ impl<'a> Evaluator<'a> {
 
                 let arr_name = self.context.def_interner.definition_name(collection_name.id);
                 let ident_span = collection_name.span;
-                let arr = env.get_array(&arr_name).map_err(|kind|kind.add_span(ident_span))?;
+                let arr = env.get_array(arr_name).map_err(|kind|kind.add_span(ident_span))?;
 
                 //
                 // Evaluate the index expression

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -535,9 +535,15 @@ impl<'a> IRGenerator<'a> {
             },
             HirExpression::Index(indexed_expr) => {
                 // Currently these only happen for arrays
-                let arr_def = self.def_interner().ident_def(&indexed_expr.collection_name);
-                let arr_name = self.def_interner().ident_name(&indexed_expr.collection_name);
-                let ident_span = self.def_interner().ident_span(&indexed_expr.collection_name);
+                let collection_name = match self.def_interner().expression(&indexed_expr.collection) {
+                    HirExpression::Ident(id) => id,
+                    other => todo!("Array indexing with an lhs of '{:?}' is unimplemented, you must use an expression in the form `identifier[expression]` for now.", other)
+                };
+
+                let arr_def = self.def_interner().ident_def(&collection_name);
+                let arr_name = self.def_interner().ident_name(&collection_name);
+                let ident_span = self.def_interner().ident_span(&collection_name);
+
                 let arr_type = self.def_interner().id_type(arr_def.unwrap());
                 let o_type = arr_type.into();
                 let mut array_index = self.context.mem.arrays.len() as u32;

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -75,13 +75,6 @@ impl ExpressionKind {
         ExpressionKind::Constructor(Box::new(ConstructorExpression { type_name, fields }))
     }
 
-    pub fn index(collection_name: Ident, index: Expression) -> ExpressionKind {
-        ExpressionKind::Index(Box::new(IndexExpression {
-            collection_name,
-            index,
-        }))
-    }
-
     /// Returns true if the expression is a literal integer
     pub fn is_integer(&self) -> bool {
         self.as_integer().is_some()
@@ -175,11 +168,14 @@ impl Expression {
         Expression::new(kind, span)
     }
 
+    pub fn index(collection: Expression, index: Expression, span: Span) -> Expression {
+        let kind = ExpressionKind::Index(Box::new(IndexExpression { collection, index }));
+        Expression::new(kind, span)
+    }
+
     pub fn cast(lhs: Expression, r#type: UnresolvedType, span: Span) -> Expression {
-        Expression {
-            kind: ExpressionKind::Cast(Box::new(CastExpression { lhs, r#type })),
-            span,
-        }
+        let kind = ExpressionKind::Cast(Box::new(CastExpression { lhs, r#type }));
+        Expression::new(kind, span)
     }
 }
 
@@ -385,7 +381,7 @@ pub struct MemberAccessExpression {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct IndexExpression {
-    pub collection_name: Ident, // XXX: For now, this will be the name of the array, as we do not support other collections
+    pub collection: Expression, // XXX: For now, this will be the name of the array, as we do not support other collections
     pub index: Expression, // XXX: We accept two types of indices, either a normal integer or a constant
 }
 
@@ -483,7 +479,7 @@ impl Display for UnaryOp {
 
 impl Display for IndexExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}[{}]", self.collection_name, self.index)
+        write!(f, "{}[{}]", self.collection, self.index)
     }
 }
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -388,7 +388,7 @@ impl<'a> Resolver<'a> {
                 alternative: if_expr.alternative.map(|e| self.intern_block(e)),
             }),
             ExpressionKind::Index(indexed_expr) => HirExpression::Index(HirIndexExpression {
-                collection_name: self.find_variable(&indexed_expr.collection_name),
+                collection: self.resolve_expression(indexed_expr.collection),
                 index: self.resolve_expression(indexed_expr.index),
             }),
             ExpressionKind::Path(path) => {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -94,34 +94,31 @@ pub(crate) fn type_check_expression(
             }
         }
         HirExpression::Index(index_expr) => {
-            if let Some(ident_def) = interner.ident_def(&index_expr.collection_name) {
-                let index_type = type_check_expression(interner, &index_expr.index, errors);
-                if !index_type.matches(&Type::CONSTANT) {
-                    let span = interner.id_span(&index_expr.index);
+            let index_type = type_check_expression(interner, &index_expr.index, errors);
+            if !index_type.matches(&Type::CONSTANT) {
+                let span = interner.id_span(&index_expr.index);
+                errors.push(TypeCheckError::TypeMismatch {
+                    expected_typ: "const Field".to_owned(),
+                    expr_typ: index_type.to_string(),
+                    expr_span: span,
+                });
+            }
+
+            let lhs_type = type_check_expression(interner, &index_expr.collection, errors);
+            match lhs_type {
+                // XXX: We can check the array bounds here also, but it may be better to constant fold first
+                // and have ConstId instead of ExprId for constants
+                Type::Array(_, _, base_type) => *base_type,
+                Type::Error => Type::Error,
+                typ => {
+                    let span = interner.id_span(&index_expr.collection);
                     errors.push(TypeCheckError::TypeMismatch {
-                        expected_typ: "const Field".to_owned(),
-                        expr_typ: index_type.to_string(),
+                        expected_typ: "Array".to_owned(),
+                        expr_typ: typ.to_string(),
                         expr_span: span,
                     });
+                    Type::Error
                 }
-
-                match interner.id_type(&ident_def) {
-                    // XXX: We can check the array bounds here also, but it may be better to constant fold first
-                    // and have ConstId instead of ExprId for constants
-                    Type::Array(_, _, base_type) => *base_type,
-                    Type::Error => Type::Error,
-                    typ => {
-                        let span = interner.id_span(&index_expr.collection_name);
-                        errors.push(TypeCheckError::TypeMismatch {
-                            expected_typ: "Array".to_owned(),
-                            expr_typ: typ.to_string(),
-                            expr_span: span,
-                        });
-                        Type::Error
-                    }
-                }
-            } else {
-                Type::Error
             }
         }
         HirExpression::Call(call_expr) => {

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -223,7 +223,7 @@ pub struct HirConstructorExpression {
 
 #[derive(Debug, Clone)]
 pub struct HirIndexExpression {
-    pub collection_name: IdentId,
+    pub collection: ExprId,
     pub index: ExprId,
 }
 


### PR DESCRIPTION
Per a request from @guipublic. 

This PR adds support for nested arrays such as `[[1, 2], [3, 4]]` in the frontend. It also supports some related features like nested indexing `a[0][2]`. Part of the requirement for this change was that array indexing nodes in the ast used to only accept an Ident as their lhs, this has been changed to accept an arbitrary expression such that, e.g. `foo()[5]` or `[1, 2][0]` are now valid. Both ssa and the interpreter now need code to handle this case since both seemed to store arrays by name previously when they aren't guaranteed to have one.

Additionally the parser that parses postfix unary expressions has been rewritten since it did not allow for expressions like `a[0].foo[6].baz[3]` before.