### PR TITLE
feat: make `noirc_driver` aware of contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,6 +2192,7 @@ dependencies = [
  "acvm 0.6.0",
  "clap 4.1.8",
  "fm",
+ "iter-extended",
  "noirc_abi",
  "noirc_errors",
  "noirc_evaluator",

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -1,8 +1,5 @@
 use acvm::ProofSystemCompiler;
-use iter_extended::{try_btree_map, try_vecmap};
 use noirc_driver::{CompileOptions, CompiledProgram, Driver};
-use noirc_frontend::{hir::def_map::Contract, node_interner::FuncId};
-use std::collections::BTreeMap;
 use std::path::Path;
 
 use clap::Args;
@@ -27,25 +24,16 @@ pub(crate) struct CompileCommand {
     compile_options: CompileOptions,
 }
 
-struct CompiledContract {
-    /// The name of the contract.
-    name: String,
-    /// Each of the contract's functions are compiled into a separate `CompiledProgram`
-    /// stored in this `BTreeMap`.
-    functions: BTreeMap<String, CompiledProgram>,
-}
-
 pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliError> {
-    let driver = check_crate(&config.program_dir, &args.compile_options)?;
-
-    let mut circuit_dir = config.program_dir;
+    let mut circuit_dir = config.program_dir.clone();
     circuit_dir.push(TARGET_DIR);
 
     // If contracts is set we're compiling every function in a 'contract' rather than just 'main'.
     if args.contracts {
-        let compiled_contracts = try_vecmap(driver.get_all_contracts(), |contract| {
-            compile_contract(&driver, contract, &args.compile_options)
-        })?;
+        let mut driver = setup_driver(&config.program_dir)?;
+        let compiled_contracts = driver
+            .compile_contracts(&args.compile_options)
+            .map_err(|_| CliError::CompilationError)?;
 
         // Flatten each contract into a list of its functions, each being assigned a unique name.
         let compiled_programs = compiled_contracts.into_iter().flat_map(|contract| {
@@ -61,8 +49,7 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
         }
         Ok(())
     } else {
-        let main = driver.main_function().map_err(|_| CliError::CompilationError)?;
-        let program = compile_program(&driver, main, &args.compile_options, &args.circuit_name)?;
+        let program = compile_circuit(&config.program_dir, &args.compile_options)?;
         save_and_preprocess_program(&program, &args.circuit_name, &circuit_dir)
     }
 }
@@ -72,40 +59,6 @@ fn setup_driver(program_dir: &Path) -> Result<Driver, CliError> {
     let mut driver = Resolver::resolve_root_config(program_dir, backend.np_language())?;
     add_std_lib(&mut driver);
     Ok(driver)
-}
-
-fn check_crate(program_dir: &Path, options: &CompileOptions) -> Result<Driver, CliError> {
-    let mut driver = setup_driver(program_dir)?;
-    driver.check_crate(options).map_err(|_| CliError::CompilationError)?;
-    Ok(driver)
-}
-
-/// Compiles all of the functions associated with a Noir contract.
-fn compile_contract(
-    driver: &Driver,
-    contract: Contract,
-    compile_options: &CompileOptions,
-) -> Result<CompiledContract, CliError> {
-    let functions = try_btree_map(&contract.functions, |function| {
-        let function_name = driver.function_name(*function).to_owned();
-        let program_id = format!("{}-{}", contract.name, function_name);
-
-        compile_program(driver, *function, compile_options, &program_id)
-            .map(|program| (function_name, program))
-    })?;
-
-    Ok(CompiledContract { name: contract.name, functions })
-}
-
-fn compile_program(
-    driver: &Driver,
-    main: FuncId,
-    compile_options: &CompileOptions,
-    program_id: &str,
-) -> Result<CompiledProgram, CliError> {
-    driver
-        .compile_no_check(compile_options, main)
-        .map_err(|_| CliError::Generic(format!("'{}' failed to compile", program_id)))
 }
 
 /// Save a program to disk along with proving and verification keys.
@@ -122,7 +75,7 @@ fn save_and_preprocess_program(
 pub(crate) fn compile_circuit(
     program_dir: &Path,
     compile_options: &CompileOptions,
-) -> Result<noirc_driver::CompiledProgram, CliError> {
+) -> Result<CompiledProgram, CliError> {
     let mut driver = setup_driver(program_dir)?;
     driver.compile_main(compile_options).map_err(|_| CliError::CompilationError)
 }

--- a/crates/noirc_driver/Cargo.toml
+++ b/crates/noirc_driver/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 clap.workspace = true
+iter-extended.workspace = true
 noirc_errors.workspace = true
 noirc_frontend.workspace = true
 noirc_evaluator.workspace = true

--- a/crates/noirc_driver/src/contract.rs
+++ b/crates/noirc_driver/src/contract.rs
@@ -1,0 +1,11 @@
+use std::collections::BTreeMap;
+
+use crate::CompiledProgram;
+
+pub struct CompiledContract {
+    /// The name of the contract.
+    pub name: String,
+    /// Each of the contract's functions are compiled into a separate `CompiledProgram`
+    /// stored in this `BTreeMap`.
+    pub functions: BTreeMap<String, CompiledProgram>,
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -64,18 +64,20 @@ pub fn compile(args: JsValue) -> JsValue {
     driver.check_crate(&options.compile_options).unwrap_or_else(|_| panic!("Crate check failed"));
 
     if options.contracts {
-        let mut collected_compiled_programs = vec![];
+        let compiled_contracts = driver
+            .compile_contracts(&options.compile_options)
+            .unwrap_or_else(|_| panic!("Contract compilation failed"));
 
-        for contract in driver.get_all_contracts() {
-            contract.functions.into_iter().for_each(|function| {
-                let name = driver.function_name(function);
-                let key = format!("{}-{name}", &contract.name);
-                let compiled_program = driver
-                    .compile_no_check(&options.compile_options, function)
-                    .unwrap_or_else(|_| panic!("Compilation of `{key}` failed"));
-                collected_compiled_programs.push((key, compiled_program));
-            });
-        }
+        // Flatten each contract into a list of its functions, each being assigned a unique name.
+        let collected_compiled_programs: Vec<_> = compiled_contracts
+            .into_iter()
+            .flat_map(|contract| {
+                contract.functions.into_iter().map(move |(function, program)| {
+                    let program_name = format!("{}-{}", &contract.name, function);
+                    (program_name, program)
+                })
+            })
+            .collect();
 
         <JsValue as JsValueSerdeExt>::from_serde(&collected_compiled_programs).unwrap()
     } else {


### PR DESCRIPTION
# Related issue(s)


Followup PR for #966

# Description

## Summary of changes

Currently a lot of the compilation logic for contract lives inside `nargo`. In order to make them a first class citizen, ideally we'd be able to just tell the driver to compile the contracts within a crate similarly to how we can do for standard noir programs.

This PR then pushes much of this logic inside of `noirc_driver` so we just need to call  `driver.compile_contracts(&args.compile_options)`


## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
