### PR TITLE
chore: Remove  #[allow(clippy::map_entry)] lint

### DIFF
--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -111,18 +111,16 @@ impl SsaContext {
         self.dummy_load[&a]
     }
 
-    #[allow(clippy::map_entry)]
     pub fn add_dummy_load(&mut self, a: ArrayId) {
-        if !self.dummy_load.contains_key(&a) {
+        if self.dummy_load.get(&a).is_none() {
             let op_a = Operation::Load { array_id: a, index: NodeId::dummy() };
             let dummy_load = node::Instruction::new(op_a, self.mem[a].element_type, None);
             let id = self.add_instruction(dummy_load);
             self.dummy_load.insert(a, id);
         }
     }
-    #[allow(clippy::map_entry)]
     pub fn add_dummy_store(&mut self, a: ArrayId) {
-        if !self.dummy_store.contains_key(&a) {
+        if self.dummy_store.get(&a).is_none() {
             let op_a =
                 Operation::Store { array_id: a, index: NodeId::dummy(), value: NodeId::dummy() };
             let dummy_store = node::Instruction::new(op_a, node::ObjectType::NotAnObject, None);


### PR DESCRIPTION
# Related issue(s)

# Description

Ideally, we would fix by using `.entry.or_insert_with` however since `self` is borrowed when we call `.entry` and then again when we call `add_instruction`. 

The rust compiler cannot see that this is safe. If we were operating on separate fields in the struct, then it should have no problem deducing this, but since we call a method it falls short. This IIRC is something that the new borrow checker Polonius will be able to solve.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
