### PR TITLE
Adds binary build GitHub Action for x86_64-unknown-linux-gnu target

### DIFF
--- a/.github/build-nix
+++ b/.github/build-nix
@@ -1,0 +1,16 @@
+#!/usr/bin/env nix-shell
+#!nix-shell ../nix/mixed.nix -i bash
+
+echo ✨ System Details
+uname -a
+
+echo ✨ PWD=$PWD
+
+echo ✨ CC=$CC
+echo ✨ CXX=$CXX
+
+echo ✨ rustup target add $1
+rustup target add $1
+
+echo 👷 Cargo Build
+cargo build --release --locked --target $1

--- a/.github/workflows/publish-x86_64-unknown-linux-gnu.yml
+++ b/.github/workflows/publish-x86_64-unknown-linux-gnu.yml
@@ -1,0 +1,64 @@
+name: build-x86_64-unknown-linux-gnu
+# <arch>-<vendor>-<os>-<env>
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-x86_64-unknown-linux-gnu:
+    runs-on: ubuntu-22.04
+    strategy:
+      max-parallel: 1
+      matrix:
+        target: [x86_64-unknown-linux-gnu]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-22.05
+
+      - uses: cachix/cachix-action@v11
+        with:
+          name: nargo-cache
+          # If you chose signing key for write access
+          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+          # If you chose API tokens for write access OR if you have a private cache
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build environment and Compile
+        run: |
+          chmod +x .github/build-nix
+          .github/build-nix ${{ matrix.target }}
+
+      - name: Package artifacts
+        run: |
+          mkdir dist
+          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
+          mkdir -p ./dist/noir-lang/std
+          cp crates/std_lib/src/*.nr ./dist/noir-lang/std
+          7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.gz
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./nargo-${{ matrix.target }}.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/nix/mixed.nix
+++ b/nix/mixed.nix
@@ -1,0 +1,38 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [ 
+    which
+    git
+    pkg-config
+    cmake
+  ];
+  
+  buildInputs = with pkgs; [ 
+    llvmPackages.openmp
+    openssl
+    rustup
+  ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+    pkgs.llvmPackages.openmp
+    pkgs.openssl
+  ];
+  
+  shellHook = ''
+    echo 🧪 NIX_CFLAGS_COMPILE=$NIX_CFLAGS_COMPILE
+    echo 🧪 NIX_LDFLAGS=$NIX_LDFLAGS
+    echo 🧪 LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+    echo 🧪 CPATH=$CPATH
+    echo 🧪 $CC $AR $CXX $LD
+    echo 🧪 $(which $CC) 
+    echo 🧪 $(which $AR) 
+    echo 🧪 $(which $CXX) 
+    echo 🧪 $(which $LD)
+    echo 🧪 $(which pkg-config)
+    echo 🧪 pkg-config --list-all ↩️
+    pkg-config --list-all
+    echo ⌛
+  '';
+
+}


### PR DESCRIPTION
# Related issue(s)

#225 Releases don't contain binaries anymore

# Resolves (link to issue)

#225 Releases don't contain binaries anymore _- resolves partially as it provides Linux Intel only, others to follow._

# Description

As a Developer, I would like to have access to the pre-build binary release
so that I could download system appropriate executables and start working with Noir Language.

## Summary of changes

`.github/workflows/publish-x86_64-unknown-linux-gnu.yml` - where the base of GitHub Action is defined
`.github/build-nix` -  where shell script is defined to compile releasable binary along with std_lib contents
`nix/mixed.nix` - nix definition to fix the linux build environment

## Dependency additions / changes
N/A

## Test additions / changes
N/A

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x]  I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context
N/A