### PR TITLE
chore: silence deprecation warnings in wasm crate

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -33,6 +33,7 @@ pub fn compile(src: String) -> JsValue {
 #[deprecated(
     note = "we have moved away from this serialization strategy. Call `acir_read_bytes` instead"
 )]
+#[allow(deprecated)]
 #[wasm_bindgen]
 pub fn acir_from_bytes(bytes: Vec<u8>) -> JsValue {
     console_error_panic_hook::set_once();
@@ -43,6 +44,7 @@ pub fn acir_from_bytes(bytes: Vec<u8>) -> JsValue {
 #[deprecated(
     note = "we have moved away from this serialization strategy. Call `acir_write_bytes` instead"
 )]
+#[allow(deprecated)]
 #[wasm_bindgen]
 pub fn acir_to_bytes(acir: JsValue) -> Vec<u8> {
     console_error_panic_hook::set_once();


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

I've silenced the warnings for using deprecated functions inside the deprecated functions in the `wasm` crate.

## Dependency additions / changes

None

## Test additions / changes

None

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
