### PR TITLE
feat(abi)!: add an explicit mapping from ABI params to witness indices

### DIFF
--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -65,7 +65,7 @@ pub(crate) fn execute_program(
     // Solve the remaining witnesses
     let solved_witness = solve_witness(compiled_program, inputs_map)?;
 
-    let public_abi = compiled_program.abi.as_ref().unwrap().clone().public_abi();
+    let public_abi = compiled_program.abi.clone().public_abi();
     let public_inputs = public_abi.decode_from_witness(&solved_witness)?;
     let return_value = public_inputs.get(MAIN_RETURN_NAME).cloned();
 

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -1,16 +1,14 @@
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use acvm::acir::native_types::Witness;
-use acvm::{FieldElement, PartialWitnessGenerator};
+use acvm::PartialWitnessGenerator;
 use clap::ArgMatches;
-use iter_extended::{try_btree_map, vecmap};
 use noirc_abi::errors::AbiError;
 use noirc_abi::input_parser::{Format, InputValue};
-use noirc_abi::{decode_value, encode_value, Abi, AbiParameter, MAIN_RETURN_NAME};
+use noirc_abi::{InputMap, WitnessMap, MAIN_RETURN_NAME};
 use noirc_driver::CompiledProgram;
 
-use super::{create_named_dir, read_inputs_from_file, write_to_file, InputMap, WitnessMap};
+use super::{create_named_dir, read_inputs_from_file, write_to_file};
 use crate::{
     cli::compile_cmd::compile_circuit,
     constants::{PROVER_INPUT_FILE, TARGET_DIR, WITNESS_EXT},
@@ -68,7 +66,7 @@ pub(crate) fn execute_program(
     let solved_witness = solve_witness(compiled_program, inputs_map)?;
 
     let public_abi = compiled_program.abi.as_ref().unwrap().clone().public_abi();
-    let public_inputs = extract_public_inputs(&public_abi, &solved_witness)?;
+    let public_inputs = public_abi.decode_from_witness(&solved_witness)?;
     let return_value = public_inputs.get(MAIN_RETURN_NAME).cloned();
 
     Ok((return_value, solved_witness))
@@ -80,66 +78,17 @@ pub(crate) fn solve_witness(
 ) -> Result<WitnessMap, CliError> {
     let abi = compiled_program.abi.as_ref().unwrap();
 
-    let mut solved_witness =
-        input_map_to_witness_map(abi, input_map).map_err(|error| match error {
-            AbiError::UndefinedInput(_) => {
-                CliError::Generic(format!("{error} in the {PROVER_INPUT_FILE}.toml file."))
-            }
-            _ => CliError::from(error),
-        })?;
+    let mut solved_witness = abi.encode_to_witness(input_map).map_err(|error| match error {
+        AbiError::UndefinedInput(_) => {
+            CliError::Generic(format!("{error} in the {PROVER_INPUT_FILE}.toml file."))
+        }
+        _ => CliError::from(error),
+    })?;
 
     let backend = crate::backends::ConcreteBackend;
     backend.solve(&mut solved_witness, compiled_program.circuit.opcodes.clone())?;
 
     Ok(solved_witness)
-}
-
-/// Given an InputMap and an Abi, produce a WitnessMap
-///
-/// In particular, this method shows one how to associate values in a Toml/JSON
-/// file with witness indices
-fn input_map_to_witness_map(abi: &Abi, input_map: &InputMap) -> Result<WitnessMap, AbiError> {
-    // First encode each input separately
-    let encoded_input_map: BTreeMap<String, Vec<FieldElement>> =
-        try_btree_map(input_map, |(key, value)| {
-            encode_value(value.clone(), key).map(|v| (key.clone(), v))
-        })?;
-
-    // Write input field elements into witness indices specified in `abi_witness_map`.
-    let witness_map = encoded_input_map
-        .iter()
-        .flat_map(|(param_name, encoded_param_fields)| {
-            let param_witness_indices = &abi.param_witnesses[param_name];
-            param_witness_indices
-                .iter()
-                .zip(encoded_param_fields.iter())
-                .map(|(&witness, &field_element)| (witness, field_element))
-        })
-        .collect();
-
-    Ok(witness_map)
-}
-
-pub(crate) fn extract_public_inputs(
-    public_abi: &Abi,
-    solved_witness: &WitnessMap,
-) -> Result<InputMap, AbiError> {
-    let public_inputs_map = public_abi
-        .parameters
-        .iter()
-        .map(|AbiParameter { name, typ, .. }| {
-            let param_witness_values =
-                vecmap(public_abi.param_witnesses[name].clone(), |witness_index| {
-                    solved_witness[&witness_index]
-                });
-
-            decode_value(&mut param_witness_values.into_iter(), typ)
-                .map(|input_value| (name.clone(), input_value))
-                .unwrap()
-        })
-        .collect();
-
-    Ok(public_inputs_map)
 }
 
 pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -1,19 +1,13 @@
-use acvm::{
-    acir::{circuit::PublicInputs, native_types::Witness},
-    FieldElement,
-};
+use acvm::{acir::circuit::PublicInputs, FieldElement};
 pub use check_cmd::check_from_path;
 use clap::{App, AppSettings, Arg};
 use const_format::formatcp;
 use git_version::git_version;
-use noirc_abi::{
-    input_parser::{Format, InputValue},
-    Abi,
-};
+use noirc_abi::{input_parser::Format, Abi, InputMap};
 use noirc_driver::Driver;
 use noirc_frontend::graph::{CrateName, CrateType};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fs::File,
     io::Write,
     path::{Path, PathBuf},
@@ -35,12 +29,6 @@ mod verify_cmd;
 
 const SHORT_GIT_HASH: &str = git_version!(prefix = "git:");
 const VERSION_STRING: &str = formatcp!("{} ({})", env!("CARGO_PKG_VERSION"), SHORT_GIT_HASH);
-
-/// A map from the fields in an TOML/JSON file which correspond to some ABI to their values
-pub type InputMap = BTreeMap<String, InputValue>;
-
-/// A map from the witnesses in a constraint system to the field element values
-pub type WitnessMap = BTreeMap<Witness, FieldElement>;
 
 pub fn start_cli() {
     let allow_warnings = Arg::with_name("allow-warnings")

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -57,7 +57,8 @@ pub fn prove_with_path<P: AsRef<Path>>(
     let (_, solved_witness) = execute_program(&compiled_program, &inputs_map)?;
 
     // Write public inputs into Verifier.toml
-    let public_inputs = extract_public_inputs(&compiled_program, &solved_witness)?;
+    let public_abi = compiled_program.abi.as_ref().unwrap().clone().public_abi();
+    let public_inputs = extract_public_inputs(&public_abi, &solved_witness)?;
     write_inputs_to_file(&public_inputs, &program_dir, VERIFIER_INPUT_FILE, Format::Toml)?;
 
     // Since the public outputs are added onto the public inputs list, there can be duplicates.

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -9,10 +9,7 @@ use super::{
     write_to_file,
 };
 use crate::{
-    cli::{
-        execute_cmd::{execute_program, extract_public_inputs},
-        verify_cmd::verify_proof,
-    },
+    cli::{execute_cmd::execute_program, verify_cmd::verify_proof},
     constants::{PROOFS_DIR, PROOF_EXT, PROVER_INPUT_FILE, VERIFIER_INPUT_FILE},
     errors::CliError,
 };
@@ -58,7 +55,7 @@ pub fn prove_with_path<P: AsRef<Path>>(
 
     // Write public inputs into Verifier.toml
     let public_abi = compiled_program.abi.as_ref().unwrap().clone().public_abi();
-    let public_inputs = extract_public_inputs(&public_abi, &solved_witness)?;
+    let public_inputs = public_abi.decode_from_witness(&solved_witness)?;
     write_inputs_to_file(&public_inputs, &program_dir, VERIFIER_INPUT_FILE, Format::Toml)?;
 
     // Since the public outputs are added onto the public inputs list, there can be duplicates.

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -54,7 +54,7 @@ pub fn prove_with_path<P: AsRef<Path>>(
     let (_, solved_witness) = execute_program(&compiled_program, &inputs_map)?;
 
     // Write public inputs into Verifier.toml
-    let public_abi = compiled_program.abi.as_ref().unwrap().clone().public_abi();
+    let public_abi = compiled_program.abi.clone().public_abi();
     let public_inputs = public_abi.decode_from_witness(&solved_witness)?;
     write_inputs_to_file(&public_inputs, &program_dir, VERIFIER_INPUT_FILE, Format::Toml)?;
 

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -64,7 +64,7 @@ pub(crate) fn verify_proof(
 ) -> Result<bool, CliError> {
     let public_abi = compiled_program.abi.unwrap().public_abi();
     let public_inputs =
-        public_abi.encode(&public_inputs_map, false).map_err(|error| match error {
+        public_abi.encode_to_array(&public_inputs_map).map_err(|error| match error {
             AbiError::UndefinedInput(_) => {
                 CliError::Generic(format!("{error} in the {VERIFIER_INPUT_FILE}.toml file."))
             }

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -1,4 +1,5 @@
 use crate::{input_parser::InputValue, AbiParameter, AbiType};
+use acvm::acir::native_types::Witness;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -41,4 +42,8 @@ pub enum AbiError {
     UndefinedInput(String),
     #[error("ABI specifies an input of length {expected} but received input of length {actual}")]
     UnexpectedInputLength { expected: u32, actual: u32 },
+    #[error(
+        "Could not read witness value at index {witness_index:?} (required for parameter \"{name}\")"
+    )]
+    MissingParamWitnessValue { name: String, witness_index: Witness },
 }

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -10,6 +10,7 @@ use crate::{Abi, AbiType};
 /// This is what all formats eventually transform into
 /// For example, a toml file will parse into TomlTypes
 /// and those TomlTypes will be mapped to Value
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Clone, Serialize)]
 pub enum InputValue {
     Field(FieldElement),

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -176,7 +176,7 @@ impl Abi {
                 Self::encode_value(value.clone(), key).map(|v| (key.clone(), v))
             })?;
 
-        // Write input field elements into witness indices specified in `abi_witness_map`.
+        // Write input field elements into witness indices specified in `self.param_witnesses`.
         let witness_map = encoded_input_map
             .iter()
             .flat_map(|(param_name, encoded_param_fields)| {

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 use std::{collections::BTreeMap, convert::TryInto, str};
 
-use acvm::FieldElement;
+use acvm::{acir::native_types::Witness, FieldElement};
 use errors::AbiError;
 use input_parser::InputValue;
 use serde::{Deserialize, Serialize};
@@ -120,6 +120,7 @@ impl AbiParameter {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Abi {
     pub parameters: Vec<AbiParameter>,
+    pub param_witnesses: BTreeMap<String, Vec<Witness>>,
 }
 
 impl Abi {
@@ -149,7 +150,12 @@ impl Abi {
     pub fn public_abi(self) -> Abi {
         let parameters: Vec<_> =
             self.parameters.into_iter().filter(|param| param.is_public()).collect();
-        Abi { parameters }
+        let param_witnesses = self
+            .param_witnesses
+            .into_iter()
+            .filter(|(param_name, _)| parameters.iter().any(|param| &param.name == param_name))
+            .collect();
+        Abi { parameters, param_witnesses }
     }
 
     /// Encode a set of inputs as described in the ABI into a vector of `FieldElement`s.

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -251,20 +251,16 @@ impl Abi {
         &self,
         witness_map: &BTreeMap<Witness, FieldElement>,
     ) -> Result<BTreeMap<String, InputValue>, AbiError> {
-        let public_inputs_map = self
-            .parameters
-            .iter()
-            .map(|AbiParameter { name, typ, .. }| {
+        let public_inputs_map =
+            try_btree_map(self.parameters.clone(), |AbiParameter { name, typ, .. }| {
                 let param_witness_values =
-                    vecmap(self.param_witnesses[name].clone(), |witness_index| {
+                    vecmap(self.param_witnesses[&name].clone(), |witness_index| {
                         witness_map[&witness_index]
                     });
 
-                Self::decode_value(&mut param_witness_values.into_iter(), typ)
+                Self::decode_value(&mut param_witness_values.into_iter(), &typ)
                     .map(|input_value| (name.clone(), input_value))
-                    .unwrap()
-            })
-            .collect();
+            })?;
 
         Ok(public_inputs_map)
     }

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -165,10 +165,7 @@ impl Abi {
     }
 
     /// Encode a set of inputs as described in the ABI into a `WitnessMap`.
-    pub fn encode_to_witness(
-        &self,
-        input_map: &BTreeMap<String, InputValue>,
-    ) -> Result<BTreeMap<Witness, FieldElement>, AbiError> {
+    pub fn encode_to_witness(&self, input_map: &InputMap) -> Result<WitnessMap, AbiError> {
         // TODO: add handling for missing inputs similarly to how we do in `encode_to_array`.
 
         self.check_for_unexpected_inputs(input_map)?;
@@ -195,10 +192,7 @@ impl Abi {
     }
 
     /// Encode a set of inputs as described in the ABI into a vector of `FieldElement`s.
-    pub fn encode_to_array(
-        self,
-        inputs: &BTreeMap<String, InputValue>,
-    ) -> Result<Vec<FieldElement>, AbiError> {
+    pub fn encode_to_array(self, inputs: &InputMap) -> Result<Vec<FieldElement>, AbiError> {
         let mut encoded_inputs = Vec::new();
 
         self.check_for_unexpected_inputs(inputs)?;
@@ -220,10 +214,7 @@ impl Abi {
     }
 
     /// Checks that no extra witness values have been provided.
-    fn check_for_unexpected_inputs(
-        &self,
-        inputs: &BTreeMap<String, InputValue>,
-    ) -> Result<(), AbiError> {
+    fn check_for_unexpected_inputs(&self, inputs: &InputMap) -> Result<(), AbiError> {
         let param_names = self.parameter_names();
         if param_names.len() < inputs.len() {
             let unexpected_params: Vec<String> =
@@ -256,10 +247,7 @@ impl Abi {
     }
 
     /// Decode a `WitnessMap` into the types specified in the ABI.
-    pub fn decode_from_witness(
-        &self,
-        witness_map: &BTreeMap<Witness, FieldElement>,
-    ) -> Result<BTreeMap<String, InputValue>, AbiError> {
+    pub fn decode_from_witness(&self, witness_map: &WitnessMap) -> Result<InputMap, AbiError> {
         let public_inputs_map =
             try_btree_map(self.parameters.clone(), |AbiParameter { name, typ, .. }| {
                 let param_witness_values =
@@ -275,10 +263,7 @@ impl Abi {
     }
 
     /// Decode a vector of `FieldElements` into the types specified in the ABI.
-    pub fn decode_from_array(
-        &self,
-        encoded_inputs: &[FieldElement],
-    ) -> Result<BTreeMap<String, InputValue>, AbiError> {
+    pub fn decode_from_array(&self, encoded_inputs: &[FieldElement]) -> Result<InputMap, AbiError> {
         let input_length: u32 = encoded_inputs.len().try_into().unwrap();
         if input_length != self.field_count() {
             return Err(AbiError::UnexpectedInputLength {

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -179,7 +179,7 @@ impl Abi {
         // First encode each input separately
         let encoded_input_map: BTreeMap<String, Vec<FieldElement>> =
             try_btree_map(input_map, |(key, value)| {
-                encode_value(value, &key).map(|v| (key.clone(), v))
+                Self::encode_value(value, &key).map(|v| (key.clone(), v))
             })?;
 
         // Write input field elements into witness indices specified in `abi_witness_map`.
@@ -216,7 +216,7 @@ impl Abi {
                 return Err(AbiError::TypeMismatch { param, value });
             }
 
-            encoded_inputs.extend(encode_value(value, &param.name)?);
+            encoded_inputs.extend(Self::encode_value(value, &param.name)?);
         }
 
         // Check that no extra witness values have been provided.
@@ -228,6 +228,27 @@ impl Abi {
         }
 
         Ok(encoded_inputs)
+    }
+
+    fn encode_value(value: InputValue, param_name: &String) -> Result<Vec<FieldElement>, AbiError> {
+        let mut encoded_value = Vec::new();
+        match value {
+            InputValue::Field(elem) => encoded_value.push(elem),
+            InputValue::Vec(vec_elem) => encoded_value.extend(vec_elem),
+            InputValue::String(string) => {
+                let str_as_fields =
+                    string.bytes().map(|byte| FieldElement::from_be_bytes_reduce(&[byte]));
+                encoded_value.extend(str_as_fields)
+            }
+            InputValue::Struct(object) => {
+                for (field_name, value) in object {
+                    let new_name = format!("{param_name}.{field_name}");
+                    encoded_value.extend(Self::encode_value(value, &new_name)?)
+                }
+            }
+            InputValue::Undefined => return Err(AbiError::UndefinedInput(param_name.to_string())),
+        }
+        Ok(encoded_value)
     }
 
     /// Decode a `WitnessMap` into the types specified in the ABI.
@@ -244,7 +265,7 @@ impl Abi {
                         witness_map[&witness_index]
                     });
 
-                decode_value(&mut param_witness_values.into_iter(), typ)
+                Self::decode_value(&mut param_witness_values.into_iter(), typ)
                     .map(|input_value| (name.clone(), input_value))
                     .unwrap()
             })
@@ -269,79 +290,59 @@ impl Abi {
         let mut field_iterator = encoded_inputs.iter().cloned();
         let mut decoded_inputs = BTreeMap::new();
         for param in &self.parameters {
-            let decoded_value = decode_value(&mut field_iterator, &param.typ)?;
+            let decoded_value = Self::decode_value(&mut field_iterator, &param.typ)?;
 
             decoded_inputs.insert(param.name.to_owned(), decoded_value);
         }
         Ok(decoded_inputs)
     }
-}
 
-fn encode_value(value: InputValue, param_name: &String) -> Result<Vec<FieldElement>, AbiError> {
-    let mut encoded_value = Vec::new();
-    match value {
-        InputValue::Field(elem) => encoded_value.push(elem),
-        InputValue::Vec(vec_elem) => encoded_value.extend(vec_elem),
-        InputValue::String(string) => {
-            let str_as_fields =
-                string.bytes().map(|byte| FieldElement::from_be_bytes_reduce(&[byte]));
-            encoded_value.extend(str_as_fields)
-        }
-        InputValue::Struct(object) => {
-            for (field_name, value) in object {
-                let new_name = format!("{param_name}.{field_name}");
-                encoded_value.extend(encode_value(value, &new_name)?)
+    fn decode_value(
+        field_iterator: &mut impl Iterator<Item = FieldElement>,
+        value_type: &AbiType,
+    ) -> Result<InputValue, AbiError> {
+        // This function assumes that `field_iterator` contains enough `FieldElement`s in order to decode a `value_type`
+        // `Abi.decode` enforces that the encoded inputs matches the expected length defined by the ABI so this is safe.
+        let value = match value_type {
+            AbiType::Field | AbiType::Integer { .. } | AbiType::Boolean => {
+                let field_element = field_iterator.next().unwrap();
+
+                InputValue::Field(field_element)
             }
-        }
-        InputValue::Undefined => return Err(AbiError::UndefinedInput(param_name.to_string())),
+            AbiType::Array { length, .. } => {
+                let field_elements: Vec<FieldElement> =
+                    field_iterator.take(*length as usize).collect();
+
+                InputValue::Vec(field_elements)
+            }
+            AbiType::String { length } => {
+                let string_as_slice: Vec<u8> = field_iterator
+                    .take(*length as usize)
+                    .map(|e| {
+                        let mut field_as_bytes = e.to_be_bytes();
+                        let char_byte = field_as_bytes.pop().unwrap(); // A character in a string is represented by a u8, thus we just want the last byte of the element
+                        assert!(field_as_bytes.into_iter().all(|b| b == 0)); // Assert that the rest of the field element's bytes are empty
+                        char_byte
+                    })
+                    .collect();
+
+                let final_string = str::from_utf8(&string_as_slice).unwrap();
+
+                InputValue::String(final_string.to_owned())
+            }
+            AbiType::Struct { fields, .. } => {
+                let mut struct_map = BTreeMap::new();
+
+                for (field_key, param_type) in fields {
+                    let field_value = Self::decode_value(field_iterator, param_type)?;
+
+                    struct_map.insert(field_key.to_owned(), field_value);
+                }
+
+                InputValue::Struct(struct_map)
+            }
+        };
+
+        Ok(value)
     }
-    Ok(encoded_value)
-}
-
-fn decode_value(
-    field_iterator: &mut impl Iterator<Item = FieldElement>,
-    value_type: &AbiType,
-) -> Result<InputValue, AbiError> {
-    // This function assumes that `field_iterator` contains enough `FieldElement`s in order to decode a `value_type`
-    // `Abi.decode` enforces that the encoded inputs matches the expected length defined by the ABI so this is safe.
-    let value = match value_type {
-        AbiType::Field | AbiType::Integer { .. } | AbiType::Boolean => {
-            let field_element = field_iterator.next().unwrap();
-
-            InputValue::Field(field_element)
-        }
-        AbiType::Array { length, .. } => {
-            let field_elements: Vec<FieldElement> = field_iterator.take(*length as usize).collect();
-
-            InputValue::Vec(field_elements)
-        }
-        AbiType::String { length } => {
-            let string_as_slice: Vec<u8> = field_iterator
-                .take(*length as usize)
-                .map(|e| {
-                    let mut field_as_bytes = e.to_be_bytes();
-                    let char_byte = field_as_bytes.pop().unwrap(); // A character in a string is represented by a u8, thus we just want the last byte of the element
-                    assert!(field_as_bytes.into_iter().all(|b| b == 0)); // Assert that the rest of the field element's bytes are empty
-                    char_byte
-                })
-                .collect();
-
-            let final_string = str::from_utf8(&string_as_slice).unwrap();
-
-            InputValue::String(final_string.to_owned())
-        }
-        AbiType::Struct { fields, .. } => {
-            let mut struct_map = BTreeMap::new();
-
-            for (field_key, param_type) in fields {
-                let field_value = decode_value(field_iterator, param_type)?;
-
-                struct_map.insert(field_key.to_owned(), field_value);
-            }
-
-            InputValue::Struct(struct_map)
-        }
-    };
-
-    Ok(value)
 }

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -169,16 +169,12 @@ impl Abi {
         &self,
         input_map: &BTreeMap<String, InputValue>,
     ) -> Result<BTreeMap<Witness, FieldElement>, AbiError> {
-        // TODO: Avoid this clone
-        let mut input_map = input_map.clone();
-
-        // Remove the return value parameter
-        input_map.remove(MAIN_RETURN_NAME);
+        // TODO: add handling for unexpected inputs similarly to how we to in `encode_to_array`.
 
         // First encode each input separately
         let encoded_input_map: BTreeMap<String, Vec<FieldElement>> =
             try_btree_map(input_map, |(key, value)| {
-                Self::encode_value(value, &key).map(|v| (key.clone(), v))
+                Self::encode_value(value.clone(), key).map(|v| (key.clone(), v))
             })?;
 
         // Write input field elements into witness indices specified in `abi_witness_map`.

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -125,7 +125,10 @@ impl AbiParameter {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Abi {
+    /// An ordered list of the arguments to the program's `main` function, specifying their types and visibility.
     pub parameters: Vec<AbiParameter>,
+    /// A map from the ABI's parameters to the indices they are written to in the [`WitnessMap`].
+    /// This defines how to convert between the [`InputMap`] and [`WitnessMap`].
     pub param_witnesses: BTreeMap<String, Vec<Witness>>,
 }
 

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -189,7 +189,7 @@ impl Abi {
                     return Err(AbiError::TypeMismatch { param: missing_param, value });
                 }
 
-                Self::encode_value(value.clone(), &param_name).map(|v| (param_name, v))
+                Self::encode_value(value, &param_name).map(|v| (param_name, v))
             })
             .collect::<Result<_, _>>()?;
 

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -194,7 +194,7 @@ impl Driver {
                 let files = &self.context.file_manager;
                 let error = reporter::report(files, &err.into(), file, allow_warnings);
                 reporter::finish_report(error as u32)?;
-                return Err(ReportedError);
+                Err(ReportedError)
             }
         }
     }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -52,8 +52,7 @@ pub fn create_circuit(
         .public_abi()
         .parameter_names()
         .into_iter()
-        .cloned()
-        .flat_map(|param_name| evaluator.param_witnesses[&param_name].clone())
+        .flat_map(|param_name| evaluator.param_witnesses[param_name].clone())
         .collect();
 
     let witness_index = evaluator.current_witness_index();

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -307,5 +307,9 @@ impl Evaluator {
             self.param_to_var(param_name, def, &abi_param.typ, &abi_param.visibility, ir_gen)
                 .unwrap();
         }
+
+        // Store the number of witnesses used to represent the types
+        // in the ABI
+        self.num_witnesses_abi_len = self.current_witness_index as usize;
     }
 }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -39,7 +39,7 @@ pub fn create_circuit(
     np_language: Language,
     is_blackbox_supported: IsBlackBoxSupported,
     enable_logging: bool,
-) -> Result<Circuit, RuntimeError> {
+) -> Result<(Circuit, BTreeMap<String, Vec<Witness>>), RuntimeError> {
     let mut evaluator = Evaluator::new();
 
     // First evaluate the main function
@@ -68,7 +68,7 @@ pub fn create_circuit(
     )
     .map_err(|_| RuntimeErrorKind::Spanless(String::from("produced an acvm compile error")))?;
 
-    Ok(optimized_circuit)
+    Ok((optimized_circuit, evaluator.param_witnesses))
 }
 
 impl Evaluator {

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -55,12 +55,11 @@ pub fn create_circuit(
     let mut abi = program.abi;
     abi.param_witnesses = evaluator.param_witnesses;
 
-    let public_inputs = evaluator.public_inputs.into_iter().collect();
     let optimized_circuit = acvm::compiler::compile(
         Circuit {
             current_witness_index: witness_index,
             opcodes: evaluator.opcodes,
-            public_inputs: PublicInputs(public_inputs),
+            public_inputs: PublicInputs(evaluator.public_inputs),
         },
         np_language,
         is_blackbox_supported,

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -46,7 +46,6 @@ pub fn create_circuit(
     // First evaluate the main function
     evaluator.evaluate_main_alt(program.clone(), enable_logging, show_output)?;
 
-    // TODO: shrink this ungodly mess.
     let public_inputs = program
         .abi
         .public_abi()

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -54,6 +54,7 @@ pub(crate) fn evaluate(
             }
             witnesses.push(witness);
         }
+        evaluator.public_inputs.extend(witnesses.clone());
         evaluator.param_witnesses.insert(MAIN_RETURN_NAME.to_owned(), witnesses);
     }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -1,3 +1,6 @@
+use acvm::acir::native_types::Witness;
+use noirc_abi::MAIN_RETURN_NAME;
+
 use crate::{
     errors::RuntimeErrorKind,
     ssa::{
@@ -37,6 +40,7 @@ pub(crate) fn evaluate(
             }
         };
 
+        let mut witnesses: Vec<Witness> = Vec::new();
         for mut object in objects {
             let witness = object.get_or_compute_witness(evaluator, true).expect(
                 "infallible: `None` can only be returned when we disallow constant Expressions.",
@@ -48,8 +52,9 @@ pub(crate) fn evaluate(
                     "we do not allow private ABI inputs to be returned as public outputs",
                 )));
             }
-            evaluator.public_inputs.push(witness);
+            witnesses.push(witness);
         }
+        evaluator.param_witnesses.insert(MAIN_RETURN_NAME.to_owned(), witnesses);
     }
 
     Ok(None)

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -122,7 +122,7 @@ mod test {
             let mut eval = Evaluator {
                 current_witness_index: 0,
                 num_witnesses_abi_len: 0,
-                public_inputs: Vec::new(),
+                param_witnesses: BTreeMap::new(),
                 opcodes: Vec::new(),
             };
 

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use iter_extended::vecmap;
 use noirc_abi::{Abi, AbiParameter, AbiVisibility, MAIN_RETURN_NAME};
 use noirc_errors::{Location, Span};
@@ -61,7 +63,7 @@ impl Parameters {
             let as_abi = param.1.as_abi_type();
             AbiParameter { name: param_name, typ: as_abi, visibility: param.2 }
         });
-        noirc_abi::Abi { parameters }
+        noirc_abi::Abi { parameters, param_witnesses: BTreeMap::new() }
     }
 
     pub fn span(&self) -> Span {


### PR DESCRIPTION
# Related issue(s)

Resolves #684 

# Description

## Summary of changes

This PR builds out the logic for passing up an explicit mapping for ABI parameters to their witness indices.

This is done in the `Evaluator` as rather than pushing a public param's witnesses onto the `public_inputs` vector we insert all params' witnesses into the `param_witnesses` `BTreeMap<String, Vec<Witness>>`. This allows us to get the witness indices for any parameter defined in the ABI.

The `Circuit` struct still uses a `PublicInputs` as this can be easily calculated from `param_witnesses`.

This new `param_witnesses` map is passed up and stored in the ABI as it's crucial to be able to abi encode inputs into the initial witness. As we're now directly encoding into a witness map, I've split the ABI `encode` method into `encode_to_witness` and `encode_to_array` (similarly for decoding) where the array variant is used for passing to the verifer. (We can likely remove this if we make `PublicInputs` a mapping as discussed in Slack).

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
