### PR TITLE
Quick fix remove unnecessary field

### DIFF
--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -284,8 +284,7 @@ fn type_check_global_consts(
     for (file_id, stmt_id) in global_const_ids {
         let mut type_check_errs = Vec::new();
         let _stmt_type = type_check(interner, &stmt_id, &mut type_check_errs);
-        let type_check_err_diagnostics =
-            vecmap(type_check_errs, |error| error.into_diagnostic());
+        let type_check_err_diagnostics = vecmap(type_check_errs, |error| error.into_diagnostic());
 
         if !type_check_err_diagnostics.is_empty() {
             let collected_errors = CollectedErrors { file_id, errors: type_check_err_diagnostics };

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -285,7 +285,7 @@ fn type_check_global_consts(
         let mut type_check_errs = Vec::new();
         let _stmt_type = type_check(interner, &stmt_id, &mut type_check_errs);
         let type_check_err_diagnostics =
-            vecmap(type_check_errs, |error| error.into_diagnostic(interner));
+            vecmap(type_check_errs, |error| error.into_diagnostic());
 
         if !type_check_err_diagnostics.is_empty() {
             let collected_errors = CollectedErrors { file_id, errors: type_check_err_diagnostics };


### PR DESCRIPTION
The global consts PR was safe to merge, however, an interner was still being passed to the `into_diagnostic` method when type checking the consts. This simply removes that interner from being passed in