### PR TITLE
Accessing array inside a struct bug fix

### DIFF
--- a/crates/nargo/tests/test_data/struct/src/main.nr
+++ b/crates/nargo/tests/test_data/struct/src/main.nr
@@ -2,6 +2,7 @@ use dep::std;
 
 struct Foo {
     bar: Field,
+    array: [Field; 2],
 }
 
 struct Pair {
@@ -10,8 +11,8 @@ struct Pair {
 }
 
 impl Foo {
-    fn default() -> Self {
-        Self { bar: 0 }
+    fn default(x: Field,y: Field) -> Self {
+        Self { bar: 0, array: [x,y] }
     }
 }
 
@@ -26,10 +27,11 @@ impl Pair {
 }
 
 fn main(x: Field, y: Field) {
-    let first = Foo::default();
+    let first = Foo::default(x,y);
     let p = Pair { first, second: 1 };
 
     constrain p.bar() == x;
     constrain p.second == y;
+    constrain p.first.array[0] != p.first.array[1];
 }
     

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -255,13 +255,6 @@ impl ObjectType {
         }
     }
 
-    pub fn type_to_pointer(&self) -> ArrayId {
-        match self {
-            ObjectType::Pointer(a) => *a,
-            _ => unreachable!("Type is not a pointer",),
-        }
-    }
-
     pub fn field_to_type(&self, f: FieldElement) -> FieldElement {
         match self {
             ObjectType::NotAnObject | ObjectType::Pointer(_) => {


### PR DESCRIPTION
We were getting the struct object rather than the field element of the structure when accessing an array inside a struct via index.
I added a regression test.