### PR TITLE
fix: Resolve globals in types

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -360,16 +360,16 @@ impl<'a> Resolver<'a> {
         args: Vec<UnresolvedType>,
         new_variables: &mut Generics,
     ) -> Type {
+        if args.is_empty() {
+            if let Some(typ) = self.lookup_generic_or_global_type(&path) {
+                return typ;
+            }
+        }
+
         // Check if the path is a type variable first. We currently disallow generics on type
         // variables since we do not support higher-kinded types.
         if path.segments.len() == 1 {
             let name = &path.last_segment().0.contents;
-
-            if args.is_empty() {
-                if let Some((name, var, _)) = self.find_generic(name) {
-                    return Type::NamedGeneric(var.clone(), name.clone());
-                }
-            }
 
             if name == SELF_TYPE_NAME {
                 if let Some(self_type) = self.self_type.clone() {
@@ -405,6 +405,23 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    fn lookup_generic_or_global_type(&mut self, path: &Path) -> Option<Type> {
+        if path.segments.len() == 1 {
+            let name = &path.last_segment().0.contents;
+            if let Some((name, var, _)) = self.find_generic(name) {
+                return Some(Type::NamedGeneric(var.clone(), name.clone()));
+            }
+        }
+
+        // If we cannot find a local generic of the same name, try to look up a global
+        match self.path_resolver.resolve(self.def_maps, path.clone()) {
+            Ok(ModuleDefId::GlobalId(id)) => {
+                Some(Type::Constant(self.eval_global_as_array_length(id)))
+            }
+            _ => None,
+        }
+    }
+
     fn resolve_array_size(
         &mut self,
         length: Option<UnresolvedTypeExpression>,
@@ -428,22 +445,10 @@ impl<'a> Resolver<'a> {
     fn convert_expression_type(&mut self, length: UnresolvedTypeExpression) -> Type {
         match length {
             UnresolvedTypeExpression::Variable(path) => {
-                if path.segments.len() == 1 {
-                    let name = &path.last_segment().0.contents;
-                    if let Some((name, var, _)) = self.find_generic(name) {
-                        return Type::NamedGeneric(var.clone(), name.clone());
-                    }
-                }
-
-                // If we cannot find a local generic of the same name, try to look up a global
-                if let Ok(ModuleDefId::GlobalId(id)) =
-                    self.path_resolver.resolve(self.def_maps, path.clone())
-                {
-                    Type::Constant(self.eval_global_as_array_length(id))
-                } else {
+                self.lookup_generic_or_global_type(&path).unwrap_or_else(|| {
                     self.push_err(ResolverError::NoSuchNumericTypeVariable { path });
                     Type::Constant(0)
-                }
+                })
             }
             UnresolvedTypeExpression::Constant(int, _) => Type::Constant(int),
             UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, _) => {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1042

# Description

## Summary of changes

Previously we checked for global constants when resolving array sizes in types but not when resolving arbitrary types. This lead to issues when trying to pass globals as a struct's numeric generics. I've factored out the common code to check for this in both places to resolve the issue.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
