### PR TITLE
Patch M1 Compilation Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aztec_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=01b922adcb5a9d70b2d12304e1cb7487d9f28188#01b922adcb5a9d70b2d12304e1cb7487d9f28188"
+source = "git+https://github.com/Entropy1729/aztec_backend?branch=fix/mac_m1_compilation#cf353bfec3d20ed9dd4e6edba06ab92c8912983a"
 dependencies = [
  "acvm",
  "barretenberg_wrapper",
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/AztecProtocol/barretenberg?rev=804c7dcf21111acd1302a768a8fa2f453dcec50f#804c7dcf21111acd1302a768a8fa2f453dcec50f"
+source = "git+https://github.com/AztecProtocol/barretenberg?rev=bb09420f1ed3af7209f5b97d36904d87f8f31a9b#bb09420f1ed3af7209f5b97d36904d87f8f31a9b"
 dependencies = [
  "cmake",
  "hex",

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -25,7 +25,7 @@ hex = "0.4.2"
 tempdir = "0.3.7"
 
 # Backends
-aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend", rev = "01b922adcb5a9d70b2d12304e1cb7487d9f28188" }
+aztec_backend = { optional = true, git = "https://github.com/Entropy1729/aztec_backend", branch = "fix/mac_m1_compilation" }
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "601e24dcb5dcbe72e3de7a33879aaf84e171d541" }
 
 [features]


### PR DESCRIPTION
# Related issue(s)

It is kinda related to #202 but not with Macs using Intel otherwise with Macs using M1.

# Description

## Summary of changes

See https://github.com/AztecProtocol/barretenberg/pull/100 for more information.

## Dependency additions / changes

`aztec_backend` is being updated.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

This PR is still on Draft because the final version should not have the `aztec_backend` dependency pointing to our fork, instead, it should be pointing to the commit of the merge of the PR corresponding to the fix (on the aztec_backend repo side). But this way if you have an M1 you can clone this and have a successful compilation.

---

Feedback is more than welcome and let me know if this PR is misplaced. 