### PR TITLE
Improve `nargo`'s handling of absent subcommand

### DIFF
--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -1,5 +1,5 @@
 pub use build_cmd::build_from_path;
-use clap::{App, Arg};
+use clap::{App, AppSettings, Arg};
 use noirc_driver::Driver;
 use noirc_frontend::graph::{CrateName, CrateType};
 use std::{
@@ -88,6 +88,7 @@ pub fn start_cli() {
                 .arg(show_ssa)
                 .arg(allow_warnings),
         )
+        .setting(AppSettings::SubcommandRequiredElseHelp)
         .get_matches();
 
     let result = match matches.subcommand_name() {
@@ -98,8 +99,8 @@ pub fn start_cli() {
         Some("compile") => compile_cmd::run(matches),
         Some("verify") => verify_cmd::run(matches),
         Some("gates") => gates_cmd::run(matches),
-        None => Err(CliError::Generic("No subcommand was used".to_owned())),
         Some(x) => Err(CliError::Generic(format!("unknown command : {}", x))),
+        _ => unreachable!(),
     };
     if let Err(err) = result {
         err.write()


### PR DESCRIPTION
# Related issue(s)

Resolves #558.

# Description

## Summary of changes

 - Add a setting to the existing `clap` `App` requiring a subcommand (see [this forum post](https://users.rust-lang.org/t/clap-how-to-group-require-top-level-subcommands/24789/2)).

## Dependency additions / changes

None.

## Test additions / changes

None.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

None.
