### PR TITLE
chore: restrict function visibility where overly broad

### DIFF
--- a/crates/arena/src/lib.rs
+++ b/crates/arena/src/lib.rs
@@ -1,3 +1,5 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 // For now we use a wrapper around generational-arena
 pub use generational_arena::{Arena, Index};

--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
             fn read_file(path: &str) -> Result<String, JsValue>;
         }
 
-        pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
+        pub(crate) fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
             use std::io::ErrorKind;
             let path_str = path_to_file.as_os_str().to_str().unwrap();
             match read_file(path_str) {
@@ -22,7 +22,7 @@ cfg_if::cfg_if! {
             }
         }
     } else {
-        pub fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
+        pub(crate) fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
             std::fs::read_to_string(path_to_file)
         }
     }

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 mod file_map;
 mod file_reader;
 

--- a/crates/iter-extended/src/lib.rs
+++ b/crates/iter-extended/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 use std::collections::BTreeMap;
 
 /// Equivalent to .into_iter().map(f).collect::<Vec<_>>()

--- a/crates/nargo/src/backends.rs
+++ b/crates/nargo/src/backends.rs
@@ -1,11 +1,11 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "plonk_bn254")] {
-        pub use aztec_backend::Plonk as ConcreteBackend;
+        pub(crate) use aztec_backend::Plonk as ConcreteBackend;
     } else if #[cfg(feature = "plonk_bn254_wasm")] {
-        pub use aztec_wasm_backend::Plonk as ConcreteBackend;
+        pub(crate) use aztec_wasm_backend::Plonk as ConcreteBackend;
     } else if #[cfg(feature = "marlin")] {
         // R1CS_MARLIN_ARKWORKS
-        pub use marlin_arkworks_backend::Marlin as ConcreteBackend;
+        pub(crate) use marlin_arkworks_backend::Marlin as ConcreteBackend;
     } else {
         compile_error!("please specify a backend to compile with");
     }

