### PR TITLE
chore: serialize circuit as hex string in build artifact file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hmac"
@@ -2197,6 +2200,7 @@ version = "0.2.0"
 dependencies = [
  "acvm 0.5.0",
  "fm",
+ "hex",
  "noirc_abi",
  "noirc_errors",
  "noirc_evaluator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ codespan = "0.9.5"
 codespan-reporting = "0.9.5"
 chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
 dirs = "4"
+hex = { version = "0.4.2", features = ["serde"] }
 serde = { version = "1.0.136", features = ["derive"] }
 smol_str = "0.1.17"
 thiserror = "1.0.21"

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -22,12 +22,12 @@ noirc_abi.workspace = true
 fm.workspace = true
 acvm.workspace = true
 cfg-if.workspace = true
+hex.workspace = true
 toml.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 clap = { version = "4.1.4", features = ["derive"]}
 const_format = "0.2.30"
-hex = "0.4.2"
 serde_json = "1.0"
 termcolor = "1.1.2"
 tempdir = "0.3.7"

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -14,3 +14,4 @@ noirc_abi.workspace = true
 acvm.workspace = true
 fm.workspace = true
 serde.workspace = true
+hex.workspace = true

--- a/crates/noirc_driver/src/program.rs
+++ b/crates/noirc_driver/src/program.rs
@@ -16,14 +16,14 @@ where
     let mut circuit_bytes: Vec<u8> = Vec::new();
     circuit.write(&mut circuit_bytes).unwrap();
 
-    circuit_bytes.serialize(s)
+    hex::serialize(circuit_bytes, s)
 }
 
 fn deserialize_circuit<'de, D>(deserializer: D) -> Result<Circuit, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let circuit_bytes = Vec::<u8>::deserialize(deserializer)?;
+    let circuit_bytes: Vec<u8> = hex::deserialize(deserializer)?;
     let circuit = Circuit::read(&*circuit_bytes).unwrap();
     Ok(circuit)
 }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

We now output the `CompiledProgram` json file with the circuit represented as a hex string rather than as a long array of byte values. This is more consistent with standard solidity tooling.

Note that this hex is not 0x-prefixed, in case there are strong feelings around this.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.
   - Relevant to https://github.com/noir-lang/book/issues/63

# Additional context

<!-- If applicable. -->
