### PR TITLE
Check for solved witness before setting its value

### DIFF
--- a/crates/acvm/src/lib.rs
+++ b/crates/acvm/src/lib.rs
@@ -164,7 +164,16 @@ pub trait PartialWitnessGenerator {
                                     } else {
                                         FieldElement::zero()
                                     };
-                                    initial_witness.insert(b[j], v);
+                                    match initial_witness.entry(b[j]) {
+                                        std::collections::btree_map::Entry::Vacant(e) => {
+                                            e.insert(v);
+                                        }
+                                        std::collections::btree_map::Entry::Occupied(e) => {
+                                            if e.get() != &v {
+                                                return GateResolution::UnsatisfiedConstrain;
+                                            }
+                                        }
+                                    }
                                 }
                                 false
                             }


### PR DESCRIPTION
# Related issue(s)

Resolves  #534 

# Description

## Summary of changes

We check if a witness was already solved or not before setting its value. If the previous value does not match the new one, then the gate is not satisfied

## Test additions / changes

No change, it is not easy to validate the behavior currently as the test should fail and was also failing to verify before the fix.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
