### PR TITLE
chore(github): Separate `doc needed` Checkbox in PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,8 @@ Resolves # <!-- link to issue -->
 - [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
 - [ ] I have reviewed the changes on GitHub, line by line.
 - [ ] I have ensured all changes are covered in the description.
+
+## Documentation needs
 - [ ] This PR requires documentation updates when merged.
 
 # Additional context


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

Separate the documentation needs checkbox in the PR template of this repo from the pre-merge checklist.

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.
