### PR TITLE
chore(nargo)!: restrict `CliError` visibility to crate

### DIFF
--- a/crates/nargo/src/cli/check_cmd.rs
+++ b/crates/nargo/src/cli/check_cmd.rs
@@ -26,7 +26,7 @@ pub(crate) fn run(args: CheckCommand, config: NargoConfig) -> Result<(), CliErro
     Ok(())
 }
 // This is exposed so that we can run the examples and verify that they pass
-pub fn check_from_path<P: AsRef<Path>>(p: P, allow_warnings: bool) -> Result<(), CliError> {
+fn check_from_path<P: AsRef<Path>>(p: P, allow_warnings: bool) -> Result<(), CliError> {
     let backend = crate::backends::ConcreteBackend;
 
     let mut driver = Resolver::resolve_root_config(p.as_ref(), backend.np_language())?;

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -50,7 +50,7 @@ fn compile_and_preprocess_circuit<P: AsRef<Path>>(
     Ok(circuit_path)
 }
 
-pub fn compile_circuit<P: AsRef<Path>>(
+pub(crate) fn compile_circuit<P: AsRef<Path>>(
     program_dir: P,
     show_ssa: bool,
     allow_warnings: bool,

--- a/crates/nargo/src/cli/fs/inputs.rs
+++ b/crates/nargo/src/cli/fs/inputs.rs
@@ -15,7 +15,7 @@ use super::write_to_file;
 /// let (input_map, return_value): (InputMap, Option<InputValue>) =
 ///   read_inputs_from_file(path, "Verifier", Format::Toml, &abi)?;
 /// ```
-pub fn read_inputs_from_file<P: AsRef<Path>>(
+pub(crate) fn read_inputs_from_file<P: AsRef<Path>>(
     path: P,
     file_name: &str,
     format: Format,
@@ -42,7 +42,7 @@ pub fn read_inputs_from_file<P: AsRef<Path>>(
     Ok((input_map, return_value))
 }
 
-pub fn write_inputs_to_file<P: AsRef<Path>>(
+pub(crate) fn write_inputs_to_file<P: AsRef<Path>>(
     input_map: &InputMap,
     return_value: &Option<InputValue>,
     path: P,

--- a/crates/nargo/src/cli/fs/mod.rs
+++ b/crates/nargo/src/cli/fs/mod.rs
@@ -37,7 +37,7 @@ pub(crate) fn write_to_file(bytes: &[u8], path: &Path) -> String {
     }
 }
 
-pub fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, CliError> {
+pub(crate) fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, CliError> {
     let hex_data: Vec<_> =
         std::fs::read(&path).map_err(|_| CliError::PathNotValid(path.as_ref().to_path_buf()))?;
 

--- a/crates/nargo/src/cli/gates_cmd.rs
+++ b/crates/nargo/src/cli/gates_cmd.rs
@@ -23,7 +23,7 @@ pub(crate) fn run(args: GatesCommand, config: NargoConfig) -> Result<(), CliErro
     count_gates_with_path(config.program_dir, args.show_ssa, args.allow_warnings)
 }
 
-pub fn count_gates_with_path<P: AsRef<Path>>(
+fn count_gates_with_path<P: AsRef<Path>>(
     program_dir: P,
     show_ssa: bool,
     allow_warnings: bool,

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -1,4 +1,3 @@
-pub use check_cmd::check_from_path;
 use clap::{Args, Parser, Subcommand};
 use const_format::formatcp;
 use noirc_abi::InputMap;

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -64,7 +64,7 @@ pub(crate) fn run(args: ProveCommand, config: NargoConfig) -> Result<(), CliErro
     Ok(())
 }
 
-pub fn prove_with_path<P: AsRef<Path>>(
+pub(crate) fn prove_with_path<P: AsRef<Path>>(
     proof_name: Option<String>,
     program_dir: P,
     proof_dir: P,

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -6,7 +6,7 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum CliError {
+pub(crate) enum CliError {
     #[error("{0}")]
     Generic(String),
     #[error("Error: destination {} already exists", .0.display())]

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -19,10 +19,6 @@ pub(crate) enum CliError {
         " Error: cannot find {0}.toml file.\n Expected location: {1:?} \n Please generate this file at the expected location."
     )]
     MissingTomlFile(String, PathBuf),
-    #[error("Error: cannot find proving key located at {}\nEither run `nargo compile` to generate the missing proving key or check that the correct file name has been provided", .0.display())]
-    MissingProvingKey(PathBuf),
-    #[error("Error: cannot find verification key located at {}\nEither run `nargo compile` to generate the missing verification key or check that the correct file name has been provided", .0.display())]
-    MissingVerificationkey(PathBuf),
     #[error("Error: the circuit you are trying to prove differs from the build artifact at {}\nYou must call `nargo compile` to generate the correct proving and verification keys for this circuit", .0.display())]
     MismatchedAcir(PathBuf),
     #[error("Failed to verify proof {}", .0.display())]

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -35,7 +35,7 @@ struct CachedDep {
 /// or it uses the repo on the cache.
 /// Downloading will be recursive, so if a package contains packages
 /// We need to download those too
-pub struct Resolver<'a> {
+pub(crate) struct Resolver<'a> {
     cached_packages: HashMap<PathBuf, (CrateId, CachedDep)>,
     driver: &'a mut Driver,
 }

--- a/crates/nargo/src/toml.rs
+++ b/crates/nargo/src/toml.rs
@@ -51,7 +51,7 @@ pub enum Dependency {
 /// Parses a Nargo.toml file from it's path
 /// The path to the toml file must be present.
 /// Calling this function without this guarantee is an ICE.
-pub fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<Config, CliError> {
+pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<Config, CliError> {
     let toml_as_string =
         std::fs::read_to_string(&path_to_toml).expect("ice: path given for toml file is invalid");
 


### PR DESCRIPTION
# Related issue(s)

Followup to #907 

# Description

## Summary of changes

`CliError` shouldn't be made public so I've adjusted its visibility to ensure that it stays only visible within the crate. I've had to adjust the visibility of other functions to match ~~(we don't change the crate's interface doing this however)~~.

This PR is technically breaking as we've removed the `check_from_path` from the crate interface.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
