### PR TITLE
chore: remove clone when using preprocessed keys

### DIFF
--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -202,7 +202,7 @@ fn fetch_pk_and_vk<P: AsRef<Path>>(
         acir_hash_path.set_extension(ACIR_EXT.to_owned() + ".sha256");
         let expected_acir_hash = load_hex_data(acir_hash_path.clone())?;
 
-        let new_acir_hash = hash_constraint_system(&circuit);
+        let new_acir_hash = hash_constraint_system(circuit);
 
         if new_acir_hash[..] != expected_acir_hash {
             return Err(CliError::MismatchedAcir(acir_hash_path));

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -190,7 +190,7 @@ pub fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, CliError> {
 }
 
 fn fetch_pk_and_vk<P: AsRef<Path>>(
-    circuit: Circuit,
+    circuit: &Circuit,
     circuit_build_path: Option<P>,
     prove_circuit: bool,
     check_proof: bool,
@@ -233,7 +233,7 @@ fn fetch_pk_and_vk<P: AsRef<Path>>(
         Ok((proving_key, verification_key))
     } else {
         // If a path to the circuit's build dir has not been provided, run preprocess and generate the proving and verification keys
-        let (proving_key, verification_key) = backend.preprocess(circuit);
+        let (proving_key, verification_key) = backend.preprocess(circuit.clone());
         Ok((proving_key, verification_key))
     }
 }

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -73,12 +73,8 @@ pub fn prove_with_path<P: AsRef<Path>>(
 ) -> Result<Option<PathBuf>, CliError> {
     let compiled_program =
         super::compile_cmd::compile_circuit(program_dir.as_ref(), show_ssa, allow_warnings)?;
-    let (proving_key, verification_key) = fetch_pk_and_vk(
-        compiled_program.circuit.clone(),
-        circuit_build_path.as_ref(),
-        true,
-        check_proof,
-    )?;
+    let (proving_key, verification_key) =
+        fetch_pk_and_vk(&compiled_program.circuit, circuit_build_path.as_ref(), true, check_proof)?;
 
     // Parse the initial witness values from Prover.toml
     let inputs_map = read_inputs_from_file(

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -63,7 +63,7 @@ pub fn verify_with_path<P: AsRef<Path>>(
 ) -> Result<bool, CliError> {
     let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa, allow_warnings)?;
     let (_, verification_key) =
-        fetch_pk_and_vk(compiled_program.circuit.clone(), circuit_build_path, false, true)?;
+        fetch_pk_and_vk(&compiled_program.circuit, circuit_build_path, false, true)?;
 
     // Load public inputs (if any) from `VERIFIER_INPUT_FILE`.
     let public_abi = compiled_program.abi.clone().public_abi();


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

`fetch_pk_and_vk` only needs ownership of the circuit if we don't have any preprocessed keys (in order to generate them using the backend). We can delay cloning the circuit until we've checked for if we have preprocessed keys and avoid this clone when we don't need it.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
