### PR TITLE
Remove variable length arrays, Add length-polymorphic arrays

### DIFF
--- a/crates/nargo/tests/test_data/6_array/src/main.nr
+++ b/crates/nargo/tests/test_data/6_array/src/main.nr
@@ -1,6 +1,6 @@
 //Basic tests for arrays 
 
-fn main(x: [5]u32, y: [5]u32, mut z: u32, t: u32) {  
+fn main(x: [u32; 5], y: [u32; 5], mut z: u32, t: u32) {  
    let mut c = (z-z+2301) as u32;
 
    //t= t+x[0]-x[0];

--- a/crates/nargo/tests/test_data/7_function/src/main.nr
+++ b/crates/nargo/tests/test_data/7_function/src/main.nr
@@ -46,86 +46,83 @@ fn pow(base : Field, exponent : Field) -> Field {
     r
 }
 
-fn test3(x: [3]u8) -> [3]u8 {
-      let mut buffer: [3]u8 = [0 as u8,0 as u8, 0 as u8];
-       for i in 0..3   {
-       buffer[i] = x[i] ;
-     };
-     constrain buffer == x;
-     buffer
+fn test3(x: [u8; 3]) -> [u8; 3] {
+    let mut buffer = [0 as u8; 3];
+    for i in 0..3 {
+        buffer[i] = x[i];
+    };
+    constrain buffer == x;
+    buffer
 }
 
-fn test_multiple(x: u32, y: u32) -> (u32, u32)
-{
+fn test_multiple(x: u32, y: u32) -> (u32, u32) {
     (y,x)
 }
 
-fn test_multiple2() -> my_struct
-{
-     my_struct{a:5 as u32, b:7 as u32}
+fn test_multiple2() -> my_struct {
+    my_struct { a: 5 as u32, b: 7 as u32 }
 }
 
-fn test_multiple3(x: u32, y: u32)
-{
-     constrain x == y;
+fn test_multiple3(x: u32, y: u32) {
+    constrain x == y;
 }
 
 struct my_struct {
-     a: u32,
-     b: u32,
+    a: u32,
+    b: u32,
 }
+
 struct my2 {
-     aa: my_struct,
-     bb: my_struct,
+    aa: my_struct,
+    bb: my_struct,
 }
 
-fn test_multiple4(s : my_struct) {
-     constrain s.a == s.b+2;
-
+fn test_multiple4(s: my_struct) {
+    constrain s.a == s.b+2;
 }
 
 fn test_multiple5(a: (u32, u32)) {
-     constrain a.0 == a.1+2;
+    constrain a.0 == a.1+2;
 }
 
 
 fn test_multiple6(a: my2, b: my_struct, c: (my2, my_struct)) {
-     test_multiple4(a.aa);
-     test_multiple5((b.a, b.b));
-     constrain c.0.aa.a == c.1.a;
+    test_multiple4(a.aa);
+    test_multiple5((b.a, b.b));
+    constrain c.0.aa.a == c.1.a;
 }
 
 fn main(x : u32 , y : u32 , a : Field) {  
-     let mut ss: my_struct =  my_struct{ b:x,a:x+2,};
-     test_multiple4(ss);
-     test_multiple5((ss.a,ss.b));
-     let my: my2 = my2{
-          aa: ss,
-          bb: ss,
-     };
-     ss.a = 61;
-     test_multiple6(my, ss, (my,ss));
+    let mut ss: my_struct = my_struct { b: x, a: x+2, };
+    test_multiple4(ss);
+    test_multiple5((ss.a,ss.b));
+    let my = my2 {
+        aa: ss,
+        bb: ss,
+    };
+    ss.a = 61;
+    test_multiple6(my, ss, (my,ss));
 
-     let my_block = { 
-          let mut ab = f2(a);
-          ab = ab + a;
-          (x,ab)
-     };
-     constrain my_block.1 == 4;
-     
-     test0(a);
-     test1(a);
-     test2(x as Field,y);
+    let my_block = { 
+        let mut ab = f2(a);
+        ab = ab + a;
+        (x,ab)
+    };
+    constrain my_block.1 == 4;
+    
+    test0(a);
+    test1(a);
+    test2(x as Field, y);
 
-     let mut b: [3]u8 =[0 as u8, 5 as u8, 2 as u8];
-     let c = test3(b);
-     constrain b == c;
-     b[0] = 1 as u8;
-     let cc = test3(b);
-     constrain c != cc;
-     let e = test_multiple(x,y) ;
-     constrain e.1==e.0+54 as u32;
-     let d = test_multiple2();
-     constrain d.b == d.a + 2 as u32;
-     test_multiple3(y,y);
+    let mut b = [0 as u8, 5 as u8, 2 as u8];
+    let c = test3(b);
+    constrain b == c;
+    b[0] = 1 as u8;
+    let cc = test3(b);
+    constrain c != cc;
+    let e = test_multiple(x, y);
+    constrain e.1 == e.0 + 54 as u32;
+    let d = test_multiple2();
+    constrain d.b == d.a + 2 as u32;
+    test_multiple3(y, y);
 }

--- a/crates/nargo/tests/test_data/8_integration/src/main.nr
+++ b/crates/nargo/tests/test_data/8_integration/src/main.nr
@@ -1,8 +1,8 @@
-fn matrix_mul_2(a: [4]u32, b:[4]u32) ->[4]u32{
-    let mut c:[4]u32 = [0 as u32; 4];
+fn matrix_mul_2(a: [u32; 4], b: [u32; 4]) ->[u32; 4] {
+    let mut c = [0 as u32; 4];
     for i in 0..2 {
         for j in 0..2 {
-            c[i+2*j] = 0 as u32;
+            c[i+2*j] = 0;
             for k in 0..2 {
                c[i+2*j] = c[i+2*j] + a[i+2*k]*b[k+2*j];
             };
@@ -11,8 +11,8 @@ fn matrix_mul_2(a: [4]u32, b:[4]u32) ->[4]u32{
     c
 }
 
-fn matrix_mul_10(a: [100]u32, b:[100]u32) ->[100]u32{
-    let mut c:[100]u32 = [0 as u32; 100];
+fn matrix_mul_10(a: [u32; 100], b: [u32; 100]) -> [u32; 100] {
+    let mut c = [0 as u32; 100];
     for i in 0..10 {
         for j in 0..10 {
             c[i+10*j] = 0 as u32;
@@ -31,129 +31,125 @@ fn siggy(x: u32) -> u32 {
 }
 
 
-fn test4 (mut a: [4]u32) -> [4]u32 {
+fn test4 (mut a: [u32; 4]) -> [u32; 4] {
     for i in 3..4 {
-    a[i] = siggy(a[i-2]);
-     };
+        a[i] = siggy(a[i-2]);
+    };
     a
 }
 
 fn iterate1(mut a0: u32) -> u32{
-    let mut t1: u32 = 0 as u32;
-    let mut t2: u32 = 0 as u32;
-    let mut a: u32 = 1 as u32;
-    let mut f: u32 =2 as u32;
-    let mut g: u32 =3 as u32;
-    let mut h: u32 =4 as u32;
-
+    let mut t1 = 0 as u32;
+    let mut t2 = 0 as u32;
+    let mut a = 1 as u32;
+    let mut f = 2 as u32;
+    let mut g = 3 as u32;
+    let mut h = 4 as u32;
 
     for _i in 0..2 {
-       t1 = h;
+        t1 = h;
         h = g;
         g = f;
-        a = t1+t2;
+        a = t1 + t2;
     };
-    a0=a0+a;
+    a0 = a0 + a;
     a0
 }
 
-fn array_noteq(a: [4]u32, b:[4]u32) {
-    constrain a!= b;
+fn array_noteq(a: [u32; 4], b: [u32; 4]) {
+    constrain a != b;
 }
 
-fn test3(mut b: [4]Field) ->  [4]Field
-{
+fn test3(mut b: [Field; 4]) -> [Field; 4] {
     for i in 0..5 {
-        b[i] = i as Field;
+        b[i] = i;
     };
     b
 }
 
-fn iterate2(mut hash: [8]u32) -> [8]u32 {
- 
-    let mut t1: u32 = 0 as u32;
+fn iterate2(mut hash: [u32; 8]) -> [u32; 8] {
+    let mut t1 = 0 as u32;
   
-    let mut a: u32 = hash[0];
-    let mut e: u32 = hash[4];
-    let mut f: u32 = hash[5];
-    let mut g: u32 = hash[6];
-    let mut h: u32 = hash[7];
+    let mut a = hash[0];
+    let mut e = hash[4];
+    let mut f = hash[5];
+    let mut g = hash[6];
+    let mut h = hash[7];
 
     for _i in 0..2 { 
-       t1 = ch2(e, f);
-         h = g;
-         g = f;
-         a = t1;
+        t1 = ch2(e, f);
+        h = g;
+        g = f;
+        a = t1;
     };
 
-    hash[0] = hash[0]+a;
+    hash[0] = hash[0] + a;
     hash
 }
 
-fn iterate3( mut hash: [8]u32) -> [8]u32 {
-    let mut t1: u32 = 0 as u32;
-    let mut t2: u32 = 0 as u32;
-    let mut a: u32 = hash[0];
-    let mut b: u32 = hash[1];
-    let mut c: u32 = hash[2];
-    let mut d: u32 = hash[3];
-    let mut e: u32 = hash[4];
-    let mut f: u32 =hash[5];
-    let mut g: u32 =hash[6];
-    let mut h: u32 =hash[7];
+fn iterate3( mut hash: [u32; 8]) -> [u32; 8] {
+    let mut t1 = 0 as u32;
+    let mut t2 = 0 as u32;
+    let mut a = hash[0];
+    let mut b = hash[1];
+    let mut c = hash[2];
+    let mut d = hash[3];
+    let mut e = hash[4];
+    let mut f = hash[5];
+    let mut g = hash[6];
+    let mut h = hash[7];
 
     for _i in 0..3 { 
         t1 = ep2(e)+ch2(e, f);
-         h = g;
-         g = f;
-         a = t1+t2;
-
+        h = g;
+        g = f;
+        a = t1+t2;
     };
-    constrain a ==2470696267;
-    hash[0] = hash[0]+a;
-    hash[1] = hash[1]+b;
-    hash[2] = hash[2]+c;
-    hash[3] = hash[3]+d;
-    hash[4] = hash[4]+e;
-    hash[5] = hash[5]+f;
-    hash[6] = hash[6]+g;
-    hash[7] = hash[7]+h;
+    constrain a == 2470696267;
+    hash[0] = hash[0] + a;
+    hash[1] = hash[1] + b;
+    hash[2] = hash[2] + c;
+    hash[3] = hash[3] + d;
+    hash[4] = hash[4] + e;
+    hash[5] = hash[5] + f;
+    hash[6] = hash[6] + g;
+    hash[7] = hash[7] + h;
     hash
 }
 
 
 fn test5() {
-    let mut sha_hash: [8]u32 = [
-    0 as u32, 1 as u32, 2 as u32, 3 as u32,
-    4 as u32, 5 as u32, 6 as u32, 7 as u32];
+    let mut sha_hash = [
+        0 as u32, 1, 2, 3,
+        4, 5, 6, 7
+    ];
 
     sha_hash = iterate2(sha_hash);
 
-    constrain sha_hash[0]==9;
+    constrain sha_hash[0] == 9;
 }
 
 
 fn ch2(x: u32, y: u32) -> u32 {
-    x+y
+    x + y
 }
+
 fn ep2(x: u32) -> u32 {
-  (2 as u32)*too(x)
-
+    (2 as u32) * too(x)
 }
+
 fn too(x: u32) -> u32 {
-  (x+17 as u32)*(x+3 as u32)
+    (x + 17 as u32) * (x + 3 as u32)
 }
 
-fn test6(x: [32]u8) ->  [8]u32 {
-    let mut sha_m : [64]u32 = [0 as u32; 64];
+fn test6(x: [u8; 32]) ->  [u32; 8] {
+    let mut sha_m = [0 as u32; 64];
 
-    let mut sha_hash: [8]u32 = [
-        1 as u32, 2 as u32, 3 as u32, 4 as u32,
-        5 as u32, 6 as u32, 7 as u32, 8 as u32
+    let mut sha_hash = [
+        1 as u32, 2, 3, 4, 5, 6, 7, 8
     ];
 
-    let mut buffer: [64]u8 = [0 as u8; 64];
-
+    let mut buffer = [0 as u8; 64];
     for i in 0..32 {  
        buffer[i] = x[i];
     };
@@ -163,34 +159,36 @@ fn test6(x: [32]u8) ->  [8]u32 {
     sha_hash
 }
 
-fn iterate6_1(mut sha_m: [64]u32, next_chunk: [64]u8) -> [64]u32 {
+fn iterate6_1(mut sha_m: [u32; 64], next_chunk: [u8; 64]) -> [u32; 64] {
     let mut j = 0;
     for i in 0..16 {
         j = (i ) * 4;
-      sha_m[i] =   ((next_chunk[j] as u32) << 24 as u32)  | ((next_chunk[j + 1] as u32) << 16 as u32) | ((next_chunk[j + 2] as u32) << 8 as u32) | (next_chunk[j + 3] as u32);
+        sha_m[i] = ((next_chunk[j] as u32) << 24 as u32)  
+            | ((next_chunk[j + 1] as u32) << 16 as u32) 
+            | ((next_chunk[j + 2] as u32) << 8 as u32) 
+            | (next_chunk[j + 3] as u32);
     };
-    for i in 16..64
-     {
+    for i in 16..64 {
         sha_m[i] = sig1(sha_m[i - 2])+(sha_m[i - 7])+(sig0(sha_m[i - 15]))+(sha_m[i - 16]);
     };
     sha_m
 }
 
-fn iterate6_2(sha_m: [64]u32, mut hash: [8]u32) -> [8]u32 {
-    let mut t1: u32 = 0 as u32;
-    let mut t2: u32 = 0 as u32;
-    let mut a: u32 = 1 as u32;
-    let mut b: u32 = 2 as u32;
-    let mut c: u32 = 3 as u32;
-    let mut d: u32 = 4 as u32;
-    let mut e: u32 = 5 as u32;
-    let mut f: u32 = 6 as u32;
-    let mut g: u32 = 7 as u32;
-    let mut h: u32 = 8 as u32;
+fn iterate6_2(sha_m: [u32; 64], mut hash: [u32; 8]) -> [u32; 8] {
+    let mut t1 = 0 as u32;
+    let mut t2 = 0 as u32;
+    let mut a = 1 as u32;
+    let mut b = 2 as u32;
+    let mut c = 3 as u32;
+    let mut d = 4 as u32;
+    let mut e = 5 as u32;
+    let mut f = 6 as u32;
+    let mut g = 7 as u32;
+    let mut h = 8 as u32;
 
     for i in 0..11 { 
-        t1 = h+ep1(e)+ch(e, f, g)+sha_m[i];
-        t2 = epo(a)+maj(a, b, c);
+        t1 = h + ep1(e) + ch(e, f, g) + sha_m[i];
+        t2 = epo(a) + maj(a, b, c);
         h = g;
         g = f;
         f = e;
@@ -213,17 +211,17 @@ fn iterate6_2(sha_m: [64]u32, mut hash: [8]u32) -> [8]u32 {
 }
 
 fn rot_right(a: u32, b: u32) -> u32 {
-    (((a) >> (b)) | ((a) << (32 as u32 - (b))))
+    ((a >> b) | (a << (32 as u32 - b)))
 }
 
 
 fn ch(x: u32, y: u32, z: u32) -> u32 {
-    (((x) & (y)) ^ (!(x) & (z)))
+    ((x & y) ^ (!x & z))
 }
 
 
 fn maj(x: u32, y: u32, z: u32) -> u32 {
-    (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+    ((x & y) ^ (x & z) ^ (y & z))
 }
 
 
@@ -235,30 +233,26 @@ fn ep1(x: u32) -> u32 {
    (rot_right(x, 6) ^ rot_right(x, 11) ^ rot_right(x, 25))
 }
 
-
 fn sig0(x: u32) -> u32 {
     (rot_right(x, 7) ^ rot_right(x, 18) ^ (x >> 3))
 }
-
 
 fn sig1(x: u32) -> u32 {
     (rot_right(x, 17) ^ rot_right(x, 19) ^ (x >> 10))
 }
 
 
-
-
-fn main(a: [100]u32,b: [100]u32, c: [4]u32, mut d: [4]u32, m: [32]u8){  
+fn main(a: [u32; 100], b: [u32; 100], c: [u32; 4], mut d: [u32; 4], m: [u8; 32]) {  
     let e = matrix_mul_10(a,b);
-    constrain e[6]==1866842232;
+    constrain e[6] == 1866842232;
     let f = matrix_mul_2(c,d);
-    constrain f[3]==2082554100;
+    constrain f[3] == 2082554100;
 
-    let mut a:[4]u32 = [1 as u32, 2 as u32, 3 as u32, 4 as u32];
+    let mut a = [1 as u32, 2, 3, 4];
     a = test4(a);
     constrain a[3] == 20;
-    a =test4(c);
-    constrain a[3] == c[1]*10;
+    a = test4(c);
+    constrain a[3] == c[1] * 10;
 
     d[0] = d[0] + c[0];
     d[0] = d[0] + c[1];
@@ -268,21 +262,22 @@ fn main(a: [100]u32,b: [100]u32, c: [4]u32, mut d: [4]u32, m: [32]u8){
     constrain h == 4;
 
     let x = d;
-    array_noteq(x, [d[0],d[1],d[2],0]);
+    array_noteq(x, [d[0], d[1], d[2], 0]);
 
-    let mut h5 : [4]Field = [d[0] as Field,d[1] as Field,d[2] as Field,d[3] as Field];
-    let t5 =  test3(h5);
-    constrain(t5[3]==3);
-    h5 =  test3(h5);
-    constrain(h5[3]==3);
+    let mut h5 = [d[0] as Field, d[1] as Field, d[2] as Field, d[3] as Field];
+    let t5 = test3(h5);
+    constrain t5[3] == 3;
+    h5 = test3(h5);
+    constrain h5[3] == 3;
 
     test5();
 
-    let mut sha_hash: [8]u32 = [
-    0x6a09e667 as u32, 0xbb67ae85 as u32, 0x3c6ef372 as u32, 0xa54ff53a as u32,
-    0x510e527f as u32, 0x9b05688c as u32, 0x1f83d9ab as u32, 0x5be0cd19 as u32];
-    sha_hash=iterate3(sha_hash);
+    let mut sha_hash = [
+        0x6a09e667 as u32, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+    ];
+    sha_hash = iterate3(sha_hash);
 
     let h6 = test6(m);
-    constrain h6[0]== 523008072;//31.. 3800709683;
+    constrain h6[0]== 523008072; //31.. 3800709683;
 }

--- a/crates/nargo/tests/test_data/9_conditional/src/main.nr
+++ b/crates/nargo/tests/test_data/9_conditional/src/main.nr
@@ -1,17 +1,12 @@
-
-
-
-fn main(a: u32, mut c: [4]u32
-    ){  
+fn main(a: u32, mut c: [u32; 4]){  
     //test 1
     let mut x: u32 = 0;
     if a == 0 {
-        c[0]=12;
-        if a!=0 {
-            x=6;
-        }
-        else {
-            x=2;
+        c[0] = 12;
+        if a != 0 {
+            x = 6;
+        } else {
+            x = 2;
             constrain x == 2;
         }
     } else {
@@ -22,12 +17,11 @@ fn main(a: u32, mut c: [4]u32
 
     //test2: loops!
     x = 0;
-    x= a-a;
+    x = a-a;
     for i in 0..3 {
-        if c[i] == 0
-        {
-            x=i as u32 +2;
+        if c[i] == 0 {
+            x = i as u32 +2;
         }
     };
-    constrain x==0;
+    constrain x == 0;
 }

--- a/crates/nargo/tests/test_data/generics/src/main.nr
+++ b/crates/nargo/tests/test_data/generics/src/main.nr
@@ -10,7 +10,7 @@ fn foo<T>(bar: Bar<T>) {
 
 fn main(x : Field, y : Field) {
     let bar1: Bar<Field> = Bar { one: x, two: y, other: 0 };
-    let bar2 = Bar { one: x, two: y, other: [0] };
+    let bar2: Bar<i32> = Bar { one: x, two: y, other: [0] };
 
     foo(bar1);
     foo(bar2);

--- a/crates/noir_field/src/generic_ark.rs
+++ b/crates/noir_field/src/generic_ark.rs
@@ -186,6 +186,10 @@ impl<F: PrimeField> FieldElement<F> {
         self.fits_in_u128().then(|| self.to_u128())
     }
 
+    pub fn try_to_u64(&self) -> Option<u64> {
+        (self.num_bits() <= 64).then(|| self.to_u128() as u64)
+    }
+
     /// Computes the inverse or returns zero if the inverse does not exist
     /// Before using this FieldElement, please ensure that this behaviour is necessary
     pub fn inverse(&self) -> FieldElement<F> {

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -4,6 +4,7 @@ use super::mem::ArrayId;
 use super::node::{Binary, BinaryOp, NodeId, ObjectType, Operation, Variable};
 use super::{block, node, ssa_form};
 use std::collections::HashMap;
+use std::convert::TryInto;
 
 use super::super::environment::Environment;
 use super::super::errors::RuntimeError;
@@ -372,13 +373,11 @@ impl<'a> IRGenerator<'a> {
                 self.insert_new_struct(def, values)
             }
             noirc_frontend::Type::Array(len, _) => {
-                {
-                    //TODO support array of structs
-                    let obj_type = node::ObjectType::from(typ);
-                    let v_id =
-                        self.new_array(base_name, obj_type, super::mem::get_array_size(len), def);
-                    Value::Single(v_id)
-                }
+                //TODO support array of structs
+                let obj_type = node::ObjectType::from(typ);
+                let len = len.array_length().unwrap();
+                let v_id = self.new_array(base_name, obj_type, len.try_into().unwrap(), def);
+                Value::Single(v_id)
             }
             _ => {
                 let obj_type = node::ObjectType::from(typ);

--- a/crates/noirc_evaluator/src/ssa/mem.rs
+++ b/crates/noirc_evaluator/src/ssa/mem.rs
@@ -3,7 +3,6 @@ use super::context::SsaContext;
 use super::node::{self, Node, NodeId};
 use acvm::FieldElement;
 use noirc_frontend::node_interner::DefinitionId;
-use noirc_frontend::ArraySize;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use std::collections::HashMap;
@@ -127,12 +126,5 @@ impl std::ops::Index<ArrayId> for Memory {
 impl std::ops::IndexMut<ArrayId> for Memory {
     fn index_mut(&mut self, index: ArrayId) -> &mut Self::Output {
         &mut self.arrays[index.0 as usize]
-    }
-}
-
-pub fn get_array_size(array_size: &ArraySize) -> u32 {
-    match array_size {
-        ArraySize::Fixed(l) => *l as u32,
-        ArraySize::Variable => todo!(),
     }
 }

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -14,43 +14,14 @@ pub use structure::*;
 
 use crate::{token::IntType, util::vecmap, IsConst};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum ArraySize {
-    Variable,
-    Fixed(u128),
-}
-
-impl ArraySize {
-    pub fn is_fixed(&self) -> bool {
-        matches!(self, ArraySize::Fixed(_))
-    }
-
-    pub fn is_variable(&self) -> bool {
-        !self.is_fixed()
-    }
-
-    pub fn is_subtype_of(&self, argument: &ArraySize) -> bool {
-        (self.is_fixed() && argument.is_variable()) || (self == argument)
-    }
-}
-
-impl std::fmt::Display for ArraySize {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ArraySize::Variable => write!(f, "[]"),
-            ArraySize::Fixed(size) => write!(f, "[{}]", size),
-        }
-    }
-}
-
 /// The parser parses types as 'UnresolvedType's which
 /// require name resolution to resolve any typenames used
 /// for structs within, but are otherwise identical to Types.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum UnresolvedType {
     FieldElement(IsConst),
-    Array(ArraySize, Box<UnresolvedType>), // [4]Witness = Array(4, Witness)
-    Integer(IsConst, Signedness, u32),     // u32 = Integer(unsigned, 32)
+    Array(Option<u64>, Box<UnresolvedType>), // Array(Some(3), Field) = [Field; 3] (None = generic length)
+    Integer(IsConst, Signedness, u32),       // u32 = Integer(unsigned, 32)
     Bool(IsConst),
     Unit,
 
@@ -75,7 +46,8 @@ impl std::fmt::Display for UnresolvedType {
         use UnresolvedType::*;
         match self {
             FieldElement(is_const) => write!(f, "{}Field", is_const),
-            Array(size, typ) => write!(f, "{}{}", size, typ),
+            Array(Some(len), typ) => write!(f, "[{}; {}]", typ, len),
+            Array(None, typ) => write!(f, "[{}]", typ),
             Integer(is_const, sign, num_bits) => match sign {
                 Signedness::Signed => write!(f, "{}i{}", is_const, num_bits),
                 Signedness::Unsigned => write!(f, "{}u{}", is_const, num_bits),

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -225,8 +225,12 @@ impl<'a> Resolver<'a> {
     fn resolve_type(&mut self, typ: UnresolvedType) -> Type {
         match typ {
             UnresolvedType::FieldElement(is_const) => Type::FieldElement(is_const),
-            UnresolvedType::Array(size, elem) => {
-                Type::Array(size, Box::new(self.resolve_type(*elem)))
+            UnresolvedType::Array(len, elem) => {
+                let len = match len {
+                    Some(len) => Type::ArrayLength(len),
+                    None => self.interner.next_type_variable(),
+                };
+                Type::Array(Box::new(len), Box::new(self.resolve_type(*elem)))
             }
             UnresolvedType::Integer(is_const, sign, bits) => Type::Integer(is_const, sign, bits),
             UnresolvedType::Bool(is_const) => Type::Bool(is_const),


### PR DESCRIPTION
Removes variable-length arrays in favor of length-polymorphic arrays. Additionally the array type syntax has been changed to match rust's. Now:

- `[Field; 4]` is an array type of 4 Fields
- `[Field]` is an array type of polymorphic length of Fields. The main difference between variable-length arrays are that these can later be resolved to a known length and will be used to monomorphise functions accepting any length array into a new copy per each new array length.