### PR TITLE
chore: remove support for InputValue::Undefined

### DIFF
--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -86,13 +86,7 @@ pub(crate) fn solve_witness(
     compiled_program: &CompiledProgram,
     input_map: &InputMap,
 ) -> Result<WitnessMap, CliError> {
-    let mut solved_witness =
-        compiled_program.abi.encode(input_map, true).map_err(|error| match error {
-            AbiError::UndefinedInput(_) => {
-                CliError::Generic(format!("{error} in the {PROVER_INPUT_FILE}.toml file."))
-            }
-            _ => CliError::from(error),
-        })?;
+    let mut solved_witness = compiled_program.abi.encode(input_map, true)?;
 
     let backend = crate::backends::ConcreteBackend;
     backend.solve(&mut solved_witness, compiled_program.circuit.opcodes.clone())?;

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use acvm::acir::native_types::Witness;
 use acvm::PartialWitnessGenerator;
 use clap::Args;
-use noirc_abi::errors::AbiError;
 use noirc_abi::input_parser::{Format, InputValue};
 use noirc_abi::{InputMap, WitnessMap, MAIN_RETURN_NAME};
 use noirc_driver::CompiledProgram;

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use acvm::{FieldElement, ProofSystemCompiler};
 use clap::Args;
-use noirc_abi::errors::AbiError;
 use noirc_abi::input_parser::Format;
 use noirc_driver::CompiledProgram;
 use std::{collections::BTreeMap, path::Path};

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -93,13 +93,7 @@ pub(crate) fn verify_proof(
     verification_key: Vec<u8>,
 ) -> Result<bool, CliError> {
     let public_abi = compiled_program.abi.public_abi();
-    let public_inputs =
-        public_abi.encode(&public_inputs_map, false).map_err(|error| match error {
-            AbiError::UndefinedInput(_) => {
-                CliError::Generic(format!("{error} in the {VERIFIER_INPUT_FILE}.toml file."))
-            }
-            _ => CliError::from(error),
-        })?;
+    let public_inputs = public_abi.encode(&public_inputs_map, false)?;
 
     let public_inputs_vec: Vec<FieldElement> = public_inputs.values().copied().collect();
 

--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -38,8 +38,6 @@ pub enum AbiError {
     TypeMismatch { param: AbiParameter, value: InputValue },
     #[error("ABI expects the parameter `{0}`, but this was not found")]
     MissingParam(String),
-    #[error("Input value `{0}` is not defined")]
-    UndefinedInput(String),
     #[error(
         "Could not read witness value at index {witness_index:?} (required for parameter \"{name}\")"
     )]

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -17,7 +17,6 @@ pub enum InputValue {
     Vec(Vec<FieldElement>),
     String(String),
     Struct(BTreeMap<String, InputValue>),
-    Undefined,
 }
 
 impl InputValue {
@@ -58,8 +57,6 @@ impl InputValue {
                     }
                 })
             }
-
-            (InputValue::Undefined, _) => true,
 
             // All other InputValue-AbiType combinations are fundamentally incompatible.
             _ => false,

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -78,7 +78,6 @@ impl From<InputValue> for TomlTypes {
                     btree_map(map, |(key, value)| (key, TomlTypes::from(value)));
                 TomlTypes::Table(map_with_toml_types)
             }
-            InputValue::Undefined => unreachable!(),
         }
     }
 }
@@ -92,11 +91,7 @@ impl InputValue {
             TomlTypes::String(string) => match param_type {
                 AbiType::String { .. } => InputValue::String(string),
                 AbiType::Field | AbiType::Integer { .. } => {
-                    if string.is_empty() {
-                        InputValue::Undefined
-                    } else {
-                        InputValue::Field(parse_str_to_field(&string)?)
-                    }
+                    InputValue::Field(parse_str_to_field(&string)?)
                 }
                 _ => return Err(InputParserError::AbiTypeMismatch(param_type.clone())),
             },

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -144,3 +144,14 @@ fn parse_str_to_field(value: &str) -> Result<FieldElement, InputParserError> {
             .map(FieldElement::from)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::parse_str_to_field;
+
+    #[test]
+    fn parse_empty_str_fails() {
+        // Check that this fails appropriately rather than being treated as 0, etc.
+        assert!(parse_str_to_field("").is_err());
+    }
+}

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -192,7 +192,7 @@ impl Abi {
                     return Err(AbiError::TypeMismatch { param: missing_param, value });
                 }
 
-                Self::encode_value(value, &param_name).map(|v| (param_name, v))
+                Self::encode_value(value).map(|v| (param_name, v))
             })
             .collect::<Result<_, _>>()?;
 
@@ -223,7 +223,7 @@ impl Abi {
         Ok(())
     }
 
-    fn encode_value(value: InputValue, param_name: &String) -> Result<Vec<FieldElement>, AbiError> {
+    fn encode_value(value: InputValue) -> Result<Vec<FieldElement>, AbiError> {
         let mut encoded_value = Vec::new();
         match value {
             InputValue::Field(elem) => encoded_value.push(elem),
@@ -234,12 +234,10 @@ impl Abi {
                 encoded_value.extend(str_as_fields)
             }
             InputValue::Struct(object) => {
-                for (field_name, value) in object {
-                    let new_name = format!("{param_name}.{field_name}");
-                    encoded_value.extend(Self::encode_value(value, &new_name)?)
+                for value in object.into_values() {
+                    encoded_value.extend(Self::encode_value(value)?)
                 }
             }
-            InputValue::Undefined => return Err(AbiError::UndefinedInput(param_name.to_string())),
         }
         Ok(encoded_value)
     }
@@ -364,8 +362,8 @@ mod test {
             ("thing2".to_string(), InputValue::Field(FieldElement::zero())),
         ]);
 
-        let witness_map = abi.encode_to_witness(&inputs).unwrap();
-        let reconstructed_inputs = abi.decode_from_witness(&witness_map).unwrap();
+        let witness_map = abi.encode(&inputs, true).unwrap();
+        let reconstructed_inputs = abi.decode(&witness_map).unwrap();
 
         for (key, expected_value) in inputs {
             assert_eq!(reconstructed_inputs[&key], expected_value);


### PR DESCRIPTION
# Related issue(s)

Consequence of #731 

# Description

## Summary of changes

After #731 there's never a situation in which leaving an undefined parameter in a toml file is a valid input. This PR then removes support for this variant of `InputValue` which allows us to remove a lot of the error handling associated with it.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
