### PR TITLE
Quick fix clippy lint errs

### DIFF
--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -27,9 +27,9 @@ fn find_package_config(current_path: &Path) -> Result<PathBuf, CliError> {
     match fm::find_file(current_path, "Nargo", "toml") {
         Some(p) => Ok(p),
         None => Err(CliError::Generic(format!(
-                "cannot find a Nargo.toml in {}",
-                current_path.display()
-            ))),
+            "cannot find a Nargo.toml in {}",
+            current_path.display()
+        ))),
     }
 }
 

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -26,12 +26,10 @@ mod toml;
 fn find_package_config(current_path: &Path) -> Result<PathBuf, CliError> {
     match fm::find_file(current_path, "Nargo", "toml") {
         Some(p) => Ok(p),
-        None => {
-            return Err(CliError::Generic(format!(
+        None => Err(CliError::Generic(format!(
                 "cannot find a Nargo.toml in {}",
                 current_path.display()
-            )))
-        }
+            ))),
     }
 }
 

--- a/crates/noirc_evaluator/src/binary_op/xor.rs
+++ b/crates/noirc_evaluator/src/binary_op/xor.rs
@@ -8,11 +8,11 @@ pub fn handle_xor_op(
     match (left, right) {
         (Object::Integer(x), Object::Integer(y)) => Ok(Object::Integer(x.xor(y, evaluator)?)),
         (x, y) => Err(RuntimeErrorKind::UnstructuredError {
-                message: format!(
-                    "bitwise operations are only available on integers, found types : {} and {}",
-                    x.r#type(),
-                    y.r#type()
-                ),
-            }),
+            message: format!(
+                "bitwise operations are only available on integers, found types : {} and {}",
+                x.r#type(),
+                y.r#type()
+            ),
+        }),
     }
 }

--- a/crates/noirc_evaluator/src/binary_op/xor.rs
+++ b/crates/noirc_evaluator/src/binary_op/xor.rs
@@ -7,14 +7,12 @@ pub fn handle_xor_op(
 ) -> Result<Object, RuntimeErrorKind> {
     match (left, right) {
         (Object::Integer(x), Object::Integer(y)) => Ok(Object::Integer(x.xor(y, evaluator)?)),
-        (x, y) => {
-            return Err(RuntimeErrorKind::UnstructuredError {
+        (x, y) => Err(RuntimeErrorKind::UnstructuredError {
                 message: format!(
                     "bitwise operations are only available on integers, found types : {} and {}",
                     x.r#type(),
                     y.r#type()
                 ),
-            })
-        }
+            }),
     }
 }

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum BlockType {
     Normal,
     ForJoin,

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -120,9 +120,9 @@ impl<'a> SsaContext<'a> {
     //Display an object for debugging puposes
     fn node_to_string(&self, id: NodeId) -> String {
         if let Some(var) = self.try_get_node(id) {
-            return format!("{}", var);
+            format!("{}", var)
         } else {
-            return format!("unknown {:?}", id.0.into_raw_parts().0);
+            format!("unknown {:?}", id.0.into_raw_parts().0)
         }
     }
 

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -19,7 +19,7 @@ use super::{
     ssa_form,
 };
 
-#[derive(Clone, Debug, PartialEq, Copy)]
+#[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub struct FuncIndex(pub usize);
 
 impl FuncIndex {

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -171,7 +171,7 @@ impl Variable {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ObjectType {
     //Numeric(NumericType),
     NativeField,
@@ -186,7 +186,7 @@ pub enum ObjectType {
     NotAnObject, //not an object
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NumericType {
     Signed(u32),
     Unsigned(u32),

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -18,7 +18,7 @@ pub struct NoirFunction {
 /// - Normal functions
 /// - LowLevel/Foreign which link to an OPCODE in ACIR
 /// - BuiltIn which are provided by the runtime
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FunctionKind {
     LowLevel,
     Builtin,

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -8,7 +8,7 @@ use super::{FunctionDefinition, UnresolvedType};
 // A closure / function definition will be stored under a name, so we do not differentiate between their variants
 // The name for function literal will be the variable it is binded to, and the name for a function definition will
 // be the function name itself.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NoirFunction {
     pub kind: FunctionKind,
     pub def: FunctionDefinition,

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -233,7 +233,7 @@ impl ParsedModule {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
 pub enum Precedence {
     Lowest,
     LessGreater,


### PR DESCRIPTION
PR #315 showed no errors on the CI when pushed and locally when running `cargo clippy -- -D warnings`. There must have been a new push to the stable build for clippy as there were a couple lint errors that appeared once the PR was merged to master. 