### PR TITLE
chore(ci): Remove failing bors workflow

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -1,9 +1,0 @@
-name: ci
-if: ${{ success() }}
-needs:
-  - exfmt
-  - test
-runs-on: ubuntu-latest
-steps:
-  - name: CI succeeded
-    run: exit 0


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #292  <!-- link to issue -->

# Description

This removes the bors.yml workflow file. We're instead opting for a GitHub branch protection that requires a branch to be up-to-date before it can be squashed into master.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

Just removing the file since it is creating failing CI runs.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

<!-- If applicable. -->
