### PR TITLE
chore: updated "HirFunction::unsafe_from_expr" to "HirFunction::unchecked_from_expr"

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -296,7 +296,7 @@ impl<'a> Resolver<'a> {
             FunctionKind::Normal => {
                 let expr_id = self.intern_block(func.def.body);
                 self.interner.push_expr_location(expr_id, func.def.span, self.file);
-                HirFunction::unsafe_from_expr(expr_id)
+                HirFunction::unchecked_from_expr(expr_id)
             }
         };
 

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -134,7 +134,7 @@ mod test {
         interner.push_expr_location(expr_id, Span::single_char(0), file);
 
         // Create function to enclose the let statement
-        let func = HirFunction::unsafe_from_expr(expr_id);
+        let func = HirFunction::unchecked_from_expr(expr_id);
         let func_id = interner.push_fn(func);
 
         let name = HirIdent {

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -18,9 +18,10 @@ impl HirFunction {
         HirFunction(ExprId::empty_block_id())
     }
 
+    // <Note> Originally named unsafe_from_expr changed to unchecked_from_expr as per this issue https://github.com/noir-lang/noir/issues/812 </Note>
     // This function is marked as unsafe because
     // the expression kind is not being checked
-    pub const fn unsafe_from_expr(expr_id: ExprId) -> HirFunction {
+    pub const fn unchecked_from_expr(expr_id: ExprId) -> HirFunction {
         HirFunction(expr_id)
     }
 

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -18,7 +18,6 @@ impl HirFunction {
         HirFunction(ExprId::empty_block_id())
     }
 
-    // <Note> Originally named unsafe_from_expr changed to unchecked_from_expr as per this issue https://github.com/noir-lang/noir/issues/812 </Note>
     // This function is marked as unsafe because
     // the expression kind is not being checked
     pub const fn unchecked_from_expr(expr_id: ExprId) -> HirFunction {


### PR DESCRIPTION
As per this issue https://github.com/noir-lang/noir/issues/812

Renamed

``HirFunction::unsafe_from_expr``
You can use the search function in your IDE to search for unsafe_from_expr, I cannot find it elsewhere only three places

to
``HirFunction::unchecked_from_expr``

# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #812 

# Description

## Summary of changes

### Changes 1

``crates\noirc_frontend\src\hir\resolution\resolver.rs line number 299``
from
``HirFunction::unsafe_from_expr(expr_id)``
to
``HirFunction::unchecked_from_expr(expr_id)``

### Changes 2

``crates\noirc_frontend\src\hir\type_check\mod.rs line number 137``
from
``let func = HirFunction::unsafe_from_expr(expr_id);``
to
``let func = HirFunction::unchecked_from_expr(expr_id);``

### Changes 3

Added a comment in ``crates\noirc_frontend\src\hir_def\function.rs line number: 21 ``

### Changes 4

``crates\noirc_frontend\src\hir_def\function.rs line number 23/24``
from
``pub const fn unsafe_from_expr(expr_id: ExprId) -> HirFunction {``
to
``pub const fn unchecked_from_expr(expr_id: ExprId) -> HirFunction {``

Basically just changing every unsafe_from_expr to unchecked_from_expr, nothing else has been changed

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
