### PR TITLE
Adds nightly build schedule

### DIFF
--- a/.github/workflows/publish-x86_64-apple-darwin.yml
+++ b/.github/workflows/publish-x86_64-apple-darwin.yml
@@ -1,6 +1,9 @@
 name: build-x86_64-apple-darwin
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *" # run at 2 AM UTC
   push:
     tags:
       - "v*"
@@ -49,13 +52,22 @@ jobs:
           cp ./target/x86_64-apple-darwin/release/nargo ./dist/nargo
           mkdir -p ./dist/noir-lang/std
           cp crates/std_lib/src/*.nr ./dist/noir-lang/std
-          7z a -ttar -so -an ./dist | 7z a -si ./nargo-x86_64-apple-darwin.tar.gz
+          7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-x86_64-apple-darwin.tar.gz
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload binaries to nightly
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./nargo-x86_64-apple-darwin.tar.gz
+          asset_name: nargo-x86_64-apple-darwin.tar.gz
+          overwrite: true
+          tag: nightly
+
+      - name: Upload binaries to Version
+        uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            ./nargo-x86_64-apple-darwin.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./nargo-x86_64-apple-darwin.tar.gz
+          asset_name: nargo-x86_64-apple-darwin.tar.gz

--- a/.github/workflows/publish-x86_64-unknown-linux-gnu.yml
+++ b/.github/workflows/publish-x86_64-unknown-linux-gnu.yml
@@ -3,6 +3,8 @@ name: build-x86_64-unknown-linux-gnu
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *" # run at 2 AM UTC
   push:
     tags:
       - "v*"
@@ -52,13 +54,22 @@ jobs:
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           mkdir -p ./dist/noir-lang/std
           cp crates/std_lib/src/*.nr ./dist/noir-lang/std
-          7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.gz
+          7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload binaries to nightly
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./nargo-${{ matrix.target }}.tar.gz
+          asset_name: nargo-${{ matrix.target }}.tar.gz
+          overwrite: true
+          tag: nightly
+
+      - name: Upload binaries to Version
+        uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            ./nargo-${{ matrix.target }}.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./nargo-${{ matrix.target }}.tar.gz
+          asset_name: nargo-${{ matrix.target }}.tar.gz


### PR DESCRIPTION
# Related issue(s)

#225 Releases don't contain binaries anymore

# Resolves 

#225 - Partially Releases don't contain binaries anymore - _enables nightly schedule to upload binaries_

# Description

As a Developer, I would like to have access to the pre-build binary release
so that I could download system appropriate executables and start working with Noir Language.

## Summary of changes

`.github/workflows/publish-x86_64-apple-darwin.yml`
`.github/workflows/publish-x86_64-unknown-linux-gnu.yml`

both received cron schedules to run at 2 AM UTC

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

N/A
