### PR TITLE
SSA: Clean up import paths

### DIFF
--- a/crates/noirc_evaluator/src/errors.rs
+++ b/crates/noirc_evaluator/src/errors.rs
@@ -1,6 +1,4 @@
-use noirc_errors::CustomDiagnostic as Diagnostic;
-use noirc_errors::DiagnosableError;
-use noirc_errors::Location;
+use noirc_errors::{CustomDiagnostic as Diagnostic, DiagnosableError, Location};
 use thiserror::Error;
 
 #[derive(Debug)]

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -1,17 +1,18 @@
 mod errors;
 mod ssa;
 
-use acvm::acir::circuit::{opcodes::Opcode as AcirOpcode, Circuit, PublicInputs};
-use acvm::acir::native_types::{Expression, Witness};
-use acvm::compiler::fallback::IsBlackBoxSupported;
-use acvm::Language;
+use acvm::{
+    acir::circuit::{opcodes::Opcode as AcirOpcode, Circuit, PublicInputs},
+    acir::native_types::{Expression, Witness},
+    compiler::fallback::IsBlackBoxSupported,
+    Language,
+};
 use errors::{RuntimeError, RuntimeErrorKind};
 use iter_extended::btree_map;
 use noirc_abi::{AbiType, AbiVisibility};
 use noirc_frontend::monomorphization::ast::*;
-use std::collections::BTreeMap;
-
 use ssa::{code_gen::IRGenerator, node};
+use std::collections::BTreeMap;
 
 pub struct Evaluator {
     // Why is this not u64?

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -1,26 +1,26 @@
-use super::builtin::{self, Opcode};
-use super::mem::{ArrayId, MemArray, Memory};
-use super::node::{BinaryOp, Instruction, ObjectType, Operation};
-use acvm::FieldElement;
-
-use super::node::NodeId;
-
-use num_traits::{One, Zero};
-use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::ops::{Mul, Neg};
-//use crate::acir::native_types::{Arithmetic, Witness};
-use crate::ssa::context::SsaContext;
-use crate::ssa::node::Node;
-use crate::ssa::{mem, node};
-use crate::Evaluator;
-use crate::RuntimeErrorKind;
-use acvm::acir::circuit::directives::Directive;
-use acvm::acir::circuit::opcodes::{BlackBoxFuncCall, FunctionInput};
-
-use acvm::acir::circuit::Opcode as AcirOpcode;
-use acvm::acir::native_types::{Expression, Linear, Witness};
+use crate::ssa::{
+    builtin::Opcode,
+    context::SsaContext,
+    mem::{ArrayId, MemArray, Memory},
+    node::{BinaryOp, Instruction, Node, NodeId, ObjectType, Operation},
+    {builtin, mem, node},
+};
+use crate::{Evaluator, RuntimeErrorKind};
+use acvm::{
+    acir::circuit::{
+        directives::Directive,
+        opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode},
+    },
+    acir::native_types::{Expression, Linear, Witness},
+    FieldElement,
+};
 use num_bigint::BigUint;
