### PR TITLE
chore(ssa): Handle loops when building the decision tree

### DIFF
--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -279,7 +279,9 @@ impl DecisionTree {
                     ctx[r].assumption = block_assumption;
                     result = vec![l, r];
                 }
-                (None, Some(_)) => unreachable!(),
+                (None, Some(_)) => {
+                    unreachable!("Infallible, only a split block can have right successor")
+                }
                 (None, None) => (),
             }
         }


### PR DESCRIPTION
# Description

## Summary of changes

Decision tree is compatible with loops in the CFG

## Dependency additions / changes

Because we unroll before handling the IF statements, the decision tree was assuming the CFG does not contains any cycle. We do not do this assumption anymore and are now able to handle cycles in the CFG when building the decision tree.

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
- [ ] This PR requires documentation updates when merged.

# Additional context

This will enable us to do the unrolling after handling the IF statements. The later we unroll the better as unrolling has a big impact on performance.

