### PR TITLE
fix(nargo): Use yml extension for bug report link presented upon panic

### DIFF
--- a/crates/nargo/src/main.rs
+++ b/crates/nargo/src/main.rs
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     // Register a panic hook to display more readable panic messages to end-users
     let (panic_hook, _) = HookBuilder::default()
         .display_env_section(false)
-        .panic_section("This is a bug. Consider opening an issue at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.md")
+        .panic_section("This is a bug. Consider opening an issue at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml")
         .into_hooks();
     panic_hook.install();
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

I noticed that I forgot to update this link when I changed the templates, so users got dropped into an empty issue when following the link.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
