### PR TITLE
fix(noir_wasm): Update wasm ACIR serialization

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -28,7 +28,11 @@ pub fn compile(src: String) -> JsValue {
     let compiled_program = noirc_driver::Driver::compile_file(path, language);
     <JsValue as JsValueSerdeExt>::from_serde(&compiled_program).unwrap()
 }
+
 // Deserializes bytes into ACIR structure
+#[deprecated(
+    note = "we have moved away from this serialization strategy. Call `acir_read_bytes` instead"
+)]
 #[wasm_bindgen]
 pub fn acir_from_bytes(bytes: Vec<u8>) -> JsValue {
     console_error_panic_hook::set_once();
@@ -36,6 +40,9 @@ pub fn acir_from_bytes(bytes: Vec<u8>) -> JsValue {
     <JsValue as JsValueSerdeExt>::from_serde(&circuit).unwrap()
 }
 
+#[deprecated(
+    note = "we have moved away from this serialization strategy. Call `acir_write_bytes` instead"
+)]
 #[wasm_bindgen]
 pub fn acir_to_bytes(acir: JsValue) -> Vec<u8> {
     console_error_panic_hook::set_once();
@@ -65,5 +72,3 @@ pub fn build_info() -> JsValue {
     console_error_panic_hook::set_once();
     <JsValue as JsValueSerdeExt>::from_serde(&BUILD_INFO).unwrap()
 }
-
-

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -43,8 +43,27 @@ pub fn acir_to_bytes(acir: JsValue) -> Vec<u8> {
     circuit.to_bytes()
 }
 
+// Deserializes bytes into ACIR structure
+#[wasm_bindgen]
+pub fn acir_read_bytes(bytes: Vec<u8>) -> JsValue {
+    console_error_panic_hook::set_once();
+    let circuit = Circuit::read(&*bytes).unwrap();
+    <JsValue as JsValueSerdeExt>::from_serde(&circuit).unwrap()
+}
+
+#[wasm_bindgen]
+pub fn acir_write_bytes(acir: JsValue) -> Vec<u8> {
+    console_error_panic_hook::set_once();
+    let circuit: Circuit = JsValueSerdeExt::into_serde(&acir).unwrap();
+    let mut bytes = Vec::new();
+    circuit.write(&mut bytes).unwrap();
+    bytes
+}
+
 #[wasm_bindgen]
 pub fn build_info() -> JsValue {
     console_error_panic_hook::set_once();
     <JsValue as JsValueSerdeExt>::from_serde(&BUILD_INFO).unwrap()
 }
+
+


### PR DESCRIPTION
# Related issue(s)

No issue yet as discovered while quickly iterating development

Resolves #

# Description

We switched to using `read` and `write` on a `Circuit` in Noir. 

## Summary of changes

I switched the `noir_wasm` to use `Circuit::read` and and `circuit.write` instead of `Circuit::from_bytes` and `circuit.to_bytes()`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
