### PR TITLE
chore: remove abi decoding from `execute_program`

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -67,8 +67,7 @@ pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
             &compiled_program.abi,
         )?;
 
-        let (_, solved_witness) =
-            super::execute_cmd::execute_program(&compiled_program, &inputs_map)?;
+        let solved_witness = super::execute_cmd::execute_program(&compiled_program, &inputs_map)?;
 
         circuit_path.pop();
         save_witness_to_dir(solved_witness, circuit_name, &circuit_path)?;

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -66,7 +66,7 @@ fn execute_with_path<P: AsRef<Path>>(
 
     let solved_witness = execute_program(&compiled_program, &inputs_map)?;
 
-    let public_abi = compiled_program.abi.clone().public_abi();
+    let public_abi = compiled_program.abi.public_abi();
     let public_inputs = public_abi.decode(&solved_witness)?;
     let return_value = public_inputs.get(MAIN_RETURN_NAME).cloned();
 

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -64,15 +64,7 @@ fn execute_with_path<P: AsRef<Path>>(
         &compiled_program.abi,
     )?;
 
-    execute_program(&compiled_program, &inputs_map)
-}
-
-pub(crate) fn execute_program(
-    compiled_program: &CompiledProgram,
-    inputs_map: &InputMap,
-) -> Result<(Option<InputValue>, WitnessMap), CliError> {
-    // Solve the remaining witnesses
-    let solved_witness = solve_witness(compiled_program, inputs_map)?;
+    let solved_witness = execute_program(&compiled_program, &inputs_map)?;
 
     let public_abi = compiled_program.abi.clone().public_abi();
     let public_inputs = public_abi.decode(&solved_witness)?;
@@ -81,11 +73,11 @@ pub(crate) fn execute_program(
     Ok((return_value, solved_witness))
 }
 
-pub(crate) fn solve_witness(
+pub(crate) fn execute_program(
     compiled_program: &CompiledProgram,
-    input_map: &InputMap,
+    inputs_map: &InputMap,
 ) -> Result<WitnessMap, CliError> {
-    let mut solved_witness = compiled_program.abi.encode(input_map, true)?;
+    let mut solved_witness = compiled_program.abi.encode(inputs_map, true)?;
 
     let backend = crate::backends::ConcreteBackend;
     backend.solve(&mut solved_witness, compiled_program.circuit.opcodes.clone())?;

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -88,7 +88,7 @@ pub fn prove_with_path<P: AsRef<Path>>(
         &compiled_program.abi,
     )?;
 
-    let (_, solved_witness) = execute_program(&compiled_program, &inputs_map)?;
+    let solved_witness = execute_program(&compiled_program, &inputs_map)?;
 
     // Write public inputs into Verifier.toml
     let public_abi = compiled_program.abi.clone().public_abi();


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

We only really make use of the decoded circuit return value which is returned from `execute_program` inside `execute_cmd::run` - in all other usages we just immediately drop it and just use the returned witness map.

This PR then moves the return value decoding up into `execute_with_path` and inlines `solve_witness` into `execute_program`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
