### PR TITLE
Remove wasm & std features by using target_arch

### DIFF
--- a/crates/fm/Cargo.toml
+++ b/crates/fm/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2018"
 
 [dependencies]
 codespan-reporting = "0.9.5"
-wasm-bindgen = { version = "*", features = [
-    "serde-serialize",
-], optional = true }
 cfg-if = "*"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "*", features = ["serde-serialize"] }
+
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/crates/fm/Cargo.toml
+++ b/crates/fm/Cargo.toml
@@ -14,9 +14,3 @@ wasm-bindgen = { version = "*", features = [
 cfg-if = "*"
 [dev-dependencies]
 tempfile = "3.1.0"
-
-
-[features]
-default = []
-std = []
-wasm = ["wasm-bindgen"]

--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -4,16 +4,8 @@ use std::path::Path;
 // read files using the javascript host function
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-
-        pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
-            std::fs::read_to_string(path_to_file)
-        }
-
-    } else if #[cfg(feature = "wasm")] {
-
+    if #[cfg(target_arch = "wasm32")] {
         use wasm_bindgen::{prelude::*, JsValue};
-
 
         #[wasm_bindgen(module = "@noir-lang/noir-source-resolver")]
         extern "C" {
@@ -30,6 +22,8 @@ cfg_if::cfg_if! {
             }
         }
     } else {
-        compile_error!("need to select wasm or std");
+        pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
+            std::fs::read_to_string(path_to_file)
+        }
     }
 }

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -13,7 +13,7 @@ dirs = "4"
 dirs = "3.0.1"
 url = "2.2.0"
 iter-extended = { path = "../iter-extended" }
-noirc_driver = { path = "../noirc_driver", features = ["std"] }
+noirc_driver = { path = "../noirc_driver" }
 noirc_frontend = { path = "../noirc_frontend" }
 noirc_abi = { path = "../noirc_abi" }
 fm = { path = "../fm" }

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -17,8 +17,3 @@ serde = { version = "1.0.136", features = ["derive"] }
 
 dirs = "3.0"
 pathdiff = "0.2"
-
-[features]
-default = []
-std = ["fm/std"]
-wasm = ["fm/wasm"]

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Compile with bn254 field as a default for now
 acvm = { path = "../acvm", features = ["bn254"] }
-noirc_driver = { path = "../noirc_driver", features = ["wasm"] }
+noirc_driver = { path = "../noirc_driver" }
 
 console_error_panic_hook = "*"
 


### PR DESCRIPTION
# Related issue(s)

Resolves #639

# Description

## Summary of changes

This removes the `std` and `wasm` features added by `fm` and then re-exported by `noirc_driver` and instead relies on checking if the `target_arch` is `wasm32` which gets set when building for the wasm target. This also removes the flags specified by other crates when depending on `noirc_driver`.

## Dependency additions / changes

None

## Test additions / changes

None

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
