### PR TITLE
fix: Prevent calling contract functions from outside the contract

### DIFF
--- a/crates/iter-extended/src/lib.rs
+++ b/crates/iter-extended/src/lib.rs
@@ -41,3 +41,24 @@ where
 {
     iterable.into_iter().map(f).collect()
 }
+
+/// Given an iterator over a Result, filter out the Ok values from the Err values
+/// and return both in separate Vecs. Unlike other collect-like functions over Results,
+/// this function will always consume the entire iterator.
+pub fn partition_results<It, T, E, F>(iterable: It, mut f: F) -> (Vec<T>, Vec<E>)
+where
+    It: IntoIterator,
+    F: FnMut(It::Item) -> Result<T, E>,
+{
+    let mut oks = vec![];
+    let mut errors = vec![];
+
+    for elem in iterable {
+        match f(elem) {
+            Ok(ok) => oks.push(ok),
+            Err(error) => errors.push(error),
+        }
+    }
+
+    (oks, errors)
+}

--- a/crates/nargo/tests/test_data/contracts/src/main.nr
+++ b/crates/nargo/tests/test_data/contracts/src/main.nr
@@ -1,5 +1,5 @@
 fn main(x : Field, y : pub Field) {
-    constrain Foo::double(x) == Foo::triple(y);
+    constrain x * 2 == y * 3;
 }
 
 contract Foo {

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -127,9 +127,9 @@ impl DefCollector {
 
         let current_def_map = context.def_maps.get(&crate_id).unwrap();
 
-        errors.extend(vecmap(unresolved_imports, |import| {
-            let file_id = current_def_map.modules[import.module_id.0].origin.file_id();
-            let error = DefCollectorErrorKind::UnresolvedImport { import };
+        errors.extend(vecmap(unresolved_imports, |(error, module_id)| {
+            let file_id = current_def_map.modules[module_id.0].origin.file_id();
+            let error = DefCollectorErrorKind::PathResolutionError(error);
             error.into_file_diagnostic(file_id)
         }));
 

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -122,16 +122,16 @@ impl DefCollector {
         context.def_maps.insert(crate_id, def_collector.def_map);
 
         // Resolve unresolved imports collected from the crate
-        let (unresolved, resolved) =
+        let (resolved, unresolved_imports) =
             resolve_imports(crate_id, def_collector.collected_imports, &context.def_maps);
 
         let current_def_map = context.def_maps.get(&crate_id).unwrap();
-        for unresolved_import in unresolved.into_iter() {
-            // File if that the import was declared
-            let file_id = current_def_map.modules[unresolved_import.module_id.0].origin.file_id();
-            let error = DefCollectorErrorKind::UnresolvedImport { import: unresolved_import };
-            errors.push(error.into_file_diagnostic(file_id));
-        }
+
+        errors.extend(vecmap(unresolved_imports, |import| {
+            let file_id = current_def_map.modules[import.module_id.0].origin.file_id();
+            let error = DefCollectorErrorKind::UnresolvedImport { import };
+            error.into_file_diagnostic(file_id)
+        }));
 
         // Populate module namespaces according to the imports used
         let current_def_map = context.def_maps.get_mut(&crate_id).unwrap();

--- a/crates/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/errors.rs
@@ -1,4 +1,5 @@
-use crate::{hir::resolution::import::ImportDirective, Ident};
+use crate::hir::resolution::import::ImportDirective;
+use crate::Ident;
 
 use noirc_errors::CustomDiagnostic as Diagnostic;
 use noirc_errors::FileDiagnostic;

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 
 use crate::{Ident, Shared, StructType, Type};
 
+use super::import::PathResolutionError;
+
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ResolverError {
     #[error("Duplicate definition")]
@@ -15,7 +17,7 @@ pub enum ResolverError {
     #[error("path is not an identifier")]
     PathIsNotIdent { span: Span },
     #[error("could not resolve path")]
-    PathUnresolved { span: Span, name: String, segment: Ident },
+    PathResolutionError(PathResolutionError),
     #[error("Expected")]
     Expected { span: Span, expected: String, got: String },
     #[error("Duplicate field in constructor")]
@@ -99,22 +101,7 @@ impl From<ResolverError> for Diagnostic {
                 String::new(),
                 span,
             ),
-            ResolverError::PathUnresolved { span, name, segment } => {
-                let mut diag = Diagnostic::simple_error(
-                    format!("could not resolve path '{name}'"),
-                    String::new(),
-                    span,
-                );
-                // XXX: When the secondary and primary labels have spans that
-                // overlap, you cannot differentiate between them.
-                // This error is an example of this.
-                diag.add_secondary(
-                    format!("could not resolve `{}` in path", &segment.0.contents),
-                    segment.0.span(),
-                );
-
-                diag
-            }
+            ResolverError::PathResolutionError(error) => error.into(),
             ResolverError::Expected { span, expected, got } => Diagnostic::simple_error(
                 format!("expected {expected} got {got}"),
                 String::new(),

--- a/crates/noirc_frontend/src/hir/resolution/import.rs
+++ b/crates/noirc_frontend/src/hir/resolution/import.rs
@@ -53,7 +53,7 @@ pub fn resolve_imports(
     crate_id: CrateId,
     imports_to_resolve: Vec<ImportDirective>,
     def_maps: &HashMap<CrateId, CrateDefMap>,
-) -> (Vec<ResolvedImport>, Vec<ImportDirective>) {
+) -> (Vec<ResolvedImport>, Vec<(PathResolutionError, LocalModuleId)>) {
     let def_map = &def_maps[&crate_id];
 
     partition_results(imports_to_resolve, |import_directive| {
@@ -63,7 +63,7 @@ pub fn resolve_imports(
         let module_scope = import_directive.module_id;
         let resolved_namespace =
             resolve_path_to_ns(&import_directive, def_map, def_maps, allow_contracts)
-                .map_err(|_| import_directive.clone())?;
+                .map_err(|error| (error, module_scope))?;
 
         let name = resolve_path_name(&import_directive);
         Ok(ResolvedImport { name, resolved_namespace, module_scope })

--- a/crates/noirc_frontend/src/hir/resolution/path_resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/path_resolver.rs
@@ -1,5 +1,7 @@
-use super::import::{resolve_path_to_ns, ImportDirective, PathResolution};
-use crate::{Ident, Path};
+use super::import::{
+    allow_referencing_contracts, resolve_path_to_ns, ImportDirective, PathResolutionError,
+};
+use crate::Path;
 use std::collections::HashMap;
 
 use crate::graph::CrateId;
@@ -11,7 +13,7 @@ pub trait PathResolver {
         &self,
         def_maps: &HashMap<CrateId, CrateDefMap>,
         path: Path,
-    ) -> Result<ModuleDefId, Ident>;
+    ) -> Result<ModuleDefId, PathResolutionError>;
 
     fn local_module_id(&self) -> LocalModuleId;
 }
@@ -32,7 +34,7 @@ impl PathResolver for StandardPathResolver {
         &self,
         def_maps: &HashMap<CrateId, CrateDefMap>,
         path: Path,
-    ) -> Result<ModuleDefId, Ident> {
+    ) -> Result<ModuleDefId, PathResolutionError> {
         resolve_path(def_maps, self.module_id, path)
     }
 
@@ -47,16 +49,14 @@ pub fn resolve_path(
     def_maps: &HashMap<CrateId, CrateDefMap>,
     module_id: ModuleId,
     path: Path,
-) -> Result<ModuleDefId, Ident> {
+) -> Result<ModuleDefId, PathResolutionError> {
     // lets package up the path into an ImportDirective and resolve it using that
     let import = ImportDirective { module_id: module_id.local_id, path, alias: None };
+    let allow_referencing_contracts =
+        allow_referencing_contracts(def_maps, module_id.krate, module_id.local_id);
 
     let def_map = &def_maps[&module_id.krate];
-    let path_res = resolve_path_to_ns(&import, def_map, def_maps);
-    let ns = match path_res {
-        PathResolution::Unresolved(seg) => return Err(seg),
-        PathResolution::Resolved(ns) => ns,
-    };
+    let ns = resolve_path_to_ns(&import, def_map, def_maps, allow_referencing_contracts)?;
 
     let function = ns.values.map(|(id, _)| id);
     let id = function.or_else(|| ns.types.map(|(id, _)| id));

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1334,7 +1334,7 @@ mod test {
         assert_eq!(errors.len(), 1);
         let err = errors.pop().unwrap();
 
-        path_unresolved_error(err, "some::path::to::a::func");
+        path_unresolved_error(err, "func");
     }
 
     #[test]
@@ -1374,7 +1374,7 @@ mod test {
                 ResolverError::VariableNotDeclared { name, .. } => {
                     assert_eq!(name, "a");
                 }
-                ResolverError::PathResolutionError(_) => path_unresolved_error(err, "foo::bar"),
+                ResolverError::PathResolutionError(_) => path_unresolved_error(err, "bar"),
                 _ => unimplemented!(),
             };
         }
@@ -1440,7 +1440,7 @@ mod test {
             // Not here that foo::bar and hello::foo::bar would fetch the same thing
             let name = path.segments.last().unwrap();
             let mod_def = self.0.get(&name.0.contents).cloned();
-            mod_def.ok_or_else(move || PathResolutionError::Unresolved(name))
+            mod_def.ok_or_else(move || PathResolutionError::Unresolved(name.clone()))
         }
 
         fn local_module_id(&self) -> LocalModuleId {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1048,11 +1048,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_path(&mut self, path: Path) -> Result<ModuleDefId, ResolverError> {
-        let span = path.span();
-        let name = path.as_string();
-        self.path_resolver
-            .resolve(self.def_maps, path)
-            .map_err(|segment| ResolverError::PathUnresolved { name, span, segment })
+        self.path_resolver.resolve(self.def_maps, path).map_err(ResolverError::PathResolutionError)
     }
 
     fn resolve_block(&mut self, block_expr: BlockExpression) -> HirExpression {
@@ -1212,7 +1208,8 @@ mod test {
     use fm::FileId;
     use iter_extended::vecmap;
 
-    use crate::{hir::resolution::errors::ResolverError, Ident};
+    use crate::hir::resolution::errors::ResolverError;
+    use crate::hir::resolution::import::PathResolutionError;
 
     use crate::graph::CrateId;
     use crate::hir_def::function::HirFunction;
@@ -1377,11 +1374,12 @@ mod test {
                 ResolverError::VariableNotDeclared { name, .. } => {
                     assert_eq!(name, "a");
                 }
-                ResolverError::PathUnresolved { .. } => path_unresolved_error(err, "foo::bar"),
+                ResolverError::PathResolutionError(_) => path_unresolved_error(err, "foo::bar"),
                 _ => unimplemented!(),
             };
         }
     }
+
     #[test]
     fn resolve_prefix_expr() {
         let src = r#"
@@ -1424,8 +1422,8 @@ mod test {
 
     fn path_unresolved_error(err: ResolverError, expected_unresolved_path: &str) {
         match err {
-            ResolverError::PathUnresolved { span: _, name, segment: _ } => {
-                assert_eq!(name, expected_unresolved_path)
+            ResolverError::PathResolutionError(PathResolutionError::Unresolved(name)) => {
+                assert_eq!(name.to_string(), expected_unresolved_path)
             }
             _ => unimplemented!("expected an unresolved path"),
         }
@@ -1438,11 +1436,11 @@ mod test {
             &self,
             _def_maps: &HashMap<CrateId, CrateDefMap>,
             path: Path,
-        ) -> Result<ModuleDefId, Ident> {
+        ) -> Result<ModuleDefId, PathResolutionError> {
             // Not here that foo::bar and hello::foo::bar would fetch the same thing
             let name = path.segments.last().unwrap();
             let mod_def = self.0.get(&name.0.contents).cloned();
-            mod_def.ok_or_else(|| name.clone())
+            mod_def.ok_or_else(move || PathResolutionError::Unresolved(name))
         }
 
         fn local_module_id(&self) -> LocalModuleId {


### PR DESCRIPTION
# Related issue(s)

Resolves #955

# Description

## Summary of changes

Prevents referencing items defined within a contract's scope from outside of a contract. Note that this currently will still allow calling these functions within another contract in the same program.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

Updated contracts test to no longer reference contract functions within main.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

# Additional context

<!-- If applicable. -->
