### PR TITLE
Add serialisation format of ABIs into JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,7 @@ dependencies = [
  "blake2",
  "serde",
  "serde_derive",
+ "serde_json",
  "toml",
 ]
 

--- a/crates/nargo/src/cli/build_cmd.rs
+++ b/crates/nargo/src/cli/build_cmd.rs
@@ -25,7 +25,7 @@ pub fn build_from_path<P: AsRef<Path>>(p: P, allow_warnings: bool) -> Result<(),
     add_std_lib(&mut driver);
     driver.build(allow_warnings);
     // XXX: We can have a --overwrite flag to determine if you want to overwrite the Prover/Verifier.toml files
-    if let Some(x) = driver.compute_abi() {
+    if let Some(abi) = driver.compute_abi() {
         // XXX: The root config should return an enum to determine if we are looking for .json or .toml
         // For now it is hard-coded to be toml.
         //
@@ -37,12 +37,12 @@ pub fn build_from_path<P: AsRef<Path>>(p: P, allow_warnings: bool) -> Result<(),
         // If they are not available, then create them and
         // populate them based on the ABI
         if !path_to_prover_input.exists() {
-            let toml = toml::to_string(&build_empty_map(&x)).unwrap();
+            let toml = toml::to_string(&build_empty_map(&abi)).unwrap();
             write_to_file(toml.as_bytes(), &path_to_prover_input);
         }
         if !path_to_verifier_input.exists() {
-            let abi = x.public_abi();
-            let toml = toml::to_string(&build_empty_map(&abi)).unwrap();
+            let public_abi = abi.public_abi();
+            let toml = toml::to_string(&build_empty_map(&public_abi)).unwrap();
             write_to_file(toml.as_bytes(), &path_to_verifier_input);
         }
     } else {

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -12,3 +12,6 @@ toml = "0.5.8"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0.136"
 blake2 = "0.9.1"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/noirc_abi/src/serialization.rs
+++ b/crates/noirc_abi/src/serialization.rs
@@ -1,0 +1,233 @@
+use std::convert::TryInto;
+
+use serde::{Deserialize, Serialize, Serializer};
+
+use crate::{Abi, AbiFEType, AbiType, Sign};
+
+// Serializing the `Abi` struct directly doesn't result in the most convenient serialized format for outside use.
+// To fix this we convert `Abi` into a `Vec<AbiParameter>` before serialization as this avoids having to write a custom
+// serializer and deserializer.
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct AbiParameter {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    visibility: Option<AbiFEType>,
+    #[serde(rename = "type")]
+    param_type: Type,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "name", rename_all = "lowercase")]
+enum Type {
+    Field,
+    Array {
+        length: u64,
+        #[serde(rename = "type")]
+        typ: Box<Type>,
+    },
+    Integer {
+        sign: Sign,
+        width: u32,
+    },
+    Struct {
+        fields: Vec<AbiParameter>,
+    },
+}
+
+impl From<AbiType> for Type {
+    fn from(param_type: AbiType) -> Self {
+        match param_type {
+            AbiType::Field(_) => Self::Field,
+            AbiType::Array { visibility: _, length, typ } => {
+                Self::Array { length: length.try_into().unwrap(), typ: Box::new(Self::from(*typ)) }
+            }
+            AbiType::Integer { visibility: _, sign, width } => Self::Integer { sign, width },
+            AbiType::Struct { visibility: _, fields } => Self::Struct {
+                fields: fields
+                    .into_iter()
+                    .map(|(name, value)| AbiParameter {
+                        name,
+                        visibility: None,
+                        param_type: Type::from(value),
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
+impl AbiType {
+    fn from_type(param_type: Type, visibility: AbiFEType) -> Self {
+        match param_type {
+            Type::Field => AbiType::Field(visibility),
+            Type::Integer { sign, width } => AbiType::Integer { visibility, sign, width },
+            Type::Array { length, typ } => AbiType::Array {
+                visibility,
+                length: length.into(),
+                typ: Box::new(Self::from_type(*typ, visibility)),
+            },
+            Type::Struct { fields } => AbiType::Struct {
+                visibility,
+                fields: fields
+                    .into_iter()
+                    .map(|field| (field.name, AbiType::from_type(field.param_type, visibility)))
+                    .collect(),
+            },
+        }
+    }
+}
+
+impl Serialize for Abi {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let parameter_vec: Vec<AbiParameter> = self
+            .parameters
+            .clone()
+            .into_iter()
+            .map(|(name, param_type)| {
+                let visibility = Some(param_type.visibility());
+                AbiParameter { name, visibility, param_type: Type::from(param_type) }
+            })
+            .collect();
+
+        parameter_vec.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Abi {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let parameters = Vec::<AbiParameter>::deserialize(deserializer)?;
+
+        let parameters = parameters
+            .into_iter()
+            .map(|AbiParameter { name, visibility, param_type }| {
+                (name, AbiType::from_type(param_type, visibility.unwrap()))
+            })
+            .collect();
+
+        Ok(Abi { parameters })
+    }
+
+    fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Default implementation just delegates to `deserialize` impl.
+        *place = Deserialize::deserialize(deserializer)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{Abi, AbiFEType, AbiType, Sign};
+
+    #[test]
+    fn abi_deserializes_correctly() {
+        let serialized_abi = "
+        [
+            {
+                \"name\": \"thing1\",
+                \"visibility\": \"public\",
+                \"type\": {
+                    \"name\": \"field\"
+                }
+            },
+            {
+                \"name\": \"thing2\",
+                \"visibility\": \"private\",
+                \"type\": {
+                    \"name\": \"array\",
+                    \"length\": 2,
+                    \"type\": {
+                        \"name\": \"integer\",
+                        \"width\": 3,
+                        \"sign\": \"unsigned\"
+                    }
+                }
+            },
+            {
+                \"name\": \"thing3\",
+                \"visibility\": \"private\",
+                \"type\": {
+                    \"name\": \"struct\",
+                    \"fields\": [
+                        {
+                            \"name\": \"field1\",
+                            \"type\": {
+                                \"name\": \"integer\",
+                                \"width\": 3,
+                                \"sign\": \"unsigned\"
+                            }
+                        },
+                        {
+                            \"name\": \"field2\",
+                            \"type\": {
+                                \"name\": \"array\",
+                                \"length\": 2,
+                                \"type\": {
+                                    \"name\": \"field\"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]";
+
+        let deserialized_abi: Abi = serde_json::from_str(serialized_abi).unwrap();
+
+        let mut params = deserialized_abi.parameters.iter();
+        assert_eq!(params.next(), Some(&("thing1".to_string(), AbiType::Field(AbiFEType::Public))));
+        assert_eq!(
+            params.next(),
+            Some(&(
+                "thing2".to_string(),
+                AbiType::Array {
+                    visibility: AbiFEType::Private,
+                    length: 2,
+                    typ: Box::new(AbiType::Integer {
+                        visibility: AbiFEType::Private,
+                        sign: Sign::Unsigned,
+                        width: 3
+                    })
+                }
+            ))
+        );
+        assert_eq!(
+            params.next(),
+            Some(&(
+                "thing3".to_string(),
+                AbiType::Struct {
+                    visibility: AbiFEType::Private,
+                    fields: BTreeMap::from([
+                        (
+                            "field1".to_string(),
+                            AbiType::Integer {
+                                visibility: AbiFEType::Private,
+                                sign: Sign::Unsigned,
+                                width: 3
+                            }
+                        ),
+                        (
+                            "field2".to_string(),
+                            AbiType::Array {
+                                visibility: AbiFEType::Private,
+                                length: 2,
+                                typ: Box::new(AbiType::Field(AbiFEType::Private))
+                            }
+                        )
+                    ])
+                }
+            ))
+        );
+    }
+}


### PR DESCRIPTION
# Related issue(s)

Serialisation logic relies on array lengths fitting in a `u64` #525 

Logic being format used to serialise ABI described in #524 

Closes #524 

# Description

## Summary of changes

This PR adds logic to serialise/deserialise circuit ABIs so it can be saved to a JSON file and used elsewhere.

The `Abi` struct is not suitable for serialising directly (see #524 and #525) so we convert it to an intermediary format and then serialise this instead (this allows us to use the derived serde implementations rather than making the modifications inside a custom implementation). 

Storing the ABI in JSON is useful as it makes generating/verifying proofs from TS much more robust. Currently TS users [don't get any typechecking on their inputs ](https://github.com/noir-lang/aztec-connect/blob/001897fbd96dbea45cd5b1071bbbe5c0439b89f7/barretenberg.js/src/client_proofs/generic_proof/index.ts#L97-L111) to proving/verifying which means they get arcane wasm errors should they update their circuit and forget to update their TS code to match. With this however, we could automatically generate TS bindings for Noir circuits ("typechain for noir") which would avoid these issues.

More generally, this is very useful anywhere you need to generate/verify proofs without having access to the noir source code.

The generation of `Prover.toml`/`Verifier.toml` template files was piggybacking on the `Deserialize` trait so I had to create a new function to create those.

## Dependency additions / changes

Added `serde_json` as a dev dependency to `noirc_abi` for a test

## Test additions / changes

Added a test that we can successfully deserialise a JSON representation of an ABI.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
