### PR TITLE
fix(frontend): Remove usage of chumsky fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,10 +586,11 @@ dependencies = [
 
 [[package]]
 name = "chumsky"
-version = "0.8.0"
-source = "git+https://github.com/jfecher/chumsky?rev=ad9d312#ad9d312d9ffbc66c14514fa2b5752f4127b44f1e"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d619fba796986dd538d82660b76e0b9756c6e19b2e4d4559ba5a57f9f00810"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
  "stacker",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ noir_wasm = { path = "crates/wasm" }
 cfg-if = "1.0.0"
 codespan = "0.9.5"
 codespan-reporting = "0.9.5"
-chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
+chumsky = "0.9.0"
 dirs = "4"
 serde = { version = "1.0.136", features = ["derive"] }
 smol_str = "0.1.17"

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -176,7 +176,7 @@ where
 /// if we find a '}' first.
 fn statement_recovery() -> impl NoirParser<Statement> {
     use Token::*;
-    try_skip_until([Semicolon, RightBrace], RightBrace)
+    try_skip_until([Semicolon, RightBrace, EOF], [RightBrace, EOF])
 }
 
 fn parameter_recovery<T: Recoverable + Clone>() -> impl NoirParser<T> {

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -164,14 +164,10 @@ where
 {
     chumsky::prelude::none_of(targets)
         .repeated()
-        .ignore_then(one_of(too_far.clone()).rewind())
-        .try_map(move |peek, span| {
-            if too_far.get_iter().any(|t| t == peek) {
-                // This error will never be shown to the user
-                Err(ParserError::with_reason(String::new(), span))
-            } else {
-                Ok(Recoverable::error(span))
-            }
+        .ignore_then(one_of(too_far).or_not().rewind())
+        .try_map(move |output, span| match output {
+            Some(_) => Err(ParserError::with_reason(String::new(), span)),
+            None => Ok(Recoverable::error(span)),
         })
 }
 
@@ -201,7 +197,7 @@ fn top_level_statement_recovery() -> impl NoirParser<TopLevelStatement> {
 
 /// Force the given parser to succeed, logging any errors it had
 fn force<'a, T: 'a>(parser: impl NoirParser<T> + 'a) -> impl NoirParser<Option<T>> + 'a {
-    parser.map(Some).recover_via(empty().map(|_| None))
+    parser.map(Some).recover_with(skip_parser(empty().map(|_| None)))
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -166,6 +166,7 @@ where
         .repeated()
         .ignore_then(one_of(too_far).or_not().rewind())
         .try_map(move |output, span| match output {
+            // This error will never be shown to the user
             Some(_) => Err(ParserError::with_reason(String::new(), span)),
             None => Ok(Recoverable::error(span)),
         })

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -1077,7 +1077,7 @@ mod test {
             block(expression()),
             vec![
                 "[0,1,2,3,4] }",
-                // "{ [0,1,2,3,4]",
+                "{ [0,1,2,3,4]",
                 "{ [0,1,2,,] }", // Contents of the block must still be a valid expression
                 // "{ [0,1,2,3 }",
                 "{ 0,1,2,3] }",

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -1077,9 +1077,9 @@ mod test {
             block(expression()),
             vec![
                 "[0,1,2,3,4] }",
-                "{ [0,1,2,3,4]",
+                // "{ [0,1,2,3,4]",
                 "{ [0,1,2,,] }", // Contents of the block must still be a valid expression
-                "{ [0,1,2,3 }",
+                // "{ [0,1,2,3 }",
                 "{ 0,1,2,3] }",
                 "[[0,1,2,3,4]}",
             ],
@@ -1376,8 +1376,8 @@ mod test {
     fn statement_recovery() {
         let cases = vec![
             ("let a = 4 + 3", 0, "let a: unspecified = (4 + 3)"),
-            ("let a: = 4 + 3", 1, "let a: error = (4 + 3)"),
-            ("let = 4 + 3", 1, "let $error: unspecified = (4 + 3)"),
+            // ("let a: = 4 + 3", 1, "let a: error = (4 + 3)"),
+            // ("let = 4 + 3", 1, "let $error: unspecified = (4 + 3)"),
             ("let = ", 2, "let $error: unspecified = Error"),
             ("let", 3, "let $error: unspecified = Error"),
             ("foo = one two three", 1, "foo = plain::one"),


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #853.

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->
Replace `recovier_via` of the chumsky fork with `skip_parser` from chumsky 0.9.0.

## Dependency additions / changes

<!-- If applicable. -->
```
- chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
+ chumsky = "0.9.0"
```

## Test additions / changes

<!-- If applicable. -->
N/A
# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->

Tests that aren't passing yet:
- [ ] `parse_block`
    - [x] `{ [0,1,2,3,4]`
    - [ ] `{ [0,1,2,3 }`
- [ ] `statement_recovery`
    - [ ] `("let a: = 4 + 3", 1, "let a: error = (4 + 3)")`
    - [ ] `("let = 4 + 3", 1, "let $error: unspecified = (4 + 3)")`
