### PR TITLE
chore: encapsulate IO logic in IO functions

### DIFF
--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -57,7 +57,7 @@ fn execute_with_path<P: AsRef<Path>>(
     let compiled_program = compile_circuit(&program_dir, show_ssa, allow_warnings)?;
 
     // Parse the initial witness values from Prover.toml
-    let inputs_map = read_inputs_from_file(
+    let (inputs_map, _) = read_inputs_from_file(
         &program_dir,
         PROVER_INPUT_FILE,
         Format::Toml,

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -164,14 +164,14 @@ pub fn write_inputs_to_file<P: AsRef<Path>>(
 
     // We must insert the return value into the `InputMap` in order for it to be written to file.
     let serialized_output = match return_value {
-        // We don't want to modify the original map as this is an I/O implementation detail.
-        // We must then clone the map before insertion.
+        // Parameters and return values are kept separate except for when they're being written to file.
+        // As a result, we don't want to modify the original map and must clone it before insertion.
         Some(return_value) => {
             let mut input_map = input_map.clone();
             input_map.insert(MAIN_RETURN_NAME.to_owned(), return_value.clone());
             format.serialize(&input_map)?
         }
-        // If no return value exists then we can serialize the original map directly.
+        // If no return value exists, then we can serialize the original map directly.
         None => format.serialize(input_map)?,
     };
 

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -156,12 +156,13 @@ pub fn write_inputs_to_file<P: AsRef<Path>>(
     };
 
     // If it exists, insert return value into input map so it's written to file.
-    let serialized_output = if let Some(return_value) = return_value {
-        let mut input_map = input_map.clone();
-        input_map.insert(MAIN_RETURN_NAME.to_owned(), return_value.clone());
-        format.serialize(&input_map)?
-    } else {
-        format.serialize(input_map)?
+    let serialized_output = match return_value {
+        Some(return_value) => {
+            let mut input_map = input_map.clone();
+            input_map.insert(MAIN_RETURN_NAME.to_owned(), return_value.clone());
+            format.serialize(&input_map)?
+        }
+        None => format.serialize(input_map)?,
     };
 
     write_to_file(serialized_output.as_bytes(), &file_path);

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -114,6 +114,13 @@ fn write_to_file(bytes: &[u8], path: &Path) -> String {
     }
 }
 
+/// Returns the circuit's parameters and its return value, if one exists.
+/// # Examples
+///
+/// ```ignore
+/// let (input_map, return_value): (InputMap, Option<InputValue>) =
+///   read_inputs_from_file(path, "Verifier", Format::Toml, &abi)?;
+/// ```
 pub fn read_inputs_from_file<P: AsRef<Path>>(
     path: P,
     file_name: &str,

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -155,13 +155,16 @@ pub fn write_inputs_to_file<P: AsRef<Path>>(
         dir_path
     };
 
-    // If it exists, insert return value into input map so it's written to file.
+    // We must insert the return value into the `InputMap` in order for it to be written to file.
     let serialized_output = match return_value {
+        // We don't want to modify the original map as this is an I/O implementation detail.
+        // We must then clone the map before insertion.
         Some(return_value) => {
             let mut input_map = input_map.clone();
             input_map.insert(MAIN_RETURN_NAME.to_owned(), return_value.clone());
             format.serialize(&input_map)?
         }
+        // If no return value exists then we can serialize the original map directly.
         None => format.serialize(input_map)?,
     };
 

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -9,9 +9,8 @@ use crate::{
 use acvm::{FieldElement, ProofSystemCompiler};
 use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
-use noirc_abi::MAIN_RETURN_NAME;
 use noirc_driver::CompiledProgram;
-use std::{collections::BTreeMap, path::Path};
+use std::path::Path;
 
 /// Given a proof and a program, verify whether the proof is valid
 #[derive(Debug, Clone, Args)]
@@ -67,15 +66,8 @@ pub fn verify_with_path<P: AsRef<Path>>(
 
     // Load public inputs (if any) from `VERIFIER_INPUT_FILE`.
     let public_abi = compiled_program.abi.clone().public_abi();
-    let (public_inputs_map, return_value) = if public_abi.has_public_inputs() {
-        let current_dir = program_dir;
-        let mut public_inputs_map =
-            read_inputs_from_file(current_dir, VERIFIER_INPUT_FILE, Format::Toml, &public_abi)?;
-        let return_value = public_inputs_map.remove(MAIN_RETURN_NAME);
-        (public_inputs_map, return_value)
-    } else {
-        (BTreeMap::new(), None)
-    };
+    let (public_inputs_map, return_value) =
+        read_inputs_from_file(program_dir, VERIFIER_INPUT_FILE, Format::Toml, &public_abi)?;
 
     let valid_proof = verify_proof(
         compiled_program,

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -153,6 +153,11 @@ impl Abi {
         self.return_type.is_some() || self.parameters.iter().any(|param| param.is_public())
     }
 
+    /// Returns `true` if the ABI contains no parameters or return value.
+    pub fn is_empty(&self) -> bool {
+        self.return_type.is_none() && self.parameters.is_empty()
+    }
+
     pub fn to_btree_map(&self) -> BTreeMap<String, AbiType> {
         let mut map = BTreeMap::new();
         for param in self.parameters.iter() {


### PR DESCRIPTION
# Related issue(s)

Resolves # <!-- link to issue -->

# Description

## Summary of changes

We currently had some special logic related to:
- avoiding reading files which we expect to be empty
- splitting off return value from BTreeMap loaded from file / inserting return value to be saved to file.

which exists in the CLI business logic. As this is purely an IO implementation detail I've pushed it inside the relevant helpers.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally. (Tested and confirmed to work in conjunction with #883)
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
