### PR TITLE
feat(compiler): WASM compilation w/ dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "console_error_panic_hook",
  "gloo-utils",
  "noirc_driver",
+ "noirc_frontend",
  "serde",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,7 @@ dependencies = [
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
+ "js-sys",
  "noirc_driver",
  "noirc_frontend",
  "serde",

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 
 console_error_panic_hook = "0.1.7"
 gloo-utils = { version = "0.1", features = ["serde"] }
+js-sys = "0.3.61"
 
 [dev-dependencies]
 wasm-bindgen-test.workspace = true

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 
 acvm.workspace = true
 noirc_driver.workspace = true
+noirc_frontend.workspace = true
 wasm-bindgen.workspace = true
 serde.workspace = true
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -37,7 +37,6 @@ pub fn compile(src: String, optional_dependencies_set: js_sys::Set) -> JsValue {
     // For now we default to plonk width = 3, though we can add it as a parameter
     let language = acvm::Language::PLONKCSat { width: 3 };
     let path = PathBuf::from(src);
-    // let compiled_program = noirc_driver::Driver::compile_file(path, language);
     let mut driver = noirc_driver::Driver::new(&language);
 
     driver.create_local_crate(path, CrateType::Binary);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -51,8 +51,9 @@ pub fn compile(src: String, optional_dependencies_set: js_sys::Set) -> JsValue {
         }
     }
 
-    let compiled_program =
-        driver.into_compiled_program(false, false).unwrap_or_else(|_| std::process::exit(1));
+    let compiled_program = driver
+        .into_compiled_program(false, false)
+        .unwrap_or_else(|_| panic!("could not compile program"));
 
     <JsValue as JsValueSerdeExt>::from_serde(&compiled_program).unwrap()
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -41,7 +41,6 @@ pub fn compile(src: String, optional_dependencies_set: js_sys::Set) -> JsValue {
 
     driver.create_local_crate(path, CrateType::Binary);
 
-    // add_noir_lib(&mut driver, &"std");
     if !optional_dependencies_set.is_undefined() {
         for optional_dependency in optional_dependencies_set.values() {
             let dependency = optional_dependency.unwrap();

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -46,8 +46,8 @@ pub fn compile(src: String, optional_dependencies_set: js_sys::Set) -> JsValue {
     if !optional_dependencies_set.is_undefined() {
         for optional_dependency in optional_dependencies_set.values() {
             let dependency = optional_dependency.unwrap();
-            if dependency.is_string() {
-                add_noir_lib(&mut driver, dependency.as_string().unwrap());
+            if let Some(dep_name) = dependency.as_string() {
+                add_noir_lib(&mut driver, dep_name);
             }
         }
     }


### PR DESCRIPTION
# Related issue(s)

#952 Allow compilation with dependencies from WASM, https://github.com/noir-lang/noir/issues/888#issuecomment-1453388917

Resolves #952 Allow compilation with dependencies from WASM

# Description

Allows to call `compile` with a set of dependencies as a second argument. Those dependencies will be later resolved from [noir-lang/noir-source-resolver](https://github.com/noir-lang/noir-source-resolver)

## Summary of changes

[crates/wasm/src/lib.rs](https://github.com/noir-lang/noir/compare/kh-wasm-compile-w-dependency?expand=1#diff-6ce577db55a8f1aababd2da61a6292df631cbc475f3282c5a58e0dbe58987f07R35) adds the additional argument which will be iterated over to resolves dependencies. It's equivalent to declaring it in project configuration.


## Dependency additions / changes

`noirc_driver` is now required by `wasm`

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

# Additional context
