### PR TITLE
Add regression test for the bug fixed by PR373

### DIFF
--- a/crates/nargo/tests/test_data/pedersen_check/Prover.toml
+++ b/crates/nargo/tests/test_data/pedersen_check/Prover.toml
@@ -1,5 +1,6 @@
 x = "0"
 y = "1"
+salt = "42"
 
 out_x = "0x108800e84e0f1dafb9fdf2e4b5b311fd59b8b08eaf899634c59cc985b490234b"
 out_y = "0x2d43ef68df82e0adf74fed92b1bc950670b9806afcfbcda08bb5baa6497bdf14"

--- a/crates/nargo/tests/test_data/pedersen_check/src/main.nr
+++ b/crates/nargo/tests/test_data/pedersen_check/src/main.nr
@@ -1,8 +1,17 @@
 use dep::std;
 
-fn main(x: Field, y: Field, out_x: Field, out_y: Field ) {
+fn main(x: Field, y: Field, salt: Field, out_x: Field, out_y: Field ) {
     let res = std::hash::pedersen([x, y]);
     constrain res[0] == out_x;
     constrain res[1] == out_y;
+
+    let raw_data = [x,y];
+    let mut state = 0;
+    for i in 0..2 {
+        state = state * 8 + raw_data[i];
+    };
+    state = state + salt;
+    let hash = std::hash::pedersen([state]);
+    constrain std::hash::pedersen([43])[0] == hash[0];
 }
     


### PR DESCRIPTION
I added the test case to the pedersen check test. If we remove the guard on gadget inputs and the sorting of the optimised gates, this test case fails.

