### PR TITLE
Allow expressions in array length types

### DIFF
--- a/crates/nargo/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo/tests/test_data/global_consts/src/main.nr
@@ -11,7 +11,7 @@ struct Dummy {
      y: [Field; foo::MAGIC_NUMBER]
 }
 
-fn main(a: [Field; M], b: [Field; M], c : pub [Field; foo::MAGIC_NUMBER], d: [Field; foo::bar::N]) {
+fn main(a: [Field; M + N - N], b: [Field; 30 + N / 2], c : pub [Field; foo::MAGIC_NUMBER], d: [Field; foo::bar::N]) {
      let test_struct = Dummy { x: d, y: c };
 
      for i in 0..foo::MAGIC_NUMBER {

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -14,31 +14,14 @@ pub use structure::*;
 
 use crate::{token::IntType, util::vecmap, Comptime};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum UnresolvedArraySize {
-    Variable,
-    Fixed(u64),
-    FixedVariable(Path),
-}
-
-impl std::fmt::Display for UnresolvedArraySize {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UnresolvedArraySize::Variable => write!(f, "[]"),
-            UnresolvedArraySize::Fixed(size) => write!(f, "[{}]", size),
-            UnresolvedArraySize::FixedVariable(ident) => write!(f, "[{}]", ident),
-        }
-    }
-}
-
 /// The parser parses types as 'UnresolvedType's which
 /// require name resolution to resolve any typenames used
 /// for structs within, but are otherwise identical to Types.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum UnresolvedType {
     FieldElement(Comptime),
-    Array(UnresolvedArraySize, Box<UnresolvedType>), // [4]Witness = Array(4, Witness)
-    Integer(Comptime, Signedness, u32),              // u32 = Integer(unsigned, 32)
+    Array(Option<Expression>, Box<UnresolvedType>), // [4]Witness = Array(4, Witness)
+    Integer(Comptime, Signedness, u32),             // u32 = Integer(unsigned, 32)
     Bool(Comptime),
     Unit,
 
@@ -64,8 +47,8 @@ impl std::fmt::Display for UnresolvedType {
         match self {
             FieldElement(is_const) => write!(f, "{}Field", is_const),
             Array(len, typ) => match len {
-                UnresolvedArraySize::Variable => write!(f, "[{}]", typ),
-                _ => write!(f, "[{}; {}]", typ, len),
+                None => write!(f, "[{}]", typ),
+                Some(len) => write!(f, "[{}; {}]", typ, len),
             },
             Integer(is_const, sign, num_bits) => match sign {
                 Signedness::Signed => write!(f, "{}i{}", is_const, num_bits),

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -34,7 +34,7 @@ use crate::util::vecmap;
 use crate::{
     hir::{def_map::CrateDefMap, resolution::path_resolver::PathResolver},
     BlockExpression, Expression, ExpressionKind, FunctionKind, Ident, Literal, NoirFunction,
-    Statement, UnresolvedArraySize,
+    Statement,
 };
 use crate::{
     ArrayLiteral, Generics, LValue, NoirStruct, Path, Pattern, Shared, StructType, Type,
@@ -277,8 +277,8 @@ impl<'a> Resolver<'a> {
         match typ {
             UnresolvedType::FieldElement(comptime) => Type::FieldElement(comptime),
             UnresolvedType::Array(size, elem) => {
-                let resolved_size = match size {
-                    UnresolvedArraySize::Variable => {
+                let resolved_size = match &size {
+                    None => {
                         let id = self.interner.next_type_variable_id();
                         let typevar = Shared::new(TypeBinding::Unbound(id));
                         new_variables.push((id, typevar.clone()));
@@ -288,9 +288,9 @@ impl<'a> Resolver<'a> {
                         // require users to explicitly be generic over array lengths.
                         Type::NamedGeneric(typevar, Rc::new("".into()))
                     }
-                    UnresolvedArraySize::Fixed(length) => Type::ArrayLength(length),
-                    UnresolvedArraySize::FixedVariable(path) => {
-                        self.resolve_fixed_variable_array_length(path)
+                    Some(expr) => {
+                        let len = self.eval_array_length(expr);
+                        Type::ArrayLength(len)
                     }
                 };
                 let elem = Box::new(self.resolve_type_inner(*elem, new_variables));
@@ -323,32 +323,6 @@ impl<'a> Resolver<'a> {
                 Type::Tuple(vecmap(fields, |field| self.resolve_type_inner(field, new_variables)))
             }
         }
-    }
-
-    fn resolve_fixed_variable_array_length(&mut self, path: Path) -> Type {
-        let hir_ident = self.get_ident_from_path(path.clone());
-
-        let definition_info = self.interner.definition(hir_ident.id);
-        if definition_info.mutable {
-            self.push_err(ResolverError::ExpectedComptimeVariable {
-                name: path.as_string(),
-                span: path.span(),
-            });
-            return Type::Error;
-        }
-
-        let error = if let Some(rhs_expr_id) = definition_info.rhs {
-            match self.try_eval_array_length_id(rhs_expr_id).map(|length| length.try_into()) {
-                Ok(Ok(length)) => return Type::ArrayLength(length),
-                Ok(Err(_cast_err)) => ResolverError::IntegerTooLarge { span: path.span() },
-                Err(Some(error)) => error,
-                Err(None) => return Type::Error,
-            }
-        } else {
-            ResolverError::MissingRhsExpr { name: path.as_string(), span: path.span() }
-        };
-        self.push_err(error);
-        Type::Error
     }
 
     fn get_ident_from_path(&mut self, path: Path) -> HirIdent {
@@ -547,21 +521,9 @@ impl<'a> Resolver<'a> {
                     HirLiteral::Array(vecmap(elems, |elem| self.resolve_expression(elem)))
                 }
                 Literal::Array(ArrayLiteral::Repeated { repeated_element, length }) => {
-                    match self.try_eval_array_length(&length).map(|length| length.try_into()) {
-                        Ok(Ok(length_value)) => {
-                            let elem = self.resolve_expression(*repeated_element);
-                            HirLiteral::Array(vec![elem; length_value])
-                        }
-                        Ok(Err(_cast_err)) => {
-                            self.push_err(ResolverError::IntegerTooLarge { span: length.span });
-                            HirLiteral::Array(vec![])
-                        }
-                        Err(Some(error)) => {
-                            self.push_err(error);
-                            HirLiteral::Array(vec![])
-                        }
-                        Err(None) => HirLiteral::Array(vec![]),
-                    }
+                    let len = self.eval_array_length(&length);
+                    let elem = self.resolve_expression(*repeated_element);
+                    HirLiteral::Array(vec![elem; len.try_into().unwrap()])
                 }
                 Literal::Integer(integer) => HirLiteral::Integer(integer),
                 Literal::Str(str) => HirLiteral::Str(str),
@@ -846,6 +808,18 @@ impl<'a> Resolver<'a> {
         self.interner.push_expr(hir_block)
     }
 
+    fn eval_array_length(&mut self, length: &Expression) -> u64 {
+        match self.try_eval_array_length(length).map(|length| length.try_into()) {
+            Ok(Ok(length_value)) => return length_value,
+            Ok(Err(_cast_err)) => {
+                self.push_err(ResolverError::IntegerTooLarge { span: length.span })
+            }
+            Err(Some(error)) => self.push_err(error),
+            Err(None) => (),
+        }
+        0
+    }
+
     /// This function is a mini interpreter inside name resolution.
     /// We should eventually get rid of it and only have 1 evaluator - the existing
     /// one inside the ssa pass. Doing this would mean ssa would need to handle these
@@ -929,7 +903,9 @@ impl<'a> Resolver<'a> {
 
         let definition = self.interner.definition(id);
         match definition.rhs {
-            Some(rhs) if definition.is_global => self.try_eval_array_length_id(rhs),
+            Some(rhs) if definition.is_global || !definition.mutable => {
+                self.try_eval_array_length_id(rhs)
+            }
             _ => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
         }
     }


### PR DESCRIPTION
# Related issue(s)

Resolves #495

# Description

## Summary of changes

Allows expressions using basic operators to be used in array length types. This was previously allowed in array length expressions and is now added here for consistency.

This PR also allows the array-length mini evaluator to evaluate immutable variables recursively as we previously allowed their evaluation when we had several separate ways of evaluating array lengths. All of these separate ways have now been removed as of this PR and changed so that the mini evaluator during name resolution is the only thing evaluating array lengths.

## Test additions / changes

Changes a couple types in the global_consts test to evaluate to the same array lengths but less directly.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
