### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/acir/src/circuit/gate.rs
+++ b/crates/acir/src/circuit/gate.rs
@@ -117,9 +117,9 @@ impl std::fmt::Debug for Gate {
                     r.witness_index()
                 )
             }
-            Gate::And(g) => write!(f, "{:?}", g),
-            Gate::Xor(g) => write!(f, "{:?}", g),
-            Gate::GadgetCall(g) => write!(f, "{:?}", g),
+            Gate::And(g) => write!(f, "{g:?}"),
+            Gate::Xor(g) => write!(f, "{g:?}"),
+            Gate::GadgetCall(g) => write!(f, "{g:?}"),
             Gate::Directive(Directive::Split { a, b, bit_size: _ }) => {
                 write!(
                     f,

--- a/crates/acvm/src/lib.rs
+++ b/crates/acvm/src/lib.rs
@@ -351,7 +351,7 @@ impl CustomGate for Language {
 pub fn hash_constraint_system(cs: &Circuit) {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
-    hasher.update(&format!("{:?}", cs));
+    hasher.update(format!("{cs:?}"));
     let result = hasher.finalize();
     println!("hash of constraint system : {:x?}", &result[..]);
 }

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -85,7 +85,7 @@ impl FileManager {
 
         let dir = self.path(anchor).to_path_buf();
 
-        candidate_files.push(dir.join(format!("{}.{}", mod_name, FILE_EXTENSION)));
+        candidate_files.push(dir.join(format!("{mod_name}.{FILE_EXTENSION}")));
 
         for candidate in candidate_files.iter() {
             if let Some(file_id) = self.add_file(candidate, FileType::Normal) {

--- a/crates/nargo/build.rs
+++ b/crates/nargo/build.rs
@@ -34,7 +34,7 @@ pub fn copy<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<(), std::i
             output_root.join(&src)
         };
         if fs::metadata(&dest).is_err() {
-            println!(" mkdir: {:?}", dest);
+            println!(" mkdir: {dest:?}");
             fs::create_dir_all(&dest)?;
         }
 
@@ -52,7 +52,7 @@ pub fn copy<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<(), std::i
                         fs::copy(&path, &dest_path)?;
                     }
                     None => {
-                        println!("failed: {:?}", path);
+                        println!("failed: {path:?}");
                     }
                 }
             }

--- a/crates/nargo/src/cli/build_cmd.rs
+++ b/crates/nargo/src/cli/build_cmd.rs
@@ -27,8 +27,8 @@ pub fn build_from_path<P: AsRef<Path>>(p: P, allow_warnings: bool) -> Result<(),
         //
         // Check for input.toml and verifier.toml
         let path_to_root = PathBuf::from(p.as_ref());
-        let path_to_prover_input = path_to_root.join(format!("{}.toml", PROVER_INPUT_FILE));
-        let path_to_verifier_input = path_to_root.join(format!("{}.toml", VERIFIER_INPUT_FILE));
+        let path_to_prover_input = path_to_root.join(format!("{PROVER_INPUT_FILE}.toml"));
+        let path_to_verifier_input = path_to_root.join(format!("{VERIFIER_INPUT_FILE}.toml"));
 
         // If they are not available, then create them and
         // populate them based on the ABI

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -48,7 +48,7 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
     circuit_path.push(circuit_name);
     circuit_path.set_extension(crate::cli::ACIR_EXT);
     let path = write_to_file(serialized.as_slice(), &circuit_path);
-    println!("Generated ACIR code into {}", path);
+    println!("Generated ACIR code into {path}");
     println!("{:?}", std::fs::canonicalize(&circuit_path));
 
     if generate_witness {

--- a/crates/nargo/src/cli/contract_cmd.rs
+++ b/crates/nargo/src/cli/contract_cmd.rs
@@ -22,6 +22,6 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     contract_path.set_extension("sol");
 
     let path = write_to_file(smart_contract_string.as_bytes(), &contract_path);
-    println!("Contract successfully created and located at {}", path);
+    println!("Contract successfully created and located at {path}");
     Ok(())
 }

--- a/crates/nargo/src/cli/gates_cmd.rs
+++ b/crates/nargo/src/cli/gates_cmd.rs
@@ -29,7 +29,7 @@ pub fn count_gates_with_path<P: AsRef<Path>>(
     println!("Total gates generated for language {:?}: {}\n", backend.np_language(), gates.len());
 
     let exact_circuit_size = backend.get_exact_circuit_size(compiled_program.circuit);
-    println!("\nBackend circuit size: {}\n", exact_circuit_size);
+    println!("\nBackend circuit size: {exact_circuit_size}\n");
 
     Ok(())
 }

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -101,7 +101,7 @@ pub fn start_cli() {
         Some("compile") => compile_cmd::run(matches),
         Some("verify") => verify_cmd::run(matches),
         Some("gates") => gates_cmd::run(matches),
-        Some(x) => Err(CliError::Generic(format!("unknown command : {}", x))),
+        Some(x) => Err(CliError::Generic(format!("unknown command : {x}"))),
         _ => unreachable!(),
     };
     if let Err(err) = result {
@@ -184,7 +184,7 @@ pub fn prove_and_verify(proof_name: &str, prg_dir: &Path, show_ssa: bool) -> boo
     ) {
         Ok(p) => p,
         Err(error) => {
-            println!("{}", error);
+            println!("{error}");
             return false;
         }
     };

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -89,7 +89,7 @@ fn solve_witness(
     let abi = compiled_program.abi.as_ref().unwrap();
     let encoded_inputs = abi.clone().encode(witness_map, true).map_err(|error| match error {
         AbiError::UndefinedInput(_) => {
-            CliError::Generic(format!("{} in the {}.toml file.", error, PROVER_INPUT_FILE))
+            CliError::Generic(format!("{error} in the {PROVER_INPUT_FILE}.toml file."))
         }
         _ => CliError::from(error),
     })?;
@@ -108,8 +108,7 @@ fn solve_witness(
 
     match solver_res {
         GateResolution::UnsupportedOpcode(opcode) => return Err(CliError::Generic(format!(
-                "backend does not currently support the {} opcode. ACVM does not currently fall back to arithmetic gates.",
-                opcode
+                "backend does not currently support the {opcode} opcode. ACVM does not currently fall back to arithmetic gates.",
         ))),
         GateResolution::UnsatisfiedConstrain => return Err(CliError::Generic(
                 "could not satisfy all constraints".to_string()
@@ -141,7 +140,7 @@ pub fn prove_with_path<P: AsRef<Path>>(
     println!("proof : {}", hex::encode(&proof));
 
     let path = write_to_file(hex::encode(&proof).as_bytes(), &proof_path);
-    println!("Proof successfully created and located at {}", path);
+    println!("Proof successfully created and located at {path}");
     println!("{:?}", std::fs::canonicalize(&proof_path));
 
     Ok(proof_path)

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -20,7 +20,7 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
 
     let allow_warnings = args.is_present("allow-warnings");
     let result = verify(proof_name, allow_warnings)?;
-    println!("Proof verified : {}\n", result);
+    println!("Proof verified : {result}\n");
     Ok(())
 }
 
@@ -63,7 +63,7 @@ fn verify_proof(
     let public_abi = compiled_program.abi.unwrap().public_abi();
     let public_inputs = public_abi.encode(&public_inputs, false).map_err(|error| match error {
         AbiError::UndefinedInput(_) => {
-            CliError::Generic(format!("{} in the {}.toml file.", error, VERIFIER_INPUT_FILE))
+            CliError::Generic(format!("{error} in the {VERIFIER_INPUT_FILE}.toml file."))
         }
         _ => CliError::from(error),
     })?;

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -18,7 +18,7 @@ impl CliError {
         stderr
             .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
             .expect("cannot set color for stderr in StandardStream");
-        writeln!(&mut stderr, "{}", self).expect("cannot write to stderr");
+        writeln!(&mut stderr, "{self}").expect("cannot write to stderr");
 
         std::process::exit(1)
     }
@@ -27,16 +27,16 @@ impl CliError {
 impl Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-                CliError::Generic(msg) => write!(f, "Error: {}", msg),
+                CliError::Generic(msg) => write!(f, "Error: {msg}"),
                 CliError::DestinationAlreadyExists(path) =>
                 write!(f, "Error: destination {} already exists", path.display()),
                 CliError::PathNotValid(path) => {
                     write!(f, "Error: {} is not a valid path", path.display())
                 }
                 CliError::ProofNotValid(hex_error) => {
-                    write!(f, "Error: could not parse proof data ({})", hex_error)
+                    write!(f, "Error: could not parse proof data ({hex_error})")
                 }
-                CliError::MissingTomlFile(path) => write!(f, "cannot find input file located at {:?}, run nargo build to generate the missing Prover and/or Verifier toml files", path),
+                CliError::MissingTomlFile(path) => write!(f, "cannot find input file located at {path:?}, run nargo build to generate the missing Prover and/or Verifier toml files"),
             }
     }
 }

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -82,8 +82,7 @@ impl<'a> Resolver<'a> {
 
             if crate_type == &CrateType::Binary {
                 return Err(CliError::Generic(format!(
-                    "{} is a binary package and so it cannot be depended upon. src : {:?}",
-                    dep_pkg_name, pkg_src
+                    "{dep_pkg_name} is a binary package and so it cannot be depended upon. src : {pkg_src:?}"
                 )));
             }
 

--- a/crates/noir_field/src/generic_ark.rs
+++ b/crates/noir_field/src/generic_ark.rs
@@ -17,16 +17,16 @@ impl<F: PrimeField> std::fmt::Display for FieldElement<F> {
         let s = big_f.bits();
         let big_s = BigUint::one() << s;
         if big_s == big_f {
-            return write!(f, "2^{}", s);
+            return write!(f, "2^{s}");
         }
         if big_f == BigUint::zero() {
             return write!(f, "0");
         }
         let big_minus = BigUint::from_bytes_be(&(self.neg()).to_bytes());
         if big_minus.to_string().len() < big_f.to_string().len() {
-            return write!(f, "-{}", big_minus);
+            return write!(f, "-{big_minus}");
         }
-        write!(f, "{}", big_f)
+        write!(f, "{big_f}")
     }
 }
 
@@ -47,13 +47,13 @@ impl<F: PrimeField> std::fmt::Debug for FieldElement<F> {
         let s = big_f.bits();
         let big_s = BigUint::one() << s;
         if big_s == big_f {
-            return write!(f, "2^{}", s);
+            return write!(f, "2^{s}");
         }
         if big_f.clone() % BigUint::from(2_u128).pow(32) == BigUint::zero() {
             return write!(f, "2^32*{}", big_f / BigUint::from(2_u128).pow(32));
         }
 
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -106,7 +106,7 @@ impl<'de, T: ark_ff::PrimeField> Deserialize<'de> for FieldElement<T> {
         let s = <&str>::deserialize(deserializer)?;
         match Self::from_hex(s) {
             Some(value) => Ok(value),
-            None => Err(serde::de::Error::custom(format!("Invalid hex for FieldElement: {}", s))),
+            None => Err(serde::de::Error::custom(format!("Invalid hex for FieldElement: {s}"))),
         }
     }
 }

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -12,18 +12,17 @@ impl std::fmt::Display for InputParserError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             InputParserError::ParseTomlMap(err_msg) => {
-                write!(f, "input.toml file is badly formed, could not parse, {}", err_msg)
+                write!(f, "input.toml file is badly formed, could not parse, {err_msg}")
             }
             InputParserError::ParseStr(err_msg) => write!(
                 f,
-                "Expected witness values to be integers, provided value causes `{}` error",
-                err_msg
+                "Expected witness values to be integers, provided value causes `{err_msg}` error"
             ),
             InputParserError::ParseHexStr(err_msg) => {
-                write!(f, "Could not parse hex value {}", err_msg)
+                write!(f, "Could not parse hex value {err_msg}")
             }
             InputParserError::DuplicateVariableName(err_msg) => {
-                write!(f, "duplicate variable name {}", err_msg)
+                write!(f, "duplicate variable name {err_msg}")
             }
         }
     }
@@ -47,7 +46,7 @@ impl std::fmt::Display for AbiError {
             match self {
                 AbiError::Generic(msg) => msg.clone(),
                 AbiError::UnexpectedParams(unexpected_params) =>
-                    format!("Received parameters not expected by ABI: {:?}", unexpected_params),
+                    format!("Received parameters not expected by ABI: {unexpected_params:?}"),
                 AbiError::TypeMismatch { param, value } => {
                     format!(
                         "The parameter {} is expected to be a {:?} but found incompatible value {:?}",
@@ -55,15 +54,14 @@ impl std::fmt::Display for AbiError {
                     )
                 }
                 AbiError::MissingParam(name) => {
-                    format!("ABI expects the parameter `{}`, but this was not found", name)
+                    format!("ABI expects the parameter `{name}`, but this was not found")
                 }
                 AbiError::UndefinedInput(name) => {
-                    format!("Input value `{}` is not defined", name)
+                    format!("Input value `{name}` is not defined")
                 }
                 AbiError::UnexpectedInputLength { expected, actual } => {
                     format!(
-                        "ABI specifies an input of length {} but received input of length {}",
-                        expected, actual
+                        "ABI specifies an input of length {expected} but received input of length {actual}"
                     )
                 }
             }

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -179,7 +179,7 @@ impl Abi {
             InputValue::Vec(vec_elem) => encoded_value.extend(vec_elem),
             InputValue::Struct(object) => {
                 for (field_name, value) in object {
-                    let new_name = format!("{}.{}", param_name, field_name);
+                    let new_name = format!("{param_name}.{field_name}");
                     encoded_value.extend(Self::encode_value(value, &new_name)?)
                 }
             }

--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -75,7 +75,7 @@ impl std::fmt::Display for CustomDiagnostic {
         }
 
         for note in &self.notes {
-            write!(f, "\nnote: {}", note)?;
+            write!(f, "\nnote: {note}")?;
         }
 
         Ok(())
@@ -154,8 +154,7 @@ impl Reporter {
 
             writer.set_color(ColorSpec::new().set_fg(Some(Color::Red))).unwrap();
 
-            writeln!(&mut writer, "error: aborting due to {} previous errors", error_count)
-                .unwrap();
+            writeln!(&mut writer, "error: aborting due to {error_count} previous errors").unwrap();
 
             std::process::exit(1);
         }

--- a/crates/noirc_evaluator/src/errors.rs
+++ b/crates/noirc_evaluator/src/errors.rs
@@ -61,7 +61,7 @@ pub enum RuntimeErrorKind {
 impl RuntimeErrorKind {
     pub fn expected_type(expected_type: &'static str, found_type: &str) -> RuntimeErrorKind {
         RuntimeErrorKind::UnstructuredError {
-            message: format!("Expected a {}, but found {}", expected_type, found_type),
+            message: format!("Expected a {expected_type}, but found {found_type}"),
         }
     }
 }
@@ -73,12 +73,12 @@ impl DiagnosableError for RuntimeError {
         match &self.kind {
             RuntimeErrorKind::ArrayOutOfBounds { index, bound } => Diagnostic::simple_error(
                 "index out of bounds".to_string(),
-                format!("out of bounds error, index is {} but length is {}", index, bound),
+                format!("out of bounds error, index is {index} but length is {bound}"),
                 span,
             ),
             RuntimeErrorKind::ArrayNotFound { found_type, name } => Diagnostic::simple_error(
-                format!("cannot find an array with name {}", name),
-                format!("{} has type", found_type),
+                format!("cannot find an array with name {name}"),
+                format!("{found_type} has type"),
                 span,
             ),
             RuntimeErrorKind::UnstructuredError { message } => {
@@ -87,7 +87,7 @@ impl DiagnosableError for RuntimeError {
             RuntimeErrorKind::UnsupportedOp { op, first_type, second_type } => {
                 Diagnostic::simple_error(
                     "unsupported operation".to_owned(),
-                    format!("no support for {} with types {} and {}", op, first_type, second_type),
+                    format!("no support for {op} with types {first_type} and {second_type}"),
                     span,
                 )
             }
@@ -95,7 +95,7 @@ impl DiagnosableError for RuntimeError {
             RuntimeErrorKind::Unimplemented(message) => Diagnostic::from_message(message),
             RuntimeErrorKind::FunctionNonMainContext { func_name } => Diagnostic::simple_error(
                 "cannot call function outside of main".to_owned(),
-                format!("function {} can only be called in main", func_name),
+                format!("function {func_name} can only be called in main"),
                 span,
             ),
         }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -146,7 +146,7 @@ impl Evaluator {
             AbiType::Struct { fields } => {
                 let mut struct_witnesses: BTreeMap<String, Vec<Witness>> = BTreeMap::new();
                 let new_fields = btree_map(fields, |(inner_name, value)| {
-                    let new_name = format!("{}.{}", name, inner_name);
+                    let new_name = format!("{name}.{inner_name}");
                     (new_name, value.clone())
                 });
                 self.generate_struct_witnesses(&mut struct_witnesses, visibility, &new_fields)?;
@@ -187,7 +187,7 @@ impl Evaluator {
                 AbiType::Struct { fields, .. } => {
                     let mut new_fields: BTreeMap<String, AbiType> = BTreeMap::new();
                     for (inner_name, value) in fields {
-                        let new_name = format!("{}.{}", name, inner_name);
+                        let new_name = format!("{name}.{inner_name}");
                         new_fields.insert(new_name, value.clone());
                     }
                     self.generate_struct_witnesses(struct_witnesses, visibility, &new_fields)?

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -352,7 +352,7 @@ impl Acir {
 
     pub fn print_circuit(gates: &[Gate]) {
         for gate in gates {
-            println!("{:?}", gate);
+            println!("{gate:?}");
         }
     }
 
@@ -1281,7 +1281,7 @@ fn bound_check_with_offset(
 
 fn try_range_constraint(w: Witness, bits: u32, evaluator: &mut Evaluator) {
     if let Err(err) = range_constraint(w, bits, evaluator) {
-        eprintln!("{}", err);
+        eprintln!("{err}");
     }
 }
 

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -184,7 +184,7 @@ impl IRGenerator {
         witnesses: BTreeMap<String, Vec<acvm::acir::native_types::Witness>>,
     ) -> Value {
         let values = vecmap(fields, |(name, field_typ)| {
-            let new_name = format!("{}.{}", struct_name, name);
+            let new_name = format!("{struct_name}.{name}");
             match field_typ {
                 noirc_abi::AbiType::Array { length, typ } => {
                     let v_id =
@@ -192,7 +192,7 @@ impl IRGenerator {
                     Value::Single(v_id)
                 }
                 noirc_abi::AbiType::Struct { fields, .. } => {
-                    let new_name = format!("{}.{}", struct_name, name);
+                    let new_name = format!("{struct_name}.{name}");
                     self.abi_struct(&new_name, None, fields, witnesses.clone())
                 }
                 _ => {
@@ -320,7 +320,7 @@ impl IRGenerator {
         match typ {
             Type::Tuple(fields) => {
                 let values = vecmap(fields.iter().enumerate(), |(i, field)| {
-                    let name = format!("{}.{}", base_name, i);
+                    let name = format!("{base_name}.{i}");
                     self.create_new_value(field, &name, None)
                 });
                 self.insert_new_struct(def, values)
@@ -399,7 +399,7 @@ impl IRGenerator {
                     .into_iter()
                     .enumerate()
                     .map(|(i, value)| {
-                        let name = format!("{}.{}", basename, i);
+                        let name = format!("{basename}.{i}");
                         self.bind_fresh_pattern(&name, value)
                     })
                     .collect::<Result<Vec<_>, _>>()?;

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -297,7 +297,7 @@ impl IRGenerator {
         let (len, elem_type) = get_result_type(op);
         let result_type = if len > 1 {
             //We create an array that will contain the result and set the res_type to point to that array
-            let result_index = self.new_array(&format!("{}_result", op), elem_type, len, None).1;
+            let result_index = self.new_array(&format!("{op}_result"), elem_type, len, None).1;
             node::ObjectType::Pointer(result_index)
         } else {
             elem_type

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -113,7 +113,7 @@ fn truncate(
     // get type
     let obj = &ctx[obj_id];
     let obj_type = obj.get_type();
-    let obj_name = format!("{}", obj);
+    let obj_name = format!("{obj}");
     //ensure truncate is needed:
     let v_max = &max_map[&obj_id];
 
@@ -492,7 +492,7 @@ fn get_max_value(ins: &Instruction, max_map: &mut HashMap<NodeId, BigUint>) -> B
                 OPCODE::SchnorrVerify
                 | OPCODE::EcdsaSecp256k1
                 | acvm::acir::OPCODE::MerkleMembership => BigUint::one(), //verify returns 0 or 1
-                _ => todo!("max value must be implemented for opcode {} ", opcode),
+                _ => todo!("max value must be implemented for opcode {opcode} "),
             }
         }
     };

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -34,9 +34,9 @@ impl std::fmt::Display for Variable {
 impl std::fmt::Display for NodeObj {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            NodeObj::Obj(o) => write!(f, "{}", o),
-            NodeObj::Instr(i) => write!(f, "{}", i),
-            NodeObj::Const(c) => write!(f, "{}", c),
+            NodeObj::Obj(o) => write!(f, "{o}"),
+            NodeObj::Instr(i) => write!(f, "{i}"),
+            NodeObj::Const(c) => write!(f, "{c}"),
         }
     }
 }

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -453,11 +453,11 @@ impl Display for Literal {
                 write!(f, "[{}]", contents.join(", "))
             }
             Literal::Array(ArrayLiteral::Repeated { repeated_element, length }) => {
-                write!(f, "[{}; {}]", repeated_element, length)
+                write!(f, "[{repeated_element}; {length}]")
             }
             Literal::Bool(boolean) => write!(f, "{}", if *boolean { "true" } else { "false" }),
             Literal::Integer(integer) => write!(f, "{}", integer.to_u128()),
-            Literal::Str(string) => write!(f, "\"{}\"", string),
+            Literal::Str(string) => write!(f, "\"{string}\""),
         }
     }
 }
@@ -468,7 +468,7 @@ impl Display for BlockExpression {
         for statement in &self.0 {
             let statement = statement.to_string();
             for line in statement.lines() {
-                writeln!(f, "    {}", line)?;
+                writeln!(f, "    {line}")?;
             }
         }
         write!(f, "}}")
@@ -518,11 +518,8 @@ impl Display for CastExpression {
 
 impl Display for ConstructorExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let fields = self
-            .fields
-            .iter()
-            .map(|(ident, expr)| format!("{}: {}", ident, expr))
-            .collect::<Vec<_>>();
+        let fields =
+            self.fields.iter().map(|(ident, expr)| format!("{ident}: {expr}")).collect::<Vec<_>>();
 
         write!(f, "({} {{ {} }})", self.type_name, fields.join(", "))
     }
@@ -577,7 +574,7 @@ impl Display for IfExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "if {} {}", self.condition, self.consequence)?;
         if let Some(alternative) = &self.alternative {
-            write!(f, " else {}", alternative)?;
+            write!(f, " else {alternative}")?;
         }
         Ok(())
     }
@@ -586,11 +583,11 @@ impl Display for IfExpression {
 impl Display for FunctionDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(attribute) = &self.attribute {
-            writeln!(f, "{}", attribute)?;
+            writeln!(f, "{attribute}")?;
         }
 
         let parameters = vecmap(&self.parameters, |(name, r#type, visibility)| {
-            format!("{}: {} {}", name, visibility, r#type)
+            format!("{name}: {visibility} {type}")
         });
 
         write!(

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -46,19 +46,19 @@ impl std::fmt::Display for UnresolvedType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use UnresolvedType::*;
         match self {
-            FieldElement(is_const) => write!(f, "{}Field", is_const),
+            FieldElement(is_const) => write!(f, "{is_const}Field"),
             Array(len, typ) => match len {
-                None => write!(f, "[{}]", typ),
-                Some(len) => write!(f, "[{}; {}]", typ, len),
+                None => write!(f, "[{typ}]"),
+                Some(len) => write!(f, "[{typ}; {len}]"),
             },
             Integer(is_const, sign, num_bits) => match sign {
-                Signedness::Signed => write!(f, "{}i{}", is_const, num_bits),
-                Signedness::Unsigned => write!(f, "{}u{}", is_const, num_bits),
+                Signedness::Signed => write!(f, "{is_const}i{num_bits}"),
+                Signedness::Unsigned => write!(f, "{is_const}u{num_bits}"),
             },
             Named(s, args) => {
                 let args = vecmap(args, ToString::to_string);
                 if args.is_empty() {
-                    write!(f, "{}", s)
+                    write!(f, "{s}")
                 } else {
                     write!(f, "{}<{}>", s, args.join(", "))
                 }
@@ -67,7 +67,7 @@ impl std::fmt::Display for UnresolvedType {
                 let elements = vecmap(elements, ToString::to_string);
                 write!(f, "({})", elements.join(", "))
             }
-            Bool(is_const) => write!(f, "{}bool", is_const),
+            Bool(is_const) => write!(f, "{is_const}bool"),
             Unit => write!(f, "()"),
             Error => write!(f, "error"),
             Unspecified => write!(f, "unspecified"),

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -348,7 +348,7 @@ impl Display for Statement {
             Statement::Constrain(constrain) => constrain.fmt(f),
             Statement::Expression(expression) => expression.fmt(f),
             Statement::Assign(assign) => assign.fmt(f),
-            Statement::Semi(semi) => write!(f, "{};", semi),
+            Statement::Semi(semi) => write!(f, "{semi};"),
             Statement::Error => write!(f, "Error"),
         }
     }
@@ -376,8 +376,8 @@ impl Display for LValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LValue::Ident(ident) => ident.fmt(f),
-            LValue::MemberAccess { object, field_name } => write!(f, "{}.{}", object, field_name),
-            LValue::Index { array, index } => write!(f, "{}[{}]", array, index),
+            LValue::MemberAccess { object, field_name } => write!(f, "{object}.{field_name}"),
+            LValue::Index { array, index } => write!(f, "{array}[{index}]"),
         }
     }
 }
@@ -403,7 +403,7 @@ impl Display for ImportStatement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "use {}", self.path)?;
         if let Some(alias) = &self.alias {
-            write!(f, " as {}", alias)?;
+            write!(f, " as {alias}")?;
         }
         Ok(())
     }
@@ -413,13 +413,13 @@ impl Display for Pattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Pattern::Identifier(name) => name.fmt(f),
-            Pattern::Mutable(name, _) => write!(f, "mut {}", name),
+            Pattern::Mutable(name, _) => write!(f, "mut {name}"),
             Pattern::Tuple(fields, _) => {
                 let fields = vecmap(fields, ToString::to_string);
                 write!(f, "({})", fields.join(", "))
             }
             Pattern::Struct(typename, fields, _) => {
-                let fields = vecmap(fields, |(name, pattern)| format!("{}: {}", name, pattern));
+                let fields = vecmap(fields, |(name, pattern)| format!("{name}: {pattern}"));
                 write!(f, "{} {{ {} }}", typename, fields.join(", "))
             }
         }

--- a/crates/noirc_frontend/src/ast/structure.rs
+++ b/crates/noirc_frontend/src/ast/structure.rs
@@ -33,7 +33,7 @@ impl Display for NoirStruct {
         writeln!(f, "struct {} {{", self.name)?;
 
         for (name, typ) in self.fields.iter() {
-            writeln!(f, "    {}: {},", name, typ)?;
+            writeln!(f, "    {name}: {typ},")?;
         }
 
         write!(f, "}}")
@@ -47,7 +47,7 @@ impl Display for NoirImpl {
         for method in self.methods.iter() {
             let method = method.to_string();
             for line in method.lines() {
-                writeln!(f, "    {}", line)?;
+                writeln!(f, "    {line}")?;
             }
         }
 

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -22,8 +22,8 @@ struct ModCollector<'a> {
 }
 
 /// Walk a module and collect it's definitions
-pub fn collect_defs<'a>(
-    def_collector: &'a mut DefCollector,
+pub fn collect_defs(
+    def_collector: &mut DefCollector,
     ast: ParsedModule,
     file_id: FileId,
     module_id: LocalModuleId,

--- a/crates/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/errors.rs
@@ -29,7 +29,7 @@ impl DiagnosableError for DefCollectorErrorKind {
                 let func_name = &first_def.0.contents;
 
                 let mut diag = Diagnostic::simple_error(
-                    format!("duplicate definitions of {} function found", func_name),
+                    format!("duplicate definitions of {func_name} function found"),
                     "first definition found here".to_string(),
                     first_span,
                 );
@@ -42,7 +42,7 @@ impl DiagnosableError for DefCollectorErrorKind {
                 let mod_name = &first_def.0.contents;
 
                 let mut diag = Diagnostic::simple_error(
-                    format!("module {} has been declared twice", mod_name),
+                    format!("module {mod_name} has been declared twice"),
                     "first declaration found here".to_string(),
                     first_span,
                 );
@@ -55,7 +55,7 @@ impl DiagnosableError for DefCollectorErrorKind {
                 let import_name = &first_def.0.contents;
 
                 let mut diag = Diagnostic::simple_error(
-                    format!("the name `{}` is defined multiple times", import_name),
+                    format!("the name `{import_name}` is defined multiple times"),
                     "first import found here".to_string(),
                     first_span,
                 );
@@ -68,7 +68,7 @@ impl DiagnosableError for DefCollectorErrorKind {
                 let import_name = &first_def.0.contents;
 
                 let mut diag = Diagnostic::simple_error(
-                    format!("the name `{}` is defined multiple times", import_name),
+                    format!("the name `{import_name}` is defined multiple times"),
                     "first global declaration found here".to_string(),
                     first_span,
                 );
@@ -80,7 +80,7 @@ impl DiagnosableError for DefCollectorErrorKind {
                 let mod_name = &mod_name.0.contents;
 
                 Diagnostic::simple_error(
-                    format!("could not resolve module `{}` ", mod_name),
+                    format!("could not resolve module `{mod_name}` "),
                     String::new(),
                     span,
                 )

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -48,7 +48,7 @@ impl ResolverError {
         match self {
             ResolverError::DuplicateDefinition { name, first_span, second_span } => {
                 let mut diag = Diagnostic::simple_error(
-                    format!("duplicate definitions of {} found", name),
+                    format!("duplicate definitions of {name} found"),
                     "first definition found here".to_string(),
                     first_span,
                 );
@@ -59,13 +59,13 @@ impl ResolverError {
                 let name = &ident.0.contents;
 
                 Diagnostic::simple_warning(
-                    format!("unused variable {}", name),
+                    format!("unused variable {name}"),
                     "unused variable ".to_string(),
                     ident.span(),
                 )
             }
             ResolverError::VariableNotDeclared { name, span } => Diagnostic::simple_error(
-                format!("cannot find `{}` in this scope ", name),
+                format!("cannot find `{name}` in this scope "),
                 "not found in this scope".to_string(),
                 span,
             ),
@@ -76,7 +76,7 @@ impl ResolverError {
             ),
             ResolverError::PathUnresolved { span, name, segment } => {
                 let mut diag = Diagnostic::simple_error(
-                    format!("could not resolve path '{}'", name),
+                    format!("could not resolve path '{name}'"),
                     String::new(),
                     span,
                 );
@@ -91,24 +91,24 @@ impl ResolverError {
                 diag
             }
             ResolverError::Expected { span, expected, got } => Diagnostic::simple_error(
-                format!("expected {} got {}", expected, got),
+                format!("expected {expected} got {got}"),
                 String::new(),
                 span,
             ),
             ResolverError::DuplicateField { field } => Diagnostic::simple_error(
-                format!("duplicate field {}", field),
+                format!("duplicate field {field}"),
                 String::new(),
                 field.span(),
             ),
             ResolverError::NoSuchField { field, struct_definition } => {
                 let mut error = Diagnostic::simple_error(
-                    format!("no such field {} defined in struct {}", field, struct_definition),
+                    format!("no such field {field} defined in struct {struct_definition}"),
                     String::new(),
                     field.span(),
                 );
 
                 error.add_secondary(
-                    format!("{} defined here with no {} field", struct_definition, field),
+                    format!("{struct_definition} defined here with no {field} field"),
                     struct_definition.span(),
                 );
                 error
@@ -118,13 +118,13 @@ impl ResolverError {
                 let missing_fields = missing_fields.join(", ");
 
                 let mut error = Diagnostic::simple_error(
-                    format!("missing field{}: {}", plural, missing_fields),
+                    format!("missing field{plural}: {missing_fields}"),
                     String::new(),
                     span,
                 );
 
                 error.add_secondary(
-                    format!("{} defined here", struct_definition),
+                    format!("{struct_definition} defined here"),
                     struct_definition.span(),
                 );
                 error
@@ -145,7 +145,7 @@ impl ResolverError {
                 let name = &ident.0.contents;
 
                 let mut diag = Diagnostic::simple_error(
-                    format!("unnecessary pub keyword on parameter for function {}", name),
+                    format!("unnecessary pub keyword on parameter for function {name}"),
                     "unnecessary pub parameter".to_string(),
                     ident.0.span(),
                 );
@@ -157,7 +157,7 @@ impl ResolverError {
                 let name = &ident.0.contents;
 
                 let mut diag = Diagnostic::simple_error(
-                    format!("missing pub keyword on return type of function {}", name),
+                    format!("missing pub keyword on return type of function {name}"),
                     "missing pub on return type".to_string(),
                     ident.0.span(),
                 );
@@ -166,14 +166,13 @@ impl ResolverError {
                 diag
             }
             ResolverError::ExpectedComptimeVariable { name, span } => Diagnostic::simple_error(
-                format!("expected constant variable where non-constant variable {} was used", name),
+                format!("expected constant variable where non-constant variable {name} was used"),
                 "expected const variable".to_string(),
                 span,
             ),
             ResolverError::MissingRhsExpr { name, span } => Diagnostic::simple_error(
                 format!(
-                    "no expression specifying the value stored by the constant variable {}",
-                    name
+                    "no expression specifying the value stored by the constant variable {name}"
                 ),
                 "expected expression to be stored for let statement".to_string(),
                 span,

--- a/crates/noirc_frontend/src/hir/resolution/import.rs
+++ b/crates/noirc_frontend/src/hir/resolution/import.rs
@@ -160,7 +160,7 @@ fn resolve_external_dep(
     let dep_module = current_def_map
         .extern_prelude
         .get(&crate_name)
-        .unwrap_or_else(|| panic!("error reporter: could not find crate {}", crate_name));
+        .unwrap_or_else(|| panic!("error reporter: could not find crate {crate_name}"));
 
     // Create an import directive for the dependency crate
     let path_without_crate_name = &path[1..]; // XXX: This will panic if the path is of the form `use dep::std` Ideal algorithm will not distinguish between crate and module

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -337,7 +337,7 @@ impl<'a> Resolver<'a> {
                 }
             }
         } else {
-            let stmt_id = self.lookup_global(path.clone());
+            let stmt_id = self.lookup_global(path);
             let hir_let_stmt = self.interner.let_statement(&stmt_id);
             hir_let_stmt.ident()
         }

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -48,13 +48,13 @@ impl TypeCheckError {
                 diag
             }
             TypeCheckError::OpCannotBeUsed { op, place, span } => Diagnostic::simple_error(
-                format!("The operator {:?} cannot be used in a {}", op, place),
+                format!("The operator {op:?} cannot be used in a {place}"),
                 String::new(),
                 span,
             ),
             TypeCheckError::TypeMismatch { expected_typ, expr_typ, expr_span } => {
                 Diagnostic::simple_error(
-                    format!("Expected type {}, found type {}", expected_typ, expr_typ),
+                    format!("Expected type {expected_typ}, found type {expr_typ}"),
                     String::new(),
                     expr_span,
                 )
@@ -69,18 +69,17 @@ impl TypeCheckError {
             } => {
                 let mut diag = Diagnostic::simple_error(
                     format!(
-                        "Non homogeneous array, different element types found at indices ({},{})",
-                        first_index, second_index
+                        "Non homogeneous array, different element types found at indices ({first_index},{second_index})"
                     ),
-                    format!("Found type {}", first_type),
+                    format!("Found type {first_type}"),
                     first_span,
                 );
-                diag.add_secondary(format!("but then found type {}", second_type), second_span);
+                diag.add_secondary(format!("but then found type {second_type}"), second_span);
                 diag
             }
             TypeCheckError::ArityMisMatch { expected, found, span } => {
                 let plural = if expected == 1 { "" } else { "s" };
-                let msg = format!("Expected {} argument{}, but found {}", expected, plural, found);
+                let msg = format!("Expected {expected} argument{plural}, but found {found}");
                 Diagnostic::simple_error(msg, String::new(), span)
             }
             TypeCheckError::Unstructured { msg, span } => {
@@ -88,7 +87,7 @@ impl TypeCheckError {
             }
             TypeCheckError::PublicReturnType { typ, span } => Diagnostic::simple_error(
                 "Functions cannot declare a public return type".to_string(),
-                format!("return type is {}", typ),
+                format!("return type is {typ}"),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -239,7 +239,7 @@ fn type_check_index_expression(
         // Specialize the error in the case the user has a Field, just not a comptime one.
         if matches!(index_type, Type::FieldElement(..)) {
             TypeCheckError::Unstructured {
-                msg: format!("Array index must be known at compile-time, but here a non-comptime {} was used instead", index_type),
+                msg: format!("Array index must be known at compile-time, but here a non-comptime {index_type} was used instead"),
                 span,
             }
         } else {
@@ -281,8 +281,7 @@ fn check_cast(from: Type, to: Type, span: Span, errors: &mut Vec<TypeCheckError>
         Type::Error => return Type::Error,
         from => {
             let msg = format!(
-                "Cannot cast type {}, 'as' is only for primitive field or integer types",
-                from
+                "Cannot cast type {from}, 'as' is only for primitive field or integer types",
             );
             errors.push(TypeCheckError::Unstructured { msg, span });
             return Type::Error;
@@ -340,8 +339,7 @@ fn lookup_method(
                     errors.push(TypeCheckError::Unstructured {
                         span: interner.expr_span(expr_id),
                         msg: format!(
-                            "No method named '{}' found for type '{}'",
-                            method_name, object_type
+                            "No method named '{method_name}' found for type '{object_type}'",
                         ),
                     });
                     None
@@ -357,7 +355,7 @@ fn lookup_method(
         other => {
             errors.push(TypeCheckError::Unstructured {
                 span: interner.expr_span(expr_id),
-                msg: format!("Type '{}' must be a struct type to call methods on it", other),
+                msg: format!("Type '{other}' must be a struct type to call methods on it"),
             });
             None
         }
@@ -432,7 +430,7 @@ fn bind_function_type(
         Type::Error => Type::Error,
         other => {
             errors.push(TypeCheckError::Unstructured {
-                msg: format!("Expected a function, but found a(n) {}", other),
+                msg: format!("Expected a function, but found a(n) {other}"),
                 span,
             });
             Type::Error
@@ -472,10 +470,10 @@ pub fn infix_operand_type_rules(
     match (lhs_type, rhs_type)  {
         (Integer(comptime_x, sign_x, bit_width_x), Integer(comptime_y, sign_y, bit_width_y)) => {
             if sign_x != sign_y {
-                return Err(format!("Integers must have the same signedness LHS is {:?}, RHS is {:?} ", sign_x, sign_y))
+                return Err(format!("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?} "))
             }
             if bit_width_x != bit_width_y {
-                return Err(format!("Integers must have the same bit width LHS is {}, RHS is {} ", bit_width_x, bit_width_y))
+                return Err(format!("Integers must have the same bit width LHS is {bit_width_x}, RHS is {bit_width_y} "))
             }
             let comptime = comptime_x.and(comptime_y, op.location.span);
             Ok(Integer(comptime, *sign_x, *bit_width_x))
@@ -491,11 +489,11 @@ pub fn infix_operand_type_rules(
             if other.try_bind_to_polymorphic_int(int, comptime, true, op.location.span).is_ok() || other == &Type::Error {
                 Ok(other.clone())
             } else {
-                Err(format!("Types in a binary operation should match, but found {} and {}", lhs_type, rhs_type))
+                Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
             }
         }
         (Integer(..), typ) | (typ,Integer(..)) => {
-            Err(format!("Integer cannot be used with type {}", typ))
+            Err(format!("Integer cannot be used with type {typ}"))
         }
         // These types are not supported in binary operations
         (Array(..), _) | (_, Array(..)) => Err("Arrays cannot be used in an infix operation".to_string()),
@@ -514,7 +512,7 @@ pub fn infix_operand_type_rules(
 
         (Bool(comptime_x), Bool(comptime_y)) => Ok(Bool(comptime_x.and(comptime_y, op.location.span))),
 
-        (lhs, rhs) => Err(format!("Unsupported types for binary operation: {} and {}", lhs, rhs)),
+        (lhs, rhs) => Err(format!("Unsupported types for binary operation: {lhs} and {rhs}")),
     }
 }
 
@@ -627,7 +625,7 @@ pub fn check_member_access(
 
     if lhs_type != Type::Error {
         errors.push(TypeCheckError::Unstructured {
-            msg: format!("Type {} has no member named {}", lhs_type, access.rhs),
+            msg: format!("Type {lhs_type} has no member named {}", access.rhs),
             span: interner.expr_span(&access.lhs),
         });
     }
@@ -646,10 +644,10 @@ pub fn comparator_operand_type_rules(
     match (lhs_type, rhs_type)  {
         (Integer(comptime_x, sign_x, bit_width_x), Integer(comptime_y, sign_y, bit_width_y)) => {
             if sign_x != sign_y {
-                return Err(format!("Integers must have the same signedness LHS is {:?}, RHS is {:?} ", sign_x, sign_y))
+                return Err(format!("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?} "))
             }
             if bit_width_x != bit_width_y {
-                return Err(format!("Integers must have the same bit width LHS is {}, RHS is {} ", bit_width_x, bit_width_y))
+                return Err(format!("Integers must have the same bit width LHS is {bit_width_x}, RHS is {bit_width_y} "))
             }
             let comptime = comptime_x.and(comptime_y, op.location.span);
             Ok(Bool(comptime))
@@ -665,11 +663,11 @@ pub fn comparator_operand_type_rules(
             if other.try_bind_to_polymorphic_int(int, comptime, true, op.location.span).is_ok() || other == &Type::Error {
                 Ok(Bool(comptime.clone()))
             } else {
-                Err(format!("Types in a binary operation should match, but found {} and {}", lhs_type, rhs_type))
+                Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
             }
         }
         (Integer(..), typ) | (typ,Integer(..)) => {
-            Err(format!("Integer cannot be used with type {}", typ))
+            Err(format!("Integer cannot be used with type {typ}"))
         }
         (FieldElement(comptime_x), FieldElement(comptime_y)) => {
             match op.kind {
@@ -696,14 +694,13 @@ pub fn comparator_operand_type_rules(
         (Array(x_size, x_type), Array(y_size, y_type)) if matches!(op.kind, Equal | NotEqual) => {
             x_type.unify(y_type, op.location.span, errors, || {
                 TypeCheckError::Unstructured {
-                    msg: format!("Cannot compare {} and {}, the array element types differ", lhs_type, rhs_type),
+                    msg: format!("Cannot compare {lhs_type} and {rhs_type}, the array element types differ"),
                     span: op.location.span,
                 }
             });
 
             if x_size != y_size {
-                return Err(format!("Can only compare arrays of the same length. Here LHS is of length {}, and RHS is {} ", 
-                    x_size, y_size));
+                return Err(format!("Can only compare arrays of the same length. Here LHS is of length {x_size}, and RHS is {y_size} "));
             }
 
             // We could check if all elements of all arrays are comptime but I am lazy
@@ -713,8 +710,8 @@ pub fn comparator_operand_type_rules(
             if binding_a == binding_b {
                 return Ok(Bool(Comptime::No(Some(op.location.span))));
             }
-            Err(format!("Unsupported types for comparison: {} and {}", name_a, name_b))
+            Err(format!("Unsupported types for comparison: {name_a} and {name_b}"))
         }
-        (lhs, rhs) => Err(format!("Unsupported types for comparison: {} and {}", lhs, rhs)),
+        (lhs, rhs) => Err(format!("Unsupported types for comparison: {lhs} and {rhs}")),
     }
 }

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -121,8 +121,7 @@ fn type_check_assign_stmt(
     let span = interner.expr_span(&assign_stmt.expression);
     expr_type.make_subtype_of(&lvalue_type, span, errors, || {
         let msg = format!(
-            "Cannot assign an expression of type {} to a value of type {}",
-            expr_type, lvalue_type
+            "Cannot assign an expression of type {expr_type} to a value of type {lvalue_type}"
         );
 
         TypeCheckError::Unstructured { msg, span }
@@ -161,7 +160,7 @@ fn type_check_lvalue(
 
             let mut error = |typ| {
                 errors.push(TypeCheckError::Unstructured {
-                    msg: format!("Type {} has no member named {}", typ, field_name),
+                    msg: format!("Type {typ} has no member named {field_name}"),
                     span: field_name.span(),
                 });
                 (Type::Error, None)

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -74,7 +74,7 @@ impl HirPattern {
             HirPattern::Tuple(fields, _) => {
                 Box::new(fields.iter().enumerate().map(|(i, field)| (i.to_string(), field)))
             }
-            other => panic!("Tried to iterate over the fields of '{:?}', which has none", other),
+            other => panic!("Tried to iterate over the fields of '{other:?}', which has none"),
         }
     }
 }

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -446,15 +446,15 @@ impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Type::FieldElement(comptime) => {
-                write!(f, "{}Field", comptime)
+                write!(f, "{comptime}Field")
             }
             Type::Array(len, typ) => match len.array_length() {
-                Some(len) => write!(f, "[{}; {}]", typ, len),
-                None => write!(f, "[{}]", typ),
+                Some(len) => write!(f, "[{typ}; {len}]"),
+                None => write!(f, "[{typ}]"),
             },
             Type::Integer(comptime, sign, num_bits) => match sign {
-                Signedness::Signed => write!(f, "{}i{}", comptime, num_bits),
-                Signedness::Unsigned => write!(f, "{}u{}", comptime, num_bits),
+                Signedness::Signed => write!(f, "{comptime}i{num_bits}"),
+                Signedness::Unsigned => write!(f, "{comptime}u{num_bits}"),
             },
             Type::PolymorphicInteger(_, binding) => {
                 if let TypeBinding::Unbound(_) = &*binding.borrow() {
@@ -478,14 +478,14 @@ impl std::fmt::Display for Type {
                 let elements = vecmap(elements, ToString::to_string);
                 write!(f, "({})", elements.join(", "))
             }
-            Type::Bool(comptime) => write!(f, "{}bool", comptime),
+            Type::Bool(comptime) => write!(f, "{comptime}bool"),
             Type::Unit => write!(f, "()"),
             Type::Error => write!(f, "error"),
             Type::TypeVariable(id) => write!(f, "{}", id.borrow()),
             Type::NamedGeneric(binding, name) => match &*binding.borrow() {
                 TypeBinding::Bound(binding) => binding.fmt(f),
                 TypeBinding::Unbound(_) if name.is_empty() => write!(f, "_"),
-                TypeBinding::Unbound(_) => write!(f, "{}", name),
+                TypeBinding::Unbound(_) => write!(f, "{name}"),
             },
             Type::ArrayLength(n) => n.fmt(f),
             Type::Forall(typevars, typ) => {
@@ -996,7 +996,7 @@ impl Type {
                 let fields = fields.iter().enumerate();
                 vecmap(fields, |(i, field)| (i.to_string(), field.clone()))
             }
-            other => panic!("Tried to iterate over the fields of '{}', which has none", other),
+            other => panic!("Tried to iterate over the fields of '{other}', which has none"),
         };
         fields.into_iter()
     }
@@ -1010,7 +1010,7 @@ impl Type {
                 let mut fields = fields.iter().enumerate();
                 fields.find(|(i, _)| i.to_string() == *field_name).unwrap().1.clone()
             }
-            other => panic!("Tried to iterate over the fields of '{}', which has none", other),
+            other => panic!("Tried to iterate over the fields of '{other}', which has none"),
         }
     }
 

--- a/crates/noirc_frontend/src/lexer/errors.rs
+++ b/crates/noirc_frontend/src/lexer/errors.rs
@@ -44,32 +44,30 @@ impl LexerErrorKind {
                 found,
             } => (
                 "an unexpected character was found".to_string(),
-                format!(" expected {} , but got {}", expected, found),
+                format!(" expected {expected} , but got {found}"),
                 *span,
             ),
             LexerErrorKind::NotADoubleChar { span, found } => (
-                format!("tried to parse {} as double char", found),
+                format!("tried to parse {found} as double char"),
                 format!(
-                    " {:?} is not a double char, this is an internal error",
-                    found
+                    " {found:?} is not a double char, this is an internal error"
                 ),
                 *span,
             ),
             LexerErrorKind::InvalidIntegerLiteral { span, found } => (
                 "invalid integer literal".to_string(),
-                format!(" {} is not an integer", found),
+                format!(" {found} is not an integer"),
                 *span,
             ),
             LexerErrorKind::MalformedFuncAttribute { span, found } => (
                 "malformed function attribute".to_string(),
-                format!(" {} is not a valid attribute", found),
+                format!(" {found} is not a valid attribute"),
                 *span,
             ),
             LexerErrorKind::TooManyBits { span, max, got } => (
                 "integer literal too large".to_string(),
                 format!(
-                    "The maximum number of bits needed to represent a field is {}, This integer type needs {} bits",
-                    max, got
+                    "The maximum number of bits needed to represent a field is {max}, This integer type needs {got} bits"
                 ),
                 *span,
             ),

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -137,13 +137,13 @@ pub enum Token {
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Token::Ident(ref s) => write!(f, "{}", s),
+            Token::Ident(ref s) => write!(f, "{s}"),
             Token::Int(n) => write!(f, "{}", n.to_u128()),
-            Token::Bool(b) => write!(f, "{}", b),
-            Token::Str(ref b) => write!(f, "{}", b),
-            Token::Keyword(k) => write!(f, "{}", k),
-            Token::Attribute(ref a) => write!(f, "{}", a),
-            Token::IntType(ref i) => write!(f, "{}", i),
+            Token::Bool(b) => write!(f, "{b}"),
+            Token::Str(ref b) => write!(f, "{b}"),
+            Token::Keyword(k) => write!(f, "{k}"),
+            Token::Attribute(ref a) => write!(f, "{a}"),
+            Token::IntType(ref i) => write!(f, "{i}"),
             Token::Less => write!(f, "<"),
             Token::LessEqual => write!(f, "<="),
             Token::Greater => write!(f, ">"),
@@ -178,7 +178,7 @@ impl fmt::Display for Token {
             Token::Bang => write!(f, "!"),
             Token::Underscore => write!(f, "_"),
             Token::EOF => write!(f, "end of input"),
-            Token::Invalid(c) => write!(f, "{}", c),
+            Token::Invalid(c) => write!(f, "{c}"),
         }
     }
 }
@@ -196,7 +196,7 @@ pub enum TokenKind {
 impl fmt::Display for TokenKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TokenKind::Token(ref tok) => write!(f, "{}", tok),
+            TokenKind::Token(ref tok) => write!(f, "{tok}"),
             TokenKind::Ident => write!(f, "identifier"),
             TokenKind::Literal => write!(f, "literal"),
             TokenKind::Keyword => write!(f, "keyword"),
@@ -237,8 +237,8 @@ pub enum IntType {
 impl fmt::Display for IntType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            IntType::Unsigned(num) => write!(f, "u{}", num),
-            IntType::Signed(num) => write!(f, "i{}", num),
+            IntType::Unsigned(num) => write!(f, "u{num}"),
+            IntType::Signed(num) => write!(f, "i{num}"),
         }
     }
 }
@@ -292,9 +292,9 @@ pub enum Attribute {
 impl fmt::Display for Attribute {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Attribute::Foreign(ref k) => write!(f, "#[foreign({})]", k),
-            Attribute::Builtin(ref k) => write!(f, "#[builtin({})]", k),
-            Attribute::Alternative(ref k) => write!(f, "#[alternative({})]", k),
+            Attribute::Foreign(ref k) => write!(f, "#[foreign({k})]"),
+            Attribute::Builtin(ref k) => write!(f, "#[builtin({k})]"),
+            Attribute::Alternative(ref k) => write!(f, "#[alternative({k})]"),
         }
     }
 }

--- a/crates/noirc_frontend/src/monomorphisation/ast.rs
+++ b/crates/noirc_frontend/src/monomorphisation/ast.rs
@@ -249,10 +249,10 @@ impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Type::Field => write!(f, "Field"),
-            Type::Array(len, elems) => write!(f, "[{}; {}]", elems, len),
+            Type::Array(len, elems) => write!(f, "[{elems}; {len}]"),
             Type::Integer(sign, bits) => match sign {
-                Signedness::Unsigned => write!(f, "u{}", bits),
-                Signedness::Signed => write!(f, "i{}", bits),
+                Signedness::Unsigned => write!(f, "u{bits}"),
+                Signedness::Signed => write!(f, "i{bits}"),
             },
             Type::Bool => write!(f, "bool"),
             Type::Unit => write!(f, "()"),

--- a/crates/noirc_frontend/src/monomorphisation/printer.rs
+++ b/crates/noirc_frontend/src/monomorphisation/printer.rs
@@ -51,7 +51,7 @@ impl AstPrinter {
             Expression::Tuple(tuple) => self.print_tuple(tuple, f),
             Expression::ExtractTupleField(expr, index) => {
                 self.print_expr(expr, f)?;
-                write!(f, ".{}", index)
+                write!(f, ".{index}")
             }
             Expression::Call(call) => self.print_call(call, f),
             Expression::CallBuiltin(call) => self.print_lowlevel(call, f),
@@ -95,9 +95,9 @@ impl AstPrinter {
                 self.print_comma_separated(&array.contents, f)?;
                 write!(f, "]")
             }
-            super::ast::Literal::Integer(x, _) => write!(f, "{}", x),
-            super::ast::Literal::Bool(x) => write!(f, "{}", x),
-            super::ast::Literal::Str(s) => write!(f, "{}", s),
+            super::ast::Literal::Integer(x, _) => write!(f, "{x}"),
+            super::ast::Literal::Bool(x) => write!(f, "{x}"),
+            super::ast::Literal::Str(s) => write!(f, "{s}"),
         }
     }
 
@@ -281,7 +281,7 @@ impl AstPrinter {
             }
             LValue::MemberAccess { object, field_index } => {
                 self.print_lvalue(object, f)?;
-                write!(f, ".{}", field_index)
+                write!(f, ".{field_index}")
             }
         }
     }

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -340,7 +340,7 @@ impl ForRange {
                 let start_range = Expression::new(start_range, array_span);
 
                 let next_unique_id = UNIQUE_NAME_COUNTER.fetch_add(1, Ordering::Relaxed);
-                let fresh_name1 = format!("$i{}", next_unique_id);
+                let fresh_name1 = format!("$i{next_unique_id}");
                 let array_span = array.span;
                 let fresh_ident1 = Ident::new(fresh_name1.clone(), array_span);
 
@@ -363,7 +363,7 @@ impl ForRange {
                 let end_range = Expression::new(end_range, array_span);
 
                 let next_unique_id = UNIQUE_NAME_COUNTER.fetch_add(1, Ordering::Relaxed);
-                let fresh_name = format!("$i{}", next_unique_id);
+                let fresh_name = format!("$i{next_unique_id}");
                 let fresh_identifier = Ident::new(fresh_name.clone(), array_span);
 
                 // array[i]
@@ -402,7 +402,7 @@ impl std::fmt::Display for TopLevelStatement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TopLevelStatement::Function(fun) => fun.fmt(f),
-            TopLevelStatement::Module(m) => write!(f, "mod {}", m),
+            TopLevelStatement::Module(m) => write!(f, "mod {m}"),
             TopLevelStatement::Import(i) => i.fmt(f),
             TopLevelStatement::Struct(s) => s.fmt(f),
             TopLevelStatement::Impl(i) => i.fmt(f),
@@ -416,31 +416,31 @@ impl std::fmt::Display for TopLevelStatement {
 impl std::fmt::Display for ParsedModule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for decl in &self.module_decls {
-            writeln!(f, "mod {};", decl)?;
+            writeln!(f, "mod {decl};")?;
         }
 
         for import in &self.imports {
-            write!(f, "{}", import)?;
+            write!(f, "{import}")?;
         }
 
         for global_const in &self.globals {
-            write!(f, "{}", global_const)?;
+            write!(f, "{global_const}")?;
         }
 
         for type_ in &self.types {
-            write!(f, "{}", type_)?;
+            write!(f, "{type_}")?;
         }
 
         for function in &self.functions {
-            write!(f, "{}", function)?;
+            write!(f, "{function}")?;
         }
 
         for impl_ in &self.impls {
-            write!(f, "{}", impl_)?;
+            write!(f, "{impl_}")?;
         }
 
         for submodule in &self.submodules {
-            write!(f, "{}", submodule)?;
+            write!(f, "{submodule}")?;
         }
 
         Ok(())
@@ -452,7 +452,7 @@ impl std::fmt::Display for SubModule {
         write!(f, "mod {} {{", self.name)?;
 
         for line in self.contents.to_string().lines() {
-            write!(f, "\n    {}", line)?;
+            write!(f, "\n    {line}")?;
         }
 
         write!(f, "\n}}")

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -766,7 +766,7 @@ fn field_name() -> impl NoirParser<Ident> {
     ident().or(tokenkind(TokenKind::Literal).validate(|token, span, emit| match token {
         Token::Int(_) => Ident::from(Spanned::from(span, token.to_string())),
         other => {
-            let reason = format!("Unexpected '{}', expected a field name", other);
+            let reason = format!("Unexpected '{other}', expected a field name");
             emit(ParserError::with_reason(reason, span));
             Ident::error(span)
         }


### PR DESCRIPTION
# Description

## Summary of changes

Clippy recently added a new warning suggesting to change `println!("foo {} baz", bar)` to `println!("foo {bar} baz")`. The first style was used pervasively throughout our codebase so there were many changes required, most of which were automated with `cargo clippy --fix`.

The codebase now checks without warnings on clippy `1.68.0-nightly`.

# Alternatives

Alternatively, we can disable this lint in a toml file... somewhere.
