### PR TITLE
fix: Optimize parser

### DIFF
--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -592,14 +592,12 @@ where
         let next_precedence =
             if is_type_expression { precedence.next_type_precedence() } else { precedence.next() };
 
-        expression_with_precedence(precedence.next(), expr_parser.clone(), is_type_expression)
-            .then(
-                then_commit(
-                    operator_with_precedence(precedence),
-                    expression_with_precedence(next_precedence, expr_parser, is_type_expression),
-                )
-                .repeated(),
-            )
+        let next_expr =
+            expression_with_precedence(next_precedence, expr_parser.clone(), is_type_expression);
+
+        next_expr
+            .clone()
+            .then(then_commit(operator_with_precedence(precedence), next_expr).repeated())
             .foldl(create_infix_expression)
             .boxed()
             .labelled("expression")

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -593,7 +593,7 @@ where
             if is_type_expression { precedence.next_type_precedence() } else { precedence.next() };
 
         let next_expr =
-            expression_with_precedence(next_precedence, expr_parser.clone(), is_type_expression);
+            expression_with_precedence(next_precedence, expr_parser, is_type_expression);
 
         next_expr
             .clone()


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #791 

# Description

Optimizes the `expression_with_precedence` parser which was the main cause of performance lost in the frontend.

The command used for testing was `nargo prove p` on the source project
```rs
fn main(x: bool) {
    constrain x;
}
```

Timing details are averages of 10 runs and the results are as follows:

```
           master     this branch
debug      1.758s        0.350s
release    0.470s        0.163s
```

So it is roughly a 5x speedup in debug and a 2.9x speedup on release.

For a more detailed flamegraph, see the graphs uploaded in #791.

## Summary of changes

The old `expression_with_precedence` parser recursively called itself for each precedence level, but also called each child level twice when constructing `expr <op> expr`, leading to an exponential blowup. Note though that this is from the time it takes to construct the parser before running it, so this was a large fixed cost rather than one that scaled with program size. This PR simply adds a `.clone()` to reuse the first parser and make this function linear rather than exponential in time.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [x] This PR requires documentation updates when merged.
