### PR TITLE
Fix the behavior that was broken

### DIFF
--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -598,6 +598,7 @@ impl<'a> SsaContext<'a> {
         //ACIR
         self.acir(evaluator);
         if enable_logging {
+            Acir::print_circuit(&evaluator.gates);
             println!("DONE");
             dbg!(&evaluator.current_witness_index);
         }
@@ -615,7 +616,6 @@ impl<'a> SsaContext<'a> {
             //TODO we should rather follow the jumps
             fb = block.left.map(|block_id| &self[block_id]);
         }
-        Acir::print_circuit(&evaluator.gates);
     }
 
     pub fn generate_empty_phi(&mut self, target_block: BlockId, phi_root: NodeId) -> NodeId {

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -215,10 +215,19 @@ pub fn inline_in_block(
                             ctx.get_result_instruction_mut(target_block_id, call_id, i as u32)
                                 .unwrap()
                                 .mark = Mark::ReplaceWith(*value);
+                            let call_ins = ctx.get_mut_instruction(call_id);
+                            call_ins.mark = Mark::Deleted;
+                        } else {
+                            //TODO - when implementing multiple return values: to remove and use result instruction instead
+                            let call_ins = ctx.get_mut_instruction(call_id);
+                            call_ins.mark = Mark::ReplaceWith(*value);
+                            if let Some(a_id) = array_id {
+                                if let Some(&i_pointer) = stack_frame.try_get(a_id) {
+                                    call_ins.res_type = node::ObjectType::Pointer(i_pointer);
+                                }
+                            }
                         }
                     }
-                    let call_ins = ctx.get_mut_instruction(call_id);
-                    call_ins.mark = Mark::Deleted;
                 }
                 Operation::Call(..) => {
                     *nested_call = true;


### PR DESCRIPTION
by the merge of the ssa refactoring into function-return PR, the previous behavior is restored but it should be refactored again when we will support multiple return values.
