### PR TITLE
feat: Add storage slots to globals

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -203,8 +203,8 @@ impl Driver {
     ) -> Result<CompiledContract, ReportedError> {
         let functions = try_btree_map(&contract.functions, |function| {
             let function_name = self.function_name(*function).to_owned();
-
-            self.compile_no_check(options, *function).map(|program| (function_name, program))
+            let program = self.compile_no_check(options, *function)?;
+            Ok((function_name, program))
         })?;
 
         Ok(CompiledContract { name: contract.name, functions })
@@ -225,10 +225,7 @@ impl Driver {
         };
 
         // All Binaries should have a main function
-        match local_crate.main_function() {
-            Some(func_id) => Ok(func_id),
-            None => Err(ReportedError),
-        }
+        local_crate.main_function().ok_or(ReportedError)
     }
 
     /// Compile the current crate. Assumes self.check_crate is called beforehand!

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -276,7 +276,7 @@ fn resolve_globals(
 
         context.def_interner.update_global(global.stmt_id, hir_stmt);
 
-        context.def_interner.push_global(global.stmt_id, name.clone(), global.module_id);
+        context.def_interner.push_global(global.stmt_id, name, global.module_id);
 
         (global.file_id, global.stmt_id)
     })

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -272,11 +272,11 @@ fn resolve_globals(
 
         let name = global.stmt_def.pattern.name_ident().clone();
 
-        let hir_stmt = resolver.resolve_global_let(global.stmt_def, storage_slot);
+        let hir_stmt = resolver.resolve_global_let(global.stmt_def);
 
         context.def_interner.update_global(global.stmt_id, hir_stmt);
 
-        context.def_interner.push_global(global.stmt_id, name, global.module_id);
+        context.def_interner.push_global(global.stmt_id, name, global.module_id, storage_slot);
 
         (global.file_id, global.stmt_id)
     })

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -258,11 +258,10 @@ fn resolve_globals(
     globals: Vec<UnresolvedGlobal>,
     crate_id: CrateId,
 ) -> Vec<(FileId, StmtId)> {
-    let mut global_ids = Vec::new();
-
-    for global in globals {
-        let path_resolver =
-            StandardPathResolver::new(ModuleId { local_id: global.module_id, krate: crate_id });
+    vecmap(globals, |global| {
+        let module_id = ModuleId { local_id: global.module_id, krate: crate_id };
+        let path_resolver = StandardPathResolver::new(module_id);
+        let storage_slot = context.next_storage_slot(module_id);
 
         let mut resolver = Resolver::new(
             &mut context.def_interner,
@@ -273,15 +272,14 @@ fn resolve_globals(
 
         let name = global.stmt_def.pattern.name_ident().clone();
 
-        let hir_stmt = resolver.resolve_global_let(global.stmt_def);
+        let hir_stmt = resolver.resolve_global_let(global.stmt_def, storage_slot);
 
         context.def_interner.update_global(global.stmt_id, hir_stmt);
 
         context.def_interner.push_global(global.stmt_id, name.clone(), global.module_id);
 
-        global_ids.push((global.file_id, global.stmt_id));
-    }
-    global_ids
+        (global.file_id, global.stmt_id)
+    })
 }
 
 fn type_check_globals(

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -20,7 +20,13 @@ pub struct Context {
     pub crate_graph: CrateGraph,
     pub(crate) def_maps: HashMap<CrateId, CrateDefMap>,
     pub file_manager: FileManager,
+
+    /// Maps a given (contract) module id to the next available storage slot
+    /// for that contract.
+    pub storage_slots: HashMap<def_map::ModuleId, StorageSlot>,
 }
+
+pub type StorageSlot = u32;
 
 impl Context {
     pub fn new(file_manager: FileManager, crate_graph: CrateGraph, language: Language) -> Context {
@@ -29,10 +35,12 @@ impl Context {
             def_maps: HashMap::new(),
             crate_graph,
             file_manager,
+            storage_slots: HashMap::new(),
         };
         ctx.def_interner.set_language(&language);
         ctx
     }
+
     /// Returns the CrateDefMap for a given CrateId.
     /// It is perfectly valid for the compiler to look
     /// up a CrateDefMap and it is not available.
@@ -45,5 +53,21 @@ impl Context {
     /// successfully
     pub fn crates(&self) -> impl Iterator<Item = CrateId> + '_ {
         self.crate_graph.iter_keys()
+    }
+
+    fn module(&self, module_id: def_map::ModuleId) -> &def_map::ModuleData {
+        &self.def_maps[&module_id.krate].modules()[module_id.local_id.0]
+    }
+
+    /// Returns the next available storage slot in the given module.
+    /// Returns None if the given module is not a contract module.
+    fn next_storage_slot(&mut self, module_id: def_map::ModuleId) -> Option<StorageSlot> {
+        let module = self.module(module_id);
+
+        module.is_contract.then(|| {
+            let next_slot = self.storage_slots.entry(module_id).or_insert(0);
+            *next_slot += 1;
+            *next_slot
+        })
     }
 }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1,3 +1,4 @@
+use crate::hir::StorageSlot;
 // Fix usage of intern and resolve
 // In some places, we do intern, however in others we are resolving and interning
 // Ideally, I want to separate the interning and resolving abstractly
@@ -567,7 +568,7 @@ impl<'a> Resolver<'a> {
         for (stmt_id, global_info) in self.interner.get_all_globals() {
             if global_info.local_id == self.path_resolver.local_module_id() {
                 let global_stmt = self.interner.let_statement(&stmt_id);
-                let definition = DefinitionKind::Global(global_stmt.expression);
+                let definition = DefinitionKind::Global(global_stmt.expression, None); // TODO
                 self.add_global_variable_decl(global_info.ident, definition);
             }
         }
@@ -722,9 +723,14 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub fn resolve_global_let(&mut self, let_stmt: crate::LetStatement) -> HirStatement {
+    pub fn resolve_global_let(
+        &mut self,
+        let_stmt: crate::LetStatement,
+        storage_slot: Option<StorageSlot>,
+    ) -> HirStatement {
         let expression = self.resolve_expression(let_stmt.expression);
-        let definition = DefinitionKind::Global(expression);
+        let definition = DefinitionKind::Global(expression, storage_slot);
+
         HirStatement::Let(HirLetStatement {
             pattern: self.resolve_pattern(let_stmt.pattern, definition),
             r#type: self.resolve_type(let_stmt.r#type),

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1,4 +1,3 @@
-use crate::hir::StorageSlot;
 // Fix usage of intern and resolve
 // In some places, we do intern, however in others we are resolving and interning
 // Ideally, I want to separate the interning and resolving abstractly
@@ -568,7 +567,7 @@ impl<'a> Resolver<'a> {
         for (stmt_id, global_info) in self.interner.get_all_globals() {
             if global_info.local_id == self.path_resolver.local_module_id() {
                 let global_stmt = self.interner.let_statement(&stmt_id);
-                let definition = DefinitionKind::Global(global_stmt.expression, None); // TODO
+                let definition = DefinitionKind::Global(global_stmt.expression);
                 self.add_global_variable_decl(global_info.ident, definition);
             }
         }
@@ -723,13 +722,9 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub fn resolve_global_let(
-        &mut self,
-        let_stmt: crate::LetStatement,
-        storage_slot: Option<StorageSlot>,
-    ) -> HirStatement {
+    pub fn resolve_global_let(&mut self, let_stmt: crate::LetStatement) -> HirStatement {
         let expression = self.resolve_expression(let_stmt.expression);
-        let definition = DefinitionKind::Global(expression, storage_slot);
+        let definition = DefinitionKind::Global(expression);
 
         HirStatement::Let(HirLetStatement {
             pattern: self.resolve_pattern(let_stmt.pattern, definition),

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -504,7 +504,7 @@ impl<'interner> Monomorphizer<'interner> {
                 let ident = ast::Ident { location, mutable, definition, name, typ };
                 ast::Expression::Ident(ident)
             }
-            DefinitionKind::Global(expr_id) => self.expr_infer(*expr_id),
+            DefinitionKind::Global(expr_id, _slot) => self.expr_infer(*expr_id),
             DefinitionKind::Local(_) => {
                 let ident = self.local_ident(&ident).unwrap();
                 ast::Expression::Ident(ident)

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -504,7 +504,7 @@ impl<'interner> Monomorphizer<'interner> {
                 let ident = ast::Ident { location, mutable, definition, name, typ };
                 ast::Expression::Ident(ident)
             }
-            DefinitionKind::Global(expr_id, _slot) => self.expr_infer(*expr_id),
+            DefinitionKind::Global(expr_id) => self.expr_infer(*expr_id),
             DefinitionKind::Local(_) => {
                 let ident = self.local_ident(&ident).unwrap();
                 ast::Expression::Ident(ident)

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -204,9 +204,7 @@ impl DefinitionInfo {
 pub enum DefinitionKind {
     Function(FuncId),
 
-    /// Global definitions have an associated storage slot if they are defined within
-    /// a contract. If they're defined elsewhere, this value is None.
-    Global(ExprId, Option<StorageSlot>),
+    Global(ExprId),
 
     /// Locals may be defined in let statements or parameters,
     /// in which case they will not have an associated ExprId
@@ -227,7 +225,7 @@ impl DefinitionKind {
     pub fn get_rhs(self) -> Option<ExprId> {
         match self {
             DefinitionKind::Function(_) => None,
-            DefinitionKind::Global(id, ..) => Some(id),
+            DefinitionKind::Global(id) => Some(id),
             DefinitionKind::Local(id) => id,
             DefinitionKind::GenericType(_) => None,
         }
@@ -238,6 +236,10 @@ impl DefinitionKind {
 pub struct GlobalInfo {
     pub ident: Ident,
     pub local_id: LocalModuleId,
+
+    /// Global definitions have an associated storage slot if they are defined within
+    /// a contract. If they're defined elsewhere, this value is None.
+    pub storage_slot: Option<StorageSlot>,
 }
 
 impl Default for NodeInterner {
@@ -335,8 +337,14 @@ impl NodeInterner {
         self.id_to_type.insert(definition_id.into(), typ);
     }
 
-    pub fn push_global(&mut self, stmt_id: StmtId, ident: Ident, local_id: LocalModuleId) {
-        self.globals.insert(stmt_id, GlobalInfo { ident, local_id });
+    pub fn push_global(
+        &mut self,
+        stmt_id: StmtId,
+        ident: Ident,
+        local_id: LocalModuleId,
+        storage_slot: Option<StorageSlot>,
+    ) {
+        self.globals.insert(stmt_id, GlobalInfo { ident, local_id, storage_slot });
     }
 
     /// Intern an empty global stmt. Used for collecting globals

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -203,6 +203,9 @@ impl DefinitionInfo {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DefinitionKind {
     Function(FuncId),
+
+    /// Global definitions have an associated storage slot if they are defined within
+    /// a contract. If they're defined elsewhere, this value is None.
     Global(ExprId, Option<StorageSlot>),
 
     /// Locals may be defined in let statements or parameters,

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -11,6 +11,7 @@ use crate::graph::CrateId;
 use crate::hir::def_collector::dc_crate::UnresolvedStruct;
 use crate::hir::def_map::{LocalModuleId, ModuleId};
 use crate::hir::type_check::TypeCheckError;
+use crate::hir::StorageSlot;
 use crate::hir_def::stmt::HirLetStatement;
 use crate::hir_def::types::{StructType, Type};
 use crate::hir_def::{
@@ -202,7 +203,7 @@ impl DefinitionInfo {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DefinitionKind {
     Function(FuncId),
-    Global(ExprId),
+    Global(ExprId, Option<StorageSlot>),
 
     /// Locals may be defined in let statements or parameters,
     /// in which case they will not have an associated ExprId
@@ -217,13 +218,13 @@ impl DefinitionKind {
     /// True if this definition is for a global variable.
     /// Note that this returns false for top-level functions.
     pub fn is_global(&self) -> bool {
-        matches!(self, DefinitionKind::Global(_))
+        matches!(self, DefinitionKind::Global(..))
     }
 
     pub fn get_rhs(self) -> Option<ExprId> {
         match self {
             DefinitionKind::Function(_) => None,
-            DefinitionKind::Global(id) => Some(id),
+            DefinitionKind::Global(id, ..) => Some(id),
             DefinitionKind::Local(id) => id,
             DefinitionKind::GenericType(_) => None,
         }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1018

# Description

## Summary of changes

This PR assigns a storage slot to each global, starting from 1, and resetting back each time a new contract is identified.

Note that this PR does not add a way to actually access this value within noir code yet. I expect this to be more difficult since we will need to track whether e.g. a parameter of a function will have its storage slot taken, requiring us to verify the function is either called with a global as its argument or with another parameter.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
