### PR TITLE
Adds `aarch64-apple-darwin` build target, switches to WASM backend

### DIFF
--- a/.github/build-x86_64-apple-darwin
+++ b/.github/build-x86_64-apple-darwin
@@ -44,8 +44,8 @@ echo ✨ /usr/local/opt/llvm/bin/clang --version
 echo ✨ /usr/local/opt/llvm/bin/clang++ --version 
 /usr/local/opt/llvm/bin/clang++ --version 
 
-echo ✨ rustup target add x86_64-apple-darwin
-rustup target add x86_64-apple-darwin
+echo ✨ rustup target add matrix target
+rustup target add $1
 
 echo 👷 Cargo Build
-cargo build --release --locked --target x86_64-apple-darwin
+cargo build --release --target $1

--- a/.github/workflows/publish-x86_64-apple-darwin.yml
+++ b/.github/workflows/publish-x86_64-apple-darwin.yml
@@ -11,10 +11,21 @@ on:
 jobs:
   build-mac:
     runs-on: macos-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Setup for Apple Silicon
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_13.2.1.app/Contents/Developer/
+          echo "SDKROOT=$(xcrun -sdk macosx$(sw_vers -productVersion) --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx$(sw_vers -productVersion) --show-sdk-platform-version)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:
@@ -30,11 +41,11 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-apple-darwin
+          target: ${{ matrix.target }}
           default: true
           override: true
 
-      - name: Tools adn Dependencies Install
+      - name: Tools and Dependencies Install
         run: |
           echo ✨ brew config
           brew config
@@ -43,24 +54,26 @@ jobs:
 
       - name: Build environment and Compile
         run: |
+          sed -E -i '' 's/^aztec_backend.+}/aztec_backend = { optional = true, git = "https:\/\/github.com\/noir-lang\/aztec_backend\", features = ["wasm-base"], default-features = false }/g' crates/nargo/Cargo.toml
+          echo 🧪 patched backend = ''$(cat crates/nargo/Cargo.toml | grep aztec_backend)''
           chmod +x ./.github/build-x86_64-apple-darwin
-          ./.github/build-x86_64-apple-darwin
+          ./.github/build-x86_64-apple-darwin ${{ matrix.target }}
 
       - name: Package artifacts
         run: |
           mkdir dist
-          cp ./target/x86_64-apple-darwin/release/nargo ./dist/nargo
+          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           mkdir -p ./dist/noir-lang/std
           cp noir_stdlib/src/*.nr ./dist/noir-lang/std
-          7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-x86_64-apple-darwin.tar.gz
+          7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload binaries to nightly
         uses: svenstaro/upload-release-action@v2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./nargo-x86_64-apple-darwin.tar.gz
-          asset_name: nargo-x86_64-apple-darwin.tar.gz
+          file: ./nargo-${{ matrix.target }}.tar.gz
+          asset_name: nargo-${{ matrix.target }}.tar.gz
           overwrite: true
           tag: nightly
 
@@ -69,5 +82,5 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./nargo-x86_64-apple-darwin.tar.gz
-          asset_name: nargo-x86_64-apple-darwin.tar.gz
+          file: ./nargo-${{ matrix.target }}.tar.gz
+          asset_name: nargo-${{ matrix.target }}.tar.gz


### PR DESCRIPTION
# Related issue(s)

#225 Releases don't contain binaries anymore

# Resolves (link to issue)

#225 Releases don't contain binaries anymore _- switches apple builds to WASM, adds aarch64 (M1) target._

# Description

As a Developer, I would like to have access to the pre-build binary release
so that I could download system appropriate executables and start working with Noir Language.

## Summary of changes

`.github/workflows/publish-x86_64-apple-darwin.yml` - Adds `aarch64-apple-darwin` build target and switches to WASM based backend.
`.github/build-x86_64-apple-darwin` - accepts target as parameter instead of hard coded value.

## Dependency additions / changes
N/A

## Test additions / changes
N/A

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x]  I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context
N/A