### PR TITLE
fix:  generate valid toml when outputting nested structs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,6 +3018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,11 +3350,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4064,6 +4098,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dirs = "4"
 serde = { version = "1.0.136", features = ["derive"] }
 smol_str = "0.1.17"
 thiserror = "1.0.21"
-toml = "0.5.8"
+toml = "0.7.2"
 url = "2.2.0"
 wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"

--- a/crates/nargo/tests/test_data/struct_inputs/Prover.toml
+++ b/crates/nargo/tests/test_data/struct_inputs/Prover.toml
@@ -11,6 +11,8 @@ array = [0, 1]
 message = "helld"
 
 [a]
+baz = 0
+
 [a.bar_struct]
 val = "1"
 array = [0, 1]

--- a/crates/nargo/tests/test_data/struct_inputs/src/foo.nr
+++ b/crates/nargo/tests/test_data/struct_inputs/src/foo.nr
@@ -1,5 +1,6 @@
 mod bar;
 
 struct fooStruct {
-    bar_struct: bar::barStruct
+    bar_struct: bar::barStruct,
+    baz: Field,
 }

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -30,18 +30,10 @@ pub(crate) fn parse_toml(
 pub(crate) fn serialize_to_toml(
     w_map: &BTreeMap<String, InputValue>,
 ) -> Result<String, InputParserError> {
-    // Toml requires that values be emitted before tables. Thus, we must reorder our map in case a TomlTypes::Table comes before any other values in the toml map
-    // BTreeMap orders by key and we need the name of the input as our key, so we must split our maps in case a table type has a name that is alphanumerically less
-    // than any other value type
-    let (tables_map, to_map): (BTreeMap<String, TomlTypes>, BTreeMap<String, TomlTypes>) = w_map
-        .iter()
-        .map(|(key, value)| (key.to_owned(), TomlTypes::from(value.clone())))
-        .partition(|(_, v)| matches!(v, TomlTypes::Table(_)));
+    let to_map: BTreeMap<_, _> =
+        w_map.iter().map(|(key, value)| (key.to_owned(), TomlTypes::from(value.clone()))).collect();
 
-    let mut toml_string = toml::to_string(&to_map)?;
-    let toml_string_tables = toml::to_string(&tables_map)?;
-
-    toml_string.push_str(&toml_string_tables);
+    let toml_string = toml::to_string(&to_map)?;
 
     Ok(toml_string)
 }

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -31,7 +31,7 @@ pub(crate) fn serialize_to_toml(
     w_map: &BTreeMap<String, InputValue>,
 ) -> Result<String, InputParserError> {
     let to_map: BTreeMap<_, _> =
-        w_map.iter().map(|(key, value)| (key.to_owned(), TomlTypes::from(value.clone()))).collect();
+        w_map.iter().map(|(key, value)| (key, TomlTypes::from(value.clone()))).collect();
 
     let toml_string = toml::to_string(&to_map)?;
 


### PR DESCRIPTION
# Related issue(s)

Resolves #934 

# Description

## Summary of changes

`toml` wasn't automatically ordering fields before tables in the toml it generated so we were manually partitioning the input map to ensure this happens. We however not we're enforcing this for nested tables which also include non-table fields.

`toml` has been since updated to handle this automatically so I've updated to the new version.

## Dependency additions / changes

`toml` has been bumped to 0.7.2

## Test additions / changes

Added a regression test for #934 

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
