### PR TITLE
fix: evaluate constant division

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
@@ -145,17 +145,24 @@ pub(crate) fn evaluate(
                 let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
                 let mut r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 let predicate = get_predicate(var_cache,binary, evaluator, ctx).expression().clone();
-                //TODO avoid creating witnesses here.
-                let x_witness = r_c.get_or_compute_witness(evaluator, false).expect("unexpected constant expression"); 
-
-                let inverse = Expression::from(&constraints::evaluate_inverse(
-                    x_witness, &predicate, evaluator,
-                ));
-                InternalVar::from(constraints::mul_with_witness(
-                    evaluator,
-                    l_c.expression(),
-                    &inverse,
-                ))
+                if let Some(r_value) = r_c.to_const() {
+                    if r_value.is_zero() {
+                        panic!("Panic - division by zero");
+                    } else {
+                        constraints::add(&Expression::zero(), r_value.inverse(), l_c.expression()).into()
+                    }
+                } else {
+                    //TODO avoid creating witnesses here.
+                    let x_witness = r_c.get_or_compute_witness(evaluator, false).expect("unexpected constant expression"); 
+                    let inverse = Expression::from(&constraints::evaluate_inverse(
+                        x_witness, &predicate, evaluator,
+                    ));
+                    InternalVar::from(constraints::mul_with_witness(
+                        evaluator,
+                        l_c.expression(),
+                        &inverse,
+                    ))
+                }
             }
             BinaryOp::Eq => {
                 let l_c = var_cache.get_or_compute_internal_var(binary.lhs, evaluator, ctx);


### PR DESCRIPTION


# Description

## Summary of changes

Fix constant division by evaluating it at compile time


## Test additions / changes

The test that raised the error is too complex to be included as a unit test, although it is most certainly possible to get a simple test with some research, I don't think it matters considering the fix. For the record the constant value was coming from evaluating a  condition with predicate.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

The division by 0 panic should become a user error but it should be done when we refactor the acir_gen pass to add error handling.