### PR TITLE
Experiment with a true slice type

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -187,6 +187,7 @@ impl Driver {
         let abi = func_meta.into_abi(&self.context.def_interner);
 
         let program = monomorphise(main_function, self.context.def_interner);
+        println!("{program}");
 
         // Compile Program
         let circuit = match create_circuit(program, np_language, show_ssa) {

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -187,7 +187,6 @@ impl Driver {
         let abi = func_meta.into_abi(&self.context.def_interner);
 
         let program = monomorphise(main_function, self.context.def_interner);
-        println!("{program}");
 
         // Compile Program
         let circuit = match create_circuit(program, np_language, show_ssa) {

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -358,6 +358,13 @@ impl IRGenerator {
                 let (v_id, _) = self.new_array(base_name, obj_type, len.try_into().unwrap(), def);
                 Value::Single(v_id)
             }
+            Type::Slice(elem) => {
+                //TODO support array of structs
+                let obj_type = self.context.convert_type(elem);
+                let len = 256; // TODO: Do not have a length for slices
+                let (v_id, _) = self.new_array(base_name, obj_type, len, def);
+                Value::Single(v_id)
+            }
             _ => {
                 let obj_type = self.context.convert_type(typ);
                 let v_id = self.create_new_variable(base_name.to_string(), def, obj_type, None);

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -1124,6 +1124,7 @@ impl SsaContext {
                 }
             }
             Type::Array(..) => panic!("Cannot convert an array type {} into an ObjectType since it is unknown which array it refers to", t),
+            Type::Slice(..) => panic!("Cannot convert a slice type {} into an ObjectType since it is unknown which array it refers to", t),
             Type::Unit => ObjectType::NotAnObject,
             Type::Function(..) => ObjectType::Function,
             Type::Tuple(_) => todo!("Conversion to ObjectType is unimplemented for tuples"),

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -170,6 +170,7 @@ impl IRGenerator {
             func.result_types.push(match typ {
                 Type::Unit => ObjectType::NotAnObject,
                 Type::Array(_, _) => ObjectType::Pointer(crate::ssa::mem::ArrayId::dummy()),
+                Type::Slice(_) => ObjectType::Pointer(crate::ssa::mem::ArrayId::dummy()),
                 _ => self.context.convert_type(&typ),
             });
         }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -256,6 +256,7 @@ fn type_check_index_expression(
         // XXX: We can check the array bounds here also, but it may be better to constant fold first
         // and have ConstId instead of ExprId for constants
         Type::Array(_, base_type) => *base_type,
+        Type::Slice(base_type) => *base_type,
         Type::Error => Type::Error,
         typ => {
             let span = interner.expr_span(&index_expr.collection);

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -196,6 +196,7 @@ fn type_check_lvalue(
 
             let typ = match result {
                 Type::Array(_, elem_type) => *elem_type,
+                Type::Slice(elem_type) => *elem_type,
                 Type::Error => Type::Error,
                 other => {
                     // TODO: Need a better span here

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -191,7 +191,8 @@ impl std::fmt::Display for StructType {
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Type {
     FieldElement(Comptime),
-    Array(Box<Type>, Box<Type>),        // Array(4, Field) = [Field; 4]
+    Array(Box<Type>, Box<Type>), // Array(4, Field) = [Field; 4]
+    Slice(Box<Type>),
     Integer(Comptime, Signedness, u32), // u32 = Integer(unsigned, 32)
     PolymorphicInteger(Comptime, TypeVariable),
     Bool(Comptime),
@@ -452,6 +453,7 @@ impl std::fmt::Display for Type {
                 Some(len) => write!(f, "[{typ}; {len}]"),
                 None => write!(f, "[{typ}]"),
             },
+            Type::Slice(typ) => write!(f, "[{typ}]"),
             Type::Integer(comptime, sign, num_bits) => match sign {
                 Signedness::Signed => write!(f, "{comptime}i{num_bits}"),
                 Signedness::Unsigned => write!(f, "{comptime}u{num_bits}"),
@@ -741,6 +743,8 @@ impl Type {
                 elem_a.try_unify(elem_b, span)
             }
 
+            (Slice(elem_a), Slice(elem_b)) => elem_a.try_unify(elem_b, span),
+
             (Tuple(elems_a), Tuple(elems_b)) => {
                 if elems_a.len() != elems_b.len() {
                     Err(SpanKind::None)
@@ -862,6 +866,10 @@ impl Type {
                 elem_a.is_subtype_of(elem_b, span)
             }
 
+            (Array(_len, elem_a), Slice(elem_b)) => elem_a.is_subtype_of(elem_b, span),
+
+            (Slice(elem_a), Slice(elem_b)) => elem_a.is_subtype_of(elem_b, span),
+
             (Tuple(elems_a), Tuple(elems_b)) => {
                 if elems_a.len() != elems_b.len() {
                     Err(SpanKind::None)
@@ -948,6 +956,9 @@ impl Type {
                     .array_length()
                     .expect("Cannot have variable sized arrays as a parameter to main");
                 AbiType::Array { length: size, typ: Box::new(typ.as_abi_type()) }
+            }
+            Type::Slice(_) => {
+                panic!("Cannot have variable sized arrays as a parameter to main")
             }
             Type::Integer(_, sign, bit_width) => {
                 let sign = match sign {
@@ -1057,6 +1068,10 @@ impl Type {
                 let element = Box::new(element.substitute(type_bindings));
                 Type::Array(size, element)
             }
+            Type::Slice(element) => {
+                let element = Box::new(element.substitute(type_bindings));
+                Type::Slice(element)
+            }
             Type::PolymorphicInteger(_, binding)
             | Type::NamedGeneric(binding, _)
             | Type::TypeVariable(binding) => substitute_binding(binding),
@@ -1100,6 +1115,7 @@ impl Type {
     fn occurs(&self, target_id: TypeVariableId) -> bool {
         match self {
             Type::Array(len, elem) => len.occurs(target_id) || elem.occurs(target_id),
+            Type::Slice(elem) => elem.occurs(target_id),
             Type::Struct(_, generic_args) => generic_args.iter().any(|arg| arg.occurs(target_id)),
             Type::Tuple(fields) => fields.iter().any(|field| field.occurs(target_id)),
             Type::PolymorphicInteger(_, binding)
@@ -1136,6 +1152,7 @@ impl Type {
             Array(size, elem) => {
                 Array(Box::new(size.follow_bindings()), Box::new(elem.follow_bindings()))
             }
+            Slice(elem) => Slice(Box::new(elem.follow_bindings())),
             Struct(def, args) => {
                 let args = vecmap(args, |arg| arg.follow_bindings());
                 Struct(def.clone(), args)

--- a/crates/noirc_frontend/src/monomorphisation/ast.rs
+++ b/crates/noirc_frontend/src/monomorphisation/ast.rs
@@ -164,7 +164,8 @@ pub struct Function {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Type {
     Field,
-    Array(/*len:*/ u64, Box<Type>),     // Array(4, Field) = [Field; 4]
+    Array(/*len:*/ u64, Box<Type>), // Array(4, Field) = [Field; 4]
+    Slice(Box<Type>),
     Integer(Signedness, /*bits:*/ u32), // u32 = Integer(unsigned, 32)
     Bool,
     Unit,
@@ -256,6 +257,7 @@ impl std::fmt::Display for Type {
         match self {
             Type::Field => write!(f, "Field"),
             Type::Array(len, elems) => write!(f, "[{elems}; {len}]"),
+            Type::Slice(elems) => write!(f, "[{elems}]"),
             Type::Integer(sign, bits) => match sign {
                 Signedness::Unsigned => write!(f, "u{bits}"),
                 Signedness::Signed => write!(f, "i{bits}"),

--- a/crates/noirc_frontend/src/monomorphisation/mod.rs
+++ b/crates/noirc_frontend/src/monomorphisation/mod.rs
@@ -485,6 +485,11 @@ impl Monomorphiser {
                 ast::Type::Array(size, Box::new(element))
             }
 
+            HirType::Slice(element) => {
+                let element = Self::convert_type(element.as_ref());
+                ast::Type::Slice(Box::new(element))
+            }
+
             HirType::PolymorphicInteger(_, binding)
             | HirType::TypeVariable(binding)
             | HirType::NamedGeneric(binding, _) => {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #606 and #562

# Description

## Summary of changes

Currently slices in noir are not "true" slices. Instead, something like `fn foo(a: [Field], b: [Field]) -> [Field]` is sugar for `fn foo<A, B, C>(a: [Field; A], b: [Field; B]) -> [Field; C]`.

This has been known to cause issues when these slices are used as return types. The compiler can later infer the correct lengths of these arrays (e.g. inferring `A == C`), although this may fail if these functions are inferred in an incorrect order. See #562.

This PR does away with this desugaring entirely and implements true slices without associated lengths into noir.

Currently this is a draft, the changes to the type system are finished but changes are still needed to the ssa form. Specifically, we will need the ability to reason about arrays of unknown length within a function until it can be later inlined and the concrete length becomes known. Changes are also needed to delay evaluation of `std::array::len` since it will no longer always be known during monomorphisation.

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Alternatives

Possible alternatives:
1. Disallow slices entirely and force users to use explicit lengths everywhere. This is likely the easiest approach development wise but is the most restrictive to users.
2. Build a call graph during name resolution and use this ordering to guide the type checker on the correct order to type check functions. This would fix the issues with the current desugaring of slices within functions, although we would still have to disallow storing slices within structs.
