### PR TITLE
Fix CSE for constrain and intrinsic

### DIFF
--- a/crates/nargo/tests/test_data/6/src/main.nr
+++ b/crates/nargo/tests/test_data/6/src/main.nr
@@ -9,7 +9,8 @@ use dep::std;
 
 fn main(x : [5]u8, result : pub [32]u8) {
 
-     let digest = std::hash::sha256(x);
-     
+     let mut digest = std::hash::sha256(x);
+     digest[0] = 5 as u8;
+     digest = std::hash::sha256(x);
      constrain digest == result;
 }

--- a/crates/nargo/tests/test_data/7_function/src/main.nr
+++ b/crates/nargo/tests/test_data/7_function/src/main.nr
@@ -61,7 +61,7 @@ fn test_multiple(x: u32, y: u32) -> (u32, u32)
 
 fn test_multiple2() -> my_struct
 {
-     my_struct{a:5, b:7}
+     my_struct{a:5 as u32, b:7 as u32}
 }
 
 fn test_multiple3(x: u32, y: u32)
@@ -79,13 +79,15 @@ fn main(x : u32 , y : u32 , a : Field) {
      test1(a);
      test2(x as Field,y);
 
-     let b: [3]u8 =[0 as u8, 5 as u8, 2 as u8];
+     let mut b: [3]u8 =[0 as u8, 5 as u8, 2 as u8];
      let c = test3(b);
      constrain b == c;
-
+     b[0] = 1 as u8;
+     let cc = test3(b);
+     constrain c != cc;
      let e = test_multiple(x,y) ;
-     constrain e.1==e.0+54;
+     constrain e.1==e.0+54 as u32;
      let d = test_multiple2();
-     constrain d.b == d.a + 2;
+     constrain d.b == d.a + 2 as u32;
      test_multiple3(y,y);
 }

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -107,26 +107,10 @@ impl<'a> IRGenerator<'a> {
         len: u128,
         witness: Vec<acvm::acir::native_types::Witness>,
     ) {
-        self.context.mem.create_new_array(len as u32, el_type.into(), name);
-
+        let v_id = self.new_array(name, el_type.into(), len as u32, ident_def);
         let array_idx = self.context.mem.last_id();
-
-        self.context.mem[array_idx].def = ident_def;
         self.context.mem[array_idx].values = vecmap(witness, |w| w.into());
-        let pointer = node::Variable {
-            id: NodeId::dummy(),
-            name: name.to_string(),
-            obj_type: node::ObjectType::Pointer(array_idx),
-            root: None,
-            def: Some(ident_def),
-            witness: None,
-            parent_block: self.context.current_block,
-        };
-        let v_id = self.context.add_variable(pointer, None);
         self.context.get_current_block_mut().update_variable(v_id, v_id);
-
-        let v_value = Value::Single(v_id);
-        self.variable_values.insert(ident_def, v_value); //TODO ident_def or ident_id??
     }
 
     pub fn abi_var(
@@ -163,39 +147,30 @@ impl<'a> IRGenerator<'a> {
         let obj = env.get(&ident_name);
         let o_type = self.context.context.def_interner.id_type(ident.id);
 
-        let var = match obj {
+        let v_id = match obj {
             Object::Array(a) => {
                 let obj_type = o_type.into();
                 //We should create an array from 'a' witnesses
-                let array =
-                    self.context.mem.create_array_from_object(&a, ident.id, obj_type, &ident_name);
-
-                node::Variable {
-                    id: NodeId::dummy(),
-                    name: ident_name.clone(),
-                    obj_type: ObjectType::Pointer(array.id),
-                    root: None,
-                    def: Some(ident.id),
-                    witness: None,
-                    parent_block: self.context.current_block,
-                }
+                self.context.create_array_from_object(&a, ident.id, obj_type, &ident_name)
             }
             _ => {
                 let obj_type = ObjectType::get_type_from_object(&obj);
                 //new variable - should be in a let statement? The let statement should set the type
-                node::Variable {
-                    id: NodeId::dummy(),
-                    name: ident_name.clone(),
-                    obj_type,
-                    root: None,
-                    def: Some(ident.id),
-                    witness: node::get_witness_from_object(&obj),
-                    parent_block: self.context.current_block,
-                }
+                self.context.add_variable(
+                    node::Variable {
+                        id: NodeId::dummy(),
+                        name: ident_name.clone(),
+                        obj_type,
+                        root: None,
+                        def: Some(ident.id),
+                        witness: node::get_witness_from_object(&obj),
+                        parent_block: self.context.current_block,
+                    },
+                    None,
+                )
             }
         };
 
-        let v_id = self.context.add_variable(var, None);
         self.context.get_current_block_mut().update_variable(v_id, v_id);
 
         Value::Single(v_id)
@@ -320,6 +295,18 @@ impl<'a> IRGenerator<'a> {
         let v_value = Value::Single(v_id);
         self.variable_values.insert(def, v_value);
         v_id
+    }
+
+    pub fn new_array(
+        &mut self,
+        name: &str,
+        element_type: ObjectType,
+        len: u32,
+        def_id: noirc_frontend::node_interner::DefinitionId,
+    ) -> NodeId {
+        let id = self.context.new_array(name, element_type, len, Some(def_id));
+        self.variable_values.insert(def_id, super::code_gen::Value::Single(id));
+        id
     }
 
     // Add a constraint to constrain two expression together
@@ -540,13 +527,18 @@ impl<'a> IRGenerator<'a> {
                 let arr_type = self.def_interner().id_type(expr_id);
                 let element_type = arr_type.into();    //WARNING array type!
 
-                let array_id = self.context.mem.create_new_array(arr_lit.length as u32, element_type, &String::new());
+                let new_var = self.context.new_array(
+                    &String::new(),
+                    element_type,
+                    arr_lit.length as u32,
+                    None,
+                );
+                let array_id = self.context.mem.last_id();
                 //We parse the array definition
                 let elements = self.expression_list_to_objects(env, &arr_lit.contents);
                 let array = &mut self.context.mem[array_id];
                 let array_adr = array.adr;
                 for (pos, object) in elements.into_iter().enumerate() {
-                    //array.witness.push(node::get_witness_from_object(&object));
                     let lhs_adr = self.context.get_or_create_const(FieldElement::from((array_adr + pos as u32) as u128), ObjectType::NativeField);
                     let store = Operation::Store {
                         array_id,
@@ -555,17 +547,7 @@ impl<'a> IRGenerator<'a> {
                     };
                     self.context.new_instruction(store, element_type);
                 }
-                //Finally, we create a variable pointing to this MemArray
-                let new_var = node::Variable {
-                    id: NodeId::dummy(),
-                    obj_type : ObjectType::Pointer(array_id),
-                    name: String::new(),
-                    root: None,
-                    def: None,
-                    witness: None,
-                    parent_block: self.context.current_block,
-                };
-                Ok(Value::Single(self.context.add_variable(new_var, None)))
+                Ok(Value::Single(new_var))
             },
             HirExpression::Ident(x) =>  {
                Ok(self.evaluate_identifier(env, x))
@@ -619,7 +601,9 @@ impl<'a> IRGenerator<'a> {
                     }
                 } else {
                     let arr = env.get_array(&arr_name).map_err(|kind|kind.add_span(ident_span)).unwrap();
-                    self.context.mem.create_array_from_object(&arr, arr_def, o_type, &arr_name)
+                    self.context.create_array_from_object(&arr, arr_def, o_type, &arr_name);
+                    let array_id = self.context.mem.last_id();
+                    &self.context.mem[array_id]
                 };
 
                 let array_id = array.id;

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -17,6 +17,7 @@ use noirc_frontend::node_interner::FuncId;
 use noirc_frontend::util::vecmap;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
+use std::convert::TryFrom;
 
 // This is a 'master' class for generating the SSA IR from the AST
 // It contains all the data; the node objects representing the source code in the nodes arena
@@ -555,6 +556,8 @@ impl<'a> SsaContext<'a> {
         def_id: Option<noirc_frontend::node_interner::DefinitionId>,
     ) -> NodeId {
         let array_index = self.mem.create_new_array(len, element_type, name);
+        self.add_dummy_load(array_index);
+        self.add_dummy_store(array_index);
         //we create a variable pointing to this MemArray
         let new_var = node::Variable {
             id: NodeId::dummy(),
@@ -571,6 +574,20 @@ impl<'a> SsaContext<'a> {
         self.add_variable(new_var, None)
     }
 
+    pub fn create_array_from_object(
+        &mut self,
+        array: &crate::object::Array,
+        definition: noirc_frontend::node_interner::DefinitionId,
+        el_type: node::ObjectType,
+        arr_name: &str,
+    ) -> NodeId {
+        let len = u32::try_from(array.length).unwrap();
+        let result = self.new_array(arr_name, el_type, len, Some(definition));
+        let array_id = self.mem.last_id();
+        self.mem[array_id].set_witness(array);
+
+        result
+    }
     //blocks/////////////////////////
     pub fn try_get_block_mut(&mut self, id: BlockId) -> Option<&mut block::BasicBlock> {
         self.blocks.get_mut(id.0)
@@ -723,6 +740,7 @@ impl<'a> SsaContext<'a> {
             }) = self.try_get_mut_instruction(rhs)
             {
                 *rtype = lhs_type;
+                return lhs;
             } else {
                 self.memcpy(lhs_type, rhs_type);
                 return lhs;

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -68,13 +68,6 @@ impl SSAFunction {
         env: &mut Environment,
     ) -> Vec<NodeId> {
         let arguments = igen.expression_list_to_objects(env, arguments);
-        for a in &arguments {
-            if let Some(obj) = igen.context.try_get_node(*a) {
-                if let ObjectType::Pointer(a) = obj.get_type() {
-                    igen.context.add_dummy_load(a);
-                }
-            }
-        }
         let call_instruction = igen.context.new_instruction(
             node::Operation::Call(func, arguments, Vec::new()),
             ObjectType::NotAnObject,
@@ -213,9 +206,6 @@ pub fn create_function(
     for i in &returned_values {
         if let Some(node) = igen.context.try_get_node(*i) {
             func.result_types.push(node.get_type());
-            if let ObjectType::Pointer(a) = node.get_type() {
-                igen.context.add_dummy_store(a);
-            }
         } else {
             func.result_types.push(ObjectType::NotAnObject);
         }

--- a/crates/noirc_evaluator/src/ssa/mem.rs
+++ b/crates/noirc_evaluator/src/ssa/mem.rs
@@ -6,7 +6,6 @@ use noirc_frontend::node_interner::DefinitionId;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 use crate::Array;
 use std::convert::TryInto;
@@ -34,7 +33,7 @@ pub struct MemArray {
 }
 
 impl MemArray {
-    fn set_witness(&mut self, array: &Array) {
+    pub fn set_witness(&mut self, array: &Array) {
         for object in &array.contents {
             if let Some(w) = node::get_witness_from_object(object) {
                 self.values.push(w.into());
@@ -81,21 +80,6 @@ impl Memory {
             node::ObjectType::Pointer(a) => Some(a),
             _ => None,
         })
-    }
-
-    pub fn create_array_from_object(
-        &mut self,
-        array: &Array,
-        definition: DefinitionId,
-        el_type: node::ObjectType,
-        arr_name: &str,
-    ) -> &MemArray {
-        let len = u32::try_from(array.length).unwrap();
-        let id = self.create_new_array(len, el_type, arr_name);
-        let mem_array = &mut self[id];
-        mem_array.set_witness(array);
-        mem_array.def = definition;
-        mem_array
     }
 
     pub fn create_new_array(

--- a/crates/noirc_evaluator/src/ssa/ssa_form.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_form.rs
@@ -134,13 +134,12 @@ pub fn create_function_parameter(igen: &mut IRGenerator, ident_id: &DefinitionId
         let id = var.unwrap_id(); //TODO handle multiple values
         return get_current_value(&mut igen.context, id);
     }
-    let mut obj_type = node::ObjectType::from(&o_type);
-    if let noirc_frontend::Type::Array(_, len, _) = o_type {
-        let array_idx =
-            igen.context.mem.create_new_array(get_array_size(&len), obj_type, &ident_name);
-        obj_type = node::ObjectType::Pointer(array_idx);
-    }
-    let v_id = igen.create_new_variable(ident_name.clone(), *ident_id, obj_type, None);
+    let obj_type = node::ObjectType::from(&o_type);
+    let v_id = if let noirc_frontend::Type::Array(_, len, _) = o_type {
+        igen.new_array(&ident_name, obj_type, get_array_size(&len), *ident_id)
+    } else {
+        igen.create_new_variable(ident_name.clone(), *ident_id, obj_type, None)
+    };
     igen.context.get_current_block_mut().update_variable(v_id, v_id);
     v_id
 }


### PR DESCRIPTION
When constrain or intrinsic use arrays we disable CSE because arrays are not in SSA form.
Furthermore, we add dummy load/store to avoid over-simplification of memory operations during CSE
Finally, we put all writing to arrays inside the memory_map to ensure the correct value is used.
