### PR TITLE
fix: Remove uses of std::process::exit

### DIFF
--- a/crates/nargo/src/cli/check_cmd.rs
+++ b/crates/nargo/src/cli/check_cmd.rs
@@ -32,9 +32,7 @@ fn check_from_path<P: AsRef<Path>>(p: P, compile_options: &CompileOptions) -> Re
     let mut driver = Resolver::resolve_root_config(p.as_ref(), backend.np_language())?;
     add_std_lib(&mut driver);
 
-    if driver.check_crate(compile_options).is_err() {
-        return Err(CliError::CompilationError);
-    }
+    driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 
     // XXX: We can have a --overwrite flag to determine if you want to overwrite the Prover/Verifier.toml files
     if let Some((parameters, return_type)) = driver.compute_function_signature() {

--- a/crates/nargo/src/cli/check_cmd.rs
+++ b/crates/nargo/src/cli/check_cmd.rs
@@ -33,7 +33,7 @@ fn check_from_path<P: AsRef<Path>>(p: P, compile_options: &CompileOptions) -> Re
     add_std_lib(&mut driver);
 
     if driver.check_crate(compile_options).is_err() {
-        std::process::exit(1);
+        return Err(CliError::CompilationError);
     }
 
     // XXX: We can have a --overwrite flag to determine if you want to overwrite the Prover/Verifier.toml files

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -45,10 +45,7 @@ pub(crate) fn run(mut args: CompileCommand, config: NargoConfig) -> Result<(), C
         }
         Ok(())
     } else {
-        let main = match driver.main_function() {
-            Ok(m) => m,
-            Err(_) => return Err(CliError::CompilationError),
-        };
+        let main = driver.main_function().map_err(|_| CliError::CompilationError)?;
         compile_and_save_program(&driver, main, &args, &circuit_dir)
     }
 }

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -45,7 +45,10 @@ pub(crate) fn run(mut args: CompileCommand, config: NargoConfig) -> Result<(), C
         }
         Ok(())
     } else {
-        let main = driver.main_function();
+        let main = match driver.main_function() {
+            Ok(m) => m,
+            Err(_) => return Err(CliError::CompilationError),
+        };
         compile_and_save_program(&driver, main, &args, &circuit_dir)
     }
 }

--- a/crates/nargo/src/cli/test_cmd.rs
+++ b/crates/nargo/src/cli/test_cmd.rs
@@ -36,9 +36,7 @@ fn run_tests(
     let mut driver = Resolver::resolve_root_config(program_dir, backend.np_language())?;
     add_std_lib(&mut driver);
 
-    if driver.check_crate(compile_options).is_err() {
-        return Err(CliError::CompilationError);
-    }
+    driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 
     let test_functions = driver.get_all_test_functions_in_crate_matching(test_name);
     println!("Running {} test functions...", test_functions.len());

--- a/crates/nargo/src/cli/test_cmd.rs
+++ b/crates/nargo/src/cli/test_cmd.rs
@@ -68,9 +68,7 @@ fn run_tests(
         writeln!(writer, "All tests passed").ok();
     } else {
         let plural = if failing == 1 { "" } else { "s" };
-        writer.set_color(ColorSpec::new().set_fg(Some(Color::Red))).unwrap();
-        writeln!(writer, "{failing} test{plural} failed").ok();
-        return Err(CliError::Generic("".to_string()));
+        return Err(CliError::Generic(format!("{failing} test{plural} failed")));
     }
 
     writer.reset().ok();

--- a/crates/nargo/src/cli/test_cmd.rs
+++ b/crates/nargo/src/cli/test_cmd.rs
@@ -37,7 +37,7 @@ fn run_tests(
     add_std_lib(&mut driver);
 
     if driver.check_crate(compile_options).is_err() {
-        std::process::exit(1);
+        return Err(CliError::CompilationError);
     }
 
     let test_functions = driver.get_all_test_functions_in_crate_matching(test_name);
@@ -70,7 +70,7 @@ fn run_tests(
         let plural = if failing == 1 { "" } else { "s" };
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Red))).unwrap();
         writeln!(writer, "{failing} test{plural} failed").ok();
