### PR TITLE
Fix non-determinism of truncate instruction ordering

### DIFF
--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -10,7 +10,7 @@ use acvm::{acir::OPCODE, FieldElement};
 use noirc_frontend::util::vecmap;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
-use std::convert::TryInto;
+use std::{convert::TryInto, collections::BTreeMap};
 use std::{collections::HashMap, ops::Neg};
 
 //Returns the maximum bit size of short integers
@@ -161,7 +161,7 @@ fn add_to_truncate(
     ctx: &SsaContext,
     obj_id: NodeId,
     bit_size: u32,
-    to_truncate: &mut HashMap<NodeId, u32>,
+    to_truncate: &mut BTreeMap<NodeId, u32>,
     max_map: &HashMap<NodeId, BigUint>,
 ) {
     let v_max = &max_map[&obj_id];
@@ -181,7 +181,7 @@ fn add_to_truncate(
 fn process_to_truncate(
     ctx: &mut SsaContext,
     new_list: &mut Vec<NodeId>,
-    to_truncate: &mut HashMap<NodeId, u32>,
+    to_truncate: &mut BTreeMap<NodeId, u32>,
     max_map: &mut HashMap<NodeId, BigUint>,
     block_idx: BlockId,
     vmap: &mut HashMap<NodeId, NodeId>,
@@ -229,7 +229,7 @@ fn block_overflow(
     // The instructions are insterted in a duplicate list( because of rust ownership..), which we use for
     // processing another cse round for the block because the truncates may be duplicated.
     let mut new_list = Vec::new();
-    let mut truncate_map = HashMap::new();
+    let mut truncate_map = BTreeMap::new();
     let mut modified = false;
     let instructions =
         vecmap(&ctx[block_id].instructions, |id| ctx.try_get_instruction(*id).unwrap().clone());


### PR DESCRIPTION
Fixes #271.

The `to_truncate` HashMap was being collected into a Vec of new truncate instructions to insert. Since iterating over a hashmap is non-deterministic due to hashes changing on different program runs this results in a non-deterministic order for these new instructions. Since the ssa pass used the same witness indices, this caused the original bug.

This fixes the immediate issue but there is still the question of why the same witness indices were used when ssa produced a different program.