+use num_traits::{One, Zero};
+use std::{
+    cmp::Ordering,
+    collections::HashMap,
+    ops::{Mul, Neg},
+};
 
 #[derive(Default)]
 pub struct Acir {

--- a/crates/noirc_evaluator/src/ssa/anchor.rs
+++ b/crates/noirc_evaluator/src/ssa/anchor.rs
@@ -1,12 +1,10 @@
-use std::collections::{HashMap, VecDeque};
-
 use crate::errors::{RuntimeError, RuntimeErrorKind};
-
-use super::{
+use crate::ssa::{
     context::SsaContext,
     mem::ArrayId,
     node::{NodeId, ObjectType, Opcode, Operation},
 };
+use std::collections::{HashMap, VecDeque};
 
 #[derive(Clone, Debug)]
 pub enum MemItem {

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -1,10 +1,10 @@
 use crate::errors::RuntimeError;
-
-use super::{
+use crate::ssa::{
     conditional::AssumptionId,
     context::SsaContext,
     mem::ArrayId,
-    node::{self, Instruction, Mark, NodeId, Opcode},
+    node,
+    node::{Instruction, Mark, NodeId, Opcode},
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 

--- a/crates/noirc_evaluator/src/ssa/builtin.rs
+++ b/crates/noirc_evaluator/src/ssa/builtin.rs
@@ -1,8 +1,7 @@
+use crate::ssa::node::ObjectType;
 use acvm::{acir::BlackBoxFunc, FieldElement};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
-
-use super::node::ObjectType;
 
 #[derive(Clone, Debug, Hash, Copy, PartialEq, Eq)]
 pub enum Opcode {

--- a/crates/noirc_evaluator/src/ssa/code_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/code_gen.rs
@@ -1,21 +1,24 @@
-use super::context::SsaContext;
-use super::function::FuncIndex;
-use super::mem::ArrayId;
-use super::node::{Binary, BinaryOp, NodeId, ObjectType, Operation, Variable};
-use super::{block, builtin, node, ssa_form};
-use std::collections::{BTreeMap, HashMap};
-use std::convert::TryInto;
-
-use super::super::errors::RuntimeError;
-
-use crate::errors;
-use crate::ssa::block::BlockType;
+use crate::ssa::{
+    block::BlockType,
+    context::SsaContext,
+    function::FuncIndex,
+    mem::ArrayId,
+    node::{Binary, BinaryOp, NodeId, ObjectType, Operation, Variable},
+    {block, builtin, node, ssa_form},
+};
+use crate::{errors, errors::RuntimeError};
 use acvm::FieldElement;
 use iter_extended::vecmap;
-use noirc_frontend::monomorphization::ast::*;
-use noirc_frontend::{BinaryOpKind, UnaryOp};
+use noirc_frontend::{
+    monomorphization::ast::{
+        ArrayLiteral, Definition, Expression, For, Ident, If, LValue, Let, Literal, LocalId,
+        Program, Type,
+    },
+    BinaryOpKind, UnaryOp,
+};
 use num_bigint::BigUint;
 use num_traits::Zero;
+use std::collections::{BTreeMap, HashMap};
 
 pub struct IRGenerator {
     pub context: SsaContext,

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -1,21 +1,14 @@
+use crate::ssa::{
+    block::{BlockId, BlockType},
+    context::SsaContext,
+    flatten::UnrollContext,
+    inline::StackFrame,
+    node::{BinaryOp, Instruction, Mark, NodeId, ObjectType, Opcode, Operation},
+    {block, flatten, node, optimizations},
+};
+use crate::{errors, errors::RuntimeError};
 use num_bigint::BigUint;
 use num_traits::One;
-
-use crate::{
-    errors::{self, RuntimeError},
-    ssa::{
-        node::{Mark, ObjectType},
-        optimizations,
-    },
-};
-
-use super::{
-    block::{self, BlockId, BlockType},
-    context::SsaContext,
-    flatten::{self, UnrollContext},
-    inline::StackFrame,
-    node::{self, BinaryOp, Instruction, NodeId, Opcode, Operation},
-};
 
 // Functions that modify arrays work on a fresh array, which is copied to the original one,
 // so that the writing to the array is made explicit and handled like all the other ones with store instructions

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -1,23 +1,23 @@
-use super::block::{BasicBlock, BlockId};
-use super::conditional::{DecisionTree, TreeBuilder};
-use super::function::{FuncIndex, SSAFunction};
-use super::inline::StackFrame;
-use super::mem::{ArrayId, Memory};
-use super::node::{BinaryOp, FunctionKind, Instruction, NodeId, NodeObject, ObjectType, Operation};
-use super::{block, builtin, flatten, inline, integer, node, optimizations};
-use std::collections::{HashMap, HashSet};
-
-use super::super::errors::RuntimeError;
-use crate::errors::RuntimeErrorKind;
-use crate::ssa::acir_gen::Acir;
-use crate::ssa::function;
-use crate::ssa::node::{Mark, Node};
+use crate::errors::{RuntimeError, RuntimeErrorKind};
+use crate::ssa::{
+    acir_gen::Acir,
+    block::{BasicBlock, BlockId},
+    conditional::{DecisionTree, TreeBuilder},
+    function::{FuncIndex, SSAFunction},
+    inline::StackFrame,
+    mem::{ArrayId, Memory},
+    node::{
+        BinaryOp, FunctionKind, Instruction, Mark, Node, NodeId, NodeObject, ObjectType, Operation,
+    },
+    {block, builtin, flatten, function, inline, integer, node, optimizations},
+};
 use crate::Evaluator;
 use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_frontend::monomorphization::ast::{Definition, FuncId};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
+use std::collections::{HashMap, HashSet};
 
 // This is a 'master' class for generating the SSA IR from the AST
 // It contains all the data; the node objects representing the source code in the nodes arena

--- a/crates/noirc_evaluator/src/ssa/flatten.rs
+++ b/crates/noirc_evaluator/src/ssa/flatten.rs
@@ -1,10 +1,9 @@
 use crate::errors::RuntimeError;
-
-use super::{
-    block::{self, BlockId},
+use crate::ssa::{
+    block::BlockId,
     context::SsaContext,
-    node::{self, BinaryOp, Mark, Node, NodeEval, NodeId, NodeObject, Operation},
-    optimizations,
+    node::{BinaryOp, Mark, Node, NodeEval, NodeId, NodeObject, Operation},
+    {block, node, optimizations},
 };
 use acvm::FieldElement;
 use std::collections::HashMap;

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -1,22 +1,16 @@
-use std::collections::{HashMap, VecDeque};
-
 use crate::errors::RuntimeError;
-use crate::ssa::node::Opcode;
-use iter_extended::try_vecmap;
-use noirc_frontend::monomorphization::ast::{Call, Definition, FuncId, LocalId, Type};
-
-use super::builtin;
-use super::conditional::{AssumptionId, DecisionTree, TreeBuilder};
-use super::mem::ArrayId;
-use super::node::{Node, Operation};
-use super::{
-    block,
+use crate::ssa::{
     block::BlockId,
     code_gen::IRGenerator,
+    conditional::{AssumptionId, DecisionTree, TreeBuilder},
     context::SsaContext,
-    node::{self, NodeId, ObjectType},
-    ssa_form,
+    mem::ArrayId,
+    node::{Node, NodeId, ObjectType, Opcode, Operation},
+    {block, builtin, node, ssa_form},
 };
+use iter_extended::try_vecmap;
+use noirc_frontend::monomorphization::ast::{Call, Definition, FuncId, LocalId, Type};
+use std::collections::{HashMap, VecDeque};
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub struct FuncIndex(pub usize);

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -1,23 +1,14 @@
-use std::collections::{hash_map::Entry, HashMap};
-
-use noirc_frontend::monomorphization::ast::FuncId;
-
-use crate::{
-    errors::RuntimeError,
-    ssa::{
-        node::{Node, Operation},
-        optimizations,
-    },
-};
-
-use super::{
-    block::{self, BlockId},
+use crate::errors::RuntimeError;
+use crate::ssa::{
+    block::BlockId,
     conditional::DecisionTree,
     context::SsaContext,
-    function,
     mem::{ArrayId, Memory},
-    node::{self, Instruction, Mark, NodeId, ObjectType},
+    node::{Instruction, Mark, Node, NodeId, ObjectType, Operation},
+    {block, function, node, optimizations},
 };
+use noirc_frontend::monomorphization::ast::FuncId;
+use std::collections::{hash_map::Entry, HashMap};
 
 // Number of allowed times for inlining function calls inside a code block.
 // If a function calls another function, the inlining of the first function will leave the second function call that needs to be inlined as well.

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -1,19 +1,19 @@
 use crate::errors::RuntimeError;
-
-use super::{
+use crate::ssa::{
     block::BlockId,
-    //block,
     context::SsaContext,
     mem::{ArrayId, Memory},
-    node::{self, BinaryOp, Instruction, Mark, Node, NodeId, NodeObject, ObjectType, Operation},
-    optimizations,
+    node::{BinaryOp, Instruction, Mark, Node, NodeId, NodeObject, ObjectType, Operation},
+    {node, optimizations},
 };
 use acvm::FieldElement;
 use iter_extended::vecmap;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
-use std::collections::BTreeMap;
-use std::{collections::HashMap, ops::Neg};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Neg,
+};
 
 //Returns the maximum bit size of short integers
 pub fn short_integer_max_bit_size() -> u32 {

--- a/crates/noirc_evaluator/src/ssa/mem.rs
+++ b/crates/noirc_evaluator/src/ssa/mem.rs
@@ -1,13 +1,14 @@
-use super::acir_gen::InternalVar;
-use super::context::SsaContext;
-use super::node::{self, Node, NodeId};
+use crate::ssa::{
+    acir_gen::InternalVar,
+    context::SsaContext,
+    node,
+    node::{Node, NodeId},
+};
 use acvm::FieldElement;
 use noirc_frontend::monomorphization::ast::{Definition, LocalId};
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
-
 use std::collections::HashMap;
-use std::convert::TryInto;
 
 #[derive(Default)]
 pub struct Memory {

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -1,22 +1,16 @@
-use std::convert::TryInto;
-
 use crate::errors::{RuntimeError, RuntimeErrorKind};
-use acvm::acir::native_types::Witness;
-use acvm::FieldElement;
+use crate::ssa::{block::BlockId, builtin, conditional, context::SsaContext, mem::ArrayId};
+use acvm::{acir::native_types::Witness, FieldElement};
 use arena;
 use iter_extended::vecmap;
 use noirc_errors::Location;
-use noirc_frontend::monomorphization::ast::{Definition, FuncId};
-use noirc_frontend::BinaryOpKind;
+use noirc_frontend::{
+    monomorphization::ast::{Definition, FuncId},
+    BinaryOpKind,
+};
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, One};
-use std::ops::{Add, Mul, Sub};
-use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr};
-
-use super::block::BlockId;
-use super::context::SsaContext;
-use super::mem::ArrayId;
-use super::{builtin, conditional};
+use std::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
 pub trait Node: std::fmt::Display {
     fn get_type(&self) -> ObjectType;

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -1,14 +1,12 @@
-use acvm::FieldElement;
-
 use crate::errors::RuntimeError;
-
-use super::{
+use crate::ssa::{
     anchor::{Anchor, CseAction},
     block::BlockId,
     builtin,
     context::SsaContext,
     node::{Binary, BinaryOp, Instruction, Mark, Node, NodeEval, NodeId, ObjectType, Operation},
 };
+use acvm::FieldElement;
 
 pub fn simplify_id(ctx: &mut SsaContext, ins_id: NodeId) -> Result<(), RuntimeError> {
     let mut ins = ctx.get_instruction(ins_id).clone();

--- a/crates/noirc_evaluator/src/ssa/ssa_form.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_form.rs
@@ -1,12 +1,10 @@
-use std::collections::HashSet;
-
-use crate::ssa::node::{Mark, Operation};
-
-use super::{
-    block::{self, BlockId},
+use crate::ssa::{
+    block::BlockId,
     context::SsaContext,
-    node::{self, NodeId},
+    node::{Mark, NodeId, Operation},
+    {block, node},
 };
+use std::collections::HashSet;
 
 // create phi arguments from the predecessors of the block (containing phi)
 pub fn write_phi(ctx: &mut SsaContext, predecessors: &[BlockId], var: NodeId, phi: NodeId) {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

Using `super::` and `crate::ssa::` in the same file to refer to the same path is confusing and stops one from seeing common import paths. This PR uses `crate::ssa` and groups together common import paths.

There is no standard accepted rule when it comes to formatting imports, at the very least one should use one way to import different objects in the same file.  


(We may want to check for this in other modules, however this refactor is simply focussed on the ssa module)
## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
