### PR TITLE
chore: replace usage of `new()` with `default()` 

### DIFF
--- a/crates/fm/src/file_map.rs
+++ b/crates/fm/src/file_map.rs
@@ -57,10 +57,6 @@ impl<'input> File<'input> {
 }
 
 impl FileMap {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn add_file(&mut self, file_name: PathString, code: String) -> FileId {
         let file_id = self.0.add(file_name, code);
         FileId(file_id)

--- a/crates/fm/src/file_map.rs
+++ b/crates/fm/src/file_map.rs
@@ -58,7 +58,7 @@ impl<'input> File<'input> {
 
 impl FileMap {
     pub fn new() -> Self {
-        FileMap(SimpleFiles::new())
+        Self::default()
     }
 
     pub fn add_file(&mut self, file_name: PathString, code: String) -> FileId {
@@ -72,7 +72,7 @@ impl FileMap {
 
 impl Default for FileMap {
     fn default() -> Self {
-        Self::new()
+        FileMap(SimpleFiles::new())
     }
 }
 

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -34,10 +34,6 @@ pub struct FileManager {
 }
 
 impl FileManager {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     // XXX: Maybe use a AsRef<Path> here, for API ergonomics
     pub fn add_file(&mut self, path_to_file: &Path, file_type: FileType) -> Option<FileId> {
         let source = file_reader::read_file_to_string(path_to_file).ok()?;
@@ -123,7 +119,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dummy_file_path(&dir, "my_dummy_file.nr");
 
-        let mut fm = FileManager::new();
+        let mut fm = FileManager::default();
 
         let file_id = fm.add_file(&file_path, FileType::Root).unwrap();
 
@@ -135,7 +131,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dummy_file_path(&dir, "foo.noir");
 
-        let mut fm = FileManager::new();
+        let mut fm = FileManager::default();
 
         let file_id = fm.add_file(&file_path, FileType::Normal).unwrap();
 
@@ -143,7 +139,7 @@ mod tests {
     }
     #[test]
     fn path_resolve_sub_module() {
-        let mut fm = FileManager::new();
+        let mut fm = FileManager::default();
 
         let dir = tempdir().unwrap();
         // Create a lib.nr file at the root.

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -26,7 +26,7 @@ pub enum FileType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct VirtualPath(PathBuf);
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct FileManager {
     file_map: file_map::FileMap,
     id_to_path: HashMap<FileId, VirtualPath>,
@@ -35,11 +35,7 @@ pub struct FileManager {
 
 impl FileManager {
     pub fn new() -> Self {
-        Self {
-            file_map: file_map::FileMap::new(),
-            id_to_path: HashMap::new(),
-            path_to_id: HashMap::new(),
-        }
+        Self::default()
     }
 
     // XXX: Maybe use a AsRef<Path> here, for API ergonomics
@@ -87,12 +83,6 @@ impl FileManager {
         }
 
         Err(candidate_files.remove(0).as_os_str().to_str().unwrap().to_owned())
-    }
-}
-
-impl Default for FileManager {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -78,8 +78,6 @@ pub fn create_circuit(
 }
 
 impl Evaluator {
-    // Evaluator::default()
-    // current_witness_index: 0
     // XXX: Barretenberg, reserves the first index to have value 0.
     // When we increment, we do not use this index at all.
     // This means that every constraint system at the moment, will either need

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -22,6 +22,14 @@ pub struct Evaluator {
     // At the moment, wasm32 is being used in the default backend
     // so it is safer to use a u32, at least until clang is changed
     // to compile wasm64.
+    //
+    // XXX: Barretenberg, reserves the first index to have value 0.
+    // When we increment, we do not use this index at all.
+    // This means that every constraint system at the moment, will either need
+    // to decrease each index by 1, or create a dummy witness.
+    //
+    // We ideally want to not have this and have Barretenberg apply the
+    // following transformation to the witness index : f(i) = i + 1
     current_witness_index: u32,
     // This is the number of witnesses indices used when
     // creating the private/public inputs of the ABI.
@@ -78,14 +86,6 @@ pub fn create_circuit(
 }
 
 impl Evaluator {
-    // XXX: Barretenberg, reserves the first index to have value 0.
-    // When we increment, we do not use this index at all.
-    // This means that every constraint system at the moment, will either need
-    // to decrease each index by 1, or create a dummy witness.
-    //
-    // We ideally want to not have this and have Barretenberg apply the
-    // following transformation to the witness index : f(i) = i + 1
-    //
 
     // Returns true if the `witness_index`
     // was created in the ABI as a private input.

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -46,7 +46,7 @@ pub fn create_circuit(
     enable_logging: bool,
     show_output: bool,
 ) -> Result<(Circuit, Abi), RuntimeError> {
-    let mut evaluator = Evaluator::new();
+    let mut evaluator = Evaluator::default();
 
     // First evaluate the main function
     evaluator.evaluate_main_alt(program.clone(), enable_logging, show_output)?;
@@ -78,6 +78,7 @@ pub fn create_circuit(
 }
 
 impl Evaluator {
+    // Evaluator::default()
     // current_witness_index: 0
     // XXX: Barretenberg, reserves the first index to have value 0.
     // When we increment, we do not use this index at all.
@@ -87,9 +88,6 @@ impl Evaluator {
     // We ideally want to not have this and have Barretenberg apply the
     // following transformation to the witness index : f(i) = i + 1
     //
-    fn new() -> Self {
-        Self::default()
-    }
 
     // Returns true if the `witness_index`
     // was created in the ABI as a private input.

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -15,6 +15,7 @@ use noirc_frontend::monomorphization::ast::*;
 use ssa::{node, ssa_gen::IrGenerator};
 use std::collections::{BTreeMap, BTreeSet};
 
+#[derive(Default)]
 pub struct Evaluator {
     // Why is this not u64?
     //
@@ -76,26 +77,16 @@ pub fn create_circuit(
     Ok((optimized_circuit, abi))
 }
 
-impl Default for Evaluator {
-    fn default() -> Self {
-        Evaluator {
-            num_witnesses_abi_len: 0,
-            public_inputs: BTreeSet::new(),
-            param_witnesses: BTreeMap::new(),
-            // XXX: Barretenberg, reserves the first index to have value 0.
-            // When we increment, we do not use this index at all.
-            // This means that every constraint system at the moment, will either need
-            // to decrease each index by 1, or create a dummy witness.
-            //
-            // We ideally want to not have this and have Barretenberg apply the
-            // following transformation to the witness index : f(i) = i + 1
-            //
-            current_witness_index: 0,
-            opcodes: Vec::new(),
-        }
-    }
-}
 impl Evaluator {
+    // current_witness_index: 0
+    // XXX: Barretenberg, reserves the first index to have value 0.
+    // When we increment, we do not use this index at all.
+    // This means that every constraint system at the moment, will either need
+    // to decrease each index by 1, or create a dummy witness.
+    //
+    // We ideally want to not have this and have Barretenberg apply the
+    // following transformation to the witness index : f(i) = i + 1
+    //
     fn new() -> Self {
         Self::default()
     }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -76,8 +76,8 @@ pub fn create_circuit(
     Ok((optimized_circuit, abi))
 }
 
-impl Evaluator {
-    fn new() -> Self {
+impl Default for Evaluator {
+    fn default() -> Self {
         Evaluator {
             num_witnesses_abi_len: 0,
             public_inputs: BTreeSet::new(),
@@ -93,6 +93,11 @@ impl Evaluator {
             current_witness_index: 0,
             opcodes: Vec::new(),
         }
+    }
+}
+impl Evaluator {
+    fn new() -> Self {
+        Self::default()
     }
 
     // Returns true if the `witness_index`

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -86,7 +86,6 @@ pub fn create_circuit(
 }
 
 impl Evaluator {
-
     // Returns true if the `witness_index`
     // was created in the ABI as a private input.
     //

--- a/crates/noirc_evaluator/src/ssa/acir_gen/internal_var.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/internal_var.rs
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn internal_var_const_expression() {
-        let mut evaluator = Evaluator::new();
+        let mut evaluator = Evaluator::default();
 
         let expected_constant = FieldElement::from(123456789u128);
 
@@ -216,7 +216,7 @@ mod tests {
     }
     #[test]
     fn internal_var_from_witness() {
-        let mut evaluator = Evaluator::new();
+        let mut evaluator = Evaluator::default();
 
         let expected_witness = Witness(1234);
         // Initialize an InternalVar with a `Witness`

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -119,7 +119,7 @@ mod test {
     fn test_permutation() {
         let mut rng = rand::thread_rng();
         for n in 2..50 {
-            let mut eval = Evaluator::new();
+            let mut eval = Evaluator::default();
 
             //we generate random inputs
             let mut input = Vec::new();

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -41,8 +41,8 @@ pub struct SsaContext {
     dummy_load: HashMap<ArrayId, NodeId>,
 }
 
-impl SsaContext {
-    pub fn new() -> SsaContext {
+impl Default for SsaContext {
+    fn default() -> Self {
         let mut pc = SsaContext {
             first_block: BlockId::dummy(),
             current_block: BlockId::dummy(),
@@ -61,6 +61,12 @@ impl SsaContext {
         pc.one_with_type(node::ObjectType::Boolean);
         pc.zero_with_type(node::ObjectType::Boolean);
         pc
+    }
+}
+
+impl SsaContext {
+    pub fn new() -> SsaContext {
+        Self::default()
     }
 
     pub fn zero(&self) -> NodeId {

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -65,10 +65,6 @@ impl Default for SsaContext {
 }
 
 impl SsaContext {
-    pub fn new() -> SsaContext {
-        Self::default()
-    }
-
     pub fn zero(&self) -> NodeId {
         self.find_const_with_type(&BigUint::zero(), node::ObjectType::Boolean).unwrap()
     }

--- a/crates/noirc_evaluator/src/ssa/ssa_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen.rs
@@ -35,7 +35,7 @@ pub struct IrGenerator {
 impl IrGenerator {
     pub fn new(program: Program) -> IrGenerator {
         IrGenerator {
-            context: SsaContext::new(),
+            context: SsaContext::default(),
             variable_values: HashMap::new(),
             function_context: None,
             program,

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -191,7 +191,7 @@ mod tests {
 
     fn dummy_file_ids(n: usize) -> Vec<FileId> {
         use fm::{FileMap, FILE_EXTENSION};
-        let mut fm = FileMap::new();
+        let mut fm = FileMap::default();
 
         let mut vec_ids = Vec::with_capacity(n);
         for i in 0..n {

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -24,7 +24,7 @@ impl Default for Context {
         Context {
             def_interner: NodeInterner::default(),
             crate_graph: CrateGraph::default(),
-            file_manager: FileManager::new(),
+            file_manager: FileManager::default(),
             def_maps: HashMap::new(),
         }
     }

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -12,22 +12,12 @@ use fm::FileManager;
 use std::collections::HashMap;
 
 /// Global context that is accessible during each stage
+#[derive(Default)]
 pub struct Context {
     pub def_interner: NodeInterner,
     pub crate_graph: CrateGraph,
     pub(crate) def_maps: HashMap<CrateId, CrateDefMap>,
     pub file_manager: FileManager,
-}
-
-impl Default for Context {
-    fn default() -> Self {
-        Context {
-            def_interner: NodeInterner::default(),
-            crate_graph: CrateGraph::default(),
-            file_manager: FileManager::default(),
-            def_maps: HashMap::new(),
-        }
-    }
 }
 
 impl Context {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -98,7 +98,7 @@ impl<'a> Resolver<'a> {
         Self {
             path_resolver,
             def_maps,
-            scopes: ScopeForest::new(),
+            scopes: ScopeForest::default(),
             interner,
             self_type: None,
             generics: Vec::new(),

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -25,10 +25,6 @@ It's not implemented yet, because nothing has been benched
 pub struct Scope<K, V>(pub HashMap<K, V>);
 
 impl<K: std::hash::Hash + Eq + Clone, V> Scope<K, V> {
-    pub fn new() -> Self {
-        Scope(HashMap::with_capacity(10))
-    }
-
     pub fn find<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
     where
         K: std::borrow::Borrow<Q>,
@@ -56,7 +52,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> Scope<K, V> {
 
 impl<K: std::hash::Hash + Eq + Clone, V> Default for Scope<K, V> {
     fn default() -> Self {
-        Self::new()
+        Scope(HashMap::with_capacity(10))
     }
 }
 
@@ -66,10 +62,6 @@ impl<K: std::hash::Hash + Eq + Clone, V> Default for Scope<K, V> {
 pub struct ScopeTree<K, V>(pub Vec<Scope<K, V>>);
 
 impl<K: std::hash::Hash + Eq + Clone, V> ScopeTree<K, V> {
-    pub fn new() -> Self {
-        ScopeTree(vec![Scope::new()])
-    }
-
     pub fn last_index(&self) -> usize {
         self.0.len() - 1
     }
@@ -98,7 +90,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeTree<K, V> {
     }
 
     pub fn push_scope(&mut self) {
-        self.0.push(Scope::new())
+        self.0.push(Scope::default())
     }
 
     pub fn pop_scope(&mut self) -> Scope<K, V> {
@@ -108,7 +100,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeTree<K, V> {
 
 impl<K: std::hash::Hash + Eq + Clone, V> Default for ScopeTree<K, V> {
     fn default() -> Self {
-        Self::new()
+        ScopeTree(vec![Scope::default()])
     }
 }
 
@@ -117,7 +109,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> Default for ScopeTree<K, V> {
 // we only have an API for this with ScopeTree in the resolver.
 impl<K: std::hash::Hash + Eq + Clone, V> From<Scope<K, V>> for ScopeTree<K, V> {
     fn from(scp: Scope<K, V>) -> Self {
-        let mut tree = ScopeTree::new();
+        let mut tree = ScopeTree::default();
         tree.0.push(scp);
         tree
     }
@@ -126,10 +118,6 @@ impl<K: std::hash::Hash + Eq + Clone, V> From<Scope<K, V>> for ScopeTree<K, V> {
 pub struct ScopeForest<K, V>(pub Vec<ScopeTree<K, V>>);
 
 impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
-    pub fn new() -> ScopeForest<K, V> {
-        ScopeForest(vec![ScopeTree::new()])
-    }
-
     pub fn current_scope_tree(&mut self) -> &mut ScopeTree<K, V> {
         self.0.last_mut().expect("ice: tried to fetch the current scope, however none was found")
     }
@@ -155,7 +143,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
     /// Starting a function requires a new scope tree, as you do not want the functions scope to
     /// have access to the scope of the caller
     pub fn start_function(&mut self) {
-        self.0.push(ScopeTree::new())
+        self.0.push(ScopeTree::default())
     }
     /// Ending a function requires that we removes it's whole tree of scope
     /// This is by design the current scope, which is the last element in the vector
@@ -177,7 +165,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
 
 impl<K: std::hash::Hash + Eq + Clone, V> Default for ScopeForest<K, V> {
     fn default() -> Self {
-        Self::new()
+        ScopeForest(vec![ScopeTree::default()])
     }
 }
 

--- a/crates/noirc_frontend/src/main.rs
+++ b/crates/noirc_frontend/src/main.rs
@@ -8,7 +8,7 @@ use noirc_frontend::hir::{self, def_map::ModuleDefId};
 // XXX: This is another sandbox test
 fn main() {
     // File Manager
-    let mut fm = FileManager::new();
+    let mut fm = FileManager::default();
     //
     // Add root file to file manager
     let dir_path: PathBuf = PathBuf::from("example_project/lib.nr");


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/noir/issues/874

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

# Description

See `Constructors` section of the guide in the issue 

## Summary of changes

1. Add `impl Default` to `new()` functions that do not take inputs. 
2. Change `new()` to call the default function. (update: remove empty new())
// 3. `vec![]` to `Vec::new()` (discarded this change)

// I'm not sure if removing `new()` functions is a good idea (this seems to be what the guide is suggesting from my //understanding) so I changed them to calling the `default` function.

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
