### PR TITLE
fix: check the argument count of generic types

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -373,9 +373,24 @@ impl<'a> Resolver<'a> {
             }
         }
 
+        let span = path.span();
         match self.lookup_struct_or_error(path) {
             Some(struct_type) => {
-                let args = vecmap(args, |arg| self.resolve_type_inner(arg, new_variables));
+                let mut args = vecmap(args, |arg| self.resolve_type_inner(arg, new_variables));
+                let expected_generic_count = struct_type.borrow().generics.len();
+
+                if args.len() != expected_generic_count {
+                    self.push_err(ResolverError::IncorrectGenericCount {
+                        span,
+                        struct_type: struct_type.clone(),
+                        actual: args.len(),
+                        expected: expected_generic_count,
+                    });
+
+                    // Fix the generic count so we can continue typechecking
+                    args.resize_with(expected_generic_count, || self.interner.next_type_variable())
+                }
+
                 Type::Struct(struct_type, args)
             }
             None => Type::Error,


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves the first part of #969

# Description

## Summary of changes

This PR issues an error when a type constructor is given an incorrect number of generic arguments. If these are not checked, we later fail an assert while instantiating struct types later on during type checking. To ensure we do not hit this assert even in the presence of bad input, we resize the generics vector on error. Either truncating it or filling it with fresh type variables until it is the desired size.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.
