### PR TITLE
chore: maintain structure of errors in `CliError`

### DIFF
--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -26,22 +26,16 @@ pub(crate) enum CliError {
     /// Error while compiling Noir into ACIR.
     #[error("Failed to compile circuit")]
     CompilationError,
-}
 
-impl From<OpcodeResolutionError> for CliError {
-    fn from(value: OpcodeResolutionError) -> Self {
-        CliError::Generic(value.to_string())
-    }
-}
+    /// Input parsing error
+    #[error(transparent)]
+    InputParserError(#[from] InputParserError),
 
-impl From<InputParserError> for CliError {
-    fn from(error: InputParserError) -> Self {
-        CliError::Generic(error.to_string())
-    }
-}
+    /// ABI encoding/decoding error
+    #[error(transparent)]
+    AbiError(#[from] AbiError),
 
-impl From<AbiError> for CliError {
-    fn from(error: AbiError) -> Self {
-        CliError::Generic(error.to_string())
-    }
+    /// ACIR circuit solving error
+    #[error(transparent)]
+    SolvingError(#[from] OpcodeResolutionError),
 }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

I'd like to move to `CliError` being an umbrella error type which contains different types of errors for IO, abi encoding, compiling, solving, proving, etc. There's no reason to throw away all the information here and convert to a generic error.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
