### PR TITLE
delete unused blake2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,6 @@ dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff",
- "blake2",
  "cfg-if 1.0.0",
  "hex",
  "num-bigint",

--- a/crates/noir_field/Cargo.toml
+++ b/crates/noir_field/Cargo.toml
@@ -17,7 +17,6 @@ ark-bls12-381 = { version = "^0.3.0", optional = true, default-features = false,
 ] }
 ark-ff = { version = "^0.3.0", optional = true, default-features = false }
 
-blake2 = "0.9.1"
 cfg-if = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
 


### PR DESCRIPTION
# Related issue(s)

https://github.com/noir-lang/noir/issues/602#issue-1511279328

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

don't think blake2 is used in noir_field crate

## Summary of changes

delete blake 2 dependency

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

delete blake 2 dependency

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
