### PR TITLE
Move the constant folding for IF statements at the time they are processed

### DIFF
--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -336,4 +336,3 @@ pub fn merge_path(ctx: &mut SsaContext, start: BlockId, end: BlockId) -> VecDequ
     //housekeeping for the caller
     removed_blocks
 }
-

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -337,14 +337,3 @@ pub fn merge_path(ctx: &mut SsaContext, start: BlockId, end: BlockId) -> VecDequ
     removed_blocks
 }
 
-pub fn remove_child(ctx: &mut SsaContext, child: BlockId, parent: BlockId) {
-    let mut parent_block = &mut ctx[parent];
-    if parent_block.left == Some(child) {
-        parent_block.left = parent_block.right;
-    } else {
-        assert_eq!(parent_block.right, Some(child));
-        parent_block.right = parent_block.left;
-    }
-    parent_block.dominated.retain(|&b| b != child);
-    ctx.remove_block(child);
-}

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -382,7 +382,7 @@ impl DecisionTree {
         result: &mut StackFrame,
         predicate: AssumptionId,
     ) {
-        if predicate != AssumptionId::dummy() && self[predicate].value != Some(ctx.zero()) {
+        if predicate == AssumptionId::dummy() || self[predicate].value != Some(ctx.zero()) {
             for i in instructions {
                 self.conditionalise_into(ctx, result, *i, predicate);
             }

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -335,9 +335,8 @@ impl DecisionTree {
                 merged_ins = ctx[left].instructions.clone();
             } else {
                 merged_ins = ctx[right].instructions.clone();
-            } 
-        }
-        else {
+            }
+        } else {
             let left_ins = ctx[left].instructions.clone();
             let right_ins = ctx[right].instructions.clone();
             merged_ins = self.synchronise(ctx, &left_ins, &right_ins, left);

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -71,29 +71,6 @@ pub fn simplify(ctx: &mut SsaContext, ins: &mut Instruction) -> Result<(), Runti
                 ins.mark = Mark::ReplaceWith(evaluate_intrinsic(ctx, *opcode, args));
             }
         }
-        Operation::Jeq(cond, jump_block) => {
-            if let Some(cond) = NodeEval::from_id(ctx, *cond).into_const_value() {
-                // we do not simplify for loops, it will be evaluated during unrolling
-                if ctx[ins.parent_block].kind == super::block::BlockType::Normal {
-                    if cond.is_zero() {
-                        ins.operation = Operation::Jmp(*jump_block);
-                        super::block::remove_child(
-                            ctx,
-                            ctx[ins.parent_block].left.unwrap(),
-                            ins.parent_block,
-                        );
-                    } else {
-                        ins.mark = Mark::Deleted;
-                        super::block::remove_child(
-                            ctx,
-                            ctx[ins.parent_block].right.unwrap(),
-                            ins.parent_block,
-                        );
-                    }
-                    ctx[ins.parent_block].kind = super::block::BlockType::Normal;
-                }
-            }
-        }
         _ => (),
     }
 


### PR DESCRIPTION
Although simplifying early is better (e.g during unrolling), simplification of IF statements has a lot of implications; not only on the structure of the CFG itself but also on some PHI instructions. Handling all these impacts is not straightforward and it is much simpler to handle this during the IF reduction by simply ignoring the instructions coming from the dead branch.

We should investigate later on whether this could also be handled during the construction of the decision tree.