### PR TITLE
Use correct bit size in a range check

### DIFF
--- a/crates/nargo/tests/test_data/3_add/src/main.nr
+++ b/crates/nargo/tests/test_data/3_add/src/main.nr
@@ -2,4 +2,7 @@
 fn main(mut x: u32, y: u32, z: u32) {
     x = x + y;
     constrain x == z;
+
+    x = 8*x;
+    constrain x>9;
 }

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -294,11 +294,11 @@ impl Acir {
                 self.evaluate_neq(binary.lhs, binary.rhs, &l_c, &r_c, ctx, evaluator),
             ),
             BinaryOp::Ult => {
-                let size = ctx[binary.lhs].size_in_bits();
+                let size = ctx[binary.lhs].get_type().bits();
                 evaluate_cmp(&l_c, &r_c, size, false, evaluator).into()
             }
             BinaryOp::Ule => {
-                let size = ctx[binary.lhs].size_in_bits();
+                let size = ctx[binary.lhs].get_type().bits();
                 let w = evaluate_cmp(&r_c, &l_c, size, false, evaluator);
                 Expression {
                     mul_terms: Vec::new(),
@@ -308,11 +308,11 @@ impl Acir {
                 .into()
             }
             BinaryOp::Slt => {
-                let s = ctx[binary.lhs].size_in_bits();
+                let s = ctx[binary.lhs].get_type().bits();
                 evaluate_cmp(&l_c, &r_c, s, true, evaluator).into()
             }
             BinaryOp::Sle => {
-                let s = ctx[binary.lhs].size_in_bits();
+                let s = ctx[binary.lhs].get_type().bits();
                 let w = evaluate_cmp(&r_c, &l_c, s, true, evaluator);
                 Expression {
                     mul_terms: Vec::new(),
@@ -323,7 +323,7 @@ impl Acir {
             }
             BinaryOp::Lt => todo!(),
             BinaryOp::Lte => {
-                let size = ctx[binary.lhs].size_in_bits();
+                let size = ctx[binary.lhs].get_type().bits();
                 // TODO: Should this be signed?
                 evaluate_cmp(&l_c, &r_c, size, false, evaluator).into()
             }


### PR DESCRIPTION
Small fix to use the correct bit size in a range check.
Alternatively, we could use the max of the operands bit size but we would need some dataflow analysis to benefit from this.

I also added a test that should have failed before the fix.
