### PR TITLE
fix bit operation with non-linear expressions

### DIFF
--- a/crates/nargo/tests/test_data/bool_or/src/main.nr
+++ b/crates/nargo/tests/test_data/bool_or/src/main.nr
@@ -1,5 +1,7 @@
 use dep::std;
 fn main(x: u1, y: u1) {
     constrain x | y == 1;
+
+    constrain x | y | x == 1;
 }
     

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -744,7 +744,6 @@ pub fn evaluate_and(
         return const_and(rhs, l_c, bit_size, evaluator);
     }
 
-    let result = evaluator.add_witness_to_cs();
     let a_witness = generate_witness(&lhs, evaluator);
     let b_witness = generate_witness(&rhs, evaluator);
     //TODO checks the cost of the gate vs bit_size (cf. #164)
@@ -755,6 +754,7 @@ pub fn evaluate_and(
             q_c: FieldElement::zero(),
         };
     }
+    let result = evaluator.add_witness_to_cs();
     let bsize = if bit_size % 2 == 1 { bit_size + 1 } else { bit_size };
     assert!(bsize < FieldElement::max_num_bits() - 1);
     evaluator.gates.push(Gate::And(acvm::acir::circuit::gate::AndGate {
@@ -779,16 +779,15 @@ pub fn evaluate_xor(
         return const_xor(rhs, l_c, bit_size, evaluator);
     }
 
-    let result = evaluator.add_witness_to_cs();
-
-    let a_witness = generate_witness(&lhs, evaluator);
-    let b_witness = generate_witness(&rhs, evaluator);
     //TODO checks the cost of the gate vs bit_size (cf. #164)
     if bit_size == 1 {
         let sum = add(&lhs.expression, FieldElement::one(), &rhs.expression);
-        let mul = mul(&lhs.expression, &rhs.expression);
+        let mul = mul_with_witness(evaluator, &lhs.expression, &rhs.expression);
         return subtract(&sum, FieldElement::from(2_i128), &mul);
     }
+    let result = evaluator.add_witness_to_cs();
+    let a_witness = generate_witness(&lhs, evaluator);
+    let b_witness = generate_witness(&rhs, evaluator);
     let bsize = if bit_size % 2 == 1 { bit_size + 1 } else { bit_size };
     assert!(bsize < FieldElement::max_num_bits() - 1);
     evaluator.gates.push(Gate::Xor(acvm::acir::circuit::gate::XorGate {
@@ -815,7 +814,7 @@ pub fn evaluate_or(
 
     if bit_size == 1 {
         let sum = add(&lhs.expression, FieldElement::one(), &rhs.expression);
-        let mul = mul(&lhs.expression, &rhs.expression);
+        let mul = mul_with_witness(evaluator, &lhs.expression, &rhs.expression);
         return subtract(&sum, FieldElement::one(), &mul);
     }
 


### PR DESCRIPTION
# Description

## Summary of changes

Bit operations (i.e bitwise operation of length 1) do not use an acir opcode so they do not need a witness. However they may need some nonetheless because they involve multiplication. This PR make sure we create a witness if needed.

## Test additions / changes

Added a regression test case in bool_or

