### PR TITLE
Consts insert resolution

### DIFF
--- a/crates/nargo/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo/tests/test_data/global_consts/src/main.nr
@@ -2,15 +2,14 @@ let N: const Field = 5;
 let M: const Field = 32;
 //a: [M]Field, b: [M]Field
 fn main(a: [M]Field, b: [M]Field) {
-     // let q = [N]Field;
      // let N: const Field = 5;
-
-     //let mut y = 5;
-     //for i in 0..N*N {
-     //     y = i;
-     //};
-     //constrain y == 24;
      constrain N != M;
+
+     let mut y = 5;
+     for i in 0..N*N {
+          y = i;
+     };
+     constrain y == 24;
 
      let mut x = M / 4;
      //x = 5;

--- a/crates/noirc_evaluator/src/environment.rs
+++ b/crates/noirc_evaluator/src/environment.rs
@@ -50,7 +50,11 @@ impl Environment {
     pub fn store(&mut self, name: String, object: Object, is_global: bool) {
         let global_scope = self.env.get_global_scope();
         if is_global {
-            println!("storing global const object, name: {:?}, object: {:?}", name.clone(), object.clone());
+            println!(
+                "storing global const object, name: {:?}, object: {:?}",
+                name.clone(),
+                object.clone()
+            );
             global_scope.add_key_value(name, object);
             return;
         };

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -215,11 +215,11 @@ impl<'a> Evaluator<'a> {
         self.parse_abi_alt(env, &mut igen)?;
 
         // NOTE: this is how we were evaluating constants before, now we are inserting them into functions of the ast and then evaluating them
-        let mut stmt_ids = vec![];
-        for (_ident, stmt_id) in self.context.def_interner.get_all_global_consts() {
-            self.evaluate_statement(env, &stmt_id, true)?;
-            stmt_ids.push(stmt_id);
-        }
+        // let mut stmt_ids = vec![];
+        // for (_ident, stmt_id) in self.context.def_interner.get_all_global_consts() {
+        //     self.evaluate_statement(env, &stmt_id, true)?;
+        //     stmt_ids.push(stmt_id);
+        // }
 
         // Now call the main function
         let main_func_body = self.context.def_interner.function(&self.main_function);
@@ -639,7 +639,10 @@ impl<'a> Evaluator<'a> {
             }
             Type::PolymorphicInteger(is_const, typ_var) if is_const.is_const() => {
                 println!("Polymorphic integer typ_var: {:?}", typ_var);
-                println!("Polymorphic integer expression: {:?}", self.context.def_interner.expression(rhs));
+                println!(
+                    "Polymorphic integer expression: {:?}",
+                    self.context.def_interner.expression(rhs)
+                );
                 let span = self.context.def_interner.expr_location(rhs);
                 let value =
                     self.evaluate_integer(env, rhs).map_err(|kind| kind.add_location(span))?;

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -122,19 +122,18 @@ impl<K: std::hash::Hash + Eq + Clone, V> From<Scope<K, V>> for ScopeTree<K, V> {
 
 pub struct ScopeForest<K, V> {
     pub global_scope: Scope<K, V>,
-    pub scope_forest: Vec<ScopeTree<K, V>>
+    pub scope_forest: Vec<ScopeTree<K, V>>,
 }
 
 impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
     pub fn new() -> ScopeForest<K, V> {
-        ScopeForest {
-            global_scope: Scope::new(),
-            scope_forest: vec![ScopeTree::new()],
-        }
+        ScopeForest { global_scope: Scope::new(), scope_forest: vec![ScopeTree::new()] }
         // ScopeForest(vec![ScopeTree::new()])
     }
     pub fn current_scope_tree(&mut self) -> &mut ScopeTree<K, V> {
-        self.scope_forest.last_mut().expect("ice: tried to fetch the current scope, however none was found")
+        self.scope_forest
+            .last_mut()
+            .expect("ice: tried to fetch the current scope, however none was found")
     }
 
     /// Returns the last pushed scope from the current scope tree

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -605,7 +605,9 @@ impl Type {
     }
 
     fn get_fixed_variable_array_length(&self, ident: &Ident, interner: &NodeInterner) -> u128 {
-        let stmt_id = interner.get_global_const(&ident).expect("no statement associated with fixed sized array variable");
+        let stmt_id = interner
+            .get_global_const(&ident)
+            .expect("no statement associated with fixed sized array variable");
         let statement = interner.statement(&stmt_id);
         let length = match statement {
             HirStatement::Let(let_stmt) => {


### PR DESCRIPTION
WIP

This PR shows an example where we remove the need for the global scope within the scope forest. The global const resolution statement's in the previous PR are now unused as global const statements live within functions. Global const statements are cached in the interner to account for edge cases such as not erroring out on an unused global const. 