### PR TITLE
chore(github): Making a small change to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Resolves # <!-- link to issue -->
 
 <!-- If applicable. -->
 
-# Checklist
+## Checklist
 
 - [ ] I have tested the changes locally.
 - [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
@@ -27,9 +27,11 @@ Resolves # <!-- link to issue -->
 - [ ] I have ensured all changes are covered in the description.
 
 ## Documentation needs
-- [ ] This PR requires documentation updates when merged.
 
-<!-- If checked, list / describe what needs to be documented. -->
+- [ ] I have submitted PR documentation changes in [the noir book repo](https://github.com/noir-lang/book)
+- [ ] The PR with the documentation change is ready to merge
+
+<!-- If checked, refer the relevant PR -->
 
 # Additional context
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,8 +28,9 @@ Resolves # <!-- link to issue -->
 
 ## Documentation needs
 
-- [ ] I have submitted PR documentation changes in [the noir book repo](https://github.com/noir-lang/book)
-- [ ] The PR with the documentation change is ready to merge
+- [ ] I have documented the changes in this PR
+    or
+- [ ] I had a quick call with DevRel team explaining the changes needed in the [book](https://github.com/noir-lang/book)
 
 <!-- If checked, refer the relevant PR -->
 


### PR DESCRIPTION
# Description

## Summary of changes

Regarding the documentation, the small changes should be documented by the engineers making them. This will make both DevRel and Noir teams more efficient with less information-passing.

This way, each new PR in the Noir repo requires that:

1. A similar PR is made in the Noir Book repo
2. Changes are reviewed by team members including DevRels