### PR TITLE
fix: compute witness when println evaluated before input

### DIFF
--- a/crates/nargo/tests/test_data/merkle_insert/src/main.nr
+++ b/crates/nargo/tests/test_data/merkle_insert/src/main.nr
@@ -16,6 +16,7 @@ fn main(
     constrain new_leaf_exists == 1;
 
     let h = std::hash::mimc_bn254(mimc_input);
+    // Regression test for PR #891
     std::println(h);
     constrain h == 18226366069841799622585958305961373004333097209608110160936134895615261821931;
 }

--- a/crates/nargo/tests/test_data/merkle_insert/src/main.nr
+++ b/crates/nargo/tests/test_data/merkle_insert/src/main.nr
@@ -16,6 +16,7 @@ fn main(
     constrain new_leaf_exists == 1;
 
     let h = std::hash::mimc_bn254(mimc_input);
+    std::println(h);
     constrain h == 18226366069841799622585958305961373004333097209608110160936134895615261821931;
 }
     

--- a/crates/nargo/tests/test_data/strings/src/main.nr
+++ b/crates/nargo/tests/test_data/strings/src/main.nr
@@ -21,9 +21,6 @@ fn main(message : pub str<11>, y : Field, hex_as_string : str<4>, hex_as_field :
 
     let hash = std::hash::pedersen([x]);
     std::println(hash);
-
-    let mimc_hash = std::hash::mimc_bn254(array);
-    std::println(mimc_hash);
     
     constrain hex_as_string == "0x41";
     // constrain hex_as_string != 0x41; This will fail with a type mismatch between str[4] and Field

--- a/crates/nargo/tests/test_data/strings/src/main.nr
+++ b/crates/nargo/tests/test_data/strings/src/main.nr
@@ -21,6 +21,9 @@ fn main(message : pub str<11>, y : Field, hex_as_string : str<4>, hex_as_field :
 
     let hash = std::hash::pedersen([x]);
     std::println(hash);
+
+    let mimc_hash = std::hash::mimc_bn254(array);
+    std::println(mimc_hash);
     
     constrain hex_as_string == "0x41";
     // constrain hex_as_string != 0x41; This will fail with a type mismatch between str[4] and Field


### PR DESCRIPTION
# Related issue(s)

No issue as found issue while debugging separate project and is a quick fix

# Description

I was attempting to print the hash result of `mimc_bn254` in the std lib, but was hitting an unreachable case in the recently adding `evaluate_println` method in the acir_gen. It looks as though the println was being evaluated before the mimc result thus resulting in a situation where the non-constant expression had no cached witness. 

## Summary of changes

During `evaluate_println` we instead use `get_or_compute_witness` to compute the witness for InternalVar's that do not have a cached_witness rather than panicking. 

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

I tested this by adding a println to the `merkle_insert` test where we check that we can print the mimc hash. I also checked the output of the mimc hash in `merkle_insert`, where the printed output was correct.  

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
- [X] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
