### PR TITLE
Ensure barrenenberg_wrapper is locked to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec-connect?branch=kw/noir-dsl#2ef8be41993ead9993c09b1d99fef6dc68e231a6"
+source = "git+https://github.com/noir-lang/aztec-connect?branch=kw/noir-dsl#85dcb7c404b824b420c92e1010a9e363fe91fbd2"
 dependencies = [
  "bindgen",
  "cmake",


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

This locks barrenenberg_wrapper to the latest commit. Even though we are using the `kw/noir-dsl` branch in the dependency graph, it will still resolve to the older commit if you install exactly from the lock.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

I just ran `cargo update --package barretenberg_wrapper` to update it.

## Dependency additions / changes

<!-- If applicable. -->

`barretenberg_wrapper` is now the latest commit.

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
