### PR TITLE
Rework noir_wasm package & introduce wit-bindgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ examples/9
 .vscode
 node_modules
 pkg/
+crates/wasm/binding/
 
 # Nargo output
 *.proof

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
 name = "arena"
 version = "0.1.0"
 dependencies = [
@@ -796,7 +802,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "codespan-reporting",
  "tempfile",
- "wasm-bindgen",
+ "wit-bindgen-guest-rust",
 ]
 
 [[package]]
@@ -975,10 +981,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -986,19 +990,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "gloo-utils"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "group"
@@ -1044,6 +1035,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1148,6 +1148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1242,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -1347,7 +1359,6 @@ dependencies = [
  "barretenberg_static_lib",
  "cfg-if 1.0.0",
  "clap 2.34.0",
- "dirs 3.0.2",
  "dirs 4.0.0",
  "fm",
  "hex",
@@ -1401,13 +1412,9 @@ name = "noir_wasm"
 version = "0.1.0"
 dependencies = [
  "acvm",
- "console_error_panic_hook",
- "getrandom",
- "gloo-utils",
- "js-sys",
  "noirc_driver",
- "wasm-bindgen",
- "wasm-bindgen-test",
+ "serde_json",
+ "wit-bindgen-guest-rust",
 ]
 
 [[package]]
@@ -1427,7 +1434,7 @@ name = "noirc_driver"
 version = "0.1.0"
 dependencies = [
  "acvm",
- "dirs 3.0.2",
+ "dirs 4.0.0",
  "fm",
  "noirc_abi",
  "noirc_errors",
@@ -1720,6 +1727,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,12 +1960,6 @@ dependencies = [
  "lazy_static",
  "windows-sys 0.36.1",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2372,6 +2384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2412,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
@@ -2456,8 +2483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2518,27 +2543,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
-name = "wasm-bindgen-test"
-version = "0.3.33"
+name = "wasm-encoder"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
- "console_error_panic_hook",
- "js-sys",
- "scoped-tls",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
+ "leb128",
 ]
 
 [[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.33"
+name = "wasmparser"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
 dependencies = [
- "proc-macro2",
- "quote",
+ "indexmap",
+ "url",
 ]
 
 [[package]]
@@ -2700,6 +2720,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.3.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#d24b97fcb1378cd8f61efbfd956ca8dcb57d2db0"
+dependencies = [
+ "anyhow",
+ "wit-component",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-gen-guest-rust"
+version = "0.3.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#d24b97fcb1378cd8f61efbfd956ca8dcb57d2db0"
+dependencies = [
+ "heck",
+ "wit-bindgen-core",
+ "wit-bindgen-gen-rust-lib",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-gen-rust-lib"
+version = "0.3.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#d24b97fcb1378cd8f61efbfd956ca8dcb57d2db0"
+dependencies = [
+ "heck",
+ "wit-bindgen-core",
+]
+
+[[package]]
+name = "wit-bindgen-guest-rust"
+version = "0.3.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#d24b97fcb1378cd8f61efbfd956ca8dcb57d2db0"
+dependencies = [
+ "bitflags",
+ "wit-bindgen-guest-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-guest-rust-macro"
+version = "0.3.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#d24b97fcb1378cd8f61efbfd956ca8dcb57d2db0"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-gen-guest-rust",
+ "wit-bindgen-rust-macro-shared",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro-shared"
+version = "0.3.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#d24b97fcb1378cd8f61efbfd956ca8dcb57d2db0"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292a4db4b7de170ce349e2575f305ad592623ce16cbe824344894a10e60ab879"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "wasm-encoder",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703eb1d2f89ff2c52d50f7ff002735e423cea75f0a5dc5c8a4626c4c47cd9ca6"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "pulldown-cmark",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,15 +52,11 @@ cfg-if = "1.0.0"
 clap = "2.33.3"
 codespan = "0.9.5"
 codespan-reporting = "0.9.5"
-console_error_panic_hook = "*"
 dirs = "4"
 flate2 = "1.0.24"
 generational-arena = "0.2.8"
-getrandom = { version = "0.2.4", features = ["js"] }
-gloo-utils = { version = "0.1", features = ["serde"] }
 hex = "0.4.2"
 indexmap = "1.7.0"
-js-sys = "0.3.55"
 lazy_static = "1.4.0"
 k256 = { version = "0.7.2", features = [
     "ecdsa",
@@ -86,9 +82,7 @@ termcolor = "1.1.2"
 thiserror = "1.0.21"
 toml = "0.5.8"
 url = "2.2.0"
-wasm-bindgen = { version = "*", features = ["serde-serialize"] }
-wasm-bindgen-test = "*"
-
+wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }
 
 # Patch github versions of acvm with local copy
 [patch.'https://github.com/noir-lang/noir']

--- a/crates/fm/Cargo.toml
+++ b/crates/fm/Cargo.toml
@@ -9,7 +9,10 @@ edition.workspace = true
 [dependencies]
 codespan-reporting.workspace = true
 cfg-if.workspace = true
+
+# Comment the [target] line if you need to debug the macro expansion
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "*", features = ["serde-serialize"] }
+wit-bindgen-guest-rust.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -5,23 +5,19 @@ use std::path::Path;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-        use wasm_bindgen::{prelude::*, JsValue};
-
-        #[wasm_bindgen(module = "@noir-lang/noir-source-resolver")]
-        extern "C" {
-            #[wasm_bindgen(catch)]
-            fn read_file(path: &str) -> Result<String, JsValue>;
-        }
+        wit_bindgen_guest_rust::generate!({
+            path: "./wit/fm.wit",
+        });
 
         pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
             use std::io::ErrorKind;
             let path_str = path_to_file.as_os_str().to_str().unwrap();
-            match read_file(path_str) {
+            match fs::read_file(path_str) {
                 Ok(buffer) => Ok(buffer),
-                Err(_) => Err(Error::new(ErrorKind::Other, "could not read file using wasm")),
+                Err(msg) => Err(Error::new(ErrorKind::Other, msg)),
             }
         }
-    } else {
+    } else  {
         pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
             std::fs::read_to_string(path_to_file)
         }

--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
                 Err(msg) => Err(Error::new(ErrorKind::Other, msg)),
             }
         }
-    } else  {
+    } else {
         pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
             std::fs::read_to_string(path_to_file)
         }

--- a/crates/fm/wit/fm.wit
+++ b/crates/fm/wit/fm.wit
@@ -1,0 +1,5 @@
+world fm {
+  import fs: interface {
+    read-file: func(path: string) -> result<string, string>
+  }
+}

--- a/crates/wasm/.cargo/config.toml
+++ b/crates/wasm/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -15,13 +15,5 @@ crate-type = ["cdylib"]
 acvm = { path = "../acvm", features = ["bn254"] }
 noirc_driver = { path = "../noirc_driver" }
 
-console_error_panic_hook.workspace = true
-
-wasm-bindgen.workspace = true
-gloo-utils.workspace = true
-
-getrandom.workspace = true
-js-sys.workspace = true
-
-[dev-dependencies]
-wasm-bindgen-test.workspace = true
+serde_json.workspace = true
+wit-bindgen-guest-rust.workspace = true

--- a/crates/wasm/build-wasm
+++ b/crates/wasm/build-wasm
@@ -1,25 +1,36 @@
 #!/usr/bin/env bash
 
-# Clear out the existing build artifacts as these aren't automatically removed by wasm-pack.
-if [ -d ./pkg/ ]; then
-    rm -rf ./pkg/
+# Clear out the existing build artifacts as these aren't automatically removed
+if [ -d ./binding/ ]; then
+    rm -rf ./binding/
 fi
 
-# Build the new wasm package
-wasm-pack build --scope noir-lang --target nodejs --out-dir pkg/nodejs
-
-wasm-pack build --scope noir-lang --target web --out-dir pkg/web
-
-COMMIT_SHORT=$(git rev-parse --short HEAD)
-VERSION_APPENDIX=""
-if [ -n "$COMMIT_SHORT" ]; then
-    VERSION_APPENDIX="-$COMMIT_SHORT"
+# Determine system.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    OS=macos
+elif [[ "$OSTYPE" == "linux-gnu" ]]; then
+    OS=linux
 else
-    VERSION_APPENDIX="-NOGIT"
+    echo "Unknown OS: $OSTYPE"
+    exit 1
 fi
 
-jq -s '.[0] * .[1]' pkg/nodejs/package.json pkg/web/package.json | jq '.files = ["nodejs", "web", "package.json"]' | jq ".version += \"$VERSION_APPENDIX\"" | jq '.main = "./nodejs/" + .main | .module = "./web/" + .module | .types = "./web/" + .types | .peerDependencies = { "@noir-lang/noir-source-resolver": "1.0.0" }' | tee ./pkg/package.json
+if [ "$OS" == "macos" ]; then
+    export BREW_PREFIX=$(brew --prefix)
+    # Ensure we have toolchain.
+    if [ ! "$?" -eq 0 ] || [ ! -f "$BREW_PREFIX/opt/llvm/bin/clang++" ]; then
+        echo "Default clang not sufficient. Install homebrew, and then: brew install llvm"
+        exit 1
+    fi
+    export CC=$BREW_PREFIX/opt/llvm/bin/clang
+    export AR=$BREW_PREFIX/opt/llvm/bin/llvm-ar
+else
+    export CC=clang
+    export AR=llvm-ar
+fi
 
-rm pkg/nodejs/package.json pkg/nodejs/README.md pkg/nodejs/.gitignore
-
-rm pkg/web/package.json pkg/web/README.md pkg/web/.gitignore
+# Build the new wasm code
+cargo build --lib --release
+wasm-tools component new ../../target/wasm32-unknown-unknown/release/noir_wasm.wasm -o ../../target/wasm32-unknown-unknown/release/noir_wasm.component.wasm
+# -I is the important part because it allows "instantiation" which allows us to pass in our imports
+wit-bindgen host js -I ../../target/wasm32-unknown-unknown/release/noir_wasm.component.wasm --out-dir binding

--- a/crates/wasm/init.js
+++ b/crates/wasm/init.js
@@ -1,0 +1,15 @@
+import { instantiate } from "./binding/noir_wasm.component.js";
+
+export async function init(compileWasm, fs) {
+  return await instantiate(compileWasm, {
+    fs,
+    console: {
+      log(msg) {
+        console.log(msg);
+      },
+      error(msg) {
+        console.error(msg);
+      },
+    },
+  });
+}

--- a/crates/wasm/noir-browser.js
+++ b/crates/wasm/noir-browser.js
@@ -1,0 +1,18 @@
+// WIP - need to test with bundlers
+
+import { init } from "./init.js";
+
+async function compileWasm(filename) {
+  const base = new URL("./binding/", import.meta.url);
+  const path = new URL(filename, base);
+  const wasm = await fetch(path);
+  return WebAssembly.compile(wasm);
+}
+
+const { compile, acirToBytes, acirFromBytes } = await init(compileWasm, {
+  readFile(file) {
+    return fetch(file).then((res) => res.text());
+  },
+});
+
+export { compile, acirToBytes, acirFromBytes };

--- a/crates/wasm/noir-node.js
+++ b/crates/wasm/noir-node.js
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+
+import { init } from "./init.js";
+
+async function compileWasm(filename) {
+  const base = new URL("./binding/", import.meta.url);
+  const path = new URL(filename, base);
+  const wasm = await fs.promises.readFile(path);
+  return WebAssembly.compile(wasm);
+}
+
+const { compile, acirToBytes, acirFromBytes } = await init(compileWasm, {
+  readFile(file) {
+    return fs.readFileSync(file, "utf8");
+  },
+});
+
+export { compile, acirToBytes, acirFromBytes };

--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@noir-lang/noir_wasm",
+  "version": "0.10.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "node": "./noir-node.js",
+      "default": "./noir-browser.js"
+    },
+    "./init": "./init.js"
+  },
+  "files": [
+    "binding/",
+    "*.js"
+  ]
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,29 +1,46 @@
 use acvm::acir::circuit::Circuit;
-use gloo_utils::format::JsValueSerdeExt;
 use std::path::PathBuf;
-use wasm_bindgen::prelude::*;
+use std::sync::Once;
 
-// Returns a compiled program which is the ACIR circuit along with the ABI
-#[wasm_bindgen]
-pub fn compile(src: String) -> JsValue {
-    console_error_panic_hook::set_once();
-    // For now we default to plonk width = 3, though we can add it as a parameter
-    let language = acvm::Language::PLONKCSat { width: 3 };
-    let path = PathBuf::from(src);
-    let compiled_program = noirc_driver::Driver::compile_file(path, language);
-    <JsValue as JsValueSerdeExt>::from_serde(&compiled_program).unwrap()
-}
-// Deserialises bytes into ACIR structure
-#[wasm_bindgen]
-pub fn acir_from_bytes(bytes: Vec<u8>) -> JsValue {
-    console_error_panic_hook::set_once();
-    let circuit = Circuit::from_bytes(&bytes);
-    <JsValue as JsValueSerdeExt>::from_serde(&circuit).unwrap()
+wit_bindgen_guest_rust::generate!({
+    path: "./wit/noir_wasm.wit",
+});
+
+struct NoirWasm;
+
+export_noir_wasm!(NoirWasm);
+
+impl noir_wasm::NoirWasm for NoirWasm {
+    // Returns a compiled program which is the ACIR circuit along with the ABI
+    fn compile(src: String) -> String {
+        init();
+        let language = acvm::Language::PLONKCSat { width: 3 };
+        let path = PathBuf::from(src);
+        let compiled_program = noirc_driver::Driver::compile_file(path, language);
+        serde_json::to_string(&compiled_program).unwrap()
+    }
+
+    // Deserialises bytes into ACIR structure
+    fn acir_from_bytes(bytes: Vec<u8>) -> String {
+        init();
+        let circuit = Circuit::from_bytes(&bytes);
+        serde_json::to_string(&circuit).unwrap()
+    }
+
+    fn acir_to_bytes(acir: String) -> Vec<u8> {
+        init();
+        let circuit: Circuit = serde_json::from_str(&acir).unwrap();
+        circuit.to_bytes()
+    }
 }
 
-#[wasm_bindgen]
-pub fn acir_to_bytes(acir: JsValue) -> Vec<u8> {
-    console_error_panic_hook::set_once();
-    let circuit: Circuit = JsValueSerdeExt::into_serde(&acir).unwrap();
-    circuit.to_bytes()
+fn init() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            console::error(&info.to_string());
+            prev_hook(info);
+        }));
+    });
 }

