### PR TITLE
feat(std_lib): Support extracting intermediate witnesses from a circuit using traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,7 @@ dependencies = [
 [[package]]
 name = "acir"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d756bcab90b3a4a84dc53245890cf9bb8fcde31a1394931f5abca551b48eb20"
+source = "git+https://github.com/noir-lang/acvm?branch=mv/trace#980e2cc4b1adec5e21c54fb0df8c166b0a9ca689"
 dependencies = [
  "acir_field 0.4.1",
  "flate2",
@@ -33,8 +32,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687506e635efa7ce15d6b93ceae14dec1519ed2e54c24298fc8c40e86edbce24"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
- "ark-ff",
+ "ark-bn254 0.3.0",
+ "ark-ff 0.3.0",
  "blake2",
  "cfg-if 1.0.0",
  "hex",
@@ -46,11 +45,11 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb7e1e30625a9125a0e700c6c6fd7442ffbcb1d235933100b791ba3786ef49e"
+source = "git+https://github.com/noir-lang/acvm?branch=mv/trace#980e2cc4b1adec5e21c54fb0df8c166b0a9ca689"
 dependencies = [
- "ark-bn254",
- "ark-ff",
+ "ark-bn254 0.4.0",
+ "ark-ff 0.4.0",
+ "ark-serialize 0.4.0",
  "blake2",
  "cfg-if 1.0.0",
  "hex",
@@ -81,13 +80,11 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fae94e7f3fe0d21bec4796de00bbf0cd8f781271b5203dea54897aa5387b9"
+source = "git+https://github.com/noir-lang/acvm?branch=mv/trace#980e2cc4b1adec5e21c54fb0df8c166b0a9ca689"
 dependencies = [
  "acir 0.4.1",
  "acvm_stdlib 0.4.1",
  "blake2",
- "hex",
  "indexmap",
  "k256",
  "num-bigint",
@@ -109,8 +106,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf6617b72c2cd4e965d425bc768bb77a803e485a7e37cbc09cccc5967becd7a"
+source = "git+https://github.com/noir-lang/acvm?branch=mv/trace#980e2cc4b1adec5e21c54fb0df8c166b0a9ca689"
 dependencies = [
  "acir 0.4.1",
 ]
@@ -137,6 +133,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
  "version_check",
 ]
@@ -172,9 +179,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65be532f9dd1e98ad0150b037276cde464c6f371059e6dd02c0222395761f6aa"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
 ]
 
 [[package]]
@@ -183,9 +190,20 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+dependencies = [
+ "ark-ec 0.4.0",
+ "ark-ff 0.4.0",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -194,10 +212,27 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d7f0c52aff14f216200a9eee06a9990fee2e51fc9599e226df448ad3232886"
+dependencies = [
+ "ark-ff 0.4.0",
+ "ark-poly 0.4.0",
+ "ark-serialize 0.4.0",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
  "num-traits",
  "zeroize",
 ]
@@ -208,10 +243,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "num-bigint",
  "num-traits",
@@ -221,10 +256,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ee31d8869a353433524dbd5a8f51f95cdafe7c66d458956ec13aa737198562"
+dependencies = [
+ "ark-ff-asm 0.4.0",
+ "ark-ff-macros 0.4.0",
+ "ark-serialize 0.4.0",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.6",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc8f7ec7fdcc20f3f110783c043d80479b42f500003cf92b71ca90f34a2ba0e"
 dependencies = [
  "quote",
  "syn",
@@ -243,19 +308,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15aa320e38052d644e569740bad208e5f9f5fafedcc9e6b1557f723be1b7ff8d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ark-marlin"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8510faa8e64f0a6841ee4b58efe2d56f7a80d86fa0ce9891bbb3aa20166d9"
 dependencies = [
- "ark-ff",
- "ark-poly",
+ "ark-ff 0.3.0",
+ "ark-poly 0.3.0",
  "ark-poly-commit",
  "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
- "digest",
+ "digest 0.9.0",
  "rand_chacha",
 ]
 
@@ -265,11 +343,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2e8741caf33ab3063f1fc65617716ffb18cba8e872998aa2eef0d4e4b56d1"
+dependencies = [
+ "ark-ff 0.4.0",
+ "ark-serialize 0.4.0",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -278,13 +369,13 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71ddfa72bad1446cab7bbecb6018dbbdc9abcbc3a0065483ae5186ad2a64dcd"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-poly 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "derivative",
- "digest",
+ "digest 0.9.0",
  "tracing",
 ]
 
@@ -294,8 +385,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cba4c1c99792a6834bd97f7fd76578ec2cd58d2afc5139a17e1d1bec65b38f6"
 dependencies = [
- "ark-ff",
- "ark-std",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
  "tracing",
 ]
 
@@ -305,9 +396,21 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
- "digest",
+ "ark-serialize-derive 0.3.0",
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ea39d00a8a4c832e6f6520e58ccec7bf909c4845863512e9b8656fd47df355"
+dependencies = [
+ "ark-serialize-derive 0.4.0",
+ "ark-std 0.4.0",
+ "digest 0.10.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -315,6 +418,17 @@ name = "ark-serialize-derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101333772a4020c883890811500d5ecc704c545a90140629af5c3b9f00d78953"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -332,20 +446,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "arkworks_backend"
 version = "0.1.0"
 source = "git+https://github.com/noir-lang/arkworks_backend?rev=2f3f0db182004d5c01008c741bf519fe6798e24d#2f3f0db182004d5c01008c741bf519fe6798e24d"
 dependencies = [
  "acvm 0.3.1",
  "ark-bls12-381",
- "ark-bn254",
- "ark-ff",
+ "ark-bn254 0.3.0",
+ "ark-ff 0.3.0",
  "ark-marlin",
- "ark-poly",
+ "ark-poly 0.3.0",
  "ark-poly-commit",
  "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
  "blake2",
  "cfg-if 1.0.0",
 ]
@@ -385,7 +509,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_static_lib"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=cff757dca7971161e4bd25e7a744d910c37c22be#cff757dca7971161e4bd25e7a744d910c37c22be"
+source = "git+https://github.com/noir-lang/aztec_backend?branch=mv/trace#dce6b540b13b5c85f10b19480beeb63bff0467e9"
 dependencies = [
  "barretenberg_wrapper",
  "blake2",
@@ -405,7 +529,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wasm"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=cff757dca7971161e4bd25e7a744d910c37c22be#cff757dca7971161e4bd25e7a744d910c37c22be"
+source = "git+https://github.com/noir-lang/aztec_backend?branch=mv/trace#dce6b540b13b5c85f10b19480beeb63bff0467e9"
 dependencies = [
  "blake2",
  "common",
@@ -479,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -621,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -733,7 +857,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=cff757dca7971161e4bd25e7a744d910c37c22be#cff757dca7971161e4bd25e7a744d910c37c22be"
+source = "git+https://github.com/noir-lang/aztec_backend?branch=mv/trace#dce6b540b13b5c85f10b19480beeb63bff0467e9"
 dependencies = [
  "acvm 0.4.1",
  "blake2",
@@ -933,6 +1057,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
 dependencies = [
  "bitvec",
- "digest",
+ "digest 0.9.0",
  "ff",
  "funty",
  "generic-array",
@@ -1521,7 +1664,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1530,7 +1673,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -1576,14 +1728,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.1",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1767,6 +1919,15 @@ name = "iter-extended"
 version = "0.2.0"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,9 +2069,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "2af2c65375e552a67fe3829ca63e8a7c27a378a62824594f43b2851d682b5ec2"
 dependencies = [
  "libc",
 ]
@@ -1981,7 +2142,7 @@ dependencies = [
  "barretenberg_wasm",
  "build-data",
  "cfg-if 1.0.0",
- "clap 4.1.4",
+ "clap 4.1.6",
  "color-eyre",
  "const_format",
  "dirs 4.0.0",
@@ -2876,7 +3037,7 @@ dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -2901,7 +3062,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ edition = "2021"
 rust-version = "1.66"
 
 [workspace.dependencies]
-acvm = "0.4.1"
+# acvm = "0.4.1"
+# acvm = { features = ["bn254"], path = "/Users/maximvezenov/Documents/dev/noir-lang/acvm/acvm" }
+acvm = { features = ["bn254"], git = "https://github.com/noir-lang/acvm", branch = "mv/trace" }
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 # acvm = "0.4.1"
-# acvm = { features = ["bn254"], path = "/Users/maximvezenov/Documents/dev/noir-lang/acvm/acvm" }
 acvm = { features = ["bn254"], git = "https://github.com/noir-lang/acvm", branch = "mv/trace" }
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -32,8 +32,8 @@ termcolor = "1.1.2"
 tempdir = "0.3.7"
 
 # Backends
-aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "cff757dca7971161e4bd25e7a744d910c37c22be" }
-aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "cff757dca7971161e4bd25e7a744d910c37c22be" }
+aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", branch = "mv/trace" }
+aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", branch = "mv/trace" }
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
 color-eyre = "0.6.2"
 

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -8,7 +8,7 @@ use noirc_abi::{InputMap, WitnessMap, MAIN_RETURN_NAME};
 use noirc_driver::CompiledProgram;
 
 use super::NargoConfig;
-use super::{create_named_dir, read_inputs_from_file, write_to_file};
+use super::{create_named_dir, handle_logs, read_inputs_from_file, write_to_file};
 use crate::{
     cli::compile_cmd::compile_circuit,
     constants::{PROVER_INPUT_FILE, TARGET_DIR, WITNESS_EXT},
@@ -79,8 +79,12 @@ pub(crate) fn execute_program(
 ) -> Result<WitnessMap, CliError> {
     let mut solved_witness = compiled_program.abi.encode(inputs_map, true)?;
 
+    let mut logs = Vec::new();
+
     let backend = crate::backends::ConcreteBackend;
-    backend.solve(&mut solved_witness, compiled_program.circuit.opcodes.clone())?;
+    backend.solve(&mut solved_witness, compiled_program.circuit.opcodes.clone(), &mut logs)?;
+
+    handle_logs(logs)?;
 
     Ok(solved_witness)
 }

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -1,4 +1,10 @@
-use acvm::{acir::circuit::Circuit, hash_constraint_system, ProofSystemCompiler};
+use acvm::{
+    acir::circuit::{
+        directives::{Directive, LogOutputInfo},
+        Circuit,
+    },
+    hash_constraint_system, ProofSystemCompiler,
+};
 pub use check_cmd::check_from_path;
 use clap::{Args, Parser, Subcommand};
 use const_format::formatcp;
@@ -236,6 +242,29 @@ fn fetch_pk_and_vk<P: AsRef<Path>>(
         let (proving_key, verification_key) = backend.preprocess(circuit);
         Ok((proving_key, verification_key))
     }
+}
+
+pub fn handle_logs(logs: Vec<Directive>) -> Result<(), CliError> {
+    for log in logs {
+        match &log {
+            Directive::Log { is_trace, output_info } => {
+                if !is_trace {
+                    match output_info {
+                        LogOutputInfo::FinalizedOutput(output_string) => println!("{output_string}"),
+                        _ => return Err(CliError::Generic(format!("Critical error: expected a log object from the compiler but got {log:?}\n",)))
+                    }
+                } else {
+                    dbg!("we got a trace still have to implement!");
+                }
+            }
+            _ => {
+                return Err(CliError::Generic(
+                    "Critical error: a log opcode was returned from evaluation unsolved".to_owned(),
+                ))
+            }
+        }
+    }
+    Ok(())
 }
 
 // FIXME: I not sure that this is the right place for this tests.

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -151,7 +151,7 @@ impl Driver {
         allow_warnings: bool,
     ) -> Result<CompiledProgram, ReportedError> {
         self.check_crate(allow_warnings)?;
-        self.compile_no_check(np_language, show_ssa, allow_warnings, None, true)
+        self.compile_no_check(np_language, show_ssa, allow_warnings, None)
     }
 
     /// Compile the current crate. Assumes self.check_crate is called beforehand!
@@ -163,7 +163,6 @@ impl Driver {
         allow_warnings: bool,
         // Optional override to provide a different `main` function to start execution
         main_function: Option<FuncId>,
-        show_output: bool,
     ) -> Result<CompiledProgram, ReportedError> {
         // Find the local crate, one should always be present
         let local_crate = self.context.def_map(LOCAL_CRATE).unwrap();
@@ -185,7 +184,7 @@ impl Driver {
 
         let blackbox_supported = acvm::default_is_black_box_supported(np_language.clone());
 
-        match create_circuit(program, np_language, blackbox_supported, show_ssa, show_output) {
+        match create_circuit(program, np_language, blackbox_supported, show_ssa) {
             Ok((circuit, abi)) => Ok(CompiledProgram { circuit, abi }),
             Err(err) => {
                 // The FileId here will be the file id of the file with the main file

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -5,7 +5,7 @@ mod ssa;
 use acvm::{
     acir::circuit::{opcodes::Opcode as AcirOpcode, Circuit, PublicInputs},
     acir::native_types::{Expression, Witness},
-    compiler::fallback::IsBlackBoxSupported,
+    compiler::transformers::IsBlackBoxSupported,
     Language,
 };
 use errors::{RuntimeError, RuntimeErrorKind};
@@ -43,12 +43,11 @@ pub fn create_circuit(
     np_language: Language,
     is_blackbox_supported: IsBlackBoxSupported,
     enable_logging: bool,
-    show_output: bool,
 ) -> Result<(Circuit, Abi), RuntimeError> {
     let mut evaluator = Evaluator::new();
 
     // First evaluate the main function
-    evaluator.evaluate_main_alt(program.clone(), enable_logging, show_output)?;
+    evaluator.evaluate_main_alt(program.clone(), enable_logging)?;
 
     let witness_index = evaluator.current_witness_index();
 
@@ -120,7 +119,6 @@ impl Evaluator {
         &mut self,
         program: Program,
         enable_logging: bool,
-        show_output: bool,
     ) -> Result<(), RuntimeError> {
         let mut ir_gen = IrGenerator::new(program);
         self.parse_abi_alt(&mut ir_gen);
@@ -129,7 +127,7 @@ impl Evaluator {
         ir_gen.ssa_gen_main()?;
 
         //Generates ACIR representation:
-        ir_gen.context.ir_to_acir(self, enable_logging, show_output)?;
+        ir_gen.context.ir_to_acir(self, enable_logging)?;
         Ok(())
     }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -1,5 +1,4 @@
 use crate::ssa::{
-    builtin,
     context::SsaContext,
     node::{Instruction, Operation},
 };
@@ -35,7 +34,6 @@ impl Acir {
         ins: &Instruction,
         evaluator: &mut Evaluator,
         ctx: &SsaContext,
-        show_output: bool,
     ) -> Result<(), RuntimeErrorKind> {
         use operations::{
             binary, condition, constrain, intrinsics, load, not, r#return, store, truncate,
@@ -59,16 +57,7 @@ impl Acir {
                 truncate::evaluate(value, *bit_size, *max_bit_size, var_cache, evaluator, ctx)
             }
             Operation::Intrinsic(opcode, args) => {
-                let opcode = match opcode {
-                    builtin::Opcode::Println(print_info) => {
-                        builtin::Opcode::Println(builtin::PrintlnInfo {
-                            is_string_output: print_info.is_string_output,
-                            show_output,
-                        })
-                    }
-                    _ => *opcode,
-                };
-                intrinsics::evaluate(args, ins, opcode, var_cache, acir_mem, ctx, evaluator)
+                intrinsics::evaluate(args, ins, *opcode, var_cache, acir_mem, ctx, evaluator)
             }
             Operation::Return(node_ids) => {
                 r#return::evaluate(node_ids, acir_mem, var_cache, evaluator, ctx)?

--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -407,6 +407,7 @@ pub(crate) fn to_radix_base(
         a: lhs.clone(),
         b: result.clone(),
         radix,
+        is_little_endian: true,
     }));
 
     evaluator.opcodes.push(AcirOpcode::Arithmetic(subtract(lhs, FieldElement::one(), &bytes)));

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -154,7 +154,7 @@ mod test {
             // compute the network output by solving the constraints
             let backend = MockBackend {};
             backend
-                .solve(&mut solved_witness, eval.opcodes.clone())
+                .solve(&mut solved_witness, eval.opcodes.clone(), &mut vec![])
                 .expect("Could not solve permutation constraints");
             let mut b_val = Vec::new();
             for i in 0..output.len() {

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -230,7 +230,7 @@ impl IrGenerator {
         let func = self.ssa_gen_expression(&call.func)?.unwrap_id();
         let arguments = self.ssa_gen_expression_list(&call.arguments);
 
-        if let Some(opcode) = self.context.get_builtin_opcode(func, &call.arguments) {
+        if let Some(opcode) = self.context.get_builtin_opcode(func) {
             return self.call_low_level(opcode, arguments);
         }
 

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -390,7 +390,7 @@ fn cse_block_with_anchor(
                     //Add dummy load for function arguments and enable CSE only if no array in argument
                     let mut activate_cse = true;
                     // We do not want to replace any print intrinsics as we want them to remain in order and unchanged
-                    if let builtin::Opcode::Println(_) = opcode {
+                    if let builtin::Opcode::Println = opcode {
                         activate_cse = false
                     }
 
@@ -447,7 +447,7 @@ fn cse_block_with_anchor(
             if let Operation::Intrinsic(opcode, args) = &update2.operation {
                 match opcode {
                     // We do not simplify print statements
-                    builtin::Opcode::Println(_) => (),
+                    builtin::Opcode::Println => (),
                     _ => {
                         let args = args.iter().map(|arg| {
                             NodeEval::from_id(ctx, *arg).into_const_value().map(|f| f.to_u128())

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -525,10 +525,35 @@ impl<'interner> Monomorphizer<'interner> {
         id: node_interner::ExprId,
     ) -> ast::Expression {
         let func = Box::new(self.expr_infer(call.func));
-        let arguments = vecmap(&call.arguments, |id| self.expr_infer(*id));
+        let mut arguments = vecmap(&call.arguments, |id| self.expr_infer(*id));
         let return_type = self.interner.id_type(id);
         let return_type = Self::convert_type(&return_type);
         let location = call.location;
+
+        if let ast::Expression::Ident(ident) = func.as_ref() {
+            match &ident.definition {
+                Definition::Builtin(opcode) if opcode == "println" => {
+                    let is_string = match &arguments[0] {
+                        ast::Expression::Ident(ident) => match ident.typ {
+                            ast::Type::String(_) => true,
+                            ast::Type::Tuple(_) => {
+                                unreachable!("logging structs/tuples is not supported")
+                            }
+                            ast::Type::Function { .. } => {
+                                unreachable!("logging functions is not supported")
+                            }
+                            _ => false,
+                        },
+                        ast::Expression::Literal(literal) => {
+                            matches!(literal, ast::Literal::Str(_))
+                        }
+                        _ => unreachable!("logging this expression type is not supported"),
+                    };
+                    arguments.push(ast::Expression::Literal(ast::Literal::Bool(is_string)));
+                }
+                _ => (),
+            }
+        }
 
         self.try_evaluate_call(&func, &call.arguments).unwrap_or(ast::Expression::Call(ast::Call {
             func,


### PR DESCRIPTION
# Related issue(s)

Resolves #688 

# Description

***CURRENTLY A DRAFT***

This PR moves towards supporting the builtin `std::trace`. This specifies that we would like to log an intermediate witness, however, we would like to handle it in a way that differs from displaying it to standard output. 

Relevant acvm PR: https://github.com/noir-lang/acvm/pull/105
aztec_backend: https://github.com/noir-lang/aztec_backend/pull/57

## Summary of changes

With the switch to returning logs from the PWG rather than handling them inside of the PWG we were able to move away from needing the `show_output` flag on `builtin::Println`. With handling of logs happening inside of the PWG we were forced to pass down a flag during evaluation that cluttered up multiple functions and leads to other challenges. `nargo` now handles whether we display output during tests. We now follow Rust where if a test passes there is no output unless specified with a flag, and if a test fails we display the output. 

- have to add support for builtin::Trace

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
