### PR TITLE
feat(stdlib): Add higher order array functions

### DIFF
--- a/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
+++ b/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
@@ -24,24 +24,26 @@ fn main() -> pub Field {
     x = x + 1;
     constrain (|y| y + z)(1) == 4;
     x = x + 1;
+    let ret = twice(add1, 3);
 
-    twice(add1, 3)
+    test_array_functions();
 
+    ret
+}
 
-    // Test the array functions in std::array
-    let myarray = [1, 2, 3];
+/// Test the array functions in std::array
+fn test_array_functions() {
+    let myarray: [i32; 3] = [1, 2, 3];
     constrain std::array::any(myarray, |n| n > 2);
 
-    let evens = [2, 4, 6];
-    constrain std::array::all(evens, |n| n % 2 == 0);
+    let evens: [i32; 3] = [2, 4, 6];
+    constrain std::array::all(evens, |n| n > 1);
 
     constrain std::array::fold(evens, 0, |a, b| a + b) == 12;
+    constrain std::array::reduce(evens, |a, b| a + b) == 12;
     
     let descending = std::array::sort_via(myarray, |a, b| a > b);
     constrain descending == [3, 2, 1];
-
-    constrain std::array::find(myarray, |e| e == 3) == 2;  // found at index 2
-    constrain std::array::find(myarray, |e| e == 5) == -1; // not found
 }
 
 fn foo() -> [u32; 2] {

--- a/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
+++ b/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
@@ -1,3 +1,5 @@
+use dep::std;
+
 fn main() -> pub Field {
     let f = if 3 * 7 > 200 { foo } else { bar };
     constrain f()[1] == 2;
@@ -24,6 +26,22 @@ fn main() -> pub Field {
     x = x + 1;
 
     twice(add1, 3)
+
+
+    // Test the array functions in std::array
+    let myarray = [1, 2, 3];
+    constrain std::array::any(myarray, |n| n > 2);
+
+    let evens = std::array::map(myarray, |n| n * 2);
+    constrain std::array::all(evens, |n| n % 2 == 0);
+
+    constrain std::array::fold(evens, 0, |a, b| a + b) == 12;
+    
+    let descending = std::array::sort_via(myarray, |a, b| a > b);
+    constrain descending == [3, 2, 1];
+
+    constrain std::array::find(myarray, |e| e == 3) == 2;  // found at index 2
+    constrain std::array::find(myarray, |e| e == 5) == -1; // not found
 }
 
 fn foo() -> [u32; 2] {

--- a/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
+++ b/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
@@ -32,7 +32,7 @@ fn main() -> pub Field {
     let myarray = [1, 2, 3];
     constrain std::array::any(myarray, |n| n > 2);
 
-    let evens = std::array::map(myarray, |n| n * 2);
+    let evens = [2, 4, 6];
     constrain std::array::all(evens, |n| n % 2 == 0);
 
     constrain std::array::fold(evens, 0, |a, b| a + b) == 12;

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -741,7 +741,7 @@ pub fn comparator_operand_type_rules(
 
             let comptime = CompTime::No(None);
             if other.try_bind_to_polymorphic_int(var, &comptime, true, op.location.span).is_ok() || other == &Type::Error {
-                Ok(other.clone())
+                Ok(Bool(comptime.clone()))
             } else {
                 Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
             }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -741,7 +741,7 @@ pub fn comparator_operand_type_rules(
 
             let comptime = CompTime::No(None);
             if other.try_bind_to_polymorphic_int(var, &comptime, true, op.location.span).is_ok() || other == &Type::Error {
-                Ok(Bool(comptime.clone()))
+                Ok(Bool(comptime))
             } else {
                 Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
             }

--- a/noir_stdlib/src/array.nr
+++ b/noir_stdlib/src/array.nr
@@ -5,7 +5,7 @@ fn len<T>(_input : [T]) -> comptime Field {}
 fn sort<T>(mut a: [T]) -> [T] { 
     for i in 1..len(a) {
         for j in 0..i {
-            if(a[i] < a[j]) {
+            if a[i] < a[j] {
                 let c = a[j];
                 a[j] = a[i];
                 a[i]= c;
@@ -13,4 +13,67 @@ fn sort<T>(mut a: [T]) -> [T] {
         };
     };
     a
+}
+
+// Sort with a custom sorting function.
+fn sort_via<T>(mut a: [T], ordering: fn(T, T) -> bool) -> [T] { 
+    for i in 1..len(a) {
+        for j in 0..i {
+            if ordering(a[i], a[j]) {
+                let c = a[j];
+                a[j] = a[i];
+                a[i]= c;
+            }
+        };
+    };
+    a
+}
+
+// Apply the given function to each element of the array
+fn map<T, U, N>(array: [T; N], f: fn(T) -> U) -> [U; N] {
+    let mut ret = [f(array[0]); N];
+    for i in 1 .. len(array) {
+        ret[i] = f(array[i]);
+    }
+    ret
+}
+
+// Apply a function to each element of the array and an accumulator value,
+// returning the final accumulated value. This function is also sometimes
+// called `foldl`, `fold_left`, `reduce`, or `inject`.
+fn fold<T, U, N>(array: [T; N], mut accumulator: U, f: fn(U, T) -> U) -> U {
+    for elem in array {
+        accumulator = f(accumulator, elem);
+    }
+    accumulator
+}
+
+// Returns the index of the first element to match the given predicate.
+// If no such element is found, this returns -1.
+fn find<T, N>(array: [T; N], predicate: fn(T) -> bool) -> i64 {
+    let mut ret = -1;
+    for i in 0 .. len(array) {
+        if predicate(array[i]) & ret != -1 {
+            ret = i as i64;
+        }
+    }
+    ret
+}
+
+// Returns true if all elements in the array satisfy the predicate
+fn all<T, N>(array: [T; N], predicate: fn(T) -> bool) -> bool {
+    let mut ret = true;
+    for elem in array {
+        ret &= predicate(elem);
+    }
+    ret
+}
+
+// Returns true if any element in the array satisfies the predicate
+fn any<T, N>(array: [T; N], predicate: fn(T) -> bool) -> bool {
+    let mut ret = false;
+    for elem in array {
+        ret |= predicate(elem);
+    }
+    ret
 }

--- a/noir_stdlib/src/array.nr
+++ b/noir_stdlib/src/array.nr
@@ -5,7 +5,7 @@ fn len<T>(_input : [T]) -> comptime Field {}
 fn sort<T, N>(_a: [T; N]) -> [T; N] {}
 
 // Sort with a custom sorting function.
-fn sort_via<T>(mut a: [T], ordering: fn(T, T) -> bool) -> [T] { 
+fn sort_via<T, N>(mut a: [T; N], ordering: fn(T, T) -> bool) -> [T; N] { 
     for i in 1..len(a) {
         for j in 0..i {
             if ordering(a[i], a[j]) {
@@ -28,16 +28,15 @@ fn fold<T, U, N>(array: [T; N], mut accumulator: U, f: fn(U, T) -> U) -> U {
     accumulator
 }
 
-// Returns the index of the first element to match the given predicate.
-// If no such element is found, this returns -1.
-fn find<T, N>(array: [T; N], predicate: fn(T) -> bool) -> i64 {
-    let mut ret: i64 = 0 - 1;
-    for i in 0 .. len(array) {
-        if predicate(array[i]) & (ret != 0 - 1) {
-            ret = i as i64;
-        }
+// Apply a function to each element of the array and an accumulator value,
+// returning the final accumulated value. Unlike fold, reduce uses the first
+// element of the given array as its starting accumulator value.
+fn reduce<T, N>(array: [T; N], f: fn(T, T) -> T) -> T {
+    let mut accumulator = array[0];
+    for i in 1 .. len(array) {
+        accumulator = f(accumulator, array[i]);
     }
-    ret
+    accumulator
 }
 
 // Returns true if all elements in the array satisfy the predicate

--- a/noir_stdlib/src/array.nr
+++ b/noir_stdlib/src/array.nr
@@ -18,15 +18,6 @@ fn sort_via<T>(mut a: [T], ordering: fn(T, T) -> bool) -> [T] {
     a
 }
 
-// Apply the given function to each element of the array
-fn map<T, U, N>(array: [T; N], f: fn(T) -> U) -> [U; N] {
-    let mut ret = [f(array[0]); N];
-    for i in 1 .. len(array) {
-        ret[i] = f(array[i]);
-    }
-    ret
-}
-
 // Apply a function to each element of the array and an accumulator value,
 // returning the final accumulated value. This function is also sometimes
 // called `foldl`, `fold_left`, `reduce`, or `inject`.
@@ -40,9 +31,9 @@ fn fold<T, U, N>(array: [T; N], mut accumulator: U, f: fn(U, T) -> U) -> U {
 // Returns the index of the first element to match the given predicate.
 // If no such element is found, this returns -1.
 fn find<T, N>(array: [T; N], predicate: fn(T) -> bool) -> i64 {
-    let mut ret = -1;
+    let mut ret: i64 = 0 - 1;
     for i in 0 .. len(array) {
-        if predicate(array[i]) & ret != -1 {
+        if predicate(array[i]) & (ret != 0 - 1) {
             ret = i as i64;
         }
     }

--- a/noir_stdlib/src/array.nr
+++ b/noir_stdlib/src/array.nr
@@ -22,8 +22,8 @@ fn sort_via<T>(mut a: [T], ordering: fn(T, T) -> bool) -> [T] {
 // returning the final accumulated value. This function is also sometimes
 // called `foldl`, `fold_left`, `reduce`, or `inject`.
 fn fold<T, U, N>(array: [T; N], mut accumulator: U, f: fn(U, T) -> U) -> U {
-    for elem in array {
-        accumulator = f(accumulator, elem);
+    for i in 0 .. len(array) {
+        accumulator = f(accumulator, array[i]);
     }
     accumulator
 }
@@ -43,8 +43,8 @@ fn find<T, N>(array: [T; N], predicate: fn(T) -> bool) -> i64 {
 // Returns true if all elements in the array satisfy the predicate
 fn all<T, N>(array: [T; N], predicate: fn(T) -> bool) -> bool {
     let mut ret = true;
-    for elem in array {
-        ret &= predicate(elem);
+    for i in 0 .. len(array) {
+        ret &= predicate(array[i]);
     }
     ret
 }
@@ -52,8 +52,8 @@ fn all<T, N>(array: [T; N], predicate: fn(T) -> bool) -> bool {
 // Returns true if any element in the array satisfies the predicate
 fn any<T, N>(array: [T; N], predicate: fn(T) -> bool) -> bool {
     let mut ret = false;
-    for elem in array {
-        ret |= predicate(elem);
+    for i in 0 .. len(array) {
+        ret |= predicate(array[i]);
     }
     ret
 }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #831

# Description

Adds some higher order array functions to the stdlib.

## Summary of changes

Adds:
- ~~`std::array::map`~~, `map` has been removed as we would need to support the syntax `[expr; comptime expr]` where we can initialize an array of any comptime length. Today it is limited to only integer literals or globals rather than any length expression.
- `std::array::fold`
- `std::array::reduce` - like fold but uses the first element in the array as the accumulator value.
- ~~`std::array::find`~~ `find` has also been removed. The negative numbers seemed to cause issues that prevented proving/verification.
- `std::array::sort_via`
- `std::array::all`
- `std::array::any`

## Test additions / changes

Tests these functions in the higher_order_functions test.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [x] This PR requires documentation updates when merged.
