### PR TITLE
Remove print to console for named proofs in `nargo prove`

### DIFF
--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -64,7 +64,7 @@ pub fn start_cli() {
         .subcommand(
             App::new("prove")
                 .about("Create proof for this program")
-                .arg(Arg::with_name("proof_name").help("The name of the proof").required(true))
+                .arg(Arg::with_name("proof_name").help("The name of the proof"))
                 .arg(show_ssa.clone())
                 .arg(allow_warnings.clone()),
         )
@@ -174,7 +174,7 @@ fn write_inputs_to_file<P: AsRef<Path>>(
 pub fn prove_and_verify(proof_name: &str, prg_dir: &Path, show_ssa: bool) -> bool {
     let tmp_dir = TempDir::new("p_and_v_tests").unwrap();
     let proof_path = match prove_cmd::prove_with_path(
-        proof_name,
+        Some(proof_name),
         prg_dir,
         &tmp_dir.into_path(),
         show_ssa,
@@ -187,7 +187,7 @@ pub fn prove_and_verify(proof_name: &str, prg_dir: &Path, show_ssa: bool) -> boo
         }
     };
 
-    verify_cmd::verify_with_path(prg_dir, &proof_path, show_ssa, false).unwrap()
+    verify_cmd::verify_with_path(prg_dir, &proof_path.unwrap(), show_ssa, false).unwrap()
 }
 
 fn add_std_lib(driver: &mut Driver) {

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -147,7 +147,7 @@ fn save_proof_to_dir<P: AsRef<Path>>(
     proof_path.push(proof_name);
     proof_path.set_extension(PROOF_EXT);
 
-    write_to_file(hex::encode(&proof).as_bytes(), &proof_path);
+    write_to_file(hex::encode(proof).as_bytes(), &proof_path);
 
     Ok(proof_path)
 }


### PR DESCRIPTION
# Related issue(s)

Resolves #702 

# Description

## Summary of changes

I've reworked `prove_with_path` so that it either prints to console or writes to file based on whether it has been passed a name for the proof its generating.

After this PR, the output of `nargo prove` is as follows

```
$ nargo prove
ACIR opcodes generated : 18
Total Proving time (Rust + Static Lib) : 103622032ns ~ 0seconds
Proof successfully created
14208d4085eb58be92293e07faec661997e0229d6df1fe0721dae6ce959810a3180d69edde0530819878d89c839728d81115c902fb64a0e548e3b42f5def18af01dba2a835d4db405afe379f88180a9ace50dd299037cab0525d2520045bb58405ed26b820e1d6b4af20257a639e01efac3b322c01952822faecdd5b6c82eb95230b6eea86f72d7a13770da2e93b9900c6bbb4c513b923d0399b1d382f081a5119de74636dcf483a589a6c20b71635375016e11c0c1f45f1287744047b2c3db00a5be2ed6892f94a447238e45376c411002d396bbe6da9102124eddcac9d225a2c6db6c1e4d24ba67b165c939d3cefd71d02ad490f6a251b6b73a0e238055d6a2014f864c9c067120c6ddf6a279422cad8938c47ba175b6437497b1b6ea3a5781b21eb9e7f6d7953d2febc4d0480e9d1411c2858fdd94ed82389c9d0d42a866306cf92e76cdd663b890150146f1eda6a6e6dacf85eceeb49ebdf40b0ba6b324023501dfcdc773adb0173467cf41f98b9e5204fc8366e90965738e5200ba5e4970aeff9df5068274ccef8961e9666f7ba7e0e8648fa9e490f911521524c15d0f027382e551daa6a038f932447586b9fab9eab578c4f0b4a39dfc0b33d1350317604f0788b37e17bcda4245ecd37a836a9eed6aa79a18096c9dfacc29085336a4f16f35fa69e5d567dcd6df87dac7ca3dcd429227de8860635848856ede8e3d5ab29b0d0f5ce600673cddbe83fcd0cfb1323f366f1885fa75ed4cb8de29cf9db330a54ec75580073b12fec8b63bea8a815d13e4b19aa7368ef070af53d182c209e2ce7b19ddad8625136ac032bd1efaeaab5ce140487e0120720707d03200b5785148213cced2eaa7417ef4eb7eaf1c877423f9c2bad31d865f0d1507f13fe266f03a709628f2551156b266afe464384fde9cbc332520594258043e7a991443d3d1c5ef1abd966c283f9693d516e6900a2a3d80a9a0577b367f8e631076784fb3c1ce5d42f512ded5be73c2cce8853b8f0e3dfe0585bd6fe912085098f5a30f2170e67be920f4240a5ae1098f66b740e7fa9cfb175f431909daf50ea4e56f92a0c1982626ceb0e1f7cd45be8124b403030ac7942d08ea607d3934ea06aba10a351264b2062b842673f280791a44bebc2b5829a2423ee487ad262aa8e5801e833a9229f856ccd17bddabbf7e920995ca5d4370e012efe262276c459e1f518ae7662229f856ccd17bddabbf7e920995ca5d4370e012efe262276c459e1f518ae76620631907bf24048a7c36fbaae2bd9c00f1f1d369e0f25fee97d59f0632477e4f12d73ae124ad073f937bb6ed4f633892724eaeaccf64b953307a94aa717321f4a0667cd5ba852625aeda1a9ac6202a7354da014523e1988d4d37965ecf5efb2411f95e2c6a5145675975a5b0bcc98b475b069d4116e11ed783c65f7ca5ecefd9f23c2bb486e4bcd6834c0f9ffc14b12b67d22f5cf94bf7213fe3549f992b0fcf80653db24b9833e83cc4b20f17bbf843dbc8d7f1eb98cda8ed5759510f81510940246b75cd0d48a05a98740e04555e95ca986c61b08725e940a8def9b3d19e439038d6c265c8fccf9e1a800bae42178995b08e4be8182a133dbc9e99318dac7102df8d212b1f994b2d0557b549baf0d6d93499d112024ec159af0ecabf023307e

```

```
$ nargo prove test
ACIR opcodes generated : 18
Total Proving time (Rust + Static Lib) : 107705233ns ~ 0seconds
Proof successfully created
Proof saved to proofs/test.proof
```

We do end up in a bit of an awkward situation where `prove_with_path` takes an option as both an argument and its return value. This happens as it's a bit of a "do everything" function, my preference is to push some of the printing/IO further up into more CLI specific code and implement #626 which would simplify it greatly, but that can happen later.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->

