### PR TITLE
feat: Silence output of prove and verify

### DIFF
--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -108,21 +108,17 @@ pub fn prove_with_path<P: AsRef<Path>>(
     let proof =
         backend.prove_with_pk(compiled_program.circuit.clone(), solved_witness, proving_key);
 
-    println!("Proof successfully created");
     if check_proof {
         let valid_proof =
             verify_proof(compiled_program, public_inputs, return_value, &proof, verification_key)?;
-        println!("Proof verified : {valid_proof}");
+
         if !valid_proof {
             return Err(CliError::Generic("Could not verify generated proof".to_owned()));
         }
     }
 
     let proof_path = if let Some(proof_name) = proof_name {
-        let proof_path = save_proof_to_dir(&proof, &proof_name, proof_dir)?;
-
-        println!("Proof saved to {}", proof_path.display());
-        Some(proof_path)
+        Some(save_proof_to_dir(&proof, &proof_name, proof_dir)?)
     } else {
         println!("{}", hex::encode(&proof));
         None

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -109,12 +109,15 @@ pub fn prove_with_path<P: AsRef<Path>>(
         backend.prove_with_pk(compiled_program.circuit.clone(), solved_witness, proving_key);
 
     if check_proof {
-        let valid_proof =
-            verify_proof(compiled_program, public_inputs, return_value, &proof, verification_key)?;
-
-        if !valid_proof {
-            return Err(CliError::Generic("Could not verify generated proof".to_owned()));
-        }
+        let no_proof_name = "".into();
+        verify_proof(
+            compiled_program,
+            public_inputs,
+            return_value,
+            &proof,
+            verification_key,
+            no_proof_name,
+        )?;
     }
 
     let proof_path = if let Some(proof_name) = proof_name {

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -44,12 +44,15 @@ pub(crate) fn run(args: VerifyCommand, config: NargoConfig) -> Result<(), CliErr
 
     let result = verify_with_path(
         config.program_dir,
-        proof_path,
+        proof_path.clone(),
         circuit_build_path,
         false,
         args.allow_warnings,
     )?;
-    println!("Proof verified : {result}");
+
+    if !result {
+        return Err(CliError::ProvingFailed(proof_path));
+    }
 
     Ok(())
 }

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -11,7 +11,10 @@ use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
 use noirc_abi::MAIN_RETURN_NAME;
 use noirc_driver::CompiledProgram;
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 /// Given a proof and a program, verify whether the proof is valid
 #[derive(Debug, Clone, Args)]
@@ -33,37 +36,29 @@ pub(crate) fn run(args: VerifyCommand, config: NargoConfig) -> Result<(), CliErr
     proof_path.push(Path::new(&args.proof));
     proof_path.set_extension(PROOF_EXT);
 
-    let circuit_build_path = if let Some(circuit_name) = args.circuit_name {
+    let circuit_build_path = args.circuit_name.map(|circuit_name| {
         let mut circuit_build_path = config.program_dir.clone();
         circuit_build_path.push(TARGET_DIR);
         circuit_build_path.push(circuit_name);
-        Some(circuit_build_path)
-    } else {
-        None
-    };
+        circuit_build_path
+    });
 
-    let result = verify_with_path(
+    verify_with_path(
         config.program_dir,
         proof_path.clone(),
         circuit_build_path,
         false,
         args.allow_warnings,
-    )?;
-
-    if !result {
-        return Err(CliError::ProvingFailed(proof_path));
-    }
-
-    Ok(())
+    )
 }
 
-pub fn verify_with_path<P: AsRef<Path>>(
+fn verify_with_path<P: AsRef<Path>>(
     program_dir: P,
-    proof_path: P,
+    proof_path: PathBuf,
     circuit_build_path: Option<P>,
     show_ssa: bool,
     allow_warnings: bool,
-) -> Result<bool, CliError> {
+) -> Result<(), CliError> {
     let compiled_program = compile_circuit(program_dir.as_ref(), show_ssa, allow_warnings)?;
     let (_, verification_key) =
         fetch_pk_and_vk(&compiled_program.circuit, circuit_build_path, false, true)?;
@@ -80,15 +75,14 @@ pub fn verify_with_path<P: AsRef<Path>>(
         (BTreeMap::new(), None)
     };
 
-    let valid_proof = verify_proof(
+    verify_proof(
         compiled_program,
         public_inputs_map,
         return_value,
-        &load_hex_data(proof_path)?,
+        &load_hex_data(&proof_path)?,
         verification_key,
-    )?;
-
-    Ok(valid_proof)
+        proof_path,
+    )
 }
 
 pub(crate) fn verify_proof(
@@ -97,7 +91,8 @@ pub(crate) fn verify_proof(
     return_value: Option<InputValue>,
     proof: &[u8],
     verification_key: Vec<u8>,
-) -> Result<bool, CliError> {
+    proof_name: PathBuf,
+) -> Result<(), CliError> {
     let public_abi = compiled_program.abi.public_abi();
     let public_inputs = public_abi.encode(&public_inputs_map, return_value)?;
 
@@ -111,5 +106,9 @@ pub(crate) fn verify_proof(
         verification_key,
     );
 
-    Ok(valid_proof)
+    if valid_proof {
+        Ok(())
+    } else {
+        Err(CliError::InvalidProof(proof_name))
+    }
 }

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -25,8 +25,8 @@ pub enum CliError {
     MissingVerificationkey(PathBuf),
     #[error("Error: the circuit you are trying to prove differs from the build artifact at {}\nYou must call `nargo compile` to generate the correct proving and verification keys for this circuit", .0.display())]
     MismatchedAcir(PathBuf),
-    #[error("Failed to prove {}", .0.display())]
-    ProvingFailed(PathBuf),
+    #[error("Failed to verify proof {}", .0.display())]
+    InvalidProof(PathBuf),
 }
 
 impl From<OpcodeResolutionError> for CliError {

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -25,6 +25,8 @@ pub enum CliError {
     MissingVerificationkey(PathBuf),
     #[error("Error: the circuit you are trying to prove differs from the build artifact at {}\nYou must call `nargo compile` to generate the correct proving and verification keys for this circuit", .0.display())]
     MismatchedAcir(PathBuf),
+    #[error("Failed to prove {}", .0.display())]
+    ProvingFailed(PathBuf),
 }
 
 impl From<OpcodeResolutionError> for CliError {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #873

# Description

## Summary of changes

Silences output of `nargo prove` and `nargo verify`, unless either encounter an error.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [x] This PR requires documentation updates when merged.

# Additional context

If approved, we should likely follow this example and do this for other commands as well, where it makes sense. E.g. `cargo compile`.
