### PR TITLE
Avoid panic if add_file path does not have `.nr` extension

### DIFF
--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -43,14 +43,6 @@ impl FileManager {
 
     // XXX: Maybe use a AsRef<Path> here, for API ergonomics
     pub fn add_file(&mut self, path_to_file: &Path, file_type: FileType) -> Option<FileId> {
-        // We expect the caller to ensure that the file is a valid noir file
-        let ext = path_to_file
-            .extension()
-            .unwrap_or_else(|| panic!("{:?} does not have an extension", path_to_file));
-        if ext != FILE_EXTENSION {
-            return None;
-        }
-
         let source = file_reader::read_file_to_string(path_to_file).ok()?;
 
         let file_id = self.file_map.add_file(path_to_file.to_path_buf().into(), source);
@@ -146,6 +138,17 @@ mod tests {
 
         let _foo_file_path = dummy_file_path(&dir, "foo.nr");
         fm.resolve_path(file_id, "foo").unwrap();
+    }
+    #[test]
+    fn path_resolve_file_module_other_ext() {
+        let dir = tempdir().unwrap();
+        let file_path = dummy_file_path(&dir, "foo.noir");
+
+        let mut fm = FileManager::new();
+
+        let file_id = fm.add_file(&file_path, FileType::Normal).unwrap();
+
+        assert!(fm.path(file_id).ends_with("foo"))
     }
     #[test]
     fn path_resolve_sub_module() {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #663 <!-- link to issue -->

# Description

This avoids a panic if `add_file` is called with a file path that doesn't end in `.nr`

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

I removed the check against the extension so we don't return `None` if the extension is something other than `.nr`. It doesn't seem like this check is necessary because we read the source code and then virtualize the path to remove the extension entirely.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

Added a test that `add_file` can accept a file with a different extension and virtualizes the path by removing the extension.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
