### PR TITLE
Fix tuple patterns

### DIFF
--- a/crates/nargo/tests/test_data/tuples/src/main.nr
+++ b/crates/nargo/tests/test_data/tuples/src/main.nr
@@ -4,4 +4,8 @@ fn main(x: Field, y: Field) {
     let pair = (x, y);
     constrain pair.0 == 1;
     constrain pair.1 == 0;
+
+    let (a, b) = (0, 1);
+    constrain a == 0;
+    constrain b == 1;
 }

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -435,7 +435,9 @@ impl<'a> IRGenerator<'a> {
                     self.bind_pattern(pattern, value)?;
                 }
             }
-            _ => unreachable!(),
+            (pattern, value) => {
+                unreachable!("Unexpected pattern {:?} used with value {:?}", pattern, value)
+            }
         }
         Ok(())
     }

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -61,9 +61,21 @@ pub fn bind_pattern(
     match pattern {
         HirPattern::Identifier(ident) => interner.push_definition_type(ident.id, typ),
         HirPattern::Mutable(pattern, _) => bind_pattern(interner, pattern, typ, errors),
-        HirPattern::Tuple(_fields, _span) => {
-            todo!("Implement tuple types")
-        }
+        HirPattern::Tuple(fields, span) => match typ {
+            Type::Tuple(field_types) if field_types.len() == fields.len() => {
+                for (field, field_type) in fields.iter().zip(field_types) {
+                    bind_pattern(interner, field, field_type, errors);
+                }
+            }
+            Type::Error => (),
+            other => {
+                errors.push(TypeCheckError::TypeMismatch {
+                    expected_typ: other.to_string(),
+                    expr_typ: other.to_string(),
+                    expr_span: *span,
+                });
+            }
+        },
         HirPattern::Struct(struct_type, fields, span) => match typ {
             Type::Struct(inner, args) if &inner == struct_type => {
                 let mut pattern_fields = fields.clone();


### PR DESCRIPTION
Previously there was a bug where doing `let (a, b) = ...` would fail with a `todo!(...)` in the code. This PR implements the todo.
The original test case used an if: `let (a, b) = if true { (0, 1) } else { (2, 3) };` but ifs returning tuples currently fail in SSA as the value returned by an if is a Value::Single rather than the expected Value::Struct. This is considered a separate issue from this PR.