### PR TITLE
feat: Allow numeric generics to be referenced and add `map`

### DIFF
--- a/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
+++ b/crates/nargo/tests/test_data/higher-order-functions/src/main.nr
@@ -44,6 +44,8 @@ fn test_array_functions() {
     
     let descending = myarray.sort_via(|a, b| a > b);
     constrain descending == [3, 2, 1];
+
+    constrain evens.map(|n| n / 2) == myarray;
 }
 
 fn foo() -> [u32; 2] {

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -2,7 +2,7 @@ pub use noirc_errors::Span;
 use noirc_errors::{CustomDiagnostic as Diagnostic, FileDiagnostic};
 use thiserror::Error;
 
-use crate::{Ident, Shared, StructType, Type};
+use crate::{parser::ParserError, Ident, Shared, StructType, Type};
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ResolverError {
@@ -57,6 +57,8 @@ pub enum ResolverError {
         actual: usize,
         expected: usize,
     },
+    #[error("{0}")]
+    ParserError(ParserError),
 }
 
 impl ResolverError {
@@ -252,6 +254,7 @@ impl From<ResolverError> for Diagnostic {
                     span,
                 )
             }
+            ResolverError::ParserError(error) => error.into(),
         }
     }
 }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -651,15 +651,17 @@ impl<'a> Resolver<'a> {
         for (name_to_find, type_variable) in Self::find_numeric_generics(params, return_type) {
             // Declare any generics to let users use numeric generics in scope.
             // Don't issue a warning if these are unused
-            let (name, _, span) = self
-                .generics
-                .iter()
-                .find(|(name, _, _)| name.as_ref() == &name_to_find)
-                .expect("Name of numeric generic should always be in the list of generics");
-
-            let ident = Ident::new(name.to_string(), *span);
-            let definition = DefinitionKind::GenericType(type_variable);
-            self.add_variable_decl_inner(ident, false, false, false, definition);
+            //
+            // We can fail to find the generic in self.generics if it is an implicit one created
+            // by the compiler. This can happen when, e.g. elliding array lengths using the slice
+            // syntax [T].
+            if let Some((name, _, span)) =
+                self.generics.iter().find(|(name, _, _)| name.as_ref() == &name_to_find)
+            {
+                let ident = Ident::new(name.to_string(), *span);
+                let definition = DefinitionKind::GenericType(type_variable);
+                self.add_variable_decl_inner(ident, false, false, false, definition);
+            }
         }
     }
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -12,7 +12,7 @@
 //
 // XXX: Resolver does not check for unused functions
 use crate::hir_def::expr::{
-    HirBinaryOp, HirBlockExpression, HirCallExpression, HirCastExpression,
+    HirArrayLiteral, HirBinaryOp, HirBlockExpression, HirCallExpression, HirCastExpression,
     HirConstructorExpression, HirExpression, HirForExpression, HirIdent, HirIfExpression,
     HirIndexExpression, HirInfixExpression, HirLambda, HirLiteral, HirMemberAccess,
     HirMethodCallExpression, HirPrefixExpression,
@@ -93,6 +93,7 @@ pub struct Resolver<'a> {
 struct ResolverMeta {
     num_times_used: usize,
     ident: HirIdent,
+    warn_if_unused: bool,
 }
 
 impl<'a> Resolver<'a> {
@@ -171,11 +172,7 @@ impl<'a> Resolver<'a> {
     fn check_for_unused_variables_in_local_scope(decl_map: Scope, unused_vars: &mut Vec<HirIdent>) {
         let unused_variables = decl_map.filter(|(variable_name, metadata)| {
             let has_underscore_prefix = variable_name.starts_with('_'); // XXX: This is used for development mode, and will be removed
-
-            if metadata.num_times_used == 0 && !has_underscore_prefix {
-                return true;
-            }
-            false
+            metadata.warn_if_unused && metadata.num_times_used == 0 && !has_underscore_prefix
         });
         unused_vars.extend(unused_variables.map(|(_, meta)| meta.ident));
     }
@@ -196,6 +193,17 @@ impl<'a> Resolver<'a> {
         allow_shadowing: bool,
         definition: DefinitionKind,
     ) -> HirIdent {
+        self.add_variable_decl_inner(name, mutable, allow_shadowing, true, definition)
+    }
+
+    fn add_variable_decl_inner(
+        &mut self,
+        name: Ident,
+        mutable: bool,
+        allow_shadowing: bool,
+        warn_if_unused: bool,
+        definition: DefinitionKind,
+    ) -> HirIdent {
         if definition.is_global() {
             return self.add_global_variable_decl(name, definition);
         }
@@ -203,7 +211,7 @@ impl<'a> Resolver<'a> {
         let id = self.interner.push_definition(name.0.contents.clone(), mutable, definition);
         let location = Location::new(name.span(), self.file);
         let ident = HirIdent { location, id };
-        let resolver_meta = ResolverMeta { num_times_used: 0, ident };
+        let resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused };
 
         let scope = self.scopes.get_mut_scope();
         let old_value = scope.add_key_value(name.0.contents.clone(), resolver_meta);
@@ -242,12 +250,12 @@ impl<'a> Resolver<'a> {
         if let Some(id) = stmt_id {
             let hir_let_stmt = self.interner.let_statement(&id);
             ident = hir_let_stmt.ident();
-            resolver_meta = ResolverMeta { num_times_used: 0, ident };
+            resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused: true };
         } else {
             let id = self.interner.push_definition(name.0.contents.clone(), false, definition);
             let location = Location::new(name.span(), self.file);
             ident = HirIdent { location, id };
-            resolver_meta = ResolverMeta { num_times_used: 0, ident };
+            resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused: true };
         }
 
         let old_global_value = scope.add_key_value(name.0.contents.clone(), resolver_meta);
@@ -576,12 +584,13 @@ impl<'a> Resolver<'a> {
 
         let attributes = func.attribute().cloned();
 
-        let mut generics = vecmap(&self.generics, |(name, typevar, _)| match &*typevar.borrow() {
-            TypeBinding::Unbound(id) => (*id, typevar.clone()),
-            TypeBinding::Bound(binding) => {
-                unreachable!("Expected {} to be unbound, but it is bound to {}", name, binding)
-            }
-        });
+        let mut generics =
+            vecmap(self.generics.clone(), |(name, typevar, _)| match &*typevar.borrow() {
+                TypeBinding::Unbound(id) => (*id, typevar.clone()),
+                TypeBinding::Bound(binding) => {
+                    unreachable!("Expected {} to be unbound, but it is bound to {}", name, binding)
+                }
+            });
 
         let mut parameters = vec![];
         let mut parameter_types = vec![];
@@ -598,6 +607,8 @@ impl<'a> Resolver<'a> {
         }
 
         let return_type = Box::new(self.resolve_type(func.return_type()));
+
+        self.declare_numeric_generics(func.parameters(), &func.return_type());
 
         if func.name() == "main"
             && *return_type != Type::Unit
@@ -629,6 +640,107 @@ impl<'a> Resolver<'a> {
             parameters: parameters.into(),
             return_visibility: func.def.return_visibility,
             has_body: !func.def.body.is_empty(),
+        }
+    }
+
+    fn declare_numeric_generics(
+        &mut self,
+        params: &[(Pattern, UnresolvedType, noirc_abi::AbiVisibility)],
+        return_type: &UnresolvedType,
+    ) {
+        if self.generics.is_empty() {
+            return;
+        }
+
+        for (name_to_find, type_variable) in self.find_numeric_generics(params, return_type) {
+            // Declare any generics to let users use numeric generics in scope.
+            // Don't issue a warning if these are unused
+            let (name, _, span) = self
+                .generics
+                .iter()
+                .find(|(name, _, _)| name.as_ref() == &name_to_find)
+                .expect("Name of numeric generic should always be in the list of generics");
+
+            let ident = Ident::new(name.to_string(), *span);
+            let definition = DefinitionKind::GenericType(type_variable);
+            self.add_variable_decl_inner(ident, false, false, false, definition);
+        }
+    }
+
+    fn find_numeric_generics(
+        &mut self,
+        params: &[(Pattern, UnresolvedType, noirc_abi::AbiVisibility)],
+        return_type: &UnresolvedType,
+    ) -> Vec<(String, TypeVariable)> {
+        let mut found = HashMap::new();
+        for (_, parameter, _) in params {
+            self.find_numeric_generics_in_type(parameter, &mut found);
+        }
+        self.find_numeric_generics_in_type(return_type, &mut found);
+        found.into_iter().collect()
+    }
+
+    fn find_numeric_generics_in_type(
+        &mut self,
+        typ: &UnresolvedType,
+        found: &mut HashMap<String, Shared<TypeBinding>>,
+    ) {
+        match typ {
+            UnresolvedType::FieldElement(_)
+            | UnresolvedType::Integer(_, _, _)
+            | UnresolvedType::Bool(_)
+            | UnresolvedType::String(_)
+            | UnresolvedType::Unit
+            | UnresolvedType::Unspecified
+            | UnresolvedType::Error => (),
+
+            UnresolvedType::Named(_, args) | UnresolvedType::Tuple(args) => {
+                for arg in args {
+                    self.find_numeric_generics_in_type(arg, found);
+                }
+            }
+
+            UnresolvedType::Function(parameters, return_type) => {
+                for parameter in parameters {
+                    self.find_numeric_generics_in_type(parameter, found);
+                }
+                self.find_numeric_generics_in_type(return_type, found);
+            }
+
+            UnresolvedType::Array(length, element) => {
+                self.find_numeric_generics_in_type(element, found);
+
+                if let Some(length) = length {
+                    self.find_numeric_generics_in_type_expr(length, found);
+                }
+            }
+            UnresolvedType::Expression(expr) => {
+                self.find_numeric_generics_in_type_expr(expr, found);
+            }
+        }
+    }
+
+    fn find_numeric_generics_in_type_expr(
+        &mut self,
+        expr: &UnresolvedTypeExpression,
+        found: &mut HashMap<String, Shared<TypeBinding>>,
+    ) {
+        match expr {
+            UnresolvedTypeExpression::Variable(variable) => {
+                if let Some(ident) = variable.as_ident() {
+                    if let Ok(ident) = self.find_variable(ident) {
+                        let definition = self.interner.definition(ident.id);
+                        if let DefinitionKind::GenericType(type_variable) = &definition.kind {
+                            found.insert(definition.name.clone(), type_variable.clone());
+                        }
+                    }
+                }
+            }
+            UnresolvedTypeExpression::Constant(_, _) => (),
+            UnresolvedTypeExpression::BinaryOperation(lhs, _, rhs, _) => {
+                self.find_numeric_generics_in_type_expr(lhs, found);
+                self.find_numeric_generics_in_type_expr(rhs, found);
+            }
         }
     }
 
@@ -696,12 +808,22 @@ impl<'a> Resolver<'a> {
             ExpressionKind::Literal(literal) => HirExpression::Literal(match literal {
                 Literal::Bool(b) => HirLiteral::Bool(b),
                 Literal::Array(ArrayLiteral::Standard(elements)) => {
-                    HirLiteral::Array(vecmap(elements, |elem| self.resolve_expression(elem)))
+                    let elements = vecmap(elements, |elem| self.resolve_expression(elem));
+                    HirLiteral::Array(HirArrayLiteral::Standard(elements))
                 }
                 Literal::Array(ArrayLiteral::Repeated { repeated_element, length }) => {
-                    let len = self.eval_array_length(&length);
-                    let elem = self.resolve_expression(*repeated_element);
-                    HirLiteral::Array(vec![elem; len.try_into().unwrap()])
+                    let span = length.span;
+                    let length = UnresolvedTypeExpression::from_expr(*length, span).unwrap_or_else(
+                        |error| {
+                            self.errors.push(ResolverError::ParserError(error));
+                            UnresolvedTypeExpression::Constant(0, span)
+                        },
+                    );
+
+                    let length = self.convert_expression_type(length);
+                    let repeated_element = self.resolve_expression(*repeated_element);
+
+                    HirLiteral::Array(HirArrayLiteral::Repeated { repeated_element, length })
                 }
                 Literal::Integer(integer) => HirLiteral::Integer(integer),
                 Literal::Str(str) => HirLiteral::Str(str),
@@ -877,7 +999,7 @@ impl<'a> Resolver<'a> {
             }
             Pattern::Tuple(fields, span) => {
                 let fields = vecmap(fields, |field| {
-                    self.resolve_pattern_mutable(field, mutable, definition)
+                    self.resolve_pattern_mutable(field, mutable, definition.clone())
                 });
                 HirPattern::Tuple(fields, span)
             }
@@ -887,7 +1009,7 @@ impl<'a> Resolver<'a> {
                     // shadowing here lets us avoid further errors if we define ERROR_IDENT
                     // multiple times.
                     let name = ERROR_IDENT.into();
-                    let identifier = this.add_variable_decl(name, false, true, definition);
+                    let identifier = this.add_variable_decl(name, false, true, definition.clone());
                     HirPattern::Identifier(identifier)
                 };
 
@@ -901,7 +1023,7 @@ impl<'a> Resolver<'a> {
                 };
 
                 let resolve_field = |this: &mut Self, pattern| {
-                    this.resolve_pattern_mutable(pattern, mutable, definition)
+                    this.resolve_pattern_mutable(pattern, mutable, definition.clone())
                 };
 
                 let typ = struct_type.clone();
@@ -1066,11 +1188,6 @@ impl<'a> Resolver<'a> {
         self.interner.push_expr(hir_block)
     }
 
-    fn eval_array_length(&mut self, length: &Expression) -> u64 {
-        let result = self.try_eval_array_length(length);
-        self.unwrap_array_length_eval_result(result, length.span)
-    }
-
     fn eval_global_as_array_length(&mut self, global: StmtId) -> u64 {
         let stmt = match self.interner.statement(&global) {
             HirStatement::Let(let_expr) => let_expr,
@@ -1082,14 +1199,7 @@ impl<'a> Resolver<'a> {
         let length = stmt.expression;
         let span = self.interner.expr_span(&length);
         let result = self.try_eval_array_length_id(length, span);
-        self.unwrap_array_length_eval_result(result, span)
-    }
 
-    fn unwrap_array_length_eval_result(
-        &mut self,
-        result: Result<u128, Option<ResolverError>>,
-        span: Span,
-    ) -> u64 {
         match result.map(|length| length.try_into()) {
             Ok(Ok(length_value)) => return length_value,
             Ok(Err(_cast_err)) => self.push_err(ResolverError::IntegerTooLarge { span }),
@@ -1097,94 +1207,6 @@ impl<'a> Resolver<'a> {
             Err(None) => (),
         }
         0
-    }
-
-    /// This function is a mini interpreter inside name resolution.
-    /// We should eventually get rid of it and only have 1 evaluator - the existing
-    /// one inside the ssa pass. Doing this would mean ssa would need to handle these
-    /// sugared array forms but would let users use any comptime expressions, including functions,
-    /// inside array lengths.
-    fn try_eval_array_length(
-        &mut self,
-        length: &Expression,
-    ) -> Result<u128, Option<ResolverError>> {
-        let span = length.span;
-        match &length.kind {
-            ExpressionKind::Literal(Literal::Integer(int)) => {
-                int.try_into_u128().ok_or(Some(ResolverError::IntegerTooLarge { span }))
-            }
-            ExpressionKind::Variable(path) => {
-                let ident = self.get_ident_from_path(path.clone());
-                self.try_eval_array_length_ident(ident.id, span)
-            }
-            ExpressionKind::Prefix(operator) => {
-                let value = self.try_eval_array_length(&operator.rhs)?;
-                match operator.operator {
-                    crate::UnaryOp::Minus => Ok(0 - value),
-                    crate::UnaryOp::Not => Ok(!value),
-                }
-            }
-            ExpressionKind::Infix(operator) => {
-                let lhs = self.try_eval_array_length(&operator.lhs)?;
-                let rhs = self.try_eval_array_length(&operator.rhs)?;
-                match operator.operator.contents {
-                    crate::BinaryOpKind::Add => Ok(lhs + rhs),
-                    crate::BinaryOpKind::Subtract => Ok(lhs - rhs),
-                    crate::BinaryOpKind::Multiply => Ok(lhs * rhs),
-                    crate::BinaryOpKind::Divide => Ok(lhs / rhs),
-                    crate::BinaryOpKind::ShiftRight => Ok(lhs >> rhs),
-                    crate::BinaryOpKind::ShiftLeft => Ok(lhs << rhs),
-                    crate::BinaryOpKind::Modulo => Ok(lhs % rhs),
-                    crate::BinaryOpKind::And => Ok(lhs & rhs),
-                    crate::BinaryOpKind::Or => Ok(lhs | rhs),
-                    crate::BinaryOpKind::Xor => Ok(lhs ^ rhs),
-
-                    crate::BinaryOpKind::Equal
-                    | crate::BinaryOpKind::NotEqual
-                    | crate::BinaryOpKind::Less
-                    | crate::BinaryOpKind::LessEqual
-                    | crate::BinaryOpKind::Greater
-                    | crate::BinaryOpKind::GreaterEqual => {
-                        Err(Some(ResolverError::InvalidArrayLengthExpr { span }))
-                    }
-                }
-            }
-
-            ExpressionKind::Literal(_)
-            | ExpressionKind::Block(_)
-            | ExpressionKind::Index(_)
-            | ExpressionKind::Call(_)
-            | ExpressionKind::MethodCall(_)
-            | ExpressionKind::Constructor(_)
-            | ExpressionKind::MemberAccess(_)
-            | ExpressionKind::Cast(_)
-            | ExpressionKind::For(_)
-            | ExpressionKind::If(_)
-            | ExpressionKind::Lambda(_)
-            | ExpressionKind::Tuple(_) => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
-
-            ExpressionKind::Error => Err(None),
-        }
-    }
-
-    fn try_eval_array_length_ident(
-        &mut self,
-        id: DefinitionId,
-        span: Span,
-    ) -> Result<u128, Option<ResolverError>> {
-        if id == DefinitionId::dummy_id() {
-            return Err(None); // error already reported
-        }
-
-        let definition = self.interner.definition(id);
-
-        use DefinitionKind::{Global, Local};
-        match definition.kind {
-            Global(rhs) | Local(Some(rhs)) if !definition.mutable => {
-                self.try_eval_array_length_id(rhs, span)
-            }
-            _ => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
-        }
     }
 
     fn try_eval_array_length_id(

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -137,14 +137,17 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
     fn extend_current_scope_tree(&mut self) {
         self.current_scope_tree().push_scope()
     }
+
     fn remove_scope_tree_extension(&mut self) -> Scope<K, V> {
         self.current_scope_tree().pop_scope()
     }
+
     /// Starting a function requires a new scope tree, as you do not want the functions scope to
     /// have access to the scope of the caller
     pub fn start_function(&mut self) {
         self.0.push(ScopeTree::default())
     }
+
     /// Ending a function requires that we removes it's whole tree of scope
     /// This is by design the current scope, which is the last element in the vector
     pub fn end_function(&mut self) -> ScopeTree<K, V> {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -3,7 +3,7 @@ use noirc_errors::Span;
 
 use crate::{
     hir_def::{
-        expr::{self, HirBinaryOp, HirExpression, HirLiteral},
+        expr::{self, HirArrayLiteral, HirBinaryOp, HirExpression, HirLiteral},
         types::Type,
     },
     node_interner::{ExprId, FuncId, NodeInterner},
@@ -38,7 +38,7 @@ pub(crate) fn type_check_expression(
         }
         HirExpression::Literal(literal) => {
             match literal {
-                HirLiteral::Array(arr) => {
+                HirLiteral::Array(HirArrayLiteral::Standard(arr)) => {
                     let elem_types =
                         vecmap(&arr, |arg| type_check_expression(interner, arg, errors));
 
@@ -67,6 +67,10 @@ pub(crate) fn type_check_expression(
                     }
 
                     arr_type
+                }
+                HirLiteral::Array(HirArrayLiteral::Repeated { repeated_element, length }) => {
+                    let elem_type = type_check_expression(interner, &repeated_element, errors);
+                    Type::Array(Box::new(length), Box::new(elem_type))
                 }
                 HirLiteral::Bool(_) => Type::Bool(CompTime::new(interner)),
                 HirLiteral::Integer(_) => {

--- a/crates/noirc_frontend/src/hir_def/expr.rs
+++ b/crates/noirc_frontend/src/hir_def/expr.rs
@@ -76,10 +76,16 @@ impl HirBinaryOp {
 
 #[derive(Debug, Clone)]
 pub enum HirLiteral {
-    Array(Vec<ExprId>),
+    Array(HirArrayLiteral),
     Bool(bool),
     Integer(FieldElement),
     Str(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum HirArrayLiteral {
+    Standard(Vec<ExprId>),
+    Repeated { repeated_element: ExprId, length: Type },
 }
 
 #[derive(Debug, Clone)]

--- a/noir_stdlib/src/array.nr
+++ b/noir_stdlib/src/array.nr
@@ -20,6 +20,19 @@ impl<T, N> [T; N] {
         a
     }
 
+    // Apply a function to each element of an array, returning a new array
+    // containing the mapped elements.
+    fn map<U>(self, f: fn(T) -> U) -> [U; N] {
+        let first_elem = f(self[0]);
+        let mut ret = [first_elem; N];
+
+        for i in 1 .. self.len() {
+            ret[i] = f(self[i]);
+        }
+
+        ret
+    }
+
     // Apply a function to each element of the array and an accumulator value,
     // returning the final accumulated value. This function is also sometimes
     // called `foldl`, `fold_left`, `reduce`, or `inject`.


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #972 

# Description

## Summary of changes

Allows numeric generics to be referenced like normal values. This resolves a common stumbling block for users when writing a function like the following:
```rs
fn foo<N>(array: [Field; N]) {
    for i in 0 .. N {
        ....
    }
}
```
Previously, we would error that there is no `N` in scope (since `N` is a type and not a value). With this PR, this code works as expected.

Notably, this PR now allows us to write the array `map` function and add it to our stdlib. This was not possible previously due to the syntax limitations placed on array-length expressions which prevented us from initializing an array using `let mut ret = [0; array.len()];`. This has been reworked slightly to reuse the same array length evaluation mechanism types use, which notably now allows us to use numeric generic type variables.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

Added a test for the new array `map` function in `higher_order_functions`.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

We should document numeric generics are now useable like any other `Field` variable. Additionally, the new `map` method for arrays will need to be documented.

<!-- If checked, list / describe what needs to be documented. -->
