### PR TITLE
chore(nargo): rename struct representing `Nargo.toml` from `Config` to `PackageManifest`

### DIFF
--- a/crates/nargo/src/cli/check_cmd.rs
+++ b/crates/nargo/src/cli/check_cmd.rs
@@ -29,7 +29,7 @@ pub(crate) fn run(args: CheckCommand, config: NargoConfig) -> Result<(), CliErro
 fn check_from_path<P: AsRef<Path>>(p: P, compile_options: &CompileOptions) -> Result<(), CliError> {
     let backend = crate::backends::ConcreteBackend;
 
-    let mut driver = Resolver::resolve_root_config(p.as_ref(), backend.np_language())?;
+    let mut driver = Resolver::resolve_root_manifest(p.as_ref(), backend.np_language())?;
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 

--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -68,7 +68,7 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
 
 fn setup_driver(program_dir: &Path) -> Result<Driver, CliError> {
     let backend = crate::backends::ConcreteBackend;
-    Resolver::resolve_root_config(program_dir, backend.np_language())
+    Resolver::resolve_root_manifest(program_dir, backend.np_language())
 }
 
 fn check_crate(program_dir: &Path, options: &CompileOptions) -> Result<Driver, CliError> {

--- a/crates/nargo/src/cli/test_cmd.rs
+++ b/crates/nargo/src/cli/test_cmd.rs
@@ -33,7 +33,7 @@ fn run_tests(
 ) -> Result<(), CliError> {
     let backend = crate::backends::ConcreteBackend;
 
-    let mut driver = Resolver::resolve_root_config(program_dir, backend.np_language())?;
+    let mut driver = Resolver::resolve_root_manifest(program_dir, backend.np_language())?;
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -25,8 +25,8 @@ pub mod cli;
 mod constants;
 mod errors;
 mod git;
+mod manifest;
 mod resolver;
-mod toml;
 
 /// Searches for the Nargo.toml file
 ///
@@ -34,7 +34,7 @@ mod toml;
 /// for the Nargo.toml file there
 /// However, it should only do this after checking the current path
 /// This allows the use of workspace settings in the future.
-fn find_package_config(current_path: &Path) -> Result<PathBuf, CliError> {
+fn find_package_manifest(current_path: &Path) -> Result<PathBuf, CliError> {
     match find_file(current_path, "Nargo", "toml") {
         Some(p) => Ok(p),
         None => Err(CliError::Generic(format!(

--- a/crates/nargo/src/manifest.rs
+++ b/crates/nargo/src/manifest.rs
@@ -5,13 +5,13 @@ use std::path::Path;
 use crate::errors::CliError;
 
 #[derive(Debug, Deserialize, Clone)]
-pub(crate) struct Config {
+pub(crate) struct PackageManifest {
     #[allow(dead_code)]
-    pub(crate) package: Package,
+    pub(crate) package: PackageMetadata,
     pub(crate) dependencies: BTreeMap<String, Dependency>,
 }
 
-impl Config {
+impl PackageManifest {
     // Local paths are usually relative and are discouraged when sharing libraries
     // It is better to separate these into different packages.
     pub(crate) fn has_local_path(&self) -> bool {
@@ -28,7 +28,7 @@ impl Config {
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
-pub(crate) struct Package {
+pub(crate) struct PackageMetadata {
     // Note: a package name is not needed unless there is a registry
     authors: Vec<String>,
     // If not compiler version is supplied, the latest is used
@@ -53,7 +53,7 @@ pub(crate) enum Dependency {
 /// Parses a Nargo.toml file from it's path
 /// The path to the toml file must be present.
 /// Calling this function without this guarantee is an ICE.
-pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<Config, CliError> {
+pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<PackageManifest, CliError> {
     let toml_as_string =
         std::fs::read_to_string(&path_to_toml).expect("ice: path given for toml file is invalid");
 
@@ -66,8 +66,8 @@ pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<Config, CliError>
     }
 }
 
-fn parse_toml_str(toml_as_string: &str) -> Result<Config, String> {
-    match toml::from_str::<Config>(toml_as_string) {
+fn parse_toml_str(toml_as_string: &str) -> Result<PackageManifest, String> {
+    match toml::from_str::<PackageManifest>(toml_as_string) {
         Ok(cfg) => Ok(cfg),
         Err(err) => {
             let mut message = "input.toml file is badly formed, could not parse\n\n".to_owned();

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -49,7 +49,7 @@ impl<'a> Resolver<'a> {
     /// Note that the backend is ignored in the dependencies.
     /// Since Noir is backend agnostic, this is okay to do.
     /// XXX: Need to handle when a local package changes!
-    pub(crate) fn resolve_root_config(
+    pub(crate) fn resolve_root_manifest(
         dir_path: &std::path::Path,
         np_language: Language,
     ) -> Result<Driver, CliError> {
@@ -62,7 +62,7 @@ impl<'a> Resolver<'a> {
         let crate_id = driver.create_local_crate(entry_path, crate_type);
 
         let mut resolver = Resolver::with_driver(&mut driver);
-        resolver.resolve_config(crate_id, manifest)?;
+        resolver.resolve_manifest(crate_id, manifest)?;
 
         add_std_lib(&mut driver);
         Ok(driver)
@@ -74,7 +74,7 @@ impl<'a> Resolver<'a> {
     // We do not need to add stdlib, as it's implicitly
     // imported. However, it may be helpful to have the stdlib imported by the
     // package manager.
-    fn resolve_config(
+    fn resolve_manifest(
         &mut self,
         parent_crate: CrateId,
         manifest: PackageManifest,
@@ -106,7 +106,7 @@ impl<'a> Resolver<'a> {
                 )));
             }
             let mut new_res = Resolver::with_driver(self.driver);
-            new_res.resolve_config(*crate_id, dep_meta.manifest.clone())?;
+            new_res.resolve_manifest(*crate_id, dep_meta.manifest.clone())?;
         }
         Ok(())
     }

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -9,7 +9,7 @@ use noirc_frontend::graph::{CrateId, CrateName, CrateType};
 
 use crate::{
     errors::CliError,
-    toml::{Config, Dependency},
+    manifest::{Dependency, PackageManifest},
 };
 
 /// Creates a unique folder name for a GitHub repo
@@ -25,7 +25,7 @@ pub(crate) fn resolve_folder_name(base: &url::Url, tag: &str) -> String {
 struct CachedDep {
     entry_path: PathBuf,
     crate_type: CrateType,
-    cfg: Config,
+    manifest: PackageManifest,
     // Whether the dependency came from
     // a remote dependency
     remote: bool,
@@ -56,13 +56,13 @@ impl<'a> Resolver<'a> {
         let mut driver = Driver::new(&np_language);
         let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;
 
-        let cfg_path = super::find_package_config(dir_path)?;
-        let cfg = super::toml::parse(cfg_path)?;
+        let manifest_path = super::find_package_manifest(dir_path)?;
+        let manifest = super::manifest::parse(manifest_path)?;
 
         let crate_id = driver.create_local_crate(entry_path, crate_type);
 
         let mut resolver = Resolver::with_driver(&mut driver);
-        resolver.resolve_config(crate_id, cfg)?;
+        resolver.resolve_config(crate_id, manifest)?;
 
         add_std_lib(&mut driver);
         Ok(driver)
@@ -74,9 +74,13 @@ impl<'a> Resolver<'a> {
     // We do not need to add stdlib, as it's implicitly
     // imported. However, it may be helpful to have the stdlib imported by the
     // package manager.
-    fn resolve_config(&mut self, parent_crate: CrateId, cfg: Config) -> Result<(), CliError> {
+    fn resolve_config(
+        &mut self,
+        parent_crate: CrateId,
+        manifest: PackageManifest,
+    ) -> Result<(), CliError> {
         // First download and add these top level dependencies crates to the Driver
-        for (dep_pkg_name, pkg_src) in cfg.dependencies.iter() {
+        for (dep_pkg_name, pkg_src) in manifest.dependencies.iter() {
             let (dir_path, dep_meta) = Resolver::cache_dep(pkg_src)?;
 
             let (entry_path, crate_type) = (&dep_meta.entry_path, &dep_meta.crate_type);
@@ -95,14 +99,14 @@ impl<'a> Resolver<'a> {
 
         // Resolve all transitive dependencies
         for (dir_path, (crate_id, dep_meta)) in self.cached_packages.iter() {
-            if dep_meta.remote && cfg.has_local_path() {
+            if dep_meta.remote && manifest.has_local_path() {
                 return Err(CliError::Generic(format!(
                     "remote(git) dependency depends on a local path. \ndependency located at {}",
                     dir_path.display()
                 )));
             }
             let mut new_res = Resolver::with_driver(self.driver);
-            new_res.resolve_config(*crate_id, dep_meta.cfg.clone())?;
+            new_res.resolve_config(*crate_id, dep_meta.manifest.clone())?;
         }
         Ok(())
     }
@@ -116,9 +120,9 @@ impl<'a> Resolver<'a> {
     fn cache_dep(dep: &Dependency) -> Result<(PathBuf, CachedDep), CliError> {
         fn retrieve_meta(dir_path: &Path, remote: bool) -> Result<CachedDep, CliError> {
             let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;
-            let cfg_path = super::find_package_config(dir_path)?;
-            let cfg = super::toml::parse(cfg_path)?;
-            Ok(CachedDep { entry_path, crate_type, cfg, remote })
+            let manifest_path = super::find_package_manifest(dir_path)?;
+            let manifest = super::manifest::parse(manifest_path)?;
+            Ok(CachedDep { entry_path, crate_type, manifest, remote })
         }
 
         match dep {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

Our `Nargo.toml` file is an analogue to Cargo's `Cargo.toml`. Cargo refers to this file as a package [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) whereas we refer to it as the package config.

For consistency's sake we should rename this to match Cargo as it adds an unnecessary translation layer. I also find the term "config" for `Nargo.toml` a bit confusing as it implies settings rather than dependencies, etc.

This PR then makes the renamings:
- `Config` -> `PackageManifest`
- `Package` -> `PackageMetadata` 

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
