### PR TITLE
fix(abi): ensure that return value is loaded from toml

### DIFF
--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -1,5 +1,5 @@
 use super::InputValue;
-use crate::{errors::InputParserError, Abi, AbiType};
+use crate::{errors::InputParserError, Abi, AbiType, MAIN_RETURN_NAME};
 use acvm::FieldElement;
 use iter_extended::{btree_map, try_btree_map, try_vecmap, vecmap};
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,10 @@ pub(crate) fn parse_toml(
     // When parsing the toml map we recursively go through each field to enable struct inputs.
     // To match this map with the correct abi type we reorganize our abi by parameter name in a BTreeMap, while the struct fields
     // in the abi are already stored in a BTreeMap.
-    let abi_map = abi.to_btree_map();
+    let mut abi_map = abi.to_btree_map();
+    if let Some(return_type) = &abi.return_type {
+        abi_map.insert(MAIN_RETURN_NAME.to_owned(), return_type.to_owned());
+    }
 
     // Convert arguments to field elements.
     try_btree_map(data, |(key, value)| {


### PR DESCRIPTION
# Related issue(s)

Resolves https://github.com/noir-lang/noir/pull/860#pullrequestreview-1306415549

# Description

## Summary of changes

When loading inputs from toml we need their `AbiType` to be included in the map `abi_map`. Due to #865, this doesn't get inserted automatically so we panic when loading return values.

We now insert the return type into the map so we can load toml files correctly again.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
