### PR TITLE
Fix 'variable must be mutable to be assigned to' error

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -115,7 +115,20 @@ fn type_check_lvalue(
     errors: &mut Vec<TypeCheckError>,
 ) -> Type {
     match lvalue {
-        HirLValue::Ident(ident) => interner.id_type(ident.id),
+        HirLValue::Ident(ident) => {
+            let definition = interner.definition(ident.id);
+            if !definition.mutable {
+                errors.push(TypeCheckError::Unstructured {
+                    msg: format!(
+                        "Variable {} must be mutable to be assigned to",
+                        definition.name
+                    ),
+                    span: ident.span,
+                });
+            }
+
+            interner.id_type(ident.id)
+        }
         HirLValue::MemberAccess { object, field_name } => {
             let result = type_check_lvalue(interner, *object, assign_span, errors);
 


### PR DESCRIPTION
A bad merge from the lvalue PR caused this error to no longer be shown.

The check was accidentally deleted when the lvalue PR removed this check accidentally by replacing it with the type_check_lvalue function which did not perform the same check.