### PR TITLE
Add support for Noir library testing

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -179,19 +179,19 @@ impl Driver {
         // Optional override to provide a different `main` function to start execution
         main_function: Option<FuncId>,
     ) -> Result<CompiledProgram, ReportedError> {
-        // Check the crate type
-        // We don't panic here to allow users to `evaluate` libraries
-        // which will do nothing
-        if self.context.crate_graph[LOCAL_CRATE].crate_type != CrateType::Binary {
-            println!("cannot compile crate into a program as the local crate is not a binary. For libraries, please use the check command");
-            std::process::exit(1);
-        };
-
         // Find the local crate, one should always be present
         let local_crate = self.context.def_map(LOCAL_CRATE).unwrap();
 
-        // All Binaries should have a main function
+        // If no override for the `main` function has not been provided, attempt to find it.
         let main_function = main_function.unwrap_or_else(|| {
+            // Check the crate type
+            // We don't panic here to allow users to `evaluate` libraries which will do nothing
+            if self.context.crate_graph[LOCAL_CRATE].crate_type != CrateType::Binary {
+                println!("cannot compile crate into a program as the local crate is not a binary. For libraries, please use the check command");
+                std::process::exit(1);
+            };
+
+            // All Binaries should have a main function
             local_crate.main_function().expect("cannot compile a program with no main function")
         });
 

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -183,7 +183,7 @@ impl Driver {
         // We don't panic here to allow users to `evaluate` libraries
         // which will do nothing
         if self.context.crate_graph[LOCAL_CRATE].crate_type != CrateType::Binary {
-            println!("cannot compile crate into a program as the local crate is not a binary. For libraries, please use the build command");
+            println!("cannot compile crate into a program as the local crate is not a binary. For libraries, please use the check command");
             std::process::exit(1);
         };
 


### PR DESCRIPTION
# Related issue(s)

Closes #751 

# Description

## Summary of changes

We now only reject compiling libraries if we haven't provided an override for the main function. This allows the test binaries from `nargo test` to be built while retaining the helpful error message for users running `nargo compile` on a library.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
