### PR TITLE
chore: Add display for binaryop

### DIFF
--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -157,35 +157,8 @@ impl SsaContext {
     fn binary_to_string(&self, binary: &node::Binary) -> String {
         let lhs = self.id_to_string(binary.lhs);
         let rhs = self.id_to_string(binary.rhs);
-        let op = match &binary.operator {
-            BinaryOp::Add => "add",
-            BinaryOp::SafeAdd => "safe_add",
-            BinaryOp::Sub { .. } => "sub",
-            BinaryOp::SafeSub { .. } => "safe_sub",
-            BinaryOp::Mul => "mul",
-            BinaryOp::SafeMul => "safe_mul",
-            BinaryOp::Udiv => "udiv",
-            BinaryOp::Sdiv => "sdiv",
-            BinaryOp::Urem => "urem",
-            BinaryOp::Srem => "srem",
-            BinaryOp::Div => "div",
-            BinaryOp::Eq => "eq",
-            BinaryOp::Ne => "ne",
-            BinaryOp::Ult => "ult",
-            BinaryOp::Ule => "ule",
-            BinaryOp::Slt => "slt",
-            BinaryOp::Sle => "sle",
-            BinaryOp::Lt => "lt",
-            BinaryOp::Lte => "lte",
-            BinaryOp::And => "and",
-            BinaryOp::Or => "or",
-            BinaryOp::Xor => "xor",
-            BinaryOp::Assign => "assign",
-            BinaryOp::Shl => "shl",
-            BinaryOp::Shr => "shr",
-        };
 
-        format!("{op} {lhs}, {rhs}")
+        format!("{} {lhs}, {rhs}", binary.operator)
     }
 
     pub fn operation_to_string(&self, op: &Operation) -> String {

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -10,6 +10,7 @@ use noirc_frontend::{
 };
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, One};
+use std::fmt::Display;
 use std::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
 pub trait Node: std::fmt::Display {
@@ -618,6 +619,39 @@ pub enum BinaryOp {
     Shr, //(>>) Shift right
 
     Assign,
+}
+
+impl Display for BinaryOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let op = match &self {
+            BinaryOp::Add => "add",
+            BinaryOp::SafeAdd => "safe_add",
+            BinaryOp::Sub { .. } => "sub",
+            BinaryOp::SafeSub { .. } => "safe_sub",
+            BinaryOp::Mul => "mul",
+            BinaryOp::SafeMul => "safe_mul",
+            BinaryOp::Udiv => "udiv",
+            BinaryOp::Sdiv => "sdiv",
+            BinaryOp::Urem => "urem",
+            BinaryOp::Srem => "srem",
+            BinaryOp::Div => "div",
+            BinaryOp::Eq => "eq",
+            BinaryOp::Ne => "ne",
+            BinaryOp::Ult => "ult",
+            BinaryOp::Ule => "ule",
+            BinaryOp::Slt => "slt",
+            BinaryOp::Sle => "sle",
+            BinaryOp::Lt => "lt",
+            BinaryOp::Lte => "lte",
+            BinaryOp::And => "and",
+            BinaryOp::Or => "or",
+            BinaryOp::Xor => "xor",
+            BinaryOp::Assign => "assign",
+            BinaryOp::Shl => "shl",
+            BinaryOp::Shr => "shr",
+        };
+        write!(f, "{op}")
+    }
 }
 
 impl Binary {

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -10,7 +10,6 @@ use noirc_frontend::{
 };
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, One};
-use std::fmt::Display;
 use std::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
 pub trait Node: std::fmt::Display {
@@ -621,7 +620,7 @@ pub enum BinaryOp {
     Assign,
 }
 
-impl Display for BinaryOp {
+impl std::fmt::Display for BinaryOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let op = match &self {
             BinaryOp::Add => "add",


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves https://github.com/noir-lang/noir/issues/837

# Description

Add `Display` for `BinaryOp` in `ssa`

## Summary of changes

1. Implement `Display` for `BinaryOp`
2. Deleted matching `BinaryOp` to `str` part in `context.rs`

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
