### PR TITLE
update backend ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aztec_backend"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=01b922adcb5a9d70b2d12304e1cb7487d9f28188#01b922adcb5a9d70b2d12304e1cb7487d9f28188"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=2d601a7d55faf601f4b183a43923c8fe04eabb7b#2d601a7d55faf601f4b183a43923c8fe04eabb7b"
 dependencies = [
  "acvm",
  "barretenberg_wrapper",
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/AztecProtocol/barretenberg?rev=804c7dcf21111acd1302a768a8fa2f453dcec50f#804c7dcf21111acd1302a768a8fa2f453dcec50f"
+source = "git+https://github.com/AztecProtocol/aztec-2.0?rev=804c7dcf21111acd1302a768a8fa2f453dcec50f#804c7dcf21111acd1302a768a8fa2f453dcec50f"
 dependencies = [
  "cmake",
  "hex",

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4.2"
 tempdir = "0.3.7"
 
 # Backends
-aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend", rev = "01b922adcb5a9d70b2d12304e1cb7487d9f28188" }
+aztec_backend = { optional = true, git = "https://github.com/noir-lang/aztec_backend", rev = "2d601a7d55faf601f4b183a43923c8fe04eabb7b" }
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "601e24dcb5dcbe72e3de7a33879aaf84e171d541" }
 
 [features]


### PR DESCRIPTION
# Related issue(s)

Resolves this [comment](https://github.com/noir-lang/noir/pull/560#issuecomment-1339541855)

# Description

The barretenberg repo was renamed which causes the Noir build to fail on the CI as the `aztec_backend` reference in `nargo`'s `Cargo.toml` file referenced the wrong repo. We are in the process of moving barretenberg to a new repo. I made a temporary PR that can be found [here](https://github.com/noir-lang/aztec_backend/pull/25) that will be used until we fix the issues from the barretenberg migration and can move to the updated repository.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
