### PR TITLE
Allow rhs of Let statements to be subtypes of the annotated type

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -232,7 +232,7 @@ fn type_check_constrain_stmt(
 fn type_check_declaration(
     interner: &mut NodeInterner,
     rhs_expr: ExprId,
-    mut annotated_type: Type,
+    annotated_type: Type,
     errors: &mut Vec<TypeCheckError>,
 ) -> Type {
     // Type check the expression on the RHS
@@ -240,20 +240,19 @@ fn type_check_declaration(
 
     // First check if the LHS is unspecified
     // If so, then we give it the same type as the expression
-    if annotated_type == Type::Unspecified {
-        annotated_type = expr_type.clone();
-    };
-
-    // Now check if LHS is the same type as the RHS
-    // Importantly, we do not co-erce any types implicitly
-    if !annotated_type.matches(&expr_type) {
-        let expr_span = interner.expr_span(&rhs_expr);
-        errors.push(TypeCheckError::TypeMismatch {
-            expected_typ: annotated_type.to_string(),
-            expr_typ: expr_type.to_string(),
-            expr_span,
-        });
+    if annotated_type != Type::Unspecified {
+        // Now check if LHS is the same type as the RHS
+        // Importantly, we do not co-erce any types implicitly
+        if !expr_type.is_subtype_of(&annotated_type) {
+            let expr_span = interner.expr_span(&rhs_expr);
+            errors.push(TypeCheckError::TypeMismatch {
+                expected_typ: annotated_type.to_string(),
+                expr_typ: expr_type.to_string(),
+                expr_span,
+            });
+        }
+        annotated_type
+    } else {
+        expr_type
     }
-
-    expr_type
 }


### PR DESCRIPTION
This PR allows you to specify more general types for let statements than that of the rhs. For example, previously `let x: Field = 32` was rejected since the rhs is `const Field` rather than Field itself.

This PR changes this to allow such code as long as the assigned type is a subtype of the annotated type.

Note that creating a variable initialized to a constant value still requires explicit annotation to remove the const-ness. So creating a non-const u32 looks like
`let x: u32 = 1234 as u32;` compared to today where you would have to do:
`let x = 1234 as u32 + private_var - private_var;`

This is only desirable for mutable variables but the repetition can be annoying nonetheless (though it is an improvement from the current constraints of needing to use a private variable to force non-constness). 
This repetition is caused by the `1234 as u32` cast actually casting to `const u32` since its lhs is already const. Making the `as u32` polymorphic over constness instead is possible but would likely require type variables.