### PR TITLE
Adds binary(wasm) build GitHub Action for x86_64-pc-windows-wasm

### DIFF
--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -1,0 +1,75 @@
+# such target does not exist, name choosen for convention only
+name: build-x86_64-pc-windows-wasm
+# <arch>-<vendor>-<os>-<env>
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *" # run at 2 AM UTC
+  push:
+
+jobs:
+  build-x86_64-pc-windows-msvc:
+    runs-on: windows-2022
+    strategy:
+      max-parallel: 1
+      matrix:
+        target: [x86_64-pc-windows-msvc]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Rust toolchain Install
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          default: true
+          override: true
+
+      - name: Patch backend in crates/nargo/Cargo.toml
+        run: |
+          (Get-Content crates/nargo/Cargo.toml) -replace 'aztec_backend = {(.+)}','aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend", features = ["wasm-base"], default-features = false }' | Out-File -encoding ASCII crates/nargo/Cargo.toml
+
+      - name: Build environment and Compile
+        run: |
+          cargo build --release --target ${{ matrix.target }}
+
+      - name: Package artifacts
+        run: |
+          mkdir dist
+          ls target
+          ls target/release
+          cp ./target/${{ matrix.target }}/release/nargo.exe ./dist/nargo.exe
+          mkdir -p ./dist/noir-lang/std
+          cp crates/std_lib/src/*.nr ./dist/noir-lang/std
+          7z a -tzip nargo-${{ matrix.target }}.zip ./dist/*
+
+      - name: Upload binaries to nightly
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./nargo-${{ matrix.target }}.zip
+          asset_name: nargo-${{ matrix.target }}.zip
+          overwrite: true
+          tag: nightly
+
+      - name: Upload binaries to Version
+        uses: svenstaro/upload-release-action@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./nargo-${{ matrix.target }}.zip
+          asset_name: nargo-${{ matrix.target }}.zip


### PR DESCRIPTION
# Related issue(s)

#225 Releases don't contain binaries anymore

# Resolves (link to issue)

#225 Releases don't contain binaries anymore _- resolves partially as it provides Windows, wasm based binaries, others to follow._

# Description

As a Developer, I would like to have access to the pre-build binary release
so that I could download system appropriate executables and start working with Noir Language.

## Summary of changes

`.github/workflows/publish-x86_64-pc-windows-wasm.yml` - adds workflow to build binary on windows based runner. This uses static wasm build of the backend hence performance is going to be suboptimal.

## Dependency additions / changes
N/A

## Test additions / changes
N/A

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x]  I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context
N/A