### PR TITLE
Reduce amount of type conversions in `toml_map_to_field`

### DIFF
--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -73,9 +73,9 @@ fn toml_map_to_field(
                 }
             }
             TomlTypes::Integer(integer) => {
-                let new_value = parse_str(&integer.to_string())?;
+                let new_value = FieldElement::from(i128::from(integer));
 
-                InputValue::Field(new_value.unwrap())
+                InputValue::Field(new_value)
             }
             TomlTypes::Bool(boolean) => {
                 let new_value = if boolean { FieldElement::one() } else { FieldElement::zero() };
@@ -85,7 +85,7 @@ fn toml_map_to_field(
             TomlTypes::ArrayNum(arr_num) => {
                 let array_elements: Vec<_> = arr_num
                     .into_iter()
-                    .map(|elem_num| parse_str(&elem_num.to_string()).unwrap().unwrap())
+                    .map(|elem_num| FieldElement::from(i128::from(elem_num)))
                     .collect();
 
                 InputValue::Vec(array_elements)


### PR DESCRIPTION
# Related issue(s)

No issue as this is a small refactor.

## Summary of changes

It was kinda bugging me how we're converting an integer to a string and back and having to unwrap the result multiple times.

Instead we now convert the `u64` directly into an `i128` to pass into the `FieldElement` without using `parse_str`.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
