### PR TITLE
chore!: upgrade to acvm 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,11 +16,11 @@ dependencies = [
 
 [[package]]
 name = "acir"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744c21590f6da95914f1d83f247dba49d4f287beb725bfbcbc54eaf823484b1a"
+checksum = "4752b7bce78f98f865733f53fae0e0ed3f0c115b090853508d27f84a2ba13e9c"
 dependencies = [
- "acir_field 0.6.0",
+ "acir_field 0.7.1",
  "flate2",
  "rmp-serde",
  "serde",
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081a09b71facabddd411bfb8459c0f4d9350c39707680da6c04debb3db9de503"
+checksum = "9b044b5d4fc80af9cae007edc2de609594ca64b34df6ad90967279bbddb356f2"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.1",
@@ -78,13 +78,14 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73876b7d5d23d0826ea4c9150b4a62af0b20a6937a79472ee0ceda30868aa207"
+checksum = "241f3ac90354dc65110f2689a0bb6b0bd2e4e4f2d7bc94d5219ebf3a95fa0a80"
 dependencies = [
- "acir 0.6.0",
- "acvm_stdlib 0.6.0",
+ "acir 0.7.1",
+ "acvm_stdlib 0.7.1",
  "blake2",
+ "crc32fast",
  "indexmap",
  "k256",
  "num-bigint",
@@ -105,11 +106,11 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2259c21b06db652e41bddb1deb22da8d303746a0e8bf877983c7d83f71943b8"
+checksum = "b043f336644ba4ac506d230c3aa4aba0f48bafe944ebaab192155673080fa32e"
 dependencies = [
- "acir 0.6.0",
+ "acir 0.7.1",
 ]
 
 [[package]]
@@ -546,7 +547,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_static_lib"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=2cb523d2ab95249157b22e198d9dcd6841c3eed8#2cb523d2ab95249157b22e198d9dcd6841c3eed8"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=d4bcec67fecfcd527e373221e942eacd7ba7c083#d4bcec67fecfcd527e373221e942eacd7ba7c083"
 dependencies = [
  "barretenberg_wrapper",
  "common",
@@ -555,7 +556,7 @@ dependencies = [
 [[package]]
 name = "barretenberg_wasm"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=2cb523d2ab95249157b22e198d9dcd6841c3eed8#2cb523d2ab95249157b22e198d9dcd6841c3eed8"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=d4bcec67fecfcd527e373221e942eacd7ba7c083#d4bcec67fecfcd527e373221e942eacd7ba7c083"
 dependencies = [
  "common",
  "wasmer",
@@ -901,9 +902,9 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=2cb523d2ab95249157b22e198d9dcd6841c3eed8#2cb523d2ab95249157b22e198d9dcd6841c3eed8"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=d4bcec67fecfcd527e373221e942eacd7ba7c083#d4bcec67fecfcd527e373221e942eacd7ba7c083"
 dependencies = [
- "acvm 0.6.0",
+ "acvm 0.7.1",
  "blake2",
  "dirs 3.0.2",
  "downloader",
@@ -2243,7 +2244,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.3.2"
 dependencies = [
- "acvm 0.6.0",
+ "acvm 0.7.1",
  "assert_cmd",
  "assert_fs",
  "barretenberg_static_lib",
@@ -2275,7 +2276,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.3.2"
 dependencies = [
- "acvm 0.6.0",
+ "acvm 0.7.1",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -2291,7 +2292,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.3.2"
 dependencies = [
- "acvm 0.6.0",
+ "acvm 0.7.1",
  "iter-extended",
  "serde",
  "serde_json",
@@ -2303,7 +2304,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.3.2"
 dependencies = [
- "acvm 0.6.0",
+ "acvm 0.7.1",
  "clap 4.1.8",
  "fm",
  "iter-extended",
@@ -2329,7 +2330,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.3.2"
 dependencies = [
- "acvm 0.6.0",
+ "acvm 0.7.1",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -2345,7 +2346,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.3.2"
 dependencies = [
- "acvm 0.6.0",
+ "acvm 0.7.1",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2021"
 rust-version = "1.66"
 
 [workspace.dependencies]
-acvm = "0.6.0"
+acvm = "0.7.1"
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -34,8 +34,8 @@ color-eyre = "0.6.2"
 
 
 # Backends
-aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "2cb523d2ab95249157b22e198d9dcd6841c3eed8" }
-aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "2cb523d2ab95249157b22e198d9dcd6841c3eed8" }
+aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "d4bcec67fecfcd527e373221e942eacd7ba7c083" }
+aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "d4bcec67fecfcd527e373221e942eacd7ba7c083" }
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
 
 [dev-dependencies]

--- a/crates/nargo/src/cli/execute_cmd.rs
+++ b/crates/nargo/src/cli/execute_cmd.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use acvm::pwg::block::Blocks;
 use acvm::PartialWitnessGenerator;
 use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
@@ -67,7 +68,15 @@ pub(crate) fn execute_program(
     let mut solved_witness = compiled_program.abi.encode(inputs_map, None)?;
 
     let backend = crate::backends::ConcreteBackend;
-    backend.solve(&mut solved_witness, compiled_program.circuit.opcodes.clone())?;
+    let mut blocks = Blocks::default();
+    let (unresolved_opcodes, oracles) = backend.solve(
+        &mut solved_witness,
+        &mut blocks,
+        compiled_program.circuit.opcodes.clone(),
+    )?;
+    if !unresolved_opcodes.is_empty() || !oracles.is_empty() {
+        todo!("Add oracle support to nargo execute")
+    }
 
     Ok(solved_witness)
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -244,12 +244,12 @@ impl Driver {
         let program = monomorphize(main_function, &self.context.def_interner);
 
         let np_language = self.language.clone();
-        let blackbox_supported = acvm::default_is_black_box_supported(np_language.clone());
+        let is_opcode_supported = acvm::default_is_opcode_supported(np_language.clone());
 
         match create_circuit(
             program,
             np_language,
-            blackbox_supported,
+            is_opcode_supported,
             options.show_ssa,
             options.show_output,
         ) {

--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -9,7 +9,7 @@ use acvm::{
             directives::Directive,
             opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode},
         },
-        native_types::{Expression, Linear, Witness},
+        native_types::{Expression, Witness},
     },
     FieldElement,
 };
@@ -266,7 +266,7 @@ pub(crate) fn range_constraint(
         let exp_big = BigUint::from(2_u128).pow(num_bits - 1);
         let exp = FieldElement::from_be_bytes_reduce(&exp_big.to_bytes_be());
         evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient {
-            a: Linear::from(witness).into(),
+            a: Expression::from(witness),
             b: Expression::from_field(exp),
             q: b_witness,
             r: r_witness,
@@ -546,7 +546,7 @@ pub(crate) fn evaluate_udiv(
     }));
 
     //r<b
-    let r_expr = Expression::from(Linear::from_witness(r_witness));
+    let r_expr = Expression::from(r_witness);
     try_range_constraint(r_witness, bit_size, evaluator);
     bound_constraint_with_offset(&r_expr, rhs, predicate, bit_size, evaluator);
     //range check q<=a

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
+use acvm::acir::circuit::opcodes::BlackBoxFuncCall;
+use acvm::acir::circuit::Opcode;
 use acvm::Language;
 use arena::{Arena, Index};
 use fm::FileId;
@@ -583,12 +585,16 @@ impl NodeInterner {
 
     #[allow(deprecated)]
     pub fn foreign(&self, opcode: &str) -> bool {
-        let is_supported = acvm::default_is_black_box_supported(self.language.clone());
+        let is_supported = acvm::default_is_opcode_supported(self.language.clone());
         let black_box_func = match acvm::acir::BlackBoxFunc::lookup(opcode) {
             Some(black_box_func) => black_box_func,
             None => return false,
         };
-        is_supported(&black_box_func)
+        is_supported(&Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+            name: black_box_func,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        }))
     }
 
     pub fn push_delayed_type_check(&mut self, f: TypeCheckFn) {


### PR DESCRIPTION
# Related issue(s)

Resolves #1046

# Description

## Summary of changes

Upgrade to ACVM 0.7.1, which add Oracle opcode support, and removes some depreciated methods.

Nargo support for executing/testing circuits containing oracle opcodes should be handled in a separate feature PR.

## Dependency additions / changes

Underlying aztec_backend needed upgrading to ACVM 0.7.1 too.

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
