### PR TITLE
chore(ssa): per array memory map

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -23,7 +23,7 @@ use acir_mem::AcirMem;
 
 #[derive(Default)]
 pub struct Acir {
-    memory_trace: AcirMem,
+    memory: AcirMem,
     var_cache: InternalVarCache,
 }
 
@@ -39,7 +39,7 @@ impl Acir {
             binary, condition, constrain, intrinsics, load, not, r#return, store, truncate,
         };
 
-        let acir_mem = &mut self.memory_trace;
+        let acir_mem = &mut self.memory;
         let var_cache = &mut self.var_cache;
 
         let output = match &ins.operation {

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_mem.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_mem.rs
@@ -8,16 +8,26 @@ use iter_extended::vecmap;
 use std::collections::BTreeMap;
 
 #[derive(Default)]
-pub struct AcirMem {
+pub struct ArrayHeap {
     // maps memory address to InternalVar
-    memory_map: BTreeMap<ArrayId, BTreeMap<u32, InternalVar>>,
+    memory_map: BTreeMap<u32, InternalVar>,
+}
+
+/// Handle virtual memory access
+#[derive(Default)]
+pub struct AcirMem {
+    virtual_memory: BTreeMap<ArrayId, ArrayHeap>,
 }
 
 impl AcirMem {
-    // returns the memory_map for the array
-    pub fn array_map_mut(&mut self, array_id: ArrayId) -> &mut BTreeMap<u32, InternalVar> {
-        let entry = self.memory_map.entry(array_id);
-        entry.or_insert(BTreeMap::new())
+    // Returns the memory_map for the array
+    fn array_map_mut(&mut self, array_id: ArrayId) -> &mut BTreeMap<u32, InternalVar> {
+        &mut self.virtual_memory.entry(array_id).or_default().memory_map
+    }
+
+    // Write the value to the array's VM at the specified index
+    pub fn insert(&mut self, array_id: ArrayId, index: u32, value: InternalVar) {
+        self.array_map_mut(array_id).insert(index, value);
     }
 
     //Map the outputs into the array

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_mem.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_mem.rs
@@ -5,26 +5,31 @@ use crate::ssa::{
 };
 use acvm::acir::native_types::Witness;
 use iter_extended::vecmap;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-// maps memory address to expression
 #[derive(Default)]
-pub struct MemoryMap {
-    inner: HashMap<u32, InternalVar>,
+pub struct AcirMem {
+    // maps memory address to InternalVar
+    memory_map: BTreeMap<ArrayId, BTreeMap<u32, InternalVar>>,
 }
 
-impl MemoryMap {
+impl AcirMem {
+    // returns the memory_map for the array
+    pub fn array_map_mut(&mut self, array_id: ArrayId) -> &mut BTreeMap<u32, InternalVar> {
+        let entry = self.memory_map.entry(array_id);
+        entry.or_insert(BTreeMap::new())
+    }
+
     //Map the outputs into the array
     pub(crate) fn map_array(&mut self, a: ArrayId, outputs: &[Witness], ctx: &SsaContext) {
         let array = &ctx.mem[a];
-        let address = array.adr;
         for i in 0..array.len {
             let var = if i < outputs.len() as u32 {
                 InternalVar::from(outputs[i as usize])
             } else {
                 InternalVar::zero_expr()
             };
-            self.inner.insert(address + i, var);
+            self.array_map_mut(array.id).insert(i, var);
         }
     }
 
@@ -60,10 +65,8 @@ impl MemoryMap {
             return None; // IndexOutOfBoundsError
         }
 
-        let address_of_element = array.absolute_adr(offset);
-
         // Check the memory_map to see if the element is there
-        if let Some(internal_var) = self.inner.get(&address_of_element) {
+        if let Some(internal_var) = self.array_map_mut(array.id).get(&offset) {
             return Some(internal_var.clone());
         };
 
@@ -77,9 +80,5 @@ impl MemoryMap {
         array_element.cached_witness().expect("ICE: since the value is not in the memory_map it must have came from the ABI, so it is a Witness");
 
         Some(array_element)
-    }
-
-    pub(crate) fn insert(&mut self, key: u32, value: InternalVar) -> Option<InternalVar> {
-        self.inner.insert(key, value)
     }
 }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
@@ -1,7 +1,7 @@
 use crate::{
     ssa::{
         acir_gen::{
-            constraints, internal_var_cache::InternalVarCache, memory_map::MemoryMap, operations,
+            acir_mem::AcirMem, constraints, internal_var_cache::InternalVarCache, operations,
             InternalVar,
         },
         context::SsaContext,
@@ -30,7 +30,7 @@ pub(crate) fn evaluate(
     binary: &node::Binary,
     res_type: ObjectType,
     var_cache: &mut InternalVarCache,
-    memory_map: &mut MemoryMap,
+    memory_map: &mut AcirMem,
     evaluator: &mut Evaluator,
     ctx: &SsaContext,
 ) -> Option<InternalVar> {

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
@@ -26,7 +26,7 @@ use iter_extended::vecmap;
 // so in reality, the NEQ instruction will be done on the fields
 // of the struct
 pub(crate) fn evaluate_neq(
-    memory_map: &mut AcirMem,
+    acir_mem: &mut AcirMem,
     lhs: NodeId,
     rhs: NodeId,
     l_c: Option<InternalVar>,
@@ -55,7 +55,7 @@ pub(crate) fn evaluate_neq(
             )
         }
 
-        let mut x = InternalVar::from(array_eq(memory_map, array_a, array_b, evaluator));
+        let mut x = InternalVar::from(array_eq(acir_mem, array_a, array_b, evaluator));
         // TODO we need a witness because of the directive, but we should use an expression
         // TODO if we change the Invert directive to take an `Expression`, then we
         // TODO can get rid of this extra gate.

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
@@ -1,6 +1,6 @@
 use crate::{
     ssa::{
-        acir_gen::{constraints, memory_map::MemoryMap, InternalVar},
+        acir_gen::{acir_mem::AcirMem, constraints, InternalVar},
         context::SsaContext,
         mem::{MemArray, Memory},
         node::NodeId,
@@ -26,7 +26,7 @@ use iter_extended::vecmap;
 // so in reality, the NEQ instruction will be done on the fields
 // of the struct
 pub(crate) fn evaluate_neq(
-    memory_map: &mut MemoryMap,
+    memory_map: &mut AcirMem,
     lhs: NodeId,
     rhs: NodeId,
     l_c: Option<InternalVar>,
@@ -89,7 +89,7 @@ pub(crate) fn evaluate_neq(
 }
 
 pub(crate) fn evaluate_eq(
-    memory_map: &mut MemoryMap,
+    memory_map: &mut AcirMem,
     lhs: NodeId,
     rhs: NodeId,
     l_c: Option<InternalVar>,
@@ -107,7 +107,7 @@ pub(crate) fn evaluate_eq(
 //
 // N.B. We assumes the lengths of a and b are the same but it is not checked inside the function.
 fn array_eq(
-    memory_map: &mut MemoryMap,
+    memory_map: &mut AcirMem,
     a: &MemArray,
     b: &MemArray,
     evaluator: &mut Evaluator,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -4,7 +4,7 @@ use crate::{
             constraints::{bound_constraint_with_offset, to_radix_base},
             expression_from_witness,
             operations::sort::evaluate_permutation,
-            InternalVar, InternalVarCache, AcirMem,
+            AcirMem, InternalVar, InternalVarCache,
         },
         builtin,
         context::SsaContext,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -197,7 +197,7 @@ fn resolve_array(
         );
         let func_input = FunctionInput { witness, num_bits };
 
-        acir_mem.array_map_mut(array.id).insert(i, arr_element); //todo ca sert a qqchose ??
+        acir_mem.insert(array.id, i, arr_element);
 
         inputs.push(func_input)
     }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/load.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/load.rs
@@ -1,6 +1,6 @@
 use crate::{
     ssa::{
-        acir_gen::{internal_var_cache::InternalVarCache, memory_map::MemoryMap, InternalVar},
+        acir_gen::{acir_mem::AcirMem, internal_var_cache::InternalVarCache, InternalVar},
         context::SsaContext,
         mem::{self, ArrayId},
         node::NodeId,
@@ -11,7 +11,7 @@ use crate::{
 pub(crate) fn evaluate(
     array_id: ArrayId,
     index: NodeId,
-    memory_map: &mut MemoryMap,
+    memory_map: &mut AcirMem,
     var_cache: &mut InternalVarCache,
     evaluator: &mut Evaluator,
     ctx: &SsaContext,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::RuntimeErrorKind,
     ssa::{
-        acir_gen::{internal_var_cache::InternalVarCache, memory_map::MemoryMap, InternalVar},
+        acir_gen::{acir_mem::AcirMem, internal_var_cache::InternalVarCache, InternalVar},
         context::SsaContext,
         mem::Memory,
         node::NodeId,
@@ -11,7 +11,7 @@ use crate::{
 
 pub(crate) fn evaluate(
     node_ids: &[NodeId],
-    memory_map: &mut MemoryMap,
+    memory_map: &mut AcirMem,
     var_cache: &mut InternalVarCache,
     evaluator: &mut Evaluator,
     ctx: &SsaContext,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/store.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/store.rs
@@ -24,8 +24,7 @@ pub(crate) fn evaluate(
     match index.to_const() {
         Some(index) => {
             let idx = mem::Memory::as_u32(index);
-            let mem_map = acir_mem.array_map_mut(array_id);
-            mem_map.insert(idx, value);
+            acir_mem.insert(array_id, idx, value);
             //we do not generate constraint, so no output.
             None
         }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/store.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/store.rs
@@ -1,6 +1,6 @@
 use crate::{
     ssa::{
-        acir_gen::{internal_var_cache::InternalVarCache, memory_map::MemoryMap, InternalVar},
+        acir_gen::{acir_mem::AcirMem, internal_var_cache::InternalVarCache, InternalVar},
         context::SsaContext,
         mem::{self, ArrayId},
         node::NodeId,
@@ -12,7 +12,7 @@ pub(crate) fn evaluate(
     array_id: ArrayId,
     index: NodeId,
     value: NodeId,
-    memory_map: &mut MemoryMap,
+    acir_mem: &mut AcirMem,
     var_cache: &mut InternalVarCache,
     evaluator: &mut Evaluator,
     ctx: &SsaContext,
@@ -24,8 +24,8 @@ pub(crate) fn evaluate(
     match index.to_const() {
         Some(index) => {
             let idx = mem::Memory::as_u32(index);
-            let absolute_adr = ctx.mem[array_id].absolute_adr(idx);
-            memory_map.insert(absolute_adr, value);
+            let mem_map = acir_mem.array_map_mut(array_id);
+            mem_map.insert(idx, value);
             //we do not generate constraint, so no output.
             None
         }

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -222,7 +222,7 @@ impl From<ResolverError> for Diagnostic {
             ),
             ResolverError::NonStructUsedInConstructor { typ, span } => Diagnostic::simple_error(
                 "Only struct types can be used in constructor expressions".into(),
-                format!("{} has no fields to construct it with", typ),
+                format!("{typ} has no fields to construct it with"),
                 span,
             ),
             ResolverError::NonStructWithGenerics { span } => Diagnostic::simple_error(


### PR DESCRIPTION

# Description

## Summary of changes

This is a fourth preparation step for dynamic memory. Instead of having a one big VM that holds all the arrays, we assign one per array, which enable support for variable length arrays.
We also use a more generic name for the structure which abstract the memory_map as it will be extended for the dynamic array feature.



# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.


