### PR TITLE
Remove unnecessary newlines in `nargo gates`

### DIFF
--- a/crates/nargo/src/cli/gates_cmd.rs
+++ b/crates/nargo/src/cli/gates_cmd.rs
@@ -27,13 +27,13 @@ pub fn count_gates_with_path<P: AsRef<Path>>(
     let backend = crate::backends::ConcreteBackend;
 
     println!(
-        "Total ACIR opcodes generated for language {:?}: {}\n",
+        "Total ACIR opcodes generated for language {:?}: {}",
         backend.np_language(),
         num_opcodes
     );
 
     let exact_circuit_size = backend.get_exact_circuit_size(compiled_program.circuit);
-    println!("\nBackend circuit size: {exact_circuit_size}\n");
+    println!("Backend circuit size: {exact_circuit_size}");
 
     Ok(())
 }


### PR DESCRIPTION
# Related issue(s)

Resolves #701 

# Description

## Summary of changes

Newlines have been remove from the print statements in `nargo gates`.

Before:
```
$ nargo gates
ACIR opcodes generated : 18
Total ACIR opcodes generated for language PLONKCSat { width: 3 }: 20

check_circuit result: 1

Backend circuit size: 62

$
```

After:
```
$ nargo gates
ACIR opcodes generated : 18
Total ACIR opcodes generated for language PLONKCSat { width: 3 }: 20
check_circuit result: 1
Backend circuit size: 62
$
```

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
