### PR TITLE
chore: switch from mutable to immutable api for building paths

### DIFF
--- a/crates/nargo/src/cli/check_cmd.rs
+++ b/crates/nargo/src/cli/check_cmd.rs
@@ -88,14 +88,16 @@ fn build_placeholder_input_map(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use noirc_driver::CompileOptions;
 
     const TEST_DATA_DIR: &str = "tests/target_tests_data";
 
     #[test]
     fn pass() {
-        let mut pass_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        pass_dir.push(&format!("{TEST_DATA_DIR}/pass"));
+        let pass_dir =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/pass"));
 
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(pass_dir).unwrap();
@@ -112,8 +114,8 @@ mod tests {
     #[test]
     #[ignore = "This test fails because the reporter exits the process with 1"]
     fn fail() {
-        let mut fail_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        fail_dir.push(&format!("{TEST_DATA_DIR}/fail"));
+        let fail_dir =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/fail"));
 
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(fail_dir).unwrap();
@@ -129,8 +131,8 @@ mod tests {
 
     #[test]
     fn pass_with_warnings() {
-        let mut pass_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        pass_dir.push(&format!("{TEST_DATA_DIR}/pass_dev_mode"));
+        let pass_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(format!("{TEST_DATA_DIR}/pass_dev_mode"));
 
         let config = CompileOptions { allow_warnings: true, ..Default::default() };
 

--- a/crates/nargo/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo/src/cli/codegen_verifier_cmd.rs
@@ -19,11 +19,9 @@ pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(
     #[allow(deprecated)]
     let smart_contract_string = backend.eth_contract_from_cs(compiled_program.circuit);
 
-    let mut contract_dir = config.program_dir;
-    contract_dir.push(CONTRACT_DIR);
-    let mut contract_path = create_named_dir(contract_dir.as_ref(), "contract");
-    contract_path.push("plonk_vk");
-    contract_path.set_extension("sol");
+    let contract_dir = config.program_dir.join(CONTRACT_DIR);
+    create_named_dir(&contract_dir, "contract");
+    let contract_path = contract_dir.join("plonk_vk").with_extension("sol");
 
     let path = write_to_file(smart_contract_string.as_bytes(), &contract_path);
     println!("Contract successfully created and located at {path}");

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -38,8 +38,7 @@ struct CompiledContract {
 pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliError> {
     let driver = check_crate(&config.program_dir, &args.compile_options)?;
 
-    let mut circuit_dir = config.program_dir;
-    circuit_dir.push(TARGET_DIR);
+    let circuit_dir = config.program_dir.join(TARGET_DIR);
 
     // If contracts is set we're compiling every function in a 'contract' rather than just 'main'.
     if args.contracts {

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -33,8 +33,7 @@ pub(crate) fn run(args: ExecuteCommand, config: NargoConfig) -> Result<(), CliEr
         println!("Circuit output: {return_value:?}");
     }
     if let Some(witness_name) = args.witness_name {
-        let mut witness_dir = config.program_dir;
-        witness_dir.push(TARGET_DIR);
+        let witness_dir = config.program_dir.join(TARGET_DIR);
 
         let witness_path = save_witness_to_dir(solved_witness, &witness_name, witness_dir)?;
 

--- a/crates/nargo/src/cli/fs/inputs.rs
+++ b/crates/nargo/src/cli/fs/inputs.rs
@@ -25,12 +25,7 @@ pub(crate) fn read_inputs_from_file<P: AsRef<Path>>(
         return Ok((BTreeMap::new(), None));
     }
 
-    let file_path = {
-        let mut dir_path = path.as_ref().to_path_buf();
-        dir_path.push(file_name);
-        dir_path.set_extension(format.ext());
-        dir_path
-    };
+    let file_path = path.as_ref().join(file_name).with_extension(format.ext());
     if !file_path.exists() {
         return Err(CliError::MissingTomlFile(file_name.to_owned(), file_path));
     }
@@ -49,12 +44,7 @@ pub(crate) fn write_inputs_to_file<P: AsRef<Path>>(
     file_name: &str,
     format: Format,
 ) -> Result<(), CliError> {
-    let file_path = {
-        let mut dir_path = path.as_ref().to_path_buf();
-        dir_path.push(file_name);
-        dir_path.set_extension(format.ext());
-        dir_path
-    };
+    let file_path = path.as_ref().join(file_name).with_extension(format.ext());
 
     // We must insert the return value into the `InputMap` in order for it to be written to file.
     let serialized_output = match return_value {

--- a/crates/nargo/src/cli/fs/keys.rs
+++ b/crates/nargo/src/cli/fs/keys.rs
@@ -12,10 +12,10 @@ pub(crate) fn save_key_to_dir<P: AsRef<Path>>(
     key_dir: P,
     is_proving_key: bool,
 ) -> Result<PathBuf, CliError> {
-    let mut key_path = create_named_dir(key_dir.as_ref(), key_name);
-    key_path.push(key_name);
+    create_named_dir(key_dir.as_ref(), key_name);
+
     let extension = if is_proving_key { PK_EXT } else { VK_EXT };
-    key_path.set_extension(extension);
+    let key_path = key_dir.as_ref().join(key_name).with_extension(extension);
 
     write_to_file(hex::encode(key).as_bytes(), &key_path);
 
@@ -28,8 +28,7 @@ pub(crate) fn fetch_pk_and_vk<P: AsRef<Path>>(
     prove_circuit: bool,
     check_proof: bool,
 ) -> Result<(Vec<u8>, Vec<u8>), CliError> {
-    let mut acir_hash_path = PathBuf::from(circuit_build_path.as_ref());
-    acir_hash_path.set_extension(ACIR_CHECKSUM);
+    let acir_hash_path = circuit_build_path.as_ref().with_extension(ACIR_CHECKSUM);
 
     let expected_acir_hash = load_hex_data(acir_hash_path.clone())?;
 
@@ -42,9 +41,7 @@ pub(crate) fn fetch_pk_and_vk<P: AsRef<Path>>(
     // This flag exists to avoid an unnecessary read of the proving key during verification
     // as this method is used by both `nargo prove` and `nargo verify`
     let proving_key = if prove_circuit {
-        let mut proving_key_path = PathBuf::new();
-        proving_key_path.push(circuit_build_path.as_ref());
-        proving_key_path.set_extension(PK_EXT);
+        let proving_key_path = circuit_build_path.as_ref().with_extension(PK_EXT);
         load_hex_data(proving_key_path)?
     } else {
         // We can return an empty Vec here as `prove_circuit` should only be false when running `nargo verify`
@@ -52,9 +49,7 @@ pub(crate) fn fetch_pk_and_vk<P: AsRef<Path>>(
     };
 
     let verification_key = if check_proof {
-        let mut verification_key_path = PathBuf::new();
-        verification_key_path.push(circuit_build_path);
-        verification_key_path.set_extension(VK_EXT);
+        let verification_key_path = circuit_build_path.as_ref().with_extension(VK_EXT);
         load_hex_data(verification_key_path)?
     } else {
         // We can return an empty Vec here as the verification key is used only is `check_proof` is true

--- a/crates/nargo/src/cli/fs/mod.rs
+++ b/crates/nargo/src/cli/fs/mod.rs
@@ -12,15 +12,11 @@ pub(super) mod program;
 pub(super) mod proof;
 pub(super) mod witness;
 
-fn create_dir<P: AsRef<Path>>(dir_path: P) -> Result<PathBuf, std::io::Error> {
-    let mut dir = std::path::PathBuf::new();
-    dir.push(dir_path);
-    std::fs::create_dir_all(&dir)?;
-    Ok(dir)
-}
-
 pub(super) fn create_named_dir(named_dir: &Path, name: &str) -> PathBuf {
-    create_dir(named_dir).unwrap_or_else(|_| panic!("could not create the `{name}` directory"))
+    std::fs::create_dir_all(named_dir)
+        .unwrap_or_else(|_| panic!("could not create the `{name}` directory"));
+
+    PathBuf::from(named_dir)
 }
 
 pub(super) fn write_to_file(bytes: &[u8], path: &Path) -> String {

--- a/crates/nargo/src/cli/fs/program.rs
+++ b/crates/nargo/src/cli/fs/program.rs
@@ -12,9 +12,8 @@ pub(crate) fn save_program_to_file<P: AsRef<Path>>(
     circuit_name: &str,
     circuit_dir: P,
 ) -> PathBuf {
-    let mut circuit_path = create_named_dir(circuit_dir.as_ref(), "target");
-    circuit_path.push(circuit_name);
-    circuit_path.set_extension("json");
+    create_named_dir(circuit_dir.as_ref(), "target");
+    let circuit_path = circuit_dir.as_ref().join(circuit_name).with_extension("json");
 
     write_to_file(&serde_json::to_vec(compiled_program).unwrap(), &circuit_path);
 

--- a/crates/nargo/src/cli/fs/proof.rs
+++ b/crates/nargo/src/cli/fs/proof.rs
@@ -9,9 +9,8 @@ pub(crate) fn save_proof_to_dir<P: AsRef<Path>>(
     proof_name: &str,
     proof_dir: P,
 ) -> Result<PathBuf, CliError> {
-    let mut proof_path = create_named_dir(proof_dir.as_ref(), "proof");
-    proof_path.push(proof_name);
-    proof_path.set_extension(PROOF_EXT);
+    create_named_dir(proof_dir.as_ref(), "proof");
+    let proof_path = proof_dir.as_ref().join(proof_name).with_extension(PROOF_EXT);
 
     write_to_file(hex::encode(proof).as_bytes(), &proof_path);
 

--- a/crates/nargo/src/cli/fs/witness.rs
+++ b/crates/nargo/src/cli/fs/witness.rs
@@ -11,9 +11,8 @@ pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     witness_name: &str,
     witness_dir: P,
 ) -> Result<PathBuf, CliError> {
-    let mut witness_path = create_named_dir(witness_dir.as_ref(), "witness");
-    witness_path.push(witness_name);
-    witness_path.set_extension(WITNESS_EXT);
+    create_named_dir(witness_dir.as_ref(), "witness");
+    let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
     let buf = Witness::to_bytes(&witness);
 

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -129,8 +129,8 @@ mod tests {
 
     #[test]
     fn compilation_pass() {
-        let mut pass_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        pass_dir.push(&format!("{TEST_DATA_DIR}/pass"));
+        let pass_dir =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/pass"));
 
         let paths = std::fs::read_dir(pass_dir).unwrap();
         for path in paths.flatten() {
@@ -141,8 +141,8 @@ mod tests {
 
     #[test]
     fn compilation_fail() {
-        let mut fail_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        fail_dir.push(&format!("{TEST_DATA_DIR}/fail"));
+        let fail_dir =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/fail"));
 
         let paths = std::fs::read_dir(fail_dir).unwrap();
         for path in paths.flatten() {

--- a/crates/nargo/src/cli/new_cmd.rs
+++ b/crates/nargo/src/cli/new_cmd.rs
@@ -18,9 +18,8 @@ pub(crate) struct NewCommand {
 }
 
 pub(crate) fn run(args: NewCommand, config: NargoConfig) -> Result<(), CliError> {
-    let mut package_dir = config.program_dir;
+    let package_dir = config.program_dir.join(args.package_name);
 
-    package_dir.push(Path::new(&args.package_name));
     if package_dir.exists() {
         return Err(CliError::DestinationAlreadyExists(package_dir));
     }
@@ -39,8 +38,8 @@ pub(crate) fn run(args: NewCommand, config: NargoConfig) -> Result<(), CliError>
         "[dependencies]"
     );
 
-    write_to_file(SETTINGS.as_bytes(), &package_dir.join(Path::new(PKG_FILE)));
-    write_to_file(EXAMPLE.as_bytes(), &src_dir.join(Path::new("main.nr")));
+    write_to_file(SETTINGS.as_bytes(), &package_dir.join(PKG_FILE));
+    write_to_file(EXAMPLE.as_bytes(), &src_dir.join("main.nr"));
     println!("Project successfully created! Binary located at {}", package_dir.display());
     Ok(())
 }

--- a/crates/nargo/src/cli/prove_cmd.rs
+++ b/crates/nargo/src/cli/prove_cmd.rs
@@ -36,17 +36,11 @@ pub(crate) struct ProveCommand {
 }
 
 pub(crate) fn run(args: ProveCommand, config: NargoConfig) -> Result<(), CliError> {
-    let mut proof_dir = config.program_dir.clone();
-    proof_dir.push(PROOFS_DIR);
+    let proof_dir = config.program_dir.join(PROOFS_DIR);
 
-    let circuit_build_path = if let Some(circuit_name) = args.circuit_name {
-        let mut circuit_build_path = config.program_dir.clone();
-        circuit_build_path.push(TARGET_DIR);
-        circuit_build_path.push(circuit_name);
-        Some(circuit_build_path)
-    } else {
-        None
-    };
+    let circuit_build_path = args
+        .circuit_name
+        .map(|circuit_name| config.program_dir.join(TARGET_DIR).join(circuit_name));
 
     prove_with_path(
         args.proof_name,

--- a/crates/nargo/src/cli/verify_cmd.rs
+++ b/crates/nargo/src/cli/verify_cmd.rs
@@ -27,17 +27,12 @@ pub(crate) struct VerifyCommand {
 }
 
 pub(crate) fn run(args: VerifyCommand, config: NargoConfig) -> Result<(), CliError> {
-    let mut proof_path = config.program_dir.clone();
-    proof_path.push(Path::new(PROOFS_DIR));
-    proof_path.push(Path::new(&args.proof));
-    proof_path.set_extension(PROOF_EXT);
+    let proof_path =
+        config.program_dir.join(PROOFS_DIR).join(&args.proof).with_extension(PROOF_EXT);
 
-    let circuit_build_path = args.circuit_name.map(|circuit_name| {
-        let mut circuit_build_path = config.program_dir.clone();
-        circuit_build_path.push(TARGET_DIR);
-        circuit_build_path.push(circuit_name);
-        circuit_build_path
-    });
+    let circuit_build_path = args
+        .circuit_name
+        .map(|circuit_name| config.program_dir.join(TARGET_DIR).join(circuit_name));
 
     verify_with_path(config.program_dir, proof_path, circuit_build_path, args.compile_options)
 }


### PR DESCRIPTION
# Related issue(s)

Addresses all instances of https://github.com/noir-lang/aztec_backend/pull/86#discussion_r1137806664 in `nargo`

# Description

## Summary of changes

I've replaced the instances of pushing onto mutable `PathBuf`s with using the `join` api with immutable `PathBuf`s. This is much clearer imo.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
