### PR TITLE
fix: Improve member access error

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -99,8 +99,8 @@ impl From<TypeCheckError> for Diagnostic {
                 span,
             ),
             TypeCheckError::TypeAnnotationsNeeded { span } => Diagnostic::simple_error(
-                "Type annotations needed before this point.".to_string(),
-                "Try adding a type annotation for this value before it is used here".to_string(),
+                "Expression type is ambiguous".to_string(),
+                "Type must be known at this point".to_string(),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -32,6 +32,8 @@ pub enum TypeCheckError {
         second_type: String,
         second_index: usize,
     },
+    #[error("Cannot infer type of expression, type annotations needed before this point")]
+    TypeAnnotationsNeeded { span: Span },
 }
 
 impl TypeCheckError {
@@ -94,6 +96,11 @@ impl From<TypeCheckError> for Diagnostic {
             TypeCheckError::PublicReturnType { typ, span } => Diagnostic::simple_error(
                 "Functions cannot declare a public return type".to_string(),
                 format!("return type is {typ}"),
+                span,
+            ),
+            TypeCheckError::TypeAnnotationsNeeded { span } => Diagnostic::simple_error(
+                "Type annotations needed before this point.".to_string(),
+                "Try adding a type annotation for this value before it is used here".to_string(),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -707,9 +707,8 @@ pub fn check_member_access(
     // If we get here the type has no field named 'access.rhs'.
     // Now we specialize the error message based on whether we know the object type in question yet.
     if let Type::TypeVariable(..) = &lhs_type {
-        errors.push(TypeCheckError::TypeAnnotationsNeeded {
-            span: interner.expr_span(&access.lhs),
-        });
+        errors
+            .push(TypeCheckError::TypeAnnotationsNeeded { span: interner.expr_span(&access.lhs) });
     } else if lhs_type != Type::Error {
         errors.push(TypeCheckError::Unstructured {
             msg: format!("Type {lhs_type} has no member named {}", access.rhs),

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -689,34 +689,32 @@ pub fn check_member_access(
 ) -> Type {
     let lhs_type = type_check_expression(interner, &access.lhs, errors).follow_bindings();
 
-    match &lhs_type {
-        Type::Struct(s, args) => {
-            let s = s.borrow();
-            if let Some((field, index)) = s.get_field(&access.rhs.0.contents, args) {
+    if let Type::Struct(s, args) = &lhs_type {
+        let s = s.borrow();
+        if let Some((field, index)) = s.get_field(&access.rhs.0.contents, args) {
+            interner.set_field_index(expr_id, index);
+            return field;
+        }
+    } else if let Type::Tuple(elements) = &lhs_type {
+        if let Ok(index) = access.rhs.0.contents.parse::<usize>() {
+            if index < elements.len() {
                 interner.set_field_index(expr_id, index);
-                return field;
+                return elements[index].clone();
             }
         }
-        Type::Tuple(elements) => {
-            if let Ok(index) = access.rhs.0.contents.parse::<usize>() {
-                if index < elements.len() {
-                    interner.set_field_index(expr_id, index);
-                    return elements[index].clone();
-                }
-            }
-        }
-        Type::TypeVariable(..) => {
-            errors.push(TypeCheckError::TypeAnnotationsNeeded {
-                span: interner.expr_span(&access.lhs),
-            });
-        }
-        Type::Error => (),
-        other => {
-            errors.push(TypeCheckError::Unstructured {
-                msg: format!("Type {other} has no member named {}", access.rhs),
-                span: interner.expr_span(&access.lhs),
-            });
-        }
+    }
+
+    // If we get here the type has no field named 'access.rhs'.
+    // Now we specialize the error message based on whether we know the object type in question yet.
+    if let Type::TypeVariable(..) = &lhs_type {
+        errors.push(TypeCheckError::TypeAnnotationsNeeded {
+            span: interner.expr_span(&access.lhs),
+        });
+    } else if lhs_type != Type::Error {
+        errors.push(TypeCheckError::Unstructured {
+            msg: format!("Type {lhs_type} has no member named {}", access.rhs),
+            span: interner.expr_span(&access.lhs),
+        });
     }
 
     Type::Error


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #939

# Description

Improves our error message when users try to access fields of an inferred type.

## Summary of changes

The previous error message:
```rs
error: Type _ has no member named x
  ┌─ /.../src/main.nr:3:20
  │
3 │     let _f = |foo| foo.x;
  │                    ---

error: aborting due to 1 previous errors
```
The new error message:
```
error: Type annotations needed before this point.
  ┌─ /.../src/main.nr:3:20
  │
3 │     let _f = |foo| foo.x;
  │                    --- Try adding a type annotation for this value before it is used here

error: aborting due to 1 previous errors
```

## Dependency additions / changes

None

## Test additions / changes

None

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

None
