### PR TITLE
chore(nargo): add integration test for "hello world" flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
 name = "arena"
 version = "0.3.2"
 dependencies = [
@@ -476,6 +482,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b2340f55d9661d76793b2bfc2eb0e62689bd79d067a95707ea762afd5e9dd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates 3.0.2",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d5bf7e5441c6393b5a9670a5036abe6b4847612f594b870f7332dbf10cf6fa"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates 3.0.2",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +645,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "once_cell",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1181,6 +1229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1281,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downloader"
@@ -1410,6 +1470,15 @@ checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1610,6 +1679,30 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "gloo-utils"
@@ -1842,6 +1935,23 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2134,6 +2244,8 @@ name = "nargo"
 version = "0.3.2"
 dependencies = [
  "acvm 0.6.0",
+ "assert_cmd",
+ "assert_fs",
  "barretenberg_static_lib",
  "barretenberg_wasm",
  "build-data",
@@ -2148,6 +2260,7 @@ dependencies = [
  "noirc_abi",
  "noirc_driver",
  "noirc_frontend",
+ "predicates 2.1.5",
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
@@ -2255,6 +2368,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
@@ -2435,6 +2554,48 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c575290b64d24745b6c57a12a31465f0a66f3a4799686a6921526a33b0797965"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2649,6 +2810,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -3296,6 +3463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3573,6 +3746,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -38,6 +38,11 @@ aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "h
 aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "2cb523d2ab95249157b22e198d9dcd6841c3eed8" }
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
 
+[dev-dependencies]
+assert_cmd = "2.0.8"
+assert_fs = "1.0.10"
+predicates = "2.1.5"
+
 [features]
 default = ["plonk_bn254"]
 # The plonk backend can only use bn254, so we do not specify the field

--- a/crates/nargo/tests/hello_world.rs
+++ b/crates/nargo/tests/hello_world.rs
@@ -44,7 +44,10 @@ fn hello_world_example() {
     cmd.arg("prove").arg(proof_name);
     cmd.assert().success();
 
-    project_dir.child("proofs").child(format!("{proof_name}.proof")).assert(predicate::path::is_file());
+    project_dir
+        .child("proofs")
+        .child(format!("{proof_name}.proof"))
+        .assert(predicate::path::is_file());
 
     // `nargo verify p`
     let mut cmd = Command::cargo_bin("nargo").unwrap();

--- a/crates/nargo/tests/hello_world.rs
+++ b/crates/nargo/tests/hello_world.rs
@@ -1,0 +1,52 @@
+//! This integration test aims to mirror the steps taken by a new user using Nargo for the first time.
+//! It then follows the steps published at https://noir-lang.org/getting_started/hello_world.html
+//! Any modifications to the commands run here MUST be documented in the noir-lang book.
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use assert_fs::prelude::{FileWriteStr, PathAssert, PathChild};
+
+#[test]
+fn hello_world_example() {
+    let test_dir = assert_fs::TempDir::new().unwrap();
+    std::env::set_current_dir(&test_dir).unwrap();
+
+    let project_name = "hello_world";
+    let project_dir = test_dir.child(project_name);
+
+    // `nargo new hello_world`
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("new").arg(project_name);
+    cmd.assert().success().stdout(predicate::str::contains("Project successfully created!"));
+
+    project_dir.child("src").assert(predicate::path::is_dir());
+    project_dir.child("Nargo.toml").assert(predicate::path::is_file());
+
+    std::env::set_current_dir(&project_dir).unwrap();
+
+    // `nargo check`
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("check");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Constraint system successfully built!"));
+
+    project_dir.child("Prover.toml").assert(predicate::path::is_file());
+    project_dir.child("Verifier.toml").assert(predicate::path::is_file());
+
+    // `nargo prove p`
+    project_dir.child("Prover.toml").write_str("x = 1\ny = 2").unwrap();
+
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("prove").arg("p");
+    cmd.assert().success();
+
+    project_dir.child("proofs").child("p.proof").assert(predicate::path::is_file());
+
+    // `nargo verify p`
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("verify").arg("p");
+    cmd.assert().success();
+}

--- a/crates/nargo/tests/hello_world.rs
+++ b/crates/nargo/tests/hello_world.rs
@@ -37,16 +37,17 @@ fn hello_world_example() {
     project_dir.child("Verifier.toml").assert(predicate::path::is_file());
 
     // `nargo prove p`
+    let proof_name = "p";
     project_dir.child("Prover.toml").write_str("x = 1\ny = 2").unwrap();
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
-    cmd.arg("prove").arg("p");
+    cmd.arg("prove").arg(proof_name);
     cmd.assert().success();
 
-    project_dir.child("proofs").child("p.proof").assert(predicate::path::is_file());
+    project_dir.child("proofs").child(format!("{proof_name}.proof")).assert(predicate::path::is_file());
 
     // `nargo verify p`
     let mut cmd = Command::cargo_bin("nargo").unwrap();
-    cmd.arg("verify").arg("p");
+    cmd.arg("verify").arg(proof_name);
     cmd.assert().success();
 }


### PR DESCRIPTION
# Related issue(s)

Related to why https://github.com/noir-lang/noir/pull/1029 wasn't caught before nightly release

# Description

## Summary of changes

I've added an integration test which tests that, using the built binary, it is possible to complete the steps listed at https://noir-lang.org/getting_started/hello_world.html

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

Integration test added for performing the "hello world" example from the book.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
