### PR TITLE
fix(nargo): only search for `Nargo.toml` in commands which act on a Nargo package

### DIFF
--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -63,8 +63,10 @@ enum NargoCommand {
 pub fn start_cli() -> eyre::Result<()> {
     let NargoCli { command, mut config } = NargoCli::parse();
 
-    // Search through parent directories to find package root.
-    config.program_dir = find_package_root(&config.program_dir)?;
+    // Search through parent directories to find package root if necessary.
+    if !matches!(command, NargoCommand::New(_)) {
+	config.program_dir = find_package_root(&config.program_dir)?;
+    }
 
     match command {
         NargoCommand::New(args) => new_cmd::run(args, config),

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -65,7 +65,7 @@ pub fn start_cli() -> eyre::Result<()> {
 
     // Search through parent directories to find package root if necessary.
     if !matches!(command, NargoCommand::New(_)) {
-	config.program_dir = find_package_root(&config.program_dir)?;
+        config.program_dir = find_package_root(&config.program_dir)?;
     }
 
     match command {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description
This PR fixes the issue where running `nargo new` unsuccessfully searches for a `Nargo.toml` file resulting in an error of the following form:

```
Error: cannot find a Nargo.toml in /tmp

Location:
    crates/nargo/src/cli/mod.rs:67:26
```

## Summary of changes

- Condition added to check command before searching for project root.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
