### PR TITLE
Logic gate solver follows now

### DIFF
--- a/crates/acvm/src/pwg/logic.rs
+++ b/crates/acvm/src/pwg/logic.rs
@@ -14,14 +14,13 @@ impl LogicSolver {
         result: Witness,
         num_bits: u32,
         is_xor_gate: bool,
-    ) {
+    ) -> bool {
         let w_l = initial_witness.get(a);
         let w_r = initial_witness.get(b);
 
-        let (w_l_value, w_r_value) = match (w_l,w_r) {
-            (Some(w_l_value), Some(w_r_value)) => { (w_l_value, w_r_value)
-            },
-            (_,_) => panic!("This should have been caught by the semantic analyser; or the gates were added in the wrong order. One of your wires are None for the logic gate")
+        let (w_l_value, w_r_value) = match (w_l, w_r) {
+            (Some(w_l_value), Some(w_r_value)) => (w_l_value, w_r_value),
+            (_, _) => return false,
         };
 
         if is_xor_gate {
@@ -31,9 +30,13 @@ impl LogicSolver {
             let assignment = w_l_value.and(w_r_value, num_bits);
             initial_witness.insert(result, assignment);
         }
+        true
     }
 
-    pub fn solve_and_gate(initial_witness: &mut BTreeMap<Witness, FieldElement>, gate: &AndGate) {
+    pub fn solve_and_gate(
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        gate: &AndGate,
+    ) -> bool {
         LogicSolver::solve_logic_gate(
             initial_witness,
             &gate.a,
@@ -43,7 +46,10 @@ impl LogicSolver {
             false,
         )
     }
-    pub fn solve_xor_gate(initial_witness: &mut BTreeMap<Witness, FieldElement>, gate: &XorGate) {
+    pub fn solve_xor_gate(
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        gate: &XorGate,
+    ) -> bool {
         LogicSolver::solve_logic_gate(
             initial_witness,
             &gate.a,

--- a/crates/aztec_backend/src/acvm_interop/pwg.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg.rs
@@ -38,11 +38,11 @@ impl PartialWitnessGenerator for Plonk {
                     false
                 }
                 Gate::And(and_gate) => {
-                    LogicSolver::solve_and_gate(initial_witness, and_gate)
+                    !LogicSolver::solve_and_gate(initial_witness, and_gate)
                     // We compute the result because the other gates may want to use the assignment to generate their assignments
                 }
                 Gate::Xor(xor_gate) => {
-                    LogicSolver::solve_xor_gate(initial_witness, xor_gate)
+                    !LogicSolver::solve_xor_gate(initial_witness, xor_gate)
                     // We compute the result because the other gates may want to use the assignment to generate their assignments
                 }
                 Gate::GadgetCall(gc) => {

--- a/crates/aztec_backend/src/acvm_interop/pwg.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg.rs
@@ -38,14 +38,12 @@ impl PartialWitnessGenerator for Plonk {
                     false
                 }
                 Gate::And(and_gate) => {
-                    LogicSolver::solve_and_gate(initial_witness, and_gate);
+                    LogicSolver::solve_and_gate(initial_witness, and_gate)
                     // We compute the result because the other gates may want to use the assignment to generate their assignments
-                    false
                 }
                 Gate::Xor(xor_gate) => {
-                    LogicSolver::solve_xor_gate(initial_witness, xor_gate);
+                    LogicSolver::solve_xor_gate(initial_witness, xor_gate)
                     // We compute the result because the other gates may want to use the assignment to generate their assignments
-                    false
                 }
                 Gate::GadgetCall(gc) => {
                     GadgetCaller::solve_gadget_call(initial_witness, gc)?;


### PR DESCRIPTION
 The logic gate solver follows now the same pattern of other solvers:
 It can delay the solve until witnesses are available