### PR TITLE
chore: add test for Keyword::lookup_keyword completeness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,8 @@ dependencies = [
  "noirc_errors",
  "rustc-hash",
  "smol_str",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -2985,6 +2987,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/crates/noirc_frontend/Cargo.toml
+++ b/crates/noirc_frontend/Cargo.toml
@@ -17,3 +17,7 @@ chumsky.workspace = true
 thiserror.workspace = true
 smol_str.workspace = true
 rustc-hash = "1.1.0"
+
+[dev-dependencies]
+strum = "0.24"
+strum_macros = "0.24"

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -402,6 +402,7 @@ impl AsRef<str> for Attribute {
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Copy, Clone, PartialOrd, Ord)]
+#[cfg_attr(test, derive(strum_macros::EnumIter))]
 // Special Keywords allowed in the target language
 pub enum Keyword {
     As,
@@ -499,6 +500,29 @@ impl Keyword {
         };
 
         Some(Token::Keyword(keyword))
+    }
+}
+
+#[cfg(test)]
+mod keywords {
+    use strum::IntoEnumIterator;
+
+    use super::{Keyword, Token};
+
+    #[test]
+    fn lookup_consistency() {
+        for keyword in Keyword::iter() {
+            let resolved_token =
+                Keyword::lookup_keyword(&format!("{keyword}")).unwrap_or_else(|| {
+                    panic!("Keyword::lookup_keyword couldn't find Keyword {}", keyword)
+                });
+
+            assert_eq!(
+                resolved_token,
+                Token::Keyword(keyword),
+                "Keyword::lookup_keyword returns unexpected Keyword"
+            )
+        }
     }
 }
 


### PR DESCRIPTION
# Related issue(s)

Addresses review comment https://github.com/noir-lang/noir/pull/903#discussion_r1116349549

# Description

## Summary of changes

I've added a test so that the `std::fmt:Display` of any `Keyword` can be looked up to recover the original keyword token.

This follows the pattern used here: https://github.com/noir-lang/acvm/blob/f57ba57c2bb2597edf2b02fb1321c69cf11993ee/acir/src/circuit/black_box_functions.rs#L200-L211

`Keyword::lookup_keyword` also includes some non-keyword entries which might benefit from being split off. Tthey don't entirely gel with the purpose of this function and require us to return an `Option<Token>` rather than an `Option<Keyword>` which is what I would expect.

## Dependency additions / changes

I've added strum as a dev dependency

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
