### PR TITLE
Add cli command to count various types of gates

### DIFF
--- a/crates/acir/src/circuit/gate.rs
+++ b/crates/acir/src/circuit/gate.rs
@@ -31,6 +31,20 @@ pub enum Gate {
 }
 
 impl Gate {
+    pub fn name(&self) -> &str {
+        match self {
+            Gate::Arithmetic(_) => "arithmetic",
+            Gate::Range(_, _) => "range",
+            Gate::And(_) => "and",
+            Gate::Xor(_) => "xor",
+            Gate::Directive(Directive::Invert { x: _, result: _ }) => "invert",
+            Gate::Directive(Directive::Truncate { a: _, b: _, c: _, bit_size: _ }) => "truncate",
+            Gate::Directive(Directive::Quotient { a: _, b: _, q: _, r: _ }) => "quotient",
+            Gate::Directive(Directive::Oddrange { a: _, b: _, r: _, bit_size: _ }) => "odd_range",
+            Gate::Directive(Directive::Split { a: _, b: _, bit_size: _ }) => "split",
+            Gate::GadgetCall(g) => g.name.name(),
+        }
+    }
     pub fn is_arithmetic(&self) -> bool {
         matches!(self, Gate::Arithmetic(_))
     }

--- a/crates/acir/src/circuit/gate.rs
+++ b/crates/acir/src/circuit/gate.rs
@@ -37,11 +37,11 @@ impl Gate {
             Gate::Range(_, _) => "range",
             Gate::And(_) => "and",
             Gate::Xor(_) => "xor",
-            Gate::Directive(Directive::Invert { x: _, result: _ }) => "invert",
-            Gate::Directive(Directive::Truncate { a: _, b: _, c: _, bit_size: _ }) => "truncate",
-            Gate::Directive(Directive::Quotient { a: _, b: _, q: _, r: _ }) => "quotient",
-            Gate::Directive(Directive::Oddrange { a: _, b: _, r: _, bit_size: _ }) => "odd_range",
-            Gate::Directive(Directive::Split { a: _, b: _, bit_size: _ }) => "split",
+            Gate::Directive(Directive::Invert { .. }) => "invert",
+            Gate::Directive(Directive::Truncate { .. }) => "truncate",
+            Gate::Directive(Directive::Quotient { .. }) => "quotient",
+            Gate::Directive(Directive::Oddrange { .. }) => "odd_range",
+            Gate::Directive(Directive::Split { .. }) => "split",
             Gate::GadgetCall(g) => g.name.name(),
         }
     }

--- a/crates/nargo/src/cli/gates_cmd.rs
+++ b/crates/nargo/src/cli/gates_cmd.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+use acvm::ProofSystemCompiler;
+use clap::ArgMatches;
+use std::path::Path;
+
+use crate::errors::CliError;
+use crate::resolver::Resolver;
+
+pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
+    let args = args.subcommand_matches("gates").unwrap();
+    let show_ssa = args.is_present("show-ssa");
+    count_gates(show_ssa)
+}
+
+pub fn count_gates(show_ssa: bool) -> Result<(), CliError> {
+    let curr_dir = std::env::current_dir().unwrap();
+    count_gates_with_path(curr_dir, show_ssa)
+}
+
+pub fn count_gates_with_path<P: AsRef<Path>>(
+    program_dir: P,
+    show_ssa: bool,
+) -> Result<(), CliError> {
+    let driver = Resolver::resolve_root_config(program_dir.as_ref())?;
+    let backend = crate::backends::ConcreteBackend;
+
+    let compiled_program = driver.into_compiled_program(backend.np_language(), show_ssa);
+    let gates = compiled_program.circuit.gates;
+
+    // Store counts of each gate type into hashmap.
+    let mut gate_counts: HashMap<&str, u32> = HashMap::new();
+    for gate in gates.iter() {
+        *gate_counts.entry(gate.name()).or_default() += 1;
+    }
+
+    // Sort gates by name alphabetically for consistent display.
+    let mut sorted_gate_counts: Vec<(&str, u32)> = gate_counts.into_iter().collect();
+    sorted_gate_counts.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap());
+
+    println!("Gates successfully counted\n");
+
+    println!("Total gates: {}\n", gates.len());
+
+    println!("By type:");
+
+    for (gate_type, count) in sorted_gate_counts {
+        println!("{}: {}", gate_type, count);
+    }
+
+    Ok(())
+}

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -13,6 +13,7 @@ use crate::errors::CliError;
 mod build_cmd;
 mod compile_cmd;
 mod contract_cmd;
+mod gates_cmd;
 mod new_cmd;
 mod prove_cmd;
 mod verify_cmd;
@@ -65,6 +66,13 @@ pub fn start_cli() {
                     Arg::with_name("circuit_name").help("The name of the ACIR file").required(true),
                 ),
         )
+        .subcommand(
+            App::new("gates").about("Counts the occurences of different gates in circuit").arg(
+                Arg::with_name("show-ssa")
+                    .long("show-ssa")
+                    .help("Emit debug information for the intermediate SSA IR"),
+            ),
+        )
         .get_matches();
 
     let result = match matches.subcommand_name() {
@@ -74,6 +82,7 @@ pub fn start_cli() {
         Some("prove") => prove_cmd::run(matches),
         Some("compile") => compile_cmd::run(matches),
         Some("verify") => verify_cmd::run(matches),
+        Some("gates") => gates_cmd::run(matches),
         None => Err(CliError::Generic("No subcommand was used".to_owned())),
         Some(x) => Err(CliError::Generic(format!("unknown command : {}", x))),
     };


### PR DESCRIPTION
closes #343 

This PR adds the `nargo gates` command which counts the number of each gate in the circuit. I've reused the existing names for the gadget calls and added names in a similar style for the "standard" gates.

Running this command on [mastermind-noir](https://github.com/vezenovm/mastermind-noir/tree/43516b105294162522d4de24ebb7a31192fa99db) gives the output below.
```
$ nargo gates
Gates successfully counted

Total gates: 336

By type:
arithmetic: 269
invert: 43
odd_range: 1
pedersen: 1
range: 13
split: 8
truncate: 1
```

Open to any opinions on formatting, etc.