### PR TITLE
Check for missing Prover.toml and empty values

### DIFF
--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -91,7 +91,13 @@ pub fn prove_with_path<P: AsRef<Path>>(
     let compiled_program = driver.into_compiled_program(backend.np_language(), show_ssa);
 
     // Parse the initial witness values
-    let witness_map = noirc_abi::input_parser::Format::Toml.parse(program_dir, PROVER_INPUT_FILE);
+    let witness_map = noirc_abi::input_parser::Format::Toml.parse(program_dir, PROVER_INPUT_FILE).or_else(
+        |err_msg| { return Err(CliError::Generic(format!(
+            "{}, run nargo build if missing a Prover.toml file",
+            err_msg
+        )));
+        }
+    )?;
 
     // Check that enough witness values were supplied
     let num_params = compiled_program.abi.as_ref().unwrap().num_parameters();

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -93,7 +93,13 @@ pub fn verify_with_path<P: AsRef<Path>>(
     let mut public_inputs = BTreeMap::new();
     if num_pub_params != 0 {
         let curr_dir = program_dir;
-        public_inputs = noirc_abi::input_parser::Format::Toml.parse(curr_dir, VERIFIER_INPUT_FILE);
+        public_inputs = noirc_abi::input_parser::Format::Toml.parse(curr_dir, VERIFIER_INPUT_FILE).or_else(
+            |err_msg| { return Err(CliError::Generic(format!(
+                "{}, run nargo build if missing a Verifier.toml file",
+                err_msg
+            )));
+            }
+        )?;
     }
 
     if num_pub_params != public_inputs.len() {

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -51,7 +51,7 @@ impl Format {
 }
 
 impl Format {
-    pub fn parse<P: AsRef<Path>>(&self, path: P, file_name: &str) -> BTreeMap<String, InputValue> {
+    pub fn parse<P: AsRef<Path>>(&self, path: P, file_name: &str) -> Result<BTreeMap<String, InputValue>, String> {
         match self {
             Format::Toml => {
                 let mut dir_path = path.as_ref().to_path_buf();

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -4,9 +4,11 @@ use std::{collections::BTreeMap, path::Path};
 
 use super::InputValue;
 
-pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> BTreeMap<String, InputValue> {
+pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<BTreeMap<String, InputValue>, String> {
     let path_to_toml = path_to_toml.as_ref();
-    assert!(path_to_toml.exists(), "cannot find input file at located {}", path_to_toml.display());
+    if !path_to_toml.exists() {
+        return Err(format!("cannot find input file at located {}", path_to_toml.display()));
+    }
 
     // Get input.toml file as a string
     let input_as_string = std::fs::read_to_string(path_to_toml).unwrap();
@@ -20,41 +22,49 @@ pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> BTreeMap<String, InputVa
 
 /// Converts the Toml mapping to the native representation that the compiler
 /// understands for Inputs
-fn toml_map_to_field(toml_map: BTreeMap<String, TomlTypes>) -> BTreeMap<String, InputValue> {
+fn toml_map_to_field(toml_map: BTreeMap<String, TomlTypes>) -> Result<BTreeMap<String, InputValue>, String> {
     let mut field_map = BTreeMap::new();
 
     for (parameter, value) in toml_map {
         match value {
             TomlTypes::String(string) => {
+                let new_value = parse_str(&string)?;       
                 let old_value =
-                    field_map.insert(parameter.clone(), InputValue::Field(parse_str(&string)));
-                assert!(old_value.is_none(), "duplicate variable name {}", parameter);
+                    field_map.insert(parameter.clone(), InputValue::Field(new_value));
+                if !old_value.is_none() {
+                    return Err(format!("duplicate variable name {}", parameter))
+                }
             }
             TomlTypes::Integer(integer) => {
+                let new_value = parse_str(&integer.to_string())?;
                 let old_value = field_map
-                    .insert(parameter.clone(), InputValue::Field(parse_str(&integer.to_string())));
-                assert!(old_value.is_none(), "duplicate variable name {}", parameter);
+                    .insert(parameter.clone(), InputValue::Field(new_value));
+                if !old_value.is_none() {
+                    return Err(format!("duplicate variable name {}", parameter))
+                }
             }
             TomlTypes::ArrayNum(arr_num) => {
-                let array_elements: Vec<_> =
+                let array_elements: Result<Vec<_>, _> =
                     arr_num.into_iter().map(|elem_num| parse_str(&elem_num.to_string())).collect();
-
                 let old_value =
-                    field_map.insert(parameter.clone(), InputValue::Vec(array_elements));
-                assert!(old_value.is_none(), "duplicate variable name {}", parameter);
+                    field_map.insert(parameter.clone(), InputValue::Vec(array_elements?));
+                if !old_value.is_none() {
+                    return Err(format!("duplicate variable name {}", parameter))
+                }           
             }
             TomlTypes::ArrayString(arr_str) => {
-                let array_elements: Vec<_> =
+                let array_elements: Result<Vec<_>, _> =
                     arr_str.into_iter().map(|elem_str| parse_str(&elem_str)).collect();
-
                 let old_value =
-                    field_map.insert(parameter.clone(), InputValue::Vec(array_elements));
-                assert!(old_value.is_none(), "duplicate variable name {}", parameter);
+                    field_map.insert(parameter.clone(), InputValue::Vec(array_elements?));
+                if !old_value.is_none() {
+                    return Err(format!("duplicate variable name {}", parameter))
+                }            
             }
         }
     }
 
-    field_map
+    Ok(field_map)
 }
 
 #[derive(Debug, Deserialize)]
@@ -71,12 +81,17 @@ enum TomlTypes {
     ArrayString(Vec<String>),
 }
 
-fn parse_str(value: &str) -> FieldElement {
+fn parse_str(value: &str) -> Result<FieldElement, String> {
     if value.starts_with("0x") {
-        FieldElement::from_hex(value)
-            .unwrap_or_else(|| panic!("Could not parse hex value {}", value))
+        match FieldElement::from_hex(value) {
+            None => Err(format!("Could not parse hex value {}", value)),
+            Some(val) => Ok(val)
+        }
     } else {
-        let val: i128 = value.parse().expect("Expected witness values to be integers");
-        FieldElement::from(val)
+        let val: i128 = match value.parse() {
+            Err(msg) => return Err(format!("Expected witness values to be integers, provided value `{}` causes `{}` error", value, msg)),
+            Ok(parsed_val) => parsed_val
+        };
+        Ok(FieldElement::from(val))
     }
 }


### PR DESCRIPTION
This PR addresses this issue: #97 

This PR checks whether a `Prover.toml` file exists when calling the nargo prove command. It also checks whether a `Verifier.toml` exists for when nargo verify is called. A cli error is also now returned when there are empty fields in the `Prover.toml` and `Verifier.toml`. 

A missing Prover or Verifier toml file will return these errors:
<img width="601" alt="Screen Shot 2022-07-19 at 2 34 04 PM" src="https://user-images.githubusercontent.com/43554004/179823869-5a793207-c4c3-4110-babd-3a22a790f237.png">

<img width="597" alt="Screen Shot 2022-07-19 at 2 34 19 PM" src="https://user-images.githubusercontent.com/43554004/179823906-78e4a141-877a-46d5-8e9d-863523040088.png">

A command call with empty inputs will return this error currently
<img width="905" alt="Screen Shot 2022-07-19 at 2 32 44 PM" src="https://user-images.githubusercontent.com/43554004/179823636-f6ea522d-dcff-4f87-ba52-dcb9130de031.png">
