### PR TITLE
Adds binary x86_64-apple-darwin 

### DIFF
--- a/.github/build-x86_64-apple-darwin
+++ b/.github/build-x86_64-apple-darwin
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+echo ✨ System Info  
+sw_vers
+echo ✨ System Details
+uname -a
+echo ✨ LLVM Version
+llvm-config --version
+
+echo ✨ CMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER
+echo ✨ CMAKE_C_COMPILER=$CMAKE_C_COMPILER
+
+# llvm@11 paths
+export CC=/usr/local/opt/llvm@11/bin/clang
+export CXX=/usr/local/opt/llvm@11/bin/clang++
+
+export PATH="/usr/local/opt/llvm@11/bin:$PATH"
+export LDFLAGS="-L/usr/local/opt/llvm@11/lib"
+export CPPFLAGS="-I/usr/local/opt/llvm@11/include"
+
+echo ✨ clang -v
+clang -v
+echo ✨ clang++ -v
+clang++ -v
+
+echo ✨ LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+
+echo ✨ CC=$CC
+echo ✨ CXX=$CXX
+echo ✨ LIBS=$LIBS
+
+# fix clang path's to bb expectations
+sudo mkdir -p /usr/local/opt/llvm/bin/
+sudo ln -s $(which $CC) /usr/local/opt/llvm/bin/clang
+sudo ln -s $(which $CXX) /usr/local/opt/llvm/bin/clang++
+
+#fix libomp path
+sudo mkdir -p /usr/local/lib/
+sudo ln -s /usr/local/Cellar/libomp/15.0.3/lib/libomp.a /usr/local/lib/libomp.a
+ls /usr/local/Cellar/libomp/15.0.3/lib
+
+echo ✨ /usr/local/opt/llvm/bin/clang --version
+/usr/local/opt/llvm/bin/clang --version 
+echo ✨ /usr/local/opt/llvm/bin/clang++ --version 
+/usr/local/opt/llvm/bin/clang++ --version 
+
+echo ✨ rustup target add x86_64-apple-darwin
+rustup target add x86_64-apple-darwin
+
+echo 👷 Cargo Build
+cargo build --release --locked --target x86_64-apple-darwin

--- a/.github/workflows/publish-x86_64-apple-darwin.yml
+++ b/.github/workflows/publish-x86_64-apple-darwin.yml
@@ -1,0 +1,61 @@
+name: build-x86_64-apple-darwin
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-mac:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Rust toolchain Install
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-apple-darwin
+          default: true
+          override: true
+
+      - name: Tools adn Dependencies Install
+        run: |
+          echo ✨ brew config
+          brew config
+          echo ✨ brew install pkg-config cmake llvm@11 libomp tree
+          brew install pkg-config cmake llvm@11 libomp
+
+      - name: Build environment and Compile
+        run: |
+          chmod +x ./.github/build-x86_64-apple-darwin
+          ./.github/build-x86_64-apple-darwin
+
+      - name: Package artifacts
+        run: |
+          mkdir dist
+          cp ./target/x86_64-apple-darwin/release/nargo ./dist/nargo
+          mkdir -p ./dist/noir-lang/std
+          cp crates/std_lib/src/*.nr ./dist/noir-lang/std
+          7z a -ttar -so -an ./dist | 7z a -si ./nargo-x86_64-apple-darwin.tar.gz
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./nargo-x86_64-apple-darwin.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add binary build GitHub Action for x86_64-apple-darwin target (Apple Mac on Intel CPU)

# Related issue(s)

#225 Releases don't contain binaries anymore

Resolves (link to issue)

#225 Releases don't contain binaries anymore _- resolves partially as it provides Mac Intel only, others to follow._

# Description

As a Developer, I would like to have access to the pre-build binary release
so that I could download system appropriate executables and start working with Noir Language.

## Summary of changes

`.github/workflows/publish-x86_64-apple-darwin.yml` where the base of GitHub Action is defined 
`.github/build-x86_64-apple-darwin` where shell script is defined to compile releasable binary along with std_lib contents 

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

N/A