### PR TITLE
use workspace inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "sha2",
- "sled",
  "tempfile",
 ]
 
@@ -1399,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "noir_wasm"
-version = "0.10.0"
+version = "0.1.0"
 dependencies = [
  "acvm",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,77 @@ members = [
 exclude = ["examples/9/merkle_tree_processor"]
 default-members = ["crates/nargo"]
 
+[workspace.package]
+version = "0.1.0"
+authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
+edition = "2021"
+
+[workspace.dependencies]
+acir = { path = "crates/acir" }
+acvm = { path = "crates/acvm" }
+arena = { path = "crates/arena" }
+fm = { path = "crates/fm" }
+iter-extended = { path = "crates/iter-extended" }
+nargo = { path = "crates/nargo" }
+noir_field = { path = "crates/noir_field" }
+noirc_abi = { path = "crates/noirc_abi" }
+noirc_driver = { path = "crates/noirc_driver" }
+noirc_errors = { path = "crates/noirc_errors" }
+noirc_evaluator = { path = "crates/noirc_evaluator" }
+noirc_frontend = { path = "crates/noirc_frontend" }
+noir_wasm = { path = "crates/wasm" }
+
+ark-bn254 = { version = "^0.3.0", default-features = false, features = [
+    "curve",
+] }
+ark-bls12-381 = { version = "^0.3.0", default-features = false, features = [
+    "curve",
+] }
+ark-ff = { version = "^0.3.0", default-features = false }
+blake2 = "0.9.1"
+chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
+cfg-if = "1.0.0"
+clap = "2.33.3"
+codespan = "0.9.5"
+codespan-reporting = "0.9.5"
+console_error_panic_hook = "*"
+dirs = "3.0.1"
+flate2 = "1.0.24"
+generational-arena = "0.2.8"
+getrandom = { version = "0.2.4", features = ["js"] }
+gloo-utils = { version = "0.1", features = ["serde"] }
+hex = "0.4.2"
+indexmap = "1.7.0"
+js-sys = "0.3.55"
+lazy_static = "1.4.0"
+k256 = { version = "0.7.2", features = [
+    "ecdsa",
+    "ecdsa-core",
+    "sha256",
+    "digest",
+    "arithmetic",
+] }
+pathdiff = "0.2"
+num-bigint = "0.4"
+num-traits = "0.2.8"
+rmp-serde = "1.1.0"
+rustc-hash = "1.1.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_derive = "1.0.123"
+serde_json = "1.0"
+sled = "0.34.6"
+sha2 = "0.9.3"
+smol_str = "0.1.17"
+tempdir = "0.3.7"
+tempfile = "3.2.0"
+termcolor = "1.1.2"
+thiserror = "1.0.21"
+toml = "0.5.8"
+url = "2.2.0"
+wasm-bindgen = { version = "*", features = ["serde-serialize"] }
+wasm-bindgen-test = "*"
+
+
 # Patch github versions of acvm with local copy
 [patch.'https://github.com/noir-lang/noir']
 acvm = { path = "crates/acvm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ clap = "2.33.3"
 codespan = "0.9.5"
 codespan-reporting = "0.9.5"
 console_error_panic_hook = "*"
-dirs = "3.0.1"
+dirs = "4"
 flate2 = "1.0.24"
 generational-arena = "0.2.8"
 getrandom = { version = "0.2.4", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default-members = ["crates/nargo"]
 version = "0.1.0"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
 edition = "2021"
+rust-version = "1.64"
 
 [workspace.dependencies]
 acir = { path = "crates/acir" }

--- a/crates/acir/Cargo.toml
+++ b/crates/acir/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "acir"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 noir_field = { path = "../noir_field", default-features = false }
-indexmap = "1.7.0"
-serde = { version = "1.0.136", features = ["derive"] }
-rmp-serde = "1.1.0"
-flate2 = "1.0.24"
+indexmap.workspace = true
+serde.workspace = true
+rmp-serde.workspace = true
+flate2.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true

--- a/crates/acvm/Cargo.toml
+++ b/crates/acvm/Cargo.toml
@@ -1,38 +1,31 @@
 [package]
 name = "acvm"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-bigint = "0.4"
-num-traits = "0.2"
-acir = { path = "../acir" }
+num-bigint.workspace = true
+num-traits.workspace = true
+acir.workspace = true
 
 # Ideally, there should be a way for the Nargo.toml file to indicate a proof system
 # and not need to pull in the other proof systems. Also ideally like to avoid using DLL (dynamically loaded lib)
 # It seems to be only way... This is not an immediate problem while dependencies are small
 # aztec_backend = { optional = true, path = "../aztec_backend" }
 # arkworks_backend = { optional = true, git = "https://github.com/noir-lang/arkworks_backend" }
-sled = "0.34.6"
 noir_field = { path = "../noir_field", default-features = false }
-sha2 = "0.9.3"
-blake2 = "0.9.1"
-hex = "0.4.2"
-k256 = { version = "0.7.2", features = [
-    "ecdsa",
-    "ecdsa-core",
-    "sha256",
-    "digest",
-    "arithmetic",
-] }
-indexmap = "1.7.0"
+sha2.workspace = true
+blake2.workspace = true
+hex.workspace = true
+k256.workspace = true
+indexmap.workspace = true
 
 [features]
 bn254 = ["noir_field/bn254"]
 bls12_381 = ["noir_field/bls12_381"]
 
 [dev-dependencies]
-tempfile = "3.2.0"
+tempfile.workspace = true

--- a/crates/acvm/src/pwg/signature/ecdsa.rs
+++ b/crates/acvm/src/pwg/signature/ecdsa.rs
@@ -74,7 +74,6 @@ mod ecdsa_secp256k1 {
 
         use sha2::{Digest, Sha256};
 
-        use std::convert::TryFrom;
         // Signing
         let signing_key = SigningKey::from_bytes(&[2u8; 32]).unwrap();
         let message =
@@ -109,7 +108,6 @@ mod ecdsa_secp256k1 {
         public_key_y_bytes: &[u8],
         signature: &[u8],
     ) -> Result<(), ()> {
-        use std::convert::TryFrom;
         // Convert the inputs into k256 data structures
 
         let signature = Signature::try_from(signature).unwrap();

--- a/crates/arena/Cargo.toml
+++ b/crates/arena/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "arena"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generational-arena = "0.2.8"
+generational-arena.workspace = true

--- a/crates/fm/Cargo.toml
+++ b/crates/fm/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "fm"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codespan-reporting = "0.9.5"
+codespan-reporting.workspace = true
+cfg-if.workspace = true
 wasm-bindgen = { version = "*", features = [
     "serde-serialize",
 ], optional = true }
-cfg-if = "*"
 [dev-dependencies]
-tempfile = "3.1.0"
+tempfile.workspace = true
 
 
 [features]

--- a/crates/iter-extended/Cargo.toml
+++ b/crates/iter-extended/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iter-extended"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-dirs = "4"
+dirs.workspace = true
 
 [dependencies]
 dirs.workspace = true

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nargo"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,23 +10,23 @@ edition = "2018"
 dirs = "4"
 
 [dependencies]
-dirs = "3.0.1"
-url = "2.2.0"
-iter-extended = { path = "../iter-extended" }
+dirs.workspace = true
+url.workspace = true
+iter-extended.workspace = true
 noirc_driver = { path = "../noirc_driver", features = ["std"] }
-noirc_frontend = { path = "../noirc_frontend" }
-noirc_abi = { path = "../noirc_abi" }
-fm = { path = "../fm" }
+noirc_frontend.workspace = true
+noirc_abi.workspace = true
+fm.workspace = true
 acvm = { git = "https://github.com/noir-lang/noir" }
-cfg-if = "1.0.0"
+cfg-if.workspace = true
 
-toml = "0.5"
-serde_derive = "1.0.123"
+toml.workspace = true
+serde_derive.workspace = true
 serde = "1.0.123"
-clap = "2.33.3"
-termcolor = "1.1.2"
-hex = "0.4.2"
-tempdir = "0.3.7"
+clap.workspace = true
+termcolor.workspace = true
+hex.workspace = true
+tempdir.workspace = true
 
 # Backends
 aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "8c8ec2dd9c376bef598d17f023fac172e5e47860" }

--- a/crates/noir_field/Cargo.toml
+++ b/crates/noir_field/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "noir_field"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hex = "0.4.2"
+hex.workspace = true
 
 ark-bn254 = { version = "^0.3.0", optional = true, default-features = false, features = [
     "curve",
@@ -17,11 +17,11 @@ ark-bls12-381 = { version = "^0.3.0", optional = true, default-features = false,
 ] }
 ark-ff = { version = "^0.3.0", optional = true, default-features = false }
 
-cfg-if = "1.0.0"
-serde = { version = "1.0.136", features = ["derive"] }
+cfg-if.workspace = true
+serde.workspace = true
 
-num-bigint = "0.4"
-num-traits = "0.2.8"
+num-bigint.workspace = true
+num-traits.workspace = true
 
 [dev-dependencies]
 ark-bn254 = { version = "^0.3.0", features = ["curve"] }

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "noirc_abi"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 acvm = { git = "https://github.com/noir-lang/noir" }
-toml = "0.5.8"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_derive = "1.0.136"
-blake2 = "0.9.1"
+toml.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+blake2.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -16,8 +16,3 @@ fm.workspace = true
 serde.workspace = true
 dirs.workspace = true
 pathdiff.workspace = true
-
-[features]
-default = []
-std = ["fm/std"]
-wasm = ["fm/wasm"]

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "noirc_driver"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-noirc_errors = { path = "../noirc_errors" }
-noirc_frontend = { path = "../noirc_frontend" }
-noirc_evaluator = { path = "../noirc_evaluator" }
-noirc_abi = { path = "../noirc_abi" }
+noirc_errors.workspace = true
+noirc_frontend.workspace = true
+noirc_evaluator.workspace = true
+noirc_abi.workspace = true
 acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" }
-fm = { path = "../fm" }
-serde = { version = "1.0.136", features = ["derive"] }
+fm.workspace = true
+serde.workspace = true
 
-dirs = "3.0"
-pathdiff = "0.2"
+dirs.workspace = true
+pathdiff.workspace = true
 
 [features]
 default = []

--- a/crates/noirc_errors/Cargo.toml
+++ b/crates/noirc_errors/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "noirc_errors"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codespan-reporting = "0.9.5"
-codespan = "0.9.5"
-fm = {path = "../fm"}
-chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
+codespan-reporting.workspace = true
+codespan.workspace = true
+fm.workspace = true
+chumsky.workspace = true

--- a/crates/noirc_evaluator/Cargo.toml
+++ b/crates/noirc_evaluator/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "noirc_evaluator"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-noirc_frontend = { path = "../noirc_frontend" }
-noirc_errors = { path = "../noirc_errors" }
-noirc_abi = { path = "../noirc_abi" }
+noirc_frontend.workspace = true
+noirc_errors.workspace = true
+noirc_abi.workspace = true
 acvm = { git = "https://github.com/noir-lang/noir" }
-arena = { path = "../arena" }
-fm = { path = "../fm" }
-iter-extended = { path = "../iter-extended" }
-lazy_static = "1.4.0"
-thiserror = "1.0.21"
-num-bigint = "0.4"
-num-traits = "0.2.8"
+arena.workspace = true
+fm.workspace = true
+iter-extended.workspace = true
+lazy_static.workspace = true
+thiserror.workspace = true
+num-bigint.workspace = true
+num-traits.workspace = true

--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "noirc_frontend"
-version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 acvm = { git = "https://github.com/noir-lang/noir" }
-noirc_abi = { path = "../noirc_abi" }
-noirc_errors = { path = "../noirc_errors" }
-fm = { path = "../fm" }
-arena = { path = "../arena" }
-iter-extended = { path = "../iter-extended" }
-chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
-thiserror = "1.0.21"
-pathdiff = "0.2"
-smol_str = "0.1.17"
-rustc-hash = "1.1.0"
+noirc_abi.workspace = true
+noirc_errors.workspace = true
+fm.workspace = true
+arena.workspace = true
+iter-extended.workspace = true
+chumsky.workspace = true
+thiserror.workspace = true
+pathdiff.workspace = true
+smol_str.workspace = true
+rustc-hash.workspace = true

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "noir_wasm"
-version = "0.10.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,13 +15,13 @@ crate-type = ["cdylib"]
 acvm = { path = "../acvm", features = ["bn254"] }
 noirc_driver = { path = "../noirc_driver", features = ["wasm"] }
 
-console_error_panic_hook = "*"
+console_error_panic_hook.workspace = true
 
-wasm-bindgen = { version = "*", features = ["serde-serialize"] }
-gloo-utils = { version = "0.1", features = ["serde"] }
+wasm-bindgen.workspace = true
+gloo-utils.workspace = true
 
-getrandom = { version = "0.2.4", features = ["js"] }
-js-sys = "0.3.55"
+getrandom.workspace = true
+js-sys.workspace = true
 
 [dev-dependencies]
-wasm-bindgen-test = "*"
+wasm-bindgen-test.workspace = true


### PR DESCRIPTION
# Related issue(s)

#629

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

use workspace inheritance for the codebase. 

## Summary of changes

change dependencies in the toml file. 

the minimal rust version supported by this is 1.64, so its added to the workspace toml file

sled doesn't seem to be used in acvm so it was removed.

there are two versions of tempfile used, one is 3.1.0, the other is 3.2.0, I changed both to 3.2.0. hope it won't be an issue.

There are other dependencies that have different version, for example both dirs 4.0 and dirs 3.0 is used, I'm not sure if it should be merged.

Most crate edition is 2018, some is 2021. I changed all to 2021

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(same as above)

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
