### PR TITLE
Add packer script to pack a directory into one file

### DIFF
--- a/noirpacker.py
+++ b/noirpacker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import os
 import re
+import sys
 
 def read_dir(path):
     ret = ""
@@ -29,7 +30,7 @@ def read_dir(path):
             elif entry.is_file():
                 ret += sanitize(open(entry).read())
 
-        if entry.name != "main.nr":
+        if name != "":
             ret += "\n}\n"
 
     return ret
@@ -44,4 +45,15 @@ def append_entry(modules, name, entry):
 def sanitize(contents):
     return re.sub(r'\bmod \w+;', '', contents)
 
-print(read_dir("."))
+if len(sys.argv) < 2:
+    print('usage: ./noirpacker.py <path-to-src-dir> [output-file]')
+else:
+    path = sys.argv[1]
+
+    packed_dir = read_dir(path)
+    if len(sys.argv) == 2:
+        print(packed_dir)
+    else:
+        f = open(sys.argv[2], 'w')
+        f.write(packed_dir)
+        f.close()

--- a/noirpacker.py
+++ b/noirpacker.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+import os
+import re
+
+def read_dir(path):
+    ret = ""
+    modules = {}
+
+    # First find all modules and group together modules of the same name.
+    # This can happen when we have a `foo.nr` file and `foo` directory.
+    for entry in os.scandir(path):
+        if entry.is_dir():
+            append_entry(modules, entry.name, entry)
+
+        elif entry.is_file() and entry.name.endswith(".nr"):
+            if entry.name != "main.nr":
+                append_entry(modules, entry.name[:-3], entry)
+            else:
+                append_entry(modules, "", entry)
+
+    for name, entries in modules.items():
+        # No mod construct for the main module
+        if name != "":
+            ret += f"mod {name} {{\n"
+
+        for entry in entries:
+            if entry.is_dir():
+                ret += read_dir(entry)
+            elif entry.is_file():
+                ret += sanitize(open(entry).read())
+
+        if entry.name != "main.nr":
+            ret += "\n}\n"
+
+    return ret
+
+def append_entry(modules, name, entry):
+    if name in modules:
+        modules[name].append(entry)
+    else:
+        modules[name] = [entry]
+
+# Remove 'mod foo;' declarations from files
+def sanitize(contents):
+    return re.sub(r'\bmod \w+;', '', contents)
+
+print(read_dir("."))


### PR DESCRIPTION
Adds a small python script to pack a project directory of noir files into a single noir file.
- Removes `mod foo;` declarations in each file and adds submodule declarations `mod foo { ... }` wrapping files as needed.

Not sure if this repository is the best place for this tool but I put it here for now for visibility.

Example of running in `crates/nargo/tests/test_data/modules_more/src`:
```rs
mod foo {
mod bar {
fn from_bar(x : Field) -> Field {
    x
}
}


fn hello(x : Field) -> Field {
    x
}

}


// An example of the module system

fn main(x : Field, y : Field) {
    constrain x != foo::bar::from_bar(y);
}
```
Which still correctly proves and verifies.