### PR TITLE
Update workflow to run on 20.04 to fix CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
         include:
           - name: linux
-            os: ubuntu-latest
+            os: ubuntu-20.04
             artifact_name: nargo
             asset_name: nargo-linux
           - name: windows

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   check_n_test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +49,7 @@ jobs:
 
   clippy:
     name: cargo clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
 
   format:
     name: cargo fmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
# Related issue(s)

(None - github CI has started to fail for more recent commits failing to link libomp).

# Description

## Summary of changes

Locks ubuntu version to ubuntu-20.04 which is known to work. We should update this to work on ubuntu-latest later on and remove this change.

# Checklist

- [x] I have tested the changes locally. (Checked to be working on the higher-order functions PR, and this one).
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
