### PR TITLE
chore: drop unnecessary build code copying stdlib

### DIFF
--- a/crates/nargo/build.rs
+++ b/crates/nargo/build.rs
@@ -1,6 +1,5 @@
 use rustc_version::{version, Version};
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Expects that the given directory is an existing path
 fn rerun_if_stdlib_changes(directory: &Path) {
@@ -23,53 +22,6 @@ fn check_rustc_version() {
     );
 }
 
-pub fn copy<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<(), std::io::Error> {
-    let mut stack = vec![PathBuf::from(from.as_ref())];
-
-    let output_root = PathBuf::from(to.as_ref());
-    let input_root = PathBuf::from(from.as_ref()).components().count();
-
-    while let Some(working_path) = stack.pop() {
-        println!("process: {:?}", &working_path);
-
-        // Generate a relative path
-        let src: PathBuf = working_path.components().skip(input_root).collect();
-
-        // Create a destination if missing
-        let dest = if src.components().count() == 0 {
-            output_root.clone()
-        } else {
-            output_root.join(&src)
-        };
-        if fs::metadata(&dest).is_err() {
-            println!(" mkdir: {dest:?}");
-            fs::create_dir_all(&dest)?;
-        }
-
-        for entry in fs::read_dir(working_path)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if path.is_dir() {
-                stack.push(path);
-            } else {
-                match path.file_name() {
-                    Some(filename) => {
-                        let dest_path = dest.join(filename);
-                        println!("  copy: {:?} -> {:?}", &path, &dest_path);
-                        fs::copy(&path, &dest_path)?;
-                    }
-                    None => {
-                        println!("failed: {path:?}");
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
 fn main() {
     check_rustc_version();
 
@@ -79,6 +31,4 @@ fn main() {
 
     let stdlib_src_dir = Path::new("../../noir_stdlib/");
     rerun_if_stdlib_changes(stdlib_src_dir);
-    let target = dirs::config_dir().unwrap().join("noir-lang").join("std");
-    copy(stdlib_src_dir, target).unwrap();
 }


### PR DESCRIPTION
# Related issue(s)

#973 #951  

Resolves 
N/A

# Description

## Summary of changes

Drops unnecessary build step code which copies stdlib.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context

N/A