### PR TITLE
fix(nargo): Switch order of writing acir file and acir checksum file

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -90,16 +90,16 @@ fn save_acir_to_dir<P: AsRef<Path>>(
     let mut circuit_path = create_named_dir(circuit_dir.as_ref(), "target");
     circuit_path.push(circuit_name);
 
-    // Save a checksum of the circuit to compare against during proving and verification
-    let acir_hash = hash_constraint_system(circuit);
-    circuit_path.set_extension(ACIR_EXT.to_owned() + ".sha256");
-    write_to_file(hex::encode(acir_hash).as_bytes(), &circuit_path);
-
     let mut serialized = Vec::new();
     circuit.write(&mut serialized).expect("could not serialize circuit");
 
     circuit_path.set_extension(ACIR_EXT);
     write_to_file(serialized.as_slice(), &circuit_path);
+
+    // Save a checksum of the circuit to compare against during proving and verification
+    let acir_hash = hash_constraint_system(circuit);
+    circuit_path.set_extension(ACIR_EXT.to_owned() + ".sha256");
+    write_to_file(hex::encode(acir_hash).as_bytes(), &circuit_path);
 
     circuit_path
 }


### PR DESCRIPTION
# Related issue(s)

Quick fix found while working on a separate project so no issue

# Description

During `nargo compile` the checksum file is being written first followed by the acir file. We set an extension `.acir.sha256` for the sha checksum. When we reset the extension we were mistakenly only resetting the last extension of `.sha256` so the acir file being written to `target` was `.acir.acir`. 

## Summary of changes

We write the ACIR file followed by the checksum now. Running `nargo compile p` for example will now correctly give `p.acir` and `p.acir.sha256`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
- [X] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