--- a/crates/wasm/wit/noir_wasm.wit
+++ b/crates/wasm/wit/noir_wasm.wit
@@ -1,0 +1,11 @@
+world noir-wasm {
+    import console: interface {
+        log: func(msg: string)
+        error: func(msg: string)
+    }
+    default export interface {
+        compile: func(src: string) -> string
+        acir-from-bytes: func(bytes: list<u8>) -> string
+        acir-to-bytes: func(acir: string) -> list<u8>
+    }
+}


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

This reworks the wasm and fm crates to use [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen), which is a sort of spiritual successor to `wasm-bindgen` but focused on [WebAssembly Component Model](https://github.com/WebAssembly/component-model/blob/main/design/high-level/Goals.md).

By using `wit-bindgen` and `*.wit` files, we can avoid needing to include libraries like `js-sys` and other wasm/JS specialized packages because we are just binding to idiomatic Rust, such as using `String` type instead of `JsValue` and the tool is doing the appropriate codegen. Additionally, it allows us to support various [generators](https://github.com/bytecodealliance/wit-bindgen#supported-generators) that allow different "guests" (most importantly C & Rust, both of which we need to bind to) and "hosts" (such as JS and Wasmtime).

The most significant change here is that generating the JS host bindings allow us to instantiate our wasm modules! This allows us to directly pass the FFI functions that our wasm compiler needs (notably `read_file`) when bootstrapping the wasm module. With this change, we'll no longer need the `@noir-lang/noir-source-resolver` 🎉  This is important because it makes for a bad bootstrapping experience.

As you can also see, we no longer need to perform multiple `wasm-pack` runs because the package is isomorphic JS. 

This is still a draft because we need to discuss the approach, build process, and packaging layout.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

See above.

## Dependency additions / changes

<!-- If applicable. -->
wasm-bindgen stuff was removed and wit-bindgen stuff was added. We also need to solve for the `wasm-tools` and `wit-bindgen` CLIs needing to be available to the build process.

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
