### PR TITLE
chore(nargo): create a specific error variant for compilation

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -59,7 +59,7 @@ pub(crate) fn compile_circuit<P: AsRef<Path>>(
     let mut driver = Resolver::resolve_root_config(program_dir.as_ref(), backend.np_language())?;
     add_std_lib(&mut driver);
 
-    driver.into_compiled_program(show_ssa, allow_warnings).map_err(|_| std::process::exit(1))
+    driver.into_compiled_program(show_ssa, allow_warnings).map_err(|_| CliError::CompilationError)
 }
 
 fn preprocess_with_path<P: AsRef<Path>>(

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -23,6 +23,10 @@ pub(crate) enum CliError {
     MismatchedAcir(PathBuf),
     #[error("Failed to verify proof {}", .0.display())]
     InvalidProof(PathBuf),
+
+    /// Error while compiling Noir into ACIR.
+    #[error("Failed to compile circuit")]
+    CompilationError,
 }
 
 impl From<OpcodeResolutionError> for CliError {


### PR DESCRIPTION
# Related issue(s)

Addresses (partially) #729 

# Description

## Summary of changes

We now pass a specific error type for issues during compilation up rather than immediately exiting.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
