### PR TITLE
Fix block assumption computation

### DIFF
--- a/crates/nargo/tests/test_data/9_conditional/src/main.nr
+++ b/crates/nargo/tests/test_data/9_conditional/src/main.nr
@@ -36,6 +36,19 @@ fn test4() -> [u32; 4] {
 }
 
 fn main(a: u32, mut c: [u32; 4], x: [u8; 5], result: pub [u8; 32]){
+    //Issue reported in #421
+    if a == c[0] {
+        constrain c[0] == 0;
+    } else  {
+        if a == c[1] {
+            constrain c[1] == 0;
+        } else  {
+            if a == c[2] {
+                constrain c[2] == 0;
+            }
+        }
+    }
+
     if a == 3 {
         c = test4();
     }

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -110,6 +110,20 @@ impl DecisionTree {
         self[parent_id].val_true.contains(&assumption)
     }
 
+    fn new_instruction(
+        ctx: &mut SsaContext,
+        block_id: BlockId,
+        operator: BinaryOp,
+        lhs: NodeId,
+        rhs: NodeId,
+        typ: ObjectType,
+    ) -> Instruction {
+        let operation = Operation::binary(operator, lhs, rhs);
+        let mut i = Instruction::new(operation, typ, Some(block_id));
+        super::optim::simplify(ctx, &mut i).unwrap();
+        i
+    }
+
     fn new_instruction_after_phi(
         ctx: &mut SsaContext,
         block_id: BlockId,
@@ -118,13 +132,28 @@ impl DecisionTree {
         rhs: NodeId,
         typ: ObjectType,
     ) -> NodeId {
-        let operation = Operation::binary(operator, lhs, rhs);
-        let mut i = Instruction::new(operation, typ, Some(block_id));
-        super::optim::simplify(ctx, &mut i).unwrap();
+        let i = DecisionTree::new_instruction(ctx, block_id, operator, lhs, rhs, typ);
         if let node::Mark::ReplaceWith(replacement) = i.mark {
             return replacement;
         }
         ctx.insert_instruction_after_phi(i, block_id)
+    }
+
+    fn new_instruction_after(
+        ctx: &mut SsaContext,
+        block_id: BlockId,
+        operator: BinaryOp,
+        lhs: NodeId,
+        rhs: NodeId,
+        typ: ObjectType,
+        after: NodeId,
+    ) -> NodeId {
+        let i = DecisionTree::new_instruction(ctx, block_id, operator, lhs, rhs, typ);
+        if let node::Mark::ReplaceWith(replacement) = i.mark {
+            return replacement;
+        }
+        let id = ctx.add_instruction(i);
+        ctx.push_instruction_after(id, block_id, after)
     }
 
     pub fn compute_assumption(&mut self, ctx: &mut SsaContext, block_id: BlockId) -> NodeId {
@@ -154,13 +183,14 @@ impl DecisionTree {
                 condition,
                 ObjectType::Boolean,
             );
-            DecisionTree::new_instruction_after_phi(
+            DecisionTree::new_instruction_after(
                 ctx,
                 block_id,
                 BinaryOp::Mul,
                 pvalue,
                 not_condition,
                 ObjectType::Boolean,
+                not_condition,
             )
         };
         self[assumption_id].value = Some(ins);

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -294,6 +294,24 @@ impl SsaContext {
         id
     }
 
+    //add the instruction to the block, after the provided instruction
+    pub fn push_instruction_after(
+        &mut self,
+        instruction_id: NodeId,
+        block: BlockId,
+        after: NodeId,
+    ) -> NodeId {
+        let mut pos = 0;
+        for i in &self[block].instructions {
+            if after == *i {
+                break;
+            }
+            pos += 1;
+        }
+        self[block].instructions.insert(pos + 1, instruction_id);
+        instruction_id
+    }
+
     pub fn add_const(&mut self, constant: node::Constant) -> NodeId {
         let obj = NodeObj::Const(constant);
         let id = NodeId(self.nodes.insert(obj));


### PR DESCRIPTION
The instructions for computing block assumption were not inserted in correct order, which make the solver unable to compute witnesses in some cases, as reported in #421.

Test case has been added to 9_conditional.
