### PR TITLE
issue 580: generate a witness if needed during division

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -953,7 +953,7 @@ pub fn evaluate_udiv(
         dbg!(err);
     });
     // a-b*q-r = 0
-    let mut d = mul(&rhs.expression, &Expression::from(&q_witness));
+    let mut d = mul_with_witness(evaluator, &rhs.expression, &Expression::from(&q_witness));
     d = add(&d, FieldElement::one(), &Expression::from(&r_witness));
     d = mul_with_witness(evaluator, &d, &predicate.expression);
     let div_eucl = subtract(&pa, FieldElement::one(), &d);


### PR DESCRIPTION
# Related issue(s)

Resolves #580

# Description

## Summary of changes

Generates an intermediate variable for multiplication when needed during division.


## Test additions / changes

No test added as the fix is using a function already tested.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
