### PR TITLE
Make issue template help text hidden comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,19 +10,19 @@ assignees: ""
 
 ## Aim
 
-(Describe what you tried to achieve.)
+<!-- Describe what you tried to achieve. -->
 
 ## Expected behavior
 
-(Describe what you expected to happen.)
+<!-- Describe what you expected to happen. -->
 
 ## Bug
 
-(Describe the bug. Supplement error codes / terminal logs if applicable.)
+<!-- Describe the bug. Supplement error codes / terminal logs if applicable. -->
 
 # To reproduce
 
-(Describe the steps to reproduce the behavior.)
+<!-- Describe the steps to reproduce the behavior. -->
 
 1.
 2.
@@ -31,7 +31,7 @@ assignees: ""
 
 # Environment
 
-(Specify your setup and versions of dependencies.)
+<!-- Specify your setup and versions of dependencies. -->
 
 - OS:
 
@@ -52,4 +52,4 @@ For TypeScript users
 
 # Additional context
 
-(If applicable.)
+<!-- If applicable. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,16 +8,16 @@ assignees: ""
 
 # Problem
 
-(Describe the problem your suggestion sets out to solve.)
+<!-- Describe the problem your suggestion sets out to solve. -->
 
 # Solution
 
-(Describe your suggestion.)
+<!-- Describe your suggestion. -->
 
 # Alternatives considered
 
-(Describe any alternative solutions you have considered.)
+<!-- Describe any alternative solutions you have considered. -->
 
 # Additional context
 
-(If applicable.)
+<!-- If applicable. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,22 @@
 # Related issue(s)
 
-(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)
+<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->
 
-Resolves (link to issue)
+Resolves # <!-- link to issue -->
 
 # Description
 
 ## Summary of changes
 
-(Describe the changes in this PR. Point out breaking changes if any.)
+<!-- Describe the changes in this PR. Point out breaking changes if any. -->
 
 ## Dependency additions / changes
 
-(If applicable.)
+<!-- If applicable. -->
 
 ## Test additions / changes
 
-(If applicable.)
+<!-- If applicable. -->
 
 # Checklist
 
@@ -28,4 +28,4 @@ Resolves (link to issue)
 
 # Additional context
 
-(If applicable.)
+<!-- If applicable. -->


### PR DESCRIPTION
# Related issue(s)

Resolves #641

# Description

## Summary of changes

Replaces the parens with `<!-- -->` (html comments) so the help text is hidden when we render markdown on an issue. This avoids needing to delete the help text or having unnecessary noise in the issue/PR.

## Dependency additions / changes

None

## Test additions / changes

None

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

