### PR TITLE
chore(nargo)!: bump MSRV to 1.66.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.1.1"
 # x-release-please-end
 authors = ["The Noir Team <kevtheappdev@gmail.com>"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 [workspace.dependencies]
 acvm = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Concretely the following items are on the road map:
 
 ## Minimum Rust version
 
-This crate's minimum supported rustc version is 1.64.0.
+This crate's minimum supported rustc version is 1.66.0.
 
 ## License
 

--- a/crates/nargo/build.rs
+++ b/crates/nargo/build.rs
@@ -18,8 +18,8 @@ fn rerun_if_stdlib_changes(directory: &Path) {
 
 fn check_rustc_version() {
     assert!(
-        version().unwrap() >= Version::parse("1.6.4").unwrap(),
-        "The minimal supported rustc version is 1.64.0."
+        version().unwrap() >= Version::parse("1.66.0").unwrap(),
+        "The minimal supported rustc version is 1.66.0."
     );
 }
 


### PR DESCRIPTION
# Related issue(s)

# Description

## Summary of changes

I've bumped any references to Rust 1.64.0 to 1.66.0

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
