### PR TITLE
Fix error compiling the `noirc_frontend` crate

### DIFF
--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -18,3 +18,7 @@ thiserror = "1.0.21"
 pathdiff = "0.2"
 smol_str = "0.1.17"
 rustc-hash = "1.1.0"
+
+[features]
+bn254 = ["acvm/bn254"]
+bls12_381 = ["acvm/bls12_381"]


### PR DESCRIPTION
# Related issue(s)

Resolves #403 

# Description

No compilation features were provided so the user wasn't able to compile this crate successfully.

## Summary of changes

Added two compilation features (`bn254` and `bls12_381`). Now the user could compile with the `bn254` feature or the `bls12_381` feature.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

This fix solves the compilation impossibility. I don't know if the idea is to have both features available for this crate. Let me know if something is off.