--- a/crates/nargo/src/cli/fs/mod.rs
+++ b/crates/nargo/src/cli/fs/mod.rs
@@ -6,11 +6,11 @@ use std::{
 
 use crate::errors::CliError;
 
-pub mod acir;
-pub mod inputs;
-pub mod keys;
-pub mod proof;
-pub mod witness;
+pub(super) mod acir;
+pub(super) mod inputs;
+pub(super) mod keys;
+pub(super) mod proof;
+pub(super) mod witness;
 
 fn create_dir<P: AsRef<Path>>(dir_path: P) -> Result<PathBuf, std::io::Error> {
     let mut dir = std::path::PathBuf::new();
@@ -19,11 +19,11 @@ fn create_dir<P: AsRef<Path>>(dir_path: P) -> Result<PathBuf, std::io::Error> {
     Ok(dir)
 }
 
-pub(crate) fn create_named_dir(named_dir: &Path, name: &str) -> PathBuf {
+pub(super) fn create_named_dir(named_dir: &Path, name: &str) -> PathBuf {
     create_dir(named_dir).unwrap_or_else(|_| panic!("could not create the `{name}` directory"))
 }
 
-pub(crate) fn write_to_file(bytes: &[u8], path: &Path) -> String {
+pub(super) fn write_to_file(bytes: &[u8], path: &Path) -> String {
     let display = path.display();
 
     let mut file = match File::create(path) {
@@ -37,7 +37,7 @@ pub(crate) fn write_to_file(bytes: &[u8], path: &Path) -> String {
     }
 }
 
-pub(crate) fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, CliError> {
+pub(super) fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, CliError> {
     let hex_data: Vec<_> =
         std::fs::read(&path).map_err(|_| CliError::PathNotValid(path.as_ref().to_path_buf()))?;
 

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -120,7 +120,7 @@ mod tests {
     /// Compiles a file and returns true if compilation was successful
     ///
     /// This is used for tests.
-    pub fn file_compiles<P: AsRef<Path>>(root_file: P) -> bool {
+    fn file_compiles<P: AsRef<Path>>(root_file: P) -> bool {
         let mut driver = Driver::new(&acvm::Language::R1CS);
         driver.create_local_crate(&root_file, CrateType::Binary);
         super::add_std_lib(&mut driver);

--- a/crates/nargo/src/git.rs
+++ b/crates/nargo/src/git.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-pub fn git_dep_location(base: &url::Url, tag: &str) -> PathBuf {
+pub(crate) fn git_dep_location(base: &url::Url, tag: &str) -> PathBuf {
     let folder_name = super::resolver::resolve_folder_name(base, tag);
 
     super::nargo_crates().join(folder_name)
@@ -12,7 +12,7 @@ pub fn git_dep_location(base: &url::Url, tag: &str) -> PathBuf {
 /// github-rs looks promising, however it seems to require an API token
 ///
 /// One advantage of using "git clone" is that there is effectively no rate limit
-pub fn clone_git_repo(url: &str, tag: &str) -> Result<PathBuf, String> {
+pub(crate) fn clone_git_repo(url: &str, tag: &str) -> Result<PathBuf, String> {
     use std::process::Command;
 
     let base = match url::Url::parse(url) {

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 use noirc_frontend::graph::CrateType;
 use std::path::{Path, PathBuf};
 

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -49,7 +49,7 @@ impl<'a> Resolver<'a> {
     /// Note that the backend is ignored in the dependencies.
     /// Since Noir is backend agnostic, this is okay to do.
     /// XXX: Need to handle when a local package changes!
-    pub fn resolve_root_config(
+    pub(crate) fn resolve_root_config(
         dir_path: &std::path::Path,
         np_language: Language,
     ) -> Result<Driver, CliError> {
@@ -134,7 +134,7 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub fn resolve_git_dep(url: &str, tag: &str) -> Result<PathBuf, CliError> {
+    fn resolve_git_dep(url: &str, tag: &str) -> Result<PathBuf, CliError> {
         match super::git::clone_git_repo(url, tag) {
             Ok(path) => Ok(path),
             Err(msg) => Err(CliError::Generic(msg)),

--- a/crates/nargo/src/toml.rs
+++ b/crates/nargo/src/toml.rs
@@ -5,15 +5,16 @@ use std::path::Path;
 use crate::errors::CliError;
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct Config {
-    pub package: Package,
-    pub dependencies: BTreeMap<String, Dependency>,
+pub(crate) struct Config {
+    #[allow(dead_code)]
+    pub(crate) package: Package,
+    pub(crate) dependencies: BTreeMap<String, Dependency>,
 }
 
 impl Config {
     // Local paths are usually relative and are discouraged when sharing libraries
     // It is better to separate these into different packages.
-    pub fn has_local_path(&self) -> bool {
+    pub(crate) fn has_local_path(&self) -> bool {
         let mut has_local_path = false;
         for dep in self.dependencies.values() {
             if let Dependency::Path { .. } = dep {
@@ -25,25 +26,26 @@ impl Config {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
-pub struct Package {
+pub(crate) struct Package {
     // Note: a package name is not needed unless there is a registry
-    pub authors: Vec<String>,
+    authors: Vec<String>,
     // If not compiler version is supplied, the latest is used
     // For now, we state that all packages must be compiled under the same
     // compiler version.
     // We also state that ACIR and the compiler will upgrade in lockstep.
     // so you will not need to supply an ACIR and compiler version
-    pub compiler_version: Option<String>,
-    pub backend: Option<String>,
-    pub license: Option<String>,
+    compiler_version: Option<String>,
+    backend: Option<String>,
+    license: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 /// Enum representing the different types of ways to
 /// supply a source for the dependency
-pub enum Dependency {
+pub(crate) enum Dependency {
     Github { git: String, tag: String },
     Path { path: String },
 }

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 use std::{collections::BTreeMap, str};
 
 use acvm::{acir::native_types::Witness, FieldElement};

--- a/crates/noirc_abi/src/serialization.rs
+++ b/crates/noirc_abi/src/serialization.rs
@@ -18,7 +18,7 @@ struct StructField {
     typ: AbiType,
 }
 
-pub fn serialize_struct_fields<S>(
+pub(crate) fn serialize_struct_fields<S>(
     fields: &BTreeMap<String, AbiType>,
     s: S,
 ) -> Result<S::Ok, S::Error>
@@ -32,7 +32,7 @@ where
     fields_vector.serialize(s)
 }
 
-pub fn deserialize_struct_fields<'de, D>(
+pub(crate) fn deserialize_struct_fields<'de, D>(
     deserializer: D,
 ) -> Result<BTreeMap<String, AbiType>, D::Error>
 where

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 use acvm::acir::circuit::Circuit;
 
 use acvm::Language;

--- a/crates/noirc_errors/src/lib.rs
+++ b/crates/noirc_errors/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 mod position;
 pub mod reporter;
 pub use position::{Location, Position, Span, Spanned};

--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -91,12 +91,12 @@ impl std::fmt::Display for CustomDiagnostic {
 
 #[derive(Debug, PartialEq, Eq)]
 struct CustomLabel {
-    pub message: String,
-    pub span: Span,
+    message: String,
+    span: Span,
 }
 
 impl CustomLabel {
-    pub fn new(message: String, span: Span) -> CustomLabel {
+    fn new(message: String, span: Span) -> CustomLabel {
         CustomLabel { message, span }
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+
 use acvm::acir::circuit::Circuit;
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
# Related issue(s)

Addresses #919 for all crates other than `noirc_evaluator` and `noirc_frontend`

# Description

## Summary of changes

I've added the `unreachable_pub` to several crates and restricted function visibility to the minimum necessary.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
