### PR TITLE
Fix globals in array types of struct fields

### DIFF
--- a/crates/nargo/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo/tests/test_data/global_consts/src/main.nr
@@ -6,9 +6,17 @@ global L: Field = 10; // Unused globals currently allowed
 global N: Field = 5;
 //global N: Field = 5; // Uncomment to see duplicate globals error 
 
+struct Dummy {
+     x: [Field; N],
+     y: [Field; foo::MAGIC_NUMBER]
+}
+
 fn main(a: [Field; M], b: [Field; M], c : pub [Field; foo::MAGIC_NUMBER], d: [Field; foo::bar::N]) {
+     let test_struct = Dummy { x: d, y: c };
+
      for i in 0..foo::MAGIC_NUMBER {
           constrain c[i] == foo::MAGIC_NUMBER;
+          constrain test_struct.y[i] == foo::MAGIC_NUMBER;
      };
 
      constrain N != M;

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -319,7 +319,7 @@ fn resolve_struct_fields(
         StandardPathResolver::new(ModuleId { local_id: unresolved.module_id, krate });
 
     let file = unresolved.file_id;
-    
+
     let (generics, fields, errs) =
         Resolver::new(&mut context.def_interner, &path_resolver, &context.def_maps, file)
             .resolve_struct_fields(unresolved.struct_def);

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -149,11 +149,11 @@ impl DefCollector {
             }
         }
 
-        resolve_structs(context, def_collector.collected_types, crate_id, errors);
-
         // We must first resolve and intern the globals before we can resolve any stmts inside each function.
         // Each function uses its own resolver with a newly created ScopeForest, and must be resolved again to be within a function's scope
         let file_global_ids = resolve_globals(context, def_collector.collected_globals, crate_id);
+
+        resolve_structs(context, def_collector.collected_types, crate_id, errors);
 
         // Before we resolve any function symbols we must go through our impls and
         // re-collect the methods within into their proper module. This cannot be
@@ -319,7 +319,7 @@ fn resolve_struct_fields(
         StandardPathResolver::new(ModuleId { local_id: unresolved.module_id, krate });
 
     let file = unresolved.file_id;
-
+    
     let (generics, fields, errs) =
         Resolver::new(&mut context.def_interner, &path_resolver, &context.def_maps, file)
             .resolve_struct_fields(unresolved.struct_def);

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -112,12 +112,7 @@ impl<'a> Resolver<'a> {
         self.scopes.start_function();
 
         // Check whether the function has globals in the local module and add them to the scope
-        for (stmt_id, global_info) in self.interner.get_all_globals() {
-            if global_info.local_id == self.path_resolver.local_module_id() {
-                let global_stmt = self.interner.let_statement(&stmt_id);
-                self.add_global_variable_decl(global_info.ident, Some(global_stmt.expression));
-            }
-        }
+        self.resolve_local_globals();
 
         self.add_generics(func.def.generics.clone());
 
@@ -406,6 +401,9 @@ impl<'a> Resolver<'a> {
     ) -> (Generics, BTreeMap<Ident, Type>, Vec<ResolverError>) {
         let generics = self.add_generics(unresolved.generics);
 
+        // Check whether the struct definition has globals in the local module and add them to the scope
+        self.resolve_local_globals();
+
         let fields = unresolved
             .fields
             .into_iter()
@@ -413,6 +411,17 @@ impl<'a> Resolver<'a> {
             .collect();
 
         (generics, fields, self.errors)
+    }
+
+    fn resolve_local_globals(
+        &mut self
+    ) {
+        for (stmt_id, global_info) in self.interner.get_all_globals() {
+            if global_info.local_id == self.path_resolver.local_module_id() {
+                let global_stmt = self.interner.let_statement(&stmt_id);
+                self.add_global_variable_decl(global_info.ident, Some(global_stmt.expression));
+            }
+        }
     }
 
     /// Extract metadata from a NoirFunction

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -413,9 +413,7 @@ impl<'a> Resolver<'a> {
         (generics, fields, self.errors)
     }
 
-    fn resolve_local_globals(
-        &mut self
-    ) {
+    fn resolve_local_globals(&mut self) {
         for (stmt_id, global_info) in self.interner.get_all_globals() {
             if global_info.local_id == self.path_resolver.local_module_id() {
                 let global_stmt = self.interner.let_statement(&stmt_id);


### PR DESCRIPTION
# Related issue(s)

This is a quick fix for a problem that a user just brought up to me. I didn't make an issue as it was a fast fix

They were getting an error when trying to build this snippet

```
global NUM_LIMBS: Field = 8;
// This defines a BigInt, a smart wrapper around a sequence of u32 limbs, least-significant limb first
struct BigInt {
    limbs: [u32; NUM_LIMBS]
}
```

I was able to then recreate the error with similar code. 

# Description

The build would fail when a local global was used in an array type within a struct definition. 

## Summary of changes

1. Globals needed to be resolved before struct definitions. 
2. We needed to resolve globals in the local module before resolving the struct fields (this is the same thing we do in `resolve_function`). This is necessary with the current resolver infrastructure which creates a new Resolver with a fresh scope for resolving the struct fields. 

## Dependency additions / changes

(If applicable.)

## Test additions / changes

I added a struct to the `global_consts` test that declares a structure using two array types. One field with a local global and one field with an imported global.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
