### PR TITLE
Prefer usage of `compile_circuit` in nargo

### DIFF
--- a/crates/nargo/src/cli/contract_cmd.rs
+++ b/crates/nargo/src/cli/contract_cmd.rs
@@ -1,6 +1,6 @@
 use super::{create_named_dir, write_to_file, CONTRACT_DIR};
-use crate::{errors::CliError, resolver::Resolver};
-use acvm::{ProofSystemCompiler, SmartContract};
+use crate::{cli::compile_cmd::compile_circuit, errors::CliError};
+use acvm::SmartContract;
 use clap::ArgMatches;
 
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
@@ -10,11 +10,10 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
         Some(path) => std::path::PathBuf::from(path),
         None => std::env::current_dir().unwrap(),
     };
-    let driver = Resolver::resolve_root_config(&package_dir)?;
+
+    let compiled_program = compile_circuit(&package_dir, false)?;
 
     let backend = crate::backends::ConcreteBackend;
-    let compiled_program = driver.into_compiled_program(backend.np_language(), false);
-
     let smart_contract_string = backend.eth_contract_from_cs(compiled_program.circuit);
 
     let mut contract_path = create_named_dir(CONTRACT_DIR.as_ref(), "contract");

--- a/crates/nargo/src/cli/gates_cmd.rs
+++ b/crates/nargo/src/cli/gates_cmd.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use acvm::ProofSystemCompiler;
 use clap::ArgMatches;
 use std::path::Path;
 
+use crate::cli::compile_cmd::compile_circuit;
 use crate::errors::CliError;
-use crate::resolver::Resolver;
 
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     let args = args.subcommand_matches("gates").unwrap();
@@ -22,10 +21,7 @@ pub fn count_gates_with_path<P: AsRef<Path>>(
     program_dir: P,
     show_ssa: bool,
 ) -> Result<(), CliError> {
-    let driver = Resolver::resolve_root_config(program_dir.as_ref())?;
-    let backend = crate::backends::ConcreteBackend;
-
-    let compiled_program = driver.into_compiled_program(backend.np_language(), show_ssa);
+    let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa)?;
     let gates = compiled_program.circuit.gates;
 
     // Store counts of each gate type into hashmap.

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -1,7 +1,7 @@
+use super::compile_cmd::compile_circuit;
 use super::{PROOFS_DIR, PROOF_EXT, VERIFIER_INPUT_FILE};
-use crate::{errors::CliError, resolver::Resolver};
-use acvm::FieldElement;
-use acvm::ProofSystemCompiler;
+use crate::errors::CliError;
+use acvm::{FieldElement, ProofSystemCompiler};
 use clap::ArgMatches;
 use noirc_abi::{input_parser::InputValue, Abi};
 use std::{collections::BTreeMap, path::Path, path::PathBuf};
@@ -66,10 +66,7 @@ pub fn verify_with_path<P: AsRef<Path>>(
     proof_path: P,
     show_ssa: bool,
 ) -> Result<bool, CliError> {
-    let driver = Resolver::resolve_root_config(program_dir.as_ref())?;
-    let backend = crate::backends::ConcreteBackend;
-
-    let compiled_program = driver.into_compiled_program(backend.np_language(), show_ssa);
+    let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa)?;
 
     let public_abi = compiled_program.abi.clone().unwrap().public_abi();
     let num_pub_params = public_abi.num_parameters();
@@ -98,6 +95,7 @@ pub fn verify_with_path<P: AsRef<Path>>(
     // XXX: Instead of unwrap, return a ProofNotValidError
     let proof = hex::decode(proof_hex).unwrap();
 
+    let backend = crate::backends::ConcreteBackend;
     let valid_proof = backend.verify_from_cs(&proof, public_inputs, compiled_program.circuit);
 
     Ok(valid_proof)


### PR DESCRIPTION
# Description

## Summary of changes

Compilation of circuits now uses the `compile_circuit` function rather than duplicating this logic in each location. This shouldn't affect functionality but improves clarity. 

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

N/A
