### PR TITLE
Add build script for `wasm` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "noir_wasm"
-version = "0.1.0"
+version = "0.10.0"
 dependencies = [
  "acvm",
  "console_error_panic_hook",

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noir_wasm"
-version = "0.1.0"
+version = "0.10.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -1,0 +1,18 @@
+# Noir wasm
+
+## Dependencies
+
+In order to build the wasm package, the following must be installed:
+
+- [wasm-pack](https://github.com/rustwasm/wasm-pack)
+- [jq](https://github.com/stedolan/jq)
+
+## Build
+
+The wasm package can be built using the command below:
+
+```bash
+./build-wasm
+```
+
+Using `wasm-pack` directly isn't recommended as it doesn't generate a complete `package.json` file, resulting in files being omitted from the published package.

--- a/crates/wasm/build-wasm
+++ b/crates/wasm/build-wasm
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Clear out the existing build artifacts as these aren't automatically removed by wasm-pack.
+if [ -d ./pkg/ ]; then
+    rm -r ./pkg/
+fi
+
+# Build the new wasm package
+wasm-pack build --scope noir-lang --target nodejs
+
+# wasm-pack doesn't add all the necessary entries to package.json so manually inject them here.
+PKG_JSON="pkg/package.json"
+cat $PKG_JSON | jq '.files += ["noir_wasm_bg.wasm.d.ts", "snippets/*"]' | tee $PKG_JSON

--- a/crates/wasm/pkg/package.json
+++ b/crates/wasm/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noir-lang/noir_wasm",
-  "version": "0.3.0",
+  "version": "0.10.0",
   "files": [
     "noir_wasm_bg.wasm",
     "noir_wasm.js",


### PR DESCRIPTION
# Related issue(s)

closes #590

# Description

## Summary of changes

I've bumped the crate version to match the version on [npm](https://www.npmjs.com/package/@noir-lang/noir_wasm) as `package.json` pulls the version from `Cargo.toml`.

I've also added `build-wasm` which produces a fresh build of the wasm package and manually inserts any missing values into `package.json` (`wasm-pack` doesn't allow customisation of the generated `package.json`).

## Dependency additions / changes

N/A

## Test additions / changes

N/A.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
