### PR TITLE
Change unused variables to warnings

### DIFF
--- a/crates/nargo/src/cli/build_cmd.rs
+++ b/crates/nargo/src/cli/build_cmd.rs
@@ -5,18 +5,19 @@ use std::path::{Path, PathBuf};
 
 use super::{add_std_lib, write_to_file, PROVER_INPUT_FILE, VERIFIER_INPUT_FILE};
 
-pub(crate) fn run(_args: ArgMatches) -> Result<(), CliError> {
+pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     let package_dir = std::env::current_dir().unwrap();
-    build_from_path(package_dir)?;
+    let allow_warnings = args.is_present("allow-warnings");
+    build_from_path(package_dir, allow_warnings)?;
     println!("Constraint system successfully built!");
     Ok(())
 }
 // This is exposed so that we can run the examples and verify that they pass
-pub fn build_from_path<P: AsRef<Path>>(p: P) -> Result<(), CliError> {
+pub fn build_from_path<P: AsRef<Path>>(p: P, allow_warnings: bool) -> Result<(), CliError> {
     let backend = crate::backends::ConcreteBackend;
     let mut driver = Resolver::resolve_root_config(p.as_ref(), backend.np_language())?;
     add_std_lib(&mut driver);
-    driver.build();
+    driver.build(allow_warnings);
     // XXX: We can have a --overwrite flag to determine if you want to overwrite the Prover/Verifier.toml files
     if let Some(x) = driver.compute_abi() {
         // XXX: The root config should return an enum to determine if we are looking for .json or .toml
@@ -56,7 +57,11 @@ mod tests {
         let paths = std::fs::read_dir(pass_dir).unwrap();
         for path in paths.flatten() {
             let path = path.path();
-            assert!(super::build_from_path(path.clone()).is_ok(), "path: {}", path.display());
+            assert!(
+                super::build_from_path(path.clone(), false).is_ok(),
+                "path: {}",
+                path.display()
+            );
         }
     }
 
@@ -69,7 +74,23 @@ mod tests {
         let paths = std::fs::read_dir(fail_dir).unwrap();
         for path in paths.flatten() {
             let path = path.path();
-            assert!(super::build_from_path(path.clone()).is_err(), "path: {}", path.display());
+            assert!(
+                super::build_from_path(path.clone(), false).is_err(),
+                "path: {}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn pass_with_warnings() {
+        let mut pass_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        pass_dir.push(&format!("{TEST_DATA_DIR}/pass_dev_mode"));
+
+        let paths = std::fs::read_dir(pass_dir).unwrap();
+        for path in paths.flatten() {
+            let path = path.path();
+            assert!(super::build_from_path(path.clone(), true).is_ok(), "path: {}", path.display());
         }
     }
 }

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -15,13 +15,19 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     let args = args.subcommand_matches("compile").unwrap();
     let circuit_name = args.value_of("circuit_name").unwrap();
     let witness = args.is_present("witness");
+    let allow_warnings = args.is_present("allow-warnings");
 
     let curr_dir = std::env::current_dir().unwrap();
     let mut circuit_path = PathBuf::new();
     circuit_path.push(BUILD_DIR);
 
-    let result =
-        generate_circuit_and_witness_to_disk(circuit_name, curr_dir, circuit_path, witness);
+    let result = generate_circuit_and_witness_to_disk(
+        circuit_name,
+        curr_dir,
+        circuit_path,
+        witness,
+        allow_warnings,
+    );
     match result {
         Ok(_) => Ok(()),
         Err(e) => Err(e),
@@ -33,8 +39,9 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
     program_dir: P,
     circuit_dir: P,
     generate_witness: bool,
+    allow_warnings: bool,
 ) -> Result<PathBuf, CliError> {
-    let compiled_program = compile_circuit(program_dir.as_ref(), false)?;
+    let compiled_program = compile_circuit(program_dir.as_ref(), false, allow_warnings)?;
     let serialized = compiled_program.circuit.to_bytes();
 
     let mut circuit_path = create_named_dir(circuit_dir.as_ref(), "build");
@@ -60,11 +67,13 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
 pub fn compile_circuit<P: AsRef<Path>>(
     program_dir: P,
     show_ssa: bool,
+    allow_warnings: bool,
 ) -> Result<noirc_driver::CompiledProgram, CliError> {
     let backend = crate::backends::ConcreteBackend;
     let mut driver = Resolver::resolve_root_config(program_dir.as_ref(), backend.np_language())?;
     add_std_lib(&mut driver);
-    let compiled_program = driver.into_compiled_program(backend.np_language(), show_ssa);
+    let compiled_program =
+        driver.into_compiled_program(backend.np_language(), show_ssa, allow_warnings);
 
     Ok(compiled_program)
 }

--- a/crates/nargo/src/cli/contract_cmd.rs
+++ b/crates/nargo/src/cli/contract_cmd.rs
@@ -11,7 +11,8 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
         None => std::env::current_dir().unwrap(),
     };
 
-    let compiled_program = compile_circuit(&package_dir, false)?;
+    let allow_warnings = args.is_present("allow-warnings");
+    let compiled_program = compile_circuit(&package_dir, false, allow_warnings)?;
 
     let backend = crate::backends::ConcreteBackend;
     let smart_contract_string = backend.eth_contract_from_cs(compiled_program.circuit);

--- a/crates/nargo/src/cli/gates_cmd.rs
+++ b/crates/nargo/src/cli/gates_cmd.rs
@@ -9,19 +9,21 @@ use crate::errors::CliError;
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     let args = args.subcommand_matches("gates").unwrap();
     let show_ssa = args.is_present("show-ssa");
-    count_gates(show_ssa)
+    let allow_warnings = args.is_present("allow-warnings");
+    count_gates(show_ssa, allow_warnings)
 }
 
-pub fn count_gates(show_ssa: bool) -> Result<(), CliError> {
+pub fn count_gates(show_ssa: bool, allow_warnings: bool) -> Result<(), CliError> {
     let curr_dir = std::env::current_dir().unwrap();
-    count_gates_with_path(curr_dir, show_ssa)
+    count_gates_with_path(curr_dir, show_ssa, allow_warnings)
 }
 
 pub fn count_gates_with_path<P: AsRef<Path>>(
     program_dir: P,
     show_ssa: bool,
+    allow_warnings: bool,
 ) -> Result<(), CliError> {
-    let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa)?;
+    let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa, allow_warnings)?;
     let gates = compiled_program.circuit.gates;
 
     // Store counts of each gate type into hashmap.

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -19,18 +19,19 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     let args = args.subcommand_matches("prove").unwrap();
     let proof_name = args.value_of("proof_name").unwrap();
     let show_ssa = args.is_present("show-ssa");
-    prove(proof_name, show_ssa)
+    let allow_warnings = args.is_present("allow-warnings");
+    prove(proof_name, show_ssa, allow_warnings)
 }
 
 /// In Barretenberg, the proof system adds a zero witness in the first index,
 /// So when we add witness values, their index start from 1.
 const WITNESS_OFFSET: u32 = 1;
 
-fn prove(proof_name: &str, show_ssa: bool) -> Result<(), CliError> {
+fn prove(proof_name: &str, show_ssa: bool, allow_warnings: bool) -> Result<(), CliError> {
     let curr_dir = std::env::current_dir().unwrap();
     let mut proof_path = PathBuf::new();
     proof_path.push(PROOFS_DIR);
-    let result = prove_with_path(proof_name, curr_dir, proof_path, show_ssa);
+    let result = prove_with_path(proof_name, curr_dir, proof_path, show_ssa, allow_warnings);
     match result {
         Ok(_) => Ok(()),
         Err(e) => Err(e),
@@ -111,8 +112,13 @@ fn process_abi_with_input(
 pub fn compile_circuit_and_witness<P: AsRef<Path>>(
     program_dir: P,
     show_ssa: bool,
+    allow_unused_variables: bool,
 ) -> Result<(noirc_driver::CompiledProgram, BTreeMap<Witness, FieldElement>), CliError> {
-    let compiled_program = super::compile_cmd::compile_circuit(program_dir.as_ref(), show_ssa)?;
+    let compiled_program = super::compile_cmd::compile_circuit(
+        program_dir.as_ref(),
+        show_ssa,
+        allow_unused_variables,
+    )?;
     let solved_witness = solve_witness(program_dir, &compiled_program)?;
     Ok((compiled_program, solved_witness))
 }
@@ -200,8 +206,10 @@ pub fn prove_with_path<P: AsRef<Path>>(
     program_dir: P,
     proof_dir: P,
     show_ssa: bool,
+    allow_warnings: bool,
 ) -> Result<PathBuf, CliError> {
-    let (compiled_program, solved_witness) = compile_circuit_and_witness(program_dir, show_ssa)?;
+    let (compiled_program, solved_witness) =
+        compile_circuit_and_witness(program_dir, show_ssa, allow_warnings)?;
 
     let backend = crate::backends::ConcreteBackend;
     let proof = backend.prove_with_meta(compiled_program.circuit, solved_witness);

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -14,18 +14,19 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     proof_path.push(Path::new(proof_name));
     proof_path.set_extension(PROOF_EXT);
 
-    let result = verify(proof_name)?;
+    let allow_warnings = args.is_present("allow-warnings");
+    let result = verify(proof_name, allow_warnings)?;
     println!("Proof verified : {}\n", result);
     Ok(())
 }
 
-fn verify(proof_name: &str) -> Result<bool, CliError> {
+fn verify(proof_name: &str, allow_warnings: bool) -> Result<bool, CliError> {
     let curr_dir = std::env::current_dir().unwrap();
     let mut proof_path = PathBuf::new(); //or cur_dir?
     proof_path.push(PROOFS_DIR);
     proof_path.push(Path::new(proof_name));
     proof_path.set_extension(PROOF_EXT);
-    verify_with_path(&curr_dir, &proof_path, false)
+    verify_with_path(&curr_dir, &proof_path, false, allow_warnings)
 }
 
 fn process_abi_with_verifier_input(
@@ -65,8 +66,9 @@ pub fn verify_with_path<P: AsRef<Path>>(
     program_dir: P,
     proof_path: P,
     show_ssa: bool,
+    allow_warnings: bool,
 ) -> Result<bool, CliError> {
-    let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa)?;
+    let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa, allow_warnings)?;
 
     let public_abi = compiled_program.abi.clone().unwrap().public_abi();
     let num_pub_params = public_abi.num_parameters();

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -132,8 +132,11 @@ impl Driver {
         CrateDefMap::collect_defs(LOCAL_CRATE, &mut self.context, &mut errs);
         let mut error_count = 0;
         for errors in &errs {
-            error_count += errors.errors.len();
-            Reporter::with_diagnostics(errors.file_id, &self.context.file_manager, &errors.errors);
+            error_count += Reporter::with_diagnostics(
+                errors.file_id,
+                &self.context.file_manager,
+                &errors.errors,
+            );
         }
 
         Reporter::finish(error_count);
@@ -184,12 +187,12 @@ impl Driver {
             Err(err) => {
                 // The FileId here will be the file id of the file with the main file
                 // Errors will be shown at the callsite without a stacktrace
-                Reporter::with_diagnostics(
+                let error_count = Reporter::with_diagnostics(
                     err.location.file,
                     &self.context.file_manager,
                     &[err.to_diagnostic()],
                 );
-                Reporter::finish(1);
+                Reporter::finish(error_count);
                 unreachable!("reporter will exit before this point")
             }
         };

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -58,14 +58,11 @@ impl ResolverError {
             ResolverError::UnusedVariable { ident } => {
                 let name = &ident.0.contents;
 
-                let mut diag = Diagnostic::simple_error(
+                Diagnostic::simple_warning(
                     format!("unused variable {}", name),
                     "unused variable ".to_string(),
-                    ident.0.span(),
-                );
-                let message = format!("A new variable usually means a constraint has been added and is being unused. \n For this reason, it is almost always a bug to declare a variable and not use it. \n help: if this is intentional, prefix it with an underscore: `_{}`", name);
-                diag.add_note(message);
-                diag
+                    ident.span(),
+                )
             }
             ResolverError::VariableNotDeclared { name, span } => Diagnostic::simple_error(
                 format!("cannot find `{}` in this scope ", name),


### PR DESCRIPTION
Changes the unused variable error to a warning since they should be optimized out by the ssa pass anyway. This affects all variables, even parameters to main.
This is also noir's first warning instead of a hard error so some small plumbing was added to implement warnings.