### PR TITLE
update backend commits for a missing hash_to_field bb.wasm fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_static_lib"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=441de9d897683f770f8cd09c34ddca69fe41f3f2#441de9d897683f770f8cd09c34ddca69fe41f3f2"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=344d66798caab9bdad4a1c7be0539b1a116124b9#344d66798caab9bdad4a1c7be0539b1a116124b9"
 dependencies = [
  "barretenberg_wrapper",
  "blake2",
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wasm"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=441de9d897683f770f8cd09c34ddca69fe41f3f2#441de9d897683f770f8cd09c34ddca69fe41f3f2"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=344d66798caab9bdad4a1c7be0539b1a116124b9#344d66798caab9bdad4a1c7be0539b1a116124b9"
 dependencies = [
  "blake2",
  "common",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=441de9d897683f770f8cd09c34ddca69fe41f3f2#441de9d897683f770f8cd09c34ddca69fe41f3f2"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=344d66798caab9bdad4a1c7be0539b1a116124b9#344d66798caab9bdad4a1c7be0539b1a116124b9"
 dependencies = [
  "acvm",
  "blake2",

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -30,8 +30,8 @@ hex.workspace = true
 tempdir.workspace = true
 
 # Backends
-aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "441de9d897683f770f8cd09c34ddca69fe41f3f2" }
-aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "441de9d897683f770f8cd09c34ddca69fe41f3f2" }
+aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "344d66798caab9bdad4a1c7be0539b1a116124b9" }
+aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "344d66798caab9bdad4a1c7be0539b1a116124b9" }
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
 
 [features]


### PR DESCRIPTION
# Related issue(s)

Resolves #662 

# Description

PR in aztec_backend: https://github.com/noir-lang/aztec_backend/pull/48

## Summary of changes

While migrating to noir-lang/aztec-connect/barretenberg I fixed the hash_to_field interop in barretenberg. However, due to us currently having a manual build process for the barretenberg.wasm file I missed that I needed to rebuild the wasm file for the aztec backend. The wasm aztec backend is what is currently used for binary releases so that is why the error still existed in the issue linked. I tested this update locally and was able to use hash_to_field with the wasm aztec backend and not just the static lib.

Our CI only runs the static lib so `hash_to_field` would still pass our Github tests. 

## Dependency additions / changes

I changed the commit to for the aztec backend in the nargo `Cargo.toml` file to reflect the newly updated `barretenberg.wasm` file.

## Test additions / changes

Install nargo using `aztec_wasm_backend` on master:
```
cargo install --locked --path=crates/nargo --no-default-features --features plonk_bn254_wasm
```
Try and nargo prove and nargo verify the `hash_to_field` test under `nargo/tests/test_data`. You will get a proof verified: false.

Now checkout to this PRs branch and install the `aztec_wasm_backend`. `hash_to_field` will now return true for proof verification like the static lib as expected.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
