### PR TITLE
Disable debug output during integration tests

### DIFF
--- a/crates/nargo/tests/prove_and_verify.rs
+++ b/crates/nargo/tests/prove_and_verify.rs
@@ -46,7 +46,7 @@ mod tests {
                 match test_name {
                     Ok(str) => {
                         if c.path().is_dir() && !conf_data["exclude"].contains(&str) {
-                            let r = nargo::cli::prove_and_verify("pp", &c.path(), true);
+                            let r = nargo::cli::prove_and_verify("pp", &c.path(), false);
                             if conf_data["fail"].contains(&str) {
                                 assert!(!r, "{:?} should not succeed", c.file_name());
                             } else {


### PR DESCRIPTION
# Related issue(s)

integration tests in the CI have issue due to the output log:
`This step has been truncated due to its large size. Download the full logs from the menu once the workflow run has completed. `

# Description

## Summary of changes

Disable the debug log when running integration tests

