### PR TITLE
feat(ci): Build binaries when a release is made

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     name: Create Release
     outputs:
       release-pr: ${{ steps.release.outputs.pr }}
+      tag-name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
@@ -52,3 +53,48 @@ jobs:
           git add Cargo.lock
           git commit -m 'chore: Update lockfile'
           git push
+
+  build-linux-binaries:
+    name: Build linux binaries
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.tag-name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to build-nargo
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: publish-linux.yml
+          repo: noir-lang/build-nargo
+          ref: master
+          token: ${{ secrets.NOIR_REPO_TOKEN }}
+          inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}" }'
+
+  build-windows-binaries:
+    name: Build windows binaries
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.tag-name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to build-nargo
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: publish-x86_64-pc-windows-wasm.yml
+          repo: noir-lang/build-nargo
+          ref: master
+          token: ${{ secrets.NOIR_REPO_TOKEN }}
+          inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}" }'
+
+  build-mac-binaries:
+    name: Build mac binaries
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.tag-name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to build-nargo
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: publish-apple-darwin-wasm.yml
+          repo: noir-lang/build-nargo
+          ref: master
+          token: ${{ secrets.NOIR_REPO_TOKEN }}
+          inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}" }'


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

# Description

This adds jobs to the release workflow that trigger creation of binaries for that tag (using the `build-nargo` repository) that will be uploaded to the release tag.

These only trigger if release-please has created a tag, so nothing extra is added for normal merging workflows.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

Added a step for each target platform.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
