### PR TITLE
chore(nargo): remove `cached_packages` field from `Resolver`

### DIFF
--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -122,7 +122,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Resolve all transitive dependencies
-        for (dependency_path, (crate_id, dep_meta)) in cached_packages.into_iter() {
+        for (dependency_path, (crate_id, dep_meta)) in cached_packages {
             if dep_meta.remote && manifest.has_local_path() {
                 return Err(DependencyResolutionError::RemoteDepWithLocalDep { dependency_path });
             }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

I've removed the `cached_packages` field from the `Resolver` struct as it doesn't need to exist. It's both constructed and consumed within `resolve_config` so we can just have it be a variable within the function.

This allows us to remove the cloning of the dependency manifest.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
