### PR TITLE
feat: Allow secret functions to use public parameters

### DIFF
--- a/crates/nargo/tests/test_data/contracts/src/main.nr
+++ b/crates/nargo/tests/test_data/contracts/src/main.nr
@@ -3,6 +3,6 @@ fn main(x : Field, y : pub Field) {
 }
 
 contract Foo {
-    fn double(x: Field) -> Field { x * 2 }
-    fn triple(x: Field) -> Field { x * 3 }
+    fn double(x: Field) -> pub Field { x * 2 }
+    fn triple(x: Field) -> pub Field { x * 3 }
 }

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -166,7 +166,7 @@ impl From<ResolverError> for Diagnostic {
                     ident.0.span(),
                 );
 
-                diag.add_note("The `pub` keyword only has effects on arguments to the main function of a program. Thus, adding it to other function parameters can be deceiving and should be removed".to_owned());
+                diag.add_note("The `pub` keyword only has effects on arguments to the entry-point function of a program. Thus, adding it to other function parameters can be deceiving and should be removed".to_owned());
                 diag
             }
             ResolverError::NecessaryPub { ident } => {
@@ -178,7 +178,7 @@ impl From<ResolverError> for Diagnostic {
                     ident.0.span(),
                 );
 
-                diag.add_note("The `pub` keyword is mandatory for the main function return type because the verifier cannot retrieve private witness and thus the function will not be able to return a 'priv' value".to_owned());
+                diag.add_note("The `pub` keyword is mandatory for the entry-point function return type because the verifier cannot retrieve private witness and thus the function will not be able to return a 'priv' value".to_owned());
                 diag
             }
             ResolverError::ExpectedComptimeVariable { name, span } => Diagnostic::simple_error(

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -596,7 +596,7 @@ impl<'a> Resolver<'a> {
         let mut parameter_types = vec![];
 
         for (pattern, typ, visibility) in func.parameters().iter().cloned() {
-            if func.name() != "main" && visibility == noirc_abi::AbiVisibility::Public {
+            if visibility == noirc_abi::AbiVisibility::Public && !self.pub_allowed(func) {
                 self.push_err(ResolverError::UnnecessaryPub { ident: func.name_ident().clone() })
             }
 
@@ -610,9 +610,7 @@ impl<'a> Resolver<'a> {
 
         self.declare_numeric_generics(&parameter_types, &return_type);
 
-        if func.name() == "main"
-            && *return_type != Type::Unit
-            && func.def.return_visibility != noirc_abi::AbiVisibility::Public
+        if func.def.return_visibility != noirc_abi::AbiVisibility::Public && self.pub_allowed(func)
         {
             self.push_err(ResolverError::NecessaryPub { ident: func.name_ident().clone() })
         }
@@ -642,6 +640,15 @@ impl<'a> Resolver<'a> {
             parameters: parameters.into(),
             return_visibility: func.def.return_visibility,
             has_body: !func.def.body.is_empty(),
+        }
+    }
+
+    /// True if the 'pub' keyword is allowed on parameters in this function
+    fn pub_allowed(&self, func: &NoirFunction) -> bool {
+        if self.in_contract() {
+            !func.def.is_unconstrained && !func.def.is_open
+        } else {
+            func.name() == "main"
         }
     }
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -610,7 +610,10 @@ impl<'a> Resolver<'a> {
 
         self.declare_numeric_generics(&parameter_types, &return_type);
 
-        if func.def.return_visibility != noirc_abi::AbiVisibility::Public && self.pub_allowed(func)
+        // 'pub_allowed' also implies 'pub' is required on return types
+        if self.pub_allowed(func)
+            && return_type.as_ref() != &Type::Unit
+            && func.def.return_visibility != noirc_abi::AbiVisibility::Public
         {
             self.push_err(ResolverError::NecessaryPub { ident: func.name_ident().clone() })
         }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

No formal issue but resolves an issue in example 1.3 of the noir-aztec3-examples.

# Description

## Summary of changes

Allows 'secret' functions in contracts to take public parameters and have public return values.

With this the generated abi for the file looks like the following. (`...` marks omitted lines)

```json
{
  "name": "PrivateToken",
  "functions": {
    "constructor": {
      "func_type": "secret",
      "function": {
        "circuit": [
            ...
        ],
        "abi": {
          "parameters": [ ... ],
          "param_witnesses": {
            "call_context": [1, 2, 3, 4, 5, 6],
            "contract_deployment_data": [7, 8, 9, 10, 11],
            "value": [12],
            "owner": [13, 14]
          },
          "return_type": {
            "kind": "struct",
            "fields": [...],
          },
          "return_witnesses": [15, 15, 15, 15, 15]
        }
      }
    }
  }
}

```

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

Once contract functions are documented, we'll need to also document that `secret` functions (the default) can use `pub` parameters and their return values must also be `pub`. They cannot use `pub` if they are also `unconstrained`.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
