### PR TITLE
chore(ci): remove nightly builds and run tests only on stable Rust 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,12 +13,6 @@ jobs:
   check_n_test:
 
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain:
-          - stable
-          - nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -27,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           override: true
 
       - name: Install dependencies
@@ -36,14 +30,14 @@ jobs:
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           command: check
           args: --all-targets --verbose
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           command: test
           args: --workspace --exclude aztec_backend
 


### PR DESCRIPTION
# Related issue(s)


# Description

- We want to build the compiler on a stable version of Rust, whereas nightly has no stable guarantees.
- If we introduce a nightly only feature, we will need to feature gate it as it would break the stable release which is something we don't plan to do for the foreseeable future.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
