### PR TITLE
chore(ssa): keep instructions with false predicate

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
@@ -37,6 +37,9 @@ pub(crate) fn evaluate(
     let r_size = ctx[binary.rhs].size_in_bits();
     let l_size = ctx[binary.lhs].size_in_bits();
     let max_size = u32::max(r_size, l_size);
+    if binary.predicate == Some(ctx.zero()) {
+        return None;
+    }
 
     let binary_output = match &binary.operator {
             BinaryOp::Add | BinaryOp::SafeAdd => {

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -704,7 +704,11 @@ impl Binary {
     }
 
     fn zero_div_error(&self) -> Result<(), RuntimeError> {
-        Err(RuntimeErrorKind::Spanless("Panic - division by zero".to_string()).into())
+        if self.predicate.is_none() {
+            Err(RuntimeErrorKind::Spanless("Panic - division by zero".to_string()).into())
+        } else {
+            Ok(())
+        }
     }
 
     fn evaluate<F>(

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -21,12 +21,6 @@ pub fn simplify(ctx: &mut SsaContext, ins: &mut Instruction) -> Result<(), Runti
     if ins.is_deleted() {
         return Ok(());
     }
-    if let Operation::Binary(bin) = &ins.operation {
-        if bin.predicate == Some(ctx.zero_with_type(ObjectType::Boolean)) {
-            ins.mark = Mark::Deleted;
-            return Ok(());
-        }
-    }
     //1. constant folding
     let new_id = ins.evaluate(ctx)?.to_index(ctx);
 


### PR DESCRIPTION

# Description

## Summary of changes

Revert PR #760 by fixing the issue in a different way.
It turned out that deleting instructions with false predicate had side effects on nested if as it could delete the condition of a nested if, so that the code would then keep both branches.
Instead of deleting them, we keep them but ignore them when generating ACIR.

## Test additions / changes

Test case added by #760 is kept.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.
