### PR TITLE
Use relative index for arrays

### DIFF
--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -602,6 +602,15 @@ impl<'a> SsaContext<'a> {
 
         result
     }
+
+    //returns the value of the element array[index], if it exists in the memory_map
+    pub fn get_indexed_value(&self, array_id: ArrayId, index: NodeId) -> Option<&NodeId> {
+        if let Some(idx) = Memory::to_u32(self, index) {
+            self.mem.get_value_from_map(array_id, idx)
+        } else {
+            None
+        }
+    }
     //blocks/////////////////////////
     pub fn try_get_block_mut(&mut self, id: BlockId) -> Option<&mut block::BasicBlock> {
         self.blocks.get_mut(id.0)
@@ -724,18 +733,12 @@ impl<'a> SsaContext<'a> {
 
         if let (ObjectType::Pointer(a), ObjectType::Pointer(b)) = (l_type, r_type) {
             let len = self.mem[a].len;
-            let adr_a = self.mem[a].adr;
-            let adr_b = self.mem[b].adr;
             let e_type = self.mem[b].element_type;
             for i in 0..len {
-                let idx_b = self.get_or_create_const(
-                    FieldElement::from((adr_b + i) as i128),
-                    ObjectType::Unsigned(32),
-                );
-                let idx_a = self.get_or_create_const(
-                    FieldElement::from((adr_a + i) as i128),
-                    ObjectType::Unsigned(32),
-                );
+                let idx_b = self
+                    .get_or_create_const(FieldElement::from(i as i128), ObjectType::Unsigned(32));
+                let idx_a = self
+                    .get_or_create_const(FieldElement::from(i as i128), ObjectType::Unsigned(32));
                 let op_b = Operation::Load { array_id: b, index: idx_b };
                 let load = self.new_instruction(op_b, e_type)?;
                 let op_a = Operation::Store { array_id: a, index: idx_a, value: load };
@@ -859,18 +862,12 @@ impl<'a> SsaContext<'a> {
 
         if let (ObjectType::Pointer(a), ObjectType::Pointer(b)) = (l_type, r_type) {
             let len = self.mem[a].len;
-            let adr_a = self.mem[a].adr;
-            let adr_b = self.mem[b].adr;
             let e_type = self.mem[b].element_type;
             for i in 0..len {
-                let idx_b = self.get_or_create_const(
-                    FieldElement::from((adr_b + i) as i128),
-                    ObjectType::Unsigned(32),
-                );
-                let idx_a = self.get_or_create_const(
-                    FieldElement::from((adr_a + i) as i128),
-                    ObjectType::Unsigned(32),
-                );
+                let idx_b = self
+                    .get_or_create_const(FieldElement::from(i as i128), ObjectType::Unsigned(32));
+                let idx_a = self
+                    .get_or_create_const(FieldElement::from(i as i128), ObjectType::Unsigned(32));
                 let op_b = Operation::Load { array_id: b, index: idx_b };
                 let load = self.new_instruction_inline(op_b, e_type, stack_frame);
                 let op_a = Operation::Store { array_id: a, index: idx_a, value: load };

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -1,8 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use acvm::FieldElement;
 use noirc_frontend::node_interner::FuncId;
-use num_bigint::BigUint;
 
 use crate::{
     errors::RuntimeError,
@@ -285,38 +283,8 @@ pub fn inline_in_block(
                     //Compute the new address:
                     //TODO use relative addressing, but that requires a few changes, mainly in acir_gen.rs and integer.rs
                     let b = stack_frame.get_or_default(*array_id);
-                    let offset = ctx.mem[b].adr as i32 - ctx.mem[*array_id].adr as i32;
-                    let adr_id = if *index == NodeId::dummy() {
-                        NodeId::dummy()
-                    } else {
-                        let index_type = ctx[*index].get_type();
-                        let offset_op = if offset < 0 {
-                            let offset_id = ctx.get_or_create_const(
-                                FieldElement::from(-offset as i128),
-                                index_type,
-                            );
-                            node::Binary {
-                                operator: node::BinaryOp::Sub {
-                                    max_rhs_value: BigUint::from(-offset as u128),
-                                },
-                                lhs: *index,
-                                rhs: offset_id,
-                            }
-                        } else {
-                            let offset_id = ctx.get_or_create_const(
-                                FieldElement::from(offset as i128),
-                                index_type,
-                            );
-                            node::Binary {
-                                operator: node::BinaryOp::Add,
-                                lhs: offset_id,
-                                rhs: *index,
-                            }
-                        };
-                        ctx.new_instruction(Operation::Binary(offset_op), index_type)?
-                    };
                     let mut new_ins = Instruction::new(
-                        Operation::Load { array_id: b, index: adr_id },
+                        Operation::Load { array_id: b, index: *index },
                         clone.res_type,
                         Some(stack_frame.block),
                     );
@@ -325,38 +293,8 @@ pub fn inline_in_block(
                 }
                 Operation::Store { array_id, index, value } => {
                     let b = stack_frame.get_or_default(*array_id);
-                    let offset = ctx.mem[b].adr as i32 - ctx.mem[*array_id].adr as i32;
-                    let adr_id = if *index == NodeId::dummy() {
-                        NodeId::dummy()
-                    } else {
-                        let index_type = ctx[*index].get_type();
-                        let offset_op = if offset < 0 {
-                            let offset_id = ctx.get_or_create_const(
-                                FieldElement::from(-offset as i128),
-                                index_type,
-                            );
-                            node::Binary {
-                                operator: node::BinaryOp::Sub {
-                                    max_rhs_value: BigUint::from(-offset as u128),
-                                },
-                                lhs: *index,
-                                rhs: offset_id,
-                            }
-                        } else {
-                            let offset_id = ctx.get_or_create_const(
-                                FieldElement::from(offset as i128),
-                                index_type,
-                            );
-                            node::Binary {
-                                operator: node::BinaryOp::Add,
-                                lhs: offset_id,
-                                rhs: *index,
-                            }
-                        };
-                        ctx.new_instruction(Operation::Binary(offset_op), index_type)?
-                    };
                     let mut new_ins = Instruction::new(
-                        Operation::Store { array_id: b, index: adr_id, value: *value },
+                        Operation::Store { array_id: b, index: *index, value: *value },
                         clone.res_type,
                         Some(stack_frame.block),
                     );

--- a/crates/noirc_evaluator/src/ssa/mem.rs
+++ b/crates/noirc_evaluator/src/ssa/mem.rs
@@ -62,6 +62,10 @@ impl MemArray {
             max: of.max_size(),
         }
     }
+
+    pub fn absolute_adr(&self, idx: u32) -> u32 {
+        self.adr + idx
+    }
 }
 
 impl Memory {
@@ -113,6 +117,12 @@ impl Memory {
             //Invalid memory address
         }
         None //Not a constant object
+    }
+
+    //returns the value of the element array[index], if it exists in the memory_map
+    pub fn get_value_from_map(&self, array_id: ArrayId, index: u32) -> Option<&NodeId> {
+        let adr = self[array_id].absolute_adr(index);
+        self.memory_map.get(&adr)
     }
 }
 


### PR DESCRIPTION
This is a small PR that change the absolute memory addresses in LOAD and STORE instructions , into relative addressing.
It makes memory instructions easier to handle as we do not need to compute the offset anymore. If the absolute addresses are required to support dynamic memory indexing, it will be trivial to re-construct them at that point.
