### PR TITLE
fix: add more readable error for missing argument in toml

### DIFF
--- a/crates/noirc_abi/src/errors.rs
+++ b/crates/noirc_abi/src/errors.rs
@@ -14,6 +14,8 @@ pub enum InputParserError {
     DuplicateVariableName(String),
     #[error("cannot parse a string toml type into {0:?}")]
     AbiTypeMismatch(AbiType),
+    #[error("Expected argument `{0}`, but none was found")]
+    MissingArgument(String),
 }
 
 impl From<toml::ser::Error> for InputParserError {

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -30,16 +30,12 @@ pub(crate) fn parse_toml(
 
     // If the toml file also includes a return value then we parse it as well.
     // This isn't required as the prover calculates the return value itself.
-    match (&abi.return_type, data.get(MAIN_RETURN_NAME)) {
-        (Some(return_type), Some(toml_return_value)) => {
-            let return_value = InputValue::try_from_toml(
-                toml_return_value.clone(),
-                return_type,
-                MAIN_RETURN_NAME,
-            )?;
-            parsed_inputs.insert(MAIN_RETURN_NAME.to_owned(), return_value);
-        }
-        _ => {}
+    if let (Some(return_type), Some(toml_return_value)) =
+        (&abi.return_type, data.get(MAIN_RETURN_NAME))
+    {
+        let return_value =
+            InputValue::try_from_toml(toml_return_value.clone(), return_type, MAIN_RETURN_NAME)?;
+        parsed_inputs.insert(MAIN_RETURN_NAME.to_owned(), return_value);
     }
 
     Ok(parsed_inputs)


### PR DESCRIPTION
# Related issue(s)

Resolves the second part of https://github.com/noir-lang/noir/issues/969

# Description

## Summary of changes

Previously we'd iterate over the fields in `Prover.toml`, assume there's a matching entry in the ABI and then decode the data. This throws an unhelpful panic if `Prover.toml` contains an entry which doesn't exist in the ABI when looking up its type.

I've updated this loop to instead work over the expected ABI fields, check if an entry exists in `Prover.toml` and if not we raise an error saying that the argument with a certain name hasn't been found. As part of this we now pass the argument name into `try_from_toml` so that we can throw a meaningful error for struct fields.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
