### PR TITLE
Apply witness visibility on a parameter level rather than witness level

### DIFF
--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -135,7 +135,10 @@ impl Evaluator {
                 );
             }
             AbiType::Array { length, typ } => {
-                let witnesses = self.generate_array_witnesses(visibility, length, typ)?;
+                let witnesses = self.generate_array_witnesses(length, typ)?;
+                if *visibility == AbiVisibility::Public {
+                    self.public_inputs.extend(witnesses.clone());
+                }
                 igen.abi_array(name, Some(def), typ.as_ref(), *length, witnesses);
             }
             AbiType::Integer { sign: _, width } => {
@@ -157,17 +160,26 @@ impl Evaluator {
                 igen.create_new_variable(name.to_owned(), Some(def), obj_type, Some(witness));
             }
             AbiType::Struct { fields } => {
-                let mut struct_witnesses: BTreeMap<String, Vec<Witness>> = BTreeMap::new();
                 let new_fields = btree_map(fields, |(inner_name, value)| {
                     let new_name = format!("{name}.{inner_name}");
                     (new_name, value.clone())
                 });
-                self.generate_struct_witnesses(&mut struct_witnesses, visibility, &new_fields)?;
+
+                let mut struct_witnesses: BTreeMap<String, Vec<Witness>> = BTreeMap::new();
+                self.generate_struct_witnesses(&mut struct_witnesses, &new_fields)?;
+                if *visibility == AbiVisibility::Public {
+                    let witnesses: Vec<Witness> =
+                        struct_witnesses.values().cloned().flatten().collect();
+                    self.public_inputs.extend(witnesses);
+                }
                 igen.abi_struct(name, Some(def), fields, struct_witnesses);
             }
             AbiType::String { length } => {
                 let typ = AbiType::Integer { sign: noirc_abi::Sign::Unsigned, width: 8 };
-                let witnesses = self.generate_array_witnesses(visibility, length, &typ)?;
+                let witnesses = self.generate_array_witnesses(length, &typ)?;
+                if *visibility == AbiVisibility::Public {
+                    self.public_inputs.extend(witnesses.clone());
+                }
                 igen.abi_array(name, Some(def), &typ, *length, witnesses);
             }
         }
@@ -177,7 +189,6 @@ impl Evaluator {
     fn generate_struct_witnesses(
         &mut self,
         struct_witnesses: &mut BTreeMap<String, Vec<Witness>>,
-        visibility: &AbiVisibility,
         fields: &BTreeMap<String, AbiType>,
     ) -> Result<(), RuntimeErrorKind> {
         for (name, typ) in fields {
@@ -186,28 +197,18 @@ impl Evaluator {
                     let witness = self.add_witness_to_cs();
                     struct_witnesses.insert(name.clone(), vec![witness]);
                     ssa::acir_gen::range_constraint(witness, *width, self)?;
-                    if *visibility == AbiVisibility::Public {
-                        self.public_inputs.push(witness);
-                    }
                 }
                 AbiType::Boolean => {
                     let witness = self.add_witness_to_cs();
                     struct_witnesses.insert(name.clone(), vec![witness]);
                     ssa::acir_gen::range_constraint(witness, 1, self)?;
-                    if *visibility == AbiVisibility::Public {
-                        self.public_inputs.push(witness);
-                    }
                 }
                 AbiType::Field => {
                     let witness = self.add_witness_to_cs();
                     struct_witnesses.insert(name.clone(), vec![witness]);
-                    if *visibility == AbiVisibility::Public {
-                        self.public_inputs.push(witness);
-                    }
                 }
                 AbiType::Array { length, typ } => {
-                    let internal_arr_witnesses =
-                        self.generate_array_witnesses(visibility, length, typ)?;
+                    let internal_arr_witnesses = self.generate_array_witnesses(length, typ)?;
                     struct_witnesses.insert(name.clone(), internal_arr_witnesses);
                 }
                 AbiType::Struct { fields, .. } => {
@@ -216,12 +217,11 @@ impl Evaluator {
                         let new_name = format!("{name}.{inner_name}");
                         new_fields.insert(new_name, value.clone());
                     }
-                    self.generate_struct_witnesses(struct_witnesses, visibility, &new_fields)?
+                    self.generate_struct_witnesses(struct_witnesses, &new_fields)?
                 }
                 AbiType::String { length } => {
                     let typ = AbiType::Integer { sign: noirc_abi::Sign::Unsigned, width: 8 };
-                    let internal_str_witnesses =
-                        self.generate_array_witnesses(visibility, length, &typ)?;
+                    let internal_str_witnesses = self.generate_array_witnesses(length, &typ)?;
                     struct_witnesses.insert(name.clone(), internal_str_witnesses);
                 }
             }
@@ -231,7 +231,6 @@ impl Evaluator {
 
     fn generate_array_witnesses(
         &mut self,
-        visibility: &AbiVisibility,
         length: &u64,
         typ: &AbiType,
     ) -> Result<Vec<Witness>, RuntimeErrorKind> {
@@ -245,9 +244,6 @@ impl Evaluator {
             witnesses.push(witness);
             if let Some(ww) = element_width {
                 ssa::acir_gen::range_constraint(witness, ww, self)?;
-            }
-            if *visibility == AbiVisibility::Public {
-                self.public_inputs.push(witness);
             }
         }
         Ok(witnesses)

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -169,7 +169,7 @@ impl Evaluator {
                 self.generate_struct_witnesses(&mut struct_witnesses, &new_fields)?;
                 if *visibility == AbiVisibility::Public {
                     let witnesses: Vec<Witness> =
-                        struct_witnesses.values().cloned().flatten().collect();
+                        struct_witnesses.values().flatten().cloned().collect();
                     self.public_inputs.extend(witnesses);
                 }
                 igen.abi_struct(name, Some(def), fields, struct_witnesses);


### PR DESCRIPTION
# Related issue(s)

Related to #684 as it makes the witness indices of each param more accessible.

# Description

## Summary of changes

An argument to `main` can either be public or private, we disallow situations where e.g. an array has a mixture of public and private elements. This means that we can simplify the evaluator by rather than eagerly pushing each witness onto the `public_inputs` vector, we can instead calculate all the witnesses associated with a parameter and push all of them if the parameter is public.

This is also useful as it surfaces all the witnesses associated with a particular parameter which makes it easier to build a mapping from a param to its witness indices when it comes to abi encoding.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
