### PR TITLE
feat(abi)!: merge both abi encoding/decoding methods

### DIFF
--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -66,7 +66,7 @@ pub(crate) fn execute_program(
     let solved_witness = solve_witness(compiled_program, inputs_map)?;
 
     let public_abi = compiled_program.abi.clone().public_abi();
-    let public_inputs = public_abi.decode_from_witness(&solved_witness)?;
+    let public_inputs = public_abi.decode(&solved_witness)?;
     let return_value = public_inputs.get(MAIN_RETURN_NAME).cloned();
 
     Ok((return_value, solved_witness))
@@ -77,7 +77,7 @@ pub(crate) fn solve_witness(
     input_map: &InputMap,
 ) -> Result<WitnessMap, CliError> {
     let mut solved_witness =
-        compiled_program.abi.encode_to_witness(input_map).map_err(|error| match error {
+        compiled_program.abi.encode(input_map, true).map_err(|error| match error {
             AbiError::UndefinedInput(_) => {
                 CliError::Generic(format!("{error} in the {PROVER_INPUT_FILE}.toml file."))
             }

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -1,7 +1,4 @@
-use acvm::{
-    acir::circuit::{Circuit, PublicInputs},
-    hash_constraint_system, FieldElement, ProofSystemCompiler,
-};
+use acvm::{acir::circuit::Circuit, hash_constraint_system, ProofSystemCompiler};
 pub use check_cmd::check_from_path;
 use clap::{App, AppSettings, Arg};
 use const_format::formatcp;
@@ -9,7 +6,6 @@ use noirc_abi::{input_parser::Format, Abi, InputMap};
 use noirc_driver::Driver;
 use noirc_frontend::graph::{CrateName, CrateType};
 use std::{
-    collections::{HashMap, HashSet},
     fs::File,
     io::Write,
     path::{Path, PathBuf},
@@ -250,44 +246,6 @@ fn add_std_lib(driver: &mut Driver) {
 
 fn path_to_stdlib() -> PathBuf {
     dirs::config_dir().unwrap().join("noir-lang").join("std/src")
-}
-
-// Removes duplicates from the list of public input witnesses
-fn dedup_public_input_indices(indices: PublicInputs) -> PublicInputs {
-    let duplicates_removed: HashSet<_> = indices.0.into_iter().collect();
-    PublicInputs(duplicates_removed.into_iter().collect())
-}
-
-// Removes duplicates from the list of public input witnesses and the
-// associated list of duplicate values.
-pub(crate) fn dedup_public_input_indices_values(
-    indices: PublicInputs,
-    values: Vec<FieldElement>,
-) -> (PublicInputs, Vec<FieldElement>) {
-    // Assume that the public input index lists and the values contain duplicates
-    assert_eq!(indices.0.len(), values.len());
-
-    let mut public_inputs_without_duplicates = Vec::new();
-    let mut already_seen_public_indices = HashMap::new();
-
-    for (index, value) in indices.0.iter().zip(values) {
-        match already_seen_public_indices.get(index) {
-            Some(expected_value) => {
-                // The index has already been added
-                // so lets check that the values already inserted is equal to the value, we wish to insert
-                assert_eq!(*expected_value, value, "witness index {index:?} does not have a canonical map. The expected value is {expected_value}, the received value is {value}.")
-            }
-            None => {
-                already_seen_public_indices.insert(*index, value);
-                public_inputs_without_duplicates.push(value)
-            }
-        }
-    }
-
-    (
-        PublicInputs(already_seen_public_indices.keys().copied().collect()),
-        public_inputs_without_duplicates,
-    )
 }
 
 pub fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, CliError> {

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -5,8 +5,8 @@ use clap::Args;
 use noirc_abi::input_parser::Format;
 
 use super::{
-    create_named_dir, fetch_pk_and_vk, read_inputs_from_file,
-    write_inputs_to_file, write_to_file, NargoConfig,
+    create_named_dir, fetch_pk_and_vk, read_inputs_from_file, write_inputs_to_file, write_to_file,
+    NargoConfig,
 };
 use crate::{
     cli::{execute_cmd::execute_program, verify_cmd::verify_proof},

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -1,6 +1,6 @@
 use super::{
-    compile_cmd::compile_circuit, fetch_pk_and_vk,
-    load_hex_data, read_inputs_from_file, InputMap, NargoConfig,
+    compile_cmd::compile_circuit, fetch_pk_and_vk, load_hex_data, read_inputs_from_file, InputMap,
+    NargoConfig,
 };
 use crate::{
     constants::{PROOFS_DIR, PROOF_EXT, TARGET_DIR, VERIFIER_INPUT_FILE},

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -40,8 +40,6 @@ pub enum AbiError {
     MissingParam(String),
     #[error("Input value `{0}` is not defined")]
     UndefinedInput(String),
-    #[error("ABI specifies an input of length {expected} but received input of length {actual}")]
-    UnexpectedInputLength { expected: u32, actual: u32 },
     #[error(
         "Could not read witness value at index {witness_index:?} (required for parameter \"{name}\")"
     )]


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves https://github.com/noir-lang/noir/pull/851#discussion_r1108927283

# Description

## Summary of changes

We've switched to tracking public inputs in the evaluator in `BTreeSet` rather than a `Vec` which naturally deduplicates them, this allows us to:
- stop deduplicating these inputs manually up in the Nargo CLI.
- always encode to a `WitnessMap` for both proving and verifying (before flattening this into an naturally deduped array for verification but we can remove this as well if the backends take a `WitnessMap` for verifier inputs)

The only sad thing about this PR is it brings back the boolean flag in the abi encoding functions (but we'll be able to handle this better with #678)

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
