### PR TITLE
feat: Add public api struct for Aztec 3

### DIFF
--- a/noir_stdlib/src/aztec3.nr
+++ b/noir_stdlib/src/aztec3.nr
@@ -1,0 +1,9 @@
+mod abi;
+
+global Nonce: comptime Field = 1;
+global NoteHash: comptime Field = 2;
+global NoteStorageSlot: comptime Field = 3;
+global MappingStorageSlot: comptime Field = 4;
+global Nullifier: comptime Field = 5;
+
+global TREE_HEIGHT: comptime Field = 5;

--- a/noir_stdlib/src/aztec3/abi.nr
+++ b/noir_stdlib/src/aztec3/abi.nr
@@ -1,0 +1,75 @@
+global MAX_ARGS: comptime Field = 5;
+global MAX_RETURN_VALUES: comptime Field = 5;
+global MAX_LOGS: comptime Field = 5;
+global MAX_NEW_COMMITMENTS: comptime Field = 5;
+global MAX_NEW_NULLIFIERS: comptime Field = 5;
+global MAX_PRIVATE_CALL_STACK : comptime Field = 5;
+global MAX_PUBLIC_CALL_STACK: comptime Field = 5;
+global MAX_L1_MSG_STACK : comptime Field = 5;
+
+struct PublicInputs {
+    call_context : CallContext,
+
+    args : [Field; MAX_ARGS],
+    return_values : [Field; MAX_RETURN_VALUES],
+    logs : [Field; MAX_LOGS],
+
+    new_commitments : [Field; MAX_NEW_COMMITMENTS],
+    new_nullifiers : [Field; MAX_NEW_NULLIFIERS],
+
+    private_call_stack : [Field; MAX_PRIVATE_CALL_STACK],
+    public_call_stack : [Field; MAX_PUBLIC_CALL_STACK],
+    l1_message_stack : [Field; MAX_L1_MSG_STACK],
+
+    old_private_data_tree_root : Field,
+    old_nullifier_tree_root : Field,
+    old_contract_tree_root : Field,
+
+    contract_deployment_data: ContractDeploymentData,
+}
+
+struct CallContext {
+    msg_sender : Field,
+    storage_contract_address : Field,
+    portal_contract_address : Field,
+
+    is_delegate_call : bool,
+    is_static_call : bool,
+    is_contract_deployment: bool,
+}
+
+struct ContractDeploymentData {
+    constructor_vk_hash : Field,
+    function_tree_root : Field,
+    contract_address_salt : Field,
+    portal_contract_address : Field,
+    hide_private_function_data : bool,
+}
+
+impl PublicInputs {
+    fn new(
+        call_context: CallContext,
+        contract_deployment_data: ContractDeploymentData,
+        args: [Field; MAX_ARGS]
+    ) -> PublicInputs {
+        PublicInputs {
+            call_context,
+            contract_deployment_data,
+            args,
+
+            return_values: [0; MAX_RETURN_VALUES],
+            logs: [0; MAX_LOGS],
+
+            new_commitments: [0; MAX_NEW_COMMITMENTS],
+            new_nullifiers: [0; MAX_NEW_NULLIFIERS],
+
+            private_call_stack: [0; MAX_PRIVATE_CALL_STACK],
+            public_call_stack: [0; MAX_PUBLIC_CALL_STACK],
+            l1_message_stack: [0; MAX_L1_MSG_STACK],
+
+            old_private_data_tree_root: 0,
+            old_nullifier_tree_root: 0,
+            old_contract_tree_root: 0,
+        }
+    } 
+}


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves (none)

# Description

## Summary of changes

This is the first of a few PRs to add some Aztec 3 related structs and functions to noir's stdlib. This PR adds the simplest struct to start out with - PublicInputs. Other structs like the execution context or notes will come later as these require more features to get working.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

I'd wait to add documentation until we have more of the abi added and it is more set in stone

# Additional context

<!-- If applicable. -->
