### PR TITLE
Aligns build to (#443) Refactor stdlib into a separate noir library

### DIFF
--- a/.github/workflows/publish-x86_64-apple-darwin.yml
+++ b/.github/workflows/publish-x86_64-apple-darwin.yml
@@ -51,7 +51,7 @@ jobs:
           mkdir dist
           cp ./target/x86_64-apple-darwin/release/nargo ./dist/nargo
           mkdir -p ./dist/noir-lang/std
-          cp crates/std_lib/src/*.nr ./dist/noir-lang/std
+          cp noir_stdlib/src/*.nr ./dist/noir-lang/std
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-x86_64-apple-darwin.tar.gz
 
       - name: Upload binaries to nightly

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -7,6 +7,8 @@ on:
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:
+    tags:
+      - "v*"
 
 jobs:
   build-x86_64-pc-windows-msvc:
@@ -53,7 +55,7 @@ jobs:
           ls target/release
           cp ./target/${{ matrix.target }}/release/nargo.exe ./dist/nargo.exe
           mkdir -p ./dist/noir-lang/std
-          cp crates/std_lib/src/*.nr ./dist/noir-lang/std
+          cp noir_stdlib/src/*.nr ./dist/noir-lang/std
           7z a -tzip nargo-${{ matrix.target }}.zip ./dist/*
 
       - name: Upload binaries to nightly


### PR DESCRIPTION
Fixes _Adds binary(wasm) build GitHub Action for x86_64-pc-windows-wasm #476_ and aligns to https://github.com/noir-lang/noir/pull/443