### PR TITLE
chore: silence `nargo compile` command

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -68,11 +68,9 @@ fn compile_and_save_program(
         .compile_no_check(&args.compile_options, main)
         .map_err(|_| CliError::Generic(format!("'{}' failed to compile", args.circuit_name)))?;
 
-    let circuit_path = save_program_to_file(&compiled_program, &args.circuit_name, circuit_dir);
+    save_program_to_file(&compiled_program, &args.circuit_name, circuit_dir);
 
     preprocess_with_path(&args.circuit_name, circuit_dir, &compiled_program.circuit)?;
-
-    println!("Generated ACIR code into {}", circuit_path.display());
     Ok(())
 }
 
@@ -100,9 +98,7 @@ fn preprocess_with_path<P: AsRef<Path>>(
     let (proving_key, verification_key) = backend.preprocess(circuit);
 
     let pk_path = save_key_to_dir(proving_key, key_name, &preprocess_dir, true)?;
-    println!("Proving key saved to {}", pk_path.display());
     let vk_path = save_key_to_dir(verification_key, key_name, preprocess_dir, false)?;
-    println!("Verification key saved to {}", vk_path.display());
 
     Ok((pk_path, vk_path))
 }


### PR DESCRIPTION
# Related issue(s)


Resolves #873 for `compile` command

# Description

## Summary of changes

We now no longer print the paths where we've saved the build artifact and proving/verification keys when running `nargo compile`.


## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
