### PR TITLE
fix: properly initialise `Evaluator` in test

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -119,12 +119,7 @@ mod test {
     fn test_permutation() {
         let mut rng = rand::thread_rng();
         for n in 2..50 {
-            let mut eval = Evaluator {
-                current_witness_index: 0,
-                num_witnesses_abi_len: 0,
-                param_witnesses: BTreeMap::new(),
-                opcodes: Vec::new(),
-            };
+            let mut eval = Evaluator::new();
 
             //we generate random inputs
             let mut input = Vec::new();


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

We're currently not creating a valid `Evaluator` in this test as the `public_inputs` field isn't specified. I've switched this to use the `new` method fix this and make this test less sensitive to changes in `Evaluator`.

Note this wasn't caught as we don't compile and run any tests outside of `nargo` pending https://github.com/noir-lang/.github/pull/13.
## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
