### PR TITLE
chore(ssa): Move type methods onto types from SsaContext

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -48,7 +48,7 @@ pub(crate) fn evaluate(
     match opcode {
         Opcode::ToBits => {
             // TODO: document where `0` and `1` are coming from, for args[0], args[1]
-            let bit_size = ctx.get_as_constant(args[1]).unwrap().to_u128() as u32;
+            let bit_size = args[1].get_as_constant(ctx).unwrap().to_u128() as u32;
             let l_c = var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
             outputs = to_radix_base(l_c.expression(), 2, bit_size, evaluator);
             if let ObjectType::Pointer(a) = res_type {
@@ -57,8 +57,8 @@ pub(crate) fn evaluate(
         }
         Opcode::ToRadix => {
             // TODO: document where `0`, `1` and `2` are coming from, for args[0],args[1], args[2]
-            let radix = ctx.get_as_constant(args[1]).unwrap().to_u128() as u32;
-            let limb_size = ctx.get_as_constant(args[2]).unwrap().to_u128() as u32;
+            let radix = args[1].get_as_constant(ctx).unwrap().to_u128() as u32;
+            let limb_size = args[2].get_as_constant(ctx).unwrap().to_u128() as u32;
             let l_c = var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
             outputs = to_radix_base(l_c.expression(), radix, limb_size, evaluator);
             if let ObjectType::Pointer(a) = res_type {
@@ -284,7 +284,7 @@ fn evaluate_println(
                 log_string = format!("[{}]", fields.join(", "));
             }
         }
-        _ => match ctx.get_as_constant(node_id) {
+        _ => match node_id.get_as_constant(ctx) {
             Some(field) => {
                 log_string = format_field_string(field);
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/store.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/store.rs
@@ -26,9 +26,9 @@ pub(crate) fn evaluate(
             Some(index) => {
                 let idx = mem::Memory::as_u32(index);
                 let value_with_predicate = if let Some(predicate) = predicate {
-                    if predicate.is_dummy() || ctx.is_one(predicate) {
+                    if predicate.is_dummy() || predicate.is_one(ctx) {
                         value
-                    } else if ctx.is_zero(predicate) {
+                    } else if predicate.is_zero(ctx) {
                         return None;
                     } else {
                         let pred =

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -219,11 +219,11 @@ fn cse_block_with_anchor(
                     if let ObjectType::Pointer(a) = ctx.object_type(binary.lhs) {
                         //No CSE for arrays because they are not in SSA form
                         //We could improve this in future by checking if the arrays are immutable or not modified in-between
-                        let id = ctx.get_dummy_load(a);
+                        let id = a.get_dummy_load(ctx);
                         anchor.push_mem_instruction(ctx, id)?;
 
                         if let ObjectType::Pointer(a) = ctx.object_type(binary.rhs) {
-                            let id = ctx.get_dummy_load(a);
+                            let id = a.get_dummy_load(ctx);
                             anchor.push_mem_instruction(ctx, id)?;
                         }
 
@@ -363,13 +363,13 @@ fn cse_block_with_anchor(
                     //No CSE for function calls because of possible side effect - TODO checks if a function has side effect when parsed and do cse for these.
                     //Add dummy store for functions that modify arrays
                     for a in returned_arrays {
-                        let id = ctx.get_dummy_store(a.0);
+                        let id = a.0.get_dummy_store(ctx);
                         anchor.push_mem_instruction(ctx, id)?;
                     }
                     if let Some(f) = ctx.try_get_ssa_func(*func) {
                         for typ in &f.result_types {
                             if let ObjectType::Pointer(a) = typ {
-                                let id = ctx.get_dummy_store(*a);
+                                let id = a.get_dummy_store(ctx);
                                 anchor.push_mem_instruction(ctx, id)?;
                             }
                         }
@@ -378,7 +378,7 @@ fn cse_block_with_anchor(
                     for arg in arguments {
                         if let Some(obj) = ctx.try_get_node(*arg) {
                             if let ObjectType::Pointer(a) = obj.get_type() {
-                                let id = ctx.get_dummy_load(a);
+                                let id = a.get_dummy_load(ctx);
                                 anchor.push_mem_instruction(ctx, id)?;
                             }
                         }
@@ -397,14 +397,14 @@ fn cse_block_with_anchor(
                     for arg in args {
                         if let Some(obj) = ctx.try_get_node(*arg) {
                             if let ObjectType::Pointer(a) = obj.get_type() {
-                                let id = ctx.get_dummy_load(a);
+                                let id = a.get_dummy_load(ctx);
                                 anchor.push_mem_instruction(ctx, id)?;
                                 activate_cse = false;
                             }
                         }
                     }
                     if let ObjectType::Pointer(a) = ins.res_type {
-                        let id = ctx.get_dummy_store(a);
+                        let id = a.get_dummy_store(ctx);
                         anchor.push_mem_instruction(ctx, id)?;
                         activate_cse = false;
                     }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

Currently the Context object has a lot of methods on it related to different ArenaIds. This PR puts some of these methods on the ArenaId's themselves and passes the context as an argument instead.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
