### PR TITLE
Replace `toml_map_to_field` and `toml_remap` with traits to map between `InputValue`s and `TomlTypes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,7 @@ version = "0.1.0"
 dependencies = [
  "acvm",
  "blake2",
+ "iter-extended",
  "serde",
  "serde_derive",
  "serde_json",

--- a/crates/iter-extended/src/lib.rs
+++ b/crates/iter-extended/src/lib.rs
@@ -27,3 +27,13 @@ where
 {
     iterable.into_iter().map(f).collect()
 }
+
+/// Equivalent to .into_iter().map(f).collect::<Result<BTreeMap<_, _>,_>>()
+pub fn try_btree_map<T, K, V, E, F>(iterable: T, f: F) -> Result<BTreeMap<K, V>, E>
+where
+    T: IntoIterator,
+    K: std::cmp::Ord,
+    F: FnMut(T::Item) -> Result<(K, V), E>,
+{
+    iterable.into_iter().map(f).collect()
+}

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 acvm.workspace = true
+iter-extended.workspace = true
 toml.workspace = true
 serde.workspace = true
 serde_derive.workspace = true

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -1,7 +1,7 @@
 use super::InputValue;
 use crate::{errors::InputParserError, Abi, AbiType};
 use acvm::FieldElement;
-use iter_extended::{btree_map, try_btree_map};
+use iter_extended::{btree_map, try_btree_map, try_vecmap, vecmap};
 use serde::Serialize;
 use serde_derive::Deserialize;
 use std::collections::BTreeMap;
@@ -116,18 +116,13 @@ impl InputValue {
                 InputValue::Field(new_value)
             }
             TomlTypes::ArrayNum(arr_num) => {
-                let array_elements: Vec<_> = arr_num
-                    .into_iter()
-                    .map(|elem_num| FieldElement::from(i128::from(elem_num)))
-                    .collect();
+                let array_elements =
+                    vecmap(arr_num, |elem_num| FieldElement::from(i128::from(elem_num)));
 
                 InputValue::Vec(array_elements)
             }
             TomlTypes::ArrayString(arr_str) => {
-                let array_elements: Vec<_> = arr_str
-                    .into_iter()
-                    .map(|elem_str| parse_str_to_field(&elem_str).unwrap())
-                    .collect();
+                let array_elements = try_vecmap(arr_str, |elem_str| parse_str_to_field(&elem_str))?;
 
                 InputValue::Vec(array_elements)
             }

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -127,8 +127,12 @@ impl InputValue {
                 InputValue::Vec(array_elements)
             }
             TomlTypes::Table(table) => {
+                let fields = match param_type {
+                    AbiType::Struct { fields } => fields,
+                    _ => return Err(InputParserError::AbiTypeMismatch(param_type.clone())),
+                };
                 let native_table = try_btree_map(table, |(key, value)| {
-                    InputValue::try_from_toml(value, param_type)
+                    InputValue::try_from_toml(value, &fields[&key])
                         .map(|input_value| (key, input_value))
                 })?;
 


### PR DESCRIPTION
# Related issue(s)

# Description

## Summary of changes

I've replaced the functions `toml_map_to_field` and `toml_remap` with implementations of `TomlTypes::from<InputValue>()` and `InputValue::try_from<TomlTypes>()`, i.e. rather than mapping the entire set of arguments at once we specify how to map a single input from one type to another.

We can then just iterate over each argument and map them individually.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
