### PR TITLE
Fix error compiling the `acir` crate

### DIFF
--- a/crates/acir/Cargo.toml
+++ b/crates/acir/Cargo.toml
@@ -15,3 +15,7 @@ flate2 = "1.0.24"
 
 [dev-dependencies]
 serde_json = "1.0"
+
+[features]
+bn254 = ["noir_field/bn254"]
+bls12_381 = ["noir_field/bls12_381"]


### PR DESCRIPTION
# Related issue(s)

Resolves #405

# Description

No compilation features were provided so the user wasn't able to compile this crate successfully.

## Summary of changes

Added two compilation features (`bn254` and `bls12_381`). Now the user could compile with the `bn254` feature or the `bls12_381` feature.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

This fix solves the compilation impossibility. I don't know if it is the idea of this crate to have both features available. Let me know if something is off.
