### PR TITLE
chore: remove newline from print output of `nargo verify`

### DIFF
--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -30,7 +30,7 @@ pub(crate) fn run(args: ArgMatches) -> Result<(), CliError> {
 
     let allow_warnings = args.is_present("allow-warnings");
     let result = verify_with_path(program_dir, proof_path, false, allow_warnings)?;
-    println!("Proof verified : {result}\n");
+    println!("Proof verified : {result}");
     Ok(())
 }
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Related to https://github.com/noir-lang/noir/issues/701

# Description

## Summary of changes

We now no longer print an empty line after the proof verification output. 

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
