### PR TITLE
Create a `constants.rs` file for Nargo

### DIFF
--- a/crates/nargo/src/cli/check_cmd.rs
+++ b/crates/nargo/src/cli/check_cmd.rs
@@ -8,7 +8,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use super::{add_std_lib, write_to_file, PROVER_INPUT_FILE, VERIFIER_INPUT_FILE};
+use super::{add_std_lib, write_to_file};
+use crate::constants::{PROVER_INPUT_FILE, VERIFIER_INPUT_FILE};
 
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     let args = args.subcommand_matches("check").unwrap();

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -7,9 +7,13 @@ use clap::ArgMatches;
 
 use std::path::Path;
 
-use crate::{errors::CliError, resolver::Resolver};
+use crate::{
+    constants::{ACIR_EXT, TARGET_DIR, WITNESS_EXT},
+    errors::CliError,
+    resolver::Resolver,
+};
 
-use super::{add_std_lib, create_named_dir, write_to_file, TARGET_DIR};
+use super::{add_std_lib, create_named_dir, write_to_file};
 
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
     let args = args.subcommand_matches("compile").unwrap();
@@ -47,7 +51,7 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
 
     let mut circuit_path = create_named_dir(circuit_dir.as_ref(), "build");
     circuit_path.push(circuit_name);
-    circuit_path.set_extension(crate::cli::ACIR_EXT);
+    circuit_path.set_extension(ACIR_EXT);
     let path = write_to_file(serialized.as_slice(), &circuit_path);
     println!("Generated ACIR code into {path}");
     println!("{:?}", std::fs::canonicalize(&circuit_path));
@@ -59,7 +63,7 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
 
         circuit_path.pop();
         circuit_path.push(circuit_name);
-        circuit_path.set_extension(crate::cli::WITNESS_EXT);
+        circuit_path.set_extension(WITNESS_EXT);
         write_to_file(buf.as_slice(), &circuit_path);
     }
 

--- a/crates/nargo/src/cli/contract_cmd.rs
+++ b/crates/nargo/src/cli/contract_cmd.rs
@@ -1,5 +1,5 @@
-use super::{create_named_dir, write_to_file, CONTRACT_DIR};
-use crate::{cli::compile_cmd::compile_circuit, errors::CliError};
+use super::{create_named_dir, write_to_file};
+use crate::{cli::compile_cmd::compile_circuit, constants::CONTRACT_DIR, errors::CliError};
 use acvm::SmartContract;
 use clap::ArgMatches;
 

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -25,17 +25,6 @@ mod new_cmd;
 mod prove_cmd;
 mod verify_cmd;
 
-const CONTRACT_DIR: &str = "contract";
-const PROOFS_DIR: &str = "proofs";
-const PROVER_INPUT_FILE: &str = "Prover";
-const VERIFIER_INPUT_FILE: &str = "Verifier";
-const SRC_DIR: &str = "src";
-const PKG_FILE: &str = "Nargo.toml";
-const PROOF_EXT: &str = "proof";
-const TARGET_DIR: &str = "target";
-const ACIR_EXT: &str = "acir";
-const WITNESS_EXT: &str = "tr";
-
 pub fn start_cli() {
     let allow_warnings = Arg::with_name("allow-warnings")
         .long("allow-warnings")

--- a/crates/nargo/src/cli/new_cmd.rs
+++ b/crates/nargo/src/cli/new_cmd.rs
@@ -1,6 +1,9 @@
-use crate::errors::CliError;
+use crate::{
+    constants::{PKG_FILE, SRC_DIR},
+    errors::CliError,
+};
 
-use super::{create_named_dir, write_to_file, PKG_FILE, SRC_DIR};
+use super::{create_named_dir, write_to_file};
 use clap::ArgMatches;
 use std::path::Path;
 

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -9,11 +9,10 @@ use noirc_abi::errors::AbiError;
 use noirc_abi::input_parser::{Format, InputValue};
 use std::path::Path;
 
-use crate::errors::CliError;
-
-use super::{
-    create_named_dir, read_inputs_from_file, write_inputs_to_file, write_to_file, PROOFS_DIR,
-    PROOF_EXT, PROVER_INPUT_FILE, VERIFIER_INPUT_FILE,
+use super::{create_named_dir, read_inputs_from_file, write_inputs_to_file, write_to_file};
+use crate::{
+    constants::{PROOFS_DIR, PROOF_EXT, PROVER_INPUT_FILE, VERIFIER_INPUT_FILE},
+    errors::CliError,
 };
 
 pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -1,6 +1,8 @@
-use super::compile_cmd::compile_circuit;
-use super::{read_inputs_from_file, PROOFS_DIR, PROOF_EXT, VERIFIER_INPUT_FILE};
-use crate::errors::CliError;
+use super::{compile_cmd::compile_circuit, read_inputs_from_file};
+use crate::{
+    constants::{PROOFS_DIR, PROOF_EXT, VERIFIER_INPUT_FILE},
+    errors::CliError,
+};
 use acvm::ProofSystemCompiler;
 use clap::ArgMatches;
 use noirc_abi::errors::AbiError;

--- a/crates/nargo/src/constants.rs
+++ b/crates/nargo/src/constants.rs
@@ -1,0 +1,25 @@
+// Directories
+/// The directory for the `nargo contract` command output
+pub(crate) const CONTRACT_DIR: &str = "contract";
+/// The directory to store serialized circuit proofs.
+pub(crate) const PROOFS_DIR: &str = "proofs";
+/// The directory to store Noir source files
+pub(crate) const SRC_DIR: &str = "src";
+/// The directory to store circuits' serialized ACIR representations.
+pub(crate) const TARGET_DIR: &str = "target";
+
+// Files
+/// The file from which Nargo pulls prover inputs
+pub(crate) const PROVER_INPUT_FILE: &str = "Prover";
+/// The file from which Nargo pulls verifier inputs
+pub(crate) const VERIFIER_INPUT_FILE: &str = "Verifier";
+/// The package definition file for a Noir project.
+pub(crate) const PKG_FILE: &str = "Nargo.toml";
+
+// Extensions
+/// The extension for files containing circuit proofs.
+pub(crate) const PROOF_EXT: &str = "proof";
+/// The extension for files containing circuit ACIR representations.
+pub(crate) const ACIR_EXT: &str = "acir";
+/// The extension for files containing proof witnesses.
+pub(crate) const WITNESS_EXT: &str = "tr";

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -12,6 +12,7 @@ fn nargo_crates() -> PathBuf {
 
 mod backends;
 pub mod cli;
+mod constants;
 mod errors;
 mod git;
 mod resolver;


### PR DESCRIPTION
# Related issue(s)

Resolves #644

# Description

## Summary of changes

The constants defined in `cli/mod.rs` have been moved to `constants.rs`, I've added a line for each on which described how it's used.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
