### PR TITLE
Improve field comparison error message

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -676,9 +676,16 @@ pub fn comparator_operand_type_rules(
         (Integer(..), typ) | (typ,Integer(..)) => {
             Err(format!("Integer cannot be used with type {}", typ))
         }
-        (FieldElement(comptime_x, ..), FieldElement(comptime_y, ..)) => {
-            let comptime = comptime_x.and(comptime_y, op.location.span);
-            Ok(Bool(comptime))
+        (FieldElement(comptime_x), FieldElement(comptime_y)) => {
+            match op.kind {
+                Equal | NotEqual => {
+                    let comptime = comptime_x.and(comptime_y, op.location.span);
+                    Ok(Bool(comptime))
+                },
+                _ => {
+                    Err("Fields cannot be compared, try casting to an integer first".into())
+                }
+            }
         }
 
         // <= and friends are technically valid for booleans, just not very useful


### PR DESCRIPTION
# Related issue(s)

Related to #498

# Description

The type system used to allow field comparisons, but since these operations are invalid we would eventually fail in SSA with a compiler crash. This fixes the check in the type system to disallow comparison for fields, but allow eq and neq operations.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
