### PR TITLE
feat(nargo): add `InvalidPackageError` and `DependencyResolutionError` error types.

### DIFF
--- a/crates/nargo/src/cli/compile_cmd.rs
+++ b/crates/nargo/src/cli/compile_cmd.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use clap::Args;
 
+use crate::resolver::DependencyResolutionError;
 use crate::{constants::TARGET_DIR, errors::CliError, resolver::Resolver};
 
 use super::fs::program::save_program_to_file;
@@ -66,7 +67,7 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
     }
 }
 
-fn setup_driver(program_dir: &Path) -> Result<Driver, CliError> {
+fn setup_driver(program_dir: &Path) -> Result<Driver, DependencyResolutionError> {
     let backend = crate::backends::ConcreteBackend;
     Resolver::resolve_root_manifest(program_dir, backend.np_language())
 }

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -4,6 +4,8 @@ use noirc_abi::errors::{AbiError, InputParserError};
 use std::path::PathBuf;
 use thiserror::Error;
 
+use crate::resolver::DependencyResolutionError;
+
 #[derive(Debug, Error)]
 pub(crate) enum CliError {
     #[error("{0}")]
@@ -22,6 +24,9 @@ pub(crate) enum CliError {
     MismatchedAcir(PathBuf),
     #[error("Failed to verify proof {}", .0.display())]
     InvalidProof(PathBuf),
+
+    #[error(transparent)]
+    ResolutionError(#[from] DependencyResolutionError),
 
     /// Error while compiling Noir into ACIR.
     #[error("Failed to compile circuit")]

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -2,6 +2,10 @@
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
 
+//! Nargo is the package manager for Noir
+//! This name was used because it sounds like `cargo` and
+//! Noir Package Manager abbreviated is npm, which is already taken.
+
 // Necessary as we use `color_eyre` in `main.rs`.
 use color_eyre as _;
 
@@ -11,15 +15,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::errors::CliError;
-// Nargo is the package manager for Noir
-// This name was used because it sounds like `cargo` and
-// Noir Package Manager abbreviated is npm, which is already taken.
-
-fn nargo_crates() -> PathBuf {
-    dirs::home_dir().unwrap().join("nargo")
-}
-
 mod backends;
 pub mod cli;
 mod constants;
@@ -28,45 +23,36 @@ mod git;
 mod manifest;
 mod resolver;
 
+use manifest::InvalidPackageError;
+
+fn nargo_crates() -> PathBuf {
+    dirs::home_dir().unwrap().join("nargo")
+}
+
 /// Searches for the Nargo.toml file
 ///
 /// XXX: In the end, this should find the root of the project and check
 /// for the Nargo.toml file there
 /// However, it should only do this after checking the current path
 /// This allows the use of workspace settings in the future.
-fn find_package_manifest(current_path: &Path) -> Result<PathBuf, CliError> {
-    match find_file(current_path, "Nargo", "toml") {
-        Some(p) => Ok(p),
-        None => Err(CliError::Generic(format!(
-            "cannot find a Nargo.toml in {}",
-            current_path.display()
-        ))),
-    }
+fn find_package_manifest(current_path: &Path) -> Result<PathBuf, InvalidPackageError> {
+    find_file(current_path, "Nargo", "toml")
+        .ok_or_else(|| InvalidPackageError::MissingManifestFile(current_path.to_path_buf()))
 }
 
-fn lib_or_bin(current_path: &Path) -> Result<(PathBuf, CrateType), CliError> {
+fn lib_or_bin(current_path: &Path) -> Result<(PathBuf, CrateType), InvalidPackageError> {
     // A library has a lib.nr and a binary has a main.nr
     // You cannot have both.
-    let src_path = match find_dir(current_path, "src") {
-        Some(path) => path,
-        None => {
-            return Err(CliError::Generic(format!(
-                "cannot find src file in path {}",
-                current_path.display()
-            )))
-        }
-    };
+    let src_path = find_dir(current_path, "src")
+        .ok_or_else(|| InvalidPackageError::NoSourceDir(current_path.to_path_buf()))?;
+
     let lib_nr_path = find_file(&src_path, "lib", "nr");
     let bin_nr_path = find_file(&src_path, "main", "nr");
     match (lib_nr_path, bin_nr_path) {
-        (Some(_), Some(_)) => Err(CliError::Generic(
-            "package cannot contain both a `lib.nr` and a `main.nr`".to_owned(),
-        )),
+        (Some(_), Some(_)) => Err(InvalidPackageError::ContainsMultipleCrates),
         (None, Some(path)) => Ok((path, CrateType::Binary)),
         (Some(path), None) => Ok((path, CrateType::Library)),
-        (None, None) => Err(CliError::Generic(
-            "package must contain either a `lib.nr`(Library) or a `main.nr`(Binary).".to_owned(),
-        )),
+        (None, None) => Err(InvalidPackageError::ContainsZeroCrates),
     }
 }
 

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -6,9 +6,6 @@
 //! This name was used because it sounds like `cargo` and
 //! Noir Package Manager abbreviated is npm, which is already taken.
 
-// Necessary as we use `color_eyre` in `main.rs`.
-use color_eyre as _;
-
 use noirc_frontend::graph::CrateType;
 use std::{
     fs::ReadDir,

--- a/crates/nargo/src/manifest.rs
+++ b/crates/nargo/src/manifest.rs
@@ -1,8 +1,31 @@
 use serde::Deserialize;
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
 
-use crate::errors::CliError;
+/// Errors covering situations where a package is either missing or malformed.
+#[derive(Debug, Error)]
+pub(crate) enum InvalidPackageError {
+    /// Package doesn't have a manifest file
+    #[error("cannot find a Nargo.toml in {}", .0.display())]
+    MissingManifestFile(PathBuf),
+
+    /// Package manifest is unreadable.
+    #[error("Nargo.toml is badly formed, could not parse.\n\n {0}")]
+    MalformedManifestFile(toml::de::Error),
+
+    /// Package does not contain Noir source files.
+    #[error("cannot find src directory in path {}", .0.display())]
+    NoSourceDir(PathBuf),
+
+    /// Package has neither of `main.nr` and `lib.nr`.
+    #[error("package must contain either a `lib.nr`(Library) or a `main.nr`(Binary).")]
+    ContainsZeroCrates,
+
+    /// Package has both a `main.nr` (for binaries) and `lib.nr` (for libraries)
+    #[error("package cannot contain both a `lib.nr` and a `main.nr`")]
+    ContainsMultipleCrates,
+}
 
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct PackageManifest {
@@ -53,32 +76,18 @@ pub(crate) enum Dependency {
 /// Parses a Nargo.toml file from it's path
 /// The path to the toml file must be present.
 /// Calling this function without this guarantee is an ICE.
-pub(crate) fn parse<P: AsRef<Path>>(path_to_toml: P) -> Result<PackageManifest, CliError> {
+pub(crate) fn parse<P: AsRef<Path>>(
+    path_to_toml: P,
+) -> Result<PackageManifest, InvalidPackageError> {
     let toml_as_string =
         std::fs::read_to_string(&path_to_toml).expect("ice: path given for toml file is invalid");
 
-    match parse_toml_str(&toml_as_string) {
-        Ok(cfg) => Ok(cfg),
-        Err(msg) => {
-            let path = path_to_toml.as_ref();
-            Err(CliError::Generic(format!("{}\n Location: {}", msg, path.display())))
-        }
-    }
+    parse_toml_str(&toml_as_string)
 }
 
-fn parse_toml_str(toml_as_string: &str) -> Result<PackageManifest, String> {
-    match toml::from_str::<PackageManifest>(toml_as_string) {
-        Ok(cfg) => Ok(cfg),
-        Err(err) => {
-            let mut message = "input.toml file is badly formed, could not parse\n\n".to_owned();
-            // XXX: This error is not always that helpful, but it gives the line number
-            // and the entry, in those cases
-            // which is useful for telling the user where the error occurred
-            // XXX: maybe there is a way to extract ErrorInner from toml
-            message.push_str(&err.to_string());
-            Err(message)
-        }
-    }
+fn parse_toml_str(toml_as_string: &str) -> Result<PackageManifest, InvalidPackageError> {
+    toml::from_str::<PackageManifest>(toml_as_string)
+        .map_err(InvalidPackageError::MalformedManifestFile)
 }
 
 #[test]


### PR DESCRIPTION
# Related issue(s)

Addresses most instances of #11 in `nargo`.

# Description

## Summary of changes

This PR defines `InvalidPackageError` and `DependencyResolutionError` to handle issues with malformed packages or invalid dependencies. Previously we would make all of these `CliError::Generic` errors.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
