### PR TITLE
fix: correct type checking to handle `false` bools

### DIFF
--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -28,7 +28,9 @@ impl InputValue {
             (InputValue::Field(field_element), AbiType::Integer { width, .. }) => {
                 field_element.num_bits() <= *width
             }
-            (InputValue::Field(field_element), AbiType::Boolean) => field_element.num_bits() <= 1,
+            (InputValue::Field(field_element), AbiType::Boolean) => {
+                field_element.is_one() || field_element.is_zero()
+            }
 
             (InputValue::Vec(field_elements), AbiType::Array { length, typ, .. }) => {
                 if field_elements.len() != *length as usize {

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -28,7 +28,7 @@ impl InputValue {
             (InputValue::Field(field_element), AbiType::Integer { width, .. }) => {
                 field_element.num_bits() <= *width
             }
-            (InputValue::Field(field_element), AbiType::Boolean) => field_element.num_bits() == 1,
+            (InputValue::Field(field_element), AbiType::Boolean) => field_element.num_bits() <= 1,
 
             (InputValue::Vec(field_elements), AbiType::Array { length, typ, .. }) => {
                 if field_elements.len() != *length as usize {


### PR DESCRIPTION
# Related issue(s)

Resolves #889 

# Description

## Summary of changes

`FieldElement.num_bits()` returns 0 for `FieldElement::zero() so the current check for satisfying the AbiType fails. I've relaxed the check to accept 0 or 1 bits to address this.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
