### PR TITLE
feat: add support for reading boolean arrays from toml

### DIFF
--- a/crates/nargo/tests/test_data/main_bool_arg/Prover.toml
+++ b/crates/nargo/tests/test_data/main_bool_arg/Prover.toml
@@ -1,1 +1,2 @@
 x = true
+y = [true, false]

--- a/crates/nargo/tests/test_data/main_bool_arg/src/main.nr
+++ b/crates/nargo/tests/test_data/main_bool_arg/src/main.nr
@@ -1,6 +1,8 @@
-fn main(x : bool) {
+fn main(x : bool, y: [bool;2]) {
     if x {
         constrain 1 != 2;
     }
+
     constrain x;
+    constrain y[0] != y[1];
 }

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -60,6 +60,8 @@ enum TomlTypes {
     ArrayNum(Vec<u64>),
     // Array of hexadecimal integers
     ArrayString(Vec<String>),
+    // Array of booleans
+    ArrayBool(Vec<bool>),
     // Struct of TomlTypes
     Table(BTreeMap<String, TomlTypes>),
 }
@@ -119,6 +121,18 @@ impl InputValue {
 
                 InputValue::Vec(array_elements)
             }
+            TomlTypes::ArrayBool(arr_bool) => {
+                let array_elements = vecmap(arr_bool, |elem_bool| {
+                    if elem_bool {
+                        FieldElement::one()
+                    } else {
+                        FieldElement::zero()
+                    }
+                });
+
+                InputValue::Vec(array_elements)
+            }
+
             TomlTypes::Table(table) => {
                 let fields = match param_type {
                     AbiType::Struct { fields } => fields,


### PR DESCRIPTION
# Related issue(s)

Resolves #844 

# Description

## Summary of changes

We previously didn't support loading arrays of booleans from toml which makes it very annoying to have an array of bools in your ABI. I've added the necessary `TomlType` to support this along with a test.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
