### PR TITLE
fea(nargo): add test to example noir program

### DIFF
--- a/crates/nargo/src/cli/new_cmd.rs
+++ b/crates/nargo/src/cli/new_cmd.rs
@@ -17,6 +17,25 @@ pub(crate) struct NewCommand {
     path: Option<PathBuf>,
 }
 
+const SETTINGS: &str = r#"[package]
+authors = [""]
+compiler_version = "0.1"
+
+[dependencies]"#;
+
+const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
+    constrain x != y;
+}
+
+#[test]
+fn test_main() {
+    main(1, 2);
+    
+    // Uncomment to make test fail
+    // main(1, 1);
+}
+"#;
+
 pub(crate) fn run(args: NewCommand, config: NargoConfig) -> Result<(), CliError> {
     let package_dir = config.program_dir.join(args.package_name);
 
@@ -26,17 +45,6 @@ pub(crate) fn run(args: NewCommand, config: NargoConfig) -> Result<(), CliError>
 
     let src_dir = package_dir.join(Path::new(SRC_DIR));
     create_named_dir(&src_dir, "src");
-
-    const EXAMPLE: &str =
-        concat!("fn main(x : Field, y : pub Field) {\n", "    constrain x != y;\n", "}");
-
-    const SETTINGS: &str = concat!(
-        "[package]\n",
-        "authors = [\"\"]\n",
-        "compiler_version = \"0.1\"\n",
-        "\n",
-        "[dependencies]"
-    );
 
     write_to_file(SETTINGS.as_bytes(), &package_dir.join(PKG_FILE));
     write_to_file(EXAMPLE.as_bytes(), &src_dir.join("main.nr"));

--- a/crates/nargo/src/cli/new_cmd.rs
+++ b/crates/nargo/src/cli/new_cmd.rs
@@ -4,8 +4,9 @@ use crate::{
 };
 
 use super::fs::{create_named_dir, write_to_file};
-use super::NargoConfig;
+use super::{NargoConfig, CARGO_PKG_VERSION};
 use clap::Args;
+use const_format::formatcp;
 use std::path::{Path, PathBuf};
 
 /// Create a new binary project
@@ -17,11 +18,13 @@ pub(crate) struct NewCommand {
     path: Option<PathBuf>,
 }
 
-const SETTINGS: &str = r#"[package]
+const SETTINGS: &str = formatcp!(
+    r#"[package]
 authors = [""]
-compiler_version = "0.1"
+compiler_version = "{CARGO_PKG_VERSION}"
 
-[dependencies]"#;
+[dependencies]"#,
+);
 
 const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
     constrain x != y;


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/book/issues/50. We'll likely want to give an example test for users to run without them having to write it themselves.

# Description

## Summary of changes

I've updated the value of `EXAMPLE` to include a test which will be tested by `nargo test`.

At the same time, I noticed that we always insert a compiler version of `0.1.0` into the `Nargo.toml`. I've changed this to pull the version from cargo.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
