### PR TITLE
Use published acvm v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,27 +8,130 @@ version = "0.1.0"
 dependencies = [
  "flate2",
  "indexmap",
- "noir_field",
+ "noir_field 0.1.0",
  "rmp-serde",
  "serde",
  "serde_json",
 ]
 
 [[package]]
+name = "acir"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b510cf711ccaedb4c56172a52745e9f1cbc2d88731430ceccd2d6eb5b2f6cd"
+dependencies = [
+ "acir_field",
+ "flate2",
+ "indexmap",
+ "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "acir"
+version = "0.1.0"
+source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
+dependencies = [
+ "flate2",
+ "indexmap",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
+ "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "acir"
+version = "0.1.0"
+source = "git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
+dependencies = [
+ "indexmap",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
+ "serde",
+]
+
+[[package]]
+name = "acir_field"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1224a7cd03cf504dafae9e0b64229ffef1a2211811a406e877c3b7e17517ff"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "blake2",
+ "cfg-if 1.0.0",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "acvm"
 version = "0.1.0"
 dependencies = [
- "acir",
+ "acir 0.1.0",
  "blake2",
  "hex",
  "indexmap",
  "k256",
- "noir_field",
+ "noir_field 0.1.0",
  "num-bigint",
  "num-traits",
  "sha2",
  "sled",
  "tempfile",
+]
+
+[[package]]
+name = "acvm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12081750c69705a0a2677ab0e171c209be69e020ca6c90c8700a40d1de7918a4"
+dependencies = [
+ "acir 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "acir_field",
+ "blake2",
+ "hex",
+ "indexmap",
+ "k256",
+ "num-bigint",
+ "num-traits",
+ "sha2",
+ "sled",
+]
+
+[[package]]
+name = "acvm"
+version = "0.1.0"
+source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
+dependencies = [
+ "acir 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
+ "blake2",
+ "hex",
+ "indexmap",
+ "k256",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
+ "num-bigint",
+ "num-traits",
+ "sha2",
+ "sled",
+]
+
+[[package]]
+name = "acvm"
+version = "0.1.0"
+source = "git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
+dependencies = [
+ "acir 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
+ "blake2",
+ "hex",
+ "indexmap",
+ "k256",
+ "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
+ "num-bigint",
+ "num-traits",
+ "sha2",
+ "sled",
 ]
 
 [[package]]
@@ -243,7 +346,7 @@ name = "arkworks_backend"
 version = "0.1.0"
 source = "git+https://github.com/noir-lang/arkworks_backend?rev=ee6d468f5cc635dc2589965b6bf16cd2a839d7d3#ee6d468f5cc635dc2589965b6bf16cd2a839d7d3"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff",
@@ -511,7 +614,7 @@ name = "common"
 version = "0.1.0"
 source = "git+https://github.com/noir-lang/aztec_backend?rev=8c8ec2dd9c376bef598d17f023fac172e5e47860#8c8ec2dd9c376bef598d17f023fac172e5e47860"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
  "blake2",
  "dirs 3.0.2",
  "downloader",
@@ -1278,7 +1381,7 @@ name = "marlin_arkworks_backend"
 version = "0.1.0"
 source = "git+https://github.com/noir-lang/marlin_arkworks_backend?rev=601e24dcb5dcbe72e3de7a33879aaf84e171d541#601e24dcb5dcbe72e3de7a33879aaf84e171d541"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f)",
  "arkworks_backend",
  "blake2",
  "dirs 3.0.2",
@@ -1344,7 +1447,7 @@ dependencies = [
 name = "nargo"
 version = "0.1.0"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "barretenberg_static_lib",
  "cfg-if 1.0.0",
  "clap 2.34.0",
@@ -1398,10 +1501,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "noir_field"
+version = "0.1.0"
+source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "blake2",
+ "cfg-if 1.0.0",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "noir_field"
+version = "0.1.0"
+source = "git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ff",
+ "blake2",
+ "cfg-if 1.0.0",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "noir_wasm"
 version = "0.10.0"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook",
  "getrandom",
  "gloo-utils",
@@ -1415,7 +1548,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.1.0"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",
  "serde",
  "serde_derive",
@@ -1427,7 +1560,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.1.0"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 3.0.2",
  "fm",
  "noirc_abi",
@@ -1452,7 +1585,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.1.0"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arena",
  "fm",
  "iter-extended",
@@ -1469,7 +1602,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.1.0"
 dependencies = [
- "acvm",
+ "acvm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,18 +30,6 @@ dependencies = [
 [[package]]
 name = "acir"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
-dependencies = [
- "flate2",
- "indexmap",
- "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
- "rmp-serde",
- "serde",
-]
-
-[[package]]
-name = "acir"
-version = "0.1.0"
 source = "git+https://github.com/noir-lang/noir?rev=cc5ee63072e09779bebd7e7dd054ae16be307d7f#cc5ee63072e09779bebd7e7dd054ae16be307d7f"
 dependencies = [
  "indexmap",
@@ -94,23 +82,6 @@ dependencies = [
  "hex",
  "indexmap",
  "k256",
- "num-bigint",
- "num-traits",
- "sha2",
- "sled",
-]
-
-[[package]]
-name = "acvm"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
-dependencies = [
- "acir 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
- "blake2",
- "hex",
- "indexmap",
- "k256",
- "noir_field 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
  "num-bigint",
  "num-traits",
  "sha2",
@@ -382,7 +353,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "barretenberg_static_lib"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=8c8ec2dd9c376bef598d17f023fac172e5e47860#8c8ec2dd9c376bef598d17f023fac172e5e47860"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=72d5a86625c4220e36da246ed1965ed5d6f411d8#72d5a86625c4220e36da246ed1965ed5d6f411d8"
 dependencies = [
  "barretenberg_wrapper",
  "blake2",
@@ -403,7 +374,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec-connect?rev=2c961d511c245d7debef04d99b42c3de4268cad8#2c961d511c245d7debef04d99b42c3de4268cad8"
+source = "git+https://github.com/noir-lang/aztec-connect?branch=kw/noir-dsl#2ef8be41993ead9993c09b1d99fef6dc68e231a6"
 dependencies = [
  "bindgen",
  "cmake",
@@ -612,9 +583,9 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=8c8ec2dd9c376bef598d17f023fac172e5e47860#8c8ec2dd9c376bef598d17f023fac172e5e47860"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=72d5a86625c4220e36da246ed1965ed5d6f411d8#72d5a86625c4220e36da246ed1965ed5d6f411d8"
 dependencies = [
- "acvm 0.1.0 (git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135)",
+ "acvm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",
  "dirs 3.0.2",
  "downloader",
@@ -1493,21 +1464,6 @@ dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff",
- "cfg-if 1.0.0",
- "hex",
- "num-bigint",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "noir_field"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/noir?rev=7460dda929130589bccfd6619f9409834b72a135#7460dda929130589bccfd6619f9409834b72a135"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "blake2",
  "cfg-if 1.0.0",
  "hex",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,3 @@ members = [
 ]
 exclude = ["examples/9/merkle_tree_processor"]
 default-members = ["crates/nargo"]
-
-# Patch github versions of acvm with local copy
-[patch.'https://github.com/noir-lang/noir']
-acvm = { path = "crates/acvm" }

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -29,7 +29,7 @@ hex = "0.4.2"
 tempdir = "0.3.7"
 
 # Backends
-aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "8c8ec2dd9c376bef598d17f023fac172e5e47860" }
+aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "72d5a86625c4220e36da246ed1965ed5d6f411d8" }
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "601e24dcb5dcbe72e3de7a33879aaf84e171d541" }
 
 [features]

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -17,7 +17,7 @@ noirc_driver = { path = "../noirc_driver", features = ["std"] }
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_abi = { path = "../noirc_abi" }
 fm = { path = "../fm" }
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = "0.1.0"
 cfg-if = "1.0.0"
 
 toml = "0.5"

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = "0.1.0"
 toml = "0.5.8"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0.136"

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -11,7 +11,7 @@ noirc_errors = { path = "../noirc_errors" }
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_evaluator = { path = "../noirc_evaluator" }
 noirc_abi = { path = "../noirc_abi" }
-acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
+acvm = "0.1.0"
 fm = { path = "../fm" }
 serde = { version = "1.0.136", features = ["derive"] }
 

--- a/crates/noirc_evaluator/Cargo.toml
+++ b/crates/noirc_evaluator/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_errors = { path = "../noirc_errors" }
 noirc_abi = { path = "../noirc_abi" }
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = "0.1.0"
 arena = { path = "../arena" }
 fm = { path = "../fm" }
 iter-extended = { path = "../iter-extended" }

--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acvm = { git = "https://github.com/noir-lang/noir" }
+acvm = "0.1.0"
 noirc_abi = { path = "../noirc_abi" }
 noirc_errors = { path = "../noirc_errors" }
 fm = { path = "../fm" }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Compile with bn254 field as a default for now
-acvm = { path = "../acvm", features = ["bn254"] }
+acvm = { version = "0.1.0", features = ["bn254"] }
 noirc_driver = { path = "../noirc_driver", features = ["wasm"] }
 
 console_error_panic_hook = "*"


### PR DESCRIPTION
# Related issue(s)

Resolves #596 

# Description

## Summary of changes

This PR swaps out the `avcm` dependency from the noir-lang/noir repo for the v0.1.0 version published on crates.io - The 0.1.0 version should be compatible with the current version of noir, but it is published from a separate repository.

## Dependency additions / changes

The published `acvm` crate.

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

This PR is needed in combination with https://github.com/noir-lang/aztec_backend/pull/36 to successfully install nargo with a completely fresh clone.
