### PR TITLE
chore(ci): Make Kev the committer on release lockfile updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ fromJSON(needs.release-please.outputs.release-pr).headBranchName }}
+          token: ${{ secrets.NOIR_RELEASES_TOKEN }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.65.0
@@ -46,8 +47,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name kevaundray
+          git config user.email kevtheappdev@gmail.com
 
       - name: Commit updates
         run: |


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Follow up to #840

# Description

We were triggering the builds on the PR itself, but the push of the lockfile was not running checks and blocking the merge. This adds the token to checkout the repo & push the new lockfile as @kevaundray so CI will run. Tested on my fork.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
