### PR TITLE
Refactor API for PWG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,10 @@ dependencies = [
 [[package]]
 name = "acir"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir#3deb5363ba5198e833812ba54d62565c4753d2b7"
+source = "git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
 dependencies = [
  "indexmap",
- "noir_field 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "serde",
 ]
 
@@ -42,14 +42,14 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir#3deb5363ba5198e833812ba54d62565c4753d2b7"
+source = "git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
 dependencies = [
- "acir 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acir 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "blake2",
  "hex",
  "indexmap",
  "k256",
- "noir_field 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "num-bigint",
  "num-traits",
  "sha2",
@@ -260,9 +260,9 @@ dependencies = [
 [[package]]
 name = "arkworks_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/arkworks_backend#0ee72cf5eb387abc1e097780dc92539365a00e2f"
+source = "git+https://github.com/noir-lang/arkworks_backend?rev=ee6d468f5cc635dc2589965b6bf16cd2a839d7d3#ee6d468f5cc635dc2589965b6bf16cd2a839d7d3"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff",
@@ -298,9 +298,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aztec_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend#a92940fd4934701a2c9f99901e10c6c729489b90"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=01b922adcb5a9d70b2d12304e1cb7487d9f28188#01b922adcb5a9d70b2d12304e1cb7487d9f28188"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "barretenberg_wrapper",
  "blake2",
  "dirs",
@@ -1117,9 +1117,9 @@ dependencies = [
 [[package]]
 name = "marlin_arkworks_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/marlin_arkworks_backend#e7b333cec118518b4d4559be66b5c0dd8b9e2e83"
+source = "git+https://github.com/noir-lang/marlin_arkworks_backend?rev=601e24dcb5dcbe72e3de7a33879aaf84e171d541#601e24dcb5dcbe72e3de7a33879aaf84e171d541"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "arkworks_backend",
  "blake2",
  "dirs",
@@ -1176,7 +1176,7 @@ dependencies = [
 name = "nargo"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "aztec_backend",
  "cfg-if 1.0.0",
  "clap",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "noir_field"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir#3deb5363ba5198e833812ba54d62565c4753d2b7"
+source = "git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1248,7 +1248,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "blake2",
  "serde",
  "serde_derive",
@@ -1259,7 +1259,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "dirs",
  "fm",
  "noirc_abi",
@@ -1284,7 +1284,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "arena",
  "fm",
  "lazy_static",
@@ -1300,7 +1300,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "arena",
  "chumsky",
  "fm",

--- a/crates/acvm/src/lib.rs
+++ b/crates/acvm/src/lib.rs
@@ -7,14 +7,15 @@ pub mod pwg;
 use std::collections::BTreeMap;
 
 use acir::{
-    circuit::{Circuit, Gate, gate::{Directive, GadgetCall}},
+    circuit::{
+        gate::{Directive, GadgetCall},
+        Circuit, Gate,
+    },
     native_types::{Expression, Witness},
     OPCODE,
 };
 
-use crate::{
-    pwg::{arithmetic::ArithmeticSolver, logic::LogicSolver},
-};
+use crate::pwg::{arithmetic::ArithmeticSolver, logic::LogicSolver};
 use num_bigint::BigUint;
 use num_traits::One;
 
@@ -161,10 +162,10 @@ pub trait PartialWitnessGenerator {
         }
         self.solve(initial_witness, unsolved_gates)
     }
-    
+
     fn solve_gadget_call(
-        initial_witness: &mut BTreeMap<Witness, FieldElement>, 
-        gc: &GadgetCall
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        gc: &GadgetCall,
     ) -> Result<(), OPCODE>;
 
     fn get_value(

--- a/crates/acvm/src/lib.rs
+++ b/crates/acvm/src/lib.rs
@@ -31,7 +31,7 @@ pub trait PartialWitnessGenerator {
     fn solve(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        gates: Vec<acir::circuit::Gate>,
+        gates: Vec<Gate>,
     ) -> Result<(), OPCODE> {
         if gates.is_empty() {
             return Ok(());

--- a/crates/acvm/src/lib.rs
+++ b/crates/acvm/src/lib.rs
@@ -7,10 +7,16 @@ pub mod pwg;
 use std::collections::BTreeMap;
 
 use acir::{
-    circuit::{Circuit, Gate},
+    circuit::{Circuit, Gate, gate::{Directive, GadgetCall}},
     native_types::{Expression, Witness},
     OPCODE,
 };
+
+use crate::{
+    pwg::{arithmetic::ArithmeticSolver, logic::LogicSolver},
+};
+use num_bigint::BigUint;
+use num_traits::One;
 
 // re-export acir
 pub use acir;
@@ -25,7 +31,140 @@ pub trait PartialWitnessGenerator {
     fn solve(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        gates: Vec<Gate>,
+        gates: Vec<acir::circuit::Gate>,
+    ) -> Result<(), OPCODE> {
+        if gates.is_empty() {
+            return Ok(());
+        }
+        let mut unsolved_gates: Vec<Gate> = Vec::new();
+
+        for gate in gates.into_iter() {
+            let unsolved = match &gate {
+                Gate::Arithmetic(arith) => {
+                    ArithmeticSolver::solve(initial_witness, arith).is_some()
+                }
+                // We do not need to solve for this gate, we have passed responsibility to the underlying
+                // proof system for intermediate witness generation
+                Gate::Range(_, _) => {
+                    // We do not need to solve for this gate, we have passed responsibility to the underlying
+                    // proof system for intermediate witness generation
+                    false
+                }
+                Gate::And(and_gate) => {
+                    !LogicSolver::solve_and_gate(initial_witness, and_gate)
+                    // We compute the result because the other gates may want to use the assignment to generate their assignments
+                }
+                Gate::Xor(xor_gate) => {
+                    !LogicSolver::solve_xor_gate(initial_witness, xor_gate)
+                    // We compute the result because the other gates may want to use the assignment to generate their assignments
+                }
+                Gate::GadgetCall(gc) => {
+                    Self::solve_gadget_call(initial_witness, gc)?;
+                    false
+                }
+                Gate::Directive(directive) => match directive {
+                    Directive::Invert { x, result } => match initial_witness.get(x) {
+                        None => true,
+                        Some(val) => {
+                            let inverse = val.inverse();
+                            initial_witness.insert(*result, inverse);
+                            false
+                        }
+                    },
+
+                    Directive::Quotient { a, b, q, r } => {
+                        match (
+                            Self::get_value(a, initial_witness),
+                            Self::get_value(b, initial_witness),
+                        ) {
+                            (Some(val_a), Some(val_b)) => {
+                                let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
+                                let int_b = BigUint::from_bytes_be(&val_b.to_bytes());
+                                let int_r = &int_a % &int_b;
+                                let int_q = &int_a / &int_b;
+
+                                initial_witness.insert(
+                                    *q,
+                                    FieldElement::from_be_bytes_reduce(&int_q.to_bytes_be()),
+                                );
+                                initial_witness.insert(
+                                    *r,
+                                    FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
+                                );
+                                false
+                            }
+                            _ => true,
+                        }
+                    }
+                    Directive::Truncate { a, b, c, bit_size } => match initial_witness.get(a) {
+                        Some(val_a) => {
+                            let pow: BigUint = BigUint::one() << bit_size;
+
+                            let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
+                            let int_b: BigUint = &int_a % &pow;
+                            let int_c: BigUint = (&int_a - &int_b) / &pow;
+
+                            initial_witness.insert(
+                                *b,
+                                FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
+                            );
+                            initial_witness.insert(
+                                *c,
+                                FieldElement::from_be_bytes_reduce(&int_c.to_bytes_be()),
+                            );
+                            false
+                        }
+                        _ => true,
+                    },
+                    Directive::Split { a, b, bit_size } => match initial_witness.get(a) {
+                        Some(val_a) => {
+                            let a_big = BigUint::from_bytes_be(&val_a.to_bytes());
+                            for i in 0..*bit_size {
+                                let j = i as usize;
+                                let v = if a_big.bit(j as u64) {
+                                    FieldElement::one()
+                                } else {
+                                    FieldElement::zero()
+                                };
+                                initial_witness.insert(b[j], v);
+                            }
+                            false
+                        }
+                        _ => true,
+                    },
+                    Directive::Oddrange { a, b, r, bit_size } => match initial_witness.get(a) {
+                        Some(val_a) => {
+                            let int_a = BigUint::from_bytes_be(&val_a.to_bytes());
+                            let pow: BigUint = BigUint::one() << (bit_size - 1);
+
+                            let bb = &int_a & &pow;
+                            let int_r = &int_a - &bb;
+                            let int_b = &bb >> (bit_size - 1);
+
+                            initial_witness.insert(
+                                *b,
+                                FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
+                            );
+                            initial_witness.insert(
+                                *r,
+                                FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
+                            );
+                            false
+                        }
+                        _ => true,
+                    },
+                },
+            };
+            if unsolved {
+                unsolved_gates.push(gate);
+            }
+        }
+        self.solve(initial_witness, unsolved_gates)
+    }
+    
+    fn solve_gadget_call(
+        initial_witness: &mut BTreeMap<Witness, FieldElement>, 
+        gc: &GadgetCall
     ) -> Result<(), OPCODE>;
 
     fn get_value(

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -13,7 +13,7 @@ noirc_driver = { path = "../noirc_driver" }
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_abi = { path = "../noirc_abi" }
 fm = { path = "../fm" }
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
 cfg-if = "1.0.0"
 
 toml = "0.5"
@@ -25,8 +25,8 @@ hex = "0.4.2"
 tempdir = "0.3.7"
 
 # Backends
-aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend" }
-marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend" }
+aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend", rev = "01b922adcb5a9d70b2d12304e1cb7487d9f28188" }
+marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "601e24dcb5dcbe72e3de7a33879aaf84e171d541" }
 
 [features]
 default = ["plonk_bn254"]

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
 toml = "0.5.8"
 serde = "1.0.123"
 serde_derive = "1.0.123"

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -11,7 +11,7 @@ noirc_errors = {path = "../noirc_errors"}
 noirc_frontend = {path = "../noirc_frontend"}
 noirc_evaluator = {path = "../noirc_evaluator"}
 noirc_abi = {path = "../noirc_abi"}
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
 std_lib = {path = "../std_lib"}
 fm = {path = "../fm"}
 

--- a/crates/noirc_evaluator/Cargo.toml
+++ b/crates/noirc_evaluator/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_errors = { path = "../noirc_errors" }
 noirc_abi = { path = "../noirc_abi" }
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
 arena = {path = "../arena"}
 fm = { path = "../fm" }
 lazy_static = "1.4.0"

--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
 noirc_abi = { path = "../noirc_abi" }
 noirc_errors = { path = "../noirc_errors" }
 std_lib = { path = "../std_lib" }


### PR DESCRIPTION
This is the PR to implement issue #47. 

The main change is switching to having a default trait implementation for `solve` in the PWG generator. Currently, aside from the gadget call gate, all the code in gate solver is the same between both the aztec and arkworks backend. A separate method was created to solve a gadget call which will be overridden in each backend's PWG where the GadgetCaller specified in the respective backend's `acvm_interop` will be called. A similar strategy can then be employed for any backend that requires a different solver implementation for a given gate. A backend will now override a specific gate solver within the PWG `solve` method rather than having to reimplement the entire arithmetic section of the PWG.  

Now that we have moved the backends out of the noir repo and are using a remote acvm reference, this PR simply makes the necessary changes to the acvm. The relevant changes in the aztec_backend can be found in this PR: https://github.com/noir-lang/aztec_backend/pull/4

marlin_arkworks_backend changes can be found here: https://github.com/noir-lang/marlin_arkworks_backend/pull/4
And arkworks_backend changes be found here: https://github.com/noir-lang/arkworks_backend/pull/2 (however this is just a dependency change to match up with the change in marlin_arkworks_backend)

I think it would be worth it to consider moving the acvm out of Noir before more refactors or changes are done to the acvm as having to match the git commits can lead to some development issues. Noir needs to be pushed broken once so that we can update the commit in the backend and then put the correct git reference for the backend in nargo's `Cargo.toml`. This PR currently references a past acvm commit that builds for all repositories. For once acvm changes are be merged into master, it felt a little odd to be referencing a past commit for the acvm. This is not the end of the world for the near-term, but it felt clearer for development to reference a separate acvm crate, especially if that crate will be separated in the future. 
