### PR TITLE
Implement polymorphic integer literals

### DIFF
--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -368,6 +368,7 @@ impl<'a> Evaluator<'a> {
                     }
                 }
             }
+            Type::PolymorphicInteger(_) => unreachable!(),
             Type::Bool => todo!(),
             Type::Unit => todo!(),
             Type::Struct(_, _) => todo!(),

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -226,6 +226,12 @@ impl From<&Type> for ObjectType {
                     Signedness::Unsigned => ObjectType::Unsigned(*bit_size),
                 }
             }
+            Type::PolymorphicInteger(binding) => {
+                match &*binding.borrow() {
+                    noirc_frontend::TypeBinding::Bound(typ) => typ.into(),
+                    noirc_frontend::TypeBinding::Unbound(_) => Type::DEFAULT_INT_TYPE.into(),
+                }
+            }
             // TODO: We should probably not convert an array type into the element type
             noirc_frontend::Type::Array(_, _, t) => ObjectType::from(t.as_ref()),
             x => unimplemented!("Conversion to ObjectType is unimplemented for type {}", x),

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -226,12 +226,10 @@ impl From<&Type> for ObjectType {
                     Signedness::Unsigned => ObjectType::Unsigned(*bit_size),
                 }
             }
-            Type::PolymorphicInteger(binding) => {
-                match &*binding.borrow() {
-                    noirc_frontend::TypeBinding::Bound(typ) => typ.into(),
-                    noirc_frontend::TypeBinding::Unbound(_) => Type::DEFAULT_INT_TYPE.into(),
-                }
-            }
+            Type::PolymorphicInteger(binding) => match &*binding.borrow() {
+                noirc_frontend::TypeBinding::Bound(typ) => typ.into(),
+                noirc_frontend::TypeBinding::Unbound(_) => Type::DEFAULT_INT_TYPE.into(),
+            },
             // TODO: We should probably not convert an array type into the element type
             noirc_frontend::Type::Array(_, _, t) => ObjectType::from(t.as_ref()),
             x => unimplemented!("Conversion to ObjectType is unimplemented for type {}", x),

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -276,7 +276,7 @@ fn check_cast(from: Type, to: Type, span: Span, errors: &mut Vec<TypeCheckError>
                     // Don't bind the type variable here. Since we're casting, we can cast from any
                     // integer, and this already represents any integer.
                     true
-                },
+                }
             }
         }
         Type::Error => return Type::Error,

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -275,7 +275,7 @@ fn check_cast(from: Type, to: Type, span: Span, errors: &mut Vec<TypeCheckError>
                 TypeBinding::Unbound(_) => {
                     // Don't bind the type variable here. Since we're casting, we can cast from any
                     // integer, and this already represents any integer.
-                    false
+                    true
                 },
             }
         }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -435,24 +435,15 @@ pub fn infix_operand_type_rules(
             let field_type = field_type_rules(int_field_type, &Constant);
             Ok(Integer(field_type,*sign_x, *bit_width_x))
         }
