### PR TITLE
chore: remove unnecessary conversion through `OsStr` in `read_file_to_string`

### DIFF
--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -43,7 +43,7 @@ cfg_if::cfg_if! {
     } else {
         pub(crate) fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
 
-            match StdLibAssets::get(path_to_file.to_str().unwrap()) {
+            match StdLibAssets::get(path_to_file.as_os_str().to_str().unwrap()) {
 
                 Some(std_lib_asset) => {
                     Ok(std::str::from_utf8(std_lib_asset.data.as_ref()).unwrap().to_string())

--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -25,9 +25,7 @@ cfg_if::cfg_if! {
         pub(crate) fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
             use std::io::ErrorKind;
 
-            let path_str = path_to_file.as_os_str().to_str().unwrap();
-
-            match StdLibAssets::get(path_str) {
+            match StdLibAssets::get(path_to_file.to_str().unwrap()) {
 
                 Some(std_lib_asset) => {
                     Ok(std::str::from_utf8(std_lib_asset.data.as_ref()).unwrap().to_string())
@@ -43,7 +41,7 @@ cfg_if::cfg_if! {
     } else {
         pub(crate) fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
 
-            match StdLibAssets::get(path_to_file.as_os_str().to_str().unwrap()) {
+            match StdLibAssets::get(path_to_file.to_str().unwrap()) {
 
                 Some(std_lib_asset) => {
                     Ok(std::str::from_utf8(std_lib_asset.data.as_ref()).unwrap().to_string())


### PR DESCRIPTION
# Related issue(s)

Noticed while looking into #981

# Description

## Summary of changes

I noticed that we're not converting through an OsStr here which looks like a candidate for the root cause of #981. I can't test this as I don't have a windows install however.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
