### PR TITLE
Use rust syntax highlighting for .nr files in this repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.nr linguist-language=rust


### PR DESCRIPTION
# Related issue(s)

No issue exists for this - it is a minor, quick change.

# Description

## Summary of changes

Noir files (*.nr) currently have no syntax highlighting when viewing them on github. This PR hints to github that it should use rust syntax highlighting for these files instead - which should be close enough.

# Checklist

- [ ] I have tested the changes locally.
  - Cannot test these changes locally, it is on github only. It works for me in other repositories though.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
