### PR TITLE
feat: Impls with generics

### DIFF
--- a/crates/nargo/tests/test_data/generics/src/main.nr
+++ b/crates/nargo/tests/test_data/generics/src/main.nr
@@ -25,6 +25,12 @@ impl<N> BigInt<N> {
     }
 }
 
+impl Bar<Field> {
+    fn get_other(self) -> Field {
+        self.other
+    }
+}
+
 fn main(x: Field, y: Field) {
     let bar1: Bar<Field> = Bar { one: x, two: y, other: 0 };
     let bar2 = Bar { one: x, two: y, other: [0] };
@@ -37,4 +43,10 @@ fn main(x: Field, y: Field) {
     let int2 = BigInt { limbs: [2] };
     let BigInt { limbs } = int1.second(int2).first(int1);
     constrain limbs == int2.limbs;
+
+    // Test impl exclusively for Bar<Field>
+    constrain bar1.get_other() == bar1.other;
+
+    // Expected type error
+    // constrain bar2.get_other() == bar2.other;
 }

--- a/crates/nargo/tests/test_data/generics/src/main.nr
+++ b/crates/nargo/tests/test_data/generics/src/main.nr
@@ -8,10 +8,33 @@ fn foo<T>(bar: Bar<T>) {
     constrain bar.one == bar.two;
 }
 
+struct BigInt<N> {
+    limbs: [u32; N],
+}
+
+impl<N> BigInt<N> {
+    // `N` is in scope of all methods in the impl
+    fn first(first: BigInt<N>, second: BigInt<N>) -> Self {
+        constrain first.limbs != second.limbs;
+        first
+    }
+
+    fn second(first: BigInt<N>, second: Self) -> Self {
+        constrain first.limbs != second.limbs;
+        second
+    }
+}
+
 fn main(x: Field, y: Field) {
     let bar1: Bar<Field> = Bar { one: x, two: y, other: 0 };
     let bar2 = Bar { one: x, two: y, other: [0] };
 
     foo(bar1);
     foo(bar2);
+
+    // Test generic impls
+    let int1 = BigInt { limbs: [1] };
+    let int2 = BigInt { limbs: [2] };
+    let BigInt { limbs } = int1.second(int2).first(int1);
+    constrain limbs == int2.limbs;
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -129,7 +129,7 @@ impl Driver {
         let mut errs = vec![];
         CrateDefMap::collect_defs(LOCAL_CRATE, &mut self.context, &mut errs);
         let error_count = reporter::report_all(&self.context.file_manager, &errs, allow_warnings);
-        reporter::finish_report_and_exit_on_error(error_count)
+        reporter::finish_report(error_count)
     }
 
     pub fn compute_abi(&self) -> Option<Abi> {
@@ -194,7 +194,7 @@ impl Driver {
                 let file = err.location.map(|loc| loc.file);
                 let files = &self.context.file_manager;
                 let error = reporter::report(files, &err.into(), file, allow_warnings);
-                reporter::finish_report_and_exit_on_error(error as u32)?;
+                reporter::finish_report(error as u32)?;
                 Err(ReportedError)
             }
         }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -3,7 +3,7 @@ use acvm::acir::circuit::Circuit;
 use acvm::Language;
 use fm::FileType;
 use noirc_abi::Abi;
-use noirc_errors::{DiagnosableError, ReportedError, Reporter};
+use noirc_errors::{reporter, ReportedError};
 use noirc_evaluator::create_circuit;
 use noirc_frontend::graph::{CrateId, CrateName, CrateType, LOCAL_CRATE};
 use noirc_frontend::hir::def_map::CrateDefMap;
@@ -47,14 +47,7 @@ impl Driver {
     pub fn file_compiles(&mut self) -> bool {
         let mut errs = vec![];
         CrateDefMap::collect_defs(LOCAL_CRATE, &mut self.context, &mut errs);
-        for errors in &errs {
-            Reporter::with_diagnostics(
-                Some(errors.file_id),
-                &self.context.file_manager,
-                &errors.errors,
-                false,
-            );
-        }
+        reporter::report_all(&self.context.file_manager, &errs, false);
         errs.is_empty()
     }
 
@@ -135,17 +128,8 @@ impl Driver {
     pub fn check_crate(&mut self, allow_warnings: bool) -> Result<(), ReportedError> {
         let mut errs = vec![];
         CrateDefMap::collect_defs(LOCAL_CRATE, &mut self.context, &mut errs);
-        let mut error_count = 0;
-        for errors in &errs {
-            error_count += Reporter::with_diagnostics(
-                Some(errors.file_id),
-                &self.context.file_manager,
-                &errors.errors,
-                allow_warnings,
-            );
-        }
-
-        Reporter::finish(error_count)
+        let error_count = reporter::report_all(&self.context.file_manager, &errs, allow_warnings);
+        reporter::finish_report_and_exit_on_error(error_count)
     }
 
     pub fn compute_abi(&self) -> Option<Abi> {
@@ -207,12 +191,10 @@ impl Driver {
             Err(err) => {
                 // The FileId here will be the file id of the file with the main file
                 // Errors will be shown at the call site without a stacktrace
-                let file_id = err.location.map(|loc| loc.file);
-                let error = &[err.to_diagnostic()];
+                let file = err.location.map(|loc| loc.file);
                 let files = &self.context.file_manager;
-
-                let error_count = Reporter::with_diagnostics(file_id, files, error, allow_warnings);
-                Reporter::finish(error_count)?;
+                let error = reporter::report(files, &err.into(), file, allow_warnings);
+                reporter::finish_report_and_exit_on_error(error as u32)?;
                 Err(ReportedError)
             }
         }

--- a/crates/noirc_errors/src/lib.rs
+++ b/crates/noirc_errors/src/lib.rs
@@ -12,14 +12,3 @@ pub struct FileDiagnostic {
     pub file_id: fm::FileId,
     pub diagnostic: CustomDiagnostic,
 }
-
-/// Extension trait just to enable the syntax err.in_file(..) for CustomDiagnostic
-pub trait IntoFileDiagnostic {
-    fn in_file(self, id: fm::FileId) -> FileDiagnostic;
-}
-
-impl IntoFileDiagnostic for CustomDiagnostic {
-    fn in_file(self, file_id: fm::FileId) -> FileDiagnostic {
-        FileDiagnostic { file_id, diagnostic: self }
-    }
-}

--- a/crates/noirc_errors/src/lib.rs
+++ b/crates/noirc_errors/src/lib.rs
@@ -1,19 +1,25 @@
 mod position;
-mod reporter;
-
+pub mod reporter;
 pub use position::{Location, Position, Span, Spanned};
-pub use reporter::*;
-
-pub trait DiagnosableError {
-    fn to_diagnostic(&self) -> CustomDiagnostic;
-}
+pub use reporter::{CustomDiagnostic, DiagnosticKind};
 
 /// Returned when the Reporter finishes after reporting errors
 #[derive(Copy, Clone)]
 pub struct ReportedError;
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct CollectedErrors {
+pub struct FileDiagnostic {
     pub file_id: fm::FileId,
-    pub errors: Vec<CustomDiagnostic>,
+    pub diagnostic: CustomDiagnostic,
+}
+
+/// Extension trait just to enable the syntax err.in_file(..) for CustomDiagnostic
+pub trait IntoFileDiagnostic {
+    fn in_file(self, id: fm::FileId) -> FileDiagnostic;
+}
+
+impl IntoFileDiagnostic for CustomDiagnostic {
+    fn in_file(self, file_id: fm::FileId) -> FileDiagnostic {
+        FileDiagnostic { file_id, diagnostic: self }
+    }
 }

--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -152,14 +152,14 @@ fn convert_diagnostic(
     diagnostic.with_message(&cd.message).with_labels(secondary_labels).with_notes(cd.notes.clone())
 }
 
-pub fn finish_report_and_exit_on_error(error_count: u32) -> Result<(), ReportedError> {
+pub fn finish_report(error_count: u32) -> Result<(), ReportedError> {
     if error_count != 0 {
         let writer = StandardStream::stderr(ColorChoice::Always);
         let mut writer = writer.lock();
 
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Red))).unwrap();
         writeln!(&mut writer, "error: aborting due to {error_count} previous errors").unwrap();
-        writer.reset().ok(); // Ignore any IO errors, we're exiting at this point anyway
+        writer.reset().ok();
 
         Err(ReportedError)
     } else {

--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -56,6 +56,10 @@ impl CustomDiagnostic {
         }
     }
 
+    pub fn in_file(self, file_id: fm::FileId) -> FileDiagnostic {
+        FileDiagnostic { file_id, diagnostic: self }
+    }
+
     pub fn add_note(&mut self, message: String) {
         self.notes.push(message);
     }

--- a/crates/noirc_evaluator/src/errors.rs
+++ b/crates/noirc_evaluator/src/errors.rs
@@ -1,4 +1,4 @@
-use noirc_errors::{CustomDiagnostic as Diagnostic, DiagnosableError, Location};
+use noirc_errors::{CustomDiagnostic as Diagnostic, Location};
 use thiserror::Error;
 
 #[derive(Debug)]
@@ -64,11 +64,11 @@ impl RuntimeErrorKind {
     }
 }
 
-impl DiagnosableError for RuntimeError {
-    fn to_diagnostic(&self) -> Diagnostic {
+impl From<RuntimeError> for Diagnostic {
+    fn from(error: RuntimeError) -> Diagnostic {
         let span =
-            if let Some(loc) = self.location { loc.span } else { noirc_errors::Span::new(0..0) };
-        match &self.kind {
+            if let Some(loc) = error.location { loc.span } else { noirc_errors::Span::new(0..0) };
+        match &error.kind {
             RuntimeErrorKind::ArrayOutOfBounds { index, bound } => Diagnostic::simple_error(
                 "index out of bounds".to_string(),
                 format!("out of bounds error, index is {index} but length is {bound}"),

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -26,6 +26,8 @@ pub enum ExpressionKind {
     Error,
 }
 
+pub type UnresolvedGenerics = Vec<Ident>;
+
 impl ExpressionKind {
     pub fn into_path(self) -> Option<Path> {
         match self {
@@ -306,7 +308,7 @@ pub struct Lambda {
 pub struct FunctionDefinition {
     pub name: Ident,
     pub attribute: Option<Attribute>, // XXX: Currently we only have one attribute defined. If more attributes are needed per function, we can make this a vector and make attribute definition more expressive
-    pub generics: Vec<Ident>,
+    pub generics: UnresolvedGenerics,
     pub parameters: Vec<(Pattern, UnresolvedType, noirc_abi::AbiVisibility)>,
     pub body: BlockExpression,
     pub span: Span,

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -26,6 +26,8 @@ pub enum ExpressionKind {
     Error,
 }
 
+/// A Vec of unresolved names for type variables.
+/// For `fn foo<A, B>(...)` this corresponds to vec!["A", "B"].
 pub type UnresolvedGenerics = Vec<Ident>;
 
 impl ExpressionKind {

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -18,7 +18,7 @@ use iter_extended::vecmap;
 /// The parser parses types as 'UnresolvedType's which
 /// require name resolution to resolve any type names used
 /// for structs within, but are otherwise identical to Types.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum UnresolvedType {
     FieldElement(CompTime),
     Array(Option<UnresolvedTypeExpression>, Box<UnresolvedType>), // [4]Witness = Array(4, Witness)
@@ -43,7 +43,7 @@ pub enum UnresolvedType {
 /// The precursor to TypeExpression, this is the type that the parser allows
 /// to be used in the length position of an array type. Only constants, variables,
 /// and numeric binary operators are allowed here.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum UnresolvedTypeExpression {
     Variable(Path),
     Constant(u64, Span),

--- a/crates/noirc_frontend/src/ast/structure.rs
+++ b/crates/noirc_frontend/src/ast/structure.rs
@@ -25,6 +25,7 @@ impl NoirStruct {
 #[derive(Clone, Debug)]
 pub struct NoirImpl {
     pub type_path: Path,
+    pub generics: Vec<Ident>,
     pub methods: Vec<NoirFunction>,
 }
 

--- a/crates/noirc_frontend/src/ast/structure.rs
+++ b/crates/noirc_frontend/src/ast/structure.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::{Ident, NoirFunction, Path, UnresolvedType};
+use crate::{Ident, NoirFunction, Path, UnresolvedGenerics, UnresolvedType};
 use noirc_errors::Span;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -25,7 +25,7 @@ impl NoirStruct {
 #[derive(Clone, Debug)]
 pub struct NoirImpl {
     pub type_path: Path,
-    pub generics: Vec<Ident>,
+    pub generics: UnresolvedGenerics,
     pub methods: Vec<NoirFunction>,
 }
 

--- a/crates/noirc_frontend/src/ast/structure.rs
+++ b/crates/noirc_frontend/src/ast/structure.rs
@@ -8,7 +8,7 @@ use noirc_errors::Span;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NoirStruct {
     pub name: Ident,
-    pub generics: Vec<Ident>,
+    pub generics: UnresolvedGenerics,
     pub fields: Vec<(Ident, UnresolvedType)>,
     pub span: Span,
 }

--- a/crates/noirc_frontend/src/ast/structure.rs
+++ b/crates/noirc_frontend/src/ast/structure.rs
@@ -4,6 +4,7 @@ use crate::{Ident, NoirFunction, UnresolvedGenerics, UnresolvedType};
 use iter_extended::vecmap;
 use noirc_errors::Span;
 
+/// Ast node for a struct
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NoirStruct {
     pub name: Ident,
@@ -23,6 +24,7 @@ impl NoirStruct {
     }
 }
 
+/// Ast node for an impl
 #[derive(Clone, Debug)]
 pub struct NoirImpl {
     pub object_type: UnresolvedType,

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -18,8 +18,8 @@ use crate::{
 };
 use fm::FileId;
 use iter_extended::vecmap;
+use noirc_errors::Span;
 use noirc_errors::{CustomDiagnostic, FileDiagnostic};
-use noirc_errors::{IntoFileDiagnostic, Span};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -104,13 +104,13 @@ impl<'a> ModCollector<'a> {
             let mut unresolved_functions =
                 UnresolvedFunctions { file_id: self.file_id, functions: Vec::new() };
 
-            for method in r#impl.methods.iter() {
+            for method in r#impl.methods {
                 let func_id = context.def_interner.push_empty_fn();
-                unresolved_functions.push_fn(self.module_id, func_id, method.clone());
                 context.def_interner.push_function_definition(method.name().to_owned(), func_id);
+                unresolved_functions.push_fn(self.module_id, func_id, method);
             }
 
-            let key = (r#impl.type_path.clone(), self.module_id);
+            let key = (r#impl.type_path, self.module_id);
             let methods = self.def_collector.collected_impls.entry(key).or_default();
             methods.push(unresolved_functions);
         }

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1,5 +1,5 @@
 use fm::FileId;
-use noirc_errors::{CollectedErrors, CustomDiagnostic, DiagnosableError};
+use noirc_errors::FileDiagnostic;
 
 use crate::{
     graph::CrateId, hir::def_collector::dc_crate::UnresolvedStruct, node_interner::StructId,
@@ -29,7 +29,7 @@ pub fn collect_defs(
     module_id: LocalModuleId,
     crate_id: CrateId,
     context: &mut Context,
-    errors: &mut Vec<CollectedErrors>,
+    errors: &mut Vec<FileDiagnostic>,
 ) {
     let mut collector = ModCollector { def_collector, file_id, module_id };
 
@@ -53,13 +53,9 @@ pub fn collect_defs(
 
     collector.collect_structs(ast.types, crate_id, errors);
 
-    let errors_in_same_file = collector.collect_functions(context, ast.functions);
+    collector.collect_functions(context, ast.functions, errors);
 
     collector.collect_impls(context, ast.impls);
-
-    if !errors_in_same_file.is_empty() {
-        errors.push(CollectedErrors { file_id: collector.file_id, errors: errors_in_same_file });
-    }
 }
 
 impl<'a> ModCollector<'a> {
@@ -67,7 +63,7 @@ impl<'a> ModCollector<'a> {
         &mut self,
         context: &mut Context,
         globals: Vec<LetStatement>,
-        errors: &mut Vec<CollectedErrors>,
+        errors: &mut Vec<FileDiagnostic>,
     ) {
         for global in globals {
             let name = global.pattern.name_ident().clone();
@@ -83,11 +79,7 @@ impl<'a> ModCollector<'a> {
 
             if let Err((first_def, second_def)) = result {
                 let err = DefCollectorErrorKind::DuplicateGlobal { first_def, second_def };
-
-                errors.push(CollectedErrors {
-                    file_id: self.file_id,
-                    errors: vec![err.to_diagnostic()],
-                });
+                errors.push(err.into_file_diagnostic(self.file_id));
             }
 
             self.def_collector.collected_globals.push(UnresolvedGlobal {
@@ -112,7 +104,7 @@ impl<'a> ModCollector<'a> {
 
             let key = (r#impl.type_path, self.module_id);
             let methods = self.def_collector.collected_impls.entry(key).or_default();
-            methods.push(unresolved_functions);
+            methods.push((r#impl.generics, unresolved_functions));
         }
     }
 
@@ -120,9 +112,8 @@ impl<'a> ModCollector<'a> {
         &mut self,
         context: &mut Context,
         functions: Vec<NoirFunction>,
-    ) -> Vec<CustomDiagnostic> {
-        let mut errors = vec![];
-
+        errors: &mut Vec<FileDiagnostic>,
+    ) {
         let mut unresolved_functions =
             UnresolvedFunctions { file_id: self.file_id, functions: Vec::new() };
 
@@ -148,16 +139,12 @@ impl<'a> ModCollector<'a> {
                 .define_func_def(name, func_id);
 
             if let Err((first_def, second_def)) = result {
-                errors.push(
-                    DefCollectorErrorKind::DuplicateFunction { first_def, second_def }
-                        .to_diagnostic(),
-                );
+                let error = DefCollectorErrorKind::DuplicateFunction { first_def, second_def };
+                errors.push(error.into_file_diagnostic(self.file_id));
             }
         }
 
         self.def_collector.collected_functions.push(unresolved_functions);
-
-        errors
     }
 
     /// Collect any struct definitions declared within the ast.
@@ -166,18 +153,15 @@ impl<'a> ModCollector<'a> {
         &mut self,
         types: Vec<NoirStruct>,
         krate: CrateId,
-        errors: &mut Vec<CollectedErrors>,
+        errors: &mut Vec<FileDiagnostic>,
     ) {
         for struct_definition in types {
             let name = struct_definition.name.clone();
 
             // Create the corresponding module for the struct namespace
-            let id = match self.push_child_module(&name, self.file_id, false) {
-                Ok(local_id) => StructId(ModuleId { krate, local_id }),
-                Err(mut more_errors) => {
-                    errors.append(&mut more_errors);
-                    continue;
-                }
+            let id = match self.push_child_module(&name, self.file_id, false, errors) {
+                Some(local_id) => StructId(ModuleId { krate, local_id }),
+                None => continue,
             };
 
             // Add the struct to scope so its path can be looked up later
@@ -187,11 +171,7 @@ impl<'a> ModCollector<'a> {
 
             if let Err((first_def, second_def)) = result {
                 let err = DefCollectorErrorKind::DuplicateFunction { first_def, second_def };
-
-                errors.push(CollectedErrors {
-                    file_id: self.file_id,
-                    errors: vec![err.to_diagnostic()],
-                });
+                errors.push(err.into_file_diagnostic(self.file_id));
             }
 
             // And store the TypeId -> StructType mapping somewhere it is reachable
@@ -210,20 +190,19 @@ impl<'a> ModCollector<'a> {
         crate_id: CrateId,
         submodules: Vec<SubModule>,
         file_id: FileId,
-        errors: &mut Vec<CollectedErrors>,
+        errors: &mut Vec<FileDiagnostic>,
     ) {
         for submodule in submodules {
-            match self.push_child_module(&submodule.name, file_id, true) {
-                Err(mut more_errors) => errors.append(&mut more_errors),
-                Ok(child_mod_id) => collect_defs(
+            if let Some(child) = self.push_child_module(&submodule.name, file_id, true, errors) {
+                collect_defs(
                     self.def_collector,
                     submodule.contents,
                     file_id,
-                    child_mod_id,
+                    child,
                     crate_id,
                     context,
                     errors,
-                ),
+                );
             }
         }
     }
@@ -236,7 +215,7 @@ impl<'a> ModCollector<'a> {
         context: &mut Context,
         mod_name: &Ident,
         crate_id: CrateId,
-        errors: &mut Vec<CollectedErrors>,
+        errors: &mut Vec<FileDiagnostic>,
     ) {
         let child_file_id =
             match context.file_manager.resolve_path(self.file_id, &mod_name.0.contents) {
@@ -244,11 +223,7 @@ impl<'a> ModCollector<'a> {
                 Err(_) => {
                     let err =
                         DefCollectorErrorKind::UnresolvedModuleDecl { mod_name: mod_name.clone() };
-
-                    errors.push(CollectedErrors {
-                        file_id: self.file_id,
-                        errors: vec![err.to_diagnostic()],
-                    });
+                    errors.push(err.into_file_diagnostic(self.file_id));
                     return;
                 }
             };
@@ -257,9 +232,8 @@ impl<'a> ModCollector<'a> {
         let ast = parse_file(&mut context.file_manager, child_file_id, errors);
 
         // Add module into def collector and get a ModuleId
-        match self.push_child_module(mod_name, child_file_id, true) {
-            Err(mut more_errors) => errors.append(&mut more_errors),
-            Ok(child_mod_id) => collect_defs(
+        if let Some(child_mod_id) = self.push_child_module(mod_name, child_file_id, true, errors) {
+            collect_defs(
                 self.def_collector,
                 ast,
                 child_file_id,
@@ -267,16 +241,19 @@ impl<'a> ModCollector<'a> {
                 crate_id,
                 context,
                 errors,
-            ),
+            );
         }
     }
 
-    pub fn push_child_module(
+    /// Add a child module to the current def_map.
+    /// On error this returns None and pushes to `errors`
+    fn push_child_module(
         &mut self,
         mod_name: &Ident,
         file_id: FileId,
         add_to_parent_scope: bool,
-    ) -> Result<LocalModuleId, Vec<CollectedErrors>> {
+        errors: &mut Vec<FileDiagnostic>,
+    ) -> Option<LocalModuleId> {
         // Create a new default module
         let module_id = self.def_collector.def_map.modules.insert(ModuleData::default());
 
@@ -305,19 +282,16 @@ impl<'a> ModCollector<'a> {
                 krate: self.def_collector.def_map.krate,
                 local_id: LocalModuleId(module_id),
             };
-            modules[self.module_id.0]
-                .scope
-                .define_module_def(mod_name.to_owned(), mod_id)
-                .map_err(|(first_def, second_def)| {
-                    let err = DefCollectorErrorKind::DuplicateModuleDecl { first_def, second_def };
 
-                    vec![CollectedErrors {
-                        file_id: self.file_id,
-                        errors: vec![err.to_diagnostic()],
-                    }]
-                })?;
+            if let Err((first_def, second_def)) =
+                modules[self.module_id.0].scope.define_module_def(mod_name.to_owned(), mod_id)
+            {
+                let err = DefCollectorErrorKind::DuplicateModuleDecl { first_def, second_def };
+                errors.push(err.into_file_diagnostic(self.file_id));
+                return None;
+            }
         }
 
-        Ok(LocalModuleId(module_id))
+        Some(LocalModuleId(module_id))
     }
 }

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -102,9 +102,9 @@ impl<'a> ModCollector<'a> {
                 unresolved_functions.push_fn(self.module_id, func_id, method);
             }
 
-            let key = (r#impl.type_path, self.module_id);
+            let key = (r#impl.object_type, self.module_id);
             let methods = self.def_collector.collected_impls.entry(key).or_default();
-            methods.push((r#impl.generics, unresolved_functions));
+            methods.push((r#impl.generics, r#impl.type_span, unresolved_functions));
         }
     }
 

--- a/crates/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/errors.rs
@@ -3,6 +3,7 @@ use crate::{hir::resolution::import::ImportDirective, Ident};
 use noirc_errors::CustomDiagnostic as Diagnostic;
 use noirc_errors::FileDiagnostic;
 use noirc_errors::IntoFileDiagnostic;
+use noirc_errors::Span;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -19,6 +20,8 @@ pub enum DefCollectorErrorKind {
     UnresolvedModuleDecl { mod_name: Ident },
     #[error("unresolved import")]
     UnresolvedImport { import: ImportDirective },
+    #[error("Non-struct type used in impl")]
+    NonStructTypeInImpl { span: Span },
 }
 
 impl DefCollectorErrorKind {
@@ -104,6 +107,11 @@ impl From<DefCollectorErrorKind> for Diagnostic {
                     span,
                 )
             }
+            DefCollectorErrorKind::NonStructTypeInImpl { span } => Diagnostic::simple_error(
+                "Non-struct type used in impl".into(),
+                "Only struct types may have implementation methods".into(),
+                span,
+            ),
         }
     }
 }

--- a/crates/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/errors.rs
@@ -2,7 +2,6 @@ use crate::{hir::resolution::import::ImportDirective, Ident};
 
 use noirc_errors::CustomDiagnostic as Diagnostic;
 use noirc_errors::FileDiagnostic;
-use noirc_errors::IntoFileDiagnostic;
 use noirc_errors::Span;
 use thiserror::Error;
 

--- a/crates/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/errors.rs
@@ -1,7 +1,8 @@
 use crate::{hir::resolution::import::ImportDirective, Ident};
 
 use noirc_errors::CustomDiagnostic as Diagnostic;
-use noirc_errors::DiagnosableError;
+use noirc_errors::FileDiagnostic;
+use noirc_errors::IntoFileDiagnostic;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -20,9 +21,15 @@ pub enum DefCollectorErrorKind {
     UnresolvedImport { import: ImportDirective },
 }
 
-impl DiagnosableError for DefCollectorErrorKind {
-    fn to_diagnostic(&self) -> Diagnostic {
-        match self {
+impl DefCollectorErrorKind {
+    pub fn into_file_diagnostic(self, file: fm::FileId) -> FileDiagnostic {
+        Diagnostic::from(self).in_file(file)
+    }
+}
+
+impl From<DefCollectorErrorKind> for Diagnostic {
+    fn from(error: DefCollectorErrorKind) -> Diagnostic {
+        match error {
             DefCollectorErrorKind::DuplicateFunction { first_def, second_def } => {
                 let first_span = first_def.0.span();
                 let second_span = second_def.0.span();

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -5,7 +5,7 @@ use crate::node_interner::FuncId;
 use crate::parser::{parse_program, ParsedModule};
 use arena::{Arena, Index};
 use fm::{FileId, FileManager};
-use noirc_errors::{FileDiagnostic, IntoFileDiagnostic};
+use noirc_errors::FileDiagnostic;
 use std::collections::HashMap;
 
 mod module_def;

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -48,8 +48,8 @@ pub enum ResolverError {
     NonStructUsedInConstructor { typ: Type, span: Span },
     #[error("Only struct types can have generics")]
     NonStructWithGenerics { span: Span },
-    #[error("This type already has generic arguments applied")]
-    TypeAlreadyHasGenericArguments { typ: Type, span: Span },
+    #[error("Cannot apply generics on Self type")]
+    GenericsOnSelfType { span: Span },
 }
 
 impl ResolverError {
@@ -230,9 +230,9 @@ impl From<ResolverError> for Diagnostic {
                 "Try removing the generic arguments".into(),
                 span,
             ),
-            ResolverError::TypeAlreadyHasGenericArguments { typ, span } => Diagnostic::simple_error(
-                format!("The type {} already has generic arguments applied", typ),
-                "Try removing the generic arguments".into(),
+            ResolverError::GenericsOnSelfType { span } => Diagnostic::simple_error(
+                "Cannot apply generics to Self type".into(),
+                "Use an explicit type name or apply the generics at the start of the impl instead".into(),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -1,5 +1,5 @@
 pub use noirc_errors::Span;
-use noirc_errors::{CustomDiagnostic as Diagnostic, FileDiagnostic, IntoFileDiagnostic};
+use noirc_errors::{CustomDiagnostic as Diagnostic, FileDiagnostic};
 use thiserror::Error;
 
 use crate::{Ident, Type};

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -355,8 +355,11 @@ impl<'a> Resolver<'a> {
             }
 
             if name == "Self" {
-                if !args.is_empty() {
-                    self.push_err(ResolverError::GenericsOnSelfType { span: path.span() });
+                if let Some(self_type) = self.self_type.clone() {
+                    if !args.is_empty() {
+                        self.push_err(ResolverError::GenericsOnSelfType { span: path.span() });
+                    }
+                    return self_type;
                 }
             }
         }
@@ -458,6 +461,20 @@ impl<'a> Resolver<'a> {
 
     pub fn take_errors(self) -> Vec<ResolverError> {
         self.errors
+    }
+
+    /// Return the current generics.
+    /// Needed to keep referring to the same type variables across many
+    /// methods in a single impl.
+    pub fn get_generics(&self) -> &[(Rc<String>, TypeVariable, Span)] {
+        &self.generics
+    }
+
+    /// Set the current generics that are in scope.
+    /// Unlike add_generics, this function will not create any new type variables,
+    /// opting to reuse the existing ones it is directly given.
+    pub fn set_generics(&mut self, generics: Vec<(Rc<String>, TypeVariable, Span)>) {
+        self.generics = generics;
     }
 
     /// Translates a (possibly Unspecified) UnresolvedType to a Type.

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -861,7 +861,7 @@ impl<'a> Resolver<'a> {
             }
             Pattern::Struct(name, fields, span) => {
                 let error_identifier = |this: &mut Self| {
-                    // Must create a name here to return a HirPattern::Identifer. Allowing
+                    // Must create a name here to return a HirPattern::Identifier. Allowing
                     // shadowing here lets us avoid further errors if we define ERROR_IDENT
                     // multiple times.
                     let name = ERROR_IDENT.into();

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -35,15 +35,21 @@ pub enum TypeCheckError {
 }
 
 impl TypeCheckError {
-    pub fn into_diagnostic(self) -> Diagnostic {
-        match self {
+    pub fn add_context(self, ctx: &'static str) -> Self {
+        TypeCheckError::Context { err: Box::new(self), ctx }
+    }
+}
+
+impl From<TypeCheckError> for Diagnostic {
+    fn from(error: TypeCheckError) -> Diagnostic {
+        match error {
             TypeCheckError::TypeCannotBeUsed { typ, place, span } => Diagnostic::simple_error(
                 format!("The type {} cannot be used in a {}", &typ, place),
                 String::new(),
                 span,
             ),
             TypeCheckError::Context { err, ctx } => {
-                let mut diag = err.into_diagnostic();
+                let mut diag = Diagnostic::from(*err);
                 diag.add_note(ctx.to_owned());
                 diag
             }
@@ -91,9 +97,5 @@ impl TypeCheckError {
                 span,
             ),
         }
-    }
-
-    pub fn add_context(self, ctx: &'static str) -> Self {
-        TypeCheckError::Context { err: Box::new(self), ctx }
     }
 }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -683,8 +683,9 @@ pub fn check_member_access(
 ) -> Type {
     let lhs_type = type_check_expression(interner, &access.lhs, errors);
 
-    if let Type::Struct(s, args) = &lhs_type {
+    if let Type::Struct(s, args) = dbg!(&lhs_type) {
         let s = s.borrow();
+        dbg!(interner.expr_span(&access.lhs));
         if let Some((field, index)) = s.get_field(&access.rhs.0.contents, args) {
             interner.set_field_index(expr_id, index);
             return field;

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -655,7 +655,7 @@ fn check_constructor(
     // Sort argument types by name so we can zip with the struct type in the same ordering.
     // Note that we use a Vec to store the original arguments (rather than a BTreeMap) to
     // preserve the evaluation order of the source code.
-    let mut args = constructor.fields.clone();
+    let mut args = constructor.fields;
     args.sort_by_key(|arg| arg.0.clone());
 
     let fields = typ.borrow().get_fields(&generics);

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -353,21 +353,16 @@ fn lookup_method(
     errors: &mut Vec<TypeCheckError>,
 ) -> Option<FuncId> {
     match &object_type {
-        Type::Struct(typ, _args) => {
-            let typ = typ.borrow();
-            match typ.methods.get(method_name) {
-                Some(method_id) => Some(*method_id),
-                None => {
-                    errors.push(TypeCheckError::Unstructured {
-                        span: interner.expr_span(expr_id),
-                        msg: format!(
-                            "No method named '{method_name}' found for type '{object_type}'",
-                        ),
-                    });
-                    None
-                }
+        Type::Struct(typ, _args) => match interner.lookup_method(typ.borrow().id, method_name) {
+            Some(method_id) => Some(method_id),
+            None => {
+                errors.push(TypeCheckError::Unstructured {
+                    span: interner.expr_span(expr_id),
+                    msg: format!("No method named '{method_name}' found for type '{object_type}'",),
+                });
+                None
             }
-        }
+        },
         // If we fail to resolve the object to a struct type, we have no way of type
         // checking its arguments as we can't even resolve the name of the function
         Type::Error => None,

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -2,7 +2,7 @@ use acvm::FieldElement;
 use fm::FileId;
 use noirc_errors::Location;
 
-use crate::node_interner::{DefinitionId, ExprId, FuncId, NodeInterner, StmtId, StructId};
+use crate::node_interner::{DefinitionId, ExprId, FuncId, NodeInterner, StmtId};
 use crate::{BinaryOp, BinaryOpKind, Ident, Shared, UnaryOp};
 
 use super::stmt::HirPattern;
@@ -149,7 +149,6 @@ impl HirMethodCallExpression {
 
 #[derive(Debug, Clone)]
 pub struct HirConstructorExpression {
-    pub type_id: StructId,
     pub r#type: Shared<StructType>,
 
     // NOTE: It is tempting to make this a BTreeSet to force ordering of field

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -150,6 +150,7 @@ impl HirMethodCallExpression {
 #[derive(Debug, Clone)]
 pub struct HirConstructorExpression {
     pub r#type: Shared<StructType>,
+    pub struct_generics: Vec<Type>,
 
     // NOTE: It is tempting to make this a BTreeSet to force ordering of field
     //       names (and thus remove the need to normalize them during type checking)

--- a/crates/noirc_frontend/src/hir_def/stmt.rs
+++ b/crates/noirc_frontend/src/hir_def/stmt.rs
@@ -1,6 +1,6 @@
 use super::expr::HirIdent;
 use crate::node_interner::ExprId;
-use crate::{Ident, Shared, StructType, Type};
+use crate::{Ident, Type};
 use fm::FileId;
 use noirc_errors::Span;
 
@@ -51,7 +51,7 @@ pub enum HirPattern {
     Identifier(HirIdent),
     Mutable(Box<HirPattern>, Span),
     Tuple(Vec<HirPattern>, Span),
-    Struct(Shared<StructType>, Vec<(Ident, HirPattern)>, Span),
+    Struct(Type, Vec<(Ident, HirPattern)>, Span),
 }
 
 impl HirPattern {

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -9,10 +9,7 @@ use iter_extended::{btree_map, vecmap};
 use noirc_abi::AbiType;
 use noirc_errors::Span;
 
-use crate::{
-    node_interner::{FuncId, StructId},
-    Ident, Signedness,
-};
+use crate::{node_interner::StructId, Ident, Signedness};
 
 /// A shared, mutable reference to some T.
 /// Wrapper is required for Hash impl of RefCell.
@@ -75,7 +72,6 @@ pub struct StructType {
     fields: BTreeMap<Ident, Type>,
 
     pub generics: Generics,
-    pub methods: HashMap<String, FuncId>,
     pub span: Span,
 }
 
@@ -101,7 +97,7 @@ impl StructType {
         fields: BTreeMap<Ident, Type>,
         generics: Generics,
     ) -> StructType {
-        StructType { id, fields, name, span, generics, methods: HashMap::new() }
+        StructType { id, fields, name, span, generics }
     }
 
     pub fn set_fields(&mut self, fields: BTreeMap<Ident, Type>) {

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -152,7 +152,7 @@ impl StructType {
 
     /// Instantiate this struct type, returning a Vec of the new generic args (in
     /// the same order as self.generics)
-    pub fn instantiate<'a>(&'a self, interner: &mut NodeInterner) -> Vec<Type> {
+    pub fn instantiate(&self, interner: &mut NodeInterner) -> Vec<Type> {
         vecmap(&self.generics, |_| interner.next_type_variable())
     }
 }

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -151,30 +151,9 @@ impl StructType {
     }
 
     /// Instantiate this struct type, returning a Vec of the new generic args (in
-    /// the same order as self.generics) and a map of each instantiated field
-    pub fn instantiate<'a>(
-        &'a self,
-        interner: &mut NodeInterner,
-    ) -> (Vec<Type>, BTreeMap<&'a str, Type>) {
-        let (generics, substitutions) = self
-            .generics
-            .iter()
-            .map(|(old_id, old_var)| {
-                let new = interner.next_type_variable();
-                (new.clone(), (*old_id, (old_var.clone(), new)))
-            })
-            .unzip();
-
-        let fields = self
-            .fields
-            .iter()
-            .map(|(name, typ)| {
-                let typ = typ.substitute(&substitutions);
-                (name.0.contents.as_str(), typ)
-            })
-            .collect();
-
-        (generics, fields)
+    /// the same order as self.generics)
+    pub fn instantiate<'a>(&'a self, interner: &mut NodeInterner) -> Vec<Type> {
+        vecmap(&self.generics, |_| interner.next_type_variable())
     }
 }
 

--- a/crates/noirc_frontend/src/lexer/errors.rs
+++ b/crates/noirc_frontend/src/lexer/errors.rs
@@ -2,7 +2,7 @@ use crate::token::SpannedToken;
 
 use super::token::Token;
 use noirc_errors::CustomDiagnostic as Diagnostic;
-use noirc_errors::{DiagnosableError, Span};
+use noirc_errors::Span;
 use thiserror::Error;
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
@@ -77,9 +77,9 @@ impl LexerErrorKind {
     }
 }
 
-impl DiagnosableError for LexerErrorKind {
-    fn to_diagnostic(&self) -> Diagnostic {
-        let (primary, secondary, span) = self.parts();
+impl From<LexerErrorKind> for Diagnostic {
+    fn from(error: LexerErrorKind) -> Diagnostic {
+        let (primary, secondary, span) = error.parts();
         Diagnostic::simple_error(primary, secondary, span)
     }
 }

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -583,6 +583,9 @@ impl NodeInterner {
         })
     }
 
+    /// Add a method to a type.
+    /// This will panic for non-struct types currently as we do not support methods
+    /// for primitives. We could allow this in the future however.
     pub fn add_method(
         &mut self,
         self_type: &Type,
@@ -598,6 +601,7 @@ impl NodeInterner {
         }
     }
 
+    /// Search by name for a method on the given struct
     pub fn lookup_method(&self, id: StructId, method_name: &str) -> Option<FuncId> {
         self.struct_methods.get(&(id, method_name.to_owned())).map(|(_, id)| *id)
     }

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -169,6 +169,11 @@ pub struct NodeInterner {
     language: Language,
 
     delayed_type_checks: Vec<TypeCheckFn>,
+
+    // A map from a struct type and method name to a function id for the method
+    // along with any generic on the struct it may require. E.g. if the impl is
+    // only for `impl Foo<String>` rather than all Foo, the generics will be `vec![String]`.
+    struct_methods: HashMap<(StructId, String), (Vec<Type>, FuncId)>,
 }
 
 type TypeCheckFn = Box<dyn FnOnce() -> Result<(), TypeCheckError>>;
@@ -236,6 +241,7 @@ impl Default for NodeInterner {
             globals: HashMap::new(),
             language: Language::R1CS,
             delayed_type_checks: vec![],
+            struct_methods: HashMap::new(),
         };
 
         // An empty block expression is used often, we add this into the `node` on startup
@@ -575,5 +581,25 @@ impl NodeInterner {
             let is_test = meta.attributes.as_ref()? == &Attribute::Test;
             is_test.then_some(*id)
         })
+    }
+
+    pub fn add_method(
+        &mut self,
+        self_type: &Type,
+        method_name: String,
+        method_id: FuncId,
+    ) -> Option<FuncId> {
+        match self_type {
+            Type::Struct(struct_type, generics) => {
+                let key = (struct_type.borrow().id, method_name);
+                self.struct_methods.insert(key, (generics.clone(), method_id)).map(|(_, id)| id)
+            }
+            other => unreachable!("Tried adding method to non-struct type '{}'", other),
+        }
+    }
+
+    pub fn lookup_method(&self, id: StructId, method_name: &str) -> Option<FuncId> {
+        // TODO: Apply generics
+        self.struct_methods.get(&(id, method_name.to_owned())).map(|(_, id)| *id)
     }
 }

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -599,7 +599,6 @@ impl NodeInterner {
     }
 
     pub fn lookup_method(&self, id: StructId, method_name: &str) -> Option<FuncId> {
-        // TODO: Apply generics
         self.struct_methods.get(&(id, method_name.to_owned())).map(|(_, id)| *id)
     }
 }

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -5,7 +5,6 @@ use crate::BinaryOp;
 
 use iter_extended::vecmap;
 use noirc_errors::CustomDiagnostic as Diagnostic;
-use noirc_errors::DiagnosableError;
 use noirc_errors::Span;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,13 +81,13 @@ impl std::fmt::Display for ParserError {
     }
 }
 
-impl DiagnosableError for ParserError {
-    fn to_diagnostic(&self) -> Diagnostic {
-        match &self.reason {
-            Some(reason) => Diagnostic::simple_error(reason.clone(), String::new(), self.span),
+impl From<ParserError> for Diagnostic {
+    fn from(error: ParserError) -> Diagnostic {
+        match &error.reason {
+            Some(reason) => Diagnostic::simple_error(reason.clone(), String::new(), error.span),
             None => {
-                let primary = self.to_string();
-                Diagnostic::simple_error(primary, String::new(), self.span)
+                let primary = error.to_string();
+                Diagnostic::simple_error(primary, String::new(), error.span)
             }
         }
     }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -228,10 +228,13 @@ fn self_parameter() -> impl NoirParser<(Pattern, UnresolvedType, AbiVisibility)>
 fn implementation() -> impl NoirParser<TopLevelStatement> {
     keyword(Keyword::Impl)
         .ignore_then(path())
+        .then(generics())
         .then_ignore(just(Token::LeftBrace))
         .then(function_definition(true).repeated())
         .then_ignore(just(Token::RightBrace))
-        .map(|(type_path, methods)| TopLevelStatement::Impl(NoirImpl { type_path, methods }))
+        .map(|((type_path, generics), methods)| {
+            TopLevelStatement::Impl(NoirImpl { type_path, generics, methods })
+        })
 }
 
 fn block_expr<'a, P>(expr_parser: P) -> impl NoirParser<Expression> + 'a


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #638

# Description

Implements generics on implementations where the `impl` keyword can introduce type variables that are visible to each method within.

## Summary of changes

This PR involved a larger amount of changes than expected. The bulk of changes are in name resolution and include changing impls to carry around a generics field, changing type lookups to carry around generics if necessary and instantiate automatically otherwise, a few added error types mostly related to applying generic to a non-struct type or attempting to apply generics to `Self`, among other changes.

## Dependency additions / changes

None

## Test additions / changes

Added a short test of impl generics to the `generics` test case.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [x] This PR requires documentation updates when merged.
