### PR TITLE
chore: update lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,8 +1887,8 @@ dependencies = [
 name = "noir_wasm"
 version = "0.1.1"
 dependencies = [
- "build-data",
  "acvm 0.4.1",
+ "build-data",
  "console_error_panic_hook",
  "getrandom",
  "gloo-utils",


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

The dependencies of `noir_wasm` are now in order to match how they're reformatted when running `cargo build` on [fd64be5](https://github.com/noir-lang/noir/commit/fd64be55fc905a032d53c9ac7a7f7b71da899c37)

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
