### PR TITLE
Refactor Operation enum

### DIFF
--- a/crates/acir/src/circuit/gate.rs
+++ b/crates/acir/src/circuit/gate.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::native_types::{Arithmetic, Witness};
-use crate::OPCODE;
+use crate::OpCode;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AndGate {
@@ -155,7 +155,7 @@ pub struct GadgetInput {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GadgetCall {
-    pub name: OPCODE,
+    pub name: OpCode,
     pub inputs: Vec<GadgetInput>,
     pub outputs: Vec<Witness>,
 }

--- a/crates/acir/src/lib.rs
+++ b/crates/acir/src/lib.rs
@@ -9,4 +9,4 @@ pub mod optimiser;
 pub mod opcode;
 
 pub use noir_field::FieldElement;
-pub use opcode::OPCODE;
+pub use opcode::OpCode;

--- a/crates/acir/src/opcode.rs
+++ b/crates/acir/src/opcode.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Hash, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum OPCODE {
+pub enum OpCode {
     #[allow(clippy::upper_case_acronyms)]
     AES,
     SHA256,
@@ -16,82 +15,82 @@ pub enum OPCODE {
     FixedBaseScalarMul,
 }
 
-impl std::fmt::Display for OPCODE {
+impl std::fmt::Display for OpCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name())
     }
 }
 
-impl OPCODE {
+impl OpCode {
     pub fn to_u16(self) -> u16 {
         match self {
-            OPCODE::AES => 0,
-            OPCODE::SHA256 => 1,
-            OPCODE::MerkleMembership => 2,
-            OPCODE::SchnorrVerify => 3,
-            OPCODE::Blake2s => 4,
-            OPCODE::Pedersen => 5,
-            OPCODE::HashToField => 6,
-            OPCODE::EcdsaSecp256k1 => 7,
-            OPCODE::FixedBaseScalarMul => 8,
-            OPCODE::InsertRegularMerkle => 9,
+            OpCode::AES => 0,
+            OpCode::SHA256 => 1,
+            OpCode::MerkleMembership => 2,
+            OpCode::SchnorrVerify => 3,
+            OpCode::Blake2s => 4,
+            OpCode::Pedersen => 5,
+            OpCode::HashToField => 6,
+            OpCode::EcdsaSecp256k1 => 7,
+            OpCode::FixedBaseScalarMul => 8,
+            OpCode::InsertRegularMerkle => 9,
         }
     }
     pub fn name(&self) -> &str {
         match self {
-            OPCODE::AES => "aes",
-            OPCODE::SHA256 => "sha256",
-            OPCODE::MerkleMembership => "merkle_membership",
-            OPCODE::SchnorrVerify => "schnorr_verify",
-            OPCODE::Blake2s => "blake2s",
-            OPCODE::Pedersen => "pedersen",
-            OPCODE::HashToField => "hash_to_field",
-            OPCODE::EcdsaSecp256k1 => "ecdsa_secp256k1",
-            OPCODE::FixedBaseScalarMul => "fixed_base_scalar_mul",
-            OPCODE::InsertRegularMerkle => "insert_regular_merkle",
+            OpCode::AES => "aes",
+            OpCode::SHA256 => "sha256",
+            OpCode::MerkleMembership => "merkle_membership",
+            OpCode::SchnorrVerify => "schnorr_verify",
+            OpCode::Blake2s => "blake2s",
+            OpCode::Pedersen => "pedersen",
+            OpCode::HashToField => "hash_to_field",
+            OpCode::EcdsaSecp256k1 => "ecdsa_secp256k1",
+            OpCode::FixedBaseScalarMul => "fixed_base_scalar_mul",
+            OpCode::InsertRegularMerkle => "insert_regular_merkle",
         }
     }
-    pub fn lookup(op_name: &str) -> Option<OPCODE> {
+    pub fn lookup(op_name: &str) -> Option<OpCode> {
         match op_name {
-            "sha256" => Some(OPCODE::SHA256),
-            "merkle_membership" => Some(OPCODE::MerkleMembership),
-            "schnorr_verify" => Some(OPCODE::SchnorrVerify),
-            "blake2s" => Some(OPCODE::Blake2s),
-            "pedersen" => Some(OPCODE::Pedersen),
-            "hash_to_field" => Some(OPCODE::HashToField),
-            "ecdsa_secp256k1" => Some(OPCODE::EcdsaSecp256k1),
-            "fixed_base_scalar_mul" => Some(OPCODE::FixedBaseScalarMul),
-            "insert_regular_merkle" => Some(OPCODE::InsertRegularMerkle),
+            "sha256" => Some(OpCode::SHA256),
+            "merkle_membership" => Some(OpCode::MerkleMembership),
+            "schnorr_verify" => Some(OpCode::SchnorrVerify),
+            "blake2s" => Some(OpCode::Blake2s),
+            "pedersen" => Some(OpCode::Pedersen),
+            "hash_to_field" => Some(OpCode::HashToField),
+            "ecdsa_secp256k1" => Some(OpCode::EcdsaSecp256k1),
+            "fixed_base_scalar_mul" => Some(OpCode::FixedBaseScalarMul),
+            "insert_regular_merkle" => Some(OpCode::InsertRegularMerkle),
             _ => None,
         }
     }
     pub fn is_valid_opcode_name(op_name: &str) -> bool {
-        OPCODE::lookup(op_name).is_some()
+        OpCode::lookup(op_name).is_some()
     }
     pub fn definition(&self) -> GadgetDefinition {
         match self {
-            OPCODE::AES => unimplemented!(),
-            OPCODE::SHA256 => GadgetDefinition {
+            OpCode::AES => unimplemented!(),
+            OpCode::SHA256 => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Variable,
                 output_size: OutputSize(32),
             },
-            OPCODE::Blake2s => GadgetDefinition {
+            OpCode::Blake2s => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Variable,
                 output_size: OutputSize(32),
             },
-            OPCODE::HashToField => GadgetDefinition {
+            OpCode::HashToField => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Variable,
                 output_size: OutputSize(1),
             },
-            OPCODE::MerkleMembership => GadgetDefinition {
+            OpCode::MerkleMembership => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Variable,
                 output_size: OutputSize(1),
             },
-            OPCODE::SchnorrVerify => GadgetDefinition {
+            OpCode::SchnorrVerify => GadgetDefinition {
                 name: self.name().into(),
                 // XXX: input_size can be changed to fixed, once we hash
                 // the message before passing it to schnorr.
@@ -99,22 +98,22 @@ impl OPCODE {
                 input_size: InputSize::Variable,
                 output_size: OutputSize(1),
             },
-            OPCODE::Pedersen => GadgetDefinition {
+            OpCode::Pedersen => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Variable,
                 output_size: OutputSize(2),
             },
-            OPCODE::EcdsaSecp256k1 => GadgetDefinition {
+            OpCode::EcdsaSecp256k1 => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Variable,
                 output_size: OutputSize(1),
             },
-            OPCODE::FixedBaseScalarMul => GadgetDefinition {
+            OpCode::FixedBaseScalarMul => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Fixed(1),
                 output_size: OutputSize(2),
             },
-            OPCODE::InsertRegularMerkle => GadgetDefinition {
+            OpCode::InsertRegularMerkle => GadgetDefinition {
                 name: self.name().into(),
                 input_size: InputSize::Variable,
                 output_size: OutputSize(1),

--- a/crates/acvm/src/lib.rs
+++ b/crates/acvm/src/lib.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use acir::{
     circuit::{Circuit, Gate},
     native_types::Witness,
-    OPCODE,
+    OpCode,
 };
 
 // re-export acir
@@ -26,7 +26,7 @@ pub trait PartialWitnessGenerator {
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gates: Vec<Gate>,
-    ) -> Result<(), OPCODE>;
+    ) -> Result<(), OpCode>;
 }
 pub trait SmartContract {
     // Takes a verification  key and produces a smart contract

--- a/crates/aztec_backend/src/acvm_interop/pwg.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg.rs
@@ -19,7 +19,7 @@ impl PartialWitnessGenerator for Plonk {
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gates: Vec<acir::circuit::Gate>,
-    ) -> Result<(), acir::OPCODE> {
+    ) -> Result<(), acir::OpCode> {
         for gate in gates.into_iter() {
             match &gate {
                 Gate::Arithmetic(arith) => {

--- a/crates/aztec_backend/src/acvm_interop/pwg/gadget_call.rs
+++ b/crates/aztec_backend/src/acvm_interop/pwg/gadget_call.rs
@@ -1,6 +1,6 @@
 use super::merkle::{flatten_path, MerkleTree};
 use crate::barretenberg_rs::Barretenberg;
-use acvm::acir::{circuit::gate::GadgetCall, native_types::Witness, OPCODE};
+use acvm::acir::{circuit::gate::GadgetCall, native_types::Witness, OpCode};
 use acvm::pwg::{self, input_to_value};
 use acvm::FieldElement;
 use blake2::Blake2s;
@@ -16,15 +16,15 @@ impl GadgetCaller {
     pub fn solve_gadget_call(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gadget_call: &GadgetCall,
-    ) -> Result<(), OPCODE> {
+    ) -> Result<(), OpCode> {
         match gadget_call.name {
-            OPCODE::SHA256 => pwg::hash::sha256(initial_witness, gadget_call),
-            OPCODE::Blake2s => pwg::hash::blake2s(initial_witness, gadget_call),
-            OPCODE::EcdsaSecp256k1 => {
+            OpCode::SHA256 => pwg::hash::sha256(initial_witness, gadget_call),
+            OpCode::Blake2s => pwg::hash::blake2s(initial_witness, gadget_call),
+            OpCode::EcdsaSecp256k1 => {
                 pwg::signature::ecdsa::secp256k1_prehashed(initial_witness, gadget_call)
             }
-            OPCODE::AES => return Err(gadget_call.name),
-            OPCODE::MerkleMembership => {
+            OpCode::AES => return Err(gadget_call.name),
+            OpCode::MerkleMembership => {
                 const SHOULD_INSERT: bool = false;
 
                 let merkle_data =
@@ -42,7 +42,7 @@ impl GadgetCaller {
 
                 initial_witness.insert(gadget_call.outputs[0], result);
             }
-            OPCODE::InsertRegularMerkle => {
+            OpCode::InsertRegularMerkle => {
                 const SHOULD_INSERT: bool = true;
 
                 let merkle_data =
@@ -54,7 +54,7 @@ impl GadgetCaller {
 
                 initial_witness.insert(gadget_call.outputs[0], new_root);
             }
-            OPCODE::SchnorrVerify => {
+            OpCode::SchnorrVerify => {
                 // In barretenberg, if the signature fails, then the whole thing fails.
                 //
                 use std::convert::TryInto;
@@ -103,7 +103,7 @@ impl GadgetCaller {
 
                 initial_witness.insert(gadget_call.outputs[0], result);
             }
-            OPCODE::Pedersen => {
+            OpCode::Pedersen => {
                 let inputs_iter = gadget_call.inputs.iter();
 
                 let scalars: Vec<_> = inputs_iter
@@ -116,7 +116,7 @@ impl GadgetCaller {
                 initial_witness.insert(gadget_call.outputs[0], res_x);
                 initial_witness.insert(gadget_call.outputs[1], res_y);
             }
-            OPCODE::HashToField => {
+            OpCode::HashToField => {
                 // Deal with Blake2s -- XXX: It's not possible for pwg to know that it is Blake2s
                 // We need to get this method from the backend
                 let mut hasher = Blake2s::new();
@@ -143,7 +143,7 @@ impl GadgetCaller {
 
                 initial_witness.insert(gadget_call.outputs[0], reduced_res);
             }
-            OPCODE::FixedBaseScalarMul => {
+            OpCode::FixedBaseScalarMul => {
                 let scalar = initial_witness.get(&gadget_call.inputs[0].witness);
                 let scalar = match scalar {
                     None => panic!("cannot find witness assignment for {:?}", scalar),

--- a/crates/aztec_backend/src/serialiser/mod.rs
+++ b/crates/aztec_backend/src/serialiser/mod.rs
@@ -7,7 +7,7 @@ use crate::barretenberg_rs::composer::{
 };
 use acvm::acir::circuit::{Circuit, Gate};
 use acvm::acir::native_types::Arithmetic;
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use acvm::FieldElement;
 
 /// Converts an `IR` into the `StandardFormat` constraint system
@@ -59,7 +59,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
             }
             Gate::GadgetCall(gadget_call) => {
                 match gadget_call.name {
-                    OPCODE::SHA256 => {
+                    OpCode::SHA256 => {
                         let mut sha256_inputs: Vec<(i32, i32)> = Vec::new();
                         for input in gadget_call.inputs.iter() {
                             let witness_index = input.witness.witness_index() as i32;
@@ -86,7 +86,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         sha256_constraints.push(sha256_constraint);
                     }
-                    OPCODE::Blake2s => {
+                    OpCode::Blake2s => {
                         let mut blake2s_inputs: Vec<(i32, i32)> = Vec::new();
                         for input in gadget_call.inputs.iter() {
                             let witness_index = input.witness.witness_index() as i32;
@@ -113,7 +113,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         blake2s_constraints.push(blake2s_constraint);
                     }
-                    OPCODE::MerkleMembership => {
+                    OpCode::MerkleMembership => {
                         let mut inputs_iter = gadget_call.inputs.iter().peekable();
 
                         // root
@@ -165,7 +165,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
                         merkle_membership_constraints.push(constraint);
                     }
                     // copies merkle membership
-                    OPCODE::InsertRegularMerkle => {
+                    OpCode::InsertRegularMerkle => {
                         let mut inputs_iter = gadget_call.inputs.iter().peekable();
 
                         // root
@@ -216,7 +216,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         insert_merkle_constraints.push(constraint);
                     }
-                    OPCODE::SchnorrVerify => {
+                    OpCode::SchnorrVerify => {
                         let mut inputs_iter = gadget_call.inputs.iter().peekable();
 
                         // pub_key_x
@@ -266,8 +266,8 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         schnorr_constraints.push(constraint);
                     }
-                    OPCODE::AES => panic!("AES has not yet been implemented"),
-                    OPCODE::Pedersen => {
+                    OpCode::AES => panic!("AES has not yet been implemented"),
+                    OpCode::Pedersen => {
                         let mut inputs = Vec::new();
                         for scalar in gadget_call.inputs.iter() {
                             let scalar_index = scalar.witness.witness_index() as i32;
@@ -285,7 +285,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         pedersen_constraints.push(constraint);
                     }
-                    OPCODE::HashToField => {
+                    OpCode::HashToField => {
                         let mut hash_to_field_inputs: Vec<(i32, i32)> = Vec::new();
                         for input in gadget_call.inputs.iter() {
                             let witness_index = input.witness.witness_index() as i32;
@@ -304,7 +304,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         hash_to_field_constraints.push(hash_to_field_constraint);
                     }
-                    OPCODE::EcdsaSecp256k1 => {
+                    OpCode::EcdsaSecp256k1 => {
                         let mut inputs_iter = gadget_call.inputs.iter().peekable();
 
                         // public key x
@@ -356,7 +356,7 @@ pub fn serialise_circuit(circuit: &Circuit) -> ConstraintSystem {
 
                         ecdsa_secp256k1_constraints.push(constraint);
                     }
-                    OPCODE::FixedBaseScalarMul => {
+                    OpCode::FixedBaseScalarMul => {
                         assert_eq!(gadget_call.inputs.len(), 1);
                         let scalar = gadget_call.inputs[0].witness.witness_index() as i32;
 

--- a/crates/noir_field/src/generic_ark.rs
+++ b/crates/noir_field/src/generic_ark.rs
@@ -191,6 +191,10 @@ impl<F: PrimeField> FieldElement<F> {
         FieldElement(inv)
     }
 
+    pub fn try_inverse(mut self) -> Option<Self> {
+        self.0.inverse_in_place().map(|f| FieldElement(*f))
+    }
+
     // XXX: This method is used while this field element
     // implementation is not generic.
     pub fn into_repr(self) -> F {

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -170,7 +170,6 @@ impl<'a> Evaluator<'a> {
                 let err = RuntimeErrorKind::Unimplemented("The Or operation is currently not implemented. First implement in Barretenberg.".to_owned());
                 Err(err)
             }
-            HirBinaryOpKind::MemberAccess => todo!("Member access for structs is unimplemented in the noir backend"),
         }.map_err(|kind|kind.add_span(op.span))
     }
 

--- a/crates/noirc_evaluator/src/low_level_function_impl/blake2s.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/blake2s.rs
@@ -3,7 +3,7 @@ use crate::low_level_function_impl::object_to_wit_bits;
 use crate::object::{Array, Integer, Object};
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 use super::RuntimeError;
@@ -13,8 +13,8 @@ use super::RuntimeError;
 pub struct Blake2sGadget;
 
 impl GadgetCaller for Blake2sGadget {
-    fn name() -> OPCODE {
-        OPCODE::Blake2s
+    fn name() -> OpCode {
+        OpCode::Blake2s
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/ecdsa_secp256k1.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/ecdsa_secp256k1.rs
@@ -3,7 +3,7 @@ use crate::low_level_function_impl::object_to_wit_bits;
 use crate::object::{Array, Object};
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 use super::RuntimeError;
@@ -11,8 +11,8 @@ use super::RuntimeError;
 pub struct EcdsaSecp256k1Gadget;
 
 impl GadgetCaller for EcdsaSecp256k1Gadget {
-    fn name() -> OPCODE {
-        OPCODE::EcdsaSecp256k1
+    fn name() -> OpCode {
+        OpCode::EcdsaSecp256k1
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/fixed_based_scalar_mul.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/fixed_based_scalar_mul.rs
@@ -3,7 +3,7 @@ use crate::low_level_function_impl::object_to_wit_bits;
 use crate::object::{Array, Object};
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 use super::RuntimeError;
@@ -11,8 +11,8 @@ use super::RuntimeError;
 pub struct FixedBaseScalarMulGadget;
 
 impl GadgetCaller for FixedBaseScalarMulGadget {
-    fn name() -> OPCODE {
-        OPCODE::FixedBaseScalarMul
+    fn name() -> OpCode {
+        OpCode::FixedBaseScalarMul
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/hash_to_field.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/hash_to_field.rs
@@ -2,7 +2,7 @@ use super::{object_to_wit_bits, GadgetCaller};
 use crate::object::{Array, Object};
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 use super::RuntimeError;
@@ -10,8 +10,8 @@ use super::RuntimeError;
 pub struct HashToFieldGadget;
 
 impl GadgetCaller for HashToFieldGadget {
-    fn name() -> OPCODE {
-        OPCODE::HashToField
+    fn name() -> OpCode {
+        OpCode::HashToField
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/insert_regular_merkle.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/insert_regular_merkle.rs
@@ -4,14 +4,14 @@ use super::RuntimeError;
 use crate::object::Object;
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 pub struct InsertRegularMerkleGadget;
 
 impl GadgetCaller for InsertRegularMerkleGadget {
-    fn name() -> OPCODE {
-        OPCODE::InsertRegularMerkle
+    fn name() -> OpCode {
+        OpCode::InsertRegularMerkle
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/merkle_membership.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/merkle_membership.rs
@@ -3,15 +3,15 @@ use super::RuntimeError;
 use crate::object::Object;
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use acvm::FieldElement;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 pub struct MerkleMembershipGadget;
 
 impl GadgetCaller for MerkleMembershipGadget {
-    fn name() -> OPCODE {
-        OPCODE::MerkleMembership
+    fn name() -> OpCode {
+        OpCode::MerkleMembership
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/mod.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/mod.rs
@@ -16,7 +16,7 @@ mod sha256;
 
 use super::RuntimeErrorKind;
 use acvm::acir::circuit::gate::GadgetInput;
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use acvm::FieldElement;
 use blake2s::Blake2sGadget;
 use ecdsa_secp256k1::EcdsaSecp256k1Gadget;
@@ -31,7 +31,7 @@ use schnorr::SchnorrVerifyGadget;
 use sha256::Sha256Gadget;
 
 pub trait GadgetCaller {
-    fn name() -> acvm::acir::OPCODE;
+    fn name() -> acvm::acir::OpCode;
     fn call(
         evaluator: &mut Evaluator,
         env: &mut Environment,
@@ -46,7 +46,7 @@ pub fn call_low_level(
     call_expr_span: (HirCallExpression, Span),
 ) -> Result<Object, RuntimeError> {
     let (call_expr, span) = call_expr_span;
-    let func = match OPCODE::lookup(opcode_name) {
+    let func = match OpCode::lookup(opcode_name) {
         None => {
             let message = format!(
                 "cannot find a low level opcode with the name {} in the IR",
@@ -60,15 +60,15 @@ pub fn call_low_level(
     };
 
     match func {
-        OPCODE::SHA256 => Sha256Gadget::call(evaluator, env, call_expr),
-        OPCODE::MerkleMembership => MerkleMembershipGadget::call(evaluator, env, call_expr),
-        OPCODE::SchnorrVerify => SchnorrVerifyGadget::call(evaluator, env, call_expr),
-        OPCODE::Blake2s => Blake2sGadget::call(evaluator, env, call_expr),
-        OPCODE::Pedersen => PedersenGadget::call(evaluator, env, call_expr),
-        OPCODE::EcdsaSecp256k1 => EcdsaSecp256k1Gadget::call(evaluator, env, call_expr),
-        OPCODE::HashToField => HashToFieldGadget::call(evaluator, env, call_expr),
-        OPCODE::FixedBaseScalarMul => FixedBaseScalarMulGadget::call(evaluator, env, call_expr),
-        OPCODE::InsertRegularMerkle => InsertRegularMerkleGadget::call(evaluator, env, call_expr),
+        OpCode::SHA256 => Sha256Gadget::call(evaluator, env, call_expr),
+        OpCode::MerkleMembership => MerkleMembershipGadget::call(evaluator, env, call_expr),
+        OpCode::SchnorrVerify => SchnorrVerifyGadget::call(evaluator, env, call_expr),
+        OpCode::Blake2s => Blake2sGadget::call(evaluator, env, call_expr),
+        OpCode::Pedersen => PedersenGadget::call(evaluator, env, call_expr),
+        OpCode::EcdsaSecp256k1 => EcdsaSecp256k1Gadget::call(evaluator, env, call_expr),
+        OpCode::HashToField => HashToFieldGadget::call(evaluator, env, call_expr),
+        OpCode::FixedBaseScalarMul => FixedBaseScalarMulGadget::call(evaluator, env, call_expr),
+        OpCode::InsertRegularMerkle => InsertRegularMerkleGadget::call(evaluator, env, call_expr),
         k => {
             let message = format!("The OPCODE {} exists, however, currently the compiler does not have a concrete implementation for it", k);
             Err(RuntimeErrorKind::UnstructuredError { message }.add_span(span))

--- a/crates/noirc_evaluator/src/low_level_function_impl/pedersen.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/pedersen.rs
@@ -4,15 +4,15 @@ use crate::low_level_function_impl::object_to_wit_bits;
 use crate::object::{Array, Object};
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use acvm::FieldElement;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 pub struct PedersenGadget;
 
 impl GadgetCaller for PedersenGadget {
-    fn name() -> OPCODE {
-        OPCODE::Pedersen
+    fn name() -> OpCode {
+        OpCode::Pedersen
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/schnorr.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/schnorr.rs
@@ -4,15 +4,15 @@ use crate::low_level_function_impl::object_to_wit_bits;
 use crate::object::{Array, Object};
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use acvm::FieldElement;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 pub struct SchnorrVerifyGadget;
 
 impl GadgetCaller for SchnorrVerifyGadget {
-    fn name() -> OPCODE {
-        OPCODE::SchnorrVerify
+    fn name() -> OpCode {
+        OpCode::SchnorrVerify
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/low_level_function_impl/sha256.rs
+++ b/crates/noirc_evaluator/src/low_level_function_impl/sha256.rs
@@ -2,7 +2,7 @@ use super::{object_to_wit_bits, GadgetCaller};
 use crate::object::{Array, Integer, Object};
 use crate::{Environment, Evaluator};
 use acvm::acir::circuit::gate::{GadgetCall, GadgetInput, Gate};
-use acvm::acir::OPCODE;
+use acvm::acir::OpCode;
 use noirc_frontend::hir_def::expr::HirCallExpression;
 
 use super::RuntimeError;
@@ -10,8 +10,8 @@ use super::RuntimeError;
 pub struct Sha256Gadget;
 
 impl GadgetCaller for Sha256Gadget {
-    fn name() -> OPCODE {
-        OPCODE::SHA256
+    fn name() -> OpCode {
+        OpCode::SHA256
     }
 
     fn call(

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -195,10 +195,14 @@ impl Acir {
                 InternalVar::from(evaluate_xor(l_c, r_c, ins.res_type.bits(), evaluator))
             }
             Operation::Cast => l_c.clone(),
-            Operation::Ass | Operation::Jne | Operation::Jeq | Operation::Jmp | Operation::Phi => {
+            Operation::Assign
+            | Operation::Jne
+            | Operation::Jeq
+            | Operation::Jmp
+            | Operation::Phi => {
                 todo!("invalid instruction");
             }
-            Operation::Trunc => {
+            Operation::Truncate => {
                 assert!(is_const(&r_c.expression));
                 InternalVar::from(evaluate_truncate(
                     l_c,

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -1,6 +1,6 @@
 use super::{
     context::SsaContext,
-    node::{self, NodeId},
+    node::{self, Instruction, NodeId, NodeObj, Operation},
 };
 use std::collections::{HashMap, VecDeque};
 
@@ -67,11 +67,13 @@ impl BasicBlock {
 
     pub fn get_result_instruction(&self, call_id: NodeId, ctx: &SsaContext) -> Option<NodeId> {
         self.instructions.iter().copied().find(|i| match ctx[*i] {
-            node::NodeObj::Instr(node::Instruction {
-                operator: node::Operation::Res,
-                lhs,
+            NodeObj::Instr(Instruction {
+                operator:
+                    Operation::Results {
+                        call_instruction, ..
+                    },
                 ..
-            }) => lhs == call_id,
+            }) => call_instruction == call_id,
             _ => false,
         })
     }
@@ -83,10 +85,7 @@ pub fn create_first_block(ctx: &mut SsaContext) {
     let first_id = first_block.id;
     ctx.first_block = first_id;
     ctx.current_block = first_id;
-    ctx.new_instruction(
-        node::Operation::Nop,
-        node::ObjectType::NotAnObject,
-    );
+    ctx.new_instruction(node::Operation::Nop, node::ObjectType::NotAnObject);
 }
 
 //Creates a new sealed block (i.e whose predecessors are known)
@@ -104,10 +103,7 @@ pub fn new_sealed_block(ctx: &mut SsaContext, kind: BlockType) -> BlockId {
     let cb = ctx.get_current_block_mut();
     cb.left = Some(new_id);
     ctx.current_block = new_id;
-    ctx.new_instruction(
-        node::Operation::Nop,
-        node::ObjectType::NotAnObject,
-    );
+    ctx.new_instruction(node::Operation::Nop, node::ObjectType::NotAnObject);
     new_id
 }
 
@@ -127,10 +123,7 @@ pub fn new_unsealed_block(ctx: &mut SsaContext, kind: BlockType, left: bool) -> 
     }
 
     ctx.current_block = new_idx;
-    ctx.new_instruction(
-        node::Operation::Nop,
-        node::ObjectType::NotAnObject,
-    );
+    ctx.new_instruction(node::Operation::Nop, node::ObjectType::NotAnObject);
     new_idx
 }
 

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -73,8 +73,6 @@ pub fn create_first_block(ctx: &mut SsaContext) {
     ctx.first_block = first_id;
     ctx.current_block = first_id;
     ctx.new_instruction(
-        NodeId::dummy(),
-        NodeId::dummy(),
         node::Operation::Nop,
         node::ObjectType::NotAnObject,
     );
@@ -96,8 +94,6 @@ pub fn new_sealed_block(ctx: &mut SsaContext, kind: BlockType) -> BlockId {
     cb.left = Some(new_id);
     ctx.current_block = new_id;
     ctx.new_instruction(
-        NodeId::dummy(),
-        NodeId::dummy(),
         node::Operation::Nop,
         node::ObjectType::NotAnObject,
     );
@@ -121,8 +117,6 @@ pub fn new_unsealed_block(ctx: &mut SsaContext, kind: BlockType, left: bool) -> 
 
     ctx.current_block = new_idx;
     ctx.new_instruction(
-        NodeId::dummy(),
-        NodeId::dummy(),
         node::Operation::Nop,
         node::ObjectType::NotAnObject,
     );

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -156,10 +156,10 @@ impl<'a> IRGenerator<'a> {
         //n.b. we do not verify rhs type as it should have been handled by the type checker.
 
         // Get the opcode from the infix operator
-        let opcode = node::to_operation(op.kind, ltype);
+        let opcode = node::to_binop(op.kind, ltype);
         // Get the result type from the opcode
         let optype = self.context.get_result_type(opcode, ltype);
-        if opcode == node::Operation::Ass {
+        if opcode == node::Operation::Assign {
             if let Some(lhs_ins) = self.context.try_get_mut_instruction(lhs) {
                 if let node::Operation::Load(array) = lhs_ins.operator {
                     //make it a store rhs
@@ -376,7 +376,7 @@ impl<'a> IRGenerator<'a> {
         //Assign rhs to lhs
         let result = self
             .context
-            .new_instruction(id, value_id, node::Operation::Ass, obj_type);
+            .new_instruction(id, value_id, node::Operation::Assign, obj_type);
         //This new variable should not be available in outer scopes.
         let cb = self.context.get_current_block_mut();
         cb.update_variable(id, result); //update the value array. n.b. we should not update the name as it is the first assignment (let)
@@ -426,7 +426,7 @@ impl<'a> IRGenerator<'a> {
                 let result = self.context.new_instruction(
                     new_var_id,
                     rhs_id,
-                    node::Operation::Ass,
+                    node::Operation::Assign,
                     r_type,
                 );
 
@@ -708,7 +708,7 @@ impl<'a> IRGenerator<'a> {
         let iter_type = self.context.get_object_type(iter_id);
         let iter_ass =
             self.context
-                .new_instruction(iter_id, start_idx, node::Operation::Ass, iter_type);
+                .new_instruction(iter_id, start_idx, node::Operation::Assign, iter_type);
         //We map the iterator to start_idx so that when we seal the join block, we will get the corrdect value.
         self.update_variable_id(iter_id, iter_ass, start_idx);
 

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -1,6 +1,5 @@
-use super::block::BlockId;
 use super::context::SsaContext;
-use super::node::{ConstrainOp, Instruction, Node, NodeId, Operation, Variable};
+use super::node::{Binary, BinaryOp, ConstrainOp, Node, NodeId, Operation, Variable, ObjectType};
 use super::{block, node, ssa_form};
 use std::collections::HashMap;
 
@@ -112,7 +111,7 @@ impl<'a> IRGenerator<'a> {
                 node::Variable {
                     id: NodeId::dummy(),
                     name: ident_name.clone(),
-                    obj_type: node::ObjectType::Pointer(array_index),
+                    obj_type: ObjectType::Pointer(array_index),
                     root: None,
                     def: ident_def,
                     witness: None,
@@ -120,7 +119,7 @@ impl<'a> IRGenerator<'a> {
                 }
             }
             _ => {
-                let obj_type = node::ObjectType::get_type_from_object(&obj);
+                let obj_type = ObjectType::get_type_from_object(&obj);
                 //new variable - should be in a let statement? The let statement should set the type
                 node::Variable {
                     id: NodeId::dummy(),
@@ -146,30 +145,26 @@ impl<'a> IRGenerator<'a> {
         &self.context.context.def_interner
     }
 
-    fn evaluate_infix_expression(
-        &mut self,
-        lhs: NodeId,
-        rhs: NodeId,
-        op: HirBinaryOp,
-    ) -> Result<NodeId, RuntimeError> {
+    fn evaluate_infix_expression(&mut self, lhs: NodeId, rhs: NodeId, op: HirBinaryOp) -> NodeId {
         let ltype = self.context.get_object_type(lhs);
         //n.b. we do not verify rhs type as it should have been handled by the type checker.
 
-        // Get the opcode from the infix operator
-        let opcode = node::to_binop(op.kind, ltype);
-        // Get the result type from the opcode
-        let optype = self.context.get_result_type(opcode, ltype);
-        if opcode == node::Operation::Assign {
-            if let Some(lhs_ins) = self.context.try_get_mut_instruction(lhs) {
-                if let node::Operation::Load(array) = lhs_ins.operator {
-                    //make it a store rhs
-                    lhs_ins.operator = node::Operation::Store(array);
-                    lhs_ins.lhs = rhs;
-                    return Ok(lhs);
-                }
+        if let (HirBinaryOpKind::Assign, Some(lhs_ins)) =
+            (op.kind, self.context.try_get_mut_instruction(lhs))
+        {
+            if let Operation::Load { array, index } = lhs_ins.operator {
+                //make it a store rhs
+                lhs_ins.operator = Operation::Store { array, index, value: rhs };
+                return lhs;
             }
         }
-        Ok(self.context.new_instruction(lhs, rhs, opcode, optype))
+
+        // Get the opcode from the infix operator
+        let binary = Binary::from_hir(op.kind, ltype, lhs, rhs);
+        let opcode = Operation::Binary(binary);
+
+        let optype = self.context.get_result_type(opcode, ltype);
+        self.context.new_instruction(opcode, optype)
     }
 
     pub fn evaluate_statement(
@@ -224,7 +219,7 @@ impl<'a> IRGenerator<'a> {
         env: &mut Environment,
     ) -> NodeId {
         let obj = env.get(&var_name);
-        let obj_type = node::ObjectType::get_type_from_object(&obj);
+        let obj_type = ObjectType::get_type_from_object(&obj);
         let new_var = node::Variable {
             id: NodeId::dummy(),
             obj_type,
@@ -256,16 +251,12 @@ impl<'a> IRGenerator<'a> {
             // HirBinaryOpKind::Multiply => binary_op::handle_mul_op(lhs, rhs, self),
             // HirBinaryOpKind::Divide => binary_op::handle_div_op(lhs, rhs, self),
             HirBinaryOpKind::NotEqual => Ok(self.context.new_instruction(
-                lhs,
-                rhs,
-                node::Operation::Constrain(ConstrainOp::Neq),
-                node::ObjectType::NotAnObject,
+                Operation::binary(BinaryOp::Constrain(ConstrainOp::Neq), lhs, rhs),
+                ObjectType::NotAnObject,
             )),
             HirBinaryOpKind::Equal => Ok(self.context.new_instruction(
-                lhs,
-                rhs,
-                node::Operation::Constrain(ConstrainOp::Eq),
-                node::ObjectType::NotAnObject,
+                Operation::binary(BinaryOp::Constrain(ConstrainOp::Eq), lhs, rhs),
+                ObjectType::NotAnObject,
             )),
             HirBinaryOpKind::And => todo!(),
             // HirBinaryOpKind::Xor => binary_op::handle_xor_op(lhs, rhs, self),
@@ -357,7 +348,7 @@ impl<'a> IRGenerator<'a> {
     ) -> Value {
         let obj_type = typ.into();
 
-        if matches!(obj_type, node::ObjectType::Pointer(_)) {
+        if matches!(obj_type, ObjectType::Pointer(_)) {
             if let Ok(rhs_mut) = self.context.get_mut_variable(value_id) {
                 rhs_mut.def = ident_def;
                 rhs_mut.name = variable_name;
@@ -374,9 +365,8 @@ impl<'a> IRGenerator<'a> {
         let id = self.context.add_variable(new_var, None);
 
         //Assign rhs to lhs
-        let result = self
-            .context
-            .new_instruction(id, value_id, node::Operation::Assign, obj_type);
+        let result = self.context.new_binary_instruction(BinaryOp::Assign, id, value_id, obj_type);
+
         //This new variable should not be available in outer scopes.
         let cb = self.context.get_current_block_mut();
         cb.update_variable(id, result); //update the value array. n.b. we should not update the name as it is the first assignment (let)
@@ -423,12 +413,8 @@ impl<'a> IRGenerator<'a> {
 
                 let rhs = &self.context[rhs_id];
                 let r_type = rhs.get_type();
-                let result = self.context.new_instruction(
-                    new_var_id,
-                    rhs_id,
-                    node::Operation::Assign,
-                    r_type,
-                );
+                let operation = Operation::binary(BinaryOp::Assign, new_var_id, rhs_id);
+                let result = self.context.new_instruction(operation, rhs.get_type());
 
                 self.update_variable_id(ls_root, new_var_id, result); //update the name and the value map
             }
@@ -488,13 +474,18 @@ impl<'a> IRGenerator<'a> {
                 let array_adr = array.adr;
                 for (pos, object) in elements.into_iter().enumerate() {
                     //array.witness.push(node::get_witness_from_object(&object));
-                    let lhs_adr = self.context.get_or_create_const(FieldElement::from((array_adr + pos as u32) as u128), node::ObjectType::Unsigned(32));
-                    self.context.new_instruction(object, lhs_adr, node::Operation::Store(array_index), element_type);
+                    let lhs_adr = self.context.get_or_create_const(FieldElement::from((array_adr + pos as u32) as u128), ObjectType::Unsigned(32));
+                    let store = Operation::Store {
+                        array: array_index,
+                        index: lhs_adr,
+                        value: object,
+                    };
+                    self.context.new_instruction(store, element_type);
                 }
                 //Finally, we create a variable pointing to this MemArray
                 let new_var = node::Variable {
                     id: NodeId::dummy(),
-                    obj_type : node::ObjectType::Pointer(array_index),
+                    obj_type : ObjectType::Pointer(array_index),
                     name: String::new(),
                     root: None,
                     def: None,
@@ -513,14 +504,13 @@ impl<'a> IRGenerator<'a> {
                 // for e.g. struct == struct in the future
                 let lhs = self.expression_to_object(env, &infx.lhs)?.unwrap_id();
                 let rhs = self.expression_to_object(env, &infx.rhs)?.unwrap_id();
-                self.evaluate_infix_expression(lhs, rhs, infx.operator)
-                    .map(Value::Single)
+                Ok(Value::Single(self.evaluate_infix_expression(lhs, rhs, infx.operator)))
             },
             HirExpression::Cast(cast_expr) => {
                 let lhs = self.expression_to_object(env, &cast_expr.lhs)?.unwrap_id();
                 let rtype = cast_expr.r#type.into();
 
-                Ok(Value::Single(self.context.new_instruction(lhs, lhs, Operation::Cast, rtype)))
+                Ok(Value::Single(self.context.new_instruction(Operation::Cast(lhs), rtype)))
 
                 //We should generate a cast instruction and handle properly type conversion:
                 // unsigned integer to field ; ok, just checks if bit size over FieldElement::max_num_bits()
@@ -541,24 +531,21 @@ impl<'a> IRGenerator<'a> {
                 let arr_type = self.def_interner().id_type(arr_def.unwrap());
                 let o_type = arr_type.into();
                 let mut array_index = self.context.mem.arrays.len() as u32;
-                let array = if let Some(moi) = self.context.mem.find_array(&arr_def) {
-                    array_index= self.context.mem.get_array_index(moi).unwrap();
-                    moi
-                }
-                 else if let Some(Value::Single(pointer)) = self.find_variable(arr_def) {
+
+                let (array, array_index) = if let Some(array) = self.context.mem.find_array(&arr_def) {
+                    (array, self.context.mem.get_array_index(array).unwrap())
+                } else if let Some(Value::Single(pointer)) = self.find_variable(arr_def) {
                     match self.context.get_object_type(*pointer) {
-                        node::ObjectType::Pointer(a_id) => {
-                            array_index = a_id;
-                            &self.context.mem.arrays[a_id as usize]
-                        }
+                        ObjectType::Pointer(a_id) => (&self.context.mem.arrays[a_id as usize], a_id),
                         _ => unreachable!(),
                     }
-                 }
-                else {
+                } else {
                     let arr = env.get_array(&arr_name).map_err(|kind|kind.add_span(ident_span)).unwrap();
-                    self.context.mem.create_array_from_object(&arr, arr_def.unwrap(), o_type, &arr_name)
+                    let array = self.context.mem.create_array_from_object(&arr, arr_def.unwrap(), o_type, &arr_name);
+                    let index = self.context.mem.arrays.len() as u32;
+                    (array, index)
                 };
-                //let array = self.mem.get_or_create_array(&arr, arr_def.unwrap(), o_type, arr_name);
+
                 let address = array.adr;
 
                 // Evaluate the index expression
@@ -566,8 +553,10 @@ impl<'a> IRGenerator<'a> {
 
                 let index_type = self.context.get_object_type(index_as_obj);
                 let base_adr = self.context.get_or_create_const(FieldElement::from(address as i128), index_type);
-                let adr_id = self.context.new_instruction(base_adr, index_as_obj, node::Operation::Add, index_type);
-                Ok(Value::Single(self.context.new_instruction(adr_id, adr_id, node::Operation::Load(array_index), o_type)))
+                let adr_id = self.context.new_instruction(Operation::binary(BinaryOp::Add, base_adr, index_as_obj), index_type);
+
+                let load = Operation::Load { array: array_index, index: adr_id };
+                Ok(Value::Single(self.context.new_instruction(load, o_type)))
             },
             HirExpression::Call(call_expr) => {
                 let func_meta = self.def_interner().function_meta(&call_expr.func_id);
@@ -706,34 +695,33 @@ impl<'a> IRGenerator<'a> {
         let iter_var = self.context.get_mut_variable(iter_id).unwrap();
         iter_var.obj_type = int_type.into();
         let iter_type = self.context.get_object_type(iter_id);
-        let iter_ass =
-            self.context
-                .new_instruction(iter_id, start_idx, node::Operation::Assign, iter_type);
+
+        let assign = Operation::binary(BinaryOp::Assign, iter_id, start_idx);
+        let iter_ass = self.context.new_instruction(assign, iter_type);
+
         //We map the iterator to start_idx so that when we seal the join block, we will get the corrdect value.
         self.update_variable_id(iter_id, iter_ass, start_idx);
 
         //join block
-        let join_idx =
-            block::new_unsealed_block(&mut self.context, block::BlockType::ForJoin, true);
+        let join_idx = block::new_unsealed_block(&mut self.context, block::BlockType::ForJoin, true);
         let exit_id = block::new_sealed_block(&mut self.context, block::BlockType::Normal);
         self.context.current_block = join_idx;
+
         //should parse a for_expr.condition statement that should evaluate to bool, but
         //we only supports i=start;i!=end for now
         //we generate the phi for the iterator because the iterator is manually created
-        let phi = self.generate_empty_phi(join_idx, iter_id);
+        let phi = self.context.generate_empty_phi(join_idx, iter_id);
         self.update_variable_id(iter_id, iter_id, phi); //is it still needed?
-        let cond =
-            self.context
-                .new_instruction(phi, end_idx, Operation::Ne, node::ObjectType::Boolean);
-        let to_fix = self.context.new_instruction(
-            cond,
-            NodeId::dummy(),
-            node::Operation::Jeq,
-            node::ObjectType::NotAnObject,
-        );
+
+        let notequal = Operation::binary(BinaryOp::Ne, phi, end_idx);
+        let cond = self.context.new_instruction(notequal, ObjectType::Boolean);
+
+        let to_fix = self.context.new_instruction(Operation::Nop, ObjectType::NotAnObject);
 
         //Body
         let body_id = block::new_sealed_block(&mut self.context, block::BlockType::Normal);
+        self.context.try_get_mut_instruction(to_fix).unwrap().operator = Operation::Jeq(cond, body_id);
+
         let block = match self.def_interner().expression(&for_expr.block) {
             HirExpression::Block(block_expr) => block_expr,
             _ => panic!("ice: expected a block expression"),
@@ -749,9 +737,10 @@ impl<'a> IRGenerator<'a> {
         let one = self
             .context
             .get_or_create_const(FieldElement::one(), iter_type);
-        let incr = self
-            .context
-            .new_instruction(phi, one, node::Operation::Add, iter_type);
+
+        let incr_op = Operation::binary(BinaryOp::Add, phi, one);
+        let incr = self.context.new_instruction(incr_op, iter_type);
+
         let cur_block_id = self.context.current_block; //It should be the body block, except if the body has CFG statements
         let cur_block = &mut self.context[cur_block_id];
         cur_block.update_variable(iter_id, incr);
@@ -760,13 +749,10 @@ impl<'a> IRGenerator<'a> {
         cur_block.left = Some(join_idx);
         let join_mut = &mut self.context[join_idx];
         join_mut.predecessor.push(cur_block_id);
+
         //jump back to join
-        self.context.new_instruction(
-            NodeId::dummy(),
-            self.context[join_idx].get_first_instruction(),
-            node::Operation::Jmp,
-            node::ObjectType::NotAnObject,
-        );
+        self.context.new_instruction(Operation::Jmp(join_idx), ObjectType::NotAnObject);
+
         //seal join
         ssa_form::seal_block(&mut self.context, join_idx);
 
@@ -775,24 +761,6 @@ impl<'a> IRGenerator<'a> {
         let exit_first = self.context.get_current_block().get_first_instruction();
         block::link_with_target(&mut self.context, join_idx, Some(exit_id), Some(body_id));
         let first_instruction = self.context[body_id].get_first_instruction();
-        self.context.try_get_mut_instruction(to_fix).unwrap().rhs = first_instruction;
         Ok(Value::Single(exit_first)) //TODO what should we return???
-    }
-
-    pub fn generate_empty_phi(&mut self, target_block: BlockId, root: NodeId) -> NodeId {
-        //Ensure there is not already a phi for the variable (n.b. probably not usefull)
-        for i in &self.context[target_block].instructions {
-            if let Some(ins) = self.context.try_get_instruction(*i) {
-                if ins.operator == node::Operation::Phi && ins.rhs == root {
-                    return *i;
-                }
-            }
-        }
-
-        let v_type = self.context.get_object_type(root);
-        let new_phi = Instruction::new(Operation::Phi, root, root, v_type, Some(target_block));
-        let phi_id = self.context.add_instruction(new_phi);
-        self.context[target_block].instructions.insert(1, phi_id);
-        phi_id
     }
 }

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -95,7 +95,9 @@ impl<'a> SsaContext<'a> {
         match op {
             Operation::Binary(binary) => self.binary_to_string(binary),
             Operation::Cast(value) => format!("cast {}", self.node_to_string(*value)),
-            Operation::Truncate { value, bit_size } => format!("truncate {}, bitsize = {}", self.node_to_string(*value), bit_size),
+            Operation::Truncate { value, bit_size, max_bit_size } => {
+                format!("truncate {}, bitsize = {}, max bitsize = {}", self.node_to_string(*value), bit_size, max_bit_size)
+            }
             Operation::Not(v) => format!("not {}", self.node_to_string(*v)),
             Operation::Jne(v, b) => format!("jne {}, {:?}", self.node_to_string(*v), b),
             Operation::Jeq(v, b) => format!("jeq {}, {:?}", self.node_to_string(*v), b),
@@ -108,7 +110,9 @@ impl<'a> SsaContext<'a> {
                 s
             }
             Operation::Load { array, index } => format!("load array {}, index {}", array, self.node_to_string(*index)),
-            Operation::Store { array, index, value } => format!("store array {}, index {}, value {}", array, self.node_to_string(*index), self.node_to_string(*value)),
+            Operation::Store { array, index, value } => {
+                format!("store array {}, index {}, value {}", array, self.node_to_string(*index), self.node_to_string(*value))
+            }
             Operation::Intrinsic(opcode) => format!("intrinsic {}", opcode),
             Operation::Nop => format!("nop"),
         }

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -292,7 +292,7 @@ impl<'a> SsaContext<'a> {
             | Operation::Constrain(_)
             | Operation::Store(_) => ObjectType::NotAnObject,
             Operation::Load(adr) => self.mem.arrays[adr as usize].element_type,
-            Operation::Cast | Operation::Trunc => unreachable!("cannot determine result type"),
+            Operation::Cast | Operation::Truncate => unreachable!("cannot determine result type"),
             _ => lhs_type,
         }
     }

--- a/crates/noirc_evaluator/src/ssa/flatten.rs
+++ b/crates/noirc_evaluator/src/ssa/flatten.rs
@@ -75,7 +75,7 @@ pub fn unroll_std_block(
                     i.operator, new_left, new_right, i.res_type, None, //TODO to fix later
                 );
                 match i.operator {
-                    Operation::Ass => {
+                    Operation::Assign => {
                         unreachable!("unsupported instruction type when unrolling: assign");
                         //To support assignments, we should create a new variable and updates the eval_map with it
                         //however assignments should have already been removed by copy propagation.

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -2,10 +2,10 @@ use super::{
     block::BlockId,
     //block,
     context::SsaContext,
-    node::{self, Instruction, Node, NodeId, NodeObj, Operation, ObjectType},
+    node::{self, Instruction, Node, NodeId, NodeObj, ObjectType, Operation},
     optim,
 };
-use acvm::{FieldElement, acir::OpCode};
+use acvm::{acir::OpCode, FieldElement};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 use std::convert::TryInto;
@@ -273,10 +273,7 @@ pub fn block_overflow(
     for mut ins in instructions {
         if matches!(
             ins.operator,
-            Operation::Nop
-                | Operation::Call(_)
-                | Operation::Res
-                | Operation::Ret
+            Operation::Nop | Operation::Call(_) | Operation::Res | Operation::Ret
         ) {
             //For now we skip completely functions from overflow; that means arguments are NOT truncated.
             //The reasoning is that this is handled by doing the overflow strategy after the function has been inlined
@@ -602,9 +599,7 @@ pub fn get_max_value(ins: &Instruction, lhs_max: BigUint, rhs_max: BigUint) -> B
                 | OpCode::Pedersen
                 | OpCode::FixedBaseScalarMul
                 | OpCode::ToBits => BigUint::zero(), //pointers do not overflow
-                OpCode::SchnorrVerify | OpCode::EcdsaSecp256k1 => {
-                    BigUint::one()
-                } //verify returns 0 or 1
+                OpCode::SchnorrVerify | OpCode::EcdsaSecp256k1 => BigUint::one(), //verify returns 0 or 1
                 _ => todo!(),
             }
         }

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -119,7 +119,7 @@ pub fn truncate(
         );
         //Create a new truncate instruction '(idx): obj trunc bit_size'
         //set current value of obj to idx
-        let mut i = Instruction::new(Operation::Trunc, obj_id, rhs_bitsize, obj_type, None);
+        let mut i = Instruction::new(Operation::Truncate, obj_id, rhs_bitsize, obj_type, None);
         if i.res_name.ends_with("_t") {
             //TODO we should use %t so that we can check for this substring (% is not a valid char for a variable name) in the name and then write name%t[number+1]
         }
@@ -347,7 +347,7 @@ pub fn block_overflow(
                     update_instruction = true;
                     trunc_size = FieldElement::from(ins.res_type.bits() as i128);
                     let mut mod_ins = Instruction::new(
-                        node::Operation::Trunc,
+                        node::Operation::Truncate,
                         l_id,
                         l_id,
                         ins.res_type,
@@ -514,12 +514,12 @@ pub fn get_max_value(ins: &Instruction, lhs_max: BigUint, rhs_max: BigUint) -> B
             let type_max = ins.res_type.max_size();
             BigUint::min(lhs_max, type_max)
         }
-        Operation::Trunc => BigUint::min(
+        Operation::Truncate => BigUint::min(
             lhs_max,
             BigUint::from(2_u32).pow(rhs_max.try_into().unwrap()) - BigUint::from(1_u32),
         ),
         //'a = b': a and b must be of same type.
-        Operation::Ass => rhs_max,
+        Operation::Assign => rhs_max,
         Operation::Nop | Operation::Jne | Operation::Jeq | Operation::Jmp => todo!(),
         Operation::Phi => BigUint::max(lhs_max, rhs_max), //TODO operands are in phi_arguments, not lhs/rhs!!
         Operation::Constrain(_) => BigUint::zero(),       //min(lhs_max, rhs_max),
@@ -529,9 +529,9 @@ pub fn get_max_value(ins: &Instruction, lhs_max: BigUint, rhs_max: BigUint) -> B
         Operation::Store(_) => BigUint::from(0_u32),
         Operation::Intrinsic(opcode) => {
             match opcode {
-                acvm::acir::OPCODE::SHA256
-                | acvm::acir::OPCODE::Blake2s
-                | acvm::acir::OPCODE::Pedersen => BigUint::zero(), //pointers do not overflow
+                acvm::acir::OpCode::SHA256
+                | acvm::acir::OpCode::Blake2s
+                | acvm::acir::OpCode::Pedersen => BigUint::zero(), //pointers do not overflow
                 _ => todo!(),
             }
         }

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -223,7 +223,7 @@ pub fn find_similar_mem_instruction(
 pub fn propagate(ctx: &SsaContext, id: NodeId) -> NodeId {
     let mut result = id;
     if let Some(obj) = ctx.try_get_instruction(id) {
-        if obj.operator == node::Operation::Ass || obj.is_deleted {
+        if obj.operator == node::Operation::Assign || obj.is_deleted {
             result = obj.rhs;
         }
     }
@@ -324,7 +324,7 @@ pub fn block_cse(
                             }
                         }
                     }
-                    node::Operation::Ass => {
+                    node::Operation::Assign => {
                         //assignement
                         i_rhs = propagate(ctx, ins.rhs);
                         to_delete = true;
@@ -373,7 +373,7 @@ pub fn block_cse(
                 update.is_deleted = to_delete;
                 //update instruction name - for debug/pretty print purposes only /////////////////////
                 if let Some(Instruction {
-                    operator: Operation::Ass,
+                    operator: Operation::Assign,
                     lhs,
                     ..
                 }) = ctx.try_get_instruction(ii_l)
@@ -388,7 +388,7 @@ pub fn block_cse(
                     }
                 }
                 if let Some(Instruction {
-                    operator: Operation::Ass,
+                    operator: Operation::Assign,
                     lhs,
                     ..
                 }) = ctx.try_get_instruction(ii_r)

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -58,7 +58,6 @@ pub enum HirBinaryOpKind {
     And,
     Or,
     Xor,
-    MemberAccess,
     Assign,
 }
 


### PR DESCRIPTION
This refactoring is part of a larger effort to clean up the ssa code to use stronger types and rely less on developers memorizing certain invariants.

In master, Operation is currently only a tag value yet how many kinds of arguments an instruction takes and what types those arguments are expected to be depends on this tag value. As an example, most ssa code assumes every instruction has two arguments (`lhs: NodeId` and `rhs: NodeId`) but quite a few instructions break this promise and it is up to developers to carefully maintain their invariants:
- `Operation::Not` and other unary instructions only have 1 argument, and the expectation is to always duplicate `lhs = rhs`
- `Jmp` and other jump instructions should hold a block to jump to, but since neither lhs nor rhs are of type BlockId, they hold the first instruction of a block instead. This obscures code and makes mistakes more likely (for example - what happens if this instruction is optimized away?)
- `Assign` does take 2 arguments but in an order which may be confusing - `rhs := lhs`. That is the location to assign to is the rhs rather than the lhs
- `Call` and `Results` previously needed to be separated into 2 instructions since the Instruction struct only allowed for 1 Vec of variable arguments. This means every Results instruction we need to go back and search for the call it refers to. This is yet to be changed in this PR but we now can have a single instruction `Call(args, results)` to store both.
- ... and others

This is a rather large change so I'll be starting the pattern discussed in slack of merging this to a new branch `jf/ssa` rather than master. It is also unfinished (but is safe to be merged anyway since it is to a new branch). I'm still working on refactoring `optim.rs` and `integer.rs`

This is also the first PR in a few I have planned. The next will be on refactoring `Instruction::is_deleted` so a few `todo!("Refactor deletions")` remain in this PR where those spots need to be changed. They aren't included in this PR to keep it "small." 