### PR TITLE
fix odd bitsize for bitwise operations

### DIFF
--- a/crates/nargo/tests/test_data/bit_and/src/main.nr
+++ b/crates/nargo/tests/test_data/bit_and/src/main.nr
@@ -5,5 +5,14 @@ fn main(x : Field, y : Field) {
     let y_as_u8 = y as u8;
     
     constrain (x_as_u8 & y_as_u8) == x_as_u8;
+
+    //bitwise and with 1 bit:
+    let flag = (x == 0) & (y == 16);
+    constrain flag == true;
+
+    //bitwise and with odd bits:
+    let x_as_u11 = x as u11;
+    let y_as_u11 = y as u11;
+    constrain (x_as_u11 & y_as_u11) == x_as_u11;
 }
     

--- a/crates/nargo/tests/test_data/bit_and/src/main.nr
+++ b/crates/nargo/tests/test_data/bit_and/src/main.nr
@@ -8,7 +8,7 @@ fn main(x : Field, y : Field) {
 
     //bitwise and with 1 bit:
     let flag = (x == 0) & (y == 16);
-    constrain flag == true;
+    constrain flag;
 
     //bitwise and with odd bits:
     let x_as_u11 = x as u11;


### PR DESCRIPTION
AND and XOR custom gates in barretenberg do not support odd bit size, which is the root cause of the issue reported here: https://github.com/snjax/zkships/tree/master/issues/segfault

One bits operation do not use the custom gate anymore (I assume this is more efficient)
Other odd-size operations are done with one more bit to get an even number