### PR TITLE
Linear cse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,29 +286,34 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aztec_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=01b922adcb5a9d70b2d12304e1cb7487d9f28188#01b922adcb5a9d70b2d12304e1cb7487d9f28188"
 dependencies = [
  "acvm",
- "barretenberg_wrapper",
  "blake2",
  "dirs",
- "downloader",
+ "hex",
  "indicatif",
  "num-bigint",
  "num-traits",
- "once_cell",
  "regex",
  "sha2",
  "sled",
+ "tempfile",
+ "wasmer",
 ]
 
 [[package]]
-name = "barretenberg_wrapper"
-version = "0.1.0"
-source = "git+https://github.com/AztecProtocol/barretenberg?rev=804c7dcf21111acd1302a768a8fa2f453dcec50f#804c7dcf21111acd1302a768a8fa2f453dcec50f"
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
- "cmake",
- "hex",
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object 0.29.0",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -344,6 +364,27 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -397,15 +438,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -474,6 +506,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "corosensei"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "libc",
+ "scopeguard",
+ "windows-sys 0.33.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,12 +528,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bforest"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+dependencies = [
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli",
+ "log",
+ "regalloc",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -533,6 +658,40 @@ checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -609,6 +768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +807,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumset"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4799cdb24d48f1f8a7a98d06b7fde65a85a2d1e42b25a889f5406aa1fbefe074"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea83a3fbdc1d999ccfbcbee717eab36f8edf2d71693a23ce0d7cca19e085304c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +871,16 @@ dependencies = [
  "bitvec",
  "rand_core 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -855,6 +1077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "group"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +1131,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -996,6 +1232,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1256,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1077,10 +1320,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
 
 [[package]]
 name = "lock_api"
@@ -1099,6 +1358,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "loupe"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
+dependencies = [
+ "indexmap",
+ "loupe-derive",
+ "rustversion",
+]
+
+[[package]]
+name = "loupe-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1133,6 +1422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,8 +1463,14 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "nargo"
@@ -1271,6 +1584,7 @@ version = "0.1.0"
 dependencies = [
  "acvm",
  "arena",
+ "flate2",
  "fm",
  "lazy_static",
  "noirc_abi",
@@ -1278,6 +1592,8 @@ dependencies = [
  "noirc_frontend",
  "num-bigint",
  "num-traits",
+ "rmp-serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -1343,6 +1659,27 @@ name = "number_prefix"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+
+[[package]]
+name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.11.2",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -1488,6 +1825,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1864,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f446d0a6efba22928558c4fb4ce0b3fd6c89b0061343e390bf01a703742b8125"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1585,6 +1966,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +2019,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc"
+version = "0.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,12 +2047,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "region"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+dependencies = [
+ "bytecheck",
 ]
 
 [[package]]
@@ -1677,6 +2114,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+dependencies = [
+ "bytecheck",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25786b0d276110195fa3d6f3f31299900cf71dfbd6c28450f3f58a0e7f7a347e"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +2182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,7 +2200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1718,6 +2214,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -1767,6 +2269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1877,6 +2388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2447,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 
 [[package]]
 name = "tempdir"
@@ -2082,6 +2605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2297,6 +2821,273 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasmer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "indexmap",
+ "js-sys",
+ "loupe",
+ "more-asserts",
+ "target-lexicon",
+ "thiserror",
+ "wasm-bindgen",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-compiler-cranelift",
+ "wasmer-derive",
+ "wasmer-engine",
+ "wasmer-engine-dylib",
+ "wasmer-engine-universal",
+ "wasmer-types",
+ "wasmer-vm",
+ "wat",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-artifact"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
+dependencies = [
+ "enumset",
+ "loupe",
+ "rkyv",
+ "serde",
+ "serde_bytes",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-types",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmer-compiler-cranelift"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "gimli",
+ "loupe",
+ "more-asserts",
+ "rayon",
+ "smallvec",
+ "target-lexicon",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-derive"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmer-engine"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
+dependencies = [
+ "backtrace",
+ "enumset",
+ "lazy_static",
+ "loupe",
+ "memmap2",
+ "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde_bytes",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-engine-dylib"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
+dependencies = [
+ "cfg-if 1.0.0",
+ "enum-iterator",
+ "enumset",
+ "leb128",
+ "libloading",
+ "loupe",
+ "object 0.28.4",
+ "rkyv",
+ "serde",
+ "tempfile",
+ "tracing",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-object",
+ "wasmer-types",
+ "wasmer-vm",
+ "which",
+]
+
+[[package]]
+name = "wasmer-engine-universal"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
+dependencies = [
+ "cfg-if 1.0.0",
+ "enumset",
+ "leb128",
+ "loupe",
+ "region",
+ "rkyv",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-engine-universal-artifact",
+ "wasmer-types",
+ "wasmer-vm",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
+dependencies = [
+ "object 0.28.4",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-types"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
+dependencies = [
+ "backtrace",
+ "enum-iterator",
+ "indexmap",
+ "loupe",
+ "more-asserts",
+ "rkyv",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "wasmer-vm"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 1.0.0",
+ "corosensei",
+ "enum-iterator",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "loupe",
+ "mach",
+ "memoffset",
+ "more-asserts",
+ "region",
+ "rkyv",
+ "scopeguard",
+ "serde",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.83.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wast"
+version = "46.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0ab19660e3ea6891bba69167b9be40fad00fb1fe3dd39c5eebcee15607131b"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f775282def4d5bffd94d60d6ecd57bfe6faa46171cdbf8d32bd5458842b1e3e"
+dependencies = [
+ "wast",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +3095,17 @@ checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -2339,16 +3141,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc 0.33.0",
+ "windows_i686_gnu 0.33.0",
+ "windows_i686_msvc 0.33.0",
+ "windows_x86_64_gnu 0.33.0",
+ "windows_x86_64_msvc 0.33.0",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2358,9 +3179,21 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2370,9 +3203,21 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -7,7 +7,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
 
         pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
-            std::fs::read_to_string(&path_to_file)
+            std::fs::read_to_string(path_to_file)
         }
 
     } else if #[cfg(feature = "wasm")] {

--- a/crates/nargo/tests/test_data/8_integration/src/main.nr
+++ b/crates/nargo/tests/test_data/8_integration/src/main.nr
@@ -61,7 +61,7 @@ fn array_noteq(a: [u32; 4], b: [u32; 4]) {
 }
 
 fn test3(mut b: [Field; 4]) -> [Field; 4] {
-    for i in 0..5 {
+    for i in 0..4 {
         b[i] = i;
     };
     b

--- a/crates/noirc_evaluator/src/ssa/anchor.rs
+++ b/crates/noirc_evaluator/src/ssa/anchor.rs
@@ -1,0 +1,264 @@
+use std::collections::{HashMap, VecDeque};
+
+use super::{
+    context::SsaContext,
+    mem::ArrayId,
+    node::{NodeId, ObjectType, Opcode, Operation},
+};
+
+#[derive(Clone, Debug)]
+pub enum MemItem {
+    NonConst(NodeId),
+    Const(usize),     //represent a bunch of memory instructions having constant index
+    ConstLoad(usize), //represent a bunch of load instructions having constant index
+}
+
+#[derive(Debug)]
+pub enum CseAction {
+    ReplaceWith(NodeId),
+    Remove(NodeId),
+    Keep,
+}
+
+/// A list of instructions with the same Operation variant
+#[derive(Default, Clone)]
+pub struct Anchor {
+    map: HashMap<Opcode, HashMap<Operation, NodeId>>, //standard anchor
+    cast_map: HashMap<NodeId, HashMap<crate::node::ObjectType, NodeId>>, //cast anchor
+    mem_map: HashMap<ArrayId, Vec<VecDeque<(usize, NodeId)>>>, //Memory anchor: one Vec for each array where Vec[i] contains the list of load and store instructions having index i, and the mem_item position in which they appear
+    mem_list: HashMap<ArrayId, VecDeque<MemItem>>, // list of the memory instructions, per array, and grouped into MemItems
+}
+
+impl Anchor {
+    pub fn push_cast_front(&mut self, operation: &Operation, id: NodeId, res_type: ObjectType) {
+        match operation {
+            Operation::Cast(cast_id) => {
+                let mut by_type = HashMap::new();
+                by_type.insert(res_type, id);
+                self.cast_map.insert(*cast_id, by_type);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn push_front(&mut self, operation: &Operation, id: NodeId) {
+        let op = operation.opcode();
+
+        match operation {
+            Operation::Cast(_) => unreachable!(),
+            _ => {
+                if let std::collections::hash_map::Entry::Vacant(e) = self.map.entry(op) {
+                    let mut prev_list = HashMap::new();
+                    prev_list.insert(operation.clone(), id);
+                    e.insert(prev_list);
+                } else {
+                    self.map.get_mut(&op).unwrap().insert(operation.clone(), id);
+                }
+            }
+        }
+    }
+
+    pub fn find_similar_instruction(&self, operation: &Operation) -> Option<NodeId> {
+        let op = operation.opcode();
+        if self.map.contains_key(&op) && self.map[&op].contains_key(operation) {
+            return Some(self.map[&op][operation]);
+        }
+        None
+    }
+
+    pub fn find_similar_cast(
+        &self,
+        igen: &SsaContext,
+        operator: &Operation,
+        res_type: super::node::ObjectType,
+    ) -> Option<NodeId> {
+        match operator {
+            Operation::Cast(id) => {
+                if self.cast_map.contains_key(id) {
+                    let by_type = &self.cast_map[id];
+                    if by_type.contains_key(&res_type) {
+                        let tu = by_type[&res_type];
+                        if let Some(ins) = igen.try_get_instruction(tu) {
+                            if !ins.is_deleted() {
+                                return Some(tu);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        None
+    }
+
+    fn get_mem_map(&self, a: ArrayId) -> &Vec<VecDeque<(usize, NodeId)>> {
+        &self.mem_map[&a]
+    }
+
+    pub fn get_mem_all(&self, a: ArrayId) -> &VecDeque<MemItem> {
+        &self.mem_list[&a]
+    }
+
+    pub fn use_array(&mut self, a: ArrayId, len: usize) {
+        if !self.mem_list.contains_key(&a) {
+            let def: VecDeque<(usize, NodeId)> = VecDeque::new();
+            self.mem_list.entry(a).or_insert_with(VecDeque::new);
+            self.mem_map.entry(a).or_insert_with(|| vec![def; len]);
+        }
+    }
+
+    pub fn push_mem_instruction(&mut self, ctx: &SsaContext, id: NodeId) {
+        let ins = ctx.get_instruction(id);
+        let (array_id, index, is_load) = Anchor::get_mem_op(&ins.operation);
+        self.use_array(array_id, ctx.mem[array_id].len as usize);
+        let prev_list = self.mem_list.get_mut(&array_id).unwrap();
+        let len = prev_list.len();
+        if let Some(index_value) = ctx.get_as_constant(index) {
+            let mem_idx = index_value.to_u128() as usize;
+            let last_item = prev_list.front();
+            let mut new_item = None;
+            match last_item {
+                Some(MemItem::Const(pos)) => {
+                    self.mem_map.get_mut(&array_id).unwrap()[mem_idx].push_front((*pos, id))
+                }
+                Some(MemItem::ConstLoad(pos)) => {
+                    if is_load {
+                        self.mem_map.get_mut(&array_id).unwrap()[mem_idx].push_front((*pos, id));
+                    } else {
+                        new_item = Some(MemItem::Const(pos + 1));
+                        self.mem_map.get_mut(&array_id).unwrap()[mem_idx].push_front((pos + 1, id));
+                    }
+                }
+                None | Some(MemItem::NonConst(_)) => {
+                    if is_load {
+                        prev_list.push_front(MemItem::ConstLoad(len));
+                        self.mem_map.get_mut(&array_id).unwrap()[mem_idx].push_front((len, id));
+                    } else {
+                        prev_list.push_front(MemItem::Const(len));
+                        self.mem_map.get_mut(&array_id).unwrap()[mem_idx].push_front((len, id));
+                    }
+                }
+            }
+            if let Some(item) = new_item {
+                prev_list.push_front(item);
+            }
+        } else {
+            prev_list.push_front(MemItem::NonConst(id));
+        }
+    }
+
+    pub fn find_similar_mem_instruction2(
+        &self,
+        ctx: &SsaContext,
+        op: &Operation,
+        prev_ins: &VecDeque<MemItem>,
+    ) -> CseAction {
+        for iter in prev_ins.iter() {
+            if let Some(action) = self.match_mem_item(ctx, iter, op) {
+                return action;
+            }
+        }
+
+        CseAction::Keep
+    }
+
+    fn get_mem_op(op: &Operation) -> (ArrayId, NodeId, bool) {
+        match op {
+            Operation::Load { array_id, index } => (*array_id, *index, true),
+            Operation::Store { array_id, index, .. } => (*array_id, *index, false),
+            _ => unreachable!(),
+        }
+    }
+
+    fn match_mem_item(
+        &self,
+        ctx: &SsaContext,
+        item: &MemItem,
+        op: &Operation,
+    ) -> Option<CseAction> {
+        //on veut: la array id, le type: load/store, le index, et s'il est const.
+        let (array_id, index, is_load) = Anchor::get_mem_op(op);
+        if let Some(b_value) = ctx.get_as_constant(index) {
+            match item {
+                MemItem::Const(p) | MemItem::ConstLoad(p) => {
+                    let a = self.get_mem_map(array_id);
+                    let b_idx = b_value.to_u128() as usize;
+                    for (pos, id) in &a[b_idx] {
+                        if pos == p {
+                            let action = Anchor::match_mem_id(ctx, *id, index, is_load);
+                            if action.is_some() {
+                                return action;
+                            }
+                        }
+                    }
+
+                    None
+                }
+                MemItem::NonConst(id) => Anchor::match_mem_id(ctx, *id, index, is_load),
+            }
+        } else {
+            match item {
+                MemItem::Const(_) => Some(CseAction::Keep),
+                MemItem::ConstLoad(_) => {
+                    if is_load {
+                        None
+                    } else {
+                        Some(CseAction::Keep)
+                    }
+                }
+                MemItem::NonConst(id) => Anchor::match_mem_id(ctx, *id, index, is_load),
+            }
+        }
+    }
+
+    fn match_mem_id(
+        ctx: &SsaContext,
+        a: NodeId,
+        b_idx: NodeId,
+        b_is_load: bool,
+    ) -> Option<CseAction> {
+        if b_is_load {
+            if let Some(ins_iter) = ctx.try_get_instruction(a) {
+                match &ins_iter.operation {
+                    Operation::Load { index, .. } => {
+                        if !ctx.maybe_distinct(*index, b_idx) {
+                            return Some(CseAction::ReplaceWith(a));
+                        }
+                    }
+                    Operation::Store { index, value, .. } => {
+                        if !ctx.maybe_distinct(*index, b_idx) {
+                            return Some(CseAction::ReplaceWith(*value));
+                        }
+                        if ctx.maybe_equal(*index, b_idx) {
+                            return Some(CseAction::Keep);
+                        }
+                    }
+                    _ => {
+                        dbg!(&ins_iter.operation);
+                        unreachable!("invalid operator in the memory anchor list")
+                    }
+                }
+            }
+        } else if let Some(ins_iter) = ctx.try_get_instruction(a) {
+            match ins_iter.operation {
+                Operation::Load { index, .. } => {
+                    if ctx.maybe_equal(index, b_idx) {
+                        return Some(CseAction::Keep);
+                    }
+                }
+                Operation::Store { index, .. } => {
+                    if !ctx.maybe_distinct(index, b_idx) {
+                        return Some(CseAction::Remove(a));
+                    }
+                    if ctx.maybe_equal(index, b_idx) {
+                        return Some(CseAction::Keep);
+                    }
+                }
+                _ => unreachable!("invalid operator in the memory anchor list"),
+            }
+        }
+
+        None
+    }
+}

--- a/crates/noirc_evaluator/src/ssa/anchor.rs
+++ b/crates/noirc_evaluator/src/ssa/anchor.rs
@@ -177,7 +177,6 @@ impl Anchor {
         item: &MemItem,
         op: &Operation,
     ) -> Option<CseAction> {
-        //on veut: la array id, le type: load/store, le index, et s'il est const.
         let (array_id, index, is_load) = Anchor::get_mem_op(op);
         if let Some(b_value) = ctx.get_as_constant(index) {
             match item {

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -678,7 +678,7 @@ impl<'a> SsaContext<'a> {
         let first_block = self.first_block;
         self[first_block].dominated.clear();
 
-        optim::full_cse(self, self.first_block)?;
+        optim::cse(self, first_block)?;
 
         //Truncation
         integer::overflow_strategy(self)?;

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -71,8 +71,13 @@ impl SSAFunction {
         let mut decision = DecisionTree::new(&igen.context);
         decision.make_decision_tree(&mut igen.context, self.entry_block);
         decision.reduce(&mut igen.context, decision.root)?;
-
-        super::optim::full_cse(&mut igen.context, self.entry_block)?;
+        //merge blocks
+        let to_remove =
+            super::block::merge_path(&mut igen.context, self.entry_block, BlockId::dummy());
+        igen.context[self.entry_block].dominated.retain(|b| !to_remove.contains(b));
+        for i in to_remove {
+            igen.context.remove_block(i);
+        }
         Ok(decision)
     }
 

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -79,7 +79,7 @@ fn inline_block(
                                 *func_id,
                                 arguments.clone(),
                                 returned_arrays.clone(),
-                                ins.parent_block,
+                                block_id
                             ));
                         }
                     } else {
@@ -88,7 +88,7 @@ fn inline_block(
                             *func_id,
                             arguments.clone(),
                             returned_arrays.clone(),
-                            ins.parent_block,
+                            block_id
                         ));
                     }
                 }
@@ -104,7 +104,7 @@ fn inline_block(
     }
 
     if to_inline.is_none() {
-        optim::cse(ctx, block_id)?; //handles the deleted call instructions
+        optim::simple_cse(ctx, block_id);
     }
     Ok(result)
 }
@@ -148,10 +148,9 @@ impl StackFrame {
         if after {
             pos += 1;
         }
-        for new_id in self.stack.iter_mut() {
-            ctx[block].instructions.insert(pos, *new_id);
-            pos += 1;
-        }
+        let after = ctx[block].instructions.split_off(pos);
+        ctx[block].instructions.extend_from_slice(&self.stack);
+        ctx[block].instructions.extend_from_slice(&after);
         self.stack.clear();
     }
 }

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -79,7 +79,7 @@ fn inline_block(
                                 *func_id,
                                 arguments.clone(),
                                 returned_arrays.clone(),
-                                block_id
+                                block_id,
                             ));
                         }
                     } else {
@@ -88,7 +88,7 @@ fn inline_block(
                             *func_id,
                             arguments.clone(),
                             returned_arrays.clone(),
-                            block_id
+                            block_id,
                         ));
                     }
                 }

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -29,6 +29,11 @@ fn get_instruction_max(
     max_map: &mut HashMap<NodeId, BigUint>,
     vmap: &HashMap<NodeId, NodeId>,
 ) -> BigUint {
+    assert_ne!(
+        ins.operation.opcode(),
+        node::Opcode::Phi,
+        "Phi instructions must have been simplified"
+    );
     ins.operation.for_each_id(|id| {
         get_obj_max_value(ctx, id, max_map, vmap);
     });
@@ -347,6 +352,7 @@ fn block_overflow(
             }
             _ => (),
         }
+
         process_to_truncate(
             ctx,
             &mut new_list,

--- a/crates/noirc_evaluator/src/ssa/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/mod.rs
@@ -1,4 +1,5 @@
 pub mod acir_gen;
+pub mod anchor;
 pub mod block;
 pub mod code_gen;
 pub mod conditional;

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -171,7 +171,7 @@ impl Variable {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ObjectType {
     //Numeric(NumericType),
     NativeField,

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -154,7 +154,6 @@ pub fn simple_cse(ctx: &mut SsaContext, block_id: BlockId) {
     cse_block(ctx, block_id, &mut instructions, &mut modified).unwrap();
 }
 
-
 pub fn cse_block(
     ctx: &mut SsaContext,
     block_id: BlockId,
@@ -256,11 +255,7 @@ fn cse_block_with_anchor(
                 }
                 Operation::Cast(_) => {
                     //Similar cast must have same type
-                    if let Some(similar) = anchor.find_similar_cast(
-                        ctx,
-                        &operator,
-                        ins.res_type,
-                    ) {
+                    if let Some(similar) = anchor.find_similar_cast(ctx, &operator, ins.res_type) {
                         new_mark = Mark::ReplaceWith(similar);
                         *modified = true;
                     } else {

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -148,6 +148,13 @@ pub fn full_cse(
     Ok(result)
 }
 
+pub fn simple_cse(ctx: &mut SsaContext, block_id: BlockId) {
+    let mut modified = false;
+    let mut instructions = Vec::new();
+    cse_block(ctx, block_id, &mut instructions, &mut modified).unwrap();
+}
+
+
 pub fn cse_block(
     ctx: &mut SsaContext,
     block_id: BlockId,

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -220,7 +220,7 @@ fn cse_block_with_anchor(
                     }
                     anchor.use_array(*x, ctx.mem[*x].len as usize);
                     let prev_ins = anchor.get_mem_all(*x);
-                    match anchor.find_similar_mem_instruction2(ctx, &operator, prev_ins) {
+                    match anchor.find_similar_mem_instruction(ctx, &operator, prev_ins) {
                         CseAction::Keep => {
                             anchor.push_mem_instruction(ctx, *ins_id);
                             new_list.push(*ins_id)

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -4,15 +4,10 @@ use crate::errors::RuntimeError;
 
 use super::{
     acir_gen::InternalVar,
+    anchor::{Anchor, CseAction},
     block::BlockId,
     context::SsaContext,
-    node::{
-        Binary, BinaryOp, Instruction, Mark, Node, NodeEval, NodeId, ObjectType, Opcode, Operation,
-    },
-};
-use std::{
-    borrow::Cow,
-    collections::{HashMap, VecDeque},
+    node::{Binary, BinaryOp, Instruction, Mark, Node, NodeEval, NodeId, ObjectType, Operation},
 };
 
 pub fn simplify_id(ctx: &mut SsaContext, ins_id: NodeId) -> Result<(), RuntimeError> {
@@ -121,100 +116,6 @@ fn evaluate_intrinsic(ctx: &mut SsaContext, op: acvm::acir::OPCODE, args: Vec<u1
 }
 ////////////////////CSE////////////////////////////////////////
 
-pub fn find_similar_instruction(
-    igen: &SsaContext,
-    operation: &Operation,
-    prev_ins: &VecDeque<NodeId>,
-) -> Option<NodeId> {
-    for iter in prev_ins {
-        if let Some(ins) = igen.try_get_instruction(*iter) {
-            if &ins.operation == operation && !ins.is_deleted() {
-                return Some(*iter);
-            }
-        }
-    }
-    None
-}
-
-pub fn find_similar_cast(
-    igen: &SsaContext,
-    operator: &Operation,
-    res_type: ObjectType,
-    prev_ins: &VecDeque<NodeId>,
-) -> Option<NodeId> {
-    for iter in prev_ins {
-        if let Some(ins) = igen.try_get_instruction(*iter) {
-            if &ins.operation == operator && ins.res_type == res_type && !ins.is_deleted() {
-                return Some(*iter);
-            }
-        }
-    }
-    None
-}
-
-#[derive(Debug)]
-pub enum CseAction {
-    ReplaceWith(NodeId),
-    Remove(NodeId),
-    Keep,
-}
-
-fn find_similar_mem_instruction(
-    ctx: &SsaContext,
-    op: &Operation,
-    prev_ins: &VecDeque<NodeId>,
-) -> CseAction {
-    match op {
-        Operation::Load { index, .. } => {
-            for iter in prev_ins.iter() {
-                if let Some(ins_iter) = ctx.try_get_instruction(*iter) {
-                    match &ins_iter.operation {
-                        Operation::Load { index: index2, .. } => {
-                            if !ctx.maybe_distinct(*index2, *index) {
-                                return CseAction::ReplaceWith(*iter);
-                            }
-                        }
-                        Operation::Store { index: index2, value, .. } => {
-                            if !ctx.maybe_distinct(*index2, *index) {
-                                return CseAction::ReplaceWith(*value);
-                            }
-                            if ctx.maybe_equal(*index2, *index) {
-                                return CseAction::Keep;
-                            }
-                        }
-                        _ => unreachable!("invalid operator in the memory anchor list"),
-                    }
-                }
-            }
-        }
-        Operation::Store { index, .. } => {
-            for node_id in prev_ins.iter() {
-                if let Some(ins_iter) = ctx.try_get_instruction(*node_id) {
-                    match ins_iter.operation {
-                        Operation::Load { index: index2, .. } => {
-                            if ctx.maybe_equal(index2, *index) {
-                                return CseAction::Keep;
-                            }
-                        }
-                        Operation::Store { index: index2, .. } => {
-                            if !ctx.maybe_distinct(index2, *index) {
-                                return CseAction::Remove(*node_id);
-                            }
-                            if ctx.maybe_equal(index2, *index) {
-                                return CseAction::Keep;
-                            }
-                        }
-                        _ => unreachable!("invalid operator in the memory anchor list"),
-                    }
-                }
-            }
-        }
-        _ => unreachable!("invalid non memory operator"),
-    }
-
-    CseAction::Keep
-}
-
 pub fn propagate(ctx: &SsaContext, id: NodeId, modified: &mut bool) -> NodeId {
     if let Some(obj) = ctx.try_get_instruction(id) {
         if let Mark::ReplaceWith(replacement) = obj.mark {
@@ -270,26 +171,6 @@ pub fn full_cse(
     Ok(result)
 }
 
-/// A list of instructions with the same Operation variant, ordered by the order
-/// they appear in their respective blocks.
-#[derive(Default, Clone)]
-struct Anchor {
-    map: HashMap<Opcode, VecDeque<NodeId>>,
-}
-
-impl Anchor {
-    fn push_front(&mut self, op: Opcode, id: NodeId) {
-        self.map.entry(op).or_insert_with(VecDeque::new).push_front(id);
-    }
-
-    fn get_all(&self, opcode: Opcode) -> Cow<VecDeque<NodeId>> {
-        match self.map.get(&opcode) {
-            Some(vec) => Cow::Borrowed(vec),
-            None => Cow::Owned(VecDeque::new()),
-        }
-    }
-}
-
 pub fn cse_block(
     ctx: &mut SsaContext,
     block_id: BlockId,
@@ -330,38 +211,35 @@ fn cse_block_with_anchor(
                         //No CSE for arrays because they are not in SSA form
                         //We could improve this in future by checking if the arrays are immutable or not modified in-between
                         let id = ctx.get_dummy_load(a);
-                        anchor.push_front(Opcode::Load(a), id);
+                        anchor.push_mem_instruction(ctx, id);
 
                         if let ObjectType::Pointer(a) = ctx.get_object_type(binary.rhs) {
                             let id = ctx.get_dummy_load(a);
-                            anchor.push_front(Opcode::Load(a), id);
+                            anchor.push_mem_instruction(ctx, id);
                         }
 
                         new_list.push(*ins_id);
+                    } else if let Some(similar) = anchor.find_similar_instruction(&operator) {
+                        debug_assert!(similar != ins.id);
+                        *modified = true;
+                        new_mark = Mark::ReplaceWith(similar);
+                    } else if binary.operator == BinaryOp::Assign {
+                        *modified = true;
+                        new_mark = Mark::ReplaceWith(binary.rhs);
                     } else {
-                        let variants = anchor.get_all(binary.opcode());
-                        if let Some(similar) = find_similar_instruction(ctx, &operator, &variants) {
-                            debug_assert!(similar != ins.id);
-                            *modified = true;
-                            new_mark = Mark::ReplaceWith(similar);
-                        } else if binary.operator == BinaryOp::Assign {
-                            *modified = true;
-                            new_mark = Mark::ReplaceWith(binary.rhs);
-                        } else {
-                            new_list.push(*ins_id);
-                            anchor.push_front(ins.operation.opcode(), *ins_id);
-                        }
+                        new_list.push(*ins_id);
+                        anchor.push_front(&ins.operation, *ins_id);
                     }
                 }
                 Operation::Load { array_id: x, .. } | Operation::Store { array_id: x, .. } => {
                     if !is_join && ins.operation.is_dummy_store() {
                         continue;
                     }
-                    let op = Opcode::Load(*x);
-                    let prev_ins = anchor.get_all(op);
-                    match find_similar_mem_instruction(ctx, &operator, &prev_ins) {
+                    anchor.use_array(*x, ctx.mem[*x].len as usize);
+                    let prev_ins = anchor.get_mem_all(*x);
+                    match anchor.find_similar_mem_instruction2(ctx, &operator, prev_ins) {
                         CseAction::Keep => {
-                            anchor.push_front(op, *ins_id);
+                            anchor.push_mem_instruction(ctx, *ins_id);
                             new_list.push(*ins_id)
                         }
                         CseAction::ReplaceWith(new_id) => {
@@ -369,7 +247,7 @@ fn cse_block_with_anchor(
                             new_mark = Mark::ReplaceWith(new_id);
                         }
                         CseAction::Remove(id_to_remove) => {
-                            anchor.push_front(op, *ins_id);
+                            anchor.push_mem_instruction(ctx, *ins_id);
                             new_list.push(*ins_id);
                             // TODO if not found, it should be removed from other blocks; we could keep a list of instructions to remove
                             if let Some(id) = new_list.iter().position(|x| *x == id_to_remove) {
@@ -394,17 +272,16 @@ fn cse_block_with_anchor(
                 }
                 Operation::Cast(_) => {
                     //Similar cast must have same type
-                    if let Some(similar) = find_similar_cast(
+                    if let Some(similar) = anchor.find_similar_cast(
                         ctx,
                         &operator,
                         ins.res_type,
-                        &anchor.get_all(Opcode::Cast),
                     ) {
                         new_mark = Mark::ReplaceWith(similar);
                         *modified = true;
                     } else {
                         new_list.push(*ins_id);
-                        anchor.push_front(operator.opcode(), *ins_id);
+                        anchor.push_cast_front(&operator, *ins_id, ins.res_type);
                     }
                 }
                 Operation::Call { func_id, arguments, returned_arrays, .. } => {
@@ -412,13 +289,13 @@ fn cse_block_with_anchor(
                     //Add dummy store for functions that modify arrays
                     for a in returned_arrays {
                         let id = ctx.get_dummy_store(a.0);
-                        anchor.push_front(Opcode::Load(a.0), id);
+                        anchor.push_mem_instruction(ctx, id);
                     }
                     if let Some(f) = ctx.get_ssafunc(*func_id) {
                         for typ in &f.result_types {
                             if let ObjectType::Pointer(a) = typ {
                                 let id = ctx.get_dummy_store(*a);
-                                anchor.push_front(Opcode::Load(*a), id);
+                                anchor.push_mem_instruction(ctx, id);
                             }
                         }
                     }
@@ -427,7 +304,7 @@ fn cse_block_with_anchor(
                         if let Some(obj) = ctx.try_get_node(*arg) {
                             if let ObjectType::Pointer(a) = obj.get_type() {
                                 let id = ctx.get_dummy_load(a);
-                                anchor.push_front(Opcode::Load(a), id);
+                                anchor.push_mem_instruction(ctx, id);
                             }
                         }
                     }
@@ -441,28 +318,24 @@ fn cse_block_with_anchor(
                         if let Some(obj) = ctx.try_get_node(*arg) {
                             if let ObjectType::Pointer(a) = obj.get_type() {
                                 let id = ctx.get_dummy_load(a);
-                                anchor.push_front(Opcode::Load(a), id);
+                                anchor.push_mem_instruction(ctx, id);
                                 activate_cse = false;
                             }
                         }
                     }
                     if let ObjectType::Pointer(a) = ins.res_type {
                         let id = ctx.get_dummy_store(a);
-                        anchor.push_front(Opcode::Load(a), id);
+                        anchor.push_mem_instruction(ctx, id);
                         activate_cse = false;
                     }
 
                     if activate_cse {
-                        if let Some(similar) = find_similar_instruction(
-                            ctx,
-                            &operator,
-                            &anchor.get_all(operator.opcode()),
-                        ) {
+                        if let Some(similar) = anchor.find_similar_instruction(&operator) {
                             *modified = true;
                             new_mark = Mark::ReplaceWith(similar);
                         } else {
                             new_list.push(*ins_id);
-                            anchor.push_front(operator.opcode(), *ins_id);
+                            anchor.push_front(&operator, *ins_id);
                         }
                     } else {
                         new_list.push(*ins_id);


### PR DESCRIPTION
The CSE implementation required to parse the list of previous instructions for each instruction, making it a quadratic algorithm.
This PR makes the CSE linear by using hashmaps so the whole list is not searched everytime.
The handling of memory instructions is trickier because the ordering kind of matter, depending on whether or not the index of the memory is known. Most of the work was related to make the CSE linear also for memory instructions but at the end it did not have much impact on the performances with the examples I tried.
I also reviewed the usage of CSE and tried lighten its use. 
