### PR TITLE
Separate `AbiType` from visibility

### DIFF
--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::{input_parser::InputValue, AbiType};
+use crate::{input_parser::InputValue, AbiParameter};
 
 #[derive(Debug)]
 pub enum InputParserError {
@@ -33,7 +33,7 @@ impl std::fmt::Display for InputParserError {
 pub enum AbiError {
     Generic(String),
     UnexpectedParams(Vec<String>),
-    TypeMismatch { param_name: String, param_type: AbiType, value: InputValue },
+    TypeMismatch { param: AbiParameter, value: InputValue },
     MissingParam(String),
     UndefinedInput(String),
     UnexpectedInputLength { expected: u32, actual: u32 },
@@ -48,11 +48,11 @@ impl std::fmt::Display for AbiError {
                 AbiError::Generic(msg) => msg.clone(),
                 AbiError::UnexpectedParams(unexpected_params) =>
                     format!("Received parameters not expected by ABI: {:?}", unexpected_params),
-                AbiError::TypeMismatch { param_name, param_type, value } => {
+                AbiError::TypeMismatch { param, value } => {
                     format!(
-                            "The parameter {} is expected to be a {:?} but found incompatible value {:?}",
-                            param_name, param_type, value
-                        )
+                        "The parameter {} is expected to be a {:?} but found incompatible value {:?}",
+                        param.name, param.typ, value
+                    )
                 }
                 AbiError::MissingParam(name) => {
                     format!("ABI expects the parameter `{}`, but this was not found", name)

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -23,17 +23,17 @@ impl InputValue {
     /// and also their arity
     pub fn matches_abi(&self, abi_param: &AbiType) -> bool {
         match (self, abi_param) {
-            (InputValue::Field(_), AbiType::Field(_)) => true,
+            (InputValue::Field(_), AbiType::Field) => true,
             (InputValue::Field(_), AbiType::Array { .. }) => false,
             (InputValue::Field(_), AbiType::Integer { .. }) => true,
             (InputValue::Field(_), AbiType::Struct { .. }) => false,
 
-            (InputValue::Vec(_), AbiType::Field(_)) => false,
+            (InputValue::Vec(_), AbiType::Field) => false,
             (InputValue::Vec(x), AbiType::Array { length, .. }) => x.len() == *length as usize,
             (InputValue::Vec(_), AbiType::Integer { .. }) => false,
             (InputValue::Vec(_), AbiType::Struct { .. }) => false,
 
-            (InputValue::Struct(_), AbiType::Field(_)) => false,
+            (InputValue::Struct(_), AbiType::Field) => false,
             (InputValue::Struct(_), AbiType::Array { .. }) => false,
             (InputValue::Struct(_), AbiType::Integer { .. }) => false,
             (InputValue::Struct(map), AbiType::Struct { fields, .. }) => map.len() == fields.len(),

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -79,6 +79,7 @@ impl AbiType {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// An argument or return value of the circuit's `main` function.
 pub struct AbiParameter {
     pub name: String,
     pub typ: AbiType,

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -32,26 +32,21 @@ pub enum AbiType {
     Integer { sign: Sign, width: u32 },
     Struct { fields: BTreeMap<String, AbiType> },
 }
-/// This is the same as the FieldElementType in AST, without constants.
-/// We don't want the ABI to depend on Noir, so types are not shared between the two
-/// Note: At the moment, it is not even possible since the ABI is in another crate and Noir depends on it
-/// This can be easily fixed by making the ABI a module.
-///
-/// In the future, maybe it will be decided that the AST will hold esoteric types and the HIR will transform them
-/// This method is a bit cleaner as we would not need to dig into the resolver, to lower from a esoteric AST type to a HIR type.
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AbiFEType {
+/// Represents whether the parameter is public or known only to the prover.
+pub enum AbiVisibility {
     Public,
     // Constants are not allowed in the ABI for main at the moment.
     // Constant,
     Private,
 }
 
-impl std::fmt::Display for AbiFEType {
+impl std::fmt::Display for AbiVisibility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AbiFEType::Public => write!(f, "pub"),
-            AbiFEType::Private => write!(f, "priv"),
+            AbiVisibility::Public => write!(f, "pub"),
+            AbiVisibility::Private => write!(f, "priv"),
         }
     }
 }
@@ -87,12 +82,12 @@ impl AbiType {
 pub struct AbiParameter {
     pub name: String,
     pub typ: AbiType,
-    pub visibility: AbiFEType,
+    pub visibility: AbiVisibility,
 }
 
 impl AbiParameter {
     pub fn is_public(&self) -> bool {
-        self.visibility == AbiFEType::Public
+        self.visibility == AbiVisibility::Public
     }
 }
 

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -235,11 +235,10 @@ impl Evaluator {
         let abi_params = std::mem::take(&mut igen.program.abi.parameters);
         assert_eq!(main_params.len(), abi_params.len());
 
-        for ((param_id, _, param_name1, _), (param_name2, param_type, visibility)) in
-            main_params.iter().zip(abi_params)
-        {
-            assert_eq!(param_name1, &param_name2);
-            self.param_to_var(param_name1, *param_id, &param_type, &visibility, igen).unwrap();
+        for ((param_id, _, param_name1, _), abi_param) in main_params.iter().zip(abi_params) {
+            assert_eq!(param_name1, &abi_param.name);
+            self.param_to_var(param_name1, *param_id, &abi_param.typ, &abi_param.visibility, igen)
+                .unwrap();
         }
     }
 }

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -147,7 +147,7 @@ impl IRGenerator {
 
     pub fn get_object_type_from_abi(&self, el_type: &noirc_abi::AbiType) -> ObjectType {
         match el_type {
-            noirc_abi::AbiType::Field(_) => ObjectType::NativeField,
+            noirc_abi::AbiType::Field => ObjectType::NativeField,
             noirc_abi::AbiType::Integer { sign, width, .. } => match sign {
                 noirc_abi::Sign::Unsigned => ObjectType::Unsigned(*width),
                 noirc_abi::Sign::Signed => ObjectType::Signed(*width),
@@ -186,7 +186,7 @@ impl IRGenerator {
         let values = vecmap(fields, |(name, field_typ)| {
             let new_name = format!("{}.{}", struct_name, name);
             match field_typ {
-                noirc_abi::AbiType::Array { visibility: _, length, typ } => {
+                noirc_abi::AbiType::Array { length, typ } => {
                     let v_id =
                         self.abi_array(&new_name, None, typ, *length, witnesses[&new_name].clone());
                     Value::Single(v_id)

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -351,11 +351,11 @@ pub struct FunctionDefinition {
     pub name: Ident,
     pub attribute: Option<Attribute>, // XXX: Currently we only have one attribute defined. If more attributes are needed per function, we can make this a vector and make attribute definition more expressive
     pub generics: Vec<Ident>,
-    pub parameters: Vec<(Pattern, UnresolvedType, noirc_abi::AbiFEType)>,
+    pub parameters: Vec<(Pattern, UnresolvedType, noirc_abi::AbiVisibility)>,
     pub body: BlockExpression,
     pub span: Span,
     pub return_type: UnresolvedType,
-    pub return_visibility: noirc_abi::AbiFEType,
+    pub return_visibility: noirc_abi::AbiVisibility,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -45,7 +45,7 @@ impl NoirFunction {
     pub fn name_ident(&self) -> &Ident {
         &self.def.name
     }
-    pub fn parameters(&self) -> &Vec<(Pattern, UnresolvedType, noirc_abi::AbiFEType)> {
+    pub fn parameters(&self) -> &Vec<(Pattern, UnresolvedType, noirc_abi::AbiVisibility)> {
         &self.def.parameters
     }
     pub fn attribute(&self) -> Option<&Attribute> {

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -29,7 +29,7 @@ pub enum UnresolvedType {
     /// A Named UnresolvedType can be a struct type or a type variable
     Named(Path, Vec<UnresolvedType>),
 
-    // Note: Tuples have no FieldElementType, instead each of their elements may have one.
+    // Note: Tuples have no visibility, instead each of their elements may have one.
     Tuple(Vec<UnresolvedType>),
 
     Unspecified, // This is for when the user declares a variable without specifying it's type

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -424,7 +424,7 @@ impl<'a> Resolver<'a> {
         let mut parameter_types = vec![];
 
         for (pattern, typ, visibility) in func.parameters().iter().cloned() {
-            if func.name() != "main" && visibility == noirc_abi::AbiFEType::Public {
+            if func.name() != "main" && visibility == noirc_abi::AbiVisibility::Public {
                 self.push_err(ResolverError::UnnecessaryPub { ident: func.name_ident().clone() })
             }
 
@@ -438,7 +438,7 @@ impl<'a> Resolver<'a> {
 
         if func.name() == "main"
             && *return_type != Type::Unit
-            && func.def.return_visibility != noirc_abi::AbiFEType::Public
+            && func.def.return_visibility != noirc_abi::AbiVisibility::Public
         {
             self.push_err(ResolverError::NecessaryPub { ident: func.name_ident().clone() })
         }

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -140,11 +140,11 @@ mod test {
             location,
             typ: Type::Function(vec![Type::field(None), Type::field(None)], Box::new(Type::Unit)),
             parameters: vec![
-                Param(Identifier(x), Type::field(None), noirc_abi::AbiFEType::Private),
-                Param(Identifier(y), Type::field(None), noirc_abi::AbiFEType::Private),
+                Param(Identifier(x), Type::field(None), noirc_abi::AbiVisibility::Private),
+                Param(Identifier(y), Type::field(None), noirc_abi::AbiVisibility::Private),
             ]
             .into(),
-            return_visibility: noirc_abi::AbiFEType::Private,
+            return_visibility: noirc_abi::AbiVisibility::Private,
             has_body: true,
         };
         interner.push_fn_meta(func_meta, func_id);

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -1,5 +1,5 @@
 use iter_extended::vecmap;
-use noirc_abi::{Abi, AbiFEType, MAIN_RETURN_NAME};
+use noirc_abi::{Abi, AbiFEType, AbiParameter, MAIN_RETURN_NAME};
 use noirc_errors::{Location, Span};
 
 use super::expr::{HirBlockExpression, HirExpression, HirIdent};
@@ -61,7 +61,7 @@ impl Parameters {
                 .expect("Abi for tuple and struct parameters is unimplemented")
                 .to_owned();
             let as_abi = param.1.as_abi_type();
-            (param_name, as_abi, param.2)
+            AbiParameter { name: param_name, typ: as_abi, visibility: param.2 }
         });
         noirc_abi::Abi { parameters }
     }
@@ -147,8 +147,12 @@ impl FuncMeta {
         let mut abi = self.parameters.into_abi(interner);
 
         if return_type != Type::Unit {
-            let typ = return_type.as_abi_type();
-            abi.parameters.push((MAIN_RETURN_NAME.into(), typ, self.return_visibility));
+            let return_param = AbiParameter {
+                name: MAIN_RETURN_NAME.into(),
+                typ: return_type.as_abi_type(),
+                visibility: self.return_visibility,
+            };
+            abi.parameters.push(return_param);
         }
 
         abi

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -1,5 +1,5 @@
 use iter_extended::vecmap;
-use noirc_abi::{Abi, AbiFEType, AbiParameter, MAIN_RETURN_NAME};
+use noirc_abi::{Abi, AbiParameter, AbiVisibility, MAIN_RETURN_NAME};
 use noirc_errors::{Location, Span};
 
 use super::expr::{HirBlockExpression, HirExpression, HirIdent};
@@ -38,7 +38,7 @@ impl HirFunction {
 
 /// An interned function parameter from a function definition
 #[derive(Debug, Clone)]
-pub struct Param(pub HirPattern, pub Type, pub noirc_abi::AbiFEType);
+pub struct Param(pub HirPattern, pub Type, pub noirc_abi::AbiVisibility);
 
 /// Attempts to retrieve the name of this parameter. Returns None
 /// if this parameter is a tuple or struct pattern.
@@ -118,7 +118,7 @@ pub struct FuncMeta {
 
     pub attributes: Option<Attribute>,
     pub parameters: Parameters,
-    pub return_visibility: AbiFEType,
+    pub return_visibility: AbiVisibility,
 
     /// The type of this function. Either a Type::Function
     /// or a Type::Forall for generic functions.

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -60,8 +60,8 @@ impl Parameters {
             let param_name = get_param_name(&param.0, interner)
                 .expect("Abi for tuple and struct parameters is unimplemented")
                 .to_owned();
-            let as_abi = param.1.as_abi_type(param.2);
-            (param_name, as_abi)
+            let as_abi = param.1.as_abi_type();
+            (param_name, as_abi, param.2)
         });
         noirc_abi::Abi { parameters }
     }
@@ -147,8 +147,8 @@ impl FuncMeta {
         let mut abi = self.parameters.into_abi(interner);
 
         if return_type != Type::Unit {
-            let typ = return_type.as_abi_type(self.return_visibility);
-            abi.parameters.push((MAIN_RETURN_NAME.into(), typ));
+            let typ = return_type.as_abi_type();
+            abi.parameters.push((MAIN_RETURN_NAME.into(), typ, self.return_visibility));
         }
 
         abi

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{hir::type_check::TypeCheckError, node_interner::NodeInterner};
 use iter_extended::{btree_map, vecmap};
-use noirc_abi::{AbiFEType, AbiType};
+use noirc_abi::AbiType;
 use noirc_errors::Span;
 
 use crate::{
@@ -940,18 +940,14 @@ impl Type {
 
     // Note; use strict_eq instead of partial_eq when comparing field types
     // in this method, you most likely want to distinguish between public and private
-    pub fn as_abi_type(&self, fe_type: AbiFEType) -> AbiType {
+    pub fn as_abi_type(&self) -> AbiType {
         match self {
-            Type::FieldElement(_) => AbiType::Field(fe_type),
+            Type::FieldElement(_) => AbiType::Field,
             Type::Array(size, typ) => {
                 let size = size
                     .array_length()
                     .expect("Cannot have variable sized arrays as a parameter to main");
-                AbiType::Array {
-                    visibility: fe_type,
-                    length: size as u128,
-                    typ: Box::new(typ.as_abi_type(fe_type)),
-                }
+                AbiType::Array { length: size as u128, typ: Box::new(typ.as_abi_type()) }
             }
             Type::Integer(_, sign, bit_width) => {
                 let sign = match sign {
@@ -959,23 +955,21 @@ impl Type {
                     Signedness::Signed => noirc_abi::Sign::Signed,
                 };
 
-                AbiType::Integer { sign, width: *bit_width, visibility: fe_type }
+                AbiType::Integer { sign, width: *bit_width }
             }
             Type::PolymorphicInteger(_, binding) => match &*binding.borrow() {
-                TypeBinding::Bound(typ) => typ.as_abi_type(fe_type),
-                TypeBinding::Unbound(_) => Type::default_int_type(None).as_abi_type(fe_type),
+                TypeBinding::Bound(typ) => typ.as_abi_type(),
+                TypeBinding::Unbound(_) => Type::default_int_type(None).as_abi_type(),
             },
-            Type::Bool(_) => {
-                AbiType::Integer { sign: noirc_abi::Sign::Unsigned, width: 1, visibility: fe_type }
-            }
+            Type::Bool(_) => AbiType::Integer { sign: noirc_abi::Sign::Unsigned, width: 1 },
             Type::Error => unreachable!(),
             Type::Unit => unreachable!(),
             Type::ArrayLength(_) => unreachable!(),
             Type::Struct(def, args) => {
                 let struct_type = def.borrow();
                 let fields = struct_type.get_fields(args);
-                let abi_map = btree_map(fields, |(name, typ)| (name, typ.as_abi_type(fe_type)));
-                AbiType::Struct { visibility: fe_type, fields: abi_map }
+                let abi_map = btree_map(fields, |(name, typ)| (name, typ.as_abi_type()));
+                AbiType::Struct { fields: abi_map }
             }
             Type::Tuple(_) => todo!("as_abi_type not yet implemented for tuple types"),
             Type::TypeVariable(_) => unreachable!(),

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use chumsky::prelude::*;
 use iter_extended::vecmap;
-use noirc_abi::AbiFEType;
+use noirc_abi::AbiVisibility;
 use noirc_errors::{CustomDiagnostic, DiagnosableError, Span, Spanned};
 
 pub fn parse_program(source_program: &str) -> (ParsedModule, Vec<CustomDiagnostic>) {
@@ -150,12 +150,12 @@ fn struct_definition() -> impl NoirParser<TopLevelStatement> {
 
 fn function_return_type<'a>(
     expr_parser: impl NoirParser<Expression> + 'a,
-) -> impl NoirParser<(AbiFEType, UnresolvedType)> + 'a {
+) -> impl NoirParser<(AbiVisibility, UnresolvedType)> + 'a {
     just(Token::Arrow)
         .ignore_then(optional_visibility())
         .then(parse_type(expr_parser))
         .or_not()
-        .map(|ret| ret.unwrap_or((AbiFEType::Private, UnresolvedType::Unit)))
+        .map(|ret| ret.unwrap_or((AbiVisibility::Private, UnresolvedType::Unit)))
 }
 
 fn attribute() -> impl NoirParser<Attribute> {
@@ -178,7 +178,7 @@ fn struct_fields<'a>(
 fn function_parameters<'a>(
     allow_self: bool,
     expr_parser: impl NoirParser<Expression> + 'a,
-) -> impl NoirParser<Vec<(Pattern, UnresolvedType, AbiFEType)>> + 'a {
+) -> impl NoirParser<Vec<(Pattern, UnresolvedType, AbiVisibility)>> + 'a {
     let typ = parse_type(expr_parser).recover_via(parameter_recovery());
 
     let full_parameter = pattern()
@@ -200,13 +200,13 @@ fn nothing<T>() -> impl NoirParser<T> {
     one_of([]).map(|_| unreachable!())
 }
 
-fn self_parameter() -> impl NoirParser<(Pattern, UnresolvedType, AbiFEType)> {
+fn self_parameter() -> impl NoirParser<(Pattern, UnresolvedType, AbiVisibility)> {
     filter_map(move |span, found: Token| match found {
         Token::Ident(ref word) if word == "self" => {
             let ident = Ident::from_token(found, span);
             let path = Path::from_single("Self".to_owned(), span);
             let self_type = UnresolvedType::Named(path, vec![]);
-            Ok((Pattern::Identifier(ident), self_type, AbiFEType::Private))
+            Ok((Pattern::Identifier(ident), self_type, AbiVisibility::Private))
         }
         _ => Err(ParserError::expected_label("parameter".to_owned(), found, span)),
     })
@@ -451,10 +451,10 @@ where
     ))
 }
 
-fn optional_visibility() -> impl NoirParser<AbiFEType> {
+fn optional_visibility() -> impl NoirParser<AbiVisibility> {
     keyword(Keyword::Pub).or_not().map(|opt| match opt {
-        Some(_) => AbiFEType::Public,
-        None => AbiFEType::Private,
+        Some(_) => AbiVisibility::Public,
+        None => AbiVisibility::Private,
     })
 }
 


### PR DESCRIPTION
# Related issue(s)

Resolves (partially) https://github.com/noir-lang/noir/pull/554#pullrequestreview-1225777575

# Description

## Summary of changes

This PR removes the concept of visibility from `AbiType` and moves it onto an `AbiParameter` struct. The reasoning for this is that, due to nested types, we currently include the visibility of a parameter potentially many times.

Removing this duplication simplifies serialisation of the `Abi` struct as we no longer need to strip out these extraneous visibility fields.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
