### PR TITLE
Add result return type to evaluate_instruction

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -133,9 +133,9 @@ impl Acir {
         ins: &Instruction,
         evaluator: &mut Evaluator,
         ctx: &SsaContext,
-    ) {
+    ) -> Result<(), RuntimeErrorKind> {
         if ins.operation == Operation::Nop {
-            return;
+            return Ok(());
         }
 
         let mut output = match &ins.operation {
@@ -233,6 +233,7 @@ impl Acir {
         };
         output.id = Some(ins.id);
         self.arith_cache.insert(ins.id, output);
+        Ok(())
     }
 
     fn get_predicate(

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -694,7 +694,7 @@ impl SsaContext {
         integer::overflow_strategy(self)?;
         self.log(enable_logging, "\noverflow:", "");
         //ACIR
-        self.acir(evaluator);
+        self.acir(evaluator)?;
         if enable_logging {
             Acir::print_circuit(&evaluator.gates);
             println!("DONE");
@@ -703,17 +703,18 @@ impl SsaContext {
         Ok(())
     }
 
-    pub fn acir(&self, evaluator: &mut Evaluator) {
+    pub fn acir(&self, evaluator: &mut Evaluator) -> Result<(), RuntimeError> {
         let mut acir = Acir::default();
         let mut fb = Some(&self[self.first_block]);
         while let Some(block) = fb {
             for iter in &block.instructions {
                 let ins = self.get_instruction(*iter);
-                acir.evaluate_instruction(ins, evaluator, self);
+                acir.evaluate_instruction(ins, evaluator, self).map_err(RuntimeError::from)?;
             }
             //TODO we should rather follow the jumps
             fb = block.left.map(|block_id| &self[block_id]);
         }
+        Ok(())
     }
 
     pub fn generate_empty_phi(&mut self, target_block: BlockId, phi_root: NodeId) -> NodeId {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

Returns a Result type for evaluate instruction. See #634 where we are currently panicking because we do not have a Result type. This is also added in #635 PR. 

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
