### PR TITLE
chore: automatically inject stdlib when resolving crate

### DIFF
--- a/crates/nargo/src/cli/check_cmd.rs
+++ b/crates/nargo/src/cli/check_cmd.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use super::fs::write_to_file;
-use super::{add_std_lib, NargoConfig};
+use super::NargoConfig;
 use crate::constants::{PROVER_INPUT_FILE, VERIFIER_INPUT_FILE};
 
 /// Checks the constraint system for errors
@@ -30,7 +30,6 @@ fn check_from_path<P: AsRef<Path>>(p: P, compile_options: &CompileOptions) -> Re
     let backend = crate::backends::ConcreteBackend;
 
     let mut driver = Resolver::resolve_root_config(p.as_ref(), backend.np_language())?;
-    add_std_lib(&mut driver);
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -11,7 +11,7 @@ use crate::{constants::TARGET_DIR, errors::CliError, resolver::Resolver};
 
 use super::fs::program::save_program_to_file;
 use super::preprocess_cmd::preprocess_with_path;
-use super::{add_std_lib, NargoConfig};
+use super::NargoConfig;
 
 /// Compile the program and its secret execution trace into ACIR format
 #[derive(Debug, Clone, Args)]
@@ -69,9 +69,7 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
 
 fn setup_driver(program_dir: &Path) -> Result<Driver, CliError> {
     let backend = crate::backends::ConcreteBackend;
-    let mut driver = Resolver::resolve_root_config(program_dir, backend.np_language())?;
-    add_std_lib(&mut driver);
-    Ok(driver)
+    Resolver::resolve_root_config(program_dir, backend.np_language())
 }
 
 fn check_crate(program_dir: &Path, options: &CompileOptions) -> Result<Driver, CliError> {

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -1,8 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use const_format::formatcp;
 use noirc_abi::InputMap;
-use noirc_driver::{CompileOptions, Driver};
-use noirc_frontend::graph::{CrateName, CrateType};
+use noirc_driver::CompileOptions;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre;
@@ -101,12 +100,6 @@ pub fn prove_and_verify(proof_name: &str, prg_dir: &Path, show_ssa: bool) -> boo
     }
 }
 
-fn add_std_lib(driver: &mut Driver) {
-    let std_crate_name = "std";
-    let path_to_std_lib_file = PathBuf::from(std_crate_name).join("lib.nr");
-    let std_crate = driver.create_non_local_crate(path_to_std_lib_file, CrateType::Library);
-    driver.propagate_dep(std_crate, &CrateName::new(std_crate_name).unwrap());
-}
 // FIXME: I not sure that this is the right place for this tests.
 #[cfg(test)]
 mod tests {
@@ -123,7 +116,7 @@ mod tests {
     fn file_compiles<P: AsRef<Path>>(root_file: P) -> bool {
         let mut driver = Driver::new(&acvm::Language::R1CS);
         driver.create_local_crate(&root_file, CrateType::Binary);
-        super::add_std_lib(&mut driver);
+        crate::resolver::add_std_lib(&mut driver);
         driver.file_compiles()
     }
 

--- a/crates/nargo/src/cli/test_cmd.rs
+++ b/crates/nargo/src/cli/test_cmd.rs
@@ -8,7 +8,7 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use crate::{errors::CliError, resolver::Resolver};
 
-use super::{add_std_lib, NargoConfig};
+use super::NargoConfig;
 
 /// Run the tests for this program
 #[derive(Debug, Clone, Args)]
@@ -34,7 +34,6 @@ fn run_tests(
     let backend = crate::backends::ConcreteBackend;
 
     let mut driver = Resolver::resolve_root_config(program_dir, backend.np_language())?;
-    add_std_lib(&mut driver);
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -5,7 +5,7 @@ use std::{
 
 use acvm::Language;
 use noirc_driver::Driver;
-use noirc_frontend::graph::{CrateId, CrateType};
+use noirc_frontend::graph::{CrateId, CrateName, CrateType};
 
 use crate::{
     errors::CliError,
@@ -64,6 +64,7 @@ impl<'a> Resolver<'a> {
         let mut resolver = Resolver::with_driver(&mut driver);
         resolver.resolve_config(crate_id, cfg)?;
 
+        add_std_lib(&mut driver);
         Ok(driver)
     }
 
@@ -140,4 +141,12 @@ impl<'a> Resolver<'a> {
             Err(msg) => Err(CliError::Generic(msg)),
         }
     }
+}
+
+// This needs to be public to support the tests in `cli/mod.rs`.
+pub(crate) fn add_std_lib(driver: &mut Driver) {
+    let std_crate_name = "std";
+    let path_to_std_lib_file = PathBuf::from(std_crate_name).join("lib.nr");
+    let std_crate = driver.create_non_local_crate(path_to_std_lib_file, CrateType::Library);
+    driver.propagate_dep(std_crate, &CrateName::new(std_crate_name).unwrap());
 }


### PR DESCRIPTION
# Related issue(s)

Addresses https://github.com/noir-lang/noir/pull/973#issuecomment-1463998180

# Description

## Summary of changes

Currently we need to remember to explicitly add the std lib whenever we resolve a crate. Instead of this I've merged this into `Resolver::resolve_root_config` to happen automatically.

The `wasm` crate still has to add the stdlib manually as it doesn't use the `Resolver`

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
