### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/acir/src/circuit/mod.rs
+++ b/crates/acir/src/circuit/mod.rs
@@ -45,7 +45,7 @@ pub struct PublicInputs(pub Vec<Witness>);
 impl PublicInputs {
     /// Returns the witness index of each public input
     pub fn indices(&self) -> Vec<u32> {
-        self.0.iter().map(|witness| witness.witness_index() as u32).collect()
+        self.0.iter().map(|witness| witness.witness_index()).collect()
     }
 
     pub fn contains(&self, index: usize) -> bool {

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -85,7 +85,7 @@ impl FileManager {
 
         let dir = self.path(anchor).to_path_buf();
 
-        candidate_files.push(dir.join(&format!("{}.{}", mod_name, FILE_EXTENSION)));
+        candidate_files.push(dir.join(format!("{}.{}", mod_name, FILE_EXTENSION)));
 
         for candidate in candidate_files.iter() {
             if let Some(file_id) = self.add_file(candidate, FileType::Normal) {

--- a/crates/nargo/build.rs
+++ b/crates/nargo/build.rs
@@ -66,5 +66,5 @@ fn main() {
     let stdlib_src_dir = Path::new("../../noir_stdlib/");
     rerun_if_stdlib_changes(stdlib_src_dir);
     let target = dirs::config_dir().unwrap().join("noir-lang").join("std");
-    copy(stdlib_src_dir, &target).unwrap();
+    copy(stdlib_src_dir, target).unwrap();
 }

--- a/crates/nargo/src/cli/contract_cmd.rs
+++ b/crates/nargo/src/cli/contract_cmd.rs
@@ -12,7 +12,7 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     };
 
     let allow_warnings = args.is_present("allow-warnings");
-    let compiled_program = compile_circuit(&package_dir, false, allow_warnings)?;
+    let compiled_program = compile_circuit(package_dir, false, allow_warnings)?;
 
     let backend = crate::backends::ConcreteBackend;
     let smart_contract_string = backend.eth_contract_from_cs(compiled_program.circuit);

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -959,7 +959,7 @@ impl Type {
                     Signedness::Signed => noirc_abi::Sign::Signed,
                 };
 
-                AbiType::Integer { sign, width: *bit_width as u32, visibility: fe_type }
+                AbiType::Integer { sign, width: *bit_width, visibility: fe_type }
             }
             Type::PolymorphicInteger(_, binding) => match &*binding.borrow() {
                 TypeBinding::Bound(typ) => typ.as_abi_type(fe_type),


### PR DESCRIPTION
# Related issue(s)

Resolves CI issues on recent PRs such as #591 

# Description

## Summary of changes

I've fixed the clippy warnings which are failing CI on recent PRs. No changes to functionality.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
