### PR TITLE
alternative for sha256

### DIFF
--- a/noir_stdlib/src/sha256.nr
+++ b/noir_stdlib/src/sha256.nr
@@ -99,6 +99,7 @@ fn msg_u8_to_u32(msg: [u8; 64]) -> [u32; 16]
 }
 
 // SHA-256 hash function
+#[alternative(sha256)]
 fn digest(msg: [u8]) -> [u8; 32]
 {
     let mut msg_block: [u8; 64] = [0; 64];


### PR DESCRIPTION
# Description

Enable sha256 for R1CS backend


## Dependency additions / changes

I just indicated the sha256 noir version as the alternative to the sha256 foreign function
