### PR TITLE
Allow casting bools to integers (and vice-versa)

### DIFF
--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -365,7 +365,7 @@ impl<'a> Evaluator<'a> {
                 }
             }
             Type::PolymorphicInteger(..) => unreachable!(),
-            Type::Bool => todo!(),
+            Type::Bool(_) => todo!(),
             Type::Unit => todo!(),
             Type::Struct(_, _) => todo!(),
             Type::Tuple(_) => todo!(),

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -339,7 +339,8 @@ impl node::Operation {
     ) {
         match self {
             //default way to handle arrays dunring inlining; we map arrays using the stack_frame
-            Operation::Binary(_) => {
+            Operation::Binary(_)
+            | Operation::Constrain(..) => {
                 self.map_id_mut(|id| {
                     if let Some(a) = Memory::deref(ctx, id) {
                         let b = stack_frame.get_or_default(a);

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -216,7 +216,7 @@ impl From<ObjectType> for NumericType {
 impl From<&Type> for ObjectType {
     fn from(t: &noirc_frontend::Type) -> ObjectType {
         match t {
-            Type::Bool => ObjectType::Boolean,
+            Type::Bool(_) => ObjectType::Boolean,
             Type::FieldElement(..) => ObjectType::NativeField,
             Type::Integer(_, _ftype, sign, bit_size) => {
                 assert!(

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -98,7 +98,7 @@ pub enum UnresolvedType {
     FieldElement(IsConst, FieldElementType),
     Array(FieldElementType, ArraySize, Box<UnresolvedType>), // [4]Witness = Array(4, Witness)
     Integer(IsConst, FieldElementType, Signedness, u32),     // u32 = Integer(unsigned, 32)
-    Bool,
+    Bool(IsConst),
     Unit,
     Struct(FieldElementType, Path),
 
@@ -143,7 +143,7 @@ impl std::fmt::Display for UnresolvedType {
                 let elements = vecmap(elements, ToString::to_string);
                 write!(f, "({})", elements.join(", "))
             }
-            Bool => write!(f, "bool"),
+            Bool(is_const) => write!(f, "{}bool", is_const),
             Unit => write!(f, "()"),
             Error => write!(f, "error"),
             Unspecified => write!(f, "unspecified"),

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -212,7 +212,7 @@ impl<'a> Resolver<'a> {
             UnresolvedType::Integer(is_const, vis, sign, bits) => {
                 Type::Integer(is_const, vis, sign, bits)
             }
-            UnresolvedType::Bool => Type::Bool,
+            UnresolvedType::Bool(is_const) => Type::Bool(is_const),
             UnresolvedType::Unit => Type::Unit,
             UnresolvedType::Unspecified => Type::Unspecified,
             UnresolvedType::Error => Type::Error,

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -5,6 +5,7 @@ use crate::hir_def::stmt::{
 };
 use crate::hir_def::types::Type;
 use crate::node_interner::{ExprId, NodeInterner, StmtId};
+use crate::IsConst;
 
 use super::{errors::TypeCheckError, expr::type_check_expression};
 
@@ -200,10 +201,13 @@ fn type_check_constrain_stmt(
     let expr_type = type_check_expression(interner, &stmt.0, errors);
     let expr_span = interner.expr_span(&stmt.0);
 
-    expr_type.unify(&Type::Bool, expr_span, errors, &mut || TypeCheckError::TypeMismatch {
-        expr_typ: expr_type.to_string(),
-        expected_typ: Type::Bool.to_string(),
-        expr_span,
+    expr_type.unify(&dbg!(Type::Bool(IsConst::new(interner))), expr_span, errors, &mut || {
+        dbg!(&expr_type);
+        TypeCheckError::TypeMismatch {
+            expr_typ: expr_type.to_string(),
+            expected_typ: Type::Bool(IsConst::No(None)).to_string(),
+            expr_span,
+        }
     });
 }
 

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -377,6 +377,7 @@ pub enum Keyword {
     // Field types
     Pub,
     Const,
+    Bool,
     //
     SetPub,
     //
@@ -409,6 +410,7 @@ impl fmt::Display for Keyword {
             Keyword::Pub => write!(f, "pub"),
             Keyword::Field => write!(f, "Field"),
             Keyword::Const => write!(f, "const"),
+            Keyword::Bool => write!(f, "bool"),
         }
     }
 }
@@ -442,6 +444,7 @@ impl Keyword {
 
             // Native Types
             "Field" => Keyword::Field,
+            "bool" => Keyword::Bool,
 
             "true" => return Some(Token::Bool(true)),
             "false" => return Some(Token::Bool(false)),

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -376,6 +376,7 @@ where
         struct_type(visibility_parser.clone()),
         array_type(visibility_parser, recursive_type_parser.clone()),
         tuple_type(recursive_type_parser),
+        bool_type(),
     ))
 }
 
@@ -409,6 +410,10 @@ where
         .then(maybe_const())
         .then_ignore(keyword(Keyword::Field))
         .map(|(vis, is_const)| UnresolvedType::FieldElement(is_const, vis))
+}
+
+fn bool_type() -> impl NoirParser<UnresolvedType> {
+    maybe_const().then_ignore(keyword(Keyword::Bool)).map(UnresolvedType::Bool)
 }
 
 fn int_type<P>(visibility_parser: P) -> impl NoirParser<UnresolvedType>


### PR DESCRIPTION
Fixes #277.

It also turns out we never parsed the bool type either, so I added support for parsing it.

Bool was also the only primitive type not to have constness tracked so I added that as well. Previously if you had a constant and casted it to a boolean and back the compiler would treat it as non-const. Now it will correctly recognize it as still const and allow it to be used as an index.