### PR TITLE
Fix for mapping the full array during acir gen for to_bytes and to_bits

### DIFF
--- a/crates/nargo/tests/test_data/to_bytes/src/main.nr
+++ b/crates/nargo/tests/test_data/to_bytes/src/main.nr
@@ -7,5 +7,8 @@ fn main(x : Field) -> pub [u8; 4] {
     for i in 0..4 {
         first_four_bytes[i] = byte_array[i];
     }
+    // Issue #617 fix
+    // We were incorrectly mapping our output array from bit decomposition functions during acir generation
+    first_four_bytes[3] = byte_array[31];
     first_four_bytes
 }

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -382,10 +382,16 @@ impl Acir {
 
     //Map the outputs into the array
     fn map_array(&mut self, a: ArrayId, outputs: &[Witness], ctx: &SsaContext) {
-        let adr = ctx.mem[a].adr;
-        for i in outputs.iter().enumerate() {
-            let var = InternalVar::from(*i.1);
-            self.memory_map.insert(adr + i.0 as u32, var);
+        let array = &ctx.mem[a];
+        let adr = array.adr;
+        for i in 0..array.len {
+            if i < outputs.len() as u32 {
+                let var = InternalVar::from(outputs[i as usize]);
+                self.memory_map.insert(adr + i, var);
+            } else {
+                let var = InternalVar::from(Expression::zero());
+                self.memory_map.insert(adr + i, var);
+            }
         }
     }
 


### PR DESCRIPTION
# Related issue(s)

Resolves #617 

# Description

After a byte decomposition, I want to be able to pass the full byte array along without having to do any hack-y methods to get around the compiler. Currently, this is not possible as we are panicking during acir generation. This is due to us incorrectly mapping the outputs of our bit/byte decomposition methods. Further information can be found in issue #617.

The outputs from `to_bits` and `to_bytes` are equal to the size of the bit size or byte size specified in the Noir program. However, we currently restrict this to be less than the full bit size or byte size of a Field for safety. Both methods return fully decomposed arrays with [u1; 256] and [u8; 32] respectively. If I specified a `byte_size` of 16 for example and I want to access any elements past index 15 in the array returned from `to_bytes` this is not possible. This is specifically confusing for a developer if they want to pass along a decomposed array directly to another std_lib function such as `verify_signature`. 

## Summary of changes

After evaluating our decomposition methods we map the outputs to the array pointer (https://github.com/noir-lang/noir/blob/4b36ea01d5ce60c3fb8d1167d0772772ea02a368/crates/noirc_evaluator/src/ssa/acir_gen.rs#L563). This array is set when we are creating our instructions and has a specified length (such as 32 or 254). When we later want to access elements in the array such as in `prepare_inputs` we are looping over this mem array (https://github.com/noir-lang/noir/blob/4b36ea01d5ce60c3fb8d1167d0772772ea02a368/crates/noirc_evaluator/src/ssa/acir_gen.rs#L496) which has a larger length than outputs that have been mapped in memory. Thus, when we check the memory map here (https://github.com/noir-lang/noir/blob/4b36ea01d5ce60c3fb8d1167d0772772ea02a368/crates/noirc_evaluator/src/ssa/acir_gen.rs#L498) the if condition fails and we panic on this line (https://github.com/noir-lang/noir/blob/4b36ea01d5ce60c3fb8d1167d0772772ea02a368/crates/noirc_evaluator/src/ssa/acir_gen.rs#L511) as the mem array we are trying to access has an empty values array.

I simply changed the `map_array` function to loop over the mem array length. When the index of the loop is still within the bounds of the outputs slice we map the output as before, otherwise we map zero. 

## Dependency additions / changes

(If applicable.)

## Test additions / changes

I added a line that was previously failing to the `to_bytes` test. 

In my repo testing aztec circuits (https://github.com/vezenovm/aztec-circuits-noir) I was able to replace my utility function for converting a field into bytes and it is fully working with `verify_signature` now. This code is what originally brought this error to my attention. (https://github.com/vezenovm/aztec-circuits-noir/blob/4dde489370813739acab26514da1dcd80ac047ea/circuits/join_split/src/main.nr#L199)

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
