### PR TITLE
fix(nargo): Set current dir to package root before executing commands

### DIFF
--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -68,7 +68,6 @@ pub fn start_cli() -> eyre::Result<()> {
     // Search through parent directories to find package root if necessary.
     if !matches!(command, NargoCommand::New(_)) {
         config.program_dir = find_package_root(&config.program_dir)?;
-        std::env::set_current_dir(&config.program_dir)?;
     }
 
     match command {

--- a/crates/nargo/src/cli/mod.rs
+++ b/crates/nargo/src/cli/mod.rs
@@ -68,6 +68,7 @@ pub fn start_cli() -> eyre::Result<()> {
     // Search through parent directories to find package root if necessary.
     if !matches!(command, NargoCommand::New(_)) {
         config.program_dir = find_package_root(&config.program_dir)?;
+        std::env::set_current_dir(&config.program_dir)?;
     }
 
     match command {

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -84,7 +84,8 @@ impl<'a> Resolver<'a> {
         let crate_id = driver.create_local_crate(entry_path, crate_type);
 
         let mut resolver = Resolver::with_driver(&mut driver);
-        resolver.resolve_manifest(crate_id, manifest, manifest_path.parent().unwrap())?;
+	let pkg_root = manifest_path.parent().expect("Every manifest path has a parent.");
+        resolver.resolve_manifest(crate_id, manifest, pkg_root)?;
 
         add_std_lib(&mut driver);
         Ok(driver)
@@ -128,7 +129,7 @@ impl<'a> Resolver<'a> {
                 return Err(DependencyResolutionError::RemoteDepWithLocalDep { dependency_path });
             }
             let mut new_res = Resolver::with_driver(self.driver);
-            new_res.resolve_manifest(crate_id, dep_meta.manifest, pkg_root)?;
+            new_res.resolve_manifest(crate_id, dep_meta.manifest, &dependency_path)?;
         }
         Ok(())
     }

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -79,12 +79,12 @@ impl<'a> Resolver<'a> {
         let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;
 
         let manifest_path = super::find_package_manifest(dir_path)?;
-        let manifest = super::manifest::parse(manifest_path)?;
+        let manifest = super::manifest::parse(&manifest_path)?;
 
         let crate_id = driver.create_local_crate(entry_path, crate_type);
 
         let mut resolver = Resolver::with_driver(&mut driver);
-        resolver.resolve_manifest(crate_id, manifest)?;
+        resolver.resolve_manifest(crate_id, manifest, manifest_path.parent().unwrap())?;
 
         add_std_lib(&mut driver);
         Ok(driver)
@@ -100,12 +100,13 @@ impl<'a> Resolver<'a> {
         &mut self,
         parent_crate: CrateId,
         manifest: PackageManifest,
+        pkg_root: &Path,
     ) -> Result<(), DependencyResolutionError> {
         let mut cached_packages: HashMap<PathBuf, (CrateId, CachedDep)> = HashMap::new();
 
         // First download and add these top level dependencies crates to the Driver
         for (dep_pkg_name, pkg_src) in manifest.dependencies.iter() {
-            let (dir_path, dep_meta) = Resolver::cache_dep(pkg_src)?;
+            let (dir_path, dep_meta) = Resolver::cache_dep(pkg_src, pkg_root)?;
 
             let (entry_path, crate_type) = (&dep_meta.entry_path, &dep_meta.crate_type);
 
@@ -127,7 +128,7 @@ impl<'a> Resolver<'a> {
                 return Err(DependencyResolutionError::RemoteDepWithLocalDep { dependency_path });
             }
             let mut new_res = Resolver::with_driver(self.driver);
-            new_res.resolve_manifest(crate_id, dep_meta.manifest)?;
+            new_res.resolve_manifest(crate_id, dep_meta.manifest, pkg_root)?;
         }
         Ok(())
     }
@@ -138,7 +139,10 @@ impl<'a> Resolver<'a> {
     ///
     /// If it's a local path, the same applies, however it will not
     /// be downloaded
-    fn cache_dep(dep: &Dependency) -> Result<(PathBuf, CachedDep), DependencyResolutionError> {
+    fn cache_dep(
+        dep: &Dependency,
+        pkg_root: &Path,
+    ) -> Result<(PathBuf, CachedDep), DependencyResolutionError> {
         fn retrieve_meta(
             dir_path: &Path,
             remote: bool,
@@ -157,7 +161,7 @@ impl<'a> Resolver<'a> {
                 Ok((dir_path, meta))
             }
             Dependency::Path { path } => {
-                let dir_path = std::path::PathBuf::from(path);
+                let dir_path = pkg_root.join(path);
                 let meta = retrieve_meta(&dir_path, false)?;
                 Ok((dir_path, meta))
             }

--- a/crates/nargo/src/resolver.rs
+++ b/crates/nargo/src/resolver.rs
@@ -84,7 +84,7 @@ impl<'a> Resolver<'a> {
         let crate_id = driver.create_local_crate(entry_path, crate_type);
 
         let mut resolver = Resolver::with_driver(&mut driver);
-	let pkg_root = manifest_path.parent().expect("Every manifest path has a parent.");
+        let pkg_root = manifest_path.parent().expect("Every manifest path has a parent.");
         resolver.resolve_manifest(crate_id, manifest, pkg_root)?;
 
         add_std_lib(&mut driver);


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description
When running `nargo` in a subdirectory of a package whose `Nargo.toml` file contains a local dependency expressed as a relative path (e.g. `pkg = { path = "../../lib" }`), the dependency is parsed relative to the subdirectory, resoluting in an error of the form

```
Error: cannot find src directory in path ../../lib

Location:
    crates/nargo/src/cli/mod.rs:69:5
```

This PR sets the current directory to the project root before executing `nargo` commands.

## Summary of changes

- A call to `std::env::set_current_dir` after determining the project root.
<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
