### PR TITLE
Fix failing test in the `noirc_driver` crate

### DIFF
--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -23,3 +23,7 @@ pathdiff = "0.2"
 default = []
 std = ["fm/std"]
 wasm = ["fm/wasm"]
+bn254_std = ["acvm/bn254", "noirc_frontend/bn254", "noirc_abi/bn254", "std"]
+bn254_wasm = ["acvm/bn254", "noirc_frontend/bn254", "noirc_abi/bn254", "wasm"]
+bls12_381_std = ["acvm/bls12_381", "noirc_frontend/bls12_381", "noirc_abi/bls12_381", "std"]
+bls12_381_wasm = ["acvm/bls12_381", "noirc_frontend/bls12_381", "noirc_abi/bls12_381", "wasm"]

--- a/crates/noirc_driver/tests/tests.rs
+++ b/crates/noirc_driver/tests/tests.rs
@@ -14,6 +14,7 @@ fn fail() {
     }
 }
 #[test]
+#[cfg(feature = "std")]
 fn pass() {
     let mut pass_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     pass_dir.push("tests/pass/");


### PR DESCRIPTION
# Note

This PR should be merged after #410 (hence [e993e3e](https://github.com/noir-lang/noir/pull/412/commits/e993e3e0e702021d5efd16d67a91abe7b9a89b88)).

# Related issue(s)

Resolves #411 

# Description

A test that should be run only with the `std` feature runs with the `wasm` feature.

## Summary of changes

Added the `#[cfg(feature = "std")]` macro above the test definition.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

The above solution works because it skips the test in the feature `wasm`. That behavior is assumed, it is also possible that the test should pass for both `std` and `wasm` features and in that case, the error should be addressed differently. Though judging by the code that doesn't seem to be the case because wasm tests should have the `#[wasm-bindgen-test]` macro above its definition.
