### PR TITLE
chore!: Make `abi` field non-optional in `CompiledProgram`

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -56,7 +56,7 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
             program_dir,
             PROVER_INPUT_FILE,
             Format::Toml,
-            compiled_program.abi.clone(),
+            &compiled_program.abi,
         )?;
 
         let (_, solved_witness) =

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -56,7 +56,7 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
             program_dir,
             PROVER_INPUT_FILE,
             Format::Toml,
-            compiled_program.abi.as_ref().unwrap().clone(),
+            compiled_program.abi.clone(),
         )?;
 
         let (_, solved_witness) =

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -56,7 +56,7 @@ fn execute_with_path<P: AsRef<Path>>(
         &program_dir,
         PROVER_INPUT_FILE,
         Format::Toml,
-        compiled_program.abi.as_ref().unwrap().clone(),
+        compiled_program.abi.clone(),
     )?;
 
     execute_program(&compiled_program, &inputs_map)
@@ -87,7 +87,7 @@ pub(crate) fn extract_public_inputs(
         .map(|index| solved_witness[index])
         .collect();
 
-    let public_abi = compiled_program.abi.as_ref().unwrap().clone().public_abi();
+    let public_abi = compiled_program.abi.clone().public_abi();
 
     public_abi.decode(&encoded_public_inputs)
 }
@@ -96,7 +96,7 @@ pub(crate) fn solve_witness(
     compiled_program: &CompiledProgram,
     input_map: &InputMap,
 ) -> Result<WitnessMap, CliError> {
-    let abi = compiled_program.abi.as_ref().unwrap().clone();
+    let abi = compiled_program.abi.clone();
     let mut solved_witness =
         input_map_to_witness_map(abi, input_map).map_err(|error| match error {
             AbiError::UndefinedInput(_) => {

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -56,7 +56,7 @@ fn execute_with_path<P: AsRef<Path>>(
         &program_dir,
         PROVER_INPUT_FILE,
         Format::Toml,
-        compiled_program.abi.clone(),
+        &compiled_program.abi,
     )?;
 
     execute_program(&compiled_program, &inputs_map)

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -186,7 +186,7 @@ pub fn read_inputs_from_file<P: AsRef<Path>>(
     path: P,
     file_name: &str,
     format: Format,
-    abi: Abi,
+    abi: &Abi,
 ) -> Result<InputMap, CliError> {
     let file_path = {
         let mut dir_path = path.as_ref().to_path_buf();

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -51,7 +51,7 @@ pub fn prove_with_path<P: AsRef<Path>>(
         &program_dir,
         PROVER_INPUT_FILE,
         Format::Toml,
-        compiled_program.abi.as_ref().unwrap().clone(),
+        compiled_program.abi.clone(),
     )?;
 
     let (_, solved_witness) = execute_program(&compiled_program, &inputs_map)?;

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -51,7 +51,7 @@ pub fn prove_with_path<P: AsRef<Path>>(
         &program_dir,
         PROVER_INPUT_FILE,
         Format::Toml,
-        compiled_program.abi.clone(),
+        &compiled_program.abi,
     )?;
 
     let (_, solved_witness) = execute_program(&compiled_program, &inputs_map)?;

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -49,7 +49,7 @@ pub fn verify_with_path<P: AsRef<Path>>(
     if num_pub_params != 0 {
         let current_dir = program_dir;
         public_inputs_map =
-            read_inputs_from_file(current_dir, VERIFIER_INPUT_FILE, Format::Toml, public_abi)?;
+            read_inputs_from_file(current_dir, VERIFIER_INPUT_FILE, Format::Toml, &public_abi)?;
     }
 
     let valid_proof = verify_proof(compiled_program, public_inputs_map, &load_proof(proof_path)?)?;

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -44,7 +44,7 @@ pub fn verify_with_path<P: AsRef<Path>>(
     let mut public_inputs_map: InputMap = BTreeMap::new();
 
     // Load public inputs (if any) from `VERIFIER_INPUT_FILE`.
-    let public_abi = compiled_program.abi.clone().unwrap().public_abi();
+    let public_abi = compiled_program.abi.clone().public_abi();
     let num_pub_params = public_abi.num_parameters();
     if num_pub_params != 0 {
         let current_dir = program_dir;
@@ -62,7 +62,7 @@ pub(crate) fn verify_proof(
     public_inputs_map: InputMap,
     proof: &[u8],
 ) -> Result<bool, CliError> {
-    let public_abi = compiled_program.abi.unwrap().public_abi();
+    let public_abi = compiled_program.abi.public_abi();
     let public_inputs =
         public_abi.encode(&public_inputs_map, false).map_err(|error| match error {
             AbiError::UndefinedInput(_) => {

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -90,7 +90,7 @@ impl Format {
     pub fn parse(
         &self,
         input_string: &str,
-        abi: Abi,
+        abi: &Abi,
     ) -> Result<BTreeMap<String, InputValue>, InputParserError> {
         match self {
             Format::Toml => toml::parse_toml(input_string, abi),

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 
 pub(crate) fn parse_toml(
     input_string: &str,
-    abi: Abi,
+    abi: &Abi,
 ) -> Result<BTreeMap<String, InputValue>, InputParserError> {
     // Parse input.toml into a BTreeMap.
     let data: BTreeMap<String, TomlTypes> = toml::from_str(input_string)?;

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -21,7 +21,7 @@ pub struct Driver {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CompiledProgram {
     pub circuit: Circuit,
-    pub abi: Option<noirc_abi::Abi>,
+    pub abi: noirc_abi::Abi,
 }
 
 impl Driver {
@@ -189,7 +189,7 @@ impl Driver {
 
         let blackbox_supported = acvm::default_is_black_box_supported(np_language.clone());
         match create_circuit(program, np_language, blackbox_supported, show_ssa, show_output) {
-            Ok(circuit) => Ok(CompiledProgram { circuit, abi: Some(abi) }),
+            Ok(circuit) => Ok(CompiledProgram { circuit, abi }),
             Err(err) => {
                 // The FileId here will be the file id of the file with the main file
                 // Errors will be shown at the call site without a stacktrace


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #855 

# Description

## Summary of changes

We don't get any benefit to allowing `CompiledProgram` to be created without an ABI as we always unwrap it. We then require the ABI to be included which allows us to remove repeated boilerplate to extract the ABI from the `CompiledProgram`

This revealed that we didn't need to clone the ABI in a number of places when reading in inputs so we can instead just borrow it from the `CompiledProgram`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
