### PR TITLE
Fix #488

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -282,11 +282,7 @@ impl<'a> Resolver<'a> {
                         let id = self.interner.next_type_variable_id();
                         let typevar = Shared::new(TypeBinding::Unbound(id));
                         new_variables.push((id, typevar.clone()));
-
-                        // 'Named'Generic is a bit of a misnomer here, we want a type variable that
-                        // wont be bound over but this one has no name since we do not currently
-                        // require users to explicitly be generic over array lengths.
-                        Type::NamedGeneric(typevar, Rc::new("".into()))
+                        Type::TypeVariable(typevar)
                     }
                     Some(expr) => {
                         let len = self.eval_array_length(expr);

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -706,10 +706,12 @@ pub fn comparator_operand_type_rules(
                 }
             });
 
-            if x_size != y_size {
-                return Err(format!("Can only compare arrays of the same length. Here LHS is of length {}, and RHS is {} ", 
-                    x_size, y_size));
-            }
+            x_size.unify(y_size, op.location.span, errors, || {
+                TypeCheckError::Unstructured {
+                    msg: format!("Cannot compare an array of length {} with an array of length {}, the array lengths must match", x_size, y_size),
+                    span: op.location.span,
+                }
+            });
 
             // We could check if all elements of all arrays are comptime but I am lazy
             Ok(Bool(Comptime::No(Some(op.location.span))))

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -1028,9 +1028,9 @@ impl Type {
             Type::Forall(typevars, typ) => {
                 let replacements = typevars
                     .iter()
-                    .map(|(id, var)| {
-                        let new = interner.next_type_variable();
-                        (*id, (var.clone(), new))
+                    .map(|(id, _)| {
+                        let new = interner.next_shared_type_variable();
+                        (*id, (new.clone(), Type::TypeVariable(new)))
                     })
                     .collect();
 

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -488,9 +488,13 @@ impl NodeInterner {
         TypeVariableId(id)
     }
 
-    pub fn next_type_variable(&mut self) -> Type {
+    pub fn next_shared_type_variable(&mut self) -> crate::TypeVariable {
         let binding = TypeBinding::Unbound(self.next_type_variable_id());
-        Type::TypeVariable(Shared::new(binding))
+        Shared::new(binding)
+    }
+
+    pub fn next_type_variable(&mut self) -> Type {
+        Type::TypeVariable(self.next_shared_type_variable())
     }
 
     pub fn store_instantiation_bindings(


### PR DESCRIPTION
# Related issue(s)

Resolves #488

# Description

## Summary of changes

Fixes #488. The main reason for the original error was the wrong type variable was being returned after instantiating functions, so when the compiler tried to undo the instantiation it was operating on a type variable that would not do this.

This issue also has a more difficult to fix bug however. When the original code is re-ordered such that `main` is typechecked before `foo`:

```rs
fn main() {
  let b= foo([1,2]);
  constrain b == [1,2];
}

fn foo(a: [u8]) -> [u8] {
  a
}
```

There is another error: the compiler has yet to peek in the definition of `foo` yet so it does not yet know that the length of the returned array is equal to the length of the parameter `a`. Fixing this likely means we will either have to topologically sort functions before type checking them or we can re-order type checking such that we start from main and lazily type check and generalize each function when it is called.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

This PR was put up mostly for visibility onto the new issue when `foo` is defined afterward.
