### PR TITLE
Sort gates by witness index

### DIFF
--- a/crates/acir/src/native_types/arithmetic.rs
+++ b/crates/acir/src/native_types/arithmetic.rs
@@ -1,6 +1,7 @@
 use crate::native_types::{Linear, Witness};
 use noir_field::FieldElement;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::ops::{Add, Mul, Neg, Sub};
 
 use super::witness::UnknownWitness;
@@ -44,6 +45,35 @@ impl std::fmt::Display for Expression {
     }
 }
 
+impl Ord for Expression {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let mut i1 = self.get_max_idx();
+        let mut i2 = other.get_max_idx();
+        let mut result = Ordering::Equal;
+        while result == Ordering::Equal {
+            let m1 = self.get_max_term(&mut i1);
+            let m2 = other.get_max_term(&mut i2);
+            if m1.is_none() && m2.is_none() {
+                return Ordering::Equal;
+            }
+            result = Expression::cmp_max(m1, m2);
+        }
+        result
+    }
+}
+
+impl PartialOrd for Expression {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+struct WitnessIdx {
+    linear: usize,
+    mul: usize,
+    second_term: bool,
+}
+
 impl Expression {
     pub const fn can_defer_constraint(&self) -> bool {
         false
@@ -62,6 +92,72 @@ impl Expression {
 
     pub fn is_linear(&self) -> bool {
         self.mul_terms.is_empty()
+    }
+
+    fn get_max_idx(&self) -> WitnessIdx {
+        WitnessIdx {
+            linear: self.linear_combinations.len(),
+            mul: self.mul_terms.len(),
+            second_term: true,
+        }
+    }
+    // Returns the maximum witness at the provided position, and decrement the position
+    // This function assumes the gate is sorted
+    fn get_max_term(&self, idx: &mut WitnessIdx) -> Option<Witness> {
+        if idx.linear > 0 {
+            if idx.mul > 0 {
+                let mul_term = if idx.second_term {
+                    self.mul_terms[idx.mul - 1].2
+                } else {
+                    self.mul_terms[idx.mul - 1].1
+                };
+                if self.linear_combinations[idx.linear - 1].1 > mul_term {
+                    idx.linear -= 1;
+                    Some(self.linear_combinations[idx.linear].1)
+                } else {
+                    if idx.second_term {
+                        idx.second_term = false;
+                    } else {
+                        idx.mul -= 1;
+                    }
+                    Some(mul_term)
+                }
+            } else {
+                idx.linear -= 1;
+                Some(self.linear_combinations[idx.linear].1)
+            }
+        } else if idx.mul > 0 {
+            if idx.second_term {
+                idx.second_term = false;
+                Some(self.mul_terms[idx.mul - 1].2)
+            } else {
+                idx.mul -= 1;
+                Some(self.mul_terms[idx.mul].1)
+            }
+        } else {
+            None
+        }
+    }
+
+    fn cmp_max(m1: Option<Witness>, m2: Option<Witness>) -> Ordering {
+        if let Some(m1) = m1 {
+            if let Some(m2) = m2 {
+                m1.cmp(&m2)
+            } else {
+                Ordering::Greater
+            }
+        } else if m2.is_some() {
+            Ordering::Less
+        } else {
+            Ordering::Equal
+        }
+    }
+
+    /// Sorts gate in a deterministic order
+    /// XXX: We can probably make this more efficient by sorting on each phase. We only care if it is deterministic
+    pub fn sort(&mut self) {
+        self.mul_terms.sort_by(|a, b| a.1.cmp(&b.1).then(a.2.cmp(&b.2)));
+        self.linear_combinations.sort_by(|a, b| a.1.cmp(&b.1));
     }
 }
 

--- a/crates/acir/src/optimiser/csat_optimiser.rs
+++ b/crates/acir/src/optimiser/csat_optimiser.rs
@@ -345,8 +345,8 @@ fn simple_reduction_smoke_test() {
         mul_terms: vec![],
         linear_combinations: vec![
             (FieldElement::one(), a),
-            (FieldElement::one(), e),
             (-FieldElement::one(), b),
+            (FieldElement::one(), e),
         ],
         q_c: FieldElement::zero(),
     };

--- a/crates/acir/src/optimiser/csat_optimiser.rs
+++ b/crates/acir/src/optimiser/csat_optimiser.rs
@@ -39,17 +39,9 @@ impl Optimiser {
         // If a gate has more than one mul term. We may need an intermediate variable for each one. Since not every variable will need to link to
         // the mul term, we could possibly do it that way.
         // We wil call this a partial gate scan optimisation which will result in the gates being able to fit into the correct width
-        let gate = self.partial_gate_scan_optimisation(gate, intermediate_variables, num_witness);
-
-        self.sort(gate)
-    }
-
-    /// Sorts gate in a deterministic order
-    /// XXX: We can probably make this more efficient by sorting on each phase. We only care if it is deterministic
-    fn sort(&self, mut gate: Expression) -> Expression {
-        gate.mul_terms.sort();
-        gate.linear_combinations.sort();
-
+        let mut gate =
+            self.partial_gate_scan_optimisation(gate, intermediate_variables, num_witness);
+        gate.sort();
         gate
     }
 
@@ -194,7 +186,7 @@ impl Optimiser {
         new_gate.mul_terms.extend(gate.mul_terms.clone());
         new_gate.linear_combinations.extend(gate.linear_combinations.clone());
         new_gate.q_c = gate.q_c;
-
+        new_gate.sort();
         new_gate
     }
 

--- a/crates/acvm/src/compiler.rs
+++ b/crates/acvm/src/compiler.rs
@@ -31,11 +31,16 @@ pub fn compile(acir: Circuit, np_language: Language) -> Circuit {
 
                 // Update next_witness counter
                 next_witness_index += intermediate_variables.len() as u32;
-
-                for (_, gate) in intermediate_variables.into_iter() {
+                let mut new_gates = Vec::new();
+                for (_, mut g) in intermediate_variables {
+                    g.sort();
+                    new_gates.push(g);
+                }
+                new_gates.push(arith_expr);
+                new_gates.sort();
+                for gate in new_gates {
                     optimised_gates.push(Gate::Arithmetic(gate));
                 }
-                optimised_gates.push(Gate::Arithmetic(arith_expr));
             }
             other_gate => optimised_gates.push(other_gate),
         }

--- a/crates/acvm/src/lib.rs
+++ b/crates/acvm/src/lib.rs
@@ -77,10 +77,20 @@ pub trait PartialWitnessGenerator {
                     // We compute the result because the other gates may want to use the assignment to generate their assignments
                 }
                 Gate::GadgetCall(gc) => {
-                    if let Err(op) = Self::solve_gadget_call(initial_witness, gc) {
-                        return GateResolution::UnsupportedOpcode(op);
+                    let mut unsolvable = false;
+                    for i in &gc.inputs {
+                        if !initial_witness.contains_key(&i.witness) {
+                            unsolvable = true;
+                            break;
+                        }
                     }
-                    false
+                    if unsolvable {
+                        true
+                    } else if let Err(op) = Self::solve_gadget_call(initial_witness, gc) {
+                        return GateResolution::UnsupportedOpcode(op);
+                    } else {
+                        false
+                    }
                 }
                 Gate::Directive(directive) => match directive {
                     Directive::Invert { x, result } => match initial_witness.get(x) {

--- a/crates/nargo/tests/test_data/config.toml
+++ b/crates/nargo/tests/test_data/config.toml
@@ -1,5 +1,6 @@
 # List of tests to be excluded (i.e not run), as their directory name in test_data
-# "1_mul", "2_div","3_add","4_sub","5_over", "6","6_array", "7_function","7","8_integration", "assign_ex", "bool_not", "bool_or", "pedersen_check", "pred_eq", "schnorr", "sha256", "tuples"
+# "1_mul", "2_div","3_add","4_sub","5_over", "6","6_array", "7_function","7","8_integration", "9_conditional", "10_slices", "assign_ex", "bool_not", "bool_or", "pedersen_check", "pred_eq", "schnorr", "sha256", "tuples",
+# "array_len", "array_neq", "bit_and", "cast_bool", "const_array_access", "generics", "global_const", "main_bool_arg", "main_return", "merkle_insert", "modules", "modules_more", "scalar_mul", "simple_shield", "struct", "submodules", 
 exclude = ["const_fail"]
 
 


### PR DESCRIPTION
This PR fixes issue #364 by sorting the intermediate gates created by the optimizer, so that intermediate values can be computed in the first pass. The gates must be internally sorted by witness index in order for the comparison function added to Expression to work properly.