### PR TITLE
chore(ci): Leverage reusable workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,94 +1,19 @@
 name: Rust
 
-on:
-  push:
-    branches: [master, staging, trying]
-  pull_request:
-    branches: [master]
-
-env:
-  CARGO_TERM_COLOR: always
+on: [push, pull_request]
 
 jobs:
   check_n_test:
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libomp-dev
-        
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: stable
-          command: check
-          args: --all-targets --verbose
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: stable
-          command: test
-          args: --workspace --exclude aztec_backend
+    name: cargo check & test
+    uses: noir-lang/.github/.github/workflows/rust-test.yml@main
 
   clippy:
     name: cargo clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libomp-dev
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-
+    uses: noir-lang/.github/.github/workflows/rust-clippy.yml@main
 
   format:
     name: cargo fmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libomp-dev
-      
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+    uses: noir-lang/.github/.github/workflows/rust-format.yml@main
 
   spellcheck:
     runs-on: ubuntu-latest
@@ -98,5 +23,5 @@ jobs:
         with:
           files: |
             **/*.{md,rs}
-          incremental_files_only : true # Run this action on files which have changed in PR
+          incremental_files_only: true # Run this action on files which have changed in PR
           strict: false # Do not fail, if a spelling mistake is found (This can be annoying for contributors)


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

# Description

This updates the Rust workflow to use our reusable workflows (available at https://github.com/noir-lang/.github/tree/main/.github/workflows) that are being consumed by our bb fork and aztec_backend and will be rolling out to the other repositories.

I also updated them to run on push and pull_request because they run with different base commits (and it can be helpful to have CI before you open a PR).

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

Use reusable workflows for the rust jobs. 

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
