### PR TITLE
feat(nargo): print-acir command

### DIFF
--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -17,6 +17,7 @@ mod execute_cmd;
 mod gates_cmd;
 mod new_cmd;
 mod preprocess_cmd;
+mod print_acir_cmd;
 mod prove_cmd;
 mod test_cmd;
 mod verify_cmd;
@@ -58,6 +59,7 @@ enum NargoCommand {
     Preprocess(preprocess_cmd::PreprocessCommand),
     Test(test_cmd::TestCommand),
     Gates(gates_cmd::GatesCommand),
+    PrintAcir(print_acir_cmd::PrintAcirCommand),
 }
 
 pub fn start_cli() -> eyre::Result<()> {
@@ -77,6 +79,7 @@ pub fn start_cli() -> eyre::Result<()> {
         NargoCommand::Test(args) => test_cmd::run(args, config),
         NargoCommand::Gates(args) => gates_cmd::run(args, config),
         NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(args, config),
+        NargoCommand::PrintAcir(args) => print_acir_cmd::run(args, config),
     }?;
 
     Ok(())

--- a/crates/nargo/src/cli/print_acir_cmd.rs
+++ b/crates/nargo/src/cli/print_acir_cmd.rs
@@ -1,0 +1,29 @@
+use clap::Args;
+use noirc_driver::CompileOptions;
+use std::path::Path;
+
+use crate::cli::compile_cmd::compile_circuit;
+use crate::errors::CliError;
+
+use super::NargoConfig;
+
+/// Prints out the ACIR for a compiled circuit
+#[derive(Debug, Clone, Args)]
+pub(crate) struct PrintAcirCommand {
+    #[clap(flatten)]
+    compile_options: CompileOptions,
+}
+
+pub(crate) fn run(args: PrintAcirCommand, config: NargoConfig) -> Result<(), CliError> {
+    print_acir_with_path(config.program_dir, &args.compile_options)
+}
+
+fn print_acir_with_path<P: AsRef<Path>>(
+    program_dir: P,
+    compile_options: &CompileOptions,
+) -> Result<(), CliError> {
+    let compiled_program = compile_circuit(program_dir.as_ref(), compile_options)?;
+    println!("{}", compiled_program.circuit);
+
+    Ok(())
+}


### PR DESCRIPTION
# Related issue(s)

Resolves #1030

# Description

## Summary of changes

Adds the ability to print a compiled circuit to stdout such that the ACIR can be inspected.

```
aztec@Aztecs-MBP pedersen % nargo print-acir
current witness index : 6
public input indices : [2, 4]
EXPR [ (1, _1) (2, _2) (-1, _3) 0 ]
BLACKBOX::PEDERSEN [(_1, num_bits: 254), (_2, num_bits: 254), (_3, num_bits: 254)] [ _4, _5]
```

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

It's a new feature that could be made known to devs as it's very useful for education.
