### PR TITLE
Handle predicate operator during inlining

### DIFF
--- a/crates/nargo/tests/test_data/9_conditional/src/main.nr
+++ b/crates/nargo/tests/test_data/9_conditional/src/main.nr
@@ -166,5 +166,13 @@ fn main(a: u32, mut c: [u32; 4], x: [u8; 5], result: pub [u8; 32]){
         c[1] = 5;
     }
     constrain c[1] == 2;
+
+    test5(4);
 }
 
+fn test5(a : u32) {
+    if a > 1 {
+        let q = a / 2;
+        constrain q == 2;
+    }
+}

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -431,7 +431,12 @@ impl DecisionTree {
         }
     }
 
-    fn short_circuit(ctx: &mut SsaContext, stack: &mut StackFrame, condition: NodeId) -> bool {
+    fn short_circuit(
+        ctx: &mut SsaContext,
+        stack: &mut StackFrame,
+        condition: NodeId,
+        error_msg: &str,
+    ) -> bool {
         if ctx.under_assumption(condition) {
             block::short_circuit_instructions(ctx, &stack.stack);
             let nop = stack.stack[0];
@@ -454,7 +459,7 @@ impl DecisionTree {
             stack.push(ins2);
             true
         } else {
-            false
+            unreachable!("{}", error_msg);
         }
     }
 
@@ -521,21 +526,39 @@ impl DecisionTree {
                 Operation::Load { array_id, index } => {
                     if let Some(idx) = ctx.get_as_constant(*index) {
                         if (idx.to_u128() as u32) >= ctx.mem[*array_id].len {
-                            if !DecisionTree::short_circuit(ctx, stack, ass_value) {
-                                unreachable!(
-                                    "index out of bounds: the len is {} but the index is {}",
-                                    ctx.mem[*array_id].len,
-                                    idx.to_u128()
-                                );
-                            }
-                            return false;
+                            let error = format!(
+                                "index out of bounds: the len is {} but the index is {}",
+                                ctx.mem[*array_id].len,
+                                idx.to_u128()
+                            );
+                            return !DecisionTree::short_circuit(ctx, stack, ass_value, &error);
                         }
                     }
                     stack.push(ins_id);
                 }
                 Operation::Binary(binop) => {
                     stack.push(ins_id);
-                    assert!(binop.predicate.is_none());
+                    let mut cond = ass_value;
+                    if let Some(pred) = binop.predicate {
+                        assert_ne!(pred, NodeId::dummy());
+                        if ass_value != NodeId::dummy() {
+                            let op = Operation::Binary(node::Binary {
+                                lhs: ass_value,
+                                rhs: pred,
+                                operator: BinaryOp::Mul,
+                                predicate: None,
+                            });
+                            cond = ctx.add_instruction(Instruction::new(
+                                op,
+                                ObjectType::Boolean,
+                                Some(stack.block),
+                            ));
+                            optim::simplify_id(ctx, cond).unwrap();
+                            stack.push(cond);
+                        } else {
+                            cond = pred;
+                        }
+                    }
                     match binop.operator {
                         BinaryOp::Udiv
                         | BinaryOp::Sdiv
@@ -543,18 +566,20 @@ impl DecisionTree {
                         | BinaryOp::Srem
                         | BinaryOp::Div => {
                             if ctx.is_zero(binop.rhs) {
-                                if !DecisionTree::short_circuit(ctx, stack, ass_value) {
-                                    unreachable!("error: attempt to divide by zero");
-                                }
-                                return false;
+                                return !DecisionTree::short_circuit(
+                                    ctx,
+                                    stack,
+                                    cond,
+                                    "error: attempt to divide by zero",
+                                );
                             }
-                            if ctx.under_assumption(ass_value) {
+                            if ctx.under_assumption(cond) {
                                 let ins2 = ctx.get_mut_instruction(ins_id);
                                 ins2.operation = Operation::Binary(crate::node::Binary {
                                     lhs: binop.lhs,
                                     rhs: binop.rhs,
                                     operator: binop.operator.clone(),
-                                    predicate: Some(ass_value),
+                                    predicate: Some(cond),
                                 });
                             }
                         }
@@ -565,14 +590,12 @@ impl DecisionTree {
                     if !ins.operation.is_dummy_store() {
                         if let Some(idx) = ctx.get_as_constant(*index) {
                             if (idx.to_u128() as u32) >= ctx.mem[*array_id].len {
-                                if !DecisionTree::short_circuit(ctx, stack, ass_value) {
-                                    unreachable!(
-                                        "index out of bounds: the len is {} but the index is {}",
-                                        ctx.mem[*array_id].len,
-                                        idx.to_u128()
-                                    );
-                                }
-                                return false;
+                                let error = format!(
+                                    "index out of bounds: the len is {} but the index is {}",
+                                    ctx.mem[*array_id].len,
+                                    idx.to_u128()
+                                );
+                                return !DecisionTree::short_circuit(ctx, stack, ass_value, &error);
                             }
                         }
                         if stack.created_arrays[array_id] != stack.block


### PR DESCRIPTION
# Related issue(s)

Resolves #530

# Description

## Summary of changes

We handle predicate in binary instructions during inlining
I also added a small refactor of short_circuit() which was suggested in PR #437 review but was not implemented.

## Test additions / changes

Regression test case added to 9_conditional

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
