### PR TITLE
Handle return values from IF blocks

### DIFF
--- a/crates/nargo/tests/test_data/6_array/src/main.nr
+++ b/crates/nargo/tests/test_data/6_array/src/main.nr
@@ -41,4 +41,8 @@ fn main(x: [u32; 5], y: [u32; 5], mut z: u32, t: u32) {
       };
    };
    constrain (z ==11539);
+
+   //Test 5:
+   let cc = if z < 1 { x } else { y };
+   constrain cc[0] == y[0];
 }

--- a/crates/nargo/tests/test_data/tuples/src/main.nr
+++ b/crates/nargo/tests/test_data/tuples/src/main.nr
@@ -9,9 +9,6 @@ fn main(x: Field, y: Field) {
     constrain a == 0;
     constrain b == 1;
 
-   let cc = if x as u32 <1 { [0,1] } else { [2,3] };
-   constrain cc[0] == 2;
-
     let (u,v) = if x as u32 <1 {
         (x,x+1)
     } else {

--- a/crates/nargo/tests/test_data/tuples/src/main.nr
+++ b/crates/nargo/tests/test_data/tuples/src/main.nr
@@ -5,7 +5,18 @@ fn main(x: Field, y: Field) {
     constrain pair.0 == 1;
     constrain pair.1 == 0;
 
-    let (a, b) = (0, 1);
+    let (a, b) = if true { (0, 1) } else { (2, 3) };
     constrain a == 0;
     constrain b == 1;
+
+   let cc = if x as u32 <1 { [0,1] } else { [2,3] };
+   constrain cc[0] == 2;
+
+    let (u,v) = if x as u32 <1 {
+        (x,x+1)
+    } else {
+        (x+1,x)
+    };
+   constrain u==x+1;
+   constrain v==x;
 }

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -56,10 +56,32 @@ impl Value {
         Value::Single(NodeId::dummy())
     }
 
+    pub fn is_dummy(&self) -> bool {
+        match self {
+            Value::Single(id) => *id == NodeId::dummy(),
+            _ => false,
+        }
+    }
+
     pub fn to_node_ids(&self) -> Vec<NodeId> {
         match self {
             Value::Single(id) => vec![*id],
             Value::Struct(v) => v.iter().flat_map(|i| i.1.to_node_ids()).collect(),
+        }
+    }
+
+    pub fn zip<F>(&self, v2: &Value, func: &mut F) -> Value
+    where
+        F: FnMut(NodeId, NodeId) -> NodeId,
+    {
+        if self.is_dummy() || v2.is_dummy() {
+            return Value::dummy();
+        }
+        match self {
+            Value::Single(id) => Value::Single(func(*id, v2.unwrap_id())),
+            Value::Struct(v) => Value::Struct(
+                v.iter().map(|i| (i.0.clone(), i.1.zip(v2.get_field_member(&i.0), func))).collect(),
+            ),
         }
     }
 
@@ -942,13 +964,12 @@ impl<'a> IRGenerator<'a> {
             if cond.is_zero() {
                 //Parse statements of ELSE branch
                 if let Some(alt) = alternative {
-                    self.codegen_expression(env, &alt).map_err(|err| err.remove_span()).unwrap();
+                    return self.codegen_expression(env, &alt);
                 }
                 return Ok(Value::dummy());
             } else {
                 //Parse statements of THEN branch
-                self.codegen_expression(env, cons).map_err(|err| err.remove_span()).unwrap();
-                return Ok(Value::dummy());
+                return self.codegen_expression(env, cons);
             }
         }
         let jump_op = Operation::Jeq(condition, block::BlockId::dummy());
@@ -957,7 +978,7 @@ impl<'a> IRGenerator<'a> {
         //Then block
         block::new_sealed_block(&mut self.context, block::BlockType::Normal, true);
         //Parse statements of THEN branch
-        self.codegen_expression(env, cons).map_err(|err| err.remove_span()).unwrap();
+        let v1 = self.codegen_expression(env, cons).map_err(|err| err.remove_span()).unwrap();
 
         //Exit block
         let exit_block =
@@ -975,8 +996,9 @@ impl<'a> IRGenerator<'a> {
             *target = block2;
         }
         //Parse statements of ELSE branch
+        let mut v2 = Value::dummy();
         if let Some(alt) = alternative {
-            self.codegen_expression(env, &alt).map_err(|err| err.remove_span()).unwrap();
+            v2 = self.codegen_expression(env, &alt).map_err(|err| err.remove_span()).unwrap();
         }
         //Connect with the exit block
         self.context.get_current_block_mut().left = Some(exit_block);
@@ -985,7 +1007,10 @@ impl<'a> IRGenerator<'a> {
         self.context.current_block = exit_block;
         self.context.get_current_block_mut().predecessor.push(block2);
         ssa_form::seal_block(&mut self.context, exit_block);
-        //
-        Ok(Value::dummy())
+
+        // return value:
+        let mut c = 0;
+        let mut phi = |a, b| self.context.new_phi(a, b, &mut c);
+        Ok(v1.zip(&v2, &mut phi))
     }
 }


### PR DESCRIPTION
This allows to use syntax like: `let (a, b) = if true { (0, 1) } else { (2, 3) };`

It highlighted  an issue caused by the iterative version of the parsing of the CFG when building the decision tree. The parsing is finally correct now.