### PR TITLE
chore: remove `witness` flag from `nargo compile`

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -90,7 +90,7 @@ pub fn compile_circuit<P: AsRef<Path>>(
         .map_err(|_| std::process::exit(1))
 }
 
-pub fn preprocess_with_path<P: AsRef<Path>>(
+fn preprocess_with_path<P: AsRef<Path>>(
     key_name: &str,
     preprocess_dir: P,
     circuit: Circuit,

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -1,13 +1,11 @@
 use acvm::ProofSystemCompiler;
 use acvm::{acir::circuit::Circuit, hash_constraint_system};
-use noirc_abi::input_parser::Format;
 use std::path::{Path, PathBuf};
 
 use clap::Args;
 
 use crate::{
-    cli::{execute_cmd::save_witness_to_dir, read_inputs_from_file},
-    constants::{ACIR_EXT, PK_EXT, PROVER_INPUT_FILE, TARGET_DIR, VK_EXT},
+    constants::{ACIR_EXT, PK_EXT, TARGET_DIR, VK_EXT},
     errors::CliError,
     resolver::Resolver,
 };
@@ -20,10 +18,6 @@ pub(crate) struct CompileCommand {
     /// The name of the ACIR file
     circuit_name: String,
 
-    /// Solve the witness and write it to file along with the ACIR
-    #[arg(short, long)]
-    witness: bool,
-
     /// Issue a warning for each unused variable instead of an error
     #[arg(short, long)]
     allow_warnings: bool,
@@ -33,45 +27,28 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
     let mut circuit_path = config.program_dir.clone();
     circuit_path.push(TARGET_DIR);
 
-    generate_circuit_and_witness_to_disk(
+    let circuit_path = compile_and_preprocess_circuit(
         &args.circuit_name,
         config.program_dir,
         circuit_path,
-        args.witness,
         args.allow_warnings,
-    )
-    .map(|_| ())
+    )?;
+
+    println!("Generated ACIR code into {}", circuit_path.display());
+
+    Ok(())
 }
 
-pub fn generate_circuit_and_witness_to_disk<P: AsRef<Path>>(
+fn compile_and_preprocess_circuit<P: AsRef<Path>>(
     circuit_name: &str,
     program_dir: P,
     circuit_dir: P,
-    generate_witness: bool,
     allow_warnings: bool,
 ) -> Result<PathBuf, CliError> {
-    let compiled_program = compile_circuit(program_dir.as_ref(), false, allow_warnings)?;
+    let compiled_program = compile_circuit(program_dir, false, allow_warnings)?;
+    let circuit_path = save_acir_to_dir(&compiled_program.circuit, circuit_name, &circuit_dir);
 
-    preprocess_with_path(circuit_name, circuit_dir.as_ref(), compiled_program.circuit.clone())?;
-
-    let mut circuit_path =
-        save_acir_to_dir(compiled_program.circuit.clone(), circuit_name, circuit_dir.as_ref());
-    println!("Generated ACIR code into {}", circuit_path.display());
-
-    if generate_witness {
-        // Parse the initial witness values from Prover.toml
-        let inputs_map = read_inputs_from_file(
-            program_dir,
-            PROVER_INPUT_FILE,
-            Format::Toml,
-            &compiled_program.abi,
-        )?;
-
-        let solved_witness = super::execute_cmd::execute_program(&compiled_program, &inputs_map)?;
-
-        circuit_path.pop();
-        save_witness_to_dir(solved_witness, circuit_name, &circuit_path)?;
-    }
+    preprocess_with_path(circuit_name, circuit_dir, compiled_program.circuit)?;
 
     Ok(circuit_path)
 }
@@ -108,7 +85,7 @@ fn preprocess_with_path<P: AsRef<Path>>(
 }
 
 fn save_acir_to_dir<P: AsRef<Path>>(
-    circuit: Circuit,
+    circuit: &Circuit,
     circuit_name: &str,
     circuit_dir: P,
 ) -> PathBuf {
@@ -116,7 +93,7 @@ fn save_acir_to_dir<P: AsRef<Path>>(
     circuit_path.push(circuit_name);
 
     // Save a checksum of the circuit to compare against during proving and verification
-    let acir_hash = hash_constraint_system(&circuit);
+    let acir_hash = hash_constraint_system(circuit);
     circuit_path.set_extension(ACIR_EXT.to_owned() + ".sha256");
     write_to_file(hex::encode(acir_hash).as_bytes(), &circuit_path);
 


### PR DESCRIPTION
# Related issue(s)

Resolves #877 

# Description

## Summary of changes

This PR removes the ability to save a witness to file from the `nargo compile` command. This should instead be done through the `nargo execute` command for reasons stated in the issue.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [x] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
