### PR TITLE
chore: Use &[NodeId] instead of &Vec<NodeId> in noirc_evaluator

### DIFF
--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -418,7 +418,7 @@ pub fn rewire_block_left(ctx: &mut SsaContext, block_id: BlockId, left: BlockId)
 pub fn short_circuit_instructions(
     ctx: &mut SsaContext,
     target: BlockId,
-    instructions: &Vec<NodeId>,
+    instructions: &[NodeId],
 ) -> Vec<NodeId> {
     // short-circuit the return instruction (if it exists)
     zero_instructions(ctx, instructions, None);
@@ -437,7 +437,7 @@ pub fn short_circuit_instructions(
         if let Some(ins) = ctx.try_get_instruction(i) {
             if ins.operation.opcode() == Opcode::Return {
                 stack.push(i);
-                zero_instructions(ctx, &vec![i], None);
+                zero_instructions(ctx, &[i], None);
             }
         }
     }
@@ -459,7 +459,7 @@ pub fn short_circuit_block(ctx: &mut SsaContext, block_id: BlockId) {
 }
 
 //Delete instructions and replace them with zeros, except for return instruction which is kept with zeroed return values, and the avoid instruction
-pub fn zero_instructions(ctx: &mut SsaContext, instructions: &Vec<NodeId>, avoid: Option<&NodeId>) {
+pub fn zero_instructions(ctx: &mut SsaContext, instructions: &[NodeId], avoid: Option<&NodeId>) {
     let mut zeros = HashMap::new();
     let mut zero_keys = Vec::new();
     for i in instructions {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Related to https://github.com/noir-lang/noir/issues/679.

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->
- Update function signatures to accept slice instead of vec.
- Change an instance of argument (to the modified function) to slice instead of vec.

## Dependency additions / changes

<!-- If applicable. -->
N/A

## Test additions / changes

<!-- If applicable. -->
N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
N/A