### PR TITLE
fix(770): rationalise witness for constant values

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -46,7 +46,7 @@ impl Acir {
 
         let output = match &ins.operation {
             Operation::Binary(binary) => {
-                binary::evaluate(binary, ins.res_type, var_cache, acir_mem, evaluator, ctx)
+                binary::evaluate(binary, ins.res_type, self, evaluator, ctx)
             }
             Operation::Constrain(value, ..) => {
                 constrain::evaluate(value, var_cache, evaluator, ctx)
@@ -97,7 +97,7 @@ impl Acir {
         // then we add it to the `InternalVar` cache
         if let Some(mut output) = output {
             output.set_id(ins.id);
-            self.var_cache.update(ins.id, output);
+            self.var_cache.update(output);
         }
 
         Ok(())

--- a/crates/noirc_evaluator/src/ssa/acir_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen.rs
@@ -68,7 +68,7 @@ impl Acir {
                     }
                     _ => *opcode,
                 };
-                intrinsics::evaluate(args, ins, opcode, var_cache, acir_mem, ctx, evaluator)
+                intrinsics::evaluate(args, ins, opcode, self, ctx, evaluator)
             }
             Operation::Return(node_ids) => {
                 r#return::evaluate(node_ids, acir_mem, var_cache, evaluator, ctx)?

--- a/crates/noirc_evaluator/src/ssa/acir_gen/internal_var.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/internal_var.rs
@@ -38,6 +38,9 @@ impl InternalVar {
     pub(crate) fn set_id(&mut self, id: NodeId) {
         self.id = Some(id)
     }
+    pub(crate) fn get_id(&self) -> Option<NodeId> {
+        self.id
+    }
     pub(crate) fn cached_witness(&self) -> &Option<Witness> {
         &self.cached_witness
     }
@@ -106,20 +109,15 @@ impl InternalVar {
     /// - If a `Witness` has previously been generated
     /// we return that.
     /// - If the Expression represents a constant, we return None.
-    pub(crate) fn get_or_compute_witness(
-        &mut self,
-        evaluator: &mut Evaluator,
-        create_witness_for_const: bool,
-    ) -> Option<Witness> {
+    pub(crate) fn get_or_compute_witness(&mut self, evaluator: &mut Evaluator) -> Option<Witness> {
         // Check if we've already generated a `Witness` which is equal to
         // the stored `Expression`
         if let Some(witness) = self.cached_witness {
             return Some(witness);
         }
 
-        // There are cases where we need to convert a constant expression
-        // into a witness.
-        if !create_witness_for_const && self.is_const_expression() {
+        // We do not generate a witness for constant values. It can only be done at the InternalVarCache level.
+        if self.is_const_expression() {
             return None;
         }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
@@ -6,12 +6,15 @@ use crate::{
     },
     Evaluator,
 };
-use acvm::FieldElement;
+use acvm::{acir::native_types::Witness, FieldElement};
 use std::collections::HashMap;
+
+use super::expression_to_witness;
 
 #[derive(Default)]
 pub struct InternalVarCache {
     inner: HashMap<NodeId, InternalVar>,
+    constants: HashMap<FieldElement, InternalVar>,
 }
 
 impl InternalVarCache {
@@ -32,7 +35,20 @@ impl InternalVarCache {
         let mut var = match ctx.try_get_node(id)? {
             NodeObject::Const(c) => {
                 let field_value = FieldElement::from_be_bytes_reduce(&c.value.to_bytes_be());
-                InternalVar::from_constant(field_value)
+                let mut result = InternalVar::from_constant(field_value);
+                if let Some(c_var) = self.constants.get(&field_value) {
+                    result = c_var.clone();
+                }
+                result.set_id(id);
+                //map nodes of other types to the same var
+                if let Some(constant_vars) = ctx.constants.get(&field_value) {
+                    for c_var in constant_vars {
+                        if let Some(id) = c_var.get_id() {
+                            self.inner.insert(id, result.to_owned());
+                        }
+                    }
+                }
+                result.to_owned()
             }
             NodeObject::Variable(variable) => {
                 let variable_type = variable.get_type();
@@ -81,5 +97,53 @@ impl InternalVarCache {
     }
     pub(super) fn get(&mut self, id: &NodeId) -> Option<&InternalVar> {
         self.inner.get(id)
+    }
+
+    // Transform a field element into a witness
+    // It implements a 'get or create' pattern to ensure only one witness is created per element
+    fn const_to_witness(
+        &mut self,
+        value: FieldElement,
+        evaluator: &mut Evaluator,
+        ctx: &SsaContext,
+    ) -> Witness {
+        if let Some(vars) = ctx.constants.get(&value) {
+            //we have a constant node object for the value
+            if !vars.is_empty() {
+                let id = vars
+                    .first()
+                    .unwrap()
+                    .get_id()
+                    .expect("infaillible: SsaContext always set the id");
+                let mut var = self.get_or_compute_internal_var_unwrap(id, evaluator, ctx);
+                return Self::const_to_witness_helper(&mut var, evaluator);
+            }
+        }
+        //if not, we use the constants map
+        let var = self.constants.entry(value).or_insert(InternalVar::from_constant(value));
+        Self::const_to_witness_helper(var, evaluator)
+    }
+
+    // Helper function which generates a witness for an InternalVar
+    // Do not call outside const_to_witness()
+    fn const_to_witness_helper(var: &mut InternalVar, evaluator: &mut Evaluator) -> Witness {
+        var.get_or_compute_witness(evaluator)
+            .unwrap_or_else(|| expression_to_witness(var.to_expression(), evaluator))
+    }
+
+    /// Get or compute a witness for an internal var
+    /// WARNING: It generates a witness even if the internal var is constant, so it should be used only if the var is an input
+    /// to some ACIR opcode which requires a witness
+    pub fn get_or_compute_witness_unwrap(
+        &mut self,
+        var: &mut InternalVar,
+        evaluator: &mut Evaluator,
+        ctx: &SsaContext,
+    ) -> Witness {
+        if let Some(v) = var.to_const() {
+            self.const_to_witness(v, evaluator, ctx)
+        } else {
+            var.get_or_compute_witness(evaluator).expect("infaillible non const expression")
+        }
     }
 }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
@@ -31,6 +31,7 @@ pub(crate) fn evaluate(
     res_type: ObjectType,
     var_cache: &mut InternalVarCache,
     memory_map: &mut AcirMem,
+    //acir_gen: &mut Acir,
     evaluator: &mut Evaluator,
     ctx: &SsaContext,
 ) -> Option<InternalVar> {
@@ -153,7 +154,7 @@ pub(crate) fn evaluate(
                     }
                 } else {
                     //TODO avoid creating witnesses here.
-                    let x_witness = r_c.get_or_compute_witness(evaluator, false).expect("unexpected constant expression"); 
+                    let x_witness = r_c.get_or_compute_witness(evaluator).expect("unexpected constant expression"); 
                     let inverse = Expression::from(&constraints::evaluate_inverse(
                         x_witness, &predicate, evaluator,
                     ));
@@ -237,7 +238,7 @@ pub(crate) fn evaluate(
                 let opcode = binary.operator.clone();
                 let bitwise_result = match operations::bitwise::simplify_bitwise(&l_c, &r_c, bit_size, &opcode) {
                     Some(simplified_internal_var) => simplified_internal_var.expression().clone(),
-                    None => operations::bitwise::evaluate_bitwise(l_c, r_c, bit_size, evaluator, opcode),
+                    None => operations::bitwise::evaluate_bitwise(l_c, r_c, bit_size, evaluator, var_cache, ctx, opcode),
                 };
                 InternalVar::from(bitwise_result)
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/binary.rs
@@ -1,8 +1,7 @@
 use crate::{
     ssa::{
         acir_gen::{
-            acir_mem::AcirMem, constraints, internal_var_cache::InternalVarCache, operations,
-            InternalVar,
+            constraints, internal_var_cache::InternalVarCache, operations, Acir, InternalVar,
         },
         context::SsaContext,
         node::{self, BinaryOp, Node, ObjectType},
@@ -29,9 +28,7 @@ fn get_predicate(
 pub(crate) fn evaluate(
     binary: &node::Binary,
     res_type: ObjectType,
-    var_cache: &mut InternalVarCache,
-    memory_map: &mut AcirMem,
-    //acir_gen: &mut Acir,
+    acir_gen: &mut Acir,
     evaluator: &mut Evaluator,
     ctx: &SsaContext,
 ) -> Option<InternalVar> {
@@ -44,8 +41,8 @@ pub(crate) fn evaluate(
 
     let binary_output = match &binary.operator {
             BinaryOp::Add | BinaryOp::SafeAdd => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 InternalVar::from(constraints::add(
                     l_c.expression(),
                     FieldElement::one(),
@@ -53,8 +50,8 @@ pub(crate) fn evaluate(
                 ))
             },
             BinaryOp::Sub { max_rhs_value } | BinaryOp::SafeSub { max_rhs_value } => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 if res_type == ObjectType::NativeField {
                     InternalVar::from(constraints::subtract(
                         l_c.expression(),
@@ -94,8 +91,8 @@ pub(crate) fn evaluate(
                 }
             }
             BinaryOp::Mul | BinaryOp::SafeMul => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 InternalVar::from(constraints::mul_with_witness(
                 evaluator,
                 l_c.expression(),
@@ -103,9 +100,9 @@ pub(crate) fn evaluate(
             ))
             },
             BinaryOp::Udiv(_) => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
-                let predicate = get_predicate(var_cache,binary, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let predicate = get_predicate(&mut acir_gen.var_cache,binary, evaluator, ctx);
                 let (q_wit, _) = constraints::evaluate_udiv(
                     l_c.expression(),
                     r_c.expression(),
@@ -116,16 +113,16 @@ pub(crate) fn evaluate(
                 InternalVar::from(q_wit)
             }
             BinaryOp::Sdiv(_) => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 InternalVar::from(
                 constraints::evaluate_sdiv(l_c.expression(), r_c.expression(), evaluator).0,
             )
         },
             BinaryOp::Urem(_) => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
-                let predicate = get_predicate(var_cache,binary, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let predicate = get_predicate(&mut acir_gen.var_cache,binary, evaluator, ctx);
                 let (_, r_wit) = constraints::evaluate_udiv(
                     l_c.expression(),
                     r_c.expression(),
@@ -136,16 +133,16 @@ pub(crate) fn evaluate(
                 InternalVar::from(r_wit)
             }
             BinaryOp::Srem(_) => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 InternalVar::from(
                 // TODO: we should use variable naming here instead of .1
                 constraints::evaluate_sdiv(l_c.expression(), r_c.expression(), evaluator).1,
             )},
             BinaryOp::Div(_) => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let mut r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
-                let predicate = get_predicate(var_cache,binary, evaluator, ctx).expression().clone();
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let predicate = get_predicate(&mut acir_gen.var_cache,binary, evaluator, ctx).expression().clone();
                 if let Some(r_value) = r_c.to_const() {
                     if r_value.is_zero() {
                         panic!("Panic - division by zero");
@@ -154,7 +151,7 @@ pub(crate) fn evaluate(
                     }
                 } else {
                     //TODO avoid creating witnesses here.
-                    let x_witness = r_c.get_or_compute_witness(evaluator).expect("unexpected constant expression"); 
+                    let x_witness = acir_gen.var_cache.get_or_compute_witness(r_c, evaluator).expect("unexpected constant expression"); 
                     let inverse = Expression::from(&constraints::evaluate_inverse(
                         x_witness, &predicate, evaluator,
                     ));
@@ -166,20 +163,20 @@ pub(crate) fn evaluate(
                 }
             }
             BinaryOp::Eq => {
-                let l_c = var_cache.get_or_compute_internal_var(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var(binary.rhs, evaluator, ctx);
                 InternalVar::from(
-                operations::cmp::evaluate_eq(memory_map,binary.lhs, binary.rhs, l_c, r_c, ctx, evaluator),
+                operations::cmp::evaluate_eq(acir_gen,binary.lhs, binary.rhs, l_c, r_c, ctx, evaluator),
             )},
             BinaryOp::Ne => {
-                let l_c = var_cache.get_or_compute_internal_var(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var(binary.rhs, evaluator, ctx);
                 InternalVar::from(
-                operations::cmp::evaluate_neq(memory_map,binary.lhs, binary.rhs, l_c, r_c, ctx, evaluator),
+                operations::cmp::evaluate_neq(acir_gen,binary.lhs, binary.rhs, l_c, r_c, ctx, evaluator),
             )},
             BinaryOp::Ult => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 let size = ctx[binary.lhs].get_type().bits();
                 constraints::evaluate_cmp(
                     l_c.expression(),
@@ -191,8 +188,8 @@ pub(crate) fn evaluate(
                 .into()
             }
             BinaryOp::Ule => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 let size = ctx[binary.lhs].get_type().bits();
                 let e = constraints::evaluate_cmp(
                     r_c.expression(),
@@ -204,15 +201,15 @@ pub(crate) fn evaluate(
                 constraints::subtract(&Expression::one(), FieldElement::one(), &e).into()
             }
             BinaryOp::Slt => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 let s = ctx[binary.lhs].get_type().bits();
                 constraints::evaluate_cmp(l_c.expression(), r_c.expression(), s, true, evaluator)
                     .into()
             }
             BinaryOp::Sle => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 let s = ctx[binary.lhs].get_type().bits();
                 let e = constraints::evaluate_cmp(
                     r_c.expression(),
@@ -232,13 +229,13 @@ pub(crate) fn evaluate(
             )
             }
             BinaryOp::And | BinaryOp::Or | BinaryOp::Xor => {
-                let l_c = var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
-                let r_c = var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
+                let l_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.lhs, evaluator, ctx);
+                let r_c = acir_gen.var_cache.get_or_compute_internal_var_unwrap(binary.rhs, evaluator, ctx);
                 let bit_size = res_type.bits();
                 let opcode = binary.operator.clone();
                 let bitwise_result = match operations::bitwise::simplify_bitwise(&l_c, &r_c, bit_size, &opcode) {
                     Some(simplified_internal_var) => simplified_internal_var.expression().clone(),
-                    None => operations::bitwise::evaluate_bitwise(l_c, r_c, bit_size, evaluator, var_cache, ctx, opcode),
+                    None => operations::bitwise::evaluate_bitwise(l_c, r_c, bit_size, evaluator, &mut acir_gen.var_cache, ctx, opcode),
                 };
                 InternalVar::from(bitwise_result)
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/bitwise.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/bitwise.rs
@@ -77,8 +77,8 @@ pub(super) fn simplify_bitwise(
 }
 // Precondition: `lhs` and `rhs` do not represent constant expressions
 pub(super) fn evaluate_bitwise(
-    mut lhs: InternalVar,
-    mut rhs: InternalVar,
+    lhs: InternalVar,
+    rhs: InternalVar,
     bit_size: u32,
     evaluator: &mut Evaluator,
     var_cache: &mut InternalVarCache,
@@ -114,8 +114,8 @@ pub(super) fn evaluate_bitwise(
     // If the gate is implemented, it is expected to be better than going through bit decomposition, even if one of the operand is a constant
     // If the gate is not implemented, we rely on the ACIR simplification to remove these witnesses
     //
-    let mut a_witness = var_cache.get_or_compute_witness_unwrap(&mut lhs, evaluator, ctx);
-    let mut b_witness = var_cache.get_or_compute_witness_unwrap(&mut rhs, evaluator, ctx);
+    let mut a_witness = var_cache.get_or_compute_witness_unwrap(lhs, evaluator, ctx);
+    let mut b_witness = var_cache.get_or_compute_witness_unwrap(rhs, evaluator, ctx);
 
     let result = evaluator.add_witness_to_cs();
     let bit_size = if bit_size % 2 == 1 { bit_size + 1 } else { bit_size };
@@ -128,12 +128,12 @@ pub(super) fn evaluate_bitwise(
             a_witness = evaluator.create_intermediate_variable(constraints::subtract(
                 &Expression::from_field(max),
                 FieldElement::one(),
-                lhs.expression(),
+                &Expression::from(a_witness),
             ));
             b_witness = evaluator.create_intermediate_variable(constraints::subtract(
                 &Expression::from_field(max),
                 FieldElement::one(),
-                rhs.expression(),
+                &Expression::from(b_witness),
             ));
             // We do not have an OR gate yet, so we use the AND gate
             acvm::acir::BlackBoxFunc::AND

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
@@ -65,7 +65,7 @@ pub(crate) fn evaluate_neq(
         // TODO if we change the Invert directive to take an `Expression`, then we
         // TODO can get rid of this extra gate.
         let x_witness =
-            x.get_or_compute_witness(evaluator, false).expect("unexpected constant expression");
+            x.get_or_compute_witness(evaluator).expect("unexpected constant expression");
 
         return Expression::from(&constraints::evaluate_zero_equality(x_witness, evaluator));
     }
@@ -90,7 +90,7 @@ pub(crate) fn evaluate_neq(
     } else {
         //todo we need a witness because of the directive, but we should use an expression
         let x_witness =
-            x.get_or_compute_witness(evaluator, false).expect("unexpected constant expression");
+            x.get_or_compute_witness(evaluator).expect("unexpected constant expression");
         Expression::from(&constraints::evaluate_zero_equality(x_witness, evaluator))
     }
 }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/cmp.rs
@@ -1,6 +1,6 @@
 use crate::{
     ssa::{
-        acir_gen::{acir_mem::AcirMem, constraints, InternalVar},
+        acir_gen::{acir_mem::AcirMem, constraints, Acir, InternalVar},
         context::SsaContext,
         mem::{MemArray, Memory},
         node::NodeId,
@@ -26,7 +26,7 @@ use iter_extended::vecmap;
 // so in reality, the NEQ instruction will be done on the fields
 // of the struct
 pub(crate) fn evaluate_neq(
-    acir_mem: &mut AcirMem,
+    acir_gen: &mut Acir,
     lhs: NodeId,
     rhs: NodeId,
     l_c: Option<InternalVar>,
@@ -60,12 +60,14 @@ pub(crate) fn evaluate_neq(
             )
         }
 
-        let mut x = InternalVar::from(array_eq(acir_mem, array_a, array_b, evaluator));
+        let x = InternalVar::from(array_eq(&mut acir_gen.memory, array_a, array_b, evaluator));
         // TODO we need a witness because of the directive, but we should use an expression
         // TODO if we change the Invert directive to take an `Expression`, then we
         // TODO can get rid of this extra gate.
-        let x_witness =
-            x.get_or_compute_witness(evaluator).expect("unexpected constant expression");
+        let x_witness = acir_gen
+            .var_cache
+            .get_or_compute_witness(x, evaluator)
+            .expect("unexpected constant expression");
 
         return Expression::from(&constraints::evaluate_zero_equality(x_witness, evaluator));
     }
@@ -73,7 +75,7 @@ pub(crate) fn evaluate_neq(
     // Arriving here means that `lhs` and `rhs` are not Arrays
     let l_c = l_c.expect("ICE: unexpected array pointer");
     let r_c = r_c.expect("ICE: unexpected array pointer");
-    let mut x = InternalVar::from(constraints::subtract(
+    let x = InternalVar::from(constraints::subtract(
         l_c.expression(),
         FieldElement::one(),
         r_c.expression(),
@@ -89,14 +91,16 @@ pub(crate) fn evaluate_neq(
         }
     } else {
         //todo we need a witness because of the directive, but we should use an expression
-        let x_witness =
-            x.get_or_compute_witness(evaluator).expect("unexpected constant expression");
+        let x_witness = acir_gen
+            .var_cache
+            .get_or_compute_witness(x, evaluator)
+            .expect("unexpected constant expression");
         Expression::from(&constraints::evaluate_zero_equality(x_witness, evaluator))
     }
 }
 
 pub(crate) fn evaluate_eq(
-    memory_map: &mut AcirMem,
+    acir_gen: &mut Acir,
     lhs: NodeId,
     rhs: NodeId,
     l_c: Option<InternalVar>,
@@ -104,7 +108,7 @@ pub(crate) fn evaluate_eq(
     ctx: &SsaContext,
     evaluator: &mut Evaluator,
 ) -> Expression {
-    let neq = evaluate_neq(memory_map, lhs, rhs, l_c, r_c, ctx, evaluator);
+    let neq = evaluate_neq(acir_gen, lhs, rhs, l_c, r_c, ctx, evaluator);
     constraints::subtract(&Expression::one(), FieldElement::one(), &neq)
 }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -181,17 +181,12 @@ fn resolve_node_id(
             // Upon the case that the `NodeObject` is not a `Variable`,
             // we attempt to fetch an associated `InternalVar`.
             // Otherwise, this is a internal compiler error.
-            let internal_var = acir_gen.var_cache.get(node_id);
-            match internal_var {
-                Some(var) => {
-                    let witness = var
-                        .clone()
-                        .get_or_compute_witness(evaluator)
-                        .expect("unexpected constant expression");
-                    vec![FunctionInput { witness, num_bits: node_object.size_in_bits() }]
-                }
-                None => unreachable!("invalid input: {:?}", node_object),
-            }
+            let internal_var = acir_gen.var_cache.get(node_id).expect("invalid input").clone();
+            let witness = acir_gen
+                .var_cache
+                .get_or_compute_witness(internal_var, evaluator)
+                .expect("unexpected constant expression");
+            vec![FunctionInput { witness, num_bits: node_object.size_in_bits() }]
         }
     }
 }
@@ -212,9 +207,9 @@ fn resolve_array(
             .load_array_element_constant_index(array, i)
             .expect("array index out of bounds");
         let witness =
-            acir_gen.var_cache.get_or_compute_witness_unwrap(&mut arr_element, evaluator, cfg);
+            acir_gen.var_cache.get_or_compute_witness_unwrap(arr_element.clone(), evaluator, cfg);
         let func_input = FunctionInput { witness, num_bits };
-
+        arr_element.set_witness(Some(witness));
         acir_gen.memory.insert(array.id, i, arr_element);
 
         inputs.push(func_input)
@@ -291,7 +286,7 @@ fn evaluate_println(
                 log_string = format_field_string(field);
             }
             None => {
-                let mut var = var_cache
+                let var = var_cache
                     .get(&node_id)
                     .unwrap_or_else(|| {
                         panic!(
@@ -302,7 +297,7 @@ fn evaluate_println(
                     .clone();
                 if let Some(field) = var.to_const() {
                     log_string = format_field_string(field);
-                } else if let Some(w) = var.get_or_compute_witness(evaluator) {
+                } else if let Some(w) = var_cache.get_or_compute_witness(var, evaluator) {
                     // We check whether there has already been a cached witness for this node. If not, we generate a new witness and include it in the logs
                     // TODO we need a witness because of the directive, but we should use an expression
                     log_witnesses.push(w);

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -3,7 +3,7 @@ use crate::{
         acir_gen::{
             constraints::{bound_constraint_with_offset, to_radix_base},
             operations::sort::evaluate_permutation,
-            AcirMem, InternalVar, InternalVarCache,
+            Acir, AcirMem, InternalVar, InternalVarCache,
         },
         builtin,
         context::SsaContext,
@@ -33,8 +33,7 @@ pub(crate) fn evaluate(
     args: &[NodeId],
     instruction: &Instruction,
     opcode: builtin::Opcode,
-    var_cache: &mut InternalVarCache,
-    memory_map: &mut AcirMem,
+    acir_gen: &mut Acir,
     ctx: &SsaContext,
     evaluator: &mut Evaluator,
 ) -> Option<InternalVar> {
@@ -48,28 +47,30 @@ pub(crate) fn evaluate(
         Opcode::ToBits(endianess) => {
             // TODO: document where `0` and `1` are coming from, for args[0], args[1]
             let bit_size = ctx.get_as_constant(args[1]).unwrap().to_u128() as u32;
-            let l_c = var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
+            let l_c =
+                acir_gen.var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
             outputs = to_radix_base(l_c.expression(), 2, bit_size, endianess, evaluator);
             if let ObjectType::Pointer(a) = res_type {
-                memory_map.map_array(a, &outputs, ctx);
+                acir_gen.memory.map_array(a, &outputs, ctx);
             }
         }
         Opcode::ToRadix(endianess) => {
             // TODO: document where `0`, `1` and `2` are coming from, for args[0],args[1], args[2]
             let radix = ctx.get_as_constant(args[1]).unwrap().to_u128() as u32;
             let limb_size = ctx.get_as_constant(args[2]).unwrap().to_u128() as u32;
-            let l_c = var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
+            let l_c =
+                acir_gen.var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
             outputs = to_radix_base(l_c.expression(), radix, limb_size, endianess, evaluator);
             if let ObjectType::Pointer(a) = res_type {
-                memory_map.map_array(a, &outputs, ctx);
+                acir_gen.memory.map_array(a, &outputs, ctx);
             }
         }
         Opcode::Println(print_info) => {
             outputs = Vec::new(); // print statements do not output anything
             if print_info.show_output {
                 evaluate_println(
-                    var_cache,
-                    memory_map,
+                    &mut acir_gen.var_cache,
+                    &mut acir_gen.memory,
                     print_info.is_string_output,
                     args,
                     ctx,
@@ -78,9 +79,10 @@ pub(crate) fn evaluate(
             }
         }
         Opcode::LowLevel(op) => {
-            let inputs = prepare_inputs(var_cache, memory_map, args, ctx, evaluator);
+            let inputs = prepare_inputs(acir_gen, args, ctx, evaluator);
             let output_count = op.definition().output_size.0 as u32;
-            outputs = prepare_outputs(memory_map, instruction_id, output_count, ctx, evaluator);
+            outputs =
+                prepare_outputs(&mut acir_gen.memory, instruction_id, output_count, ctx, evaluator);
 
             let func_call = BlackBoxFuncCall {
                 name: op,
@@ -96,10 +98,15 @@ pub(crate) fn evaluate(
             let num_bits = array.element_type.bits();
             for i in 0..array.len {
                 in_expr.push(
-                    memory_map.load_array_element_constant_index(array, i).unwrap().to_expression(),
+                    acir_gen
+                        .memory
+                        .load_array_element_constant_index(array, i)
+                        .unwrap()
+                        .to_expression(),
                 );
             }
-            outputs = prepare_outputs(memory_map, instruction_id, array.len, ctx, evaluator);
+            outputs =
+                prepare_outputs(&mut acir_gen.memory, instruction_id, array.len, ctx, evaluator);
             let out_expr: Vec<Expression> = outputs.iter().map(|w| w.into()).collect();
             for i in 0..(out_expr.len() - 1) {
                 bound_constraint_with_offset(
@@ -119,7 +126,7 @@ pub(crate) fn evaluate(
                 sort_by: vec![0],
             }));
             if let node::ObjectType::Pointer(a) = res_type {
-                memory_map.map_array(a, &outputs, ctx);
+                acir_gen.memory.map_array(a, &outputs, ctx);
             } else {
                 unreachable!();
             }
@@ -134,8 +141,7 @@ pub(crate) fn evaluate(
 
 // Transform the arguments of intrinsic functions into witnesses
 fn prepare_inputs(
-    var_cache: &mut InternalVarCache,
-    memory_map: &mut AcirMem,
+    acir_gen: &mut Acir,
     arguments: &[NodeId],
     cfg: &SsaContext,
     evaluator: &mut Evaluator,
@@ -143,15 +149,14 @@ fn prepare_inputs(
     let mut inputs: Vec<FunctionInput> = Vec::new();
 
     for argument in arguments {
-        inputs.extend(resolve_node_id(argument, var_cache, memory_map, cfg, evaluator))
+        inputs.extend(resolve_node_id(argument, acir_gen, cfg, evaluator))
     }
     inputs
 }
 
 fn resolve_node_id(
     node_id: &NodeId,
-    var_cache: &mut InternalVarCache,
-    memory_map: &mut AcirMem,
+    acir_gen: &mut Acir,
     cfg: &SsaContext,
     evaluator: &mut Evaluator,
 ) -> Vec<FunctionInput> {
@@ -162,7 +167,7 @@ fn resolve_node_id(
             match node_obj_type {
                 // If the `Variable` represents a Pointer
                 // Then we know that it is an `Array`
-                node::ObjectType::Pointer(a) => resolve_array(a, memory_map, cfg, evaluator),
+                node::ObjectType::Pointer(a) => resolve_array(a, acir_gen, cfg, evaluator),
                 // If it is not a pointer, we attempt to fetch the witness associated with it
                 _ => match v.witness {
                     Some(w) => {
@@ -176,12 +181,12 @@ fn resolve_node_id(
             // Upon the case that the `NodeObject` is not a `Variable`,
             // we attempt to fetch an associated `InternalVar`.
             // Otherwise, this is a internal compiler error.
-            let internal_var = var_cache.get(node_id);
+            let internal_var = acir_gen.var_cache.get(node_id);
             match internal_var {
                 Some(var) => {
                     let witness = var
                         .clone()
-                        .get_or_compute_witness(evaluator, false)
+                        .get_or_compute_witness(evaluator)
                         .expect("unexpected constant expression");
                     vec![FunctionInput { witness, num_bits: node_object.size_in_bits() }]
                 }
@@ -193,7 +198,7 @@ fn resolve_node_id(
 
 fn resolve_array(
     array_id: ArrayId,
-    acir_mem: &mut AcirMem,
+    acir_gen: &mut Acir,
     cfg: &SsaContext,
     evaluator: &mut Evaluator,
 ) -> Vec<FunctionInput> {
@@ -202,16 +207,15 @@ fn resolve_array(
     let array = &cfg.mem[array_id];
     let num_bits = array.element_type.bits();
     for i in 0..array.len {
-        let mut arr_element = acir_mem
+        let mut arr_element = acir_gen
+            .memory
             .load_array_element_constant_index(array, i)
             .expect("array index out of bounds");
-
-        let witness = arr_element.get_or_compute_witness(evaluator, true).expect(
-            "infallible: `None` can only be returned when we disallow constant Expressions.",
-        );
+        let witness =
+            acir_gen.var_cache.get_or_compute_witness_unwrap(&mut arr_element, evaluator, cfg);
         let func_input = FunctionInput { witness, num_bits };
 
-        acir_mem.insert(array.id, i, arr_element);
+        acir_gen.memory.insert(array.id, i, arr_element);
 
         inputs.push(func_input)
     }
@@ -298,7 +302,7 @@ fn evaluate_println(
                     .clone();
                 if let Some(field) = var.to_const() {
                     log_string = format_field_string(field);
-                } else if let Some(w) = var.get_or_compute_witness(evaluator, false) {
+                } else if let Some(w) = var.get_or_compute_witness(evaluator) {
                     // We check whether there has already been a cached witness for this node. If not, we generate a new witness and include it in the logs
                     // TODO we need a witness because of the directive, but we should use an expression
                     log_witnesses.push(w);

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -41,8 +41,8 @@ pub(crate) fn evaluate(
         };
 
         let mut witnesses: Vec<Witness> = Vec::new();
-        for mut object in objects {
-            let witness = var_cache.get_or_compute_witness_unwrap(&mut object, evaluator, ctx);
+        for object in objects {
+            let witness = var_cache.get_or_compute_witness_unwrap(object, evaluator, ctx);
             // Before pushing to the public inputs, we need to check that
             // it was not a private ABI input
             if evaluator.is_private_abi_input(witness) {

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -42,9 +42,7 @@ pub(crate) fn evaluate(
 
         let mut witnesses: Vec<Witness> = Vec::new();
         for mut object in objects {
-            let witness = object.get_or_compute_witness(evaluator, true).expect(
-                "infallible: `None` can only be returned when we disallow constant Expressions.",
-            );
+            let witness = var_cache.get_or_compute_witness_unwrap(&mut object, evaluator, ctx);
             // Before pushing to the public inputs, we need to check that
             // it was not a private ABI input
             if evaluator.is_private_abi_input(witness) {


### PR DESCRIPTION
# Related issue(s)


Resolves #770

# Description

## Summary of changes

Update the internalVarCache when we generate a witness for an internalVar. The Pr also ensures that we create only one witness per constant value.


## Test additions / changes

Unit tests added to internalVarCache

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

