### PR TITLE
Allow arbitrary noir functions to be unconstrained

### DIFF
--- a/crates/noirc_driver/src/contract.rs
+++ b/crates/noirc_driver/src/contract.rs
@@ -1,7 +1,5 @@
 use std::collections::BTreeMap;
 
-use noirc_frontend::ContractVisibility;
-
 use crate::CompiledProgram;
 
 /// Each function in the contract will be compiled
@@ -12,8 +10,26 @@ use crate::CompiledProgram;
 /// One of these being a function type.
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct ContractFunction {
-    pub func_type: ContractVisibility,
+    pub func_type: ContractFunctionType,
     pub function: CompiledProgram,
+}
+
+/// Describes the types of smart contract functions that are allowed.
+/// Unlike the similar enum in noirc_frontend, 'open' and 'unconstrained'
+/// are mutually exclusive here. In the case a function is both, 'unconstrained'
+/// takes precedence.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractFunctionType {
+    /// This function will be executed in a private
+    /// context.
+    Secret,
+    /// This function will be executed in a public
+    /// context.
+    Open,
+    /// This function cannot constrain any values and can use nondeterministic features
+    /// like arrays of a dynamic size.
+    Unconstrained,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -23,4 +39,14 @@ pub struct CompiledContract {
     /// Each of the contract's functions are compiled into a separate `CompiledProgram`
     /// stored in this `BTreeMap`.
     pub functions: BTreeMap<String, ContractFunction>,
+}
+
+impl ContractFunctionType {
+    pub fn new(kind: noirc_frontend::ContractFunctionType, is_unconstrained: bool) -> Self {
+        match (kind, is_unconstrained) {
+            (_, true) => Self::Unconstrained,
+            (noirc_frontend::ContractFunctionType::Secret, false) => Self::Secret,
+            (noirc_frontend::ContractFunctionType::Open, false) => Self::Open,
+        }
+    }
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -4,7 +4,7 @@
 
 use acvm::Language;
 use clap::Args;
-use contract::ContractFunction;
+use contract::{ContractFunction, ContractFunctionType};
 use fm::FileType;
 use iter_extended::{try_btree_map, try_vecmap};
 use noirc_abi::FunctionSignature;
@@ -209,6 +209,8 @@ impl Driver {
             let func_type = func_meta
                 .contract_visibility
                 .expect("Expected contract function to have a contract visibility");
+
+            let func_type = ContractFunctionType::new(func_type, func_meta.is_unconstrained);
 
             Ok((function_name, ContractFunction { func_type, function }))
         })?;

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -313,9 +313,11 @@ pub struct FunctionDefinition {
     // XXX: Currently we only have one attribute defined. If more attributes are needed per function, we can make this a vector and make attribute definition more expressive
     pub attribute: Option<Attribute>,
 
-    // The contract visibility is always None if the function is not in a contract.
-    // Otherwise, it is 'secret' (by default), 'open', or 'unsafe'.
-    pub contract_visibility: Option<ContractVisibility>,
+    /// True if this function was defined with the 'open' keyword
+    pub is_open: bool,
+
+    /// True if this function was defined with the 'unconstrained' keyword
+    pub is_unconstrained: bool,
 
     pub generics: UnresolvedGenerics,
     pub parameters: Vec<(Pattern, UnresolvedType, noirc_abi::AbiVisibility)>,
@@ -327,20 +329,15 @@ pub struct FunctionDefinition {
 
 /// Describes the types of smart contract functions that are allowed.
 /// - All Noir programs in the non-contract context can be seen as `Secret`.
-/// - It may be possible to have `unsafe` functions in regular Noir programs.
-///   For now we leave it as a property of only contract functions.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum ContractVisibility {
+pub enum ContractFunctionType {
     /// This function will be executed in a private
     /// context.
     Secret,
     /// This function will be executed in a public
     /// context.
     Open,
-    /// A function which is non-deterministic
-    /// and does not require any constraints.
-    Unsafe,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -245,8 +245,8 @@ impl From<ResolverError> for Diagnostic {
             }
             ResolverError::ParserError(error) => error.into(),
             ResolverError::ContractVisibilityInNormalFunction { span } => Diagnostic::simple_error(
-                "Only functions defined within contracts can set their contract visibility".into(),
-                "Non-contract functions cannot be 'open' or 'unsafe'".into(),
+                "Only functions defined within contracts can set their contract function type".into(),
+                "Non-contract functions cannot be 'open'".into(),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -6,7 +6,7 @@ use super::expr::{HirBlockExpression, HirExpression, HirIdent};
 use super::stmt::HirPattern;
 use crate::node_interner::{ExprId, NodeInterner};
 use crate::{token::Attribute, FunctionKind};
-use crate::{ContractVisibility, Type};
+use crate::{ContractFunctionType, Type};
 
 /// A Hir function is a block expression
 /// with a list of statements
@@ -123,7 +123,9 @@ pub struct FuncMeta {
 
     /// This function's visibility in its contract.
     /// If this function is not in a contract, this is always 'Secret'.
-    pub contract_visibility: Option<ContractVisibility>,
+    pub contract_visibility: Option<ContractFunctionType>,
+
+    pub is_unconstrained: bool,
 
     pub parameters: Parameters,
 

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -437,7 +437,7 @@ pub enum Keyword {
     String,
     Return,
     Struct,
-    Unsafe,
+    Unconstrained,
     Use,
     While,
 }
@@ -469,7 +469,7 @@ impl fmt::Display for Keyword {
             Keyword::String => write!(f, "str"),
             Keyword::Return => write!(f, "return"),
             Keyword::Struct => write!(f, "struct"),
-            Keyword::Unsafe => write!(f, "unsafe"),
+            Keyword::Unconstrained => write!(f, "unconstrained"),
             Keyword::Use => write!(f, "use"),
             Keyword::While => write!(f, "while"),
         }
@@ -504,7 +504,7 @@ impl Keyword {
             "str" => Keyword::String,
             "return" => Keyword::Return,
             "struct" => Keyword::Struct,
-            "unsafe" => Keyword::Unsafe,
+            "unconstrained" => Keyword::Unconstrained,
             "use" => Keyword::Use,
             "while" => Keyword::While,
 

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -33,10 +33,9 @@ use crate::lexer::Lexer;
 use crate::parser::{force, ignore_then_commit, statement_recovery};
 use crate::token::{Attribute, Keyword, Token, TokenKind};
 use crate::{
-    BinaryOp, BinaryOpKind, BlockExpression, CompTime, ConstrainStatement, ContractVisibility,
-    FunctionDefinition, Ident, IfExpression, ImportStatement, InfixExpression, LValue, Lambda,
-    NoirFunction, NoirImpl, NoirStruct, Path, PathKind, Pattern, Recoverable, UnaryOp,
-    UnresolvedTypeExpression,
+    BinaryOp, BinaryOpKind, BlockExpression, CompTime, ConstrainStatement, FunctionDefinition,
+    Ident, IfExpression, ImportStatement, InfixExpression, LValue, Lambda, NoirFunction, NoirImpl,
+    NoirStruct, Path, PathKind, Pattern, Recoverable, UnaryOp, UnresolvedTypeExpression,
 };
 
 use chumsky::prelude::*;
@@ -162,7 +161,7 @@ fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunction> {
         .map(
             |(
                 (
-                    ((((attribute, contract_visibility), name), generics), parameters),
+                    ((((attribute, (is_unconstrained, is_open)), name), generics), parameters),
                     (return_visibility, return_type),
                 ),
                 body,
@@ -171,7 +170,8 @@ fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunction> {
                     span: name.0.span(),
                     name,
                     attribute, // XXX: Currently we only have one attribute defined. If more attributes are needed per function, we can make this a vector and make attribute definition more expressive
-                    contract_visibility,
+                    is_open,
+                    is_unconstrained,
                     generics,
                     parameters,
                     body,
@@ -183,14 +183,14 @@ fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunction> {
         )
 }
 
-/// contract_visibility: 'open' | 'unsafe' | %empty
-fn contract_visibility() -> impl NoirParser<Option<ContractVisibility>> {
-    keyword(Keyword::Open).or(keyword(Keyword::Unsafe)).or_not().map(|token| match token {
-        Some(Token::Keyword(Keyword::Open)) => Some(ContractVisibility::Open),
-        Some(Token::Keyword(Keyword::Unsafe)) => Some(ContractVisibility::Unsafe),
-        None => None,
-        _ => unreachable!("Only open and unsafe keywords are parsed here"),
-    })
+/// contract_visibility: 'open' | 'unconstrained' | %empty
+///
+/// returns (is_unconstrained, is_open) for whether each keyword was present
+fn contract_visibility() -> impl NoirParser<(bool, bool)> {
+    keyword(Keyword::Unconstrained)
+        .or_not()
+        .then(keyword(Keyword::Open).or_not())
+        .map(|(unconstrained, open)| (unconstrained.is_some(), open.is_some()))
 }
 
 /// non_empty_ident_list: ident ',' non_empty_ident_list


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

- Renames `unsafe` back to `unconstrained`
- Allows any noir function (not just contract functions) to be `unconstrained`
- Renames `ContractVisibility` to `ContractFunctionKind`
- To keep the JSON ABI the same, the `ContractFunctionKind` that is outputted still contains the three possible values of 'open', 'secret', or 'unconstrained' as mutually exclusive. Despite the fact the frontend now allows functions that are both 'open' and 'unconstrained' as a side effect of them being separated.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
