### PR TITLE
feat(nargo): allow running `nargo` from any directory in package

### DIFF
--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 
 use color_eyre::eyre;
 
+use crate::find_package_root;
+
 mod fs;
 
 mod check_cmd;
@@ -59,19 +61,22 @@ enum NargoCommand {
 }
 
 pub fn start_cli() -> eyre::Result<()> {
-    let matches = NargoCli::parse();
+    let NargoCli { command, mut config } = NargoCli::parse();
 
-    match matches.command {
-        NargoCommand::New(args) => new_cmd::run(args, matches.config),
-        NargoCommand::Check(args) => check_cmd::run(args, matches.config),
-        NargoCommand::Compile(args) => compile_cmd::run(args, matches.config),
-        NargoCommand::Execute(args) => execute_cmd::run(args, matches.config),
-        NargoCommand::Prove(args) => prove_cmd::run(args, matches.config),
-        NargoCommand::Verify(args) => verify_cmd::run(args, matches.config),
-        NargoCommand::Preprocess(args) => preprocess_cmd::run(args, matches.config),
-        NargoCommand::Test(args) => test_cmd::run(args, matches.config),
-        NargoCommand::Gates(args) => gates_cmd::run(args, matches.config),
-        NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(args, matches.config),
+    // Search through parent directories to find package root.
+    config.program_dir = find_package_root(&config.program_dir)?;
+
+    match command {
+        NargoCommand::New(args) => new_cmd::run(args, config),
+        NargoCommand::Check(args) => check_cmd::run(args, config),
+        NargoCommand::Compile(args) => compile_cmd::run(args, config),
+        NargoCommand::Execute(args) => execute_cmd::run(args, config),
+        NargoCommand::Prove(args) => prove_cmd::run(args, config),
+        NargoCommand::Verify(args) => verify_cmd::run(args, config),
+        NargoCommand::Preprocess(args) => preprocess_cmd::run(args, config),
+        NargoCommand::Test(args) => test_cmd::run(args, config),
+        NargoCommand::Gates(args) => gates_cmd::run(args, config),
+        NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(args, config),
     }?;
 
     Ok(())

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -29,7 +29,7 @@ fn nargo_crates() -> PathBuf {
 /// Returns the path of the root directory of the package containing `current_path`.
 ///
 /// Returns a `CliError` if no parent directories of `current_path` contain a manifest file.
-fn find_package_root(current_path: &Path) -> Result<PathBuf, CliError> {
+fn find_package_root(current_path: &Path) -> Result<PathBuf, InvalidPackageError> {
     let manifest_path = find_package_manifest(current_path)?;
 
     let package_root =
@@ -41,13 +41,11 @@ fn find_package_root(current_path: &Path) -> Result<PathBuf, CliError> {
 /// Returns the path of the manifest file (`Nargo.toml`) of the package containing `current_path`.
 ///
 /// Returns a `CliError` if no parent directories of `current_path` contain a manifest file.
-fn find_package_manifest(current_path: &Path) -> Result<PathBuf, CliError> {
-    current_path.ancestors().find_map(|dir| find_file(dir, "Nargo", "toml")).ok_or_else(|| {
-        CliError::Generic(format!(
-            "could not find Nargo.toml in {} or any parent directory",
-            current_path.display()
-        ))
-    })
+fn find_package_manifest(current_path: &Path) -> Result<PathBuf, InvalidPackageError> {
+    current_path
+        .ancestors()
+        .find_map(|dir| find_file(dir, "Nargo", "toml"))
+        .ok_or_else(|| InvalidPackageError::MissingManifestFile(current_path.to_path_buf()))
 }
 
 fn lib_or_bin(current_path: &Path) -> Result<(PathBuf, CrateType), InvalidPackageError> {


### PR DESCRIPTION
# Related issue(s)

Baby step towards #794 

# Description

## Summary of changes

Currently `nargo` cannot run except in the root directory of a noir package. This is a little annoying if you're in the `src` directory of a package but `nargo` isn't smart enough to compile the program inside it.

When running the `nargo` CLI we now search all ancestor directories for a `Nargo.toml` file and then run in the context of that directory. 


## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
