### PR TITLE
Fix for nargo contract cmd

### DIFF
--- a/crates/aztec_backend/src/barretenberg_rs/composer.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/composer.rs
@@ -532,8 +532,7 @@ impl StandardComposer {
                 p_contract_ptr,
             );
             assert!(contract_size > 0);
-            sc_as_bytes =
-                slice::from_raw_parts(contract_ptr, contract_size as usize)
+            sc_as_bytes = slice::from_raw_parts(contract_ptr, contract_size as usize)
         }
         // TODO to check
         // XXX: We truncate the first 40 bytes, due to it being mangled

--- a/crates/aztec_backend/src/barretenberg_rs/composer.rs
+++ b/crates/aztec_backend/src/barretenberg_rs/composer.rs
@@ -2,6 +2,7 @@ use super::crs::CRS;
 use super::pippenger::Pippenger;
 use super::BARRETENBERG;
 use acvm::FieldElement as Scalar;
+use std::slice;
 
 pub struct StandardComposer {
     pippenger: Pippenger,
@@ -532,7 +533,7 @@ impl StandardComposer {
             );
             assert!(contract_size > 0);
             sc_as_bytes =
-                Vec::from_raw_parts(contract_ptr, contract_size as usize, contract_size as usize)
+                slice::from_raw_parts(contract_ptr, contract_size as usize)
         }
         // TODO to check
         // XXX: We truncate the first 40 bytes, due to it being mangled


### PR DESCRIPTION
While trying to work on a more thorough Noir example I wanted to construct a verifier contract using `nargo contract`. However, I would arrive at this error every time: 
```
nargo(89530,0x11e781e00) malloc: *** error for object 0x7fbdba80c600: pointer being freed was not allocated
nargo(89530,0x11e781e00) malloc: *** set a breakpoint in malloc_error_break to debug
zsh: abort      nargo contract
```

It looks to be happening here when interoperating with barretenberg using FFI: 
https://github.com/noir-lang/noir/blob/e9494ffd754a6a0cf7b6453d5749041035ef8bfb/crates/aztec_backend/src/barretenberg_rs/composer.rs#L520

As per the comments in the method it looks like there are some bytes getting mangled and I am suspicious that this is why when Rust would later deallocate the `Vec` the program would panic. I simply switched the `Vec::from_raw_parts` to `slice::from_raw_parts`. The contract ptr is no longer being deallocated in Rust but the contract successfully writes to file. Need to investigate a bit further where the pointer gets messed up. There are discussions about moving away from using FFI w/ barretenberg entirely, but I wasn't sure if this issue has been looked at before and thought it would be good to post this PR anyway.