### PR TITLE
Reconstruct nested values from function

### DIFF
--- a/crates/nargo/tests/test_data/struct/src/main.nr
+++ b/crates/nargo/tests/test_data/struct/src/main.nr
@@ -26,6 +26,25 @@ impl Pair {
     }
 }
 
+struct Nested {
+    a: Field,
+    b: Field
+}
+struct MyStruct {
+    my_bool: bool,
+    my_int: u32,
+    my_nest: Nested,
+}
+fn test_struct_in_tuple(a_bool : bool,x:Field, y:Field) -> (MyStruct, bool) {
+    let my_struct = MyStruct {
+        my_bool: a_bool,
+        my_int: 5,
+        my_nest: Nested{a:x,b:y},
+    };
+    (my_struct, a_bool)
+}
+
+
 fn main(x: Field, y: Field) {
     let first = Foo::default(x,y);
     let p = Pair { first, second: 1 };
@@ -33,5 +52,12 @@ fn main(x: Field, y: Field) {
     constrain p.bar() == x;
     constrain p.second == y;
     constrain p.first.array[0] != p.first.array[1];
+
+    // Nested structs
+    let (struct_from_tuple, a_bool) = test_struct_in_tuple(true,x,y);
+    constrain struct_from_tuple.my_bool == true;
+    constrain a_bool == true;
+    constrain struct_from_tuple.my_int == 5;
+    constrain struct_from_tuple.my_nest.a == 0;
 }
     


### PR DESCRIPTION
# Related issue(s)

Resolves #492

# Description

## Summary of changes

Flatten data returned from a function is reconstructed into a value using the function return type

## Test additions / changes

Regression test case added in 'struct' test case

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

