### PR TITLE
fix: reverse slash direction in `StdLibAssets` prefix on windows

### DIFF
--- a/crates/fm/src/file_reader.rs
+++ b/crates/fm/src/file_reader.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 
 #[derive(RustEmbed)]
 #[folder = "../../noir_stdlib/src"]
-#[prefix = "std/"]
+#[cfg_attr(not(target_os = "windows"), prefix = "std/")]
+#[cfg_attr(target_os = "windows", prefix = r"std\")] // Note reversed slash direction
 struct StdLibAssets;
 
 cfg_if::cfg_if! {


### PR DESCRIPTION
# Related issue(s)

Resolves #981

# Description

## Summary of changes

We now reverse the slash direction for the prefix associated with `StdLibAssets` on windows.  This ensures that the path `std/lib.nr` matches this once it has converted into a `PathBuf` and back turning it into `std\lib.nr`

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