-        (PolymorphicInteger(a), other) => {
-            if let TypeBinding::Bound(binding) = &*a.borrow() {
+        (PolymorphicInteger(int), other)
+        | (other, PolymorphicInteger(int)) => {
+            if let TypeBinding::Bound(binding) = &*int.borrow() {
                 return infix_operand_type_rules(binding, op, other);
             }
-            if other.try_bind_to_polymorphic_int(a).is_ok() {
+            if other.try_bind_to_polymorphic_int(int).is_ok() {
                 Ok(other.clone())
             } else {
-                Err(format!("Types in a binary operation should match, but found {} and {}", a.borrow(), other))
-            }
-        }
-        (other, PolymorphicInteger(b)) => {
-            if let TypeBinding::Bound(binding) = &*b.borrow() {
-                return infix_operand_type_rules(other, op, binding);
-            }
-            if other.try_bind_to_polymorphic_int(b).is_ok() {
-                Ok(other.clone())
-            } else {
-                Err(format!("Types in a binary operation should match, but found {} and {}", other, b.borrow()))
+                Err(format!("Types in a binary operation should match, but found {} and {}", int.borrow(), other))
             }
         }
         (Integer(..), typ) | (typ,Integer(..)) => {
@@ -629,24 +620,15 @@ pub fn comparator_operand_type_rules(lhs_type: &Type, other: &Type) -> Result<Ty
         (Integer(_, _, _), FieldElement(Constant))| (FieldElement(Constant),Integer(_, _, _)) => {
             Ok(Bool)
         }
-        (PolymorphicInteger(a), other) => {
-            if let TypeBinding::Bound(binding) = &*a.borrow() {
+        (PolymorphicInteger(int), other)
+        | (other, PolymorphicInteger(int)) => {
+            if let TypeBinding::Bound(binding) = &*int.borrow() {
                 return comparator_operand_type_rules(binding, other);
             }
-            if other.try_bind_to_polymorphic_int(a).is_ok() {
+            if other.try_bind_to_polymorphic_int(int).is_ok() {
                 Ok(Bool)
             } else {
-                Err(format!("Types in a binary operation should match, but found {} and {}", a.borrow(), other))
-            }
-        }
-        (other, PolymorphicInteger(b)) => {
-            if let TypeBinding::Bound(binding) = &*b.borrow() {
-                return comparator_operand_type_rules(other, binding);
-            }
-            if other.try_bind_to_polymorphic_int(b).is_ok() {
-                Ok(Bool)
-            } else {
-                Err(format!("Types in a binary operation should match, but found {} and {}", other, b.borrow()))
+                Err(format!("Types in a binary operation should match, but found {} and {}", int.borrow(), other))
             }
         }
         (Integer(..), typ) | (typ,Integer(..)) => {

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -35,7 +35,7 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     let function_last_type = type_check_expression(interner, func_as_expr, &mut errors);
 
     // Check declared return type and actual return type
-    if !can_ignore_ret { 
+    if !can_ignore_ret {
         function_last_type.unify(declared_return_type, &mut || {
             let func_span = interner.id_span(func_as_expr); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
             errors.push(TypeCheckError::TypeMismatch {

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -35,12 +35,14 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     let function_last_type = type_check_expression(interner, func_as_expr, &mut errors);
 
     // Check declared return type and actual return type
-    if !can_ignore_ret && !function_last_type.matches(declared_return_type) {
-        let func_span = interner.id_span(func_as_expr); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
-        errors.push(TypeCheckError::TypeMismatch {
-            expected_typ: declared_return_type.to_string(),
-            expr_typ: function_last_type.to_string(),
-            expr_span: func_span,
+    if !can_ignore_ret { 
+        function_last_type.unify(declared_return_type, &mut || {
+            let func_span = interner.id_span(func_as_expr); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
+            errors.push(TypeCheckError::TypeMismatch {
+                expected_typ: declared_return_type.to_string(),
+                expr_typ: function_last_type.to_string(),
+                expr_span: func_span,
+            });
         });
     }
 

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -45,6 +45,7 @@ pub enum Type {
     FieldElement(FieldElementType),
     Array(FieldElementType, ArraySize, Box<Type>), // [4]Witness = Array(4, Witness)
     Integer(FieldElementType, Signedness, u32),    // u32 = Integer(unsigned, 32)
+    PolymorphicInteger(TypeVariable),
     Bool,
     Unit,
     Struct(FieldElementType, Rc<RefCell<StructType>>),
@@ -54,12 +55,25 @@ pub enum Type {
     Unspecified, // This is for when the user declares a variable without specifying it's type
 }
 
+type TypeVariable = Rc<RefCell<TypeBinding>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeBinding {
+    Bound(Type),
+    Unbound(TypeVariableId),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct TypeVariableId(pub usize);
+
 impl Type {
     // These are here so that the code is more readable.
     // Type::WITNESS vs Type::FieldElement(FieldElementType::Private)
     pub const WITNESS: Type = Type::FieldElement(FieldElementType::Private);
     pub const CONSTANT: Type = Type::FieldElement(FieldElementType::Constant);
     pub const PUBLIC: Type = Type::FieldElement(FieldElementType::Public);
+
+    pub const DEFAULT_INT_TYPE: Type = Type::WITNESS;
 }
 
 impl From<&Type> for AbiType {
@@ -83,6 +97,7 @@ impl std::fmt::Display for Type {
                 Signedness::Signed => write!(f, "{}i{}", vis_str(*fe_type), num_bits),
                 Signedness::Unsigned => write!(f, "{}u{}", vis_str(*fe_type), num_bits),
             },
+            Type::PolymorphicInteger(binding) => write!(f, "{}", binding.borrow()),
             Type::Struct(vis, s) => write!(f, "{}{}", vis_str(*vis), s.borrow()),
             Type::Tuple(elements) => {
                 let elements = vecmap(elements, ToString::to_string);
@@ -92,6 +107,15 @@ impl std::fmt::Display for Type {
             Type::Unit => write!(f, "()"),
             Type::Error => write!(f, "error"),
             Type::Unspecified => write!(f, "unspecified"),
+        }
+    }
+}
+
+impl std::fmt::Display for TypeBinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeBinding::Bound(typ) => typ.fmt(f),
+            TypeBinding::Unbound(_) => write!(f, "Field"),
         }
     }
 }
@@ -107,29 +131,121 @@ impl Type {
         }
     }
 
-    /// True if this type 'matches' another. Matching is more strict
-    /// than subtyping but less strict than Eq. In particular, a type
-    /// matches another iff it is exactly equal to the other type or
-    /// either type is the Error type.
-    pub fn matches(&self, other: &Type) -> bool {
-        self == other || self == &Type::Error || other == &Type::Error
+    pub fn try_bind_to_polymorphic_int(&self, var: &TypeVariable) -> Result<(), ()> {
+        let target_id = match &*var.borrow() {
+            TypeBinding::Bound(_) => unreachable!(),
+            TypeBinding::Unbound(id) => *id,
+        };
+
+        match self {
+            Type::FieldElement(_)
+            | Type::Integer(_, _, _) => {
+                *var.borrow_mut() = TypeBinding::Bound(self.clone());
+                Ok(())
+            }
+            Type::PolymorphicInteger(self_var) => {
+                match &*self_var.borrow() {
+                    TypeBinding::Bound(typ) => typ.try_bind_to_polymorphic_int(var),
+                    // Avoid infinitely recursive bindings
+                    TypeBinding::Unbound(id) if *id == target_id => Ok(()),
+                    TypeBinding::Unbound(_) => {
+                        *var.borrow_mut() = TypeBinding::Bound(self.clone());
+                        Ok(())
+                    }
+                }
+            }
+            _ => Err(())
+        }
+    }
+
+    /// Try to unify this type with another, setting any type variables found
+    /// equal to the other type in the process. Unification is more strict
+    /// than subtyping but less strict than Eq. Returns true if the unification
+    /// succeeded. Note that any bindings performed in a failed unification are
+    /// not undone. This may cause further type errors later on.
+    pub fn unify(&self, other: &Type, error: &mut impl FnMut()) -> bool {
+        use Type::*;
+        match (self, other) {
+            (Error, _)
+            | (_, Error) => true,
+
+            (Unspecified, _)
+            | (_, Unspecified) => unreachable!(),
+
+            (PolymorphicInteger(binding), other)
+            | (other, PolymorphicInteger(binding)) => {
+                // If it is already bound, unify against what it is bound to
+                if let TypeBinding::Bound(link) = &*binding.borrow() {
+                    return link.unify(other, error);
+                }
+
+                // Otherwise, check it is unified against an integer and bind it
+                let success = other.try_bind_to_polymorphic_int(binding).is_ok();
+                if !success {
+                    error();
+                }
+                success
+            }
+
+            (Array(vis_a, len_a, elem_a), Array(vis_b, len_b, elem_b)) => {
+                if vis_a != vis_b || len_a != len_b {
+                    error();
+                    false
+                } else {
+                    elem_a.unify(elem_b, error)
+                }
+            },
+
+            (Tuple(elems_a), Tuple(elems_b)) => {
+                if elems_a.len() != elems_b.len() {
+                    error();
+                    false
+                } else {
+                    for (a, b) in elems_a.iter().zip(elems_b) {
+                        if !a.unify(b, error) {
+                            return false;
+                        }
+                    }
+                    true
+                }
+            },
+
+            // No recursive unify call for struct fields. Don't want
+            // to mutate shared type variables within struct definitions.
+            // This isn't possible currently but will be once noir gets generic types
+            (Struct(vis_a, fields_a), Struct(vis_b, fields_b)) => {
+                if vis_a != vis_b || fields_a != fields_b {
+                    error();
+                    false
+                } else {
+                    true
+                }
+            },
+
+            (other_a, other_b) => {
+                let success = other_a == other_b;
+                if !success {
+                    error();
+                }
+                success
+            }
+        }
     }
 
     // A feature of the language is that `Field` is like an
     // `Any` type which allows you to pass in any type which
     // is fundamentally a field element. E.g all integer types
-    pub fn is_subtype_of(&self, other: &Type) -> bool {
+    //
+    // This is 'make_subtype_of' rather than 'is_subtype_of' to
+    // allude to the side effects it has with setting any integer
+    // type variables contained within to other values
+    pub fn make_subtype_of(&self, other: &Type) -> bool {
         use FieldElementType::*;
         use Type::*;
 
         // Avoid reporting duplicate errors
         if self == &Error || other == &Error {
             return true;
-        }
-
-        // Any field element type is a subtype of `priv Field`
-        if other == &FieldElement(Private) {
-            return self.is_field_element();
         }
 
         if let (Array(_, arg_size, arg_type), Array(_, param_size, param_type)) = (self, other) {
@@ -146,6 +262,24 @@ impl Type {
         match (self, other) {
             // Const types are subtypes of non-const types
             (FieldElement(Constant), FieldElement(_)) => true,
+
+            (PolymorphicInteger(a), other) => {
+                if let TypeBinding::Bound(binding) = &*a.borrow() {
+                    return binding.make_subtype_of(other);
+                }
+                other.try_bind_to_polymorphic_int(a).is_ok()
+            }
+
+            (other, PolymorphicInteger(b)) => {
+                if let TypeBinding::Bound(binding) = &*b.borrow() {
+                    return other.make_subtype_of(binding);
+                }
+                other.try_bind_to_polymorphic_int(b).is_ok()
+            }
+
+            // Any field element type is a subtype of `priv Field`
+            (this, FieldElement(Private)) => this.is_field_element(),
+
             (Integer(Constant, self_sign, self_bits), Integer(_, other_sign, other_bits)) => {
                 self_sign == other_sign && self_bits == other_bits
             }
@@ -154,7 +288,7 @@ impl Type {
     }
 
     pub fn is_field_element(&self) -> bool {
-        matches!(self, Type::FieldElement(_) | Type::Bool | Type::Integer(_, _, _))
+        matches!(self, Type::FieldElement(_) | Type::Bool | Type::Integer(_, _, _) | Type::PolymorphicInteger(_))
     }
 
     /// Computes the number of elements in a Type
@@ -168,6 +302,7 @@ impl Type {
             Type::Tuple(fields) => fields.len(),
             Type::FieldElement(_)
             | Type::Integer(_, _, _)
+            | Type::PolymorphicInteger(_)
             | Type::Bool
             | Type::Error
             | Type::Unspecified
@@ -197,19 +332,12 @@ impl Type {
         }
     }
 
-    // Returns true if the Type can be used in a Let statement
-    pub fn can_be_used_in_let(&self) -> bool {
-        self.is_fixed_sized_array()
-            || self.is_variable_sized_array()
-            || matches!(self, &Type::Struct(..))
-            || self == &Type::Error
-    }
-
     // Returns true if the Type can be used in a Constrain statement
     pub fn can_be_used_in_constrain(&self) -> bool {
         matches!(
             self,
             Type::FieldElement(_)
+                | Type::PolymorphicInteger(_)
                 | Type::Integer(_, _, _)
                 | Type::Array(_, _, _)
                 | Type::Error
@@ -280,6 +408,12 @@ impl Type {
                 };
 
                 AbiType::Integer { sign, width: *bit_width as u32, visibility: fet_to_abi(fe_type) }
+            }
+            Type::PolymorphicInteger(binding) => {
+                match &*binding.borrow() {
+                    TypeBinding::Bound(typ) => typ.as_abi_type(),
+                    TypeBinding::Unbound(_) => Type::DEFAULT_INT_TYPE.as_abi_type(),
+                }
             }
             Type::Bool => panic!("currently, cannot have a bool in the entry point function"),
             Type::Error => unreachable!(),

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 use arena::{Arena, Index};
 use noirc_errors::Span;
 
-use crate::TypeVariableId;
 use crate::graph::CrateId;
 use crate::hir::def_collector::dc_crate::UnresolvedStruct;
 use crate::hir::def_map::{LocalModuleId, ModuleId};
@@ -15,6 +14,7 @@ use crate::hir_def::{
     function::{FuncMeta, HirFunction},
     stmt::HirStatement,
 };
+use crate::TypeVariableId;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct DefinitionId(usize);

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use arena::{Arena, Index};
 use noirc_errors::Span;
 
+use crate::TypeVariableId;
 use crate::graph::CrateId;
 use crate::hir::def_collector::dc_crate::UnresolvedStruct;
 use crate::hir::def_map::{LocalModuleId, ModuleId};
@@ -136,6 +137,8 @@ pub struct NodeInterner {
     // It is also mutated through the RefCell during name resolution to append
     // methods from impls to the type.
     structs: HashMap<StructId, Rc<RefCell<StructType>>>,
+
+    next_type_variable_id: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -153,6 +156,7 @@ impl Default for NodeInterner {
             definitions: vec![],
             id_to_type: HashMap::new(),
             structs: HashMap::new(),
+            next_type_variable_id: 0,
         };
 
         // An empty block expression is used often, we add this into the `node` on startup
@@ -338,5 +342,11 @@ impl NodeInterner {
     pub fn replace_expr(&mut self, id: &ExprId, new: HirExpression) {
         let old = self.nodes.get_mut(id.into()).unwrap();
         *old = Node::Expression(new);
+    }
+
+    pub fn next_type_variable_id(&mut self) -> TypeVariableId {
+        let id = self.next_type_variable_id;
+        self.next_type_variable_id += 1;
+        TypeVariableId(id)
     }
 }


### PR DESCRIPTION
These use type variables internally which can be bound to any Field, Integer, or other PolymorphicInteger type.

Difference in functionality versus the old `const Field` subtyping:
```rs
let foo = 5;
... foo + my_u8 ...
... foo + my_u32 ...
```
Is valid for the old approach and invalid for this PR since `foo: u8` after it is unified with u8 on the second line.

Motivation for this PR is primarily for it to be easier for the backend to track types. Alternatively, we could keep the old approach and add in explicit casts `_ as u32` each time subtyping is used.