### PR TITLE
Refactor pwg working with correct git acvm dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,10 @@ dependencies = [
 [[package]]
 name = "acir"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir#3deb5363ba5198e833812ba54d62565c4753d2b7"
+source = "git+https://github.com/noir-lang/noir?branch=refactor-pwg#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
 dependencies = [
  "indexmap",
- "noir_field 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "serde",
 ]
 
@@ -42,14 +42,14 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir#3deb5363ba5198e833812ba54d62565c4753d2b7"
+source = "git+https://github.com/noir-lang/noir?branch=refactor-pwg#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
 dependencies = [
- "acir 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acir 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "blake2",
  "hex",
  "indexmap",
  "k256",
- "noir_field 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "num-bigint",
  "num-traits",
  "sha2",
@@ -260,9 +260,9 @@ dependencies = [
 [[package]]
 name = "arkworks_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/arkworks_backend#0ee72cf5eb387abc1e097780dc92539365a00e2f"
+source = "git+https://github.com/noir-lang/arkworks_backend?branch=refactor-pwg#e37b4b0fa8d56195a5a5f23ba1b72b87000486fc"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff",
@@ -298,9 +298,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aztec_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend#a92940fd4934701a2c9f99901e10c6c729489b90"
+source = "git+https://github.com/noir-lang/aztec_backend?branch=refactor-pwg#21413b0e934cf9130d63c244519b6a890efacdf8"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "barretenberg_wrapper",
  "blake2",
  "dirs",
@@ -1117,9 +1117,9 @@ dependencies = [
 [[package]]
 name = "marlin_arkworks_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/marlin_arkworks_backend#e7b333cec118518b4d4559be66b5c0dd8b9e2e83"
+source = "git+https://github.com/noir-lang/marlin_arkworks_backend?branch=refactor-pwg#56e171b8f386c144d0731ba67f3f4bfb9bc5cfe2"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "arkworks_backend",
  "blake2",
  "dirs",
@@ -1176,7 +1176,7 @@ dependencies = [
 name = "nargo"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "aztec_backend",
  "cfg-if 1.0.0",
  "clap",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "noir_field"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir#3deb5363ba5198e833812ba54d62565c4753d2b7"
+source = "git+https://github.com/noir-lang/noir?branch=refactor-pwg#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1248,7 +1248,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "blake2",
  "serde",
  "serde_derive",
@@ -1259,7 +1259,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "dirs",
  "fm",
  "noirc_abi",
@@ -1284,7 +1284,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "arena",
  "fm",
  "lazy_static",
@@ -1300,7 +1300,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.1.0"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir)",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?branch=refactor-pwg)",
  "arena",
  "chumsky",
  "fm",

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -13,7 +13,7 @@ noirc_driver = { path = "../noirc_driver" }
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_abi = { path = "../noirc_abi" }
 fm = { path = "../fm" }
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", branch = "refactor-pwg" }
 cfg-if = "1.0.0"
 
 toml = "0.5"
@@ -25,8 +25,8 @@ hex = "0.4.2"
 tempdir = "0.3.7"
 
 # Backends
-aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend" }
-marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend" }
+aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend", branch = "refactor-pwg" }
+marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", branch = "refactor-pwg" }
 
 [features]
 default = ["plonk_bn254"]

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", branch = "refactor-pwg" }
 toml = "0.5.8"
 serde = "1.0.123"
 serde_derive = "1.0.123"

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -11,7 +11,7 @@ noirc_errors = {path = "../noirc_errors"}
 noirc_frontend = {path = "../noirc_frontend"}
 noirc_evaluator = {path = "../noirc_evaluator"}
 noirc_abi = {path = "../noirc_abi"}
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", branch = "refactor-pwg" }
 std_lib = {path = "../std_lib"}
 fm = {path = "../fm"}
 

--- a/crates/noirc_evaluator/Cargo.toml
+++ b/crates/noirc_evaluator/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_errors = { path = "../noirc_errors" }
 noirc_abi = { path = "../noirc_abi" }
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", branch = "refactor-pwg" }
 arena = {path = "../arena"}
 fm = { path = "../fm" }
 lazy_static = "1.4.0"

--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = { git = "https://github.com/noir-lang/noir", branch = "refactor-pwg" }
 noirc_abi = { path = "../noirc_abi" }
 noirc_errors = { path = "../noirc_errors" }
 std_lib = { path = "../std_lib" }


### PR DESCRIPTION
More details can be found here: https://github.com/noir-lang/noir/pull/315

This is purely to show correctness when using the changes made to the acvm in PR #315. 