### PR TITLE
Remove duplication in `toml_map_to_field` and `toml_remap`

### DIFF
--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -43,10 +43,10 @@ fn toml_map_to_field(
             TomlTypes::String(string) => {
                 let new_value = parse_str(&string)?;
 
-                if new_value.is_none() {
-                    InputValue::Undefined
+                if let Some(field_element) = new_value {
+                    InputValue::Field(field_element)
                 } else {
-                    InputValue::Field(new_value.unwrap())
+                    InputValue::Undefined
                 }
             }
             TomlTypes::Integer(integer) => {

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -88,17 +88,18 @@ fn toml_map_to_field(
 fn toml_remap(map: &BTreeMap<String, InputValue>) -> BTreeMap<String, TomlTypes> {
     let mut toml_map = BTreeMap::new();
     for (parameter, value) in map {
-        match value {
+        let mapped_value = match value {
             InputValue::Field(f) => {
                 let f_str = format!("0x{}", f.to_hex());
-                toml_map.insert(parameter.clone(), TomlTypes::String(f_str));
+                TomlTypes::String(f_str)
             }
             InputValue::Vec(v) => {
                 let array = v.iter().map(|i| format!("0x{}", i.to_hex())).collect();
-                toml_map.insert(parameter.clone(), TomlTypes::ArrayString(array));
+                TomlTypes::ArrayString(array)
             }
             InputValue::Undefined => unreachable!(),
-        }
+        };
+        toml_map.insert(parameter.clone(), mapped_value);
     }
     toml_map
 }


### PR DESCRIPTION
# Related issue(s)

This is a very small change so an issue is overkill.

# Description

## Summary of changes

Currently we call `check_toml_map_duplicates` in each arm of the match statement in `toml_map_to_field`, the only difference between arms is in the mapped value being inserted. Instead we can just return the value to be inserted from the match statement and insert values into `field_map` in a single place below it.

IMO, this improves readability and reducing LOC is always nice. For consistency I've also changed `toml_remap` to match.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
