### PR TITLE
fix!: prevent inconsistent language usage in `Driver`

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -62,9 +62,7 @@ pub fn compile_circuit<P: AsRef<Path>>(
     let mut driver = Resolver::resolve_root_config(program_dir.as_ref(), backend.np_language())?;
     add_std_lib(&mut driver);
 
-    driver
-        .into_compiled_program(backend.np_language(), show_ssa, allow_warnings)
-        .map_err(|_| std::process::exit(1))
+    driver.into_compiled_program(show_ssa, allow_warnings).map_err(|_| std::process::exit(1))
 }
 
 fn preprocess_with_path<P: AsRef<Path>>(

--- a/crates/nargo/src/cli/test_cmd.rs
+++ b/crates/nargo/src/cli/test_cmd.rs
@@ -91,10 +91,9 @@ fn run_test(
     show_output: bool,
 ) -> Result<(), CliError> {
     let backend = crate::backends::ConcreteBackend;
-    let language = backend.np_language();
 
     let program = driver
-        .compile_no_check(language, false, allow_warnings, Some(main), show_output)
+        .compile_no_check(false, allow_warnings, Some(main), show_output)
         .map_err(|_| CliError::Generic(format!("Test '{test_name}' failed to compile")))?;
 
     let mut solved_witness = BTreeMap::new();

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 
 pub struct Driver {
     context: Context,
+    language: Language,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -25,8 +26,8 @@ pub struct CompiledProgram {
 }
 
 impl Driver {
-    pub fn new(np_language: &acvm::Language) -> Self {
-        let mut driver = Driver { context: Context::default() };
+    pub fn new(np_language: &Language) -> Self {
+        let mut driver = Driver { context: Context::default(), language: np_language.clone() };
         driver.context.def_interner.set_language(np_language);
         driver
     }
@@ -37,9 +38,7 @@ impl Driver {
         let mut driver = Driver::new(&np_language);
         driver.create_local_crate(root_file, CrateType::Binary);
 
-        driver
-            .into_compiled_program(np_language, false, false)
-            .unwrap_or_else(|_| std::process::exit(1))
+        driver.into_compiled_program(false, false).unwrap_or_else(|_| std::process::exit(1))
     }
 
     /// Compiles a file and returns true if compilation was successful
@@ -146,19 +145,17 @@ impl Driver {
 
     pub fn into_compiled_program(
         mut self,
-        np_language: acvm::Language,
         show_ssa: bool,
         allow_warnings: bool,
     ) -> Result<CompiledProgram, ReportedError> {
         self.check_crate(allow_warnings)?;
-        self.compile_no_check(np_language, show_ssa, allow_warnings, None, true)
+        self.compile_no_check(show_ssa, allow_warnings, None, true)
     }
 
     /// Compile the current crate. Assumes self.check_crate is called beforehand!
     #[allow(deprecated)]
     pub fn compile_no_check(
         &self,
-        np_language: acvm::Language,
         show_ssa: bool,
         allow_warnings: bool,
         // Optional override to provide a different `main` function to start execution
@@ -183,6 +180,7 @@ impl Driver {
 
         let program = monomorphize(main_function, &self.context.def_interner);
 
+        let np_language = self.language.clone();
         let blackbox_supported = acvm::default_is_black_box_supported(np_language.clone());
 
         match create_circuit(program, np_language, blackbox_supported, show_ssa, show_output) {

--- a/crates/noirc_driver/src/main.rs
+++ b/crates/noirc_driver/src/main.rs
@@ -18,5 +18,5 @@ fn main() {
     driver.add_dep(LOCAL_CRATE, crate_id1, "coo4");
     driver.add_dep(LOCAL_CRATE, crate_id2, "coo3");
 
-    driver.into_compiled_program(acvm::Language::R1CS, false, false).ok();
+    driver.into_compiled_program(false, false).ok();
 }


### PR DESCRIPTION
# Related issue(s)

Resolves #880 

# Description

## Summary of changes

I've removed `np_language` from the interface of `Driver` and it now just uses the locally stored language when compiling.

**We could make this a non-breaking change** by maintaining the same interface while adding an `assert_eq(np_language, &self.langauge)` to each method which uses it. My feeling however is that we're going to be the only consumer of this API currently so we can make this breaking change safely.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
