### PR TITLE
chore(nargo)!: rename `contract` command to `codegen-verifier`

### DIFF
--- a/crates/nargo/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo/src/cli/codegen_verifier_cmd.rs
@@ -7,12 +7,12 @@ use noirc_driver::CompileOptions;
 
 /// Generates a Solidity verifier smart contract for the program
 #[derive(Debug, Clone, Args)]
-pub(crate) struct ContractCommand {
+pub(crate) struct CodegenVerifierCommand {
     #[clap(flatten)]
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run(args: ContractCommand, config: NargoConfig) -> Result<(), CliError> {
+pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(), CliError> {
     let compiled_program = compile_circuit(&config.program_dir, &args.compile_options)?;
 
     let backend = crate::backends::ConcreteBackend;

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -10,8 +10,8 @@ use color_eyre::eyre;
 mod fs;
 
 mod check_cmd;
+mod codegen_verifier_cmd;
 mod compile_cmd;
-mod contract_cmd;
 mod execute_cmd;
 mod gates_cmd;
 mod new_cmd;
@@ -47,7 +47,7 @@ pub(crate) struct NargoConfig {
 #[derive(Subcommand, Clone, Debug)]
 enum NargoCommand {
     Check(check_cmd::CheckCommand),
-    Contract(contract_cmd::ContractCommand),
+    CodegenVerifier(codegen_verifier_cmd::CodegenVerifierCommand),
     Compile(compile_cmd::CompileCommand),
     New(new_cmd::NewCommand),
     Execute(execute_cmd::ExecuteCommand),
@@ -69,7 +69,7 @@ pub fn start_cli() -> eyre::Result<()> {
         NargoCommand::Verify(args) => verify_cmd::run(args, matches.config),
         NargoCommand::Test(args) => test_cmd::run(args, matches.config),
         NargoCommand::Gates(args) => gates_cmd::run(args, matches.config),
-        NargoCommand::Contract(args) => contract_cmd::run(args, matches.config),
+        NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(args, matches.config),
     }?;
 
     Ok(())


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #945 

# Description

## Summary of changes

I've renamed the `nargo contract` command to `nargo codegen-verifier`. `codegen` is shorter than `generate` and is more descriptive so I opted for this name instead of what's discussed in #945 (happy to switch if there's strong feelings about this).

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
