### PR TITLE
Fix for 579: Always intialise returned arrays so they can be properly conditionalized

### DIFF
--- a/crates/nargo/tests/test_data/9_conditional/src/main.nr
+++ b/crates/nargo/tests/test_data/9_conditional/src/main.nr
@@ -82,6 +82,12 @@ fn main(a: u32, mut c: [u32; 4], x: [u8; 5], result: pub [u8; 32]){
     }
     constrain c1==1;
 
+    //Regression for Issue #579
+    let result1_true = test(true);
+    constrain result1_true.array_param[0] == 1;
+    let result1_false = test(false);
+    constrain result1_false.array_param[0] == 0;
+
     //Test case for short-circuit
     let mut data = [0 as u32; 32];
     let mut ba = a;
@@ -205,3 +211,23 @@ fn bar(x:Field) {
 }
 
 
+struct MyStruct579 {
+    array_param: [u32; 2]
+}
+
+impl MyStruct579 {
+    fn new(array_param: [u32; 2]) -> MyStruct579 {
+        MyStruct579 {
+            array_param: array_param
+        }
+    }
+}
+
+fn test(flag: bool) -> MyStruct579 {
+    let mut my_struct =  MyStruct579::new([0; 2]);
+
+    if flag == true {
+        my_struct=  MyStruct579::new([1; 2]);
+    }
+    my_struct
+}

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -617,7 +617,8 @@ impl DecisionTree {
                                 return Ok(false);
                             }
                         }
-                        if stack.created_arrays[array_id] != stack.block
+                        if (stack.created_arrays[array_id] != stack.block
+                            || stack.return_arrays.contains(array_id))
                             && ctx.under_assumption(ass_value)
                         {
                             let load = Operation::Load { array_id: *array_id, index: *index };

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -115,6 +115,7 @@ pub struct StackFrame {
     array_map: HashMap<ArrayId, ArrayId>,
     pub created_arrays: HashMap<ArrayId, BlockId>,
     zeros: HashMap<ObjectType, NodeId>,
+    pub return_arrays: Vec<ArrayId>,
 }
 
 impl StackFrame {
@@ -125,6 +126,7 @@ impl StackFrame {
             array_map: HashMap::new(),
             created_arrays: HashMap::new(),
             zeros: HashMap::new(),
+            return_arrays: Vec::new(),
         }
     }
 
@@ -191,6 +193,7 @@ pub fn inline(
     for arg_caller in arrays.iter() {
         if let node::ObjectType::Pointer(a) = ssa_func.result_types[arg_caller.1 as usize] {
             stack_frame.array_map.insert(a, arg_caller.0);
+            stack_frame.return_arrays.push(arg_caller.0);
         }
     }
 
@@ -363,6 +366,7 @@ pub fn inline_in_block(
 
     // we conditionalise the stack frame into a new stack frame (to avoid ownership issues)
     let mut stack2 = StackFrame::new(stack_frame.block);
+    stack2.return_arrays = stack_frame.return_arrays.clone();
     if short_circuit {
         super::block::short_circuit_inline(ctx, stack_frame.block);
     } else {


### PR DESCRIPTION

# Related issue(s)

Resolves #579 

# Description

We need to know if arrays are initialised when handling conditional store instructions (with predicate), because the array initialisation cannot be 'conditionalised'. However, as returned arrays may not be initialised in function call, it results that store instructions in functions under a condition were never 'conditionalised'

To fix this issue, we ensure returned arrays are initialised and notify the conditionalize() method with the returned arrays so it can conditionalise them.


## Test additions / changes

regression test is added to 9_conditional

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

There are several ways to solve this issue, for instance we could force users to always initialise arrays in the frontend:
let a = [0,2,3];   ....OK
let a = f(b);      ...NOT OK
but this seems to be a bit artificial to me and I'd rather fix the issue.

Another possibility would be to make the conditionalise compatible with unitialised arrays, but this would require dynamic memory implementation.
