### PR TITLE
Fmt: Use small heuristics

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 edition = "2018"
+use_small_heuristics="Max"

--- a/crates/acir/src/circuit/gate.rs
+++ b/crates/acir/src/circuit/gate.rs
@@ -48,12 +48,8 @@ impl std::fmt::Debug for Gate {
         match self {
             Gate::Arithmetic(a) => {
                 for i in &a.mul_terms {
-                    result += &format!(
-                        "{:?}x{}*x{} + ",
-                        i.0,
-                        i.1.witness_index(),
-                        i.2.witness_index()
-                    );
+                    result +=
+                        &format!("{:?}x{}*x{} + ", i.0, i.1.witness_index(), i.2.witness_index());
                 }
                 for i in &a.linear_combinations {
                     result += &format!("{:?}x{} + ", i.0, i.1.witness_index());
@@ -66,12 +62,7 @@ impl std::fmt::Debug for Gate {
             Gate::Directive(Directive::Invert { x, result: r }) => {
                 result = format!("x{}=1/x{}, or 0", r.witness_index(), x.witness_index());
             }
-            Gate::Directive(Directive::Truncate {
-                a,
-                b,
-                c: _c,
-                bit_size,
-            }) => {
+            Gate::Directive(Directive::Truncate { a, b, c: _c, bit_size }) => {
                 result = format!(
                     "Truncate: x{} is x{} truncated to {} bits",
                     b.witness_index(),
@@ -123,41 +114,19 @@ impl std::fmt::Debug for Gate {
 /// Directives do not apply any constraints.
 pub enum Directive {
     //Inverts the value of x and stores it in the result variable
-    Invert {
-        x: Witness,
-        result: Witness,
-    },
+    Invert { x: Witness, result: Witness },
 
     //Performs euclidian division of a / b (as integers) and stores the quotient in q and the rest in r
-    Quotient {
-        a: Witness,
-        b: Witness,
-        q: Witness,
-        r: Witness,
-    },
+    Quotient { a: Witness, b: Witness, q: Witness, r: Witness },
 
     //Reduces the value of a modulo 2^bit_size and stores the result in b: a= c*2^bit_size + b
-    Truncate {
-        a: Witness,
-        b: Witness,
-        c: Witness,
-        bit_size: u32,
-    },
+    Truncate { a: Witness, b: Witness, c: Witness, bit_size: u32 },
 
     //Computes the highest bit b of a: a = b*2^(bit_size-1) + r, where a<2^bit_size, b is 0 or 1 and r<2^(bit_size-1)
-    Oddrange {
-        a: Witness,
-        b: Witness,
-        r: Witness,
-        bit_size: u32,
-    },
+    Oddrange { a: Witness, b: Witness, r: Witness, bit_size: u32 },
 
     //bit decomposition of a: a=\sum b[i]*2^i
-    Split {
-        a: Witness,
-        b: Vec<Witness>,
-        bit_size: u32,
-    },
+    Split { a: Witness, b: Vec<Witness>, bit_size: u32 },
 }
 
 // Note: Some gadgets will not use all of the witness

--- a/crates/acir/src/circuit/mod.rs
+++ b/crates/acir/src/circuit/mod.rs
@@ -25,10 +25,7 @@ pub struct PublicInputs(pub Vec<Witness>);
 impl PublicInputs {
     /// Returns the witness index of each public input
     pub fn indices(&self) -> Vec<u32> {
-        self.0
-            .iter()
-            .map(|witness| witness.witness_index() as u32)
-            .collect()
+        self.0.iter().map(|witness| witness.witness_index() as u32).collect()
     }
 
     pub fn contains(&self, index: usize) -> bool {

--- a/crates/acir/src/native_types/arithmetic.rs
+++ b/crates/acir/src/native_types/arithmetic.rs
@@ -47,27 +47,17 @@ impl Mul<&FieldElement> for &Arithmetic {
     type Output = Arithmetic;
     fn mul(self, rhs: &FieldElement) -> Self::Output {
         // Scale the mul terms
-        let mul_terms: Vec<_> = self
-            .mul_terms
-            .iter()
-            .map(|(q_m, w_l, w_r)| (*q_m * *rhs, *w_l, *w_r))
-            .collect();
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().map(|(q_m, w_l, w_r)| (*q_m * *rhs, *w_l, *w_r)).collect();
 
         // Scale the linear combinations terms
-        let lin_combinations: Vec<_> = self
-            .linear_combinations
-            .iter()
-            .map(|(q_l, w_l)| (*q_l * *rhs, *w_l))
-            .collect();
+        let lin_combinations: Vec<_> =
+            self.linear_combinations.iter().map(|(q_l, w_l)| (*q_l * *rhs, *w_l)).collect();
 
         // Scale the constant
         let q_c = self.q_c * *rhs;
 
-        Arithmetic {
-            mul_terms,
-            q_c,
-            linear_combinations: lin_combinations,
-        }
+        Arithmetic { mul_terms, q_c, linear_combinations: lin_combinations }
     }
 }
 impl Add<&FieldElement> for Arithmetic {
@@ -76,11 +66,7 @@ impl Add<&FieldElement> for Arithmetic {
         // Increase the constant
         let q_c = self.q_c + *rhs;
 
-        Arithmetic {
-            mul_terms: self.mul_terms,
-            q_c,
-            linear_combinations: self.linear_combinations,
-        }
+        Arithmetic { mul_terms: self.mul_terms, q_c, linear_combinations: self.linear_combinations }
     }
 }
 impl Sub<&FieldElement> for Arithmetic {
@@ -89,11 +75,7 @@ impl Sub<&FieldElement> for Arithmetic {
         // Increase the constant
         let q_c = self.q_c - *rhs;
 
-        Arithmetic {
-            mul_terms: self.mul_terms,
-            q_c,
-            linear_combinations: self.linear_combinations,
-        }
+        Arithmetic { mul_terms: self.mul_terms, q_c, linear_combinations: self.linear_combinations }
     }
 }
 
@@ -102,12 +84,8 @@ impl Add<&Arithmetic> for &Arithmetic {
     fn add(self, rhs: &Arithmetic) -> Arithmetic {
         // XXX(med) : Implement an efficient way to do this
 
-        let mul_terms: Vec<_> = self
-            .mul_terms
-            .iter()
-            .cloned()
-            .chain(rhs.mul_terms.iter().cloned())
-            .collect();
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().cloned().chain(rhs.mul_terms.iter().cloned()).collect();
 
         let linear_combinations: Vec<_> = self
             .linear_combinations
@@ -117,11 +95,7 @@ impl Add<&Arithmetic> for &Arithmetic {
             .collect();
         let q_c = self.q_c + rhs.q_c;
 
-        Arithmetic {
-            mul_terms,
-            linear_combinations,
-            q_c,
-        }
+        Arithmetic { mul_terms, linear_combinations, q_c }
     }
 }
 
@@ -130,24 +104,14 @@ impl Neg for &Arithmetic {
     fn neg(self) -> Self::Output {
         // XXX(med) : Implement an efficient way to do this
 
-        let mul_terms: Vec<_> = self
-            .mul_terms
-            .iter()
-            .map(|(q_m, w_l, w_r)| (-*q_m, *w_l, *w_r))
-            .collect();
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().map(|(q_m, w_l, w_r)| (-*q_m, *w_l, *w_r)).collect();
 
-        let linear_combinations: Vec<_> = self
-            .linear_combinations
-            .iter()
-            .map(|(q_k, w_k)| (-*q_k, *w_k))
-            .collect();
+        let linear_combinations: Vec<_> =
+            self.linear_combinations.iter().map(|(q_k, w_k)| (-*q_k, *w_k)).collect();
         let q_c = -self.q_c;
 
-        Arithmetic {
-            mul_terms,
-            linear_combinations,
-            q_c,
-        }
+        Arithmetic { mul_terms, linear_combinations, q_c }
     }
 }
 
@@ -160,11 +124,7 @@ impl Sub<&Arithmetic> for &Arithmetic {
 
 impl From<&FieldElement> for Arithmetic {
     fn from(constant: &FieldElement) -> Arithmetic {
-        Arithmetic {
-            q_c: *constant,
-            linear_combinations: Vec::new(),
-            mul_terms: Vec::new(),
-        }
+        Arithmetic { q_c: *constant, linear_combinations: Vec::new(), mul_terms: Vec::new() }
     }
 }
 impl From<&Linear> for Arithmetic {
@@ -209,9 +169,7 @@ impl Sub<&UnknownWitness> for &Arithmetic {
     type Output = Arithmetic;
     fn sub(self, rhs: &UnknownWitness) -> Arithmetic {
         let mut cloned = self.clone();
-        cloned
-            .linear_combinations
-            .insert(0, (-FieldElement::one(), rhs.as_witness()));
+        cloned.linear_combinations.insert(0, (-FieldElement::one(), rhs.as_witness()));
         cloned
     }
 }

--- a/crates/acir/src/native_types/linear.rs
+++ b/crates/acir/src/native_types/linear.rs
@@ -19,11 +19,7 @@ impl Linear {
         self.mul_scale.is_one() && self.add_scale.is_zero()
     }
     pub fn from_witness(witness: Witness) -> Linear {
-        Linear {
-            mul_scale: FieldElement::one(),
-            witness,
-            add_scale: FieldElement::zero(),
-        }
+        Linear { mul_scale: FieldElement::one(), witness, add_scale: FieldElement::zero() }
     }
     // XXX: This is true for the NPC languages that we use, are there any where this is not true?
     pub const fn can_defer_constraint(&self) -> bool {
@@ -38,11 +34,7 @@ impl From<Witness> for Linear {
 }
 impl From<FieldElement> for Linear {
     fn from(element: FieldElement) -> Linear {
-        Linear {
-            add_scale: element,
-            witness: Witness::default(),
-            mul_scale: FieldElement::zero(),
-        }
+        Linear { add_scale: element, witness: Witness::default(), mul_scale: FieldElement::zero() }
     }
 }
 
@@ -63,11 +55,7 @@ impl Neg for &Linear {
     type Output = Linear;
     fn neg(self) -> Self::Output {
         // -(Ax + B) = -Ax - B
-        Linear {
-            add_scale: -self.add_scale,
-            witness: self.witness,
-            mul_scale: -self.mul_scale,
-        }
+        Linear { add_scale: -self.add_scale, witness: self.witness, mul_scale: -self.mul_scale }
     }
 }
 
@@ -109,11 +97,7 @@ impl Mul<&Linear> for &Linear {
             lc
         };
 
-        Arithmetic {
-            mul_terms,
-            linear_combinations,
-            q_c: bd,
-        }
+        Arithmetic { mul_terms, linear_combinations, q_c: bd }
     }
 }
 impl Mul<&FieldElement> for &Linear {

--- a/crates/acir/src/optimiser/csat_optimiser.rs
+++ b/crates/acir/src/optimiser/csat_optimiser.rs
@@ -110,14 +110,10 @@ impl Optimiser {
             // Check if this pair is present in the simplified fan-in
             // We are assuming that the fan-in/fan-out has been simplified.
             // Note this function is not public, and can only be called within the optimise method, so this guarantee will always hold
-            let index_wl = gate
-                .linear_combinations
-                .iter()
-                .position(|(_scale, witness)| *witness == pair.1);
-            let index_wr = gate
-                .linear_combinations
-                .iter()
-                .position(|(_scale, witness)| *witness == pair.2);
+            let index_wl =
+                gate.linear_combinations.iter().position(|(_scale, witness)| *witness == pair.1);
+            let index_wr =
+                gate.linear_combinations.iter().position(|(_scale, witness)| *witness == pair.2);
 
             match (index_wl, index_wr) {
                 (None, _) => {
@@ -182,16 +178,12 @@ impl Optimiser {
                     let inter_var = Witness(intermediate_variables.len() as u32 + num_witness);
 
                     // Constrain the gate to the intermediate variable
-                    intermediate_gate
-                        .linear_combinations
-                        .push((-FieldElement::one(), inter_var));
+                    intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
                     // Add intermediate gate to the map
                     intermediate_variables.insert(inter_var, intermediate_gate);
 
                     // Add intermediate variable to the new gate instead of the full gate
-                    new_gate
-                        .linear_combinations
-                        .push((FieldElement::one(), inter_var));
+                    new_gate.linear_combinations.push((FieldElement::one(), inter_var));
                 }
             };
             // Remove this term as we are finished processing it
@@ -200,9 +192,7 @@ impl Optimiser {
 
         // Add the rest of the elements back into the new_gate
         new_gate.mul_terms.extend(gate.mul_terms.clone());
-        new_gate
-            .linear_combinations
-            .extend(gate.linear_combinations.clone());
+        new_gate.linear_combinations.extend(gate.linear_combinations.clone());
         new_gate.q_c = gate.q_c;
 
         new_gate
@@ -269,16 +259,13 @@ impl Optimiser {
             // Push mul term into the gate
             intermediate_gate.mul_terms.push(mul_term);
             // Constrain it to be equal to the intermediate variable
-            intermediate_gate
-                .linear_combinations
-                .push((-FieldElement::one(), inter_var));
+            intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
 
             // Add intermediate gate and variable to map
             intermediate_variables.insert(inter_var, intermediate_gate);
 
             // Add intermediate variable as a part of the fan-in for the original gate
-            gate.linear_combinations
-                .push((FieldElement::one(), inter_var));
+            gate.linear_combinations.push((FieldElement::one(), inter_var));
         }
 
         // Remove all of the mul terms as we have intermediate variables to represent them now
@@ -315,9 +302,7 @@ impl Optimiser {
 
             added.push((FieldElement::one(), inter_var));
 
-            intermediate_gate
-                .linear_combinations
-                .push((-FieldElement::one(), inter_var));
+            intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
 
             // Add intermediate gate and variable to map
             intermediate_variables.insert(inter_var, intermediate_gate);

--- a/crates/acir/src/optimiser/general_optimiser.rs
+++ b/crates/acir/src/optimiser/general_optimiser.rs
@@ -13,18 +13,11 @@ impl GeneralOpt {
 // Remove all terms with zero as a coefficient
 pub fn remove_zero_coefficients(mut gate: Arithmetic) -> Arithmetic {
     // Check the mul terms
-    gate.mul_terms = gate
-        .mul_terms
-        .into_iter()
-        .filter(|(scale, _, _)| !scale.is_zero())
-        .collect();
+    gate.mul_terms = gate.mul_terms.into_iter().filter(|(scale, _, _)| !scale.is_zero()).collect();
 
     // Check the linear combination terms
-    gate.linear_combinations = gate
-        .linear_combinations
-        .into_iter()
-        .filter(|(scale, _)| !scale.is_zero())
-        .collect();
+    gate.linear_combinations =
+        gate.linear_combinations.into_iter().filter(|(scale, _)| !scale.is_zero()).collect();
 
     gate
 }
@@ -39,15 +32,10 @@ pub fn simplify_mul_terms(mut gate: Arithmetic) -> Arithmetic {
         // Sort using rust sort algorithm
         pair.sort();
 
-        *hash_map
-            .entry((pair[0], pair[1]))
-            .or_insert_with(FieldElement::zero) += scale;
+        *hash_map.entry((pair[0], pair[1])).or_insert_with(FieldElement::zero) += scale;
     }
 
-    gate.mul_terms = hash_map
-        .into_iter()
-        .map(|((w_l, w_r), scale)| (scale, w_l, w_r))
-        .collect();
+    gate.mul_terms = hash_map.into_iter().map(|((w_l, w_r), scale)| (scale, w_l, w_r)).collect();
 
     gate
 }

--- a/crates/acvm/src/pwg/hash/mod.rs
+++ b/crates/acvm/src/pwg/hash/mod.rs
@@ -35,9 +35,7 @@ fn generic_hash_256<D: Digest>(
     }
     let result = hasher.finalize();
     for i in 0..32 {
-        initial_witness.insert(
-            gadget_call.outputs[i],
-            FieldElement::from_be_bytes_reduce(&[result[i]]),
-        );
+        initial_witness
+            .insert(gadget_call.outputs[i], FieldElement::from_be_bytes_reduce(&[result[i]]));
     }
 }

--- a/crates/aztec_backend/src/acvm_interop/pwg/gadget_call.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg/gadget_call.rs
@@ -48,9 +48,8 @@ impl GadgetCaller {
                 let merkle_data =
                     process_merkle_gadget(initial_witness, gadget_call, SHOULD_INSERT);
 
-                let new_root = merkle_data
-                    .new_root
-                    .expect("new root should be computed for insertions");
+                let new_root =
+                    merkle_data.new_root.expect("new root should be computed for insertions");
 
                 initial_witness.insert(gadget_call.outputs[0], new_root);
             }
@@ -61,21 +60,14 @@ impl GadgetCaller {
 
                 let mut inputs_iter = gadget_call.inputs.iter();
 
-                let _pub_key_x = inputs_iter
-                    .next()
-                    .expect("expected `x` component for public key");
+                let _pub_key_x = inputs_iter.next().expect("expected `x` component for public key");
                 let pub_key_x = input_to_value(initial_witness, _pub_key_x).to_bytes();
 
-                let _pub_key_y = inputs_iter
-                    .next()
-                    .expect("expected `y` component for public key");
+                let _pub_key_y = inputs_iter.next().expect("expected `y` component for public key");
                 let pub_key_y = input_to_value(initial_witness, _pub_key_y).to_bytes();
 
-                let pub_key_bytes: Vec<u8> = pub_key_x
-                    .iter()
-                    .copied()
-                    .chain(pub_key_y.to_vec())
-                    .collect();
+                let pub_key_bytes: Vec<u8> =
+                    pub_key_x.iter().copied().chain(pub_key_y.to_vec()).collect();
                 let pub_key: [u8; 64] = pub_key_bytes.try_into().unwrap();
 
                 let mut signature = [0u8; 64];
@@ -106,9 +98,8 @@ impl GadgetCaller {
             OPCODE::Pedersen => {
                 let inputs_iter = gadget_call.inputs.iter();
 
-                let scalars: Vec<_> = inputs_iter
-                    .map(|input| *input_to_value(initial_witness, input))
-                    .collect();
+                let scalars: Vec<_> =
+                    inputs_iter.map(|input| *input_to_value(initial_witness, input)).collect();
 
                 let mut barretenberg = Barretenberg::new();
 
@@ -217,10 +208,7 @@ fn process_merkle_gadget(
         (_index, Some(new_root))
     } else {
         let _index = merkle_tree.find_index_from_leaf(&leaf).unwrap_or_else(|| {
-            panic!(
-                "could not find leaf in the merkle tree. {} not found",
-                leaf.to_hex()
-            )
+            panic!("could not find leaf in the merkle tree. {} not found", leaf.to_hex())
         });
         (_index, None)
     };
@@ -241,11 +229,5 @@ fn process_merkle_gadget(
         initial_witness.insert(right, right_hash);
     }
 
-    MerkleData {
-        hashpath: path,
-        old_root: root,
-        new_root,
-        leaf,
-        index: index_fr,
-    }
+    MerkleData { hashpath: path, old_root: root, new_root, leaf, index: index_fr }
 }

--- a/crates/aztec_backend/src/acvm_interop/pwg/merkle.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg/merkle.rs
@@ -29,20 +29,14 @@ fn insert_root(db: &mut sled::Db, value: FieldElement) {
     db.insert("ROOT".as_bytes(), value.to_bytes()).unwrap();
 }
 fn fetch_root(db: &sled::Db) -> FieldElement {
-    let value = db
-        .get("ROOT".as_bytes())
-        .unwrap()
-        .expect("merkle root should always be present");
+    let value = db.get("ROOT".as_bytes()).unwrap().expect("merkle root should always be present");
     FieldElement::from_be_bytes_reduce(&value.to_vec())
 }
 fn insert_depth(db: &mut sled::Db, value: u32) {
     db.insert("DEPTH".as_bytes(), &value.to_be_bytes()).unwrap();
 }
 fn fetch_depth(db: &sled::Db) -> u32 {
-    let value = db
-        .get("DEPTH".as_bytes())
-        .unwrap()
-        .expect("depth should always be present");
+    let value = db.get("DEPTH".as_bytes()).unwrap().expect("depth should always be present");
     u32::from_be_bytes(value.to_vec().try_into().unwrap())
 }
 fn insert_empty_index(db: &mut sled::Db, index: u32) {
@@ -50,18 +44,12 @@ fn insert_empty_index(db: &mut sled::Db, index: u32) {
     let depth = fetch_depth(db);
     let total_size = 1 << depth;
     if index > total_size {
-        panic!(
-            "trying to insert at index {}, but total width is {}",
-            index, total_size
-        )
+        panic!("trying to insert at index {}, but total width is {}", index, total_size)
     }
     db.insert("EMPTY".as_bytes(), &index.to_be_bytes()).unwrap();
 }
 fn fetch_empty_index(db: &sled::Db) -> u32 {
-    let value = db
-        .get("EMPTY".as_bytes())
-        .unwrap()
-        .expect("empty index should always be present");
+    let value = db.get("EMPTY".as_bytes()).unwrap().expect("empty index should always be present");
     u32::from_be_bytes(value.to_vec().try_into().unwrap())
 }
 fn insert_preimage(db: &mut sled::Db, index: u32, value: Vec<u8>) {
@@ -75,10 +63,7 @@ fn fetch_preimage(db: &sled::Db, index: usize) -> Vec<u8> {
     let tree = db.open_tree("preimages").unwrap();
 
     let index = index as u128;
-    tree.get(&index.to_be_bytes())
-        .unwrap()
-        .map(|i_vec| i_vec.to_vec())
-        .unwrap()
+    tree.get(&index.to_be_bytes()).unwrap().map(|i_vec| i_vec.to_vec()).unwrap()
 }
 fn fetch_hash(db: &sled::Db, index: usize) -> FieldElement {
     let tree = db.open_tree("hashes").unwrap();
@@ -123,12 +108,7 @@ impl MerkleTree {
 
         let total_size = 1u32 << depth;
 
-        MerkleTree {
-            depth,
-            total_size,
-            barretenberg,
-            db,
-        }
+        MerkleTree { depth, total_size, barretenberg, db }
     }
     pub fn new<P: AsRef<Path>>(depth: u32, path: P) -> MerkleTree {
         let mut barretenberg = Barretenberg::new();
@@ -140,9 +120,7 @@ impl MerkleTree {
 
         let total_size = 1u32 << depth;
 
-        let mut hashes: Vec<_> = (0..total_size * 2 - 2)
-            .map(|_| FieldElement::zero())
-            .collect();
+        let mut hashes: Vec<_> = (0..total_size * 2 - 2).map(|_| FieldElement::zero()).collect();
 
         let zero_message = [0u8; 64];
         let pre_images = (0..total_size).map(|_| zero_message.to_vec());
@@ -174,12 +152,7 @@ impl MerkleTree {
         insert_depth(&mut db, depth);
         insert_empty_index(&mut db, 0);
 
-        MerkleTree {
-            depth,
-            total_size,
-            barretenberg,
-            db,
-        }
+        MerkleTree { depth, total_size, barretenberg, db }
     }
 
     pub fn get_hash_path(&self, mut index: usize) -> HashPath {
@@ -381,10 +354,7 @@ fn basic_interop_update() {
     tree.update_message(6, &vec![6; 64]);
     let root = tree.update_message(7, &vec![7; 64]);
 
-    assert_eq!(
-        "241fc8d893854e78dd2d427e534357fe02279f209193f0f82e13a3fd4e15375e",
-        root.to_hex()
-    );
+    assert_eq!("241fc8d893854e78dd2d427e534357fe02279f209193f0f82e13a3fd4e15375e", root.to_hex());
 
     let path = tree.get_hash_path(2);
 

--- a/crates/aztec_backend/src/barretenberg_rs/composer.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/composer.rs
@@ -19,11 +19,7 @@ impl StandardComposer {
 
         let pippenger = Pippenger::new(&crs.g1_data);
 
-        StandardComposer {
-            pippenger,
-            crs,
-            constraint_system,
-        }
+        StandardComposer { pippenger, crs, constraint_system }
     }
 }
 
@@ -379,22 +375,10 @@ pub struct LogicConstraint {
 
 impl LogicConstraint {
     pub fn and(a: i32, b: i32, result: i32, num_bits: i32) -> LogicConstraint {
-        LogicConstraint {
-            a,
-            b,
-            result,
-            num_bits,
-            is_xor_gate: false,
-        }
+        LogicConstraint { a, b, result, num_bits, is_xor_gate: false }
     }
     pub fn xor(a: i32, b: i32, result: i32, num_bits: i32) -> LogicConstraint {
-        LogicConstraint {
-            a,
-            b,
-            result,
-            num_bits,
-            is_xor_gate: true,
-        }
+        LogicConstraint { a, b, result, num_bits, is_xor_gate: true }
     }
 
     fn to_bytes(&self) -> Vec<u8> {
@@ -733,11 +717,7 @@ mod test {
         };
         // Even if the public input is zero
         let case_6b = WitnessResult {
-            witness: Assignments(vec![
-                Scalar::one(),
-                Scalar::from(2_i128),
-                Scalar::from(6_i128),
-            ]),
+            witness: Assignments(vec![Scalar::one(), Scalar::from(2_i128), Scalar::from(6_i128)]),
             public_inputs: Some(Assignments(vec![Scalar::zero()])),
             result: false,
         };
@@ -799,11 +779,7 @@ mod test {
 
         // Not enough public inputs
         let case_4 = WitnessResult {
-            witness: Assignments(vec![
-                Scalar::one(),
-                Scalar::from(2_i128),
-                Scalar::from(6_i128),
-            ]),
+            witness: Assignments(vec![Scalar::one(), Scalar::from(2_i128), Scalar::from(6_i128)]),
             public_inputs: Some(Assignments(vec![Scalar::one()])),
             result: false,
         };
@@ -820,10 +796,7 @@ mod test {
             result: false,
         };
 
-        test_circuit(
-            constraint_system,
-            vec![case_1, case_2, case_3, case_4, case_5, case_6],
-        );
+        test_circuit(constraint_system, vec![case_1, case_2, case_3, case_4, case_5, case_6]);
     }
 
     #[test]
@@ -867,22 +840,12 @@ mod test {
         };
 
         let case_1 = WitnessResult {
-            witness: Assignments(vec![
-                1_i128.into(),
-                1_i128.into(),
-                2_i128.into(),
-                3_i128.into(),
-            ]),
+            witness: Assignments(vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 3_i128.into()]),
             public_inputs: Some(Assignments(vec![Scalar::one()])),
             result: true,
         };
         let case_2 = WitnessResult {
-            witness: Assignments(vec![
-                1_i128.into(),
-                1_i128.into(),
-                2_i128.into(),
-                13_i128.into(),
-            ]),
+            witness: Assignments(vec![1_i128.into(), 1_i128.into(), 2_i128.into(), 13_i128.into()]),
             public_inputs: Some(Assignments(vec![Scalar::one()])),
             result: false,
         };
@@ -979,11 +942,7 @@ mod test {
     }
     #[test]
     fn test_ped_constraints() {
-        let constraint = PedersenConstraint {
-            inputs: vec![1, 2],
-            result_x: 3,
-            result_y: 4,
-        };
+        let constraint = PedersenConstraint { inputs: vec![1, 2], result_x: 3, result_y: 4 };
 
         let x_constraint = Constraint {
             a: 3,

--- a/crates/aztec_backend/src/barretenberg_rs/crs.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/crs.rs
@@ -31,11 +31,7 @@ impl CRS {
         let g1_data = crs[G1_START..=g1_end].to_vec();
         let g2_data = crs[G2_START..=G2_END].to_vec();
 
-        CRS {
-            g1_data,
-            g2_data,
-            num_points,
-        }
+        CRS { g1_data, g2_data, num_points }
     }
 }
 
@@ -71,10 +67,8 @@ pub fn download_crs(mut path_to_transcript: std::path::PathBuf) {
 
     let url = "http://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/sealed/transcript00.dat";
     use downloader::Downloader;
-    let mut downloader = Downloader::builder()
-        .download_folder(path_to_transcript.as_path())
-        .build()
-        .unwrap();
+    let mut downloader =
+        Downloader::builder().download_folder(path_to_transcript.as_path()).build().unwrap();
 
     let dl = downloader::Download::new(url);
     let dl = dl.progress(SimpleReporter::create());
@@ -98,9 +92,7 @@ struct SimpleReporter {
 
 impl SimpleReporter {
     fn create() -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self {
-            private: std::sync::Mutex::new(None),
-        })
+        std::sync::Arc::new(Self { private: std::sync::Mutex::new(None) })
     }
 }
 
@@ -113,10 +105,8 @@ impl downloader::progress::Reporter for SimpleReporter {
                 .progress_chars("##-"),
         );
 
-        let private = SimpleReporterPrivate {
-            started: std::time::Instant::now(),
-            progress_bar: bar,
-        };
+        let private =
+            SimpleReporterPrivate { started: std::time::Instant::now(), progress_bar: bar };
         println!("\nDownloading the Ignite SRS (340MB)\n");
 
         let mut guard = self.private.lock().unwrap();
@@ -136,10 +126,7 @@ impl downloader::progress::Reporter for SimpleReporter {
         let p = guard.as_mut().unwrap();
         p.progress_bar.finish();
         println!("Downloaded the SRS successfully!");
-        println!(
-            "Time Elapsed: {}",
-            indicatif::HumanDuration(p.started.elapsed())
-        );
+        println!("Time Elapsed: {}", indicatif::HumanDuration(p.started.elapsed()));
     }
 }
 

--- a/crates/aztec_backend/src/contract/turbo_verifier.rs
+++ b/crates/aztec_backend/src/contract/turbo_verifier.rs
@@ -12,9 +12,7 @@ pub fn create(vk_method: &str) -> String {
 fn template_replace(template: &str, values: &[&str]) -> String {
     let regex = Regex::new(r#"\$(\d+)"#).unwrap();
     let mut turbo_verifier_contract = regex
-        .replace_all(template, |captures: &Captures| {
-            values.get(index(captures)).unwrap_or(&"")
-        })
+        .replace_all(template, |captures: &Captures| values.get(index(captures)).unwrap_or(&""))
         .to_string();
 
     turbo_verifier_contract.push_str(cryptography_libraries());

--- a/crates/aztec_backend/src/serialiser/mod.rs
+++ b/crates/aztec_backend/src/serialiser/mod.rs
@@ -79,10 +79,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                             let out_byte_index = out_byte.witness_index() as i32;
                             *res = out_byte_index
                         }
-                        let sha256_constraint = Sha256Constraint {
-                            inputs: sha256_inputs,
-                            result,
-                        };
+                        let sha256_constraint = Sha256Constraint { inputs: sha256_inputs, result };
 
                         sha256_constraints.push(sha256_constraint);
                     }
@@ -106,10 +103,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                             let out_byte_index = out_byte.witness_index() as i32;
                             *res = out_byte_index
                         }
-                        let blake2s_constraint = Blake2sConstraint {
-                            inputs: blake2s_inputs,
-                            result,
-                        };
+                        let blake2s_constraint =
+                            Blake2sConstraint { inputs: blake2s_inputs, result };
 
                         blake2s_constraints.push(blake2s_constraint);
                     }
@@ -123,9 +118,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         };
                         // leaf
                         let leaf = {
-                            let leaf_input = inputs_iter
-                                .next()
-                                .expect("missing leaf to check membership for");
+                            let leaf_input =
+                                inputs_iter.next().expect("missing leaf to check membership for");
                             leaf_input.witness.witness_index() as i32
                         };
                         // index
@@ -154,13 +148,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         // result
                         let result = gadget_call.outputs[0].witness_index() as i32;
 
-                        let constraint = MerkleMembershipConstraint {
-                            hash_path,
-                            root,
-                            leaf,
-                            index,
-                            result,
-                        };
+                        let constraint =
+                            MerkleMembershipConstraint { hash_path, root, leaf, index, result };
 
                         merkle_membership_constraints.push(constraint);
                     }
@@ -175,9 +164,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         };
                         // leaf
                         let leaf = {
-                            let leaf_input = inputs_iter
-                                .next()
-                                .expect("missing leaf to check membership for");
+                            let leaf_input =
+                                inputs_iter.next().expect("missing leaf to check membership for");
                             leaf_input.witness.witness_index() as i32
                         };
                         // index
@@ -221,16 +209,14 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         // pub_key_x
                         let public_key_x = {
-                            let pub_key_x = inputs_iter
-                                .next()
-                                .expect("missing `x` component for public key");
+                            let pub_key_x =
+                                inputs_iter.next().expect("missing `x` component for public key");
                             pub_key_x.witness.witness_index() as i32
                         };
                         // pub_key_y
                         let public_key_y = {
-                            let pub_key_y = inputs_iter
-                                .next()
-                                .expect("missing `y` component for public key");
+                            let pub_key_y =
+                                inputs_iter.next().expect("missing `y` component for public key");
                             pub_key_y.witness.witness_index() as i32
                         };
                         // signature
@@ -277,11 +263,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         let result_x = gadget_call.outputs[0].witness_index() as i32;
                         let result_y = gadget_call.outputs[1].witness_index() as i32;
 
-                        let constraint = PedersenConstraint {
-                            inputs,
-                            result_x,
-                            result_y,
-                        };
+                        let constraint = PedersenConstraint { inputs, result_x, result_y };
 
                         pedersen_constraints.push(constraint);
                     }
@@ -297,10 +279,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         let result = gadget_call.outputs[0].witness_index() as i32;
 
-                        let hash_to_field_constraint = HashToFieldConstraint {
-                            inputs: hash_to_field_inputs,
-                            result,
-                        };
+                        let hash_to_field_constraint =
+                            HashToFieldConstraint { inputs: hash_to_field_inputs, result };
 
                         hash_to_field_constraints.push(hash_to_field_constraint);
                     }
@@ -364,11 +344,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         let pubkey_x = gadget_call.outputs[0].witness_index() as i32;
                         let pubkey_y = gadget_call.outputs[1].witness_index() as i32;
 
-                        let fixed_base_scalar_mul = FixedBaseScalarMulConstraint {
-                            scalar,
-                            pubkey_x,
-                            pubkey_y,
-                        };
+                        let fixed_base_scalar_mul =
+                            FixedBaseScalarMulConstraint { scalar, pubkey_x, pubkey_y };
 
                         fixed_base_scalar_mul_constraints.push(fixed_base_scalar_mul);
                     }
@@ -475,14 +452,5 @@ fn serialise_arithmetic_gates(gate: &Arithmetic) -> Constraint {
     // Add the qc term
     let qc = gate.q_c;
 
-    Constraint {
-        a,
-        b,
-        c,
-        qm,
-        ql,
-        qr,
-        qo,
-        qc,
-    }
+    Constraint { a, b, c, qm, ql, qr, qo, qc }
 }

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -51,9 +51,7 @@ impl FileManager {
 
         let source = std::fs::read_to_string(&path_to_file).ok()?;
 
-        let file_id = self
-            .file_map
-            .add_file(path_to_file.to_path_buf().into(), source);
+        let file_id = self.file_map.add_file(path_to_file.to_path_buf().into(), source);
         let path_to_file = virtualise_path(path_to_file, file_type);
         self.register_path(file_id, path_to_file);
 
@@ -67,10 +65,7 @@ impl FileManager {
             "ice: the same file id was inserted into the file manager twice"
         );
         let old_value = self.path_to_id.insert(path, file_id);
-        assert!(
-            old_value.is_none(),
-            "ice: the same path was inserted into the file manager twice"
-        );
+        assert!(old_value.is_none(), "ice: the same path was inserted into the file manager twice");
     }
 
     pub fn fetch_file(&mut self, file_id: FileId) -> File {
@@ -96,12 +91,7 @@ impl FileManager {
             }
         }
 
-        Err(candidate_files
-            .remove(0)
-            .as_os_str()
-            .to_str()
-            .unwrap()
-            .to_owned())
+        Err(candidate_files.remove(0).as_os_str().to_str().unwrap().to_owned())
     }
 }
 
@@ -124,10 +114,8 @@ fn virtualise_path(path: &Path, file_type: FileType) -> VirtualPath {
         }
         FileType::Normal => {
             let base = path.parent().unwrap();
-            let path_no_ext: PathBuf = path
-                .file_stem()
-                .expect("ice: this should have been the path to a file")
-                .into();
+            let path_no_ext: PathBuf =
+                path.file_stem().expect("ice: this should have been the path to a file").into();
             base.join(path_no_ext)
         }
     };

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -34,39 +34,21 @@ pub fn start_cli() {
         .subcommand(
             App::new("new")
                 .about("Create a new binary project")
+                .arg(Arg::with_name("package_name").help("Name of the package").required(true))
                 .arg(
-                    Arg::with_name("package_name")
-                        .help("Name of the package")
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name("path")
-                        .help("The path to save the new project")
-                        .required(false),
+                    Arg::with_name("path").help("The path to save the new project").required(false),
                 ),
         )
         .subcommand(
             App::new("verify")
                 .about("Given a proof and a program, verify whether the proof is valid")
-                .arg(
-                    Arg::with_name("proof")
-                        .help("The proof to verify")
-                        .required(true),
-                ),
+                .arg(Arg::with_name("proof").help("The proof to verify").required(true)),
         )
         .subcommand(
             App::new("prove")
                 .about("Create proof for this program")
-                .arg(
-                    Arg::with_name("proof_name")
-                        .help("The name of the proof")
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name("interactive")
-                        .help("pause execution")
-                        .required(false),
-                ),
+                .arg(Arg::with_name("proof_name").help("The name of the proof").required(true))
+                .arg(Arg::with_name("interactive").help("pause execution").required(false)),
         )
         .get_matches();
 

--- a/crates/nargo/src/cli/new_cmd.rs
+++ b/crates/nargo/src/cli/new_cmd.rs
@@ -15,10 +15,7 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     };
     package_dir.push(Path::new(package_name));
     if package_dir.exists() {
-        let msg = format!(
-            "error: destination {} already exists",
-            package_dir.display()
-        );
+        let msg = format!("error: destination {} already exists", package_dir.display());
         return Err(CliError::DestinationAlreadyExists(msg));
     }
 
@@ -41,10 +38,7 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
 
     write_to_file(SETTINGS.as_bytes(), &package_dir.join(Path::new(PKG_FILE)));
     write_to_file(EXAMPLE.as_bytes(), &src_dir.join(Path::new("main.nr")));
-    println!(
-        "Project successfully created! Binary located at {}",
-        package_dir.display()
-    );
+    println!("Project successfully created! Binary located at {}", package_dir.display());
     Ok(())
 }
 

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -13,15 +13,8 @@ use crate::{errors::CliError, resolver::Resolver};
 use super::{create_dir, write_to_file, PROOFS_DIR, PROOF_EXT, PROVER_INPUT_FILE};
 
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
-    let proof_name = args
-        .subcommand_matches("prove")
-        .unwrap()
-        .value_of("proof_name")
-        .unwrap();
-    let interactive = args
-        .subcommand_matches("prove")
-        .unwrap()
-        .value_of("interactive");
+    let proof_name = args.subcommand_matches("prove").unwrap().value_of("proof_name").unwrap();
+    let interactive = args.subcommand_matches("prove").unwrap().value_of("interactive");
     let mut is_interactive = false;
     if let Some(int) = interactive {
         if int == "i" {
@@ -64,10 +57,7 @@ fn process_abi_with_input(
         let value = witness_map
             .get(&param_name)
             .unwrap_or_else(|| {
-                panic!(
-                    "ABI expects the parameter `{}`, but this was not found",
-                    param_name
-                )
+                panic!("ABI expects the parameter `{}`, but this was not found", param_name)
             })
             .clone();
 

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -13,11 +13,7 @@ use std::{collections::BTreeMap, path::Path, path::PathBuf};
 pub const RESERVED_PUBLIC_ARR: &str = "setpub";
 
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
-    let proof_name = args
-        .subcommand_matches("verify")
-        .unwrap()
-        .value_of("proof")
-        .unwrap();
+    let proof_name = args.subcommand_matches("verify").unwrap().value_of("proof").unwrap();
     let mut proof_path = std::path::PathBuf::new();
     proof_path.push(Path::new(PROOFS_DIR));
 
@@ -48,10 +44,7 @@ fn process_abi_with_verifier_input(
         let value = pi_map
             .get(&param_name)
             .unwrap_or_else(|| {
-                panic!(
-                    "ABI expects the parameter `{}`, but this was not found",
-                    param_name
-                )
+                panic!("ABI expects the parameter `{}`, but this was not found", param_name)
             })
             .clone();
 

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -41,10 +41,7 @@ pub struct Resolver<'a> {
 
 impl<'a> Resolver<'a> {
     fn with_driver(driver: &mut Driver) -> Resolver {
-        Resolver {
-            cached_packages: HashMap::new(),
-            driver,
-        }
+        Resolver { cached_packages: HashMap::new(), driver }
     }
 
     /// Returns the Driver and the backend to use
@@ -118,12 +115,7 @@ impl<'a> Resolver<'a> {
             let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;
             let cfg_path = super::find_package_config(dir_path)?;
             let cfg = super::toml::parse(cfg_path)?;
-            Ok(CachedDep {
-                entry_path,
-                crate_type,
-                cfg,
-                remote,
-            })
+            Ok(CachedDep { entry_path, crate_type, cfg, remote })
         }
 
         match dep {

--- a/crates/nargo/src/toml.rs
+++ b/crates/nargo/src/toml.rs
@@ -59,11 +59,7 @@ pub fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<Config, CliError> {
         Ok(cfg) => Ok(cfg),
         Err(msg) => {
             let path = path_to_toml.as_ref();
-            Err(CliError::Generic(format!(
-                "{}\n Location: {}",
-                msg,
-                path.display()
-            )))
+            Err(CliError::Generic(format!("{}\n Location: {}", msg, path.display())))
         }
     }
 }

--- a/crates/noir_field/src/generic_ark.rs
+++ b/crates/noir_field/src/generic_ark.rs
@@ -106,10 +106,7 @@ impl<'de, T: ark_ff::PrimeField> Deserialize<'de> for FieldElement<T> {
         let s = <&str>::deserialize(deserializer)?;
         match Self::from_hex(s) {
             Some(value) => Ok(value),
-            None => Err(serde::de::Error::custom(format!(
-                "Invalid hex for FieldElement: {}",
-                s
-            ))),
+            None => Err(serde::de::Error::custom(format!("Invalid hex for FieldElement: {}", s))),
         }
     }
 }

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -6,11 +6,7 @@ use super::InputValue;
 
 pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> BTreeMap<String, InputValue> {
     let path_to_toml = path_to_toml.as_ref();
-    assert!(
-        path_to_toml.exists(),
-        "cannot find input file at located {}",
-        path_to_toml.display()
-    );
+    assert!(path_to_toml.exists(), "cannot find input file at located {}", path_to_toml.display());
 
     // Get input.toml file as a string
     let input_as_string = std::fs::read_to_string(path_to_toml).unwrap();
@@ -35,27 +31,21 @@ fn toml_map_to_field(toml_map: BTreeMap<String, TomlTypes>) -> BTreeMap<String, 
                 assert!(old_value.is_none(), "duplicate variable name {}", parameter);
             }
             TomlTypes::Integer(integer) => {
-                let old_value = field_map.insert(
-                    parameter.clone(),
-                    InputValue::Field(parse_str(&integer.to_string())),
-                );
+                let old_value = field_map
+                    .insert(parameter.clone(), InputValue::Field(parse_str(&integer.to_string())));
                 assert!(old_value.is_none(), "duplicate variable name {}", parameter);
             }
             TomlTypes::ArrayNum(arr_num) => {
-                let array_elements: Vec<_> = arr_num
-                    .into_iter()
-                    .map(|elem_num| parse_str(&elem_num.to_string()))
-                    .collect();
+                let array_elements: Vec<_> =
+                    arr_num.into_iter().map(|elem_num| parse_str(&elem_num.to_string())).collect();
 
                 let old_value =
                     field_map.insert(parameter.clone(), InputValue::Vec(array_elements));
                 assert!(old_value.is_none(), "duplicate variable name {}", parameter);
             }
             TomlTypes::ArrayString(arr_str) => {
-                let array_elements: Vec<_> = arr_str
-                    .into_iter()
-                    .map(|elem_str| parse_str(&elem_str))
-                    .collect();
+                let array_elements: Vec<_> =
+                    arr_str.into_iter().map(|elem_str| parse_str(&elem_str)).collect();
 
                 let old_value =
                     field_map.insert(parameter.clone(), InputValue::Vec(array_elements));
@@ -86,9 +76,7 @@ fn parse_str(value: &str) -> FieldElement {
         FieldElement::from_hex(value)
             .unwrap_or_else(|| panic!("Could not parse hex value {}", value))
     } else {
-        let val: i128 = value
-            .parse()
-            .expect("Expected witness values to be integers");
+        let val: i128 = value.parse().expect("Expected witness values to be integers");
         FieldElement::from(val)
     }
 }

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -20,16 +20,8 @@ pub mod input_parser;
 /// support.
 pub enum AbiType {
     Field(AbiFEType),
-    Array {
-        visibility: AbiFEType,
-        length: u128,
-        typ: Box<AbiType>,
-    },
-    Integer {
-        visibility: AbiFEType,
-        sign: Sign,
-        width: u32,
-    },
+    Array { visibility: AbiFEType, length: u128, typ: Box<AbiType> },
+    Integer { visibility: AbiFEType, sign: Sign, width: u32 },
 }
 /// This is the same as the FieldElementType in AST, without constants.
 /// We don't want the ABI to depend on Noir, so types are not shared between the two
@@ -55,27 +47,15 @@ impl AbiType {
     pub fn num_elements(&self) -> usize {
         match self {
             AbiType::Field(_) | AbiType::Integer { .. } => 1,
-            AbiType::Array {
-                visibility: _,
-                length,
-                typ: _,
-            } => *length as usize,
+            AbiType::Array { visibility: _, length, typ: _ } => *length as usize,
         }
     }
 
     pub fn is_public(&self) -> bool {
         match self {
             AbiType::Field(fe_type) => fe_type == &AbiFEType::Public,
-            AbiType::Array {
-                visibility,
-                length: _,
-                typ: _,
-            } => visibility == &AbiFEType::Public,
-            AbiType::Integer {
-                visibility,
-                sign: _,
-                width: _,
-            } => visibility == &AbiFEType::Public,
+            AbiType::Array { visibility, length: _, typ: _ } => visibility == &AbiFEType::Public,
+            AbiType::Integer { visibility, sign: _, width: _ } => visibility == &AbiFEType::Public,
         }
     }
 }
@@ -96,11 +76,8 @@ impl Abi {
     /// ABI with only the public parameters
     #[must_use]
     pub fn public_abi(self) -> Abi {
-        let parameters: Vec<_> = self
-            .parameters
-            .into_iter()
-            .filter(|(_, param_type)| param_type.is_public())
-            .collect();
+        let parameters: Vec<_> =
+            self.parameters.into_iter().filter(|(_, param_type)| param_type.is_public()).collect();
         Abi { parameters }
     }
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -20,9 +20,7 @@ pub struct CompiledProgram {
 
 impl Driver {
     pub fn new() -> Self {
-        Driver {
-            context: Context::default(),
-        }
+        Driver { context: Context::default() }
     }
 
     // This is here for backwards compatibility
@@ -60,16 +58,9 @@ impl Driver {
         crate_type: CrateType,
     ) -> CrateId {
         let dir_path = root_file.as_ref().to_path_buf();
-        let root_file_id = self
-            .context
-            .file_manager
-            .add_file(&dir_path, FileType::Root)
-            .unwrap();
+        let root_file_id = self.context.file_manager.add_file(&dir_path, FileType::Root).unwrap();
 
-        let crate_id = self
-            .context
-            .crate_graph
-            .add_crate_root(crate_type, root_file_id);
+        let crate_id = self.context.crate_graph.add_crate_root(crate_type, root_file_id);
 
         assert!(crate_id == LOCAL_CRATE);
 
@@ -84,20 +75,14 @@ impl Driver {
         crate_type: CrateType,
     ) -> CrateId {
         let dir_path = root_file.as_ref().to_path_buf();
-        let root_file_id = self
-            .context
-            .file_manager
-            .add_file(&dir_path, FileType::Root)
-            .unwrap();
+        let root_file_id = self.context.file_manager.add_file(&dir_path, FileType::Root).unwrap();
 
         // The first crate is always the local crate
         assert!(self.context.crate_graph.number_of_crates() != 0);
 
         // You can add any crate type to the crate graph
         // but you cannot depend on Binaries
-        self.context
-            .crate_graph
-            .add_crate_root(crate_type, root_file_id)
+        self.context.crate_graph.add_crate_root(crate_type, root_file_id)
     }
 
     /// Adds a edge in the crate graph for two crates
@@ -107,10 +92,7 @@ impl Driver {
 
         // Cannot depend on a binary
         if self.context.crate_graph.crate_type(depends_on) == CrateType::Binary {
-            panic!(
-                "crates cannot depend on binaries. {:?} is a binary crate",
-                crate_name
-            )
+            panic!("crates cannot depend on binaries. {:?} is a binary crate", crate_name)
         }
 
         self.context
@@ -174,9 +156,8 @@ impl Driver {
         };
 
         // All Binaries should have a main function
-        let main_function = local_crate
-            .main_function()
-            .expect("cannot compile a program with no main function");
+        let main_function =
+            local_crate.main_function().expect("cannot compile a program with no main function");
 
         // Create ABI for main function
         let func_meta = self.context.def_interner.function_meta(&main_function);
@@ -200,10 +181,7 @@ impl Driver {
             }
         };
 
-        CompiledProgram {
-            circuit,
-            abi: Some(abi),
-        }
+        CompiledProgram { circuit, abi: Some(abi) }
     }
 
     /// XXX: It is sub-optimal to add the std as a regular crate right now because

--- a/crates/noirc_errors/src/position.rs
+++ b/crates/noirc_errors/src/position.rs
@@ -31,16 +31,10 @@ impl<T: Hash> Hash for Spanned<T> {
 
 impl<T> Spanned<T> {
     pub fn from_position(start: Position, end: Position, contents: T) -> Spanned<T> {
-        Spanned {
-            span: Span(ByteSpan::new(start, end)),
-            contents,
-        }
+        Spanned { span: Span(ByteSpan::new(start, end)), contents }
     }
     pub const fn from(t_span: Span, contents: T) -> Spanned<T> {
-        Spanned {
-            span: t_span,
-            contents,
-        }
+        Spanned { span: t_span, contents }
     }
 
     pub fn span(&self) -> Span {

--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -15,11 +15,7 @@ pub struct CustomDiagnostic {
 
 impl CustomDiagnostic {
     pub fn from_message(msg: &str) -> CustomDiagnostic {
-        Self {
-            message: msg.to_owned(),
-            secondaries: Vec::new(),
-            notes: Vec::new(),
-        }
+        Self { message: msg.to_owned(), secondaries: Vec::new(), notes: Vec::new() }
     }
 
     pub fn simple_error(
@@ -104,13 +100,7 @@ impl Reporter {
         let config = codespan_reporting::term::Config::default();
 
         for diagnostic in diagnostics.iter() {
-            term::emit(
-                &mut writer.lock(),
-                &config,
-                files.as_simple_files(),
-                diagnostic,
-            )
-            .unwrap();
+            term::emit(&mut writer.lock(), &config, files.as_simple_files(), diagnostic).unwrap();
         }
     }
 
@@ -119,16 +109,10 @@ impl Reporter {
             let writer = StandardStream::stderr(ColorChoice::Always);
             let mut writer = writer.lock();
 
-            writer
-                .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
-                .unwrap();
+            writer.set_color(ColorSpec::new().set_fg(Some(Color::Red))).unwrap();
 
-            writeln!(
-                &mut writer,
-                "error: aborting due to {} previous errors",
-                error_count
-            )
-            .unwrap();
+            writeln!(&mut writer, "error: aborting due to {} previous errors", error_count)
+                .unwrap();
 
             std::process::exit(1);
         }

--- a/crates/noirc_evaluator/src/binary_op/bound_check.rs
+++ b/crates/noirc_evaluator/src/binary_op/bound_check.rs
@@ -19,11 +19,7 @@ fn bound_check(
     upper_bound_included: bool,
     evaluator: &mut Evaluator,
 ) -> Result<Object, RuntimeErrorKind> {
-    let offset = if upper_bound_included {
-        FieldElement::zero()
-    } else {
-        FieldElement::one()
-    };
+    let offset = if upper_bound_included { FieldElement::zero() } else { FieldElement::one() };
 
     let integer = match (lower_bound, upper_bound) {
         (lower_bound, Object::Integer(y)) => {
@@ -35,11 +31,9 @@ fn bound_check(
             // This is done because, if the lower bound is a integer,
             // the compiler will complain as we cannot subtract an integer from a linear polynomial
             let lower_bound_as_arith =
-                lower_bound
-                    .to_arithmetic()
-                    .ok_or(RuntimeErrorKind::UnstructuredError {
-                        message: "invalid lower bound being used in bound check".to_string(),
-                    })?;
+                lower_bound.to_arithmetic().ok_or(RuntimeErrorKind::UnstructuredError {
+                    message: "invalid lower bound being used in bound check".to_string(),
+                })?;
 
             let k = handle_sub_op(
                 Object::Linear(x),

--- a/crates/noirc_evaluator/src/binary_op/equal.rs
+++ b/crates/noirc_evaluator/src/binary_op/equal.rs
@@ -29,9 +29,7 @@ pub fn handle_equal_op(
         Object::Integer(integer) => {
             let truncated = integer.truncate(evaluator).unwrap();
             let witness_linear = Linear::from_witness(truncated.witness);
-            evaluator
-                .gates
-                .push(Gate::Arithmetic(witness_linear.into()))
+            evaluator.gates.push(Gate::Arithmetic(witness_linear.into()))
         }
         Object::Array(arr) => arr.constrain_zero(evaluator),
     }

--- a/crates/noirc_evaluator/src/binary_op/mod.rs
+++ b/crates/noirc_evaluator/src/binary_op/mod.rs
@@ -43,11 +43,7 @@ pub fn invert(x: Object, evaluator: &mut Evaluator) -> Result<Object, RuntimeErr
     let should_be_one = handle_mul_op(x, inverse_obj.clone(), evaluator)?;
 
     // Constrain x * x_inv = 1
-    let _ = handle_equal_op(
-        should_be_one,
-        Object::Constants(FieldElement::one()),
-        evaluator,
-    );
+    let _ = handle_equal_op(should_be_one, Object::Constants(FieldElement::one()), evaluator);
 
     // Return inverse
     Ok(inverse_obj)
@@ -69,10 +65,7 @@ pub fn maybe_equal(
 
     // z = 1/u => uz = 1
     let z = evaluator.add_witness_to_cs();
-    evaluator.gates.push(Gate::Directive(Directive::Invert {
-        x: u_wit,
-        result: z,
-    }));
+    evaluator.gates.push(Gate::Directive(Directive::Invert { x: u_wit, result: z }));
 
     // y = 1 -uz
     let uz: Arithmetic = Linear::from_witness(u_wit) * Linear::from_witness(z);

--- a/crates/noirc_evaluator/src/binary_op/mul.rs
+++ b/crates/noirc_evaluator/src/binary_op/mul.rs
@@ -75,10 +75,7 @@ fn handle_linear_mul(
                 result.push(handle_linear_mul(linear, element, evaluator)?);
             }
 
-            Ok(Object::Array(Array {
-                contents: result,
-                length: arr.length,
-            }))
+            Ok(Object::Array(Array { contents: result, length: arr.length }))
         }
         Object::Null => Err(err_cannot_mul("()", "Witness")),
     }

--- a/crates/noirc_evaluator/src/builtin/mod.rs
+++ b/crates/noirc_evaluator/src/builtin/mod.rs
@@ -53,10 +53,8 @@ pub fn call_builtin(
     let (call_expr, span) = call_expr_span;
     let func = match BuiltInFunctions::look_up_func_name(builtin_name) {
         None => {
-            let message = format!(
-                "cannot find a builtin function with the attribute name {}",
-                builtin_name
-            );
+            let message =
+                format!("cannot find a builtin function with the attribute name {}", builtin_name);
             return Err(RuntimeErrorKind::UnstructuredError { message }.add_span(span));
         }
         Some(func) => func,

--- a/crates/noirc_evaluator/src/builtin/pow_const.rs
+++ b/crates/noirc_evaluator/src/builtin/pow_const.rs
@@ -23,9 +23,7 @@ impl BuiltInCaller for PowConst {
         let exponent_object = evaluator.expression_to_object(env, &exponent)?;
 
         let base = base_object.constant().map_err(|kind| kind.add_span(span))?;
-        let exp = exponent_object
-            .constant()
-            .map_err(|kind| kind.add_span(span))?;
+        let exp = exponent_object.constant().map_err(|kind| kind.add_span(span))?;
 
         let result = Object::Constants(base.pow(&exp));
 

--- a/crates/noirc_evaluator/src/builtin/setpub.rs
+++ b/crates/noirc_evaluator/src/builtin/setpub.rs
@@ -22,11 +22,8 @@ impl BuiltInCaller for SetPub {
 
         // This can only be called in the main context
         if env.func_context != FuncContext::Main {
-            let func_name = evaluator
-                .context
-                .def_interner
-                .function_name(&call_expr.func_id)
-                .to_owned();
+            let func_name =
+                evaluator.context.def_interner.function_name(&call_expr.func_id).to_owned();
 
             return Err(RuntimeErrorKind::FunctionNonMainContext { func_name }.add_span(span));
         }

--- a/crates/noirc_evaluator/src/environment.rs
+++ b/crates/noirc_evaluator/src/environment.rs
@@ -29,10 +29,7 @@ impl Environment {
     /// This flag is used because there are some functions which should only be
     /// callable within the main context.
     pub fn new(func_context: FuncContext) -> Environment {
-        Environment {
-            func_context,
-            env: ScopeForest::new(),
-        }
+        Environment { func_context, env: ScopeForest::new() }
     }
 
     pub fn start_function_environment(&mut self) {

--- a/crates/noirc_evaluator/src/errors.rs
+++ b/crates/noirc_evaluator/src/errors.rs
@@ -51,11 +51,7 @@ pub enum RuntimeErrorKind {
     Unimplemented(String),
 
     #[error("Unsupported operation error")]
-    UnsupportedOp {
-        op: String,
-        first_type: String,
-        second_type: String,
-    },
+    UnsupportedOp { op: String, first_type: String, second_type: String },
 }
 
 impl RuntimeErrorKind {
@@ -72,10 +68,7 @@ impl DiagnosableError for RuntimeError {
         match &self.kind {
             RuntimeErrorKind::ArrayOutOfBounds { index, bound } => Diagnostic::simple_error(
                 "index out of bounds".to_string(),
-                format!(
-                    "out of bounds error, index is {} but length is {}",
-                    index, bound
-                ),
+                format!("out of bounds error, index is {} but length is {}", index, bound),
                 span,
             ),
             RuntimeErrorKind::ArrayNotFound { found_type, name } => Diagnostic::simple_error(
@@ -86,18 +79,13 @@ impl DiagnosableError for RuntimeError {
             RuntimeErrorKind::UnstructuredError { message } => {
                 Diagnostic::simple_error("".to_owned(), message.to_string(), span)
             }
-            RuntimeErrorKind::UnsupportedOp {
-                op,
-                first_type,
-                second_type,
-            } => Diagnostic::simple_error(
-                "unsupported operation".to_owned(),
-                format!(
-                    "no support for {} with types {} and {}",
-                    op, first_type, second_type
-                ),
-                span,
-            ),
+            RuntimeErrorKind::UnsupportedOp { op, first_type, second_type } => {
+                Diagnostic::simple_error(
+                    "unsupported operation".to_owned(),
+                    format!("no support for {} with types {} and {}", op, first_type, second_type),
+                    span,
+                )
+            }
             RuntimeErrorKind::Spanless(message) => Diagnostic::from_message(message),
             RuntimeErrorKind::Unimplemented(message) => Diagnostic::from_message(message),
             RuntimeErrorKind::FunctionNonMainContext { func_name } => Diagnostic::simple_error(

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -241,11 +241,7 @@ impl<'a> Evaluator<'a> {
 
         for (param_name, param_type) in abi.parameters.into_iter() {
             match param_type {
-                noirc_abi::AbiType::Array {
-                    visibility,
-                    length,
-                    typ,
-                } => {
+                noirc_abi::AbiType::Array { visibility, length, typ } => {
                     let mut elements = Vec::with_capacity(length as usize);
                     for _ in 0..length as usize {
                         let witness = self.add_witness_to_cs();
@@ -255,11 +251,7 @@ impl<'a> Evaluator<'a> {
 
                         // Constrain each element in the array to be equal to the type declared in the parameter
                         let object = match *typ {
-                            noirc_abi::AbiType::Integer {
-                                visibility: _,
-                                sign,
-                                width,
-                            } => {
+                            noirc_abi::AbiType::Integer { visibility: _, sign, width } => {
                                 // XXX: Since this is in an array, the visibility
                                 // XXX: should not be settable. By default, it will be Private
                                 // since if the user does not supply a visibility,
@@ -287,21 +279,14 @@ impl<'a> Evaluator<'a> {
 
                         elements.push(object);
                     }
-                    let arr = Array {
-                        contents: elements,
-                        length,
-                    };
+                    let arr = Array { contents: elements, length };
                     env.store(param_name, Object::Array(arr));
                 }
                 noirc_abi::AbiType::Field(noirc_abi::AbiFEType::Private) => {
                     let witness = self.add_witness_to_cs();
                     self.add_witness_to_env(param_name, witness, env);
                 }
-                noirc_abi::AbiType::Integer {
-                    visibility,
-                    sign,
-                    width,
-                } => {
+                noirc_abi::AbiType::Integer { visibility, sign, width } => {
                     let witness = self.add_witness_to_cs();
                     if visibility == noirc_abi::AbiFEType::Public {
                         self.public_inputs.push(witness);
@@ -313,9 +298,7 @@ impl<'a> Evaluator<'a> {
                     );
 
                     let integer = Integer::from_witness_unconstrained(witness, width);
-                    integer
-                        .constrain(self)
-                        .map_err(|kind| kind.add_span(param_span))?;
+                    integer.constrain(self).map_err(|kind| kind.add_span(param_span))?;
 
                     env.store(param_name, Object::Integer(integer));
                 }
@@ -440,11 +423,9 @@ impl<'a> Evaluator<'a> {
 
     fn pattern_name(&self, pattern: &HirPattern) -> String {
         match pattern {
-            HirPattern::Identifier(ident) => self
-                .context
-                .def_interner
-                .definition_name(ident.id)
-                .to_owned(),
+            HirPattern::Identifier(ident) => {
+                self.context.def_interner.definition_name(ident.id).to_owned()
+            }
             HirPattern::Mutable(pattern, _) => self.pattern_name(pattern),
             HirPattern::Tuple(_, _) => todo!("Implement tuples in the backend"),
             HirPattern::Struct(_, _, _) => todo!("Implement structs in the backend"),
@@ -516,8 +497,7 @@ impl<'a> Evaluator<'a> {
                 message: "only witnesses can be used in a private statement".to_string(),
             })
             .map_err(|kind| kind.add_span(rhs_span))?;
-        self.gates
-            .push(Gate::Arithmetic(&rhs_as_witness - &witness.to_unknown()));
+        self.gates.push(Gate::Arithmetic(&rhs_as_witness - &witness.to_unknown()));
 
         // Lets go through some possible scenarios to explain why the code is correct
         // 0: priv x = 5;
@@ -613,9 +593,7 @@ impl<'a> Evaluator<'a> {
                 // const can only be integers/Field elements, cannot involve the witness, so we can possibly move this to
                 // analysis. Right now it would not make a difference, since we are not compiling to an intermediate Noir format
                 let span = self.context.def_interner.expr_span(rhs);
-                let value = self
-                    .evaluate_integer(env, rhs)
-                    .map_err(|kind| kind.add_span(span))?;
+                let value = self.evaluate_integer(env, rhs).map_err(|kind| kind.add_span(span))?;
 
                 env.store(variable_name, value);
             }
@@ -660,18 +638,13 @@ impl<'a> Evaluator<'a> {
             env.start_scope();
 
             // Add indice to environment
-            let variable_name = self
-                .context
-                .def_interner
-                .definition_name(for_expr.identifier.id)
-                .to_owned();
+            let variable_name =
+                self.context.def_interner.definition_name(for_expr.identifier.id).to_owned();
             env.store(variable_name, Object::Constants(indice));
 
             let block = self.expression_to_block(&for_expr.block);
             let statements = block.statements();
-            let return_typ = self
-                .eval_block(env, statements)
-                .map_err(|err| err.remove_span())?;
+            let return_typ = self.eval_block(env, statements).map_err(|err| err.remove_span())?;
             contents.push(return_typ);
 
             env.end_scope();
@@ -693,17 +666,13 @@ impl<'a> Evaluator<'a> {
         env: &mut Environment,
         expr_id: &ExprId,
     ) -> Result<Object, RuntimeErrorKind> {
-        let polynomial = self
-            .expression_to_object(env, expr_id)
-            .map_err(|err| err.remove_span())?;
+        let polynomial =
+            self.expression_to_object(env, expr_id).map_err(|err| err.remove_span())?;
 
         if polynomial.is_constant() {
             return Ok(polynomial);
         }
-        return Err(RuntimeErrorKind::expected_type(
-            "constant",
-            polynomial.r#type(),
-        ));
+        return Err(RuntimeErrorKind::expected_type("constant", polynomial.r#type()));
     }
 
     pub(crate) fn expression_to_object(
@@ -843,10 +812,8 @@ impl<'a> Evaluator<'a> {
         env: &mut Environment,
         exprs: &[ExprId],
     ) -> (Vec<Object>, Vec<RuntimeError>) {
-        let (objects, errors): (Vec<_>, Vec<_>) = exprs
-            .iter()
-            .map(|expr| self.expression_to_object(env, expr))
-            .partition(Result::is_ok);
+        let (objects, errors): (Vec<_>, Vec<_>) =
+            exprs.iter().map(|expr| self.expression_to_object(env, expr)).partition(Result::is_ok);
 
         let objects: Vec<_> = objects.into_iter().map(Result::unwrap).collect();
         let errors: Vec<_> = errors.into_iter().map(Result::unwrap_err).collect();

--- a/crates/noirc_evaluator/src/low_level_function_impl/blake2s.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/blake2s.rs
@@ -34,18 +34,11 @@ impl GadgetCaller for Blake2sGadget {
             contents.push(object);
         }
 
-        let blake2s_gate = GadgetCall {
-            name: Blake2sGadget::name(),
-            inputs,
-            outputs,
-        };
+        let blake2s_gate = GadgetCall { name: Blake2sGadget::name(), inputs, outputs };
 
         evaluator.gates.push(Gate::GadgetCall(blake2s_gate));
 
-        let arr = Array {
-            length: contents.len() as u128,
-            contents,
-        };
+        let arr = Array { length: contents.len() as u128, contents };
 
         Ok(Object::Array(arr))
     }

--- a/crates/noirc_evaluator/src/low_level_function_impl/fixed_based_scalar_mul.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/fixed_based_scalar_mul.rs
@@ -36,10 +36,7 @@ impl GadgetCaller for FixedBaseScalarMulGadget {
 
         evaluator.gates.push(Gate::GadgetCall(fixed_base_gate));
 
-        let arr = Array {
-            length: 2,
-            contents: vec![object_pubkey_x, object_pubkey_y],
-        };
+        let arr = Array { length: 2, contents: vec![object_pubkey_x, object_pubkey_y] };
 
         Ok(Object::Array(arr))
     }

--- a/crates/noirc_evaluator/src/low_level_function_impl/hash_to_field.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/hash_to_field.rs
@@ -24,11 +24,8 @@ impl GadgetCaller for HashToFieldGadget {
         let res_witness = evaluator.add_witness_to_cs();
         let res_object = Object::from_witness(res_witness);
 
-        let hash_to_field_gate = GadgetCall {
-            name: HashToFieldGadget::name(),
-            inputs,
-            outputs: vec![res_witness],
-        };
+        let hash_to_field_gate =
+            GadgetCall { name: HashToFieldGadget::name(), inputs, outputs: vec![res_witness] };
 
         evaluator.gates.push(Gate::GadgetCall(hash_to_field_gate));
 

--- a/crates/noirc_evaluator/src/low_level_function_impl/merkle_membership.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/merkle_membership.rs
@@ -56,27 +56,16 @@ impl MerkleMembershipGadget {
         let root = evaluator.expression_to_object(env, &root)?;
 
         // TODO: change this to convert RuntimeErrorKind into RuntimeError
-        let depth = depth
-            .constant()
-            .expect("expected depth to be a constant")
-            .to_u128();
+        let depth = depth.constant().expect("expected depth to be a constant").to_u128();
         let leaf_witness = leaf.witness().unwrap();
         let root_witness = root.witness().unwrap();
 
-        let mut inputs: Vec<GadgetInput> = vec![GadgetInput {
-            witness: root_witness,
-            num_bits: FieldElement::max_num_bits(),
-        }];
+        let mut inputs: Vec<GadgetInput> =
+            vec![GadgetInput { witness: root_witness, num_bits: FieldElement::max_num_bits() }];
 
-        inputs.push(GadgetInput {
-            witness: leaf_witness,
-            num_bits: FieldElement::max_num_bits(),
-        });
+        inputs.push(GadgetInput { witness: leaf_witness, num_bits: FieldElement::max_num_bits() });
         let index_witness = evaluator.add_witness_to_cs();
-        inputs.push(GadgetInput {
-            witness: index_witness,
-            num_bits: FieldElement::max_num_bits(),
-        });
+        inputs.push(GadgetInput { witness: index_witness, num_bits: FieldElement::max_num_bits() });
 
         // Add necessary amount of witnesses for the hashpath
         let arity = 2;

--- a/crates/noirc_evaluator/src/low_level_function_impl/mod.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/mod.rs
@@ -48,10 +48,8 @@ pub fn call_low_level(
     let (call_expr, span) = call_expr_span;
     let func = match OPCODE::lookup(opcode_name) {
         None => {
-            let message = format!(
-                "cannot find a low level opcode with the name {} in the IR",
-                opcode_name
-            );
+            let message =
+                format!("cannot find a low level opcode with the name {} in the IR", opcode_name);
 
             return Err(RuntimeErrorKind::UnstructuredError { message }.add_span(span));
         }

--- a/crates/noirc_evaluator/src/low_level_function_impl/pedersen.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/pedersen.rs
@@ -36,10 +36,7 @@ impl GadgetCaller for PedersenGadget {
 
         evaluator.gates.push(Gate::GadgetCall(pedersen_gate));
 
-        let arr = Array {
-            length: 2,
-            contents: vec![object_pedersen_x, object_pedersen_y],
-        };
+        let arr = Array { length: 2, contents: vec![object_pedersen_x, object_pedersen_y] };
 
         Ok(Object::Array(arr))
     }

--- a/crates/noirc_evaluator/src/low_level_function_impl/sha256.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/sha256.rs
@@ -32,18 +32,11 @@ impl GadgetCaller for Sha256Gadget {
             contents.push(object);
         }
 
-        let sha256_gate = GadgetCall {
-            name: Sha256Gadget::name(),
-            inputs,
-            outputs,
-        };
+        let sha256_gate = GadgetCall { name: Sha256Gadget::name(), inputs, outputs };
 
         evaluator.gates.push(Gate::GadgetCall(sha256_gate));
 
-        let arr = Array {
-            length: contents.len() as u128,
-            contents,
-        };
+        let arr = Array { length: contents.len() as u128, contents };
 
         Ok(Object::Array(arr))
     }

--- a/crates/noirc_evaluator/src/object/array.rs
+++ b/crates/noirc_evaluator/src/object/array.rs
@@ -28,17 +28,11 @@ impl Array {
             return Err(errs.pop().unwrap());
         }
 
-        Ok(Array {
-            contents: objects,
-            length: arr_lit.length,
-        })
+        Ok(Array { contents: objects, length: arr_lit.length })
     }
     pub fn get(&self, index: u128) -> Result<Object, RuntimeErrorKind> {
         if index >= self.length {
-            return Err(RuntimeErrorKind::ArrayOutOfBounds {
-                index,
-                bound: self.length,
-            });
+            return Err(RuntimeErrorKind::ArrayOutOfBounds { index, bound: self.length });
         };
 
         Ok(self.contents[index as usize].clone())
@@ -62,10 +56,7 @@ impl Array {
             contents.push(out_element);
         }
 
-        Ok(Array {
-            contents,
-            length: length as u128,
-        })
+        Ok(Array { contents, length: length as u128 })
     }
     /// Given two arrays A, B
     /// This method creates a new array C
@@ -82,10 +73,7 @@ impl Array {
             contents.push(out_element);
         }
 
-        Ok(Array {
-            contents,
-            length: length as u128,
-        })
+        Ok(Array { contents, length: length as u128 })
     }
 
     fn check_arr_len(lhs: &Array, rhs: &Array) -> Result<usize, RuntimeErrorKind> {
@@ -143,9 +131,8 @@ impl Array {
         // Then constrain the product to be equal to 0
 
         let mut predicates_iter = predicates.into_iter();
-        let mut result = predicates_iter
-            .next()
-            .expect("ice: arrays must have at least one element in them");
+        let mut result =
+            predicates_iter.next().expect("ice: arrays must have at least one element in them");
 
         for pred in predicates_iter {
             result = crate::binary_op::handle_mul_op(result, pred, evaluator)?;

--- a/crates/noirc_evaluator/src/object/mod.rs
+++ b/crates/noirc_evaluator/src/object/mod.rs
@@ -57,16 +57,10 @@ impl Object {
                 Object::Linear(linear)
             }
             Object::Array(arr) => {
-                let negated_contents: Vec<_> = arr
-                    .contents
-                    .into_iter()
-                    .map(|element| element.negate())
-                    .collect();
+                let negated_contents: Vec<_> =
+                    arr.contents.into_iter().map(|element| element.negate()).collect();
 
-                Object::Array(Array {
-                    contents: negated_contents,
-                    length: arr.length,
-                })
+                Object::Array(Array { contents: negated_contents, length: arr.length })
             }
             Object::Arithmetic(arith) => Object::Arithmetic(-&arith),
             Object::Constants(constant) => Object::Constants(-constant),
@@ -166,10 +160,7 @@ impl Object {
     }
     // Returns true if the Object is linear
     pub fn is_linear(&self) -> bool {
-        matches!(
-            self,
-            Object::Linear(_) | Object::Constants(_) | Object::Integer(_)
-        )
+        matches!(self, Object::Linear(_) | Object::Constants(_) | Object::Integer(_))
     }
     pub fn from_witness(witness: Witness) -> Object {
         Object::Linear(Linear::from_witness(witness))
@@ -186,10 +177,7 @@ impl Object {
                     result.push(element.mul_constant(constant)?);
                 }
 
-                Object::Array(Array {
-                    contents: result,
-                    length: arr.length,
-                })
+                Object::Array(Array { contents: result, length: arr.length })
             }
             Object::Linear(lin) => Object::Linear(lin * &constant),
             Object::Integer(integer) => {

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -44,11 +44,7 @@ impl InternalVar {
     }
 
     fn new(expression: Arithmetic, witness: Option<Witness>, id: NodeId) -> InternalVar {
-        InternalVar {
-            expression,
-            witness,
-            id: Some(id),
-        }
+        InternalVar { expression, witness, id: Some(id) }
     }
 
     pub fn to_const(&self) -> Option<FieldElement> {
@@ -59,29 +55,20 @@ impl InternalVar {
     }
 
     pub fn get_or_generate_witness(&mut self, evaluator: &mut Evaluator) -> Witness {
-        self.witness
-            .unwrap_or_else(|| generate_witness(self, evaluator))
+        self.witness.unwrap_or_else(|| generate_witness(self, evaluator))
     }
 }
 
 impl From<Arithmetic> for InternalVar {
     fn from(arith: Arithmetic) -> InternalVar {
         let w = is_unit(&arith);
-        InternalVar {
-            expression: arith,
-            witness: w,
-            id: None,
-        }
+        InternalVar { expression: arith, witness: w, id: None }
     }
 }
 
 impl From<Witness> for InternalVar {
     fn from(w: Witness) -> InternalVar {
-        InternalVar {
-            expression: from_witness(w),
-            witness: Some(w),
-            id: None,
-        }
+        InternalVar { expression: from_witness(w), witness: Some(w), id: None }
     }
 }
 
@@ -416,11 +403,8 @@ impl Acir {
                 }
             }
         } else {
-            let mut x = InternalVar::from(subtract(
-                &l_c.expression,
-                FieldElement::one(),
-                &r_c.expression,
-            ));
+            let mut x =
+                InternalVar::from(subtract(&l_c.expression, FieldElement::one(), &r_c.expression));
             x.witness = Some(generate_witness(&x, evaluator));
             from_witness(evaluate_zero_equality(&x, evaluator))
         }
@@ -492,11 +476,7 @@ impl Acir {
             }
             Arithmetic::default()
         } else {
-            let output = add(
-                &l_c.expression,
-                FieldElement::from(-1_i128),
-                &r_c.expression,
-            );
+            let output = add(&l_c.expression, FieldElement::from(-1_i128), &r_c.expression);
             if is_const(&output) {
                 assert!(output.q_c == FieldElement::zero());
             } else {
@@ -567,20 +547,14 @@ impl Acir {
                                 let address = array.adr + i;
                                 if self.memory_map.contains_key(&address) {
                                     if let Some(wit) = self.memory_map[&address].witness {
-                                        inputs.push(GadgetInput {
-                                            witness: wit,
-                                            num_bits,
-                                        });
+                                        inputs.push(GadgetInput { witness: wit, num_bits });
                                     } else {
                                         //TODO we should store the witnesses somewhere, else if the inputs are re-used
                                         //we will duplicate the witnesses.
                                         let (_, w) = evaluator.create_intermediate_variable(
                                             self.memory_map[&address].expression.clone(),
                                         );
-                                        inputs.push(GadgetInput {
-                                            witness: w,
-                                            num_bits,
-                                        });
+                                        inputs.push(GadgetInput { witness: w, num_bits });
                                     }
                                 } else {
                                     inputs.push(GadgetInput {
@@ -592,10 +566,7 @@ impl Acir {
                         }
                         _ => {
                             if let Some(w) = v.witness {
-                                inputs.push(GadgetInput {
-                                    witness: w,
-                                    num_bits: v.size_in_bits(),
-                                });
+                                inputs.push(GadgetInput { witness: w, num_bits: v.size_in_bits() });
                             } else {
                                 todo!("generate a witness");
                             }
@@ -817,14 +788,12 @@ pub fn evaluate_and(
     let a_witness = generate_witness(&lhs, evaluator);
     let b_witness = generate_witness(&rhs, evaluator);
     //TODO checks the cost of the gate vs bit_size (cf. #164)
-    evaluator
-        .gates
-        .push(Gate::And(acvm::acir::circuit::gate::AndGate {
-            a: a_witness,
-            b: b_witness,
-            result,
-            num_bits: bit_size,
-        }));
+    evaluator.gates.push(Gate::And(acvm::acir::circuit::gate::AndGate {
+        a: a_witness,
+        b: b_witness,
+        result,
+        num_bits: bit_size,
+    }));
     Arithmetic::from(Linear::from_witness(result))
 }
 
@@ -846,14 +815,12 @@ pub fn evaluate_xor(
     let a_witness = generate_witness(&lhs, evaluator);
     let b_witness = generate_witness(&rhs, evaluator);
     //TODO checks the cost of the gate vs bit_size (cf. #164)
-    evaluator
-        .gates
-        .push(Gate::Xor(acvm::acir::circuit::gate::XorGate {
-            a: a_witness,
-            b: b_witness,
-            result,
-            num_bits: bit_size,
-        }));
+    evaluator.gates.push(Gate::Xor(acvm::acir::circuit::gate::XorGate {
+        a: a_witness,
+        b: b_witness,
+        result,
+        num_bits: bit_size,
+    }));
     from_witness(result)
 }
 
@@ -958,16 +925,12 @@ pub fn evaluate_mul(lhs: &InternalVar, rhs: &InternalVar, evaluator: &mut Evalua
     //Generate intermediate variable
     //create new witness a and a gate: a = lhs
     let a = evaluator.add_witness_to_cs();
-    evaluator
-        .gates
-        .push(Gate::Arithmetic(&lhs.expression - &Arithmetic::from(&a)));
+    evaluator.gates.push(Gate::Arithmetic(&lhs.expression - &Arithmetic::from(&a)));
     //create new witness b and gate b = rhs
     let mut b = a;
     if !lhs.is_equal(rhs) {
         b = evaluator.add_witness_to_cs();
-        evaluator
-            .gates
-            .push(Gate::Arithmetic(&rhs.expression - &Arithmetic::from(&b)));
+        evaluator.gates.push(Gate::Arithmetic(&rhs.expression - &Arithmetic::from(&b)));
     }
     //return arith(mul=a*b)
     mul(&Arithmetic::from(&a), &Arithmetic::from(&b)) //TODO  &lhs.expression * &rhs.expression
@@ -1003,11 +966,7 @@ pub fn evaluate_udiv(
     }));
     //r<b
     let r_expr = Arithmetic::from(Linear::from_witness(r_witness));
-    let r_var = InternalVar {
-        expression: r_expr,
-        witness: Some(r_witness),
-        id: None,
-    };
+    let r_var = InternalVar { expression: r_expr, witness: Some(r_witness), id: None };
     bound_check(&r_var, rhs, true, 32, evaluator); //TODO bit size! should be max(a.bit, b.bit)
                                                    //range check q<=a
     range_constraint(q_witness, 32, evaluator).unwrap_or_else(|err| {
@@ -1033,10 +992,7 @@ pub fn evaluate_zero_equality(x: &InternalVar, evaluator: &mut Evaluator) -> Wit
     let x_witness = x.witness.unwrap(); //todo we need a witness because of the directive, but we should use an expression
 
     let m = evaluator.add_witness_to_cs(); //'inverse' of x
-    evaluator.gates.push(Gate::Directive(Directive::Invert {
-        x: x_witness,
-        result: m,
-    }));
+    evaluator.gates.push(Gate::Directive(Directive::Invert { x: x_witness, result: m }));
 
     //y=x*m         y is 1 if x is not null, and 0 else
     let y_witness = evaluator.add_witness_to_cs();
@@ -1063,10 +1019,9 @@ pub fn evaluate_inverse(x: &mut InternalVar, evaluator: &mut Evaluator) -> Witne
     let inverse_witness = evaluator.add_witness_to_cs();
     let inverse_expr = from_witness(inverse_witness);
     let x_witness = x.get_or_generate_witness(evaluator); //TODO avoid creating witnesses here.
-    evaluator.gates.push(Gate::Directive(Directive::Invert {
-        x: x_witness,
-        result: inverse_witness,
-    }));
+    evaluator
+        .gates
+        .push(Gate::Directive(Directive::Invert { x: x_witness, result: inverse_witness }));
 
     //x*inverse = 1
     Arithmetic::default();
@@ -1110,15 +1065,10 @@ pub fn mul(a: &Arithmetic, b: &Arithmetic) -> Arithmetic {
     while i1 < a.linear_combinations.len() && i2 < b.linear_combinations.len() {
         let coef_a = b.q_c * a.linear_combinations[i1].0;
         let coef_b = a.q_c * b.linear_combinations[i2].0;
-        match a.linear_combinations[i1]
-            .1
-            .cmp(&b.linear_combinations[i2].1)
-        {
+        match a.linear_combinations[i1].1.cmp(&b.linear_combinations[i2].1) {
             Ordering::Greater => {
                 if coef_b != FieldElement::zero() {
-                    output
-                        .linear_combinations
-                        .push((coef_b, b.linear_combinations[i2].1));
+                    output.linear_combinations.push((coef_b, b.linear_combinations[i2].1));
                 }
                 if i2 + 1 >= b.linear_combinations.len() {
                     i1 += 1;
@@ -1128,9 +1078,7 @@ pub fn mul(a: &Arithmetic, b: &Arithmetic) -> Arithmetic {
             }
             Ordering::Less => {
                 if coef_a != FieldElement::zero() {
-                    output
-                        .linear_combinations
-                        .push((coef_a, a.linear_combinations[i1].1));
+                    output.linear_combinations.push((coef_a, a.linear_combinations[i1].1));
                 }
                 if i1 + 1 >= a.linear_combinations.len() {
                     i2 += 1;
@@ -1140,9 +1088,7 @@ pub fn mul(a: &Arithmetic, b: &Arithmetic) -> Arithmetic {
             }
             Ordering::Equal => {
                 if coef_a + coef_b != FieldElement::zero() {
-                    output
-                        .linear_combinations
-                        .push((coef_a + coef_b, a.linear_combinations[i1].1));
+                    output.linear_combinations.push((coef_a + coef_b, a.linear_combinations[i1].1));
                 }
                 if (i1 + 1 >= a.linear_combinations.len())
                     && (i2 + 1 >= b.linear_combinations.len())
@@ -1178,16 +1124,11 @@ pub fn add(a: &Arithmetic, k: FieldElement, b: &Arithmetic) -> Arithmetic {
     let mut i1 = 0; //a
     let mut i2 = 0; //b
     while i1 < a.linear_combinations.len() && i2 < b.linear_combinations.len() {
-        match a.linear_combinations[i1]
-            .1
-            .cmp(&b.linear_combinations[i2].1)
-        {
+        match a.linear_combinations[i1].1.cmp(&b.linear_combinations[i2].1) {
             Ordering::Greater => {
                 let coef = b.linear_combinations[i2].0 * k;
                 if coef != FieldElement::zero() {
-                    output
-                        .linear_combinations
-                        .push((coef, b.linear_combinations[i2].1));
+                    output.linear_combinations.push((coef, b.linear_combinations[i2].1));
                 }
                 i2 += 1;
             }
@@ -1198,9 +1139,7 @@ pub fn add(a: &Arithmetic, k: FieldElement, b: &Arithmetic) -> Arithmetic {
             Ordering::Equal => {
                 let coef = a.linear_combinations[i1].0 + b.linear_combinations[i2].0 * k;
                 if coef != FieldElement::zero() {
-                    output
-                        .linear_combinations
-                        .push((coef, a.linear_combinations[i1].1));
+                    output.linear_combinations.push((coef, a.linear_combinations[i1].1));
                 }
                 i2 += 1;
                 i1 += 1;
@@ -1214,9 +1153,7 @@ pub fn add(a: &Arithmetic, k: FieldElement, b: &Arithmetic) -> Arithmetic {
     while i2 < b.linear_combinations.len() {
         let coef = b.linear_combinations[i2].0 * k;
         if coef != FieldElement::zero() {
-            output
-                .linear_combinations
-                .push((coef, b.linear_combinations[i2].1));
+            output.linear_combinations.push((coef, b.linear_combinations[i2].1));
         }
         i2 += 1;
     }
@@ -1231,9 +1168,7 @@ pub fn add(a: &Arithmetic, k: FieldElement, b: &Arithmetic) -> Arithmetic {
             Ordering::Greater => {
                 let coef = b.mul_terms[i2].0 * k;
                 if coef != FieldElement::zero() {
-                    output
-                        .mul_terms
-                        .push((coef, b.mul_terms[i2].1, b.mul_terms[i2].2));
+                    output.mul_terms.push((coef, b.mul_terms[i2].1, b.mul_terms[i2].2));
                 }
                 i2 += 1;
             }
@@ -1244,9 +1179,7 @@ pub fn add(a: &Arithmetic, k: FieldElement, b: &Arithmetic) -> Arithmetic {
             Ordering::Equal => {
                 let coef = a.mul_terms[i1].0 + b.mul_terms[i2].0 * k;
                 if coef != FieldElement::zero() {
-                    output
-                        .mul_terms
-                        .push((coef, a.mul_terms[i1].1, a.mul_terms[i1].2));
+                    output.mul_terms.push((coef, a.mul_terms[i1].1, a.mul_terms[i1].2));
                 }
                 i2 += 1;
                 i1 += 1;
@@ -1261,9 +1194,7 @@ pub fn add(a: &Arithmetic, k: FieldElement, b: &Arithmetic) -> Arithmetic {
     while i2 < b.mul_terms.len() {
         let coef = b.mul_terms[i2].0 * k;
         if coef != FieldElement::zero() {
-            output
-                .mul_terms
-                .push((coef, b.mul_terms[i2].1, b.mul_terms[i2].2));
+            output.mul_terms.push((coef, b.mul_terms[i2].1, b.mul_terms[i2].2));
         }
         i2 += 1;
     }
@@ -1278,13 +1209,9 @@ pub fn single_mul(w: Witness, b: &Arithmetic) -> Arithmetic {
     let mut i1 = 0;
     while i1 < b.linear_combinations.len() {
         if (w, b.linear_combinations[i1].1) < (b.linear_combinations[i1].1, w) {
-            output
-                .mul_terms
-                .push((b.linear_combinations[i1].0, w, b.linear_combinations[i1].1));
+            output.mul_terms.push((b.linear_combinations[i1].0, w, b.linear_combinations[i1].1));
         } else {
-            output
-                .mul_terms
-                .push((b.linear_combinations[i1].0, b.linear_combinations[i1].1, w));
+            output.mul_terms.push((b.linear_combinations[i1].0, b.linear_combinations[i1].1, w));
         }
         i1 += 1;
     }
@@ -1369,17 +1296,11 @@ fn bound_check(
     {
         todo!("ERROR");
     }
-    let offset = if strict {
-        FieldElement::one()
-    } else {
-        FieldElement::zero()
-    };
+    let offset = if strict { FieldElement::one() } else { FieldElement::zero() };
     let mut sub_expression = add(&b.expression, -FieldElement::one(), &a.expression); //a-b
     sub_expression.q_c += offset; //a-b+offset
     let w = evaluator.add_witness_to_cs(); //range_check requires a witness - TODO may be this can be avoided?
-    evaluator
-        .gates
-        .push(Gate::Arithmetic(&sub_expression - &Arithmetic::from(&w)));
+    evaluator.gates.push(Gate::Arithmetic(&sub_expression - &Arithmetic::from(&w)));
     range_constraint(w, bits, evaluator).unwrap_or_else(|err| {
         dbg!(err);
     });

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -68,9 +68,7 @@ impl BasicBlock {
     pub fn get_result_instruction(&self, call_id: NodeId, ctx: &SsaContext) -> Option<NodeId> {
         self.instructions.iter().copied().find(|i| match ctx[*i] {
             node::NodeObj::Instr(node::Instruction {
-                operator: node::Operation::Res,
-                lhs,
-                ..
+                operator: node::Operation::Res, lhs, ..
             }) => lhs == call_id,
             _ => false,
         })
@@ -171,10 +169,7 @@ pub fn compute_dom(ctx: &mut SsaContext) {
 
     for block in ctx.iter_blocks() {
         if let Some(dom) = block.dominator {
-            dominator_link
-                .entry(dom)
-                .or_insert_with(Vec::new)
-                .push(block.id);
+            dominator_link.entry(dom).or_insert_with(Vec::new).push(block.id);
             // dom_block.dominated.push(idx);
         }
     }

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -94,9 +94,7 @@ impl<'a> IRGenerator<'a> {
         len: u128,
         witness: Vec<acvm::acir::native_types::Witness>,
     ) {
-        self.context
-            .mem
-            .create_new_array(len as u32, el_type.into(), name);
+        self.context.mem.create_new_array(len as u32, el_type.into(), name);
         let array_idx = (self.context.mem.arrays.len() - 1) as usize;
         self.context.mem.arrays[array_idx].def = ident_def;
         self.context.mem.arrays[array_idx].values = vecmap(witness, |w| w.into());
@@ -110,9 +108,7 @@ impl<'a> IRGenerator<'a> {
             parent_block: self.context.current_block,
         };
         let v_id = self.context.add_variable(pointer, None);
-        self.context
-            .get_current_block_mut()
-            .update_variable(v_id, v_id);
+        self.context.get_current_block_mut().update_variable(v_id, v_id);
 
         let v_value = Value::Single(v_id);
         self.variable_values.insert(ident_def, v_value); //TODO ident_def or ident_id??
@@ -137,9 +133,7 @@ impl<'a> IRGenerator<'a> {
         };
         let v_id = self.context.add_variable(var, None);
 
-        self.context
-            .get_current_block_mut()
-            .update_variable(v_id, v_id);
+        self.context.get_current_block_mut().update_variable(v_id, v_id);
         let v_value = Value::Single(v_id);
         self.variable_values.insert(ident_def, v_value); //TODO ident_def or ident_id??
     }
@@ -158,9 +152,7 @@ impl<'a> IRGenerator<'a> {
             Object::Array(a) => {
                 let obj_type = o_type.into();
                 //We should create an array from 'a' witnesses
-                self.context
-                    .mem
-                    .create_array_from_object(&a, ident.id, obj_type, &ident_name);
+                self.context.mem.create_array_from_object(&a, ident.id, obj_type, &ident_name);
                 let array_index = (self.context.mem.arrays.len() - 1) as u32;
                 node::Variable {
                     id: NodeId::dummy(),
@@ -188,9 +180,7 @@ impl<'a> IRGenerator<'a> {
         };
 
         let v_id = self.context.add_variable(var, None);
-        self.context
-            .get_current_block_mut()
-            .update_variable(v_id, v_id);
+        self.context.get_current_block_mut().update_variable(v_id, v_id);
 
         Value::Single(v_id)
     }
@@ -207,13 +197,9 @@ impl<'a> IRGenerator<'a> {
         let rtype = self.context.get_object_type(rhs);
         match op {
             HirUnaryOp::Minus => {
-                Ok(self
-                    .context
-                    .new_instruction(self.context.zero(), rhs, Operation::Sub, rtype))
+                Ok(self.context.new_instruction(self.context.zero(), rhs, Operation::Sub, rtype))
             }
-            HirUnaryOp::Not => Ok(self
-                .context
-                .new_instruction(rhs, rhs, Operation::Not, rtype)),
+            HirUnaryOp::Not => Ok(self.context.new_instruction(rhs, rhs, Operation::Not, rtype)),
         }
     }
 
@@ -332,12 +318,8 @@ impl<'a> IRGenerator<'a> {
         env: &mut Environment,
         constrain_stmt: HirConstrainStatement,
     ) -> Result<(), RuntimeError> {
-        let lhs = self
-            .expression_to_object(env, &constrain_stmt.0.lhs)?
-            .unwrap_id();
-        let rhs = self
-            .expression_to_object(env, &constrain_stmt.0.rhs)?
-            .unwrap_id();
+        let lhs = self.expression_to_object(env, &constrain_stmt.0.lhs)?.unwrap_id();
+        let rhs = self.expression_to_object(env, &constrain_stmt.0.rhs)?.unwrap_id();
 
         match constrain_stmt.0.operator.kind {
             // HirBinaryOpKind::Add => binary_op::handle_add_op(lhs, rhs, self),
@@ -452,18 +434,12 @@ impl<'a> IRGenerator<'a> {
             }
         }
 
-        let new_var = Variable::new(
-            obj_type,
-            variable_name,
-            definition_id,
-            self.context.current_block,
-        );
+        let new_var =
+            Variable::new(obj_type, variable_name, definition_id, self.context.current_block);
         let id = self.context.add_variable(new_var, None);
 
         //Assign rhs to lhs
-        let result = self
-            .context
-            .new_instruction(id, value_id, node::Operation::Ass, obj_type);
+        let result = self.context.new_instruction(id, value_id, node::Operation::Ass, obj_type);
         //This new variable should not be available in outer scopes.
         let cb = self.context.get_current_block_mut();
         cb.update_variable(id, result); //update the value array. n.b. we should not update the name as it is the first assignment (let)
@@ -535,11 +511,7 @@ impl<'a> IRGenerator<'a> {
     }
 
     pub fn def_to_name(&self, def: DefinitionId) -> String {
-        self.context
-            .context
-            .def_interner
-            .definition_name(def)
-            .to_owned()
+        self.context.context.def_interner.definition_name(def).to_owned()
     }
 
     pub fn ident_name(&self, ident: &HirIdent) -> String {
@@ -744,8 +716,8 @@ impl<'a> IRGenerator<'a> {
                 }
             }
             HirLiteral::Integer(f) => {
-                self.context
-                    .get_or_create_const(*f, node::ObjectType::NativeField) //TODO support integer literrals in the fronted: 30_u8
+                self.context.get_or_create_const(*f, node::ObjectType::NativeField)
+                //TODO support integer literrals in the fronted: 30_u8
             }
             _ => todo!(), //todo: add support for Array(HirArrayLiteral), Str(String)
         }
@@ -844,10 +816,7 @@ impl<'a> IRGenerator<'a> {
             .unwrap_id();
         //We support only const range for now
         //TODO how should we handle scope (cf. start/end_for_loop)?
-        let iter_name = self
-            .def_interner()
-            .definition_name(for_expr.identifier.id)
-            .to_owned();
+        let iter_name = self.def_interner().definition_name(for_expr.identifier.id).to_owned();
         let iter_def = for_expr.identifier.id;
         let int_type = self.def_interner().id_type(iter_def);
         let iter_type = int_type.into();
@@ -856,8 +825,7 @@ impl<'a> IRGenerator<'a> {
 
         iter_var.obj_type = iter_type;
         let iter_ass =
-            self.context
-                .new_instruction(iter_id, start_idx, node::Operation::Ass, iter_type);
+            self.context.new_instruction(iter_id, start_idx, node::Operation::Ass, iter_type);
         //We map the iterator to start_idx so that when we seal the join block, we will get the corrdect value.
         self.update_variable_id(iter_id, iter_ass, start_idx);
 
@@ -872,8 +840,7 @@ impl<'a> IRGenerator<'a> {
         let phi = self.generate_empty_phi(join_idx, iter_id);
         self.update_variable_id(iter_id, iter_id, phi); //is it still needed?
         let cond =
-            self.context
-                .new_instruction(phi, end_idx, Operation::Ne, node::ObjectType::Boolean);
+            self.context.new_instruction(phi, end_idx, Operation::Ne, node::ObjectType::Boolean);
         let to_fix = self.context.new_instruction(
             cond,
             NodeId::dummy(),
@@ -894,12 +861,8 @@ impl<'a> IRGenerator<'a> {
         }
 
         //increment iter
-        let one = self
-            .context
-            .get_or_create_const(FieldElement::one(), iter_type);
-        let incr = self
-            .context
-            .new_instruction(phi, one, node::Operation::Add, iter_type);
+        let one = self.context.get_or_create_const(FieldElement::one(), iter_type);
+        let incr = self.context.new_instruction(phi, one, node::Operation::Add, iter_type);
         let cur_block_id = self.context.current_block; //It should be the body block, except if the body has CFG statements
         let cur_block = &mut self.context[cur_block_id];
         cur_block.update_variable(iter_id, incr);

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -49,8 +49,7 @@ impl<'a> SsaContext<'a> {
     }
 
     pub fn zero(&self) -> NodeId {
-        self.find_const_with_type(&BigUint::zero(), node::ObjectType::Unsigned(1))
-            .unwrap()
+        self.find_const_with_type(&BigUint::zero(), node::ObjectType::Unsigned(1)).unwrap()
     }
 
     pub fn insert_block(&mut self, block: BasicBlock) -> &mut BasicBlock {
@@ -87,11 +86,8 @@ impl<'a> SsaContext<'a> {
             if ins.operator == node::Operation::Phi {
                 ins_str += "(";
                 for (v, b) in &ins.phi_arguments {
-                    ins_str += &format!(
-                        "{:?}:{:?}, ",
-                        v.0.into_raw_parts().0,
-                        b.0.into_raw_parts().0
-                    );
+                    ins_str +=
+                        &format!("{:?}:{:?}, ", v.0.into_raw_parts().0, b.0.into_raw_parts().0);
                 }
                 ins_str += ")";
             }
@@ -183,13 +179,11 @@ impl<'a> SsaContext<'a> {
 
     //todo handle errors
     fn get_instruction(&self, id: NodeId) -> &node::Instruction {
-        self.try_get_instruction(id)
-            .expect("Index not found or not an instruction")
+        self.try_get_instruction(id).expect("Index not found or not an instruction")
     }
 
     pub fn get_mut_instruction(&mut self, id: NodeId) -> &mut node::Instruction {
-        self.try_get_mut_instruction(id)
-            .expect("Index not found or not an instruction")
+        self.try_get_mut_instruction(id).expect("Index not found or not an instruction")
     }
 
     pub fn try_get_instruction(&self, id: NodeId) -> Option<&node::Instruction> {

--- a/crates/noirc_evaluator/src/ssa/flatten.rs
+++ b/crates/noirc_evaluator/src/ssa/flatten.rs
@@ -246,10 +246,7 @@ fn evaluate_phi(
         }
         //Update the evaluation map.
         for obj in to_process {
-            to.insert(
-                obj.0,
-                NodeEval::VarOrInstruction(optim::to_index(igen, obj.1)),
-            );
+            to.insert(obj.0, NodeEval::VarOrInstruction(optim::to_index(igen, obj.1)));
         }
     }
 }
@@ -278,9 +275,7 @@ fn evaluate_conditional_jump(
 
 //Retrieve the NodeEval value of the index in the evaluation map
 fn get_current_value(id: NodeId, value_array: &HashMap<NodeId, NodeEval>) -> NodeEval {
-    *value_array
-        .get(&id)
-        .unwrap_or(&NodeEval::VarOrInstruction(id))
+    *value_array.get(&id).unwrap_or(&NodeEval::VarOrInstruction(id))
 }
 
 //Same as get_current_value but for a NodeEval object instead of a NodeObj
@@ -397,11 +392,7 @@ pub fn inline_block(ctx: &mut SsaContext, block_id: BlockId) {
 
     for ins_id in call_ins {
         let ins = ctx.try_get_instruction(ins_id).unwrap().clone();
-        if let node::Instruction {
-            operator: node::Operation::Call(f),
-            ..
-        } = ins
-        {
+        if let node::Instruction { operator: node::Operation::Call(f), .. } = ins {
             inline(f, &ins.ins_arguments, ctx, ins.parent_block, ins.id);
         }
     }
@@ -426,15 +417,8 @@ pub fn inline(
     //2. inline in the block: we assume the function cfg is already flatened.
     let mut next_block = Some(ssa_func.igen.context.first_block);
     while let Some(next_b) = next_block {
-        next_block = inline_in_block(
-            next_b,
-            block,
-            &mut inline_map,
-            &mut array_map,
-            func_id,
-            call_id,
-            ctx,
-        );
+        next_block =
+            inline_in_block(next_b, block, &mut inline_map, &mut array_map, func_id, call_id, ctx);
     }
 }
 
@@ -608,11 +592,7 @@ pub fn inline_in_block(
     }
 
     // add instruction to target_block, at proper location (really need a linked list!)
-    let mut pos = ctx[target_block_id]
-        .instructions
-        .iter()
-        .position(|x| *x == call_id)
-        .unwrap();
+    let mut pos = ctx[target_block_id].instructions.iter().position(|x| *x == call_id).unwrap();
     for &new_id in &new_instructions {
         ctx[target_block_id].instructions.insert(pos, new_id);
         pos += 1;

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -35,11 +35,7 @@ impl<'a> SSAFunction<'a> {
     }
 
     pub fn new(func: FuncId, ctx: &'a noirc_frontend::hir::Context) -> SSAFunction<'a> {
-        SSAFunction {
-            igen: IRGenerator::new(ctx),
-            id: func,
-            arguments: Vec::new(),
-        }
+        SSAFunction { igen: IRGenerator::new(ctx), id: func, arguments: Vec::new() }
     }
 
     pub fn compile(&mut self) -> Option<NodeId> {
@@ -81,10 +77,7 @@ impl<'a> SSAFunction<'a> {
                 return node_id;
             }
             let mut my_const = None;
-            let node_obj_opt = ctx.functions_cfg[&func_id]
-                .igen
-                .context
-                .try_get_node(node_id);
+            let node_obj_opt = ctx.functions_cfg[&func_id].igen.context.try_get_node(node_id);
             if let Some(node::NodeObj::Const(c)) = node_obj_opt {
                 my_const = Some((c.get_value_field(), c.value_type));
             }
@@ -193,11 +186,7 @@ pub fn create_function<'a>(
 
 pub fn add_return_instruction(cfg: &mut SsaContext, last: Option<NodeId>) {
     let last_id = last.unwrap_or_else(NodeId::dummy);
-    let result = if last_id == NodeId::dummy() {
-        Vec::new()
-    } else {
-        vec![last_id]
-    };
+    let result = if last_id == NodeId::dummy() { Vec::new() } else { vec![last_id] };
     //Create return instruction based on the last statement of the function body
     let result_id = cfg.new_instruction(
         NodeId::dummy(),

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -311,23 +311,11 @@ pub fn block_overflow(
         let to_truncate = ins.truncate_required(get_size_in_bits(l_obj), get_size_in_bits(r_obj));
         if to_truncate.0 && l_obj.is_some() && get_type(l_obj) != node::ObjectType::NativeField {
             //adds a new truncate(lhs) instruction
-            add_to_truncate(
-                ctx,
-                l_id,
-                get_size_in_bits(l_obj),
-                &mut truncate_map,
-                max_map,
-            );
+            add_to_truncate(ctx, l_id, get_size_in_bits(l_obj), &mut truncate_map, max_map);
         }
         if to_truncate.1 && r_obj.is_some() && get_type(r_obj) != node::ObjectType::NativeField {
             //adds a new truncate(rhs) instruction
-            add_to_truncate(
-                ctx,
-                r_id,
-                get_size_in_bits(r_obj),
-                &mut truncate_map,
-                max_map,
-            );
+            add_to_truncate(ctx, r_id, get_size_in_bits(r_obj), &mut truncate_map, max_map);
         }
         match ins.operator {
             node::Operation::Load(_) => {
@@ -400,20 +388,10 @@ pub fn block_overflow(
             //- insert truncate(rhs) dans la list des instructions
             //- update r_max et l_max
             //n.b we could try to truncate only one of them, but then we should check if rhs==lhs.
-            let l_trunc_max = add_to_truncate(
-                ctx,
-                l_id,
-                get_size_in_bits(l_obj),
-                &mut truncate_map,
-                max_map,
-            );
-            let r_trunc_max = add_to_truncate(
-                ctx,
-                r_id,
-                get_size_in_bits(r_obj),
-                &mut truncate_map,
-                max_map,
-            );
+            let l_trunc_max =
+                add_to_truncate(ctx, l_id, get_size_in_bits(l_obj), &mut truncate_map, max_map);
+            let r_trunc_max =
+                add_to_truncate(ctx, r_id, get_size_in_bits(r_obj), &mut truncate_map, max_map);
             ins_max = get_instruction_max_operand(
                 ctx,
                 &ins,

--- a/crates/noirc_evaluator/src/ssa/mem.rs
+++ b/crates/noirc_evaluator/src/ssa/mem.rs
@@ -59,10 +59,7 @@ impl Memory {
     }
 
     pub fn get_array_index(&self, array: &MemArray) -> Option<u32> {
-        self.arrays
-            .iter()
-            .position(|x| x.adr == array.adr)
-            .map(|p| p as u32)
+        self.arrays.iter().position(|x| x.adr == array.adr).map(|p| p as u32)
     }
 
     //dereference a pointer

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -571,11 +571,8 @@ impl Instruction {
                     //n.b we assume the type of lhs and rhs is unsigned because of the opcode, we could also verify this
                 } else if let (Some(l_const), Some(r_const)) = (l_constant, r_constant) {
                     assert!(l_bsize < 256); //comparisons are not implemented for field elements
-                    let res = if l_const >= r_const {
-                        FieldElement::one()
-                    } else {
-                        FieldElement::zero()
-                    };
+                    let res =
+                        if l_const >= r_const { FieldElement::one() } else { FieldElement::zero() };
                     return NodeEval::Const(res, ObjectType::Boolean);
                 }
             }
@@ -585,11 +582,8 @@ impl Instruction {
                     //n.b we assume the type of lhs and rhs is unsigned because of the opcode, we could also verify this
                 } else if let (Some(l_const), Some(r_const)) = (l_constant, r_constant) {
                     assert!(l_bsize < 256); //comparisons are not implemented for field elements
-                    let res = if l_const < r_const {
-                        FieldElement::one()
-                    } else {
-                        FieldElement::zero()
-                    };
+                    let res =
+                        if l_const < r_const { FieldElement::one() } else { FieldElement::zero() };
                     return NodeEval::Const(res, ObjectType::Boolean);
                 }
             }
@@ -599,11 +593,8 @@ impl Instruction {
                     //n.b we assume the type of lhs and rhs is unsigned because of the opcode, we could also verify this
                 } else if let (Some(l_const), Some(r_const)) = (l_constant, r_constant) {
                     assert!(l_bsize < 256); //comparisons are not implemented for field elements
-                    let res = if l_const <= r_const {
-                        FieldElement::one()
-                    } else {
-                        FieldElement::zero()
-                    };
+                    let res =
+                        if l_const <= r_const { FieldElement::one() } else { FieldElement::zero() };
                     return NodeEval::Const(res, ObjectType::Boolean);
                 }
             }
@@ -614,11 +605,8 @@ impl Instruction {
                 //n.b we assume the type of lhs and rhs is unsigned because of the opcode, we could also verify this
                 } else if let (Some(l_const), Some(r_const)) = (l_constant, r_constant) {
                     assert!(l_bsize < 256); //comparisons are not implemented for field elements
-                    let res = if l_const > r_const {
-                        FieldElement::one()
-                    } else {
-                        FieldElement::zero()
-                    };
+                    let res =
+                        if l_const > r_const { FieldElement::one() } else { FieldElement::zero() };
                     return NodeEval::Const(res, ObjectType::Boolean);
                 }
             }

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -73,10 +73,9 @@ pub fn simplify(ctx: &mut SsaContext, ins: &mut node::Instruction) {
         // }
         node::Operation::Constrain(op) => match op {
             node::ConstrainOp::Eq => {
-                if let (Some(a), Some(b)) = (
-                    mem::Memory::deref(ctx, ins.lhs),
-                    mem::Memory::deref(ctx, ins.rhs),
-                ) {
+                if let (Some(a), Some(b)) =
+                    (mem::Memory::deref(ctx, ins.lhs), mem::Memory::deref(ctx, ins.rhs))
+                {
                     if a == b {
                         ins.is_deleted = true;
                         ins.operator = node::Operation::Nop;
@@ -84,10 +83,9 @@ pub fn simplify(ctx: &mut SsaContext, ins: &mut node::Instruction) {
                 }
             }
             node::ConstrainOp::Neq => {
-                if let (Some(a), Some(b)) = (
-                    mem::Memory::deref(ctx, ins.lhs),
-                    mem::Memory::deref(ctx, ins.rhs),
-                ) {
+                if let (Some(a), Some(b)) =
+                    (mem::Memory::deref(ctx, ins.lhs), mem::Memory::deref(ctx, ins.rhs))
+                {
                     assert!(a != b);
                 }
             }
@@ -167,9 +165,7 @@ fn evaluate_intrinsic(
             let lhs_int = lhs.to_u128();
             let rhs_int = rhs.to_u128() as u32;
             let a =
-                irgen
-                    .mem
-                    .create_new_array(rhs_int, node::ObjectType::Unsigned(1), &String::new());
+                irgen.mem.create_new_array(rhs_int, node::ObjectType::Unsigned(1), &String::new());
             let pointer = node::Variable {
                 id: NodeId::dummy(),
                 obj_type: node::ObjectType::Pointer(a),
@@ -349,9 +345,9 @@ pub fn cse_tree(
 
 pub fn anchor_push(op: node::Operation, anchor: &mut HashMap<node::Operation, VecDeque<NodeId>>) {
     match op {
-        node::Operation::Store(x) => anchor
-            .entry(node::Operation::Load(x))
-            .or_insert_with(VecDeque::new),
+        node::Operation::Store(x) => {
+            anchor.entry(node::Operation::Load(x)).or_insert_with(VecDeque::new)
+        }
         _ => anchor.entry(op).or_insert_with(VecDeque::new),
     };
 }
@@ -523,11 +519,8 @@ pub fn block_cse(
                     update.ins_arguments = ins_args;
                 }
                 //update instruction name - for debug/pretty print purposes only /////////////////////
-                if let Some(Instruction {
-                    operator: Operation::Ass,
-                    lhs,
-                    ..
-                }) = ctx.try_get_instruction(ii_l)
+                if let Some(Instruction { operator: Operation::Ass, lhs, .. }) =
+                    ctx.try_get_instruction(ii_l)
                 {
                     if let Ok(lv) = ctx.get_variable(*lhs) {
                         let i_name = lv.name.clone();
@@ -538,11 +531,8 @@ pub fn block_cse(
                         }
                     }
                 }
-                if let Some(Instruction {
-                    operator: Operation::Ass,
-                    lhs,
-                    ..
-                }) = ctx.try_get_instruction(ii_r)
+                if let Some(Instruction { operator: Operation::Ass, lhs, .. }) =
+                    ctx.try_get_instruction(ii_r)
                 {
                     if let Ok(lv) = ctx.get_variable(*lhs) {
                         let i_name = lv.name.clone();

--- a/crates/noirc_evaluator/src/ssa/ssa_form.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_form.rs
@@ -114,14 +114,10 @@ pub fn create_function_parameter(igen: &mut IRGenerator, ident_id: &DefinitionId
     let mut obj_type = node::ObjectType::from(&o_type);
     if let noirc_frontend::Type::Array(_, len, _) = o_type {
         let array_idx =
-            igen.context
-                .mem
-                .create_new_array(get_array_size(&len), obj_type, &ident_name);
+            igen.context.mem.create_new_array(get_array_size(&len), obj_type, &ident_name);
         obj_type = node::ObjectType::Pointer(array_idx);
     }
     let v_id = igen.create_new_variable(ident_name.clone(), *ident_id, obj_type, None);
-    igen.context
-        .get_current_block_mut()
-        .update_variable(v_id, v_id);
+    igen.context.get_current_block_mut().update_variable(v_id, v_id);
     v_id
 }

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -65,10 +65,7 @@ impl ExpressionKind {
     }
 
     pub fn function_call((func_name, arguments): (Path, Vec<Expression>)) -> ExpressionKind {
-        ExpressionKind::Call(Box::new(CallExpression {
-            func_name,
-            arguments,
-        }))
+        ExpressionKind::Call(Box::new(CallExpression { func_name, arguments }))
     }
 
     pub fn constructor((type_name, fields): (Path, Vec<(Ident, Expression)>)) -> ExpressionKind {
@@ -501,13 +498,7 @@ impl Display for CallExpression {
 impl Display for MethodCallExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let args = vecmap(&self.arguments, ToString::to_string);
-        write!(
-            f,
-            "{}.{}({})",
-            self.object,
-            self.method_name,
-            args.join(", ")
-        )
+        write!(f, "{}.{}({})", self.object, self.method_name, args.join(", "))
     }
 }
 
@@ -590,9 +581,7 @@ impl Display for FunctionDefinition {
             writeln!(f, "{}", attribute)?;
         }
 
-        let parameters = vecmap(&self.parameters, |(name, r#type)| {
-            format!("{}: {}", name, r#type)
-        });
+        let parameters = vecmap(&self.parameters, |(name, r#type)| format!("{}: {}", name, r#type));
 
         write!(
             f,

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -27,22 +27,13 @@ pub enum FunctionKind {
 
 impl NoirFunction {
     pub fn normal(def: FunctionDefinition) -> NoirFunction {
-        NoirFunction {
-            kind: FunctionKind::Normal,
-            def,
-        }
+        NoirFunction { kind: FunctionKind::Normal, def }
     }
     pub fn builtin(def: FunctionDefinition) -> NoirFunction {
-        NoirFunction {
-            kind: FunctionKind::Builtin,
-            def,
-        }
+        NoirFunction { kind: FunctionKind::Builtin, def }
     }
     pub fn low_level(def: FunctionDefinition) -> NoirFunction {
-        NoirFunction {
-            kind: FunctionKind::LowLevel,
-            def,
-        }
+        NoirFunction { kind: FunctionKind::LowLevel, def }
     }
 
     pub fn return_type(&self) -> UnresolvedType {

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -67,10 +67,7 @@ impl From<SpannedToken> for Ident {
 
 impl From<Ident> for Expression {
     fn from(i: Ident) -> Expression {
-        Expression {
-            span: i.0.span(),
-            kind: ExpressionKind::Ident(i.0.contents),
-        }
+        Expression { span: i.0.span(), kind: ExpressionKind::Ident(i.0.contents) }
     }
 }
 
@@ -135,11 +132,7 @@ impl Statement {
     pub fn new_let(
         ((pattern, r#type), expression): ((Pattern, UnresolvedType), Expression),
     ) -> Statement {
-        Statement::Let(LetStatement {
-            pattern,
-            r#type,
-            expression,
-        })
+        Statement::Let(LetStatement { pattern, r#type, expression })
     }
 
     pub fn add_semicolon(
@@ -220,10 +213,7 @@ impl Path {
     /// Construct a PathKind::Plain from this single
     pub fn from_single(name: String, span: Span) -> Path {
         let segment = Ident::from(Spanned::from(span, name));
-        Path {
-            segments: vec![segment],
-            kind: PathKind::Plain,
-        }
+        Path { segments: vec![segment], kind: PathKind::Plain }
     }
 
     pub fn span(&self) -> Span {
@@ -297,14 +287,8 @@ pub struct AssignStatement {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LValue {
     Ident(Ident),
-    MemberAccess {
-        object: Box<LValue>,
-        field_name: Ident,
-    },
-    Index {
-        array: Box<LValue>,
-        index: Expression,
-    },
+    MemberAccess { object: Box<LValue>, field_name: Ident },
+    Index { array: Box<LValue>, index: Expression },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -339,11 +323,7 @@ impl Display for Statement {
 
 impl Display for LetStatement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "let {}: {} = {}",
-            self.pattern, self.r#type, self.expression
-        )
+        write!(f, "let {}: {} = {}", self.pattern, self.r#type, self.expression)
     }
 }
 

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -82,20 +82,11 @@ impl Dependency {
 
 impl CrateGraph {
     pub fn add_crate_root(&mut self, crate_type: CrateType, file_id: FileId) -> CrateId {
-        let mut roots_with_file_id = self
-            .arena
-            .iter()
-            .filter(|(_, crate_data)| crate_data.root_file_id == file_id);
-        assert!(
-            roots_with_file_id.next().is_none(),
-            "you cannot add the same file id twice"
-        );
+        let mut roots_with_file_id =
+            self.arena.iter().filter(|(_, crate_data)| crate_data.root_file_id == file_id);
+        assert!(roots_with_file_id.next().is_none(), "you cannot add the same file id twice");
 
-        let data = CrateData {
-            root_file_id: file_id,
-            crate_type,
-            dependencies: Vec::new(),
-        };
+        let data = CrateData { root_file_id: file_id, crate_type, dependencies: Vec::new() };
         let crate_id = CrateId(self.arena.len());
         let prev = self.arena.insert(crate_id, data);
         assert!(prev.is_none());
@@ -222,15 +213,9 @@ mod tests {
         let crate2 = graph.add_crate_root(CrateType::Library, file_ids[1]);
         let crate3 = graph.add_crate_root(CrateType::Library, file_ids[2]);
 
-        assert!(graph
-            .add_dep(crate1, CrateName::new("crate2").unwrap(), crate2)
-            .is_ok());
-        assert!(graph
-            .add_dep(crate2, CrateName::new("crate3").unwrap(), crate3)
-            .is_ok());
-        assert!(graph
-            .add_dep(crate3, CrateName::new("crate1").unwrap(), crate1)
-            .is_err());
+        assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
+        assert!(graph.add_dep(crate2, CrateName::new("crate3").unwrap(), crate3).is_ok());
+        assert!(graph.add_dep(crate3, CrateName::new("crate1").unwrap(), crate1).is_err());
     }
 
     #[test]
@@ -243,12 +228,8 @@ mod tests {
         let crate1 = graph.add_crate_root(CrateType::Library, file_id_0);
         let crate2 = graph.add_crate_root(CrateType::Library, file_id_1);
         let crate3 = graph.add_crate_root(CrateType::Library, file_id_2);
-        assert!(graph
-            .add_dep(crate1, CrateName::new("crate2").unwrap(), crate2)
-            .is_ok());
-        assert!(graph
-            .add_dep(crate2, CrateName::new("crate3").unwrap(), crate3)
-            .is_ok());
+        assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
+        assert!(graph.add_dep(crate2, CrateName::new("crate3").unwrap(), crate3).is_ok());
     }
     #[test]
     #[should_panic]

--- a/crates/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/errors.rs
@@ -21,10 +21,7 @@ pub enum DefCollectorErrorKind {
 impl DiagnosableError for DefCollectorErrorKind {
     fn to_diagnostic(&self) -> Diagnostic {
         match self {
-            DefCollectorErrorKind::DuplicateFunction {
-                first_def,
-                second_def,
-            } => {
+            DefCollectorErrorKind::DuplicateFunction { first_def, second_def } => {
                 let first_span = first_def.0.span();
                 let second_span = second_def.0.span();
                 let func_name = &first_def.0.contents;
@@ -37,10 +34,7 @@ impl DiagnosableError for DefCollectorErrorKind {
                 diag.add_secondary("second definition found here".to_string(), second_span);
                 diag
             }
-            DefCollectorErrorKind::DuplicateModuleDecl {
-                first_def,
-                second_def,
-            } => {
+            DefCollectorErrorKind::DuplicateModuleDecl { first_def, second_def } => {
                 let first_span = first_def.0.span();
                 let second_span = second_def.0.span();
                 let mod_name = &first_def.0.contents;
@@ -53,10 +47,7 @@ impl DiagnosableError for DefCollectorErrorKind {
                 diag.add_secondary("second declaration found here".to_string(), second_span);
                 diag
             }
-            DefCollectorErrorKind::DuplicateImport {
-                first_def,
-                second_def,
-            } => {
+            DefCollectorErrorKind::DuplicateImport { first_def, second_def } => {
                 let first_span = first_def.0.span();
                 let second_span = second_def.0.span();
                 let import_name = &first_def.0.contents;

--- a/crates/noirc_frontend/src/hir/def_map/item_scope.rs
+++ b/crates/noirc_frontend/src/hir/def_map/item_scope.rs
@@ -89,10 +89,7 @@ impl ItemScope {
         }
     }
     pub fn find_name(&self, name: &Ident) -> PerNs {
-        PerNs {
-            types: self.types.get(name).cloned(),
-            values: self.values.get(name).cloned(),
-        }
+        PerNs { types: self.types.get(name).cloned(), values: self.values.get(name).cloned() }
     }
 
     pub fn definitions(&self) -> Vec<ModuleDefId> {

--- a/crates/noirc_frontend/src/hir/def_map/namespace.rs
+++ b/crates/noirc_frontend/src/hir/def_map/namespace.rs
@@ -9,10 +9,7 @@ pub struct PerNs {
 
 impl PerNs {
     pub fn types(t: ModuleDefId) -> PerNs {
-        PerNs {
-            types: Some((t, Visibility::Public)),
-            values: None,
-        }
+        PerNs { types: Some((t, Visibility::Public)), values: None }
     }
 
     pub fn take_types(self) -> Option<ModuleDefId> {
@@ -24,10 +21,7 @@ impl PerNs {
     }
 
     pub fn iter_defs(self) -> impl Iterator<Item = ModuleDefId> {
-        self.types
-            .map(|it| it.0)
-            .into_iter()
-            .chain(self.values.map(|it| it.0).into_iter())
+        self.types.map(|it| it.0).into_iter().chain(self.values.map(|it| it.0).into_iter())
     }
 
     pub fn iter_items(self) -> impl Iterator<Item = (ModuleDefId, Visibility)> {

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -7,10 +7,7 @@ use crate::{hir_def::expr::HirIdent, node_interner::NodeInterner, Ident};
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ResolverError {
     #[error("Duplicate definition")]
-    DuplicateDefinition {
-        first_ident: HirIdent,
-        second_ident: HirIdent,
-    },
+    DuplicateDefinition { first_ident: HirIdent, second_ident: HirIdent },
     #[error("Unused variable")]
     UnusedVariable { ident: HirIdent },
     #[error("Could not find variable in this scope")]
@@ -18,30 +15,15 @@ pub enum ResolverError {
     #[error("path is not an identifier")]
     PathIsNotIdent { span: Span },
     #[error("could not resolve path")]
-    PathUnresolved {
-        span: Span,
-        name: String,
-        segment: Ident,
-    },
+    PathUnresolved { span: Span, name: String, segment: Ident },
     #[error("Expected")]
-    Expected {
-        span: Span,
-        expected: String,
-        got: String,
-    },
+    Expected { span: Span, expected: String, got: String },
     #[error("Duplicate field in constructor")]
     DuplicateField { field: Ident },
     #[error("No such field in struct")]
-    NoSuchField {
-        field: Ident,
-        struct_definition: Ident,
-    },
+    NoSuchField { field: Ident, struct_definition: Ident },
     #[error("Missing fields from struct")]
-    MissingFields {
-        span: Span,
-        missing_fields: Vec<String>,
-        struct_definition: Ident,
-    },
+    MissingFields { span: Span, missing_fields: Vec<String>, struct_definition: Ident },
     #[error("Unneeded 'mut', pattern is already marked as mutable")]
     UnnecessaryMut { first_mut: Span, second_mut: Span },
 }
@@ -52,10 +34,7 @@ impl ResolverError {
     /// soundness of the generated program
     pub fn into_diagnostic(self, interner: &NodeInterner) -> Diagnostic {
         match self {
-            ResolverError::DuplicateDefinition {
-                first_ident,
-                second_ident,
-            } => {
+            ResolverError::DuplicateDefinition { first_ident, second_ident } => {
                 let first_span = first_ident.span;
                 let second_span = second_ident.span;
 
@@ -91,11 +70,7 @@ impl ResolverError {
                 String::new(),
                 span,
             ),
-            ResolverError::PathUnresolved {
-                span,
-                name,
-                segment,
-            } => {
+            ResolverError::PathUnresolved { span, name, segment } => {
                 let mut diag = Diagnostic::simple_error(
                     format!("could not resolve path '{}'", name),
                     String::new(),
@@ -111,11 +86,7 @@ impl ResolverError {
 
                 diag
             }
-            ResolverError::Expected {
-                span,
-                expected,
-                got,
-            } => Diagnostic::simple_error(
+            ResolverError::Expected { span, expected, got } => Diagnostic::simple_error(
                 format!("expected {} got {}", expected, got),
                 String::new(),
                 span,
@@ -125,15 +96,9 @@ impl ResolverError {
                 String::new(),
                 field.span(),
             ),
-            ResolverError::NoSuchField {
-                field,
-                struct_definition,
-            } => {
+            ResolverError::NoSuchField { field, struct_definition } => {
                 let mut error = Diagnostic::simple_error(
-                    format!(
-                        "no such field {} defined in struct {}",
-                        field, struct_definition
-                    ),
+                    format!("no such field {} defined in struct {}", field, struct_definition),
                     String::new(),
                     field.span(),
                 );
@@ -144,11 +109,7 @@ impl ResolverError {
                 );
                 error
             }
-            ResolverError::MissingFields {
-                span,
-                missing_fields,
-                struct_definition,
-            } => {
+            ResolverError::MissingFields { span, missing_fields, struct_definition } => {
                 let plural = if missing_fields.len() != 1 { "s" } else { "" };
                 let missing_fields = missing_fields.join(", ");
 
@@ -164,10 +125,7 @@ impl ResolverError {
                 );
                 error
             }
-            ResolverError::UnnecessaryMut {
-                first_mut,
-                second_mut,
-            } => {
+            ResolverError::UnnecessaryMut { first_mut, second_mut } => {
                 let mut error = Diagnostic::simple_error(
                     "'mut' here is not necessary".to_owned(),
                     "".to_owned(),

--- a/crates/noirc_frontend/src/hir/resolution/import.rs
+++ b/crates/noirc_frontend/src/hir/resolution/import.rs
@@ -102,17 +102,12 @@ fn resolve_name_in_module(
     // There is a possibility that the import path is empty
     // In that case, early return
     if import_path.is_empty() {
-        let mod_id = ModuleId {
-            krate: def_map.krate,
-            local_id: starting_mod,
-        };
+        let mod_id = ModuleId { krate: def_map.krate, local_id: starting_mod };
         return PathResolution::Resolved(PerNs::types(mod_id.into()));
     }
 
     let mut import_path = import_path.iter();
-    let first_segment = import_path
-        .next()
-        .expect("ice: could not fetch first segment");
+    let first_segment = import_path.next().expect("ice: could not fetch first segment");
     let mut current_ns = current_mod.scope.find_name(first_segment);
     if current_ns.is_none() {
         return PathResolution::Unresolved(first_segment.clone());
@@ -169,15 +164,9 @@ fn resolve_external_dep(
     // Create an import directive for the dependency crate
     let path_without_crate_name = &path[1..]; // XXX: This will panic if the path is of the form `use dep::std` Ideal algorithm will not distinguish between crate and module
 
-    let path = Path {
-        segments: path_without_crate_name.to_vec(),
-        kind: PathKind::Plain,
-    };
-    let dep_directive = ImportDirective {
-        module_id: dep_module.local_id,
-        path,
-        alias: directive.alias.clone(),
-    };
+    let path = Path { segments: path_without_crate_name.to_vec(), kind: PathKind::Plain };
+    let dep_directive =
+        ImportDirective { module_id: dep_module.local_id, path, alias: directive.alias.clone() };
 
     let dep_def_map = def_maps.get(&dep_module.krate).unwrap();
 

--- a/crates/noirc_frontend/src/hir/resolution/path_resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/path_resolver.rs
@@ -42,11 +42,7 @@ pub fn resolve_path(
     path: Path,
 ) -> Result<Option<ModuleDefId>, Ident> {
     // lets package up the path into an ImportDirective and resolve it using that
-    let import = ImportDirective {
-        module_id: module_id.local_id,
-        path,
-        alias: None,
-    };
+    let import = ImportDirective { module_id: module_id.local_id, path, alias: None };
 
     let def_map = &def_maps[&module_id.krate];
     let path_res = resolve_path_to_ns(&import, def_map, def_maps);

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -127,9 +127,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
         ScopeForest(vec![ScopeTree::new()])
     }
     pub fn current_scope_tree(&mut self) -> &mut ScopeTree<K, V> {
-        self.0
-            .last_mut()
-            .expect("ice: tried to fetch the current scope, however none was found")
+        self.0.last_mut().expect("ice: tried to fetch the current scope, however none was found")
     }
 
     /// Returns the last pushed scope from the current scope tree
@@ -151,9 +149,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
     /// Ending a function requires that we removes it's whole tree of scope
     /// This is by design the current scope, which is the last element in the vector
     pub fn end_function(&mut self) -> ScopeTree<K, V> {
-        self.0
-            .pop()
-            .expect("ice: expected a scope tree, however none was found")
+        self.0.pop().expect("ice: expected a scope tree, however none was found")
     }
 
     /// The beginning of a scope always correlates with the start of a block {}.

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -9,29 +9,13 @@ use crate::node_interner::NodeInterner;
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum TypeCheckError {
     #[error("operator {op:?} cannot be used in a {place:?}")]
-    OpCannotBeUsed {
-        op: HirBinaryOp,
-        place: &'static str,
-        span: Span,
-    },
+    OpCannotBeUsed { op: HirBinaryOp, place: &'static str, span: Span },
     #[error("type {typ:?} cannot be used in a {place:?}")]
-    TypeCannotBeUsed {
-        typ: Type,
-        place: &'static str,
-        span: Span,
-    },
+    TypeCannotBeUsed { typ: Type, place: &'static str, span: Span },
     #[error("expected type {expected_typ:?} is not the same as {expr_typ:?}")]
-    TypeMismatch {
-        expected_typ: String,
-        expr_typ: String,
-        expr_span: Span,
-    },
+    TypeMismatch { expected_typ: String, expr_typ: String, expr_span: Span },
     #[error("expected {expected:?} found {found:?}")]
-    ArityMisMatch {
-        expected: u16,
-        found: u16,
-        span: Span,
-    },
+    ArityMisMatch { expected: u16, found: u16, span: Span },
     #[error("return type in a function cannot be public")]
     PublicReturnType { typ: Type, span: Span },
     // XXX: unstructured errors are not ideal for testing.
@@ -39,10 +23,7 @@ pub enum TypeCheckError {
     #[error("unstructured msg: {msg:?}")]
     Unstructured { msg: String, span: Span },
     #[error("error with additional context")]
-    Context {
-        err: Box<TypeCheckError>,
-        ctx: &'static str,
-    },
+    Context { err: Box<TypeCheckError>, ctx: &'static str },
     #[error("Array is not homogeneous")]
     NonHomogeneousArray {
         first_span: Span,
@@ -72,15 +53,13 @@ impl TypeCheckError {
                 String::new(),
                 span,
             ),
-            TypeCheckError::TypeMismatch {
-                expected_typ,
-                expr_typ,
-                expr_span,
-            } => Diagnostic::simple_error(
-                format!("expected type {}, found type {}", expected_typ, expr_typ),
-                String::new(),
-                expr_span,
-            ),
+            TypeCheckError::TypeMismatch { expected_typ, expr_typ, expr_span } => {
+                Diagnostic::simple_error(
+                    format!("expected type {}, found type {}", expected_typ, expr_typ),
+                    String::new(),
+                    expr_span,
+                )
+            }
             TypeCheckError::NonHomogeneousArray {
                 first_span,
                 first_type,
@@ -100,16 +79,9 @@ impl TypeCheckError {
                 diag.add_secondary(format!("but then found type {}", second_type), second_span);
                 diag
             }
-            TypeCheckError::ArityMisMatch {
-                expected,
-                found,
-                span,
-            } => {
+            TypeCheckError::ArityMisMatch { expected, found, span } => {
                 let plural = if expected == 1 { "" } else { "s" };
-                let msg = format!(
-                    "expected {} argument{}, but found {}",
-                    expected, plural, found
-                );
+                let msg = format!("expected {} argument{}, but found {}", expected, plural, found);
                 Diagnostic::simple_error(msg, String::new(), span)
             }
             TypeCheckError::Unstructured { msg, span } => {
@@ -124,9 +96,6 @@ impl TypeCheckError {
     }
 
     pub fn add_context(self, ctx: &'static str) -> Self {
-        TypeCheckError::Context {
-            err: Box::new(self),
-            ctx,
-        }
+        TypeCheckError::Context { err: Box::new(self), ctx }
     }
 }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -27,9 +27,8 @@ pub(crate) fn type_check_expression(
             match literal {
                 HirLiteral::Array(arr) => {
                     // Type check the contents of the array
-                    let elem_types = vecmap(&arr.contents, |arg| {
-                        type_check_expression(interner, arg, errors)
-                    });
+                    let elem_types =
+                        vecmap(&arr.contents, |arg| type_check_expression(interner, arg, errors));
 
                     let first_elem_type = elem_types.get(0).cloned().unwrap_or(Type::Error);
 
@@ -82,10 +81,8 @@ pub(crate) fn type_check_expression(
                 Err(msg) => {
                     let lhs_span = interner.expr_span(&infix_expr.lhs);
                     let rhs_span = interner.expr_span(&infix_expr.rhs);
-                    errors.push(TypeCheckError::Unstructured {
-                        msg,
-                        span: lhs_span.merge(rhs_span),
-                    });
+                    errors
+                        .push(TypeCheckError::Unstructured { msg, span: lhs_span.merge(rhs_span) });
                     Type::Error
                 }
             }
@@ -119,9 +116,8 @@ pub(crate) fn type_check_expression(
             }
         }
         HirExpression::Call(call_expr) => {
-            let args = vecmap(&call_expr.arguments, |arg| {
-                type_check_expression(interner, arg, errors)
-            });
+            let args =
+                vecmap(&call_expr.arguments, |arg| type_check_expression(interner, arg, errors));
             type_check_function_call(interner, expr_id, &call_expr.func_id, args, errors)
         }
         HirExpression::MethodCall(method_call) => {
@@ -233,10 +229,7 @@ pub(crate) fn type_check_expression(
                 Ok(typ) => typ,
                 Err(msg) => {
                     let rhs_span = interner.expr_span(&prefix_expr.rhs);
-                    errors.push(TypeCheckError::Unstructured {
-                        msg,
-                        span: rhs_span,
-                    });
+                    errors.push(TypeCheckError::Unstructured { msg, span: rhs_span });
                     Type::Error
                 }
             }
@@ -247,9 +240,9 @@ pub(crate) fn type_check_expression(
         }
         HirExpression::MemberAccess(access) => check_member_access(access, interner, errors),
         HirExpression::Error => Type::Error,
-        HirExpression::Tuple(elements) => Type::Tuple(vecmap(&elements, |elem| {
-            type_check_expression(interner, elem, errors)
-        })),
+        HirExpression::Tuple(elements) => {
+            Type::Tuple(vecmap(&elements, |elem| type_check_expression(interner, elem, errors)))
+        }
     };
 
     interner.push_expr_type(expr_id, typ.clone());
@@ -312,10 +305,7 @@ fn lookup_method(
         other => {
             errors.push(TypeCheckError::Unstructured {
                 span: interner.expr_span(expr_id),
-                msg: format!(
-                    "Type '{}' must be a struct type to call methods on it",
-                    other
-                ),
+                msg: format!("Type '{}' must be a struct type to call methods on it", other),
             });
             None
         }

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -96,39 +96,23 @@ mod test {
         //
         // Push x variable
         let x_id = interner.push_definition("x".into(), false);
-        let x = HirIdent {
-            id: x_id,
-            span: Span::default(),
-        };
+        let x = HirIdent { id: x_id, span: Span::default() };
 
         // Push y variable
         let y_id = interner.push_definition("y".into(), false);
-        let y = HirIdent {
-            id: y_id,
-            span: Span::default(),
-        };
+        let y = HirIdent { id: y_id, span: Span::default() };
 
         // Push z variable
         let z_id = interner.push_definition("z".into(), false);
-        let z = HirIdent {
-            id: z_id,
-            span: Span::default(),
-        };
+        let z = HirIdent { id: z_id, span: Span::default() };
 
         // Push x and y as expressions
         let x_expr_id = interner.push_expr(HirExpression::Ident(x));
         let y_expr_id = interner.push_expr(HirExpression::Ident(y));
 
         // Create Infix
-        let operator = HirBinaryOp {
-            span: Span::default(),
-            kind: HirBinaryOpKind::Add,
-        };
-        let expr = HirInfixExpression {
-            lhs: x_expr_id,
-            operator,
-            rhs: y_expr_id,
-        };
+        let operator = HirBinaryOp { span: Span::default(), kind: HirBinaryOpKind::Add };
+        let expr = HirInfixExpression { lhs: x_expr_id, operator, rhs: y_expr_id };
         let expr_id = interner.push_expr(HirExpression::Infix(expr));
 
         // Create let statement

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -102,10 +102,7 @@ impl From<BinaryOp> for HirBinaryOp {
     fn from(a: BinaryOp) -> HirBinaryOp {
         let kind: HirBinaryOpKind = a.contents.into();
 
-        HirBinaryOp {
-            span: a.span(),
-            kind,
-        }
+        HirBinaryOp { span: a.span(), kind }
     }
 }
 
@@ -211,10 +208,7 @@ impl HirMethodCallExpression {
         let mut arguments = vec![self.object];
         arguments.append(&mut self.arguments);
 
-        HirExpression::Call(HirCallExpression {
-            func_id: method_id,
-            arguments,
-        })
+        HirExpression::Call(HirCallExpression { func_id: method_id, arguments })
     }
 }
 

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -62,20 +62,12 @@ impl HirPattern {
     pub fn iter_fields<'a>(&'a self) -> Box<dyn Iterator<Item = (String, &'a HirPattern)> + 'a> {
         match self {
             HirPattern::Struct(_, fields, _) => Box::new(
-                fields
-                    .iter()
-                    .map(move |(name, pattern)| (name.0.contents.clone(), pattern)),
+                fields.iter().map(move |(name, pattern)| (name.0.contents.clone(), pattern)),
             ),
-            HirPattern::Tuple(fields, _) => Box::new(
-                fields
-                    .iter()
-                    .enumerate()
-                    .map(|(i, field)| (i.to_string(), field)),
-            ),
-            other => panic!(
-                "Tried to iterate over the fields of '{:?}', which has none",
-                other
-            ),
+            HirPattern::Tuple(fields, _) => {
+                Box::new(fields.iter().enumerate().map(|(i, field)| (i.to_string(), field)))
+            }
+            other => panic!("Tried to iterate over the fields of '{:?}', which has none", other),
         }
     }
 }
@@ -84,12 +76,6 @@ impl HirPattern {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum HirLValue {
     Ident(HirIdent),
-    MemberAccess {
-        object: Box<HirLValue>,
-        field_name: Ident,
-    },
-    Index {
-        array: Box<HirLValue>,
-        index: ExprId,
-    },
+    MemberAccess { object: Box<HirLValue>, field_name: Ident },
+    Index { array: Box<HirLValue>, index: ExprId },
 }

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -26,20 +26,11 @@ impl PartialEq for StructType {
 
 impl StructType {
     pub fn new(id: StructId, name: Ident, span: Span, fields: Vec<(Ident, Type)>) -> StructType {
-        StructType {
-            id,
-            fields,
-            name,
-            span,
-            methods: HashMap::new(),
-        }
+        StructType { id, fields, name, span, methods: HashMap::new() }
     }
 
     pub fn get_field(&self, field_name: &str) -> Option<&Type> {
-        self.fields
-            .iter()
-            .find(|(name, _)| name.0.contents == field_name)
-            .map(|(_, typ)| typ)
+        self.fields.iter().find(|(name, _)| name.0.contents == field_name).map(|(_, typ)| typ)
     }
 }
 
@@ -155,10 +146,7 @@ impl Type {
     }
 
     pub fn is_field_element(&self) -> bool {
-        matches!(
-            self,
-            Type::FieldElement(_) | Type::Bool | Type::Integer(_, _, _)
-        )
+        matches!(self, Type::FieldElement(_) | Type::Bool | Type::Integer(_, _, _))
     }
 
     /// Computes the number of elements in a Type
@@ -224,10 +212,7 @@ impl Type {
     // Base types are types in the language that are simply alias for a field element
     // Therefore they can be the operands in an infix comparison operator
     pub fn is_base_type(&self) -> bool {
-        matches!(
-            self,
-            Type::FieldElement(_) | Type::Integer(_, _, _) | Type::Error
-        )
+        matches!(self, Type::FieldElement(_) | Type::Integer(_, _, _) | Type::Error)
     }
 
     pub fn is_constant(&self) -> bool {
@@ -286,11 +271,7 @@ impl Type {
                     Signedness::Signed => noirc_abi::Sign::Signed,
                 };
 
-                AbiType::Integer {
-                    sign,
-                    width: *bit_width as u32,
-                    visibility: fet_to_abi(fe_type),
-                }
+                AbiType::Integer { sign, width: *bit_width as u32, visibility: fet_to_abi(fe_type) }
             }
             Type::Bool => panic!("currently, cannot have a bool in the entry point function"),
             Type::Error => unreachable!(),
@@ -309,17 +290,14 @@ impl Type {
             // only to have to call .into_iter again afterward. Trying to ellide
             // collecting to a Vec leads to us dropping the temporary Ref before
             // the iterator is returned
-            Type::Struct(_, def) => vecmap(def.borrow().fields.iter(), |(name, typ)| {
-                (name.to_string(), typ.clone())
-            }),
+            Type::Struct(_, def) => {
+                vecmap(def.borrow().fields.iter(), |(name, typ)| (name.to_string(), typ.clone()))
+            }
             Type::Tuple(fields) => {
                 let fields = fields.iter().enumerate();
                 vecmap(fields, |(i, field)| (i.to_string(), field.clone()))
             }
-            other => panic!(
-                "Tried to iterate over the fields of '{}', which has none",
-                other
-            ),
+            other => panic!("Tried to iterate over the fields of '{}', which has none", other),
         };
         fields.into_iter()
     }

--- a/crates/noirc_frontend/src/lexer/errors.rs
+++ b/crates/noirc_frontend/src/lexer/errors.rs
@@ -8,11 +8,7 @@ use thiserror::Error;
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum LexerErrorKind {
     #[error("An unexpected character {:?} was found.", found)]
-    UnexpectedCharacter {
-        span: Span,
-        expected: String,
-        found: char,
-    },
+    UnexpectedCharacter { span: Span, expected: String, found: char },
     #[error("NotADoubleChar : {:?} is not a double char token", found)]
     NotADoubleChar { span: Span, found: Token },
     #[error("InvalidIntegerLiteral : {:?} is not a integer", found)]

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -320,9 +320,8 @@ impl<'a> Lexer<'a> {
         Ok(ident_token.into_span(start, end))
     }
     fn eat_digit(&mut self, initial_char: char) -> SpannedTokenResult {
-        let (integer_str, start, end) = self.eat_while(Some(initial_char), |ch| {
-            ch.is_digit(10) | ch.is_digit(16) | (ch == 'x')
-        });
+        let (integer_str, start, end) = self
+            .eat_while(Some(initial_char), |ch| ch.is_digit(10) | ch.is_digit(16) | (ch == 'x'));
 
         let integer = match FieldElement::try_from_str(&integer_str) {
             None => {

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -268,11 +268,7 @@ impl IntType {
         let max_bits = FieldElement::max_num_bits();
 
         if str_as_u32 > max_bits {
-            return Err(LexerErrorKind::TooManyBits {
-                span,
-                max: max_bits,
-                got: str_as_u32,
-            });
+            return Err(LexerErrorKind::TooManyBits { span, max: max_bits, got: str_as_u32 });
         }
         if (str_as_u32 % 2 == 1) && (str_as_u32 > 1) {
             todo!("Barretenberg currently panics on odd integers bit widths such as u3, u5. u1 works as it is a type alias for bool, so we can use a bool gate for it");
@@ -314,10 +310,7 @@ impl Attribute {
             .collect();
 
         if word_segments.len() != 2 {
-            return Err(LexerErrorKind::MalformedFuncAttribute {
-                span,
-                found: word.to_owned(),
-            });
+            return Err(LexerErrorKind::MalformedFuncAttribute { span, found: word.to_owned() });
         }
 
         let attribute_type = word_segments[0];
@@ -327,10 +320,7 @@ impl Attribute {
             "foreign" => Token::Attribute(Attribute::Foreign(attribute_name.to_string())),
             "builtin" => Token::Attribute(Attribute::Builtin(attribute_name.to_string())),
             _ => {
-                return Err(LexerErrorKind::MalformedFuncAttribute {
-                    span,
-                    found: word.to_owned(),
-                })
+                return Err(LexerErrorKind::MalformedFuncAttribute { span, found: word.to_owned() })
             }
         };
         Ok(tok)

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -62,10 +62,7 @@ impl StructId {
     // This can be anything, as the program will ultimately fail
     // after resolution
     pub fn dummy_id() -> StructId {
-        StructId(ModuleId {
-            krate: CrateId::dummy_id(),
-            local_id: LocalModuleId::dummy_id(),
-        })
+        StructId(ModuleId { krate: CrateId::dummy_id(), local_id: LocalModuleId::dummy_id() })
     }
 }
 
@@ -237,10 +234,8 @@ impl NodeInterner {
     /// generate function identifiers and then we update at a later point in
     /// time.
     pub fn update_fn(&mut self, func_id: FuncId, hir_func: HirFunction) {
-        let def = self
-            .nodes
-            .get_mut(func_id.0)
-            .expect("ice: all function ids should have definitions");
+        let def =
+            self.nodes.get_mut(func_id.0).expect("ice: all function ids should have definitions");
 
         let func = match def {
             Node::Function(func) => func,
@@ -268,10 +263,7 @@ impl NodeInterner {
     //
     // Cloning HIR structures is cheap, so we return owned structures
     pub fn function(&self, func_id: &FuncId) -> HirFunction {
-        let def = self
-            .nodes
-            .get(func_id.0)
-            .expect("ice: all function ids should have definitions");
+        let def = self.nodes.get(func_id.0).expect("ice: all function ids should have definitions");
 
         match def {
             Node::Function(func) => func.clone(),
@@ -281,10 +273,7 @@ impl NodeInterner {
 
     /// Returns the interned meta data corresponding to `func_id`
     pub fn function_meta(&self, func_id: &FuncId) -> FuncMeta {
-        self.func_meta
-            .get(func_id)
-            .cloned()
-            .expect("ice: all function ids should have metadata")
+        self.func_meta.get(func_id).cloned().expect("ice: all function ids should have metadata")
     }
 
     pub fn function_name(&self, func_id: &FuncId) -> &str {
@@ -294,10 +283,8 @@ impl NodeInterner {
 
     /// Returns the interned statement corresponding to `stmt_id`
     pub fn statement(&self, stmt_id: &StmtId) -> HirStatement {
-        let def = self
-            .nodes
-            .get(stmt_id.0)
-            .expect("ice: all statement ids should have definitions");
+        let def =
+            self.nodes.get(stmt_id.0).expect("ice: all statement ids should have definitions");
 
         match def {
             Node::Statement(stmt) => stmt.clone(),
@@ -306,10 +293,8 @@ impl NodeInterner {
     }
     /// Returns the interned expression corresponding to `expr_id`
     pub fn expression(&self, expr_id: &ExprId) -> HirExpression {
-        let def = self
-            .nodes
-            .get(expr_id.0)
-            .expect("ice: all expression ids should have definitions");
+        let def =
+            self.nodes.get(expr_id.0).expect("ice: all expression ids should have definitions");
 
         match def {
             Node::Expression(expr) => expr.clone(),
@@ -341,10 +326,7 @@ impl NodeInterner {
 
     /// Returns the type of an item stored in the Interner or Error if it was not found.
     pub fn id_type(&self, index: impl Into<Index>) -> Type {
-        self.id_to_type
-            .get(&index.into())
-            .cloned()
-            .unwrap_or(Type::Error)
+        self.id_to_type.get(&index.into()).cloned().unwrap_or(Type::Error)
     }
 
     /// Returns the span of an item stored in the Interner

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -75,11 +75,7 @@ impl std::fmt::Display for ParserError {
                 self.found
             )
         } else {
-            let expected = expected
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(", ");
+            let expected = expected.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
 
             write!(f, "Unexpected {}, expected one of {}", self.found, expected)
         }
@@ -107,10 +103,7 @@ impl chumsky::Error<Token> for ParserError {
         Iter: IntoIterator<Item = Option<Token>>,
     {
         ParserError {
-            expected_tokens: expected
-                .into_iter()
-                .map(|opt| opt.unwrap_or(Token::EOF))
-                .collect(),
+            expected_tokens: expected.into_iter().map(|opt| opt.unwrap_or(Token::EOF)).collect(),
             expected_labels: BTreeSet::new(),
             found: found.unwrap_or(Token::EOF),
             reason: None,

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -37,14 +37,12 @@ where
     T: Recoverable,
 {
     use Token::*;
-    parser
-        .delimited_by(just(LeftParen), just(RightParen))
-        .recover_with(nested_delimiters(
-            LeftParen,
-            RightParen,
-            [(LeftBracket, RightBracket)],
-            Recoverable::error,
-        ))
+    parser.delimited_by(just(LeftParen), just(RightParen)).recover_with(nested_delimiters(
+        LeftParen,
+        RightParen,
+        [(LeftBracket, RightBracket)],
+        Recoverable::error,
+    ))
 }
 
 fn spanned<P, T>(parser: P) -> impl NoirParser<(T, Span)>


### PR DESCRIPTION
This is an incredibly important major milestone change to the project which changes our formatting options to allow struct literals and method chains to be up to 80 characters before they're wrapped onto several lines. Previously rustfmt was too eager to place fields on separate lines, often resulting in multiple lines in a row that are just `identifier,` which is unhelpful.

(This is a large, though trivial PR - all files changed were done automatically by `cargo fmt`, except `.rustfmt.toml` of course)