### PR TITLE
Replace handwritten error display methods with `thisError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
  "toml",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ dependencies = [
  "serde_derive",
  "tempdir",
  "termcolor",
+ "thiserror",
  "toml",
  "url",
 ]

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -28,6 +28,7 @@ clap.workspace = true
 termcolor.workspace = true
 hex.workspace = true
 tempdir.workspace = true
+thiserror.workspace = true
 
 # Backends
 aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "c673a14be33e445d98b35969716ac59c682036d6" }

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -1,15 +1,21 @@
 use acvm::OpcodeResolutionError;
 use hex::FromHexError;
 use noirc_abi::errors::{AbiError, InputParserError};
-use std::{fmt::Display, io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum CliError {
+    #[error("{0}")]
     Generic(String),
+    #[error("Error: destination {} already exists", .0.display())]
     DestinationAlreadyExists(PathBuf),
+    #[error("Error: {} is not a valid path", .0.display())]
     PathNotValid(PathBuf),
+    #[error("Error: could not parse proof data ({0})")]
     ProofNotValid(FromHexError),
+    #[error("cannot find input file located at {0:?}, run nargo build to generate the missing Prover and/or Verifier toml files")]
     MissingTomlFile(PathBuf),
 }
 
@@ -28,23 +34,6 @@ impl CliError {
         writeln!(&mut stderr, "{self}").expect("cannot write to stderr");
 
         std::process::exit(1)
-    }
-}
-
-impl Display for CliError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-                CliError::Generic(msg) => write!(f, "Error: {msg}"),
-                CliError::DestinationAlreadyExists(path) =>
-                write!(f, "Error: destination {} already exists", path.display()),
-                CliError::PathNotValid(path) => {
-                    write!(f, "Error: {} is not a valid path", path.display())
-                }
-                CliError::ProofNotValid(hex_error) => {
-                    write!(f, "Error: could not parse proof data ({hex_error})")
-                }
-                CliError::MissingTomlFile(path) => write!(f, "cannot find input file located at {path:?}, run nargo build to generate the missing Prover and/or Verifier toml files"),
-            }
     }
 }
 

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -12,6 +12,7 @@ toml.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 blake2.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -1,74 +1,32 @@
 use crate::{input_parser::InputValue, AbiParameter, AbiType};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum InputParserError {
+    #[error("input.toml file is badly formed, could not parse, {0}")]
     ParseTomlMap(String),
+    #[error("Expected witness values to be integers, provided value causes `{0}` error")]
     ParseStr(String),
+    #[error("Could not parse hex value {0}")]
     ParseHexStr(String),
+    #[error("duplicate variable name {0}")]
     DuplicateVariableName(String),
+    #[error("cannot parse a string toml type into {0:?}")]
     AbiTypeMismatch(AbiType),
 }
 
-impl std::fmt::Display for InputParserError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InputParserError::ParseTomlMap(err_msg) => {
-                write!(f, "input.toml file is badly formed, could not parse, {err_msg}")
-            }
-            InputParserError::ParseStr(err_msg) => write!(
-                f,
-                "Expected witness values to be integers, provided value causes `{err_msg}` error"
-            ),
-            InputParserError::ParseHexStr(err_msg) => {
-                write!(f, "Could not parse hex value {err_msg}")
-            }
-            InputParserError::DuplicateVariableName(err_msg) => {
-                write!(f, "duplicate variable name {err_msg}")
-            }
-            InputParserError::AbiTypeMismatch(abi_type) => {
-                write!(f, "cannot parse a string toml type into {abi_type:?}")
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum AbiError {
+    #[error("{0}")]
     Generic(String),
+    #[error("Received parameters not expected by ABI: {0:?}")]
     UnexpectedParams(Vec<String>),
+    #[error("The parameter {} is expected to be a {:?} but found incompatible value {value:?}", .param.name, .param.typ)]
     TypeMismatch { param: AbiParameter, value: InputValue },
+    #[error("ABI expects the parameter `{0}`, but this was not found")]
     MissingParam(String),
+    #[error("Input value `{0}` is not defined")]
     UndefinedInput(String),
+    #[error("ABI specifies an input of length {expected} but received input of length {actual}")]
     UnexpectedInputLength { expected: u32, actual: u32 },
-}
-
-impl std::fmt::Display for AbiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                AbiError::Generic(msg) => msg.clone(),
-                AbiError::UnexpectedParams(unexpected_params) =>
-                    format!("Received parameters not expected by ABI: {unexpected_params:?}"),
-                AbiError::TypeMismatch { param, value } => {
-                    format!(
-                        "The parameter {} is expected to be a {:?} but found incompatible value {:?}",
-                        param.name, param.typ, value
-                    )
-                }
-                AbiError::MissingParam(name) => {
-                    format!("ABI expects the parameter `{name}`, but this was not found")
-                }
-                AbiError::UndefinedInput(name) => {
-                    format!("Input value `{name}` is not defined")
-                }
-                AbiError::UnexpectedInputLength { expected, actual } => {
-                    format!(
-                        "ABI specifies an input of length {expected} but received input of length {actual}"
-                    )
-                }
-            }
-        )
-    }
 }

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -15,6 +15,18 @@ pub enum InputParserError {
     AbiTypeMismatch(AbiType),
 }
 
+impl From<toml::ser::Error> for InputParserError {
+    fn from(err: toml::ser::Error) -> Self {
+        Self::ParseTomlMap(err.to_string())
+    }
+}
+
+impl From<toml::de::Error> for InputParserError {
+    fn from(err: toml::de::Error) -> Self {
+        Self::ParseTomlMap(err.to_string())
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum AbiError {
     #[error("{0}")]

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -10,8 +10,7 @@ pub(crate) fn parse_toml(
     abi: Abi,
 ) -> Result<BTreeMap<String, InputValue>, InputParserError> {
     // Parse input.toml into a BTreeMap, converting the argument to field elements
-    let data: BTreeMap<String, TomlTypes> = toml::from_str(input_string)
-        .map_err(|err_msg| InputParserError::ParseTomlMap(err_msg.to_string()))?;
+    let data: BTreeMap<String, TomlTypes> = toml::from_str(input_string)?;
 
     // The toml map is stored in an ordered BTreeMap. As the keys are strings the map is in alphanumerical order.
     // When parsing the toml map we recursively go through each field to enable struct inputs.
@@ -44,11 +43,8 @@ pub(crate) fn serialise_to_toml(
         })
         .collect();
 
-    let mut toml_string = toml::to_string(&to_map)
-        .map_err(|err_msg| InputParserError::ParseTomlMap(err_msg.to_string()))?;
-
-    let toml_string_tables = toml::to_string(&tables_map)
-        .map_err(|err_msg| InputParserError::ParseTomlMap(err_msg.to_string()))?;
+    let mut toml_string = toml::to_string(&to_map)?;
+    let toml_string_tables = toml::to_string(&tables_map)?;
 
     toml_string.push_str(&toml_string_tables);
 


### PR DESCRIPTION
# Related issue(s)

No issue as this is a small refactor.

# Description

## Summary of changes

Rather than implementing `std::fmt::Display` manually for `CliError`, `InputParserError` and `AbiError`, I've used `thisError` to derive these implementations.

I've also implemented `InputParserError::from` for `toml::{ser,de}:Error` to map these errors automatically.

## Dependency additions / changes

`thisError` added to `nargo` and `noirc_abi`

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- N/A I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
