### PR TITLE
Enable integers with odd bits

### DIFF
--- a/crates/nargo/tests/test_data/5_over/src/main.nr
+++ b/crates/nargo/tests/test_data/5_over/src/main.nr
@@ -1,5 +1,9 @@
 // Test unsafe integer arithmetic
+// Test odd bits integer
 fn main(mut x: u32, y: u32) {
     x = x * x;
     constrain y == x;
+
+    let c:u3 = 2;
+    constrain c > x as u3;
 }

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -270,9 +270,6 @@ impl IntType {
         if str_as_u32 > max_bits {
             return Err(LexerErrorKind::TooManyBits { span, max: max_bits, got: str_as_u32 });
         }
-        if (str_as_u32 % 2 == 1) && (str_as_u32 > 1) {
-            todo!("Barretenberg currently panics on odd integers bit widths such as u3, u5. u1 works as it is a type alias for bool, so we can use a bool gate for it");
-        }
 
         if is_signed {
             Ok(Some(Token::IntType(IntType::Signed(str_as_u32))))


### PR DESCRIPTION
Odd bits integers were already supported so I am just removing the `todo!()`