### PR TITLE
feat(abi)!: add explicit return type field to ABI.

### DIFF
--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -4,7 +4,7 @@ use acvm::acir::native_types::Witness;
 use acvm::PartialWitnessGenerator;
 use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
-use noirc_abi::{InputMap, WitnessMap, MAIN_RETURN_NAME};
+use noirc_abi::{InputMap, WitnessMap};
 use noirc_driver::CompiledProgram;
 
 use super::NargoConfig;
@@ -75,8 +75,7 @@ pub(crate) fn execute_program(
     let solved_witness = solve_witness(compiled_program, inputs_map)?;
 
     let public_abi = compiled_program.abi.clone().public_abi();
-    let public_inputs = public_abi.decode(&solved_witness)?;
-    let return_value = public_inputs.get(MAIN_RETURN_NAME).cloned();
+    let (_, return_value) = public_abi.decode(&solved_witness)?;
 
     Ok((return_value, solved_witness))
 }
@@ -85,7 +84,7 @@ pub(crate) fn solve_witness(
     compiled_program: &CompiledProgram,
     input_map: &InputMap,
 ) -> Result<WitnessMap, CliError> {
-    let mut solved_witness = compiled_program.abi.encode(input_map, true)?;
+    let mut solved_witness = compiled_program.abi.encode(input_map, None)?;
 
     let backend = crate::backends::ConcreteBackend;
     backend.solve(&mut solved_witness, compiled_program.circuit.opcodes.clone())?;

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use acvm::{FieldElement, ProofSystemCompiler};
 use clap::Args;
-use noirc_abi::input_parser::Format;
+use noirc_abi::input_parser::{Format, InputValue};
+use noirc_abi::{errors::AbiError, MAIN_RETURN_NAME};
 use noirc_driver::CompiledProgram;
 use std::{collections::BTreeMap, path::Path};
 
@@ -64,20 +65,22 @@ pub fn verify_with_path<P: AsRef<Path>>(
     let (_, verification_key) =
         fetch_pk_and_vk(compiled_program.circuit.clone(), circuit_build_path, false, true)?;
 
-    let mut public_inputs_map: InputMap = BTreeMap::new();
-
     // Load public inputs (if any) from `VERIFIER_INPUT_FILE`.
     let public_abi = compiled_program.abi.clone().public_abi();
-    let num_pub_params = public_abi.num_parameters();
-    if num_pub_params != 0 {
+    let (public_inputs_map, return_value) = if public_abi.has_public_inputs() {
         let current_dir = program_dir;
-        public_inputs_map =
+        let mut public_inputs_map =
             read_inputs_from_file(current_dir, VERIFIER_INPUT_FILE, Format::Toml, &public_abi)?;
-    }
+        let return_value = public_inputs_map.remove(MAIN_RETURN_NAME);
+        (public_inputs_map, return_value)
+    } else {
+        (BTreeMap::new(), None)
+    };
 
     let valid_proof = verify_proof(
         compiled_program,
         public_inputs_map,
+        return_value,
         &load_hex_data(proof_path)?,
         verification_key,
     )?;
@@ -88,11 +91,12 @@ pub fn verify_with_path<P: AsRef<Path>>(
 pub(crate) fn verify_proof(
     compiled_program: CompiledProgram,
     public_inputs_map: InputMap,
+    return_value: Option<InputValue>,
     proof: &[u8],
     verification_key: Vec<u8>,
 ) -> Result<bool, CliError> {
     let public_abi = compiled_program.abi.public_abi();
-    let public_inputs = public_abi.encode(&public_inputs_map, false)?;
+    let public_inputs = public_abi.encode(&public_inputs_map, return_value)?;
 
     let public_inputs_vec: Vec<FieldElement> = public_inputs.values().copied().collect();
 

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -9,7 +9,7 @@ use crate::{
 use acvm::{FieldElement, ProofSystemCompiler};
 use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
-use noirc_abi::{errors::AbiError, MAIN_RETURN_NAME};
+use noirc_abi::MAIN_RETURN_NAME;
 use noirc_driver::CompiledProgram;
 use std::{collections::BTreeMap, path::Path};
 

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -44,4 +44,8 @@ pub enum AbiError {
     MissingParamWitnessValue { name: String, witness_index: Witness },
     #[error("Attempted to write to witness index {0:?} but it is already initialized to a different value")]
     InconsistentWitnessAssignment(Witness),
+    #[error("The return value is expected to be a {return_type:?} but found incompatible value {value:?}")]
+    ReturnTypeMismatch { return_type: AbiType, value: InputValue },
+    #[error("No return value is expected but received {0:?}")]
+    UnexpectedReturnValue(InputValue),
 }

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -42,4 +42,6 @@ pub enum AbiError {
         "Could not read witness value at index {witness_index:?} (required for parameter \"{name}\")"
     )]
     MissingParamWitnessValue { name: String, witness_index: Witness },
+    #[error("Attempted to write to witness index {0:?} but it is already initialized to a different value")]
+    InconsistentWitnessAssignment(Witness),
 }

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -234,12 +234,8 @@ impl Abi {
         match (&self.return_type, return_value) {
             (Some(return_type), Some(return_value)) => {
                 if !return_value.matches_abi(return_type) {
-                    return Err(AbiError::TypeMismatch {
-                        param: AbiParameter {
-                            name: MAIN_RETURN_NAME.to_owned(),
-                            typ: return_type.clone(),
-                            visibility: AbiVisibility::Public,
-                        },
+                    return Err(AbiError::ReturnTypeMismatch {
+                        return_type: return_type.clone(),
                         value: return_value,
                     });
                 }
@@ -257,8 +253,8 @@ impl Abi {
                     },
                 )?;
             }
-            (None, Some(_)) => {
-                return Err(AbiError::UnexpectedParams(vec![MAIN_RETURN_NAME.to_owned()]))
+            (None, Some(return_value)) => {
+                return Err(AbiError::UnexpectedReturnValue(return_value))
             }
             // We allow not passing a return value despite the circuit defining one
             // in order to generate the initial partial witness.

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -257,7 +257,9 @@ impl Abi {
                     },
                 )?;
             }
-            (None, Some(_)) => return Err(AbiError::UnexpectedParams(vec!["return".to_string()])),
+            (None, Some(_)) => {
+                return Err(AbiError::UnexpectedParams(vec![MAIN_RETURN_NAME.to_owned()]))
+            }
             // We allow not passing a return value despite the circuit defining one
             // in order to generate the initial partial witness.
             (_, None) => {}

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -229,8 +229,8 @@ impl Abi {
             })
             .collect();
 
-        // The user can optionally provide a return value to be inserted into the witness map.
-        // This is to be used when encoding public values to be passed to the verifier.
+        // When encoding public inputs to be passed to the verifier, the user can must provide a return value
+        // to be inserted into the witness map. This is not needed when generating a witness when proving the circuit.
         match (&self.return_type, return_value) {
             (Some(return_type), Some(return_value)) => {
                 if !return_value.matches_abi(return_type) {

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -237,12 +237,11 @@ impl Abi {
                     panic!("Unexpected return value")
                 }
                 let encoded_return_fields = Self::encode_value(return_value)?;
-                let return_witness_indices = &self.return_witnesses;
 
                 // We need to be more careful when writing the return value's witness values.
                 // This is as it may share witness indices with other public inputs so we must check that when
                 // this occurs the witness values are consistent with each other.
-                return_witness_indices.iter().zip(encoded_return_fields.iter()).try_for_each(
+                self.return_witnesses.iter().zip(encoded_return_fields.iter()).try_for_each(
                     |(&witness, &field_element)| match witness_map.insert(witness, field_element) {
                         Some(existing_value) if existing_value != field_element => {
                             panic!("Inconsistent return value");

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -297,15 +297,6 @@ impl Evaluator {
         let main_params = std::mem::take(&mut main.parameters);
         let abi_params = std::mem::take(&mut ir_gen.program.abi.parameters);
 
-        // Remove the return type from the parameters
-        // Since this is not in the main functions parameters.
-        //
-        // TODO(See Issue633) regarding adding a `return_type` field to the ABI struct
-        let abi_params: Vec<_> = abi_params
-            .into_iter()
-            .filter(|param| param.name != noirc_abi::MAIN_RETURN_NAME)
-            .collect();
-
         assert_eq!(main_params.len(), abi_params.len());
 
         for ((param_id, _, param_name, _), abi_param) in main_params.iter().zip(abi_params) {

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -150,8 +150,10 @@ impl FuncMeta {
     pub fn into_abi(self, interner: &NodeInterner) -> Abi {
         let return_type = self.return_type().clone();
         let mut abi = self.parameters.into_abi(interner);
-        abi.return_type =
-            if matches!(return_type, Type::Unit) { None } else { Some(return_type.as_abi_type()) };
+        abi.return_type = match return_type {
+            Type::Unit => None,
+            _ => Some(return_type.as_abi_type()),
+        };
 
         abi
     }

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use iter_extended::vecmap;
-use noirc_abi::{Abi, AbiParameter, AbiVisibility, MAIN_RETURN_NAME};
+use noirc_abi::{Abi, AbiParameter, AbiVisibility};
 use noirc_errors::{Location, Span};
 
 use super::expr::{HirBlockExpression, HirExpression, HirIdent};
@@ -63,7 +63,12 @@ impl Parameters {
             let as_abi = param.1.as_abi_type();
             AbiParameter { name: param_name, typ: as_abi, visibility: param.2 }
         });
-        noirc_abi::Abi { parameters, param_witnesses: BTreeMap::new() }
+        noirc_abi::Abi {
+            parameters,
+            param_witnesses: BTreeMap::new(),
+            return_type: None,
+            return_witnesses: Vec::new(),
+        }
     }
 
     pub fn span(&self) -> Span {
@@ -145,15 +150,8 @@ impl FuncMeta {
     pub fn into_abi(self, interner: &NodeInterner) -> Abi {
         let return_type = self.return_type().clone();
         let mut abi = self.parameters.into_abi(interner);
-
-        if return_type != Type::Unit {
-            let return_param = AbiParameter {
-                name: MAIN_RETURN_NAME.into(),
-                typ: return_type.as_abi_type(),
-                visibility: self.return_visibility,
-            };
-            abi.parameters.push(return_param);
-        }
+        abi.return_type =
+            if matches!(return_type, Type::Unit) { None } else { Some(return_type.as_abi_type()) };
 
         abi
     }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #678 

# Description

## Summary of changes

Draft pending proper error types.

The ABI now has separate fields for the type and witness assignments of the return value. As a know on effect, the circuit's return value is now no longer included in the `InputMap` and so is taken as a separate argument to `Abi.encode` and returned separately by `Abi.decode`.

Some care needs to be taken now when checking to see if an ABI contains a public input as this could either be a public param or a return value, whereas previously we could just search `abi.parameters` for a public parameter. I've added a getter to perform this check for us.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
