### PR TITLE
propagate error from cse

### DIFF
--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -104,7 +104,7 @@ fn inline_block(
     }
 
     if to_inline.is_none() {
-        optim::simple_cse(ctx, block_id);
+        optim::simple_cse(ctx, block_id)?;
     }
     Ok(result)
 }

--- a/crates/noirc_evaluator/src/ssa/optim.rs
+++ b/crates/noirc_evaluator/src/ssa/optim.rs
@@ -164,10 +164,10 @@ pub fn full_cse(
     Ok(result)
 }
 
-pub fn simple_cse(ctx: &mut SsaContext, block_id: BlockId) {
+pub fn simple_cse(ctx: &mut SsaContext, block_id: BlockId) -> Result<Option<NodeId>, RuntimeError> {
     let mut modified = false;
     let mut instructions = Vec::new();
-    cse_block(ctx, block_id, &mut instructions, &mut modified).unwrap();
+    cse_block(ctx, block_id, &mut instructions, &mut modified)
 }
 
 pub fn cse_block(


### PR DESCRIPTION
# Related issue(s)

False constraints like in #474 panic instead of generating an error.

# Description

## Summary of changes

#474 is not an issue but when getting an always false constraint like in the issue (using a=1), it leads to panic instead of having an error message.

With this PR, errors inside simple_cse are propagated to the caller.

# Checklist

- [X ] I have tested the changes locally.
- [X ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ X] I have reviewed the changes on GitHub, line by line.
- [ X] I have ensured all changes are covered in the description.
