### PR TITLE
chore: remove stale comment on HirFunction.unchecked_from_expr

### DIFF
--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -18,8 +18,6 @@ impl HirFunction {
         HirFunction(ExprId::empty_block_id())
     }
 
-    // This function is marked as unsafe because
-    // the expression kind is not being checked
     pub const fn unchecked_from_expr(expr_id: ExprId) -> HirFunction {
         HirFunction(expr_id)
     }


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/noir/issues/812

# Description

## Summary of changes

I've removed a comment which referred to the old name of `unsafe_from_expr`. The new name gives the info which was included in the comment so it is no longer neccessary.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
