### PR TITLE
Handle multiple return values from function calls

### DIFF
--- a/crates/nargo/tests/test_data/7_function/src/main.nr
+++ b/crates/nargo/tests/test_data/7_function/src/main.nr
@@ -54,12 +54,38 @@ fn test3(x: [3]u8) -> [3]u8 {
      buffer
 }
 
+fn test_multiple(x: u32, y: u32) -> (u32, u32)
+{
+    (y,x)
+}
+
+fn test_multiple2() -> my_struct
+{
+     my_struct{a:5, b:7}
+}
+
+fn test_multiple3(x: u32, y: u32)
+{
+     constrain x == y;
+}
+
+struct my_struct {
+     a: u32,
+     b: u32,
+}
+
 fn main(x : u32 , y : u32 , a : Field) {  
-   test0(a);
-   test1(a);
-   test2(x as Field,y);
+     test0(a);
+     test1(a);
+     test2(x as Field,y);
 
      let b: [3]u8 =[0 as u8, 5 as u8, 2 as u8];
      let c = test3(b);
      constrain b == c;
+
+     let e = test_multiple(x,y) ;
+     constrain e.1==e.0+54;
+     let d = test_multiple2();
+     constrain d.b == d.a + 2;
+     test_multiple3(y,y);
 }

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -215,19 +215,10 @@ pub fn inline_in_block(
                             ctx.get_result_instruction_mut(target_block_id, call_id, i as u32)
                                 .unwrap()
                                 .mark = Mark::ReplaceWith(*value);
-                            let call_ins = ctx.get_mut_instruction(call_id);
-                            call_ins.mark = Mark::Deleted;
-                        } else {
-                            //TODO - when implementing multiple return values: to remove and use result instruction instead
-                            let call_ins = ctx.get_mut_instruction(call_id);
-                            call_ins.mark = Mark::ReplaceWith(*value);
-                            if let Some(a_id) = array_id {
-                                if let Some(&i_pointer) = stack_frame.try_get(a_id) {
-                                    call_ins.res_type = node::ObjectType::Pointer(i_pointer);
-                                }
-                            }
                         }
                     }
+                    let call_ins = ctx.get_mut_instruction(call_id);
+                    call_ins.mark = Mark::Deleted;
                 }
                 Operation::Call(..) => {
                     *nested_call = true;


### PR DESCRIPTION
I have removed the optimisation for returned arrays, I will add it back in a separate PR.

A function call returns a Value where each NodeId of the Value correspond to a result instruction.
We add dummy load and stores as long as the function call is not inlined, to take into account for by-value array arguments and by-value array results.
