### PR TITLE
chore: optimize `mul` for constant expressions

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -126,7 +126,13 @@ pub(crate) fn subtract(a: &Expression, k: FieldElement, b: &Expression) -> Expre
 // TODO also check why we are doing all of this complicated logic with i1 and i2
 // TODO in either case, we can put this in ACIR, if its useful
 pub(crate) fn add(a: &Expression, k: FieldElement, b: &Expression) -> Expression {
-    let mut output = Expression::default();
+    if a.is_const() {
+        return (b * &k) + &a.q_c;
+    } else if b.is_const() {
+        return a.clone() + &(k * b.q_c);
+    }
+
+    let mut output = Expression::from_field(a.q_c + k * b.q_c);
 
     //linear combinations
     let mut i1 = 0; //a
@@ -207,7 +213,6 @@ pub(crate) fn add(a: &Expression, k: FieldElement, b: &Expression) -> Expression
         i2 += 1;
     }
 
-    output.q_c = a.q_c + k * b.q_c;
     output
 }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -55,11 +55,10 @@ pub(crate) fn mul_with_witness(
 
 //a*b
 pub(crate) fn mul(a: &Expression, b: &Expression) -> Expression {
-    let zero = Expression::zero();
     if a.is_const() {
-        return add(&zero, a.q_c, b);
+        return b * &a.q_c;
     } else if b.is_const() {
-        return add(&zero, b.q_c, a);
+        return a * &b.q_c;
     } else if !(a.is_linear() && b.is_linear()) {
         unreachable!("Can only multiply linear terms");
     }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
@@ -149,7 +149,7 @@ pub(crate) fn evaluate(
                     if r_value.is_zero() {
                         panic!("Panic - division by zero");
                     } else {
-                        constraints::add(&Expression::zero(), r_value.inverse(), l_c.expression()).into()
+                        (l_c.expression() * &r_value.inverse()).into()
                     }
                 } else {
                     //TODO avoid creating witnesses here.


### PR DESCRIPTION
# Related issue(s)

# Description

## Summary of changes

We're currently using an implementation of  `a + k*b` in a situation where we know `a = 0`. We can then simplify to use our implementation of `k*b`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
