### PR TITLE
Add support for local dependencies

### DIFF
--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -124,7 +124,11 @@ impl<'a> Resolver<'a> {
                 let meta = retrieve_meta(&dir_path, true)?;
                 Ok((dir_path, meta))
             }
-            Dependency::Path { path: _ } => todo!(),
+            Dependency::Path { path } => {
+                let dir_path = std::path::PathBuf::from(path);
+                let meta = retrieve_meta(&dir_path, false)?;
+                Ok((dir_path, meta))
+            }
         }
     }
 


### PR DESCRIPTION
# Related issue(s)

closes #399 

# Description

This PR allows us to specify paths of local dependencies inside a crate's `Nargo.toml` dependencies array.

i.e. For a project with structure:
```
root
 ├── bin
 │     ├──src
 │     │   └── main.nr
 │     └── Nargo.toml
 └── lib
     ├──src
     │   └── lib.nr
     └── Nargo.toml
      
```

by adding the following line to the dependencies array in `bin/Nargo.toml`
```
local = {path = "../lib"}
```

`bin/src/main.nr` can then make use of the functions contained within `lib/src/lib.nr`

## Summary of changes

Local dependencies can now be specified in `Nargo.toml` which will then be available inside the crate.

~~I haven't tested this past the immediate imports (i.e. I've tested local dependencies but not local dependencies of dependencies) however, even without this, it's a useful addition as it allows proper testing of libraries.~~
We already reject any dependencies which make use of local dependencies: https://github.com/noir-lang/noir/blob/20048e7ce9b651b0b46083ef5e6674331011eb10/crates/nargo/src/resolver.rs#L93-L103

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
