### PR TITLE
update deprecated `into_serde`/`from_serde`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 name = "fm"
 version = "0.1.0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "codespan-reporting",
  "tempfile",
  "wasm-bindgen",
@@ -987,6 +987,19 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "group"
@@ -1391,6 +1404,7 @@ dependencies = [
  "acvm",
  "console_error_panic_hook",
  "getrandom",
+ "gloo-utils",
  "js-sys",
  "noirc_driver",
  "wasm-bindgen",

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -17,6 +17,7 @@ noirc_driver = { path = "../noirc_driver", features = ["wasm"] }
 console_error_panic_hook = "*"
 
 wasm-bindgen = { version = "*", features = ["serde-serialize"] }
+gloo-utils = { version = "0.1", features = ["serde"] }
 
 getrandom = { version = "0.2.4", features = ["js"] }
 js-sys = "0.3.55"

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,4 +1,5 @@
 use acvm::acir::circuit::Circuit;
+use gloo_utils::format::JsValueSerdeExt;
 use std::path::PathBuf;
 use wasm_bindgen::prelude::*;
 
@@ -10,19 +11,19 @@ pub fn compile(src: String) -> JsValue {
     let language = acvm::Language::PLONKCSat { width: 3 };
     let path = PathBuf::from(src);
     let compiled_program = noirc_driver::Driver::compile_file(path, language);
-    JsValue::from_serde(&compiled_program).unwrap()
+    <JsValue as JsValueSerdeExt>::from_serde(&compiled_program).unwrap()
 }
 // Deserialises bytes into ACIR structure
 #[wasm_bindgen]
 pub fn acir_from_bytes(bytes: Vec<u8>) -> JsValue {
     console_error_panic_hook::set_once();
     let circuit = Circuit::from_bytes(&bytes);
-    JsValue::from_serde(&circuit).unwrap()
+    <JsValue as JsValueSerdeExt>::from_serde(&circuit).unwrap()
 }
 
 #[wasm_bindgen]
 pub fn acir_to_bytes(acir: JsValue) -> Vec<u8> {
     console_error_panic_hook::set_once();
-    let circuit: Circuit = acir.into_serde().unwrap();
+    let circuit: Circuit = JsValueSerdeExt::into_serde(&acir).unwrap();
     circuit.to_bytes()
 }


### PR DESCRIPTION
# Related issue(s)

The `wasm` crate is showing up in yellow with warnings.

# Description

## Summary of changes

I've updated the `from_serde` and `into_serde` method calls according to https://github.com/rustwasm/wasm-bindgen/issues/2770

```
use of deprecated associated function `wasm_bindgen::JsValue::into_serde`: causes dependency cycles, use `serde-wasm-bindgen` or `gloo_utils::format::JsValueSerdeExt` instead
```

I've chosen the `gloo_utils::format::JsValueSerdeExt` method as this is closest to the current implementation.

## Dependency additions / changes

None

## Test additions / changes

None

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
