### PR TITLE
chore: Rename NodeObject::Obj variant to NodeObject:Variable

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
@@ -34,7 +34,7 @@ impl InternalVarCache {
                 let field_value = FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be());
                 InternalVar::from_constant(field_value)
             }
-            NodeObject::Obj(variable) => {
+            NodeObject::Variable(variable) => {
                 let variable_type = variable.get_type();
                 match variable_type {
                     ObjectType::Boolean

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -159,7 +159,7 @@ fn resolve_node_id(
 ) -> Vec<FunctionInput> {
     let node_object = cfg.try_get_node(*node_id).expect("could not find node for {node_id}");
     match node_object {
-        node::NodeObject::Obj(v) => {
+        node::NodeObject::Variable(v) => {
             let node_obj_type = node_object.get_type();
             match node_obj_type {
                 // If the `Variable` represents a Pointer

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -411,7 +411,7 @@ impl SsaContext {
     pub fn get_variable(&self, id: NodeId) -> Result<&node::Variable, RuntimeErrorKind> {
         match self.nodes.get(id.0) {
             Some(t) => match t {
-                node::NodeObject::Obj(o) => Ok(o),
+                node::NodeObject::Variable(o) => Ok(o),
                 _ => Err(RuntimeErrorKind::UnstructuredError {
                     message: "Not an object".to_string(),
                 }),
@@ -426,7 +426,7 @@ impl SsaContext {
     ) -> Result<&mut node::Variable, RuntimeErrorKind> {
         match self.nodes.get_mut(id.0) {
             Some(t) => match t {
-                node::NodeObject::Obj(o) => Ok(o),
+                node::NodeObject::Variable(o) => Ok(o),
                 _ => Err(RuntimeErrorKind::UnstructuredError {
                     message: "Not an object".to_string(),
                 }),
@@ -457,9 +457,9 @@ impl SsaContext {
     }
 
     pub fn add_variable(&mut self, obj: node::Variable, root: Option<NodeId>) -> NodeId {
-        let id = NodeId(self.nodes.insert(NodeObject::Obj(obj)));
+        let id = NodeId(self.nodes.insert(NodeObject::Variable(obj)));
         match &mut self[id] {
-            node::NodeObject::Obj(v) => {
+            node::NodeObject::Variable(v) => {
                 v.id = id;
                 v.root = root;
             }

--- a/crates/noirc_evaluator/src/ssa/flatten.rs
+++ b/crates/noirc_evaluator/src/ssa/flatten.rs
@@ -335,7 +335,7 @@ fn evaluate_one(
                     let value = FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be());
                     Ok(NodeEval::Const(value, c.get_type()))
                 }
-                NodeObject::Obj(_) => Ok(NodeEval::VarOrInstruction(obj_id)),
+                NodeObject::Variable(_) => Ok(NodeEval::VarOrInstruction(obj_id)),
                 NodeObject::Function(f, id, _) => Ok(NodeEval::Function(*f, *id)),
             }
         }
@@ -377,7 +377,7 @@ fn evaluate_object(
                     let value = FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be());
                     Ok(NodeEval::Const(value, c.get_type()))
                 }
-                NodeObject::Obj(_) => Ok(NodeEval::VarOrInstruction(obj_id)),
+                NodeObject::Variable(_) => Ok(NodeEval::VarOrInstruction(obj_id)),
                 NodeObject::Function(f, id, _) => Ok(NodeEval::Function(*f, *id)),
             }
         }

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -97,7 +97,7 @@ fn get_obj_max_value(
     let obj = &ctx[id];
 
     let result = match obj {
-        NodeObject::Obj(v) => (BigUint::one() << v.size_in_bits()) - BigUint::one(), //TODO check for signed type
+        NodeObject::Variable(v) => (BigUint::one() << v.size_in_bits()) - BigUint::one(), //TODO check for signed type
         NodeObject::Instr(i) => get_instruction_max(ctx, i, max_map, value_map),
         NodeObject::Const(c) => c.value.clone(), //TODO panic for string constants
         NodeObject::Function(..) => BigUint::zero(),

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -28,7 +28,7 @@ impl std::fmt::Display for NodeObject {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use FunctionKind::*;
         match self {
-            NodeObject::Obj(o) => write!(f, "{o}"),
+            NodeObject::Variable(o) => write!(f, "{o}"),
             NodeObject::Instr(i) => write!(f, "{i}"),
             NodeObject::Const(c) => write!(f, "{c}"),
             NodeObject::Function(Normal(id), ..) => write!(f, "f{}", id.0),
@@ -60,7 +60,7 @@ impl Node for Variable {
 impl Node for NodeObject {
     fn get_type(&self) -> ObjectType {
         match self {
-            NodeObject::Obj(o) => o.get_type(),
+            NodeObject::Variable(o) => o.get_type(),
             NodeObject::Instr(i) => i.res_type,
             NodeObject::Const(o) => o.value_type,
             NodeObject::Function(..) => ObjectType::Function,
@@ -69,7 +69,7 @@ impl Node for NodeObject {
 
     fn size_in_bits(&self) -> u32 {
         match self {
-            NodeObject::Obj(o) => o.size_in_bits(),
+            NodeObject::Variable(o) => o.size_in_bits(),
             NodeObject::Instr(i) => i.res_type.bits(),
             NodeObject::Const(c) => c.size_in_bits(),
             NodeObject::Function(..) => 0,
@@ -78,7 +78,7 @@ impl Node for NodeObject {
 
     fn id(&self) -> NodeId {
         match self {
-            NodeObject::Obj(o) => o.id(),
+            NodeObject::Variable(o) => o.id(),
             NodeObject::Instr(i) => i.id,
             NodeObject::Const(c) => c.id(),
             NodeObject::Function(_, id, _) => *id,
@@ -111,7 +111,7 @@ impl NodeId {
 
 #[derive(Debug)]
 pub enum NodeObject {
-    Obj(Variable),
+    Variable(Variable),
     Instr(Instruction),
     Const(Constant),
     Function(FunctionKind, NodeId, /*name:*/ String),
@@ -305,7 +305,7 @@ impl NodeEval {
                 NodeEval::Const(value, c.get_type())
             }
             NodeObject::Function(f, id, _name) => NodeEval::Function(*f, *id),
-            NodeObject::Obj(_) | NodeObject::Instr(_) => NodeEval::VarOrInstruction(id),
+            NodeObject::Variable(_) | NodeObject::Instr(_) => NodeEval::VarOrInstruction(id),
         }
     }
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #756 

# Description

Renames `Obj` variant to `Variable` since `NodeObject::Object(Variable)` is not clear., unless this is implying that a NodeObject's Object variant and Variable are equal in some way. 

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
