### PR TITLE
Fix #577

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -904,23 +904,18 @@ impl<'a> Resolver<'a> {
         let definition = self.interner.definition(id);
         match definition.rhs {
             Some(rhs) if definition.is_global || !definition.mutable => {
-                self.try_eval_array_length_id(rhs)
+                self.try_eval_array_length_id(rhs, span)
             }
             _ => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
         }
     }
 
-    fn try_eval_array_length_id(&self, rhs: ExprId) -> Result<u128, Option<ResolverError>> {
-        let span = self.interner.expr_span(&rhs);
+    fn try_eval_array_length_id(&self, rhs: ExprId, span: Span) -> Result<u128, Option<ResolverError>> {
         match self.interner.expression(&rhs) {
             HirExpression::Literal(HirLiteral::Integer(int)) => {
                 int.try_into_u128().ok_or(Some(ResolverError::IntegerTooLarge { span }))
             }
-            HirExpression::Literal(_) => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
-            other => unreachable!(
-                "Expected global to be initialized to a literal, but found {:?}",
-                other
-            ),
+            _other => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
         }
     }
 }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -910,7 +910,11 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    fn try_eval_array_length_id(&self, rhs: ExprId, span: Span) -> Result<u128, Option<ResolverError>> {
+    fn try_eval_array_length_id(
+        &self,
+        rhs: ExprId,
+        span: Span,
+    ) -> Result<u128, Option<ResolverError>> {
         match self.interner.expression(&rhs) {
             HirExpression::Literal(HirLiteral::Integer(int)) => {
                 int.try_into_u128().ok_or(Some(ResolverError::IntegerTooLarge { span }))


### PR DESCRIPTION
# Related issue(s)

Resolves #577

# Description

## Summary of changes

What was previously an unreachable case had been made reachable after a previous PR allowed the array-length mini evaluator to evaluate local variables (for backward compatibility as it was previously erroneously allowed when we had separate systems for array expressions and array types). Since this case is no longer unreachable, the `unreachable!` was simply removed and some Spans were changed to make the error location more accurate.

The test case in the issue now errors properly with:
```
error: Expression invalid in an array-length context
   ┌─ /.../testcase/src/main.nr:13:77
   │
13 │     let mut s: [S; size] = [S { xL_in: 0, xR_in: 0, xL_out: 0, xR_out: 0 }; size];
   │                                                                             ---- Array-length expressions can only have simple integer operations and any variables used must be global constants

error: Expression invalid in an array-length context
   ┌─ /.../testcase/src/main.nr:13:20
   │
13 │     let mut s: [S; size] = [S { xL_in: 0, xR_in: 0, xL_out: 0, xR_out: 0 }; size];
   │                    ---- Array-length expressions can only have simple integer operations and any variables used must be global constants

```

## Dependency additions / changes

N/a

## Test additions / changes

N/a - this case was unreachable but is still a compile-time error.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
