### PR TITLE
fix(nargo): correct logic for rejecting transitive local dependencies

### DIFF
--- a/crates/nargo/src/manifest.rs
+++ b/crates/nargo/src/manifest.rs
@@ -35,17 +35,11 @@ pub(crate) struct PackageManifest {
 }
 
 impl PackageManifest {
+    /// Returns whether the package has a local dependency.
     // Local paths are usually relative and are discouraged when sharing libraries
     // It is better to separate these into different packages.
-    pub(crate) fn has_local_path(&self) -> bool {
-        let mut has_local_path = false;
-        for dep in self.dependencies.values() {
-            if let Dependency::Path { .. } = dep {
-                has_local_path = true;
-                break;
-            }
-        }
-        has_local_path
+    pub(crate) fn has_local_dependency(&self) -> bool {
+        self.dependencies.values().any(|dep| matches!(dep, Dependency::Path { .. }))
     }
 }
 

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -123,7 +123,7 @@ impl<'a> Resolver<'a> {
 
         // Resolve all transitive dependencies
         for (dependency_path, (crate_id, dep_meta)) in cached_packages {
-            if dep_meta.remote && manifest.has_local_dependency() {
+            if dep_meta.remote && dep_meta.manifest.has_local_dependency() {
                 return Err(DependencyResolutionError::RemoteDepWithLocalDep { dependency_path });
             }
             let mut new_res = Resolver::with_driver(self.driver);

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -123,7 +123,7 @@ impl<'a> Resolver<'a> {
 
         // Resolve all transitive dependencies
         for (dependency_path, (crate_id, dep_meta)) in cached_packages {
-            if dep_meta.remote && manifest.has_local_path() {
+            if dep_meta.remote && manifest.has_local_dependency() {
                 return Err(DependencyResolutionError::RemoteDepWithLocalDep { dependency_path });
             }
             let mut new_res = Resolver::with_driver(self.driver);


### PR DESCRIPTION
# Related issue(s)

Resolves #1014 

# Description

## Summary of changes

This PR updates the logic around the `DependencyResolutionError::RemoteDepWithLocalDep` as discussed in #1014.

I've also reworked the `PackageManifest.has_local_path()` function to make it a bit clearer.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
