### PR TITLE
use &[FieldElement] arg instead of &Vec<FieldElement> in abi.decode

### DIFF
--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -228,7 +228,7 @@ impl Abi {
     /// Decode a vector of `FieldElements` into the types specified in the ABI.
     pub fn decode(
         &self,
-        encoded_inputs: &Vec<FieldElement>,
+        encoded_inputs: &[FieldElement],
     ) -> Result<BTreeMap<String, InputValue>, AbiError> {
         let input_length: u32 = encoded_inputs.len().try_into().unwrap();
         if input_length != self.field_count() {
@@ -254,7 +254,7 @@ impl Abi {
 
     fn decode_value(
         initial_index: usize,
-        encoded_inputs: &Vec<FieldElement>,
+        encoded_inputs: &[FieldElement],
         value_type: &AbiType,
     ) -> Result<(usize, InputValue), AbiError> {
         let mut index = initial_index;


### PR DESCRIPTION
# Related issue(s)

Related to #679 

# Description

## Summary of changes

I've updated the function signature to use slices instead of a reference to a vector.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
