### PR TITLE
fix: allow parsing strings from toml into booleans

### DIFF
--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -93,7 +93,7 @@ impl InputValue {
         let input_value = match value {
             TomlTypes::String(string) => match param_type {
                 AbiType::String { .. } => InputValue::String(string),
-                AbiType::Field | AbiType::Integer { .. } => {
+                AbiType::Field | AbiType::Integer { .. } | AbiType::Boolean => {
                     InputValue::Field(parse_str_to_field(&string)?)
                 }
                 _ => return Err(InputParserError::AbiTypeMismatch(param_type.clone())),


### PR DESCRIPTION
# Related issue(s)

Resolves #890

# Description

## Summary of changes

`AbiType::Boolean` has been added to the necessary match arm to allow parsing.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
