### PR TITLE
chore(ci): only run spellcheck job on push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,5 +21,6 @@ jobs:
     uses: noir-lang/.github/.github/workflows/rust-format.yml@main
 
   spellcheck:
+    if: ${{ github.event_name == 'push' }}
     name: Spellcheck
     uses: noir-lang/.github/.github/workflows/spellcheck.yml@main

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,3 @@ jobs:
   format:
     name: Cargo fmt
     uses: noir-lang/.github/.github/workflows/rust-format.yml@main
-
-  spellcheck:
-    if: ${{ github.event_name == 'push' }}
-    name: Spellcheck
-    uses: noir-lang/.github/.github/workflows/spellcheck.yml@main

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,13 @@
+name: Spellcheck
+
+on: [push]
+
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  spellcheck:
+    name: Spellcheck
+    uses: noir-lang/.github/.github/workflows/spellcheck.yml@main


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->


# Description

## Summary of changes

Currently a PR which contains spelling errors will have two warnings thrown (one from `push`, one from `pull_request`). 

The only situation where these two jobs don't produce the same output is when the PR is behind master and either
1. master adds a new word to the dictionary and the PR uses that word. (Very niche situation)
2. master includes a spelling mistake which isn't in the PR. (Will be caught when master is merged into PR)

It's then sensible to only run spellchecks on each `push`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