-        std::process::exit(1);
+        return Err(CliError::Generic("".to_string()));
     }
 
     writer.reset().ok();

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -195,7 +195,10 @@ impl Driver {
         };
 
         // All Binaries should have a main function
-        Ok(local_crate.main_function().unwrap())
+        match local_crate.main_function() {
+            Some(func_id) => Ok(func_id),
+            None => return Err(ReportedError),
+        }
     }
 
     /// Compile the current crate. Assumes self.check_crate is called beforehand!

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -53,10 +53,13 @@ impl Driver {
 
     // This is here for backwards compatibility
     // with the restricted version which only uses one file
-    pub fn compile_file(root_file: PathBuf, np_language: acvm::Language) -> CompiledProgram {
+    pub fn compile_file(
+        root_file: PathBuf,
+        np_language: acvm::Language,
+    ) -> Result<CompiledProgram, ReportedError> {
         let mut driver = Driver::new(&np_language);
         driver.create_local_crate(root_file, CrateType::Binary);
-        driver.compile_main(&CompileOptions::default()).unwrap_or_else(|_| std::process::exit(1))
+        driver.compile_main(&CompileOptions::default())
     }
 
     /// Compiles a file and returns true if compilation was successful
@@ -167,14 +170,20 @@ impl Driver {
         options: &CompileOptions,
     ) -> Result<CompiledProgram, ReportedError> {
         self.check_crate(options)?;
-        let main = self.main_function();
+        let main = match self.main_function() {
+            Ok(m) => m,
+            Err(e) => {
+                println!("cannot compile a program with no main function");
+                return Err(e);
+            }
+        };
         self.compile_no_check(options, main)
     }
 
     /// Returns the FuncId of the 'main' funciton.
     /// - Expects check_crate to be called beforehand
     /// - Panics if no main function is found
-    pub fn main_function(&self) -> FuncId {
+    pub fn main_function(&self) -> Result<FuncId, ReportedError> {
         // Find the local crate, one should always be present
         let local_crate = self.context.def_map(LOCAL_CRATE).unwrap();
 
@@ -182,11 +191,11 @@ impl Driver {
         // We don't panic here to allow users to `evaluate` libraries which will do nothing
         if self.context.crate_graph[LOCAL_CRATE].crate_type != CrateType::Binary {
             println!("cannot compile crate into a program as the local crate is not a binary. For libraries, please use the check command");
-            std::process::exit(1);
+            return Err(ReportedError);
         };
 
         // All Binaries should have a main function
-        local_crate.main_function().expect("cannot compile a program with no main function")
+        Ok(local_crate.main_function().unwrap())
     }
 
     /// Compile the current crate. Assumes self.check_crate is called beforehand!

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -197,7 +197,7 @@ impl Driver {
         // All Binaries should have a main function
         match local_crate.main_function() {
             Some(func_id) => Ok(func_id),
-            None => return Err(ReportedError),
+            None => Err(ReportedError),
         }
     }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -30,7 +30,7 @@ pub fn compile(src: String) -> JsValue {
     let path = PathBuf::from(src);
     let compiled_program = match noirc_driver::Driver::compile_file(path, language) {
         Ok(compiled_program) => compiled_program,
-        Err(_) => panic!("Failed to compiler circuit"),
+        Err(_) => panic!("Compilation Error: Failed to compile circuit"),
     };
     <JsValue as JsValueSerdeExt>::from_serde(&compiled_program).unwrap()
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -28,7 +28,10 @@ pub fn compile(src: String) -> JsValue {
     // For now we default to plonk width = 3, though we can add it as a parameter
     let language = acvm::Language::PLONKCSat { width: 3 };
     let path = PathBuf::from(src);
-    let compiled_program = noirc_driver::Driver::compile_file(path, language);
+    let compiled_program = match noirc_driver::Driver::compile_file(path, language) {
+        Ok(compiled_program) => compiled_program,
+        Err(_) => panic!("Failed to compiler circuit"),
+    };
     <JsValue as JsValueSerdeExt>::from_serde(&compiled_program).unwrap()
 }
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves https://github.com/noir-lang/noir/issues/729

# Description

## Summary of changes

replacing std::process::exit to either

1. `CliError` if its in nargo or
2. `ReportedError` if its in driver


4. add a `panic!` to wasm crate

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
