### PR TITLE
fix: avoid testing equality between unit values in acir_gen test

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -152,7 +152,7 @@ mod test {
             for _i in 0..w.len() {
                 c.push(rng.next_u32() % 2 != 0);
             }
-            // intialize bits
+            // initialize bits
             for i in 0..w.len() {
                 solved_witness.insert(w[i], FieldElement::from(c[i] as i128));
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -20,7 +20,7 @@ pub fn evaluate_permutation(
     evaluator: &mut Evaluator,
 ) -> Vec<Witness> {
     let (w, b) = permutation_layer(in_expr, evaluator);
-    // we contrain the network output to out_expr
+    // we constrain the network output to out_expr
     for (b, o) in b.iter().zip(out_expr) {
         evaluator.opcodes.push(AcirOpcode::Arithmetic(subtract(b, FieldElement::one(), o)));
     }
@@ -45,7 +45,7 @@ pub fn permutation_layer(
         conf.push(evaluator.add_witness_to_cs());
     }
     // compute expressions after the input switches
-    // If inputs are a1,a2, and the switch value is c, then we compute expresions b1,b2 where
+    // If inputs are a1,a2, and the switch value is c, then we compute expressions b1,b2 where
     // b1 = a1+q, b2 = a2-q, q = c(a2-a1)
     let mut in_sub1 = Vec::new();
     let mut in_sub2 = Vec::new();
@@ -68,7 +68,7 @@ pub fn permutation_layer(
     // compute results for the sub networks
     let (w1, b1) = permutation_layer(&in_sub1, evaluator);
     let (w2, b2) = permutation_layer(&in_sub2, evaluator);
-    // apply the output swithces
+    // apply the output switches
     for i in 0..(n - 1) / 2 {
         let c = evaluator.add_witness_to_cs();
         conf.push(c);
@@ -152,7 +152,7 @@ mod test {
             for _i in 0..w.len() {
                 c.push(rng.next_u32() % 2 != 0);
             }
-            // intialise bits
+            // intialize bits
             for i in 0..w.len() {
                 solved_witness.insert(w[i], FieldElement::from(c[i] as i128));
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -166,7 +166,9 @@ mod test {
                 b_val.push(solved_witness[&b_wit[i]]);
             }
             // ensure the outputs are a permutation of the inputs
-            assert_eq!(a_val.sort(), b_val.sort());
+            a_val.sort();
+            b_val.sort();
+            assert_eq!(a_val, b_val);
         }
     }
 }


### PR DESCRIPTION

# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

`a_val.sort()` returns `()` so this equality will always succeed. We now sort prior to passing these arrays into the `assert_eq`.

## Dependency additions / changes

N/A

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
