### PR TITLE
feat: Allow non-comptime field indices in unconstrained functions

### DIFF
--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -8,8 +8,7 @@ use crate::hir::resolution::{
     import::{resolve_imports, ImportDirective},
     path_resolver::StandardPathResolver,
 };
-use crate::hir::type_check::type_check;
-use crate::hir::type_check::type_check_func;
+use crate::hir::type_check::{type_check_func, TypeChecker};
 use crate::hir::Context;
 use crate::node_interner::{FuncId, NodeInterner, StmtId, StructId};
 use crate::{
@@ -288,8 +287,7 @@ fn type_check_globals(
     all_errors: &mut Vec<FileDiagnostic>,
 ) {
     for (file_id, stmt_id) in global_ids {
-        let mut errors = vec![];
-        type_check(interner, &stmt_id, &mut errors);
+        let errors = TypeChecker::check_global(&stmt_id, interner);
         extend_errors(all_errors, file_id, errors);
     }
 }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -6,495 +6,809 @@ use crate::{
         expr::{self, HirArrayLiteral, HirBinaryOp, HirExpression, HirLiteral},
         types::Type,
     },
-    node_interner::{ExprId, FuncId, NodeInterner},
+    node_interner::{ExprId, FuncId},
     CompTime, Shared, TypeBinding,
 };
 
-use super::{bind_pattern, errors::TypeCheckError};
+use super::{errors::TypeCheckError, TypeChecker};
 
-/// Infers a type for a given expression, and return this type.
-/// As a side-effect, this function will also remember this type in the NodeInterner
-/// for the given expr_id key.
-///
-/// This function also converts any HirExpression::MethodCalls `a.foo(b, c)` into
-/// an equivalent HirExpression::Call in the form `foo(a, b, c)`. This cannot
-/// be done earlier since we need to know the type of the object `a` to resolve which
-/// function `foo` to refer to.
-pub(crate) fn type_check_expression(
-    interner: &mut NodeInterner,
-    expr_id: &ExprId,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    let typ = match interner.expression(expr_id) {
-        HirExpression::Ident(ident) => {
-            // An identifiers type may be forall-quantified in the case of generic functions.
-            // E.g. `fn foo<T>(t: T, field: Field) -> T` has type `forall T. fn(T, Field) -> T`.
-            // We must instantiate identifiers at every call site to replace this T with a new type
-            // variable to handle generic functions.
-            let t = interner.id_type(ident.id);
-            let (typ, bindings) = t.instantiate(interner);
-            interner.store_instantiation_bindings(*expr_id, bindings);
-            typ
-        }
-        HirExpression::Literal(literal) => {
-            match literal {
-                HirLiteral::Array(HirArrayLiteral::Standard(arr)) => {
-                    let elem_types =
-                        vecmap(&arr, |arg| type_check_expression(interner, arg, errors));
+impl<'interner> TypeChecker<'interner> {
+    /// Infers a type for a given expression, and return this type.
+    /// As a side-effect, this function will also remember this type in the NodeInterner
+    /// for the given expr_id key.
+    ///
+    /// This function also converts any HirExpression::MethodCalls `a.foo(b, c)` into
+    /// an equivalent HirExpression::Call in the form `foo(a, b, c)`. This cannot
+    /// be done earlier since we need to know the type of the object `a` to resolve which
+    /// function `foo` to refer to.
+    pub(crate) fn check_expression(&mut self, expr_id: &ExprId) -> Type {
+        let typ = match self.interner.expression(expr_id) {
+            HirExpression::Ident(ident) => {
+                // An identifiers type may be forall-quantified in the case of generic functions.
+                // E.g. `fn foo<T>(t: T, field: Field) -> T` has type `forall T. fn(T, Field) -> T`.
+                // We must instantiate identifiers at every call site to replace this T with a new type
+                // variable to handle generic functions.
+                let t = self.interner.id_type(ident.id);
+                let (typ, bindings) = t.instantiate(self.interner);
+                self.interner.store_instantiation_bindings(*expr_id, bindings);
+                typ
+            }
+            HirExpression::Literal(literal) => {
+                match literal {
+                    HirLiteral::Array(HirArrayLiteral::Standard(arr)) => {
+                        let elem_types = vecmap(&arr, |arg| self.check_expression(arg));
 
-                    let first_elem_type = elem_types.get(0).cloned().unwrap_or(Type::Error);
+                        let first_elem_type = elem_types.get(0).cloned().unwrap_or(Type::Error);
 
-                    let arr_type = Type::Array(
-                        Box::new(Type::Constant(arr.len() as u64)),
-                        Box::new(first_elem_type.clone()),
-                    );
+                        let arr_type = Type::Array(
+                            Box::new(Type::Constant(arr.len() as u64)),
+                            Box::new(first_elem_type.clone()),
+                        );
 
-                    // Check if the array is homogeneous
-                    for (index, elem_type) in elem_types.iter().enumerate().skip(1) {
-                        let location = interner.expr_location(&arr[index]);
+                        // Check if the array is homogeneous
+                        for (index, elem_type) in elem_types.iter().enumerate().skip(1) {
+                            let location = self.interner.expr_location(&arr[index]);
 
-                        elem_type.unify(&first_elem_type, location.span, errors, || {
-                            TypeCheckError::NonHomogeneousArray {
-                                first_span: interner.expr_location(&arr[0]).span,
-                                first_type: first_elem_type.to_string(),
-                                first_index: index,
-                                second_span: location.span,
-                                second_type: elem_type.to_string(),
-                                second_index: index + 1,
-                            }
-                            .add_context("elements in an array must have the same type")
-                        });
+                            elem_type.unify(
+                                &first_elem_type,
+                                location.span,
+                                &mut self.errors,
+                                || {
+                                    TypeCheckError::NonHomogeneousArray {
+                                        first_span: self.interner.expr_location(&arr[0]).span,
+                                        first_type: first_elem_type.to_string(),
+                                        first_index: index,
+                                        second_span: location.span,
+                                        second_type: elem_type.to_string(),
+                                        second_index: index + 1,
+                                    }
+                                    .add_context("elements in an array must have the same type")
+                                },
+                            );
+                        }
+
+                        arr_type
                     }
-
-                    arr_type
-                }
-                HirLiteral::Array(HirArrayLiteral::Repeated { repeated_element, length }) => {
-                    let elem_type = type_check_expression(interner, &repeated_element, errors);
-                    Type::Array(Box::new(length), Box::new(elem_type))
-                }
-                HirLiteral::Bool(_) => Type::Bool(CompTime::new(interner)),
-                HirLiteral::Integer(_) => {
-                    let id = interner.next_type_variable_id();
-                    Type::PolymorphicInteger(
-                        CompTime::new(interner),
-                        Shared::new(TypeBinding::Unbound(id)),
-                    )
-                }
-                HirLiteral::Str(string) => {
-                    let len = Type::Constant(string.len() as u64);
-                    Type::String(Box::new(len))
+                    HirLiteral::Array(HirArrayLiteral::Repeated { repeated_element, length }) => {
+                        let elem_type = self.check_expression(&repeated_element);
+                        Type::Array(Box::new(length), Box::new(elem_type))
+                    }
+                    HirLiteral::Bool(_) => Type::Bool(CompTime::new(self.interner)),
+                    HirLiteral::Integer(_) => {
+                        let id = self.interner.next_type_variable_id();
+                        Type::PolymorphicInteger(
+                            CompTime::new(self.interner),
+                            Shared::new(TypeBinding::Unbound(id)),
+                        )
+                    }
+                    HirLiteral::Str(string) => {
+                        let len = Type::Constant(string.len() as u64);
+                        Type::String(Box::new(len))
+                    }
                 }
             }
-        }
-        HirExpression::Infix(infix_expr) => {
-            // The type of the infix expression must be looked up from a type table
-            let lhs_type = type_check_expression(interner, &infix_expr.lhs, errors);
-            let rhs_type = type_check_expression(interner, &infix_expr.rhs, errors);
+            HirExpression::Infix(infix_expr) => {
+                // The type of the infix expression must be looked up from a type table
+                let lhs_type = self.check_expression(&infix_expr.lhs);
+                let rhs_type = self.check_expression(&infix_expr.rhs);
 
-            let lhs_span = interner.expr_span(&infix_expr.lhs);
-            let rhs_span = interner.expr_span(&infix_expr.rhs);
-            let span = lhs_span.merge(rhs_span);
+                let lhs_span = self.interner.expr_span(&infix_expr.lhs);
+                let rhs_span = self.interner.expr_span(&infix_expr.rhs);
+                let span = lhs_span.merge(rhs_span);
 
-            infix_operand_type_rules(
-                &lhs_type,
-                &infix_expr.operator,
-                &rhs_type,
-                span,
-                interner,
-                errors,
-            )
-            .unwrap_or_else(|error| {
-                errors.push(error);
-                Type::Error
-            })
-        }
-        HirExpression::Index(index_expr) => {
-            type_check_index_expression(interner, index_expr, errors)
-        }
-        HirExpression::Call(call_expr) => {
-            let function = type_check_expression(interner, &call_expr.func, errors);
-            let args = vecmap(&call_expr.arguments, |arg| {
-                let typ = type_check_expression(interner, arg, errors);
-                (typ, interner.expr_span(arg))
-            });
-            let span = interner.expr_span(expr_id);
-            bind_function_type(function, args, span, interner, errors)
-        }
-        HirExpression::MethodCall(method_call) => {
-            let object_type = type_check_expression(interner, &method_call.object, errors);
-            let method_name = method_call.method.0.contents.as_str();
-            match lookup_method(interner, object_type.clone(), method_name, expr_id, errors) {
-                Some(method_id) => {
-                    let mut args = vec![(object_type, interner.expr_span(&method_call.object))];
-                    let mut arg_types = vecmap(&method_call.arguments, |arg| {
-                        let typ = type_check_expression(interner, arg, errors);
-                        (typ, interner.expr_span(arg))
-                    });
-                    args.append(&mut arg_types);
-
-                    // Desugar the method call into a normal, resolved function call
-                    // so that the backend doesn't need to worry about methods
-                    let location = method_call.location;
-                    let (function_id, function_call) =
-                        method_call.into_function_call(method_id, location, interner);
-
-                    let span = interner.expr_span(expr_id);
-                    let ret = type_check_method_call(
-                        interner,
-                        &function_id,
-                        &method_id,
-                        args,
-                        span,
-                        errors,
-                    );
-
-                    interner.replace_expr(expr_id, function_call);
-                    ret
-                }
-                None => Type::Error,
+                self.infix_operand_type_rules(&lhs_type, &infix_expr.operator, &rhs_type, span)
+                    .unwrap_or_else(|error| {
+                        self.errors.push(error);
+                        Type::Error
+                    })
             }
-        }
-        HirExpression::Cast(cast_expr) => {
-            // Evaluate the LHS
-            let lhs_type = type_check_expression(interner, &cast_expr.lhs, errors);
-            let span = interner.expr_span(expr_id);
-            check_cast(lhs_type, cast_expr.r#type, span, errors)
-        }
-        HirExpression::For(for_expr) => {
-            let start_range_type = type_check_expression(interner, &for_expr.start_range, errors);
-            let end_range_type = type_check_expression(interner, &for_expr.end_range, errors);
+            HirExpression::Index(index_expr) => self.check_index_expression(index_expr),
+            HirExpression::Call(call_expr) => {
+                let function = self.check_expression(&call_expr.func);
+                let args = vecmap(&call_expr.arguments, |arg| {
+                    let typ = self.check_expression(arg);
+                    (typ, self.interner.expr_span(arg))
+                });
+                let span = self.interner.expr_span(expr_id);
+                self.bind_function_type(function, args, span)
+            }
+            HirExpression::MethodCall(method_call) => {
+                let object_type = self.check_expression(&method_call.object);
+                let method_name = method_call.method.0.contents.as_str();
+                match self.lookup_method(object_type.clone(), method_name, expr_id) {
+                    Some(method_id) => {
+                        let mut args =
+                            vec![(object_type, self.interner.expr_span(&method_call.object))];
+                        let mut arg_types = vecmap(&method_call.arguments, |arg| {
+                            let typ = self.check_expression(arg);
+                            (typ, self.interner.expr_span(arg))
+                        });
+                        args.append(&mut arg_types);
 
-            let span = interner.expr_span(&for_expr.start_range);
-            start_range_type.unify(&Type::comp_time(Some(span)), span, errors, || {
-                TypeCheckError::TypeCannotBeUsed {
-                    typ: start_range_type.clone(),
-                    place: "for loop",
-                    span,
+                        // Desugar the method call into a normal, resolved function call
+                        // so that the backend doesn't need to worry about methods
+                        let location = method_call.location;
+                        let (function_id, function_call) =
+                            method_call.into_function_call(method_id, location, self.interner);
+
+                        let span = self.interner.expr_span(expr_id);
+                        let ret = self.check_method_call(&function_id, &method_id, args, span);
+
+                        self.interner.replace_expr(expr_id, function_call);
+                        ret
+                    }
+                    None => Type::Error,
                 }
-                .add_context("The range of a loop must be known at compile-time")
-            });
+            }
+            HirExpression::Cast(cast_expr) => {
+                // Evaluate the LHS
+                let lhs_type = self.check_expression(&cast_expr.lhs);
+                let span = self.interner.expr_span(expr_id);
+                self.check_cast(lhs_type, cast_expr.r#type, span)
+            }
+            HirExpression::For(for_expr) => {
+                let start_range_type = self.check_expression(&for_expr.start_range);
+                let end_range_type = self.check_expression(&for_expr.end_range);
 
-            let span = interner.expr_span(&for_expr.end_range);
-            end_range_type.unify(&Type::comp_time(Some(span)), span, errors, || {
-                TypeCheckError::TypeCannotBeUsed {
-                    typ: end_range_type.clone(),
-                    place: "for loop",
-                    span,
-                }
-                .add_context("The range of a loop must be known at compile-time")
-            });
+                let start_span = self.interner.expr_span(&for_expr.start_range);
+                let end_span = self.interner.expr_span(&for_expr.end_range);
 
-            interner.push_definition_type(for_expr.identifier.id, start_range_type);
-
-            type_check_expression(interner, &for_expr.block, errors);
-            Type::Unit
-        }
-        HirExpression::Block(block_expr) => {
-            let mut block_type = Type::Unit;
-
-            let statements = block_expr.statements();
-            for (i, stmt) in statements.iter().enumerate() {
-                let expr_type = super::stmt::type_check(interner, stmt, errors);
-
-                if i + 1 < statements.len() {
-                    let id = match interner.statement(stmt) {
-                        crate::hir_def::stmt::HirStatement::Expression(expr) => expr,
-                        _ => *expr_id,
+                let mut unify_loop_range = |actual_type, span| {
+                    let expected_type = if self.is_unconstrained() {
+                        Type::field(Some(span))
+                    } else {
+                        Type::comp_time(Some(span))
                     };
 
-                    let span = interner.expr_span(&id);
-                    expr_type.unify(&Type::Unit, span, errors, || TypeCheckError::TypeMismatch {
-                        expected_typ: Type::Unit.to_string(),
-                        expr_typ: expr_type.to_string(),
-                        expr_span: span,
+                    self.unify(actual_type, &expected_type, span, || {
+                        TypeCheckError::TypeCannotBeUsed {
+                            typ: start_range_type.clone(),
+                            place: "for loop",
+                            span,
+                        }
+                        .add_context("The range of a loop must be known at compile-time")
                     });
-                } else {
-                    block_type = expr_type;
+                };
+
+                unify_loop_range(&start_range_type, start_span);
+                unify_loop_range(&end_range_type, end_span);
+
+                self.interner.push_definition_type(for_expr.identifier.id, start_range_type);
+
+                self.check_expression(&for_expr.block);
+                Type::Unit
+            }
+            HirExpression::Block(block_expr) => {
+                let mut block_type = Type::Unit;
+
+                let statements = block_expr.statements();
+                for (i, stmt) in statements.iter().enumerate() {
+                    let expr_type = self.check_statement(stmt);
+
+                    if i + 1 < statements.len() {
+                        let id = match self.interner.statement(stmt) {
+                            crate::hir_def::stmt::HirStatement::Expression(expr) => expr,
+                            _ => *expr_id,
+                        };
+
+                        let span = self.interner.expr_span(&id);
+                        self.unify(&expr_type, &Type::Unit, span, || {
+                            TypeCheckError::TypeMismatch {
+                                expected_typ: Type::Unit.to_string(),
+                                expr_typ: expr_type.to_string(),
+                                expr_span: span,
+                            }
+                        });
+                    } else {
+                        block_type = expr_type;
+                    }
+                }
+
+                block_type
+            }
+            HirExpression::Prefix(prefix_expr) => {
+                let rhs_type = self.check_expression(&prefix_expr.rhs);
+                match prefix_operand_type_rules(&prefix_expr.operator, &rhs_type) {
+                    Ok(typ) => typ,
+                    Err(msg) => {
+                        let rhs_span = self.interner.expr_span(&prefix_expr.rhs);
+                        self.errors.push(TypeCheckError::Unstructured { msg, span: rhs_span });
+                        Type::Error
+                    }
                 }
             }
-
-            block_type
-        }
-        HirExpression::Prefix(prefix_expr) => {
-            let rhs_type = type_check_expression(interner, &prefix_expr.rhs, errors);
-            match prefix_operand_type_rules(&prefix_expr.operator, &rhs_type) {
-                Ok(typ) => typ,
-                Err(msg) => {
-                    let rhs_span = interner.expr_span(&prefix_expr.rhs);
-                    errors.push(TypeCheckError::Unstructured { msg, span: rhs_span });
-                    Type::Error
-                }
+            HirExpression::If(if_expr) => self.check_if_expr(&if_expr, expr_id),
+            HirExpression::Constructor(constructor) => self.check_constructor(constructor, expr_id),
+            HirExpression::MemberAccess(access) => self.check_member_access(access, *expr_id),
+            HirExpression::Error => Type::Error,
+            HirExpression::Tuple(elements) => {
+                Type::Tuple(vecmap(&elements, |elem| self.check_expression(elem)))
             }
-        }
-        HirExpression::If(if_expr) => check_if_expr(&if_expr, expr_id, interner, errors),
-        HirExpression::Constructor(constructor) => {
-            check_constructor(constructor, expr_id, interner, errors)
-        }
-        HirExpression::MemberAccess(access) => {
-            check_member_access(access, interner, *expr_id, errors)
-        }
-        HirExpression::Error => Type::Error,
-        HirExpression::Tuple(elements) => {
-            Type::Tuple(vecmap(&elements, |elem| type_check_expression(interner, elem, errors)))
-        }
-        HirExpression::Lambda(lambda) => {
-            let params = vecmap(lambda.parameters, |(pattern, typ)| {
-                bind_pattern(interner, &pattern, typ.clone(), errors);
-                typ
-            });
+            HirExpression::Lambda(lambda) => {
+                let params = vecmap(lambda.parameters, |(pattern, typ)| {
+                    self.bind_pattern(&pattern, typ.clone());
+                    typ
+                });
 
-            let actual_return = type_check_expression(interner, &lambda.body, errors);
+                let actual_return = self.check_expression(&lambda.body);
 
-            let span = interner.expr_span(&lambda.body);
-            actual_return.make_subtype_of(&lambda.return_type, span, errors, || {
+                let span = self.interner.expr_span(&lambda.body);
+                actual_return.make_subtype_of(&lambda.return_type, span, &mut self.errors, || {
+                    TypeCheckError::TypeMismatch {
+                        expected_typ: lambda.return_type.to_string(),
+                        expr_typ: actual_return.to_string(),
+                        expr_span: span,
+                    }
+                });
+                Type::Function(params, Box::new(lambda.return_type))
+            }
+        };
+
+        self.interner.push_expr_type(expr_id, typ.clone());
+        typ
+    }
+
+    fn check_index_expression(&mut self, index_expr: expr::HirIndexExpression) -> Type {
+        let index_type = self.check_expression(&index_expr.index);
+        let span = self.interner.expr_span(&index_expr.index);
+
+        self.unify(&index_type, &Type::comp_time(Some(span)), span, || {
+            // Specialize the error in the case the user has a Field, just not a `comptime` one.
+            if matches!(index_type, Type::FieldElement(..)) {
+                TypeCheckError::Unstructured {
+                    msg: format!("Array index must be known at compile-time, but here a non-comptime {index_type} was used instead"),
+                    span,
+                }
+            } else {
                 TypeCheckError::TypeMismatch {
-                    expected_typ: lambda.return_type.to_string(),
-                    expr_typ: actual_return.to_string(),
+                    expected_typ: "comptime Field".to_owned(),
+                    expr_typ: index_type.to_string(),
                     expr_span: span,
                 }
-            });
-            Type::Function(params, Box::new(lambda.return_type))
-        }
-    };
-
-    interner.push_expr_type(expr_id, typ.clone());
-    typ
-}
-
-fn type_check_index_expression(
-    interner: &mut NodeInterner,
-    index_expr: expr::HirIndexExpression,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    let index_type = type_check_expression(interner, &index_expr.index, errors);
-    let span = interner.expr_span(&index_expr.index);
-
-    index_type.unify(&Type::comp_time(Some(span)), span, errors, || {
-        // Specialize the error in the case the user has a Field, just not a `comptime` one.
-        if matches!(index_type, Type::FieldElement(..)) {
-            TypeCheckError::Unstructured {
-                msg: format!("Array index must be known at compile-time, but here a non-comptime {index_type} was used instead"),
-                span,
             }
-        } else {
-            TypeCheckError::TypeMismatch {
-                expected_typ: "comptime Field".to_owned(),
-                expr_typ: index_type.to_string(),
-                expr_span: span,
-            }
-        }
-    });
-    // TODO: replace the above by the below in order to activate dynamic arrays
-    // index_type.make_subtype_of(&Type::field(Some(span)), span, errors, || {
-    //     TypeCheckError::TypeMismatch {
-    //         expected_typ: "Field".to_owned(),
-    //         expr_typ: index_type.to_string(),
-    //         expr_span: span,
-    //     }
-    // });
+        });
+        // TODO: replace the above by the below in order to activate dynamic arrays
+        // index_type.make_subtype_of(&Type::field(Some(span)), span, errors, || {
+        //     TypeCheckError::TypeMismatch {
+        //         expected_typ: "Field".to_owned(),
+        //         expr_typ: index_type.to_string(),
+        //         expr_span: span,
+        //     }
+        // });
 
-    let lhs_type = type_check_expression(interner, &index_expr.collection, errors);
-    match lhs_type {
-        // XXX: We can check the array bounds here also, but it may be better to constant fold first
-        // and have ConstId instead of ExprId for constants
-        Type::Array(_, base_type) => *base_type,
-        Type::Error => Type::Error,
-        typ => {
-            let span = interner.expr_span(&index_expr.collection);
-            errors.push(TypeCheckError::TypeMismatch {
-                expected_typ: "Array".to_owned(),
-                expr_typ: typ.to_string(),
-                expr_span: span,
-            });
-            Type::Error
-        }
-    }
-}
-
-fn check_cast(from: Type, to: Type, span: Span, errors: &mut Vec<TypeCheckError>) -> Type {
-    let is_comp_time = match from {
-        Type::Integer(is_comp_time, ..) => is_comp_time,
-        Type::FieldElement(is_comp_time) => is_comp_time,
-        Type::PolymorphicInteger(is_comp_time, binding) => match &*binding.borrow() {
-            TypeBinding::Bound(from) => return check_cast(from.clone(), to, span, errors),
-            TypeBinding::Unbound(_) => is_comp_time,
-        },
-        Type::Bool(is_comp_time) => is_comp_time,
-        Type::Error => return Type::Error,
-        from => {
-            let msg = format!(
-                "Cannot cast type {from}, 'as' is only for primitive field or integer types",
-            );
-            errors.push(TypeCheckError::Unstructured { msg, span });
-            return Type::Error;
-        }
-    };
-
-    let error_message =
-        "Cannot cast to a comptime type, argument to cast is not known at compile-time";
-    match to {
-        Type::Integer(dest_comp_time, sign, bits) => {
-            if dest_comp_time.is_comp_time() && is_comp_time.unify(&dest_comp_time, span).is_err() {
-                let msg = error_message.into();
-                errors.push(TypeCheckError::Unstructured { msg, span });
-            }
-
-            Type::Integer(is_comp_time, sign, bits)
-        }
-        Type::FieldElement(dest_comp_time) => {
-            if dest_comp_time.is_comp_time() && is_comp_time.unify(&dest_comp_time, span).is_err() {
-                let msg = error_message.into();
-                errors.push(TypeCheckError::Unstructured { msg, span });
-            }
-
-            Type::FieldElement(is_comp_time)
-        }
-        Type::Bool(dest_comp_time) => {
-            if dest_comp_time.is_comp_time() && is_comp_time.unify(&dest_comp_time, span).is_err() {
-                let msg = error_message.into();
-                errors.push(TypeCheckError::Unstructured { msg, span });
-            }
-            Type::Bool(dest_comp_time)
-        }
-        Type::Error => Type::Error,
-        _ => {
-            let msg = "Only integer and Field types may be casted to".into();
-            errors.push(TypeCheckError::Unstructured { msg, span });
-            Type::Error
-        }
-    }
-}
-
-fn lookup_method(
-    interner: &mut NodeInterner,
-    object_type: Type,
-    method_name: &str,
-    expr_id: &ExprId,
-    errors: &mut Vec<TypeCheckError>,
-) -> Option<FuncId> {
-    match &object_type {
-        Type::Struct(typ, _args) => match interner.lookup_method(typ.borrow().id, method_name) {
-            Some(method_id) => Some(method_id),
-            None => {
-                errors.push(TypeCheckError::Unstructured {
-                    span: interner.expr_span(expr_id),
-                    msg: format!("No method named '{method_name}' found for type '{object_type}'",),
+        let lhs_type = self.check_expression(&index_expr.collection);
+        match lhs_type {
+            // XXX: We can check the array bounds here also, but it may be better to constant fold first
+            // and have ConstId instead of ExprId for constants
+            Type::Array(_, base_type) => *base_type,
+            Type::Error => Type::Error,
+            typ => {
+                let span = self.interner.expr_span(&index_expr.collection);
+                self.errors.push(TypeCheckError::TypeMismatch {
+                    expected_typ: "Array".to_owned(),
+                    expr_typ: typ.to_string(),
+                    expr_span: span,
                 });
-                None
+                Type::Error
             }
-        },
-        // If we fail to resolve the object to a struct type, we have no way of type
-        // checking its arguments as we can't even resolve the name of the function
-        Type::Error => None,
-
-        // In the future we could support methods for non-struct types if we have a context
-        // (in the interner?) essentially resembling HashMap<Type, Methods>
-        other => match interner.lookup_primitive_method(other, method_name) {
-            Some(method_id) => Some(method_id),
-            None => {
-                errors.push(TypeCheckError::Unstructured {
-                    span: interner.expr_span(expr_id),
-                    msg: format!("No method named '{method_name}' found for type '{other}'",),
-                });
-                None
-            }
-        },
-    }
-}
-
-// We need a special function to type check method calls since the method
-// is not a Expression::Ident it must be manually instantiated here
-fn type_check_method_call(
-    interner: &mut NodeInterner,
-    function_ident_id: &ExprId,
-    func_id: &FuncId,
-    arguments: Vec<(Type, Span)>,
-    span: Span,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    if func_id == &FuncId::dummy_id() {
-        Type::Error
-    } else {
-        let func_meta = interner.function_meta(func_id);
-
-        // Check function call arity is correct
-        let param_len = func_meta.parameters.len();
-        let arg_len = arguments.len();
-
-        if param_len != arg_len {
-            errors.push(TypeCheckError::ArityMisMatch {
-                expected: param_len as u16,
-                found: arg_len as u16,
-                span,
-            });
         }
-
-        let (function_type, instantiation_bindings) = func_meta.typ.instantiate(interner);
-
-        interner.store_instantiation_bindings(*function_ident_id, instantiation_bindings);
-        interner.push_expr_type(function_ident_id, function_type.clone());
-
-        bind_function_type(function_type, arguments, span, interner, errors)
     }
-}
 
-fn bind_function_type(
-    function: Type,
-    args: Vec<(Type, Span)>,
-    span: Span,
-    interner: &mut NodeInterner,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    // Could do a single unification for the entire function type, but matching beforehand
-    // lets us issue a more precise error on the individual argument that fails to type check.
-    match function {
-        Type::TypeVariable(binding) => {
-            if let TypeBinding::Bound(typ) = &*binding.borrow() {
-                return bind_function_type(typ.clone(), args, span, interner, errors);
-            }
-
-            let ret = interner.next_type_variable();
-            let args = vecmap(args, |(arg, _)| arg);
-            let expected = Type::Function(args, Box::new(ret.clone()));
-            *binding.borrow_mut() = TypeBinding::Bound(expected);
-
-            ret
-        }
-        Type::Function(parameters, ret) => {
-            if parameters.len() != args.len() {
-                let empty_or_s = if parameters.len() == 1 { "" } else { "s" };
-                let was_or_were = if args.len() == 1 { "was" } else { "were" };
-
-                errors.push(TypeCheckError::Unstructured {
-                    msg: format!(
-                        "Function expects {} parameter{} but {} {} given",
-                        parameters.len(),
-                        empty_or_s,
-                        args.len(),
-                        was_or_were
-                    ),
-                    span,
-                });
+    fn check_cast(&mut self, from: Type, to: Type, span: Span) -> Type {
+        let is_comp_time = match from {
+            Type::Integer(is_comp_time, ..) => is_comp_time,
+            Type::FieldElement(is_comp_time) => is_comp_time,
+            Type::PolymorphicInteger(is_comp_time, binding) => match &*binding.borrow() {
+                TypeBinding::Bound(from) => return self.check_cast(from.clone(), to, span),
+                TypeBinding::Unbound(_) => is_comp_time,
+            },
+            Type::Bool(is_comp_time) => is_comp_time,
+            Type::Error => return Type::Error,
+            from => {
+                let msg = format!(
+                    "Cannot cast type {from}, 'as' is only for primitive field or integer types",
+                );
+                self.errors.push(TypeCheckError::Unstructured { msg, span });
                 return Type::Error;
             }
+        };
 
-            for (param, (arg, arg_span)) in parameters.iter().zip(args) {
-                arg.make_subtype_of(param, arg_span, errors, || TypeCheckError::TypeMismatch {
-                    expected_typ: param.to_string(),
-                    expr_typ: arg.to_string(),
-                    expr_span: arg_span,
+        let error_message =
+            "Cannot cast to a comptime type, argument to cast is not known at compile-time";
+        match to {
+            Type::Integer(dest_comp_time, sign, bits) => {
+                if dest_comp_time.is_comp_time()
+                    && is_comp_time.unify(&dest_comp_time, span).is_err()
+                {
+                    let msg = error_message.into();
+                    self.errors.push(TypeCheckError::Unstructured { msg, span });
+                }
+
+                Type::Integer(is_comp_time, sign, bits)
+            }
+            Type::FieldElement(dest_comp_time) => {
+                if dest_comp_time.is_comp_time()
+                    && is_comp_time.unify(&dest_comp_time, span).is_err()
+                {
+                    let msg = error_message.into();
+                    self.errors.push(TypeCheckError::Unstructured { msg, span });
+                }
+
+                Type::FieldElement(is_comp_time)
+            }
+            Type::Bool(dest_comp_time) => {
+                if dest_comp_time.is_comp_time()
+                    && is_comp_time.unify(&dest_comp_time, span).is_err()
+                {
+                    let msg = error_message.into();
+                    self.errors.push(TypeCheckError::Unstructured { msg, span });
+                }
+                Type::Bool(dest_comp_time)
+            }
+            Type::Error => Type::Error,
+            _ => {
+                let msg = "Only integer and Field types may be casted to".into();
+                self.errors.push(TypeCheckError::Unstructured { msg, span });
+                Type::Error
+            }
+        }
+    }
+
+    // We need a special function to type check method calls since the method
+    // is not a Expression::Ident it must be manually instantiated here
+    fn check_method_call(
+        &mut self,
+        function_ident_id: &ExprId,
+        func_id: &FuncId,
+        arguments: Vec<(Type, Span)>,
+        span: Span,
+    ) -> Type {
+        if func_id == &FuncId::dummy_id() {
+            Type::Error
+        } else {
+            let func_meta = self.interner.function_meta(func_id);
+
+            // Check function call arity is correct
+            let param_len = func_meta.parameters.len();
+            let arg_len = arguments.len();
+
+            if param_len != arg_len {
+                self.errors.push(TypeCheckError::ArityMisMatch {
+                    expected: param_len as u16,
+                    found: arg_len as u16,
+                    span,
                 });
             }
 
-            *ret
+            let (function_type, instantiation_bindings) = func_meta.typ.instantiate(self.interner);
+
+            self.interner.store_instantiation_bindings(*function_ident_id, instantiation_bindings);
+            self.interner.push_expr_type(function_ident_id, function_type.clone());
+
+            self.bind_function_type(function_type, arguments, span)
         }
-        Type::Error => Type::Error,
-        other => {
-            errors.push(TypeCheckError::Unstructured {
-                msg: format!("Expected a function, but found a(n) {other}"),
-                span,
+    }
+
+    fn check_if_expr(&mut self, if_expr: &expr::HirIfExpression, expr_id: &ExprId) -> Type {
+        let cond_type = self.check_expression(&if_expr.condition);
+        let then_type = self.check_expression(&if_expr.consequence);
+
+        let expr_span = self.interner.expr_span(&if_expr.condition);
+
+        let bool_type = Type::Bool(CompTime::new(self.interner));
+        self.unify(&cond_type, &bool_type, expr_span, || TypeCheckError::TypeMismatch {
+            expected_typ: Type::Bool(CompTime::No(None)).to_string(),
+            expr_typ: cond_type.to_string(),
+            expr_span,
+        });
+
+        match if_expr.alternative {
+            None => Type::Unit,
+            Some(alternative) => {
+                let else_type = self.check_expression(&alternative);
+
+                let expr_span = self.interner.expr_span(expr_id);
+                self.unify(&then_type, &else_type, expr_span, || {
+                    let err = TypeCheckError::TypeMismatch {
+                        expected_typ: then_type.to_string(),
+                        expr_typ: else_type.to_string(),
+                        expr_span,
+                    };
+
+                    let context = if then_type == Type::Unit {
+                        "Are you missing a semicolon at the end of your 'else' branch?"
+                    } else if else_type == Type::Unit {
+                        "Are you missing a semicolon at the end of the first block of this 'if'?"
+                    } else {
+                        "Expected the types of both if branches to be equal"
+                    };
+
+                    err.add_context(context)
+                });
+
+                then_type
+            }
+        }
+    }
+
+    fn check_constructor(
+        &mut self,
+        constructor: expr::HirConstructorExpression,
+        expr_id: &ExprId,
+    ) -> Type {
+        let typ = constructor.r#type;
+        let generics = constructor.struct_generics;
+
+        // Sort argument types by name so we can zip with the struct type in the same ordering.
+        // Note that we use a Vec to store the original arguments (rather than a BTreeMap) to
+        // preserve the evaluation order of the source code.
+        let mut args = constructor.fields;
+        args.sort_by_key(|arg| arg.0.clone());
+
+        let fields = typ.borrow().get_fields(&generics);
+
+        for ((param_name, param_type), (arg_ident, arg)) in fields.into_iter().zip(args) {
+            // This can be false if the user provided an incorrect field count. That error should
+            // be caught during name resolution so it is fine to skip typechecking if there is a
+            // mismatch here as long as we continue typechecking the rest of the program to the best
+            // of our ability.
+            if param_name == arg_ident.0.contents {
+                let arg_type = self.check_expression(&arg);
+
+                let span = self.interner.expr_span(expr_id);
+                self.make_subtype_of(&arg_type, &param_type, span, || {
+                    TypeCheckError::TypeMismatch {
+                        expected_typ: param_type.to_string(),
+                        expr_typ: arg_type.to_string(),
+                        expr_span: span,
+                    }
+                });
+            }
+        }
+
+        Type::Struct(typ, generics)
+    }
+
+    fn check_member_access(&mut self, access: expr::HirMemberAccess, expr_id: ExprId) -> Type {
+        let lhs_type = self.check_expression(&access.lhs).follow_bindings();
+
+        if let Type::Struct(s, args) = &lhs_type {
+            let s = s.borrow();
+            if let Some((field, index)) = s.get_field(&access.rhs.0.contents, args) {
+                self.interner.set_field_index(expr_id, index);
+                return field;
+            }
+        } else if let Type::Tuple(elements) = &lhs_type {
+            if let Ok(index) = access.rhs.0.contents.parse::<usize>() {
+                if index < elements.len() {
+                    self.interner.set_field_index(expr_id, index);
+                    return elements[index].clone();
+                }
+            }
+        }
+
+        // If we get here the type has no field named 'access.rhs'.
+        // Now we specialize the error message based on whether we know the object type in question yet.
+        if let Type::TypeVariable(..) = &lhs_type {
+            self.errors.push(TypeCheckError::TypeAnnotationsNeeded {
+                span: self.interner.expr_span(&access.lhs),
             });
-            Type::Error
+        } else if lhs_type != Type::Error {
+            self.errors.push(TypeCheckError::Unstructured {
+                msg: format!("Type {lhs_type} has no member named {}", access.rhs),
+                span: self.interner.expr_span(&access.lhs),
+            });
+        }
+
+        Type::Error
+    }
+
+    fn comparator_operand_type_rules(
+        &mut self,
+        lhs_type: &Type,
+        rhs_type: &Type,
+        op: &HirBinaryOp,
+    ) -> Result<Type, String> {
+        use crate::BinaryOpKind::{Equal, NotEqual};
+        use Type::*;
+        match (lhs_type, rhs_type)  {
+            // Matches on PolymorphicInteger and TypeVariable must be first to follow any type
+            // bindings.
+            (PolymorphicInteger(comptime, int), other)
+            | (other, PolymorphicInteger(comptime, int)) => {
+                if let TypeBinding::Bound(binding) = &*int.borrow() {
+                    return self.comparator_operand_type_rules(other, binding, op);
+                }
+                if other.try_bind_to_polymorphic_int(int, comptime, true, op.location.span).is_ok() || other == &Type::Error {
+                    Ok(Bool(comptime.clone()))
+                } else {
+                    Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
+                }
+            }
+            (TypeVariable(var), other)
+            | (other, TypeVariable(var)) => {
+                if let TypeBinding::Bound(binding) = &*var.borrow() {
+                    return self.comparator_operand_type_rules(binding, other, op);
+                }
+
+                let comptime = CompTime::No(None);
+                if other.try_bind_to_polymorphic_int(var, &comptime, true, op.location.span).is_ok() || other == &Type::Error {
+                    Ok(Bool(comptime))
+                } else {
+                    Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
+                }
+            }
+            (Integer(comptime_x, sign_x, bit_width_x), Integer(comptime_y, sign_y, bit_width_y)) => {
+                if sign_x != sign_y {
+                    return Err(format!("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?} "))
+                }
+                if bit_width_x != bit_width_y {
+                    return Err(format!("Integers must have the same bit width LHS is {bit_width_x}, RHS is {bit_width_y} "))
+                }
+                let comptime = comptime_x.and(comptime_y, op.location.span);
+                Ok(Bool(comptime))
+            }
+            (Integer(..), FieldElement(..)) | ( FieldElement(..), Integer(..) ) => {
+                Err("Cannot use an integer and a Field in a binary operation, try converting the Field into an integer first".to_string())
+            }
+            (Integer(..), typ) | (typ,Integer(..)) => {
+                Err(format!("Integer cannot be used with type {typ}"))
+            }
+            (FieldElement(comptime_x), FieldElement(comptime_y)) => {
+                match op.kind {
+                    Equal | NotEqual => {
+                        let comptime = comptime_x.and(comptime_y, op.location.span);
+                        Ok(Bool(comptime))
+                    },
+                    _ => {
+                        Err("Fields cannot be compared, try casting to an integer first".into())
+                    }
+                }
+            }
+
+            // <= and friends are technically valid for booleans, just not very useful
+            (Bool(comptime_x), Bool(comptime_y)) => {
+                let comptime = comptime_x.and(comptime_y, op.location.span);
+                Ok(Bool(comptime))
+            }
+
+            // Avoid reporting errors multiple times
+            (Error, _) | (_,Error) => Ok(Bool(CompTime::Yes(None))),
+
+            // Special-case == and != for arrays
+            (Array(x_size, x_type), Array(y_size, y_type)) if matches!(op.kind, Equal | NotEqual) => {
+                x_type.unify(y_type, op.location.span, &mut self.errors, || {
+                    TypeCheckError::Unstructured {
+                        msg: format!("Cannot compare {lhs_type} and {rhs_type}, the array element types differ"),
+                        span: op.location.span,
+                    }
+                });
+
+                self.unify(x_size, y_size, op.location.span, || {
+                    TypeCheckError::Unstructured {
+                        msg: format!("Can only compare arrays of the same length. Here LHS is of length {x_size}, and RHS is {y_size}"),
+                        span: op.location.span,
+                    }
+                });
+
+                // We could check if all elements of all arrays are comptime but I am lazy
+                Ok(Bool(CompTime::No(Some(op.location.span))))
+            }
+            (NamedGeneric(binding_a, name_a), NamedGeneric(binding_b, name_b)) => {
+                if binding_a == binding_b {
+                    return Ok(Bool(CompTime::No(Some(op.location.span))));
+                }
+                Err(format!("Unsupported types for comparison: {name_a} and {name_b}"))
+            }
+            (String(x_size), String(y_size)) => {
+                x_size.unify(y_size, op.location.span, &mut self.errors, || {
+                    TypeCheckError::Unstructured {
+                        msg: format!("Can only compare strings of the same length. Here LHS is of length {x_size}, and RHS is {y_size} "),
+                        span: op.location.span,
+                    }
+                });
+
+                Ok(Bool(CompTime::No(Some(op.location.span))))
+            }
+            (lhs, rhs) => Err(format!("Unsupported types for comparison: {lhs} and {rhs}")),
+        }
+    }
+
+    fn lookup_method(
+        &mut self,
+        object_type: Type,
+        method_name: &str,
+        expr_id: &ExprId,
+    ) -> Option<FuncId> {
+        match &object_type {
+            Type::Struct(typ, _args) => {
+                match self.interner.lookup_method(typ.borrow().id, method_name) {
+                    Some(method_id) => Some(method_id),
+                    None => {
+                        self.errors.push(TypeCheckError::Unstructured {
+                            span: self.interner.expr_span(expr_id),
+                            msg: format!(
+                                "No method named '{method_name}' found for type '{object_type}'",
+                            ),
+                        });
+                        None
+                    }
+                }
+            }
+            // If we fail to resolve the object to a struct type, we have no way of type
+            // checking its arguments as we can't even resolve the name of the function
+            Type::Error => None,
+
+            // In the future we could support methods for non-struct types if we have a context
+            // (in the interner?) essentially resembling HashMap<Type, Methods>
+            other => match self.interner.lookup_primitive_method(other, method_name) {
+                Some(method_id) => Some(method_id),
+                None => {
+                    self.errors.push(TypeCheckError::Unstructured {
+                        span: self.interner.expr_span(expr_id),
+                        msg: format!("No method named '{method_name}' found for type '{other}'",),
+                    });
+                    None
+                }
+            },
+        }
+    }
+
+    fn bind_function_type(&mut self, function: Type, args: Vec<(Type, Span)>, span: Span) -> Type {
+        // Could do a single unification for the entire function type, but matching beforehand
+        // lets us issue a more precise error on the individual argument that fails to type check.
+        match function {
+            Type::TypeVariable(binding) => {
+                if let TypeBinding::Bound(typ) = &*binding.borrow() {
+                    return self.bind_function_type(typ.clone(), args, span);
+                }
+
+                let ret = self.interner.next_type_variable();
+                let args = vecmap(args, |(arg, _)| arg);
+                let expected = Type::Function(args, Box::new(ret.clone()));
+                *binding.borrow_mut() = TypeBinding::Bound(expected);
+
+                ret
+            }
+            Type::Function(parameters, ret) => {
+                if parameters.len() != args.len() {
+                    let empty_or_s = if parameters.len() == 1 { "" } else { "s" };
+                    let was_or_were = if args.len() == 1 { "was" } else { "were" };
+
+                    self.errors.push(TypeCheckError::Unstructured {
+                        msg: format!(
+                            "Function expects {} parameter{} but {} {} given",
+                            parameters.len(),
+                            empty_or_s,
+                            args.len(),
+                            was_or_were
+                        ),
+                        span,
+                    });
+                    return Type::Error;
+                }
+
+                for (param, (arg, arg_span)) in parameters.iter().zip(args) {
+                    arg.make_subtype_of(param, arg_span, &mut self.errors, || {
+                        TypeCheckError::TypeMismatch {
+                            expected_typ: param.to_string(),
+                            expr_typ: arg.to_string(),
+                            expr_span: arg_span,
+                        }
+                    });
+                }
+
+                *ret
+            }
+            Type::Error => Type::Error,
+            other => {
+                self.errors.push(TypeCheckError::Unstructured {
+                    msg: format!("Expected a function, but found a(n) {other}"),
+                    span,
+                });
+                Type::Error
+            }
+        }
+    }
+
+    // Given a binary operator and another type. This method will produce the output type
+    // XXX: Review these rules. In particular, the interaction between integers, comptime and private/public variables
+    fn infix_operand_type_rules(
+        &mut self,
+        lhs_type: &Type,
+        op: &HirBinaryOp,
+        rhs_type: &Type,
+        span: Span,
+    ) -> Result<Type, TypeCheckError> {
+        let make_error = move |msg| TypeCheckError::Unstructured { msg, span };
+
+        if op.kind.is_comparator() {
+            return self.comparator_operand_type_rules(lhs_type, rhs_type, op).map_err(make_error);
+        }
+
+        use Type::*;
+        match (lhs_type, rhs_type)  {
+            // Matches on PolymorphicInteger and TypeVariable must be first so that we follow any type
+            // bindings.
+            (PolymorphicInteger(comptime, int), other)
+            | (other, PolymorphicInteger(comptime, int)) => {
+                if let TypeBinding::Bound(binding) = &*int.borrow() {
+                    return self.infix_operand_type_rules(binding, op, other, span);
+                }
+
+                if op.is_bitwise() && (other.is_bindable() || other.is_field()) {
+                    let other = other.follow_bindings();
+
+                    // This will be an error if these types later resolve to a Field, or stay
+                    // polymorphic as the bit size will be unknown. Delay this error until the function
+                    // finishes resolving so we can still allow cases like `let x: u8 = 1 << 2;`.
+                    self.interner.push_delayed_type_check(Box::new(move || {
+                        if other.is_field() {
+                            Err(make_error("Bitwise operations are invalid on Field types. Try casting the operands to a sized integer type first".into()))
+                        } else if other.is_bindable() {
+                            Err(make_error("The number of bits to use for this bitwise operation is ambiguous. Either the operand's type or return type should be specified".into()))
+                        } else {
+                            Ok(())
+                        }
+                    }));
+                }
+
+                if other.try_bind_to_polymorphic_int(int, comptime, true, op.location.span).is_ok() || other == &Type::Error {
+                    Ok(other.clone())
+                } else {
+                    Err(make_error(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}")))
+                }
+            }
+            (TypeVariable(var), other)
+            | (other, TypeVariable(var)) => {
+                if let TypeBinding::Bound(binding) = &*var.borrow() {
+                    return self.infix_operand_type_rules(binding, op, other, span);
+                }
+
+                let comptime = CompTime::No(None);
+                if other.try_bind_to_polymorphic_int(var, &comptime, true, op.location.span).is_ok() || other == &Type::Error {
+                    Ok(other.clone())
+                } else {
+                    Err(make_error(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}")))
+                }
+            }
+            (Integer(comptime_x, sign_x, bit_width_x), Integer(comptime_y, sign_y, bit_width_y)) => {
+                if sign_x != sign_y {
+                    return Err(make_error(format!("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?} ")))
+                }
+                if bit_width_x != bit_width_y {
+                    return Err(make_error(format!("Integers must have the same bit width LHS is {bit_width_x}, RHS is {bit_width_y} ")))
+                }
+                let comptime = comptime_x.and(comptime_y, op.location.span);
+                Ok(Integer(comptime, *sign_x, *bit_width_x))
+            }
+            (Integer(..), FieldElement(..)) | (FieldElement(..), Integer(..)) => {
+                Err(make_error("Cannot use an integer and a Field in a binary operation, try converting the Field into an integer".to_string()))
+            }
+            (Integer(..), typ) | (typ,Integer(..)) => {
+                Err(make_error(format!("Integer cannot be used with type {typ}")))
+            }
+            // These types are not supported in binary operations
+            (Array(..), _) | (_, Array(..)) => Err(make_error("Arrays cannot be used in an infix operation".to_string())),
+            (Struct(..), _) | (_, Struct(..)) => Err(make_error("Structs cannot be used in an infix operation".to_string())),
+            (Tuple(_), _) | (_, Tuple(_)) => Err(make_error("Tuples cannot be used in an infix operation".to_string())),
+
+            // An error type on either side will always return an error
+            (Error, _) | (_,Error) => Ok(Error),
+            (Unit, _) | (_,Unit) => Ok(Unit),
+
+            // The result of two Fields is always a witness
+            (FieldElement(comptime_x), FieldElement(comptime_y)) => {
+                if op.is_bitwise() {
+                    return Err(make_error("Bitwise operations are invalid on Field types. Try casting the operands to a sized integer type first.".into()));
+                }
+                let comptime = comptime_x.and(comptime_y, op.location.span);
+                Ok(FieldElement(comptime))
+            }
+
+            (Bool(comptime_x), Bool(comptime_y)) => Ok(Bool(comptime_x.and(comptime_y, op.location.span))),
+
+            (lhs, rhs) => Err(make_error(format!("Unsupported types for binary operation: {lhs} and {rhs}"))),
         }
     }
 }
@@ -513,339 +827,4 @@ fn prefix_operand_type_rules(op: &crate::UnaryOp, rhs_type: &Type) -> Result<Typ
         }
     }
     Ok(rhs_type.clone())
-}
-
-// Given a binary operator and another type. This method will produce the output type
-// XXX: Review these rules. In particular, the interaction between integers, comptime and private/public variables
-fn infix_operand_type_rules(
-    lhs_type: &Type,
-    op: &HirBinaryOp,
-    rhs_type: &Type,
-    span: Span,
-    interner: &mut NodeInterner,
-    errors: &mut Vec<TypeCheckError>,
-) -> Result<Type, TypeCheckError> {
-    let make_error = move |msg| TypeCheckError::Unstructured { msg, span };
-
-    if op.kind.is_comparator() {
-        return comparator_operand_type_rules(lhs_type, rhs_type, op, errors).map_err(make_error);
-    }
-
-    use Type::*;
-    match (lhs_type, rhs_type)  {
-        // Matches on PolymorphicInteger and TypeVariable must be first so that we follow any type
-        // bindings.
-        (PolymorphicInteger(comptime, int), other)
-        | (other, PolymorphicInteger(comptime, int)) => {
-            if let TypeBinding::Bound(binding) = &*int.borrow() {
-                return infix_operand_type_rules(binding, op, other, span, interner, errors);
-            }
-
-            if op.is_bitwise() && (other.is_bindable() || other.is_field()) {
-                let other = other.follow_bindings();
-
-                // This will be an error if these types later resolve to a Field, or stay
-                // polymorphic as the bit size will be unknown. Delay this error until the function
-                // finishes resolving so we can still allow cases like `let x: u8 = 1 << 2;`.
-                interner.push_delayed_type_check(Box::new(move || {
-                    if other.is_field() {
-                        Err(make_error("Bitwise operations are invalid on Field types. Try casting the operands to a sized integer type first".into()))
-                    } else if other.is_bindable() {
-                        Err(make_error("The number of bits to use for this bitwise operation is ambiguous. Either the operand's type or return type should be specified".into()))
-                    } else {
-                        Ok(())
-                    }
-                }));
-            }
-
-            if other.try_bind_to_polymorphic_int(int, comptime, true, op.location.span).is_ok() || other == &Type::Error {
-                Ok(other.clone())
-            } else {
-                Err(make_error(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}")))
-            }
-        }
-        (TypeVariable(var), other)
-        | (other, TypeVariable(var)) => {
-            if let TypeBinding::Bound(binding) = &*var.borrow() {
-                return infix_operand_type_rules(binding, op, other, span, interner, errors);
-            }
-
-            let comptime = CompTime::No(None);
-            if other.try_bind_to_polymorphic_int(var, &comptime, true, op.location.span).is_ok() || other == &Type::Error {
-                Ok(other.clone())
-            } else {
-                Err(make_error(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}")))
-            }
-        }
-        (Integer(comptime_x, sign_x, bit_width_x), Integer(comptime_y, sign_y, bit_width_y)) => {
-            if sign_x != sign_y {
-                return Err(make_error(format!("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?} ")))
-            }
-            if bit_width_x != bit_width_y {
-                return Err(make_error(format!("Integers must have the same bit width LHS is {bit_width_x}, RHS is {bit_width_y} ")))
-            }
-            let comptime = comptime_x.and(comptime_y, op.location.span);
-            Ok(Integer(comptime, *sign_x, *bit_width_x))
-        }
-        (Integer(..), FieldElement(..)) | (FieldElement(..), Integer(..)) => {
-            Err(make_error("Cannot use an integer and a Field in a binary operation, try converting the Field into an integer".to_string()))
-        }
-        (Integer(..), typ) | (typ,Integer(..)) => {
-            Err(make_error(format!("Integer cannot be used with type {typ}")))
-        }
-        // These types are not supported in binary operations
-        (Array(..), _) | (_, Array(..)) => Err(make_error("Arrays cannot be used in an infix operation".to_string())),
-        (Struct(..), _) | (_, Struct(..)) => Err(make_error("Structs cannot be used in an infix operation".to_string())),
-        (Tuple(_), _) | (_, Tuple(_)) => Err(make_error("Tuples cannot be used in an infix operation".to_string())),
-
-        // An error type on either side will always return an error
-        (Error, _) | (_,Error) => Ok(Error),
-        (Unit, _) | (_,Unit) => Ok(Unit),
-
-        // The result of two Fields is always a witness
-        (FieldElement(comptime_x), FieldElement(comptime_y)) => {
-            if op.is_bitwise() {
-                return Err(make_error("Bitwise operations are invalid on Field types. Try casting the operands to a sized integer type first.".into()));
-            }
-            let comptime = comptime_x.and(comptime_y, op.location.span);
-            Ok(FieldElement(comptime))
-        }
-
-        (Bool(comptime_x), Bool(comptime_y)) => Ok(Bool(comptime_x.and(comptime_y, op.location.span))),
-
-        (lhs, rhs) => Err(make_error(format!("Unsupported types for binary operation: {lhs} and {rhs}"))),
-    }
-}
-
-fn check_if_expr(
-    if_expr: &expr::HirIfExpression,
-    expr_id: &ExprId,
-    interner: &mut NodeInterner,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    let cond_type = type_check_expression(interner, &if_expr.condition, errors);
-    let then_type = type_check_expression(interner, &if_expr.consequence, errors);
-
-    let expr_span = interner.expr_span(&if_expr.condition);
-    cond_type.unify(&Type::Bool(CompTime::new(interner)), expr_span, errors, || {
-        TypeCheckError::TypeMismatch {
-            expected_typ: Type::Bool(CompTime::No(None)).to_string(),
-            expr_typ: cond_type.to_string(),
-            expr_span,
-        }
-    });
-
-    match if_expr.alternative {
-        None => Type::Unit,
-        Some(alternative) => {
-            let else_type = type_check_expression(interner, &alternative, errors);
-
-            let expr_span = interner.expr_span(expr_id);
-            then_type.unify(&else_type, expr_span, errors, || {
-                let err = TypeCheckError::TypeMismatch {
-                    expected_typ: then_type.to_string(),
-                    expr_typ: else_type.to_string(),
-                    expr_span,
-                };
-
-                let context = if then_type == Type::Unit {
-                    "Are you missing a semicolon at the end of your 'else' branch?"
-                } else if else_type == Type::Unit {
-                    "Are you missing a semicolon at the end of the first block of this 'if'?"
-                } else {
-                    "Expected the types of both if branches to be equal"
-                };
-
-                err.add_context(context)
-            });
-
-            then_type
-        }
-    }
-}
-
-fn check_constructor(
-    constructor: expr::HirConstructorExpression,
-    expr_id: &ExprId,
-    interner: &mut NodeInterner,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    let typ = constructor.r#type;
-    let generics = constructor.struct_generics;
-
-    // Sort argument types by name so we can zip with the struct type in the same ordering.
-    // Note that we use a Vec to store the original arguments (rather than a BTreeMap) to
-    // preserve the evaluation order of the source code.
-    let mut args = constructor.fields;
-    args.sort_by_key(|arg| arg.0.clone());
-
-    let fields = typ.borrow().get_fields(&generics);
-
-    for ((param_name, param_type), (arg_ident, arg)) in fields.into_iter().zip(args) {
-        // This can be false if the user provided an incorrect field count. That error should
-        // be caught during name resolution so it is fine to skip typechecking if there is a
-        // mismatch here as long as we continue typechecking the rest of the program to the best
-        // of our ability.
-        if param_name == arg_ident.0.contents {
-            let arg_type = type_check_expression(interner, &arg, errors);
-
-            let span = interner.expr_span(expr_id);
-            arg_type.make_subtype_of(&param_type, span, errors, || TypeCheckError::TypeMismatch {
-                expected_typ: param_type.to_string(),
-                expr_typ: arg_type.to_string(),
-                expr_span: span,
-            });
-        }
-    }
-
-    Type::Struct(typ, generics)
-}
-
-fn check_member_access(
-    access: expr::HirMemberAccess,
-    interner: &mut NodeInterner,
-    expr_id: ExprId,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    let lhs_type = type_check_expression(interner, &access.lhs, errors).follow_bindings();
-
-    if let Type::Struct(s, args) = &lhs_type {
-        let s = s.borrow();
-        if let Some((field, index)) = s.get_field(&access.rhs.0.contents, args) {
-            interner.set_field_index(expr_id, index);
-            return field;
-        }
-    } else if let Type::Tuple(elements) = &lhs_type {
-        if let Ok(index) = access.rhs.0.contents.parse::<usize>() {
-            if index < elements.len() {
-                interner.set_field_index(expr_id, index);
-                return elements[index].clone();
-            }
-        }
-    }
-
-    // If we get here the type has no field named 'access.rhs'.
-    // Now we specialize the error message based on whether we know the object type in question yet.
-    if let Type::TypeVariable(..) = &lhs_type {
-        errors
-            .push(TypeCheckError::TypeAnnotationsNeeded { span: interner.expr_span(&access.lhs) });
-    } else if lhs_type != Type::Error {
-        errors.push(TypeCheckError::Unstructured {
-            msg: format!("Type {lhs_type} has no member named {}", access.rhs),
-            span: interner.expr_span(&access.lhs),
-        });
-    }
-
-    Type::Error
-}
-
-fn comparator_operand_type_rules(
-    lhs_type: &Type,
-    rhs_type: &Type,
-    op: &HirBinaryOp,
-    errors: &mut Vec<TypeCheckError>,
-) -> Result<Type, String> {
-    use crate::BinaryOpKind::{Equal, NotEqual};
-    use Type::*;
-    match (lhs_type, rhs_type)  {
-        // Matches on PolymorphicInteger and TypeVariable must be first to follow any type
-        // bindings.
-        (PolymorphicInteger(comptime, int), other)
-        | (other, PolymorphicInteger(comptime, int)) => {
-            if let TypeBinding::Bound(binding) = &*int.borrow() {
-                return comparator_operand_type_rules(other, binding, op, errors);
-            }
-            if other.try_bind_to_polymorphic_int(int, comptime, true, op.location.span).is_ok() || other == &Type::Error {
-                Ok(Bool(comptime.clone()))
-            } else {
-                Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
-            }
-        }
-        (TypeVariable(var), other)
-        | (other, TypeVariable(var)) => {
-            if let TypeBinding::Bound(binding) = &*var.borrow() {
-                return comparator_operand_type_rules(binding, other, op, errors);
-            }
-
-            let comptime = CompTime::No(None);
-            if other.try_bind_to_polymorphic_int(var, &comptime, true, op.location.span).is_ok() || other == &Type::Error {
-                Ok(Bool(comptime))
-            } else {
-                Err(format!("Types in a binary operation should match, but found {lhs_type} and {rhs_type}"))
-            }
-        }
-        (Integer(comptime_x, sign_x, bit_width_x), Integer(comptime_y, sign_y, bit_width_y)) => {
-            if sign_x != sign_y {
-                return Err(format!("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?} "))
-            }
-            if bit_width_x != bit_width_y {
-                return Err(format!("Integers must have the same bit width LHS is {bit_width_x}, RHS is {bit_width_y} "))
-            }
-            let comptime = comptime_x.and(comptime_y, op.location.span);
-            Ok(Bool(comptime))
-        }
-        (Integer(..), FieldElement(..)) | ( FieldElement(..), Integer(..) ) => {
-            Err("Cannot use an integer and a Field in a binary operation, try converting the Field into an integer first".to_string())
-        }
-        (Integer(..), typ) | (typ,Integer(..)) => {
-            Err(format!("Integer cannot be used with type {typ}"))
-        }
-        (FieldElement(comptime_x), FieldElement(comptime_y)) => {
-            match op.kind {
-                Equal | NotEqual => {
-                    let comptime = comptime_x.and(comptime_y, op.location.span);
-                    Ok(Bool(comptime))
-                },
-                _ => {
-                    Err("Fields cannot be compared, try casting to an integer first".into())
-                }
-            }
-        }
-
-        // <= and friends are technically valid for booleans, just not very useful
-        (Bool(comptime_x), Bool(comptime_y)) => {
-            let comptime = comptime_x.and(comptime_y, op.location.span);
-            Ok(Bool(comptime))
-        }
-
-        // Avoid reporting errors multiple times
-        (Error, _) | (_,Error) => Ok(Bool(CompTime::Yes(None))),
-
-        // Special-case == and != for arrays
-        (Array(x_size, x_type), Array(y_size, y_type)) if matches!(op.kind, Equal | NotEqual) => {
-            x_type.unify(y_type, op.location.span, errors, || {
-                TypeCheckError::Unstructured {
-                    msg: format!("Cannot compare {lhs_type} and {rhs_type}, the array element types differ"),
-                    span: op.location.span,
-                }
-            });
-
-            x_size.unify(y_size, op.location.span, errors, || {
-                TypeCheckError::Unstructured {
-                    msg: format!("Can only compare arrays of the same length. Here LHS is of length {x_size}, and RHS is {y_size}"),
-                    span: op.location.span,
-                }
-            });
-
-            // We could check if all elements of all arrays are comptime but I am lazy
-            Ok(Bool(CompTime::No(Some(op.location.span))))
-        }
-        (NamedGeneric(binding_a, name_a), NamedGeneric(binding_b, name_b)) => {
-            if binding_a == binding_b {
-                return Ok(Bool(CompTime::No(Some(op.location.span))));
-            }
-            Err(format!("Unsupported types for comparison: {name_a} and {name_b}"))
-        }
-        (String(x_size), String(y_size)) => {
-            x_size.unify(y_size, op.location.span, errors, || {
-                TypeCheckError::Unstructured {
-                    msg: format!("Can only compare strings of the same length. Here LHS is of length {x_size}, and RHS is {y_size} "),
-                    span: op.location.span,
-                }
-            });
-
-            Ok(Bool(CompTime::No(Some(op.location.span))))
-        }
-        (lhs, rhs) => Err(format!("Unsupported types for comparison: {lhs} and {rhs}")),
-    }
 }

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -15,11 +15,18 @@ mod expr;
 mod stmt;
 
 pub use errors::TypeCheckError;
-use expr::type_check_expression;
+use noirc_errors::Span;
 
-use crate::node_interner::{FuncId, NodeInterner};
+use crate::{
+    node_interner::{ExprId, FuncId, NodeInterner, StmtId},
+    Type,
+};
 
-pub(crate) use self::stmt::{bind_pattern, type_check};
+pub struct TypeChecker<'interner> {
+    current_function: Option<FuncId>,
+    interner: &'interner mut NodeInterner,
+    errors: Vec<TypeCheckError>,
+}
 
 /// Type checks a function and assigns the
 /// appropriate types to expressions in a side table
@@ -28,19 +35,19 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     let declared_return_type = meta.return_type().clone();
     let can_ignore_ret = meta.can_ignore_return_type();
 
-    // Bind each parameter to its annotated type.
-    // This is locally obvious, but it must be bound here so that the
-    // Definition object of the parameter in the NodeInterner is given the correct type.
-    let mut errors = vec![];
-    for param in meta.parameters.into_iter() {
-        bind_pattern(interner, &param.0, param.1, &mut errors);
-    }
-
-    // Fetch the HirFunction and iterate all of it's statements
     let function_body = interner.function(&func_id);
     let function_body_id = function_body.as_expr();
 
-    let function_last_type = type_check_expression(interner, function_body_id, &mut errors);
+    let mut type_checker = TypeChecker::new(func_id, interner);
+
+    // Bind each parameter to its annotated type.
+    // This is locally obvious, but it must be bound here so that the
+    // Definition object of the parameter in the NodeInterner is given the correct type.
+    for param in meta.parameters.into_iter() {
+        type_checker.bind_pattern(&param.0, param.1);
+    }
+
+    let (function_last_type, mut errors) = type_checker.check_function_body(function_body_id);
 
     // Go through any delayed type checking errors to see if they are resolved, or error otherwise.
     for type_check_fn in interner.take_delayed_type_check_functions() {
@@ -62,6 +69,51 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     }
 
     errors
+}
+
+impl<'interner> TypeChecker<'interner> {
+    fn new(current_function: FuncId, interner: &'interner mut NodeInterner) -> Self {
+        Self { current_function: Some(current_function), interner, errors: vec![] }
+    }
+
+    fn check_function_body(mut self, body: &ExprId) -> (Type, Vec<TypeCheckError>) {
+        let body_type = self.check_expression(body);
+        (body_type, self.errors)
+    }
+
+    pub fn check_global(id: &StmtId, interner: &'interner mut NodeInterner) -> Vec<TypeCheckError> {
+        let mut this = Self { current_function: None, interner, errors: vec![] };
+        this.check_statement(id);
+        this.errors
+    }
+
+    fn is_unconstrained(&self) -> bool {
+        self.current_function.map_or(false, |current_function| {
+            self.interner.function_meta(&current_function).is_unconstrained
+        })
+    }
+
+    /// Wrapper of Type::unify using self.errors
+    fn unify(
+        &mut self,
+        actual: &Type,
+        expected: &Type,
+        span: Span,
+        make_error: impl FnOnce() -> TypeCheckError,
+    ) {
+        actual.unify(expected, span, &mut self.errors, make_error)
+    }
+
+    /// Wrapper of Type::make_subtype_of using self.errors
+    fn make_subtype_of(
+        &mut self,
+        actual: &Type,
+        expected: &Type,
+        span: Span,
+        make_error: impl FnOnce() -> TypeCheckError,
+    ) {
+        actual.make_subtype_of(expected, span, &mut self.errors, make_error)
+    }
 }
 
 // XXX: These tests are all manual currently.

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -4,287 +4,252 @@ use crate::hir_def::stmt::{
     HirAssignStatement, HirConstrainStatement, HirLValue, HirLetStatement, HirPattern, HirStatement,
 };
 use crate::hir_def::types::Type;
-use crate::node_interner::{DefinitionId, ExprId, NodeInterner, StmtId};
+use crate::node_interner::{DefinitionId, ExprId, StmtId};
 use crate::CompTime;
 
-use super::{errors::TypeCheckError, expr::type_check_expression};
+use super::errors::TypeCheckError;
+use super::TypeChecker;
 
-/// Type checks a statement and all expressions/statements contained within.
-///
-/// All statements have a unit type `()` as their type so the type of the statement
-/// is not interesting. Type checking must still be done on statements to ensure any
-/// expressions used within them are typed correctly.
-pub(crate) fn type_check(
-    interner: &mut NodeInterner,
-    stmt_id: &StmtId,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    match interner.statement(stmt_id) {
-        // Lets lay out a convincing argument that the handling of
-        // SemiExpressions and Expressions below is correct.
-        //
-        // The only time you will get a Semi expression is if
-        // you have an expression by itself
-        //
-        // Example:
-        //
-        // 5; or x; or x+a;
-        //
-        // In these cases, you cannot even get the expr_id because
-        // it is not bound to anything. We could therefore.
-        //
-        // However since TypeChecking checks the return type of the last statement
-        // the type checker could in the future incorrectly return the type.
-        //
-        // As it stands, this is also impossible because the ret_type function
-        // does not use the interner to get the type. It returns Unit.
-        //
-        // The reason why we still modify the database, is to make sure it is future-proof
-        HirStatement::Expression(expr_id) => {
-            return type_check_expression(interner, &expr_id, errors);
+impl<'interner> TypeChecker<'interner> {
+    /// Type checks a statement and all expressions/statements contained within.
+    ///
+    /// All statements have a unit type `()` as their type so the type of the statement
+    /// is not interesting. Type checking must still be done on statements to ensure any
+    /// expressions used within them are typed correctly.
+    pub(crate) fn check_statement(&mut self, stmt_id: &StmtId) -> Type {
+        match self.interner.statement(stmt_id) {
+            // Lets lay out a convincing argument that the handling of
+            // SemiExpressions and Expressions below is correct.
+            //
+            // The only time you will get a Semi expression is if
+            // you have an expression by itself
+            //
+            // Example:
+            //
+            // 5; or x; or x+a;
+            //
+            // In these cases, you cannot even get the expr_id because
+            // it is not bound to anything. We could therefore.
+            //
+            // However since TypeChecking checks the return type of the last statement
+            // the type checker could in the future incorrectly return the type.
+            //
+            // As it stands, this is also impossible because the ret_type function
+            // does not use the interner to get the type. It returns Unit.
+            //
+            // The reason why we still modify the database, is to make sure it is future-proof
+            HirStatement::Expression(expr_id) => {
+                return self.check_expression(&expr_id);
+            }
+            HirStatement::Semi(expr_id) => {
+                self.check_expression(&expr_id);
+            }
+            HirStatement::Let(let_stmt) => self.check_let_stmt(let_stmt),
+            HirStatement::Constrain(constrain_stmt) => self.check_constrain_stmt(constrain_stmt),
+            HirStatement::Assign(assign_stmt) => self.check_assign_stmt(assign_stmt, stmt_id),
+            HirStatement::Error => (),
         }
-        HirStatement::Semi(expr_id) => {
-            type_check_expression(interner, &expr_id, errors);
-        }
-        HirStatement::Let(let_stmt) => type_check_let_stmt(interner, let_stmt, errors),
-        HirStatement::Constrain(constrain_stmt) => {
-            type_check_constrain_stmt(interner, constrain_stmt, errors)
-        }
-        HirStatement::Assign(assign_stmt) => {
-            type_check_assign_stmt(interner, assign_stmt, stmt_id, errors)
-        }
-        HirStatement::Error => (),
+        Type::Unit
     }
-    Type::Unit
-}
 
-/// Associate a given HirPattern with the given Type, and remember
-/// this association in the NodeInterner.
-pub(crate) fn bind_pattern(
-    interner: &mut NodeInterner,
-    pattern: &HirPattern,
-    typ: Type,
-    errors: &mut Vec<TypeCheckError>,
-) {
-    match pattern {
-        HirPattern::Identifier(ident) => interner.push_definition_type(ident.id, typ),
-        HirPattern::Mutable(pattern, _) => bind_pattern(interner, pattern, typ, errors),
-        HirPattern::Tuple(fields, span) => match typ {
-            Type::Tuple(field_types) if field_types.len() == fields.len() => {
-                for (field, field_type) in fields.iter().zip(field_types) {
-                    bind_pattern(interner, field, field_type, errors);
-                }
-            }
-            Type::Error => (),
-            other => {
-                errors.push(TypeCheckError::TypeMismatch {
-                    expected_typ: other.to_string(),
-                    expr_typ: other.to_string(),
-                    expr_span: *span,
-                });
-            }
-        },
-        HirPattern::Struct(struct_type, fields, span) => {
-            struct_type.unify(&typ, *span, errors, || TypeCheckError::TypeMismatch {
-                expected_typ: typ.to_string(),
-                expr_typ: struct_type.to_string(),
-                expr_span: *span,
-            });
-
-            if let Type::Struct(struct_type, generics) = struct_type {
-                let mut pattern_fields = fields.clone();
-                pattern_fields.sort_by_key(|(ident, _)| ident.clone());
-                let struct_type = struct_type.borrow();
-
-                for (field_name, field_pattern) in pattern_fields {
-                    let type_field =
-                        struct_type.get_field(&field_name.0.contents, generics).unwrap().0;
-                    bind_pattern(interner, &field_pattern, type_field, errors);
-                }
-            }
-        }
-    }
-}
-
-fn type_check_assign_stmt(
-    interner: &mut NodeInterner,
-    assign_stmt: HirAssignStatement,
-    stmt_id: &StmtId,
-    errors: &mut Vec<TypeCheckError>,
-) {
-    let expr_type = type_check_expression(interner, &assign_stmt.expression, errors);
-    let span = interner.expr_span(&assign_stmt.expression);
-    let (lvalue_type, new_lvalue) = type_check_lvalue(interner, assign_stmt.lvalue, span, errors);
-
-    // Must push new lvalue to the interner, we've resolved any field indices
-    interner.update_statement(stmt_id, |stmt| match stmt {
-        HirStatement::Assign(assign) => assign.lvalue = new_lvalue,
-        _ => unreachable!(),
-    });
-
-    let span = interner.expr_span(&assign_stmt.expression);
-    expr_type.make_subtype_of(&lvalue_type, span, errors, || {
-        let msg = format!(
-            "Cannot assign an expression of type {expr_type} to a value of type {lvalue_type}"
-        );
-
-        TypeCheckError::Unstructured { msg, span }
-    });
-}
-
-/// Type check an lvalue - the left hand side of an assignment statement.
-fn type_check_lvalue(
-    interner: &mut NodeInterner,
-    lvalue: HirLValue,
-    assign_span: Span,
-    errors: &mut Vec<TypeCheckError>,
-) -> (Type, HirLValue) {
-    match lvalue {
-        HirLValue::Ident(ident, _) => {
-            let typ = if ident.id == DefinitionId::dummy_id() {
-                Type::Error
-            } else {
-                let definition = interner.definition(ident.id);
-                if !definition.mutable {
-                    errors.push(TypeCheckError::Unstructured {
-                        msg: format!(
-                            "Variable {} must be mutable to be assigned to",
-                            definition.name
-                        ),
-                        span: ident.location.span,
-                    });
-                }
-                // Do we need to store TypeBindings here?
-                interner.id_type(ident.id).instantiate(interner).0
-            };
-
-            (typ.clone(), HirLValue::Ident(ident, typ))
-        }
-        HirLValue::MemberAccess { object, field_name, .. } => {
-            let (result, object) = type_check_lvalue(interner, *object, assign_span, errors);
-            let object = Box::new(object);
-
-            let mut error = |typ| {
-                errors.push(TypeCheckError::Unstructured {
-                    msg: format!("Type {typ} has no member named {field_name}"),
-                    span: field_name.span(),
-                });
-                (Type::Error, None)
-            };
-
-            let (typ, field_index) = match result {
-                Type::Struct(def, args) => {
-                    match def.borrow().get_field(&field_name.0.contents, &args) {
-                        Some((field, index)) => (field, Some(index)),
-                        None => error(Type::Struct(def.clone(), args)),
+    /// Associate a given HirPattern with the given Type, and remember
+    /// this association in the NodeInterner.
+    pub(crate) fn bind_pattern(&mut self, pattern: &HirPattern, typ: Type) {
+        match pattern {
+            HirPattern::Identifier(ident) => self.interner.push_definition_type(ident.id, typ),
+            HirPattern::Mutable(pattern, _) => self.bind_pattern(pattern, typ),
+            HirPattern::Tuple(fields, span) => match typ {
+                Type::Tuple(field_types) if field_types.len() == fields.len() => {
+                    for (field, field_type) in fields.iter().zip(field_types) {
+                        self.bind_pattern(field, field_type);
                     }
                 }
-                Type::Error => (Type::Error, None),
-                other => error(other),
-            };
-
-            (typ.clone(), HirLValue::MemberAccess { object, field_name, field_index, typ })
-        }
-        HirLValue::Index { array, index, .. } => {
-            let index_type = type_check_expression(interner, &index, errors);
-            let expr_span = interner.expr_span(&index);
-
-            index_type.unify(&Type::comp_time(Some(expr_span)), expr_span, errors, || {
-                TypeCheckError::TypeMismatch {
-                    expected_typ: "comptime Field".to_owned(),
-                    expr_typ: index_type.to_string(),
-                    expr_span,
-                }
-            });
-            //TODO replace the above by the below in order to activate dynamic arrays
-            // index_type.make_subtype_of(&Type::field(Some(expr_span)), expr_span, errors, || {
-            //     TypeCheckError::TypeMismatch {
-            //         expected_typ: "Field".to_owned(),
-            //         expr_typ: index_type.to_string(),
-            //         expr_span,
-            //     }
-            // });
-
-            let (result, array) = type_check_lvalue(interner, *array, assign_span, errors);
-            let array = Box::new(array);
-
-            let typ = match result {
-                Type::Array(_, elem_type) => *elem_type,
-                Type::Error => Type::Error,
+                Type::Error => (),
                 other => {
-                    // TODO: Need a better span here
-                    errors.push(TypeCheckError::TypeMismatch {
-                        expected_typ: "an array".to_string(),
+                    self.errors.push(TypeCheckError::TypeMismatch {
+                        expected_typ: other.to_string(),
                         expr_typ: other.to_string(),
-                        expr_span: assign_span,
+                        expr_span: *span,
                     });
-                    Type::Error
                 }
-            };
+            },
+            HirPattern::Struct(struct_type, fields, span) => {
+                self.unify(struct_type, &typ, *span, || TypeCheckError::TypeMismatch {
+                    expected_typ: typ.to_string(),
+                    expr_typ: struct_type.to_string(),
+                    expr_span: *span,
+                });
 
-            (typ.clone(), HirLValue::Index { array, index, typ })
+                if let Type::Struct(struct_type, generics) = struct_type {
+                    let mut pattern_fields = fields.clone();
+                    pattern_fields.sort_by_key(|(ident, _)| ident.clone());
+                    let struct_type = struct_type.borrow();
+
+                    for (field_name, field_pattern) in pattern_fields {
+                        let type_field =
+                            struct_type.get_field(&field_name.0.contents, generics).unwrap().0;
+                        self.bind_pattern(&field_pattern, type_field);
+                    }
+                }
+            }
         }
     }
-}
 
-fn type_check_let_stmt(
-    interner: &mut NodeInterner,
-    let_stmt: HirLetStatement,
-    errors: &mut Vec<TypeCheckError>,
-) {
-    let mut resolved_type =
-        type_check_declaration(interner, let_stmt.expression, let_stmt.r#type, errors);
+    fn check_assign_stmt(&mut self, assign_stmt: HirAssignStatement, stmt_id: &StmtId) {
+        let expr_type = self.check_expression(&assign_stmt.expression);
+        let span = self.interner.expr_span(&assign_stmt.expression);
+        let (lvalue_type, new_lvalue) = self.check_lvalue(assign_stmt.lvalue, span);
 
-    resolved_type.set_comp_time_span(interner.expr_span(&let_stmt.expression));
+        // Must push new lvalue to the interner, we've resolved any field indices
+        self.interner.update_statement(stmt_id, |stmt| match stmt {
+            HirStatement::Assign(assign) => assign.lvalue = new_lvalue,
+            _ => unreachable!(),
+        });
 
-    // Set the type of the pattern to be equal to the annotated type
-    bind_pattern(interner, &let_stmt.pattern, resolved_type, errors);
-}
+        let span = self.interner.expr_span(&assign_stmt.expression);
+        self.make_subtype_of(&expr_type, &lvalue_type, span, || {
+            let msg = format!(
+                "Cannot assign an expression of type {expr_type} to a value of type {lvalue_type}"
+            );
 
-fn type_check_constrain_stmt(
-    interner: &mut NodeInterner,
-    stmt: HirConstrainStatement,
-    errors: &mut Vec<TypeCheckError>,
-) {
-    let expr_type = type_check_expression(interner, &stmt.0, errors);
-    let expr_span = interner.expr_span(&stmt.0);
+            TypeCheckError::Unstructured { msg, span }
+        });
+    }
 
-    expr_type.unify(&Type::Bool(CompTime::new(interner)), expr_span, errors, || {
-        TypeCheckError::TypeMismatch {
+    /// Type check an lvalue - the left hand side of an assignment statement.
+    fn check_lvalue(&mut self, lvalue: HirLValue, assign_span: Span) -> (Type, HirLValue) {
+        match lvalue {
+            HirLValue::Ident(ident, _) => {
+                let typ = if ident.id == DefinitionId::dummy_id() {
+                    Type::Error
+                } else {
+                    let definition = self.interner.definition(ident.id);
+                    if !definition.mutable {
+                        self.errors.push(TypeCheckError::Unstructured {
+                            msg: format!(
+                                "Variable {} must be mutable to be assigned to",
+                                definition.name
+                            ),
+                            span: ident.location.span,
+                        });
+                    }
+                    // Do we need to store TypeBindings here?
+                    self.interner.id_type(ident.id).instantiate(self.interner).0
+                };
+
+                (typ.clone(), HirLValue::Ident(ident, typ))
+            }
+            HirLValue::MemberAccess { object, field_name, .. } => {
+                let (result, object) = self.check_lvalue(*object, assign_span);
+                let object = Box::new(object);
+
+                let mut error = |typ| {
+                    self.errors.push(TypeCheckError::Unstructured {
+                        msg: format!("Type {typ} has no member named {field_name}"),
+                        span: field_name.span(),
+                    });
+                    (Type::Error, None)
+                };
+
+                let (typ, field_index) = match result {
+                    Type::Struct(def, args) => {
+                        match def.borrow().get_field(&field_name.0.contents, &args) {
+                            Some((field, index)) => (field, Some(index)),
+                            None => error(Type::Struct(def.clone(), args)),
+                        }
+                    }
+                    Type::Error => (Type::Error, None),
+                    other => error(other),
+                };
+
+                (typ.clone(), HirLValue::MemberAccess { object, field_name, field_index, typ })
+            }
+            HirLValue::Index { array, index, .. } => {
+                let index_type = self.check_expression(&index);
+                let expr_span = self.interner.expr_span(&index);
+
+                self.unify(&index_type, &Type::comp_time(Some(expr_span)), expr_span, || {
+                    TypeCheckError::TypeMismatch {
+                        expected_typ: "comptime Field".to_owned(),
+                        expr_typ: index_type.to_string(),
+                        expr_span,
+                    }
+                });
+                //TODO replace the above by the below in order to activate dynamic arrays
+                // index_type.make_subtype_of(&Type::field(Some(expr_span)), expr_span, || {
+                //     TypeCheckError::TypeMismatch {
+                //         expected_typ: "Field".to_owned(),
+                //         expr_typ: index_type.to_string(),
+                //         expr_span,
+                //     }
+                // });
+
+                let (result, array) = self.check_lvalue(*array, assign_span);
+                let array = Box::new(array);
+
+                let typ = match result {
+                    Type::Array(_, elem_type) => *elem_type,
+                    Type::Error => Type::Error,
+                    other => {
+                        // TODO: Need a better span here
+                        self.errors.push(TypeCheckError::TypeMismatch {
+                            expected_typ: "an array".to_string(),
+                            expr_typ: other.to_string(),
+                            expr_span: assign_span,
+                        });
+                        Type::Error
+                    }
+                };
+
+                (typ.clone(), HirLValue::Index { array, index, typ })
+            }
+        }
+    }
+
+    fn check_let_stmt(&mut self, let_stmt: HirLetStatement) {
+        let mut resolved_type = self.check_declaration(let_stmt.expression, let_stmt.r#type);
+
+        resolved_type.set_comp_time_span(self.interner.expr_span(&let_stmt.expression));
+
+        // Set the type of the pattern to be equal to the annotated type
+        self.bind_pattern(&let_stmt.pattern, resolved_type);
+    }
+
+    fn check_constrain_stmt(&mut self, stmt: HirConstrainStatement) {
+        let expr_type = self.check_expression(&stmt.0);
+        let expr_span = self.interner.expr_span(&stmt.0);
+
+        let bool_type = Type::Bool(CompTime::new(self.interner));
+        self.unify(&expr_type, &bool_type, expr_span, || TypeCheckError::TypeMismatch {
             expr_typ: expr_type.to_string(),
             expected_typ: Type::Bool(CompTime::No(None)).to_string(),
             expr_span,
-        }
-    });
-}
-
-/// All declaration statements check that the user specified type(UST) is equal to the
-/// expression on the RHS, unless the UST is unspecified in which case
-/// the type of the declaration is inferred to match the RHS.
-fn type_check_declaration(
-    interner: &mut NodeInterner,
-    rhs_expr: ExprId,
-    annotated_type: Type,
-    errors: &mut Vec<TypeCheckError>,
-) -> Type {
-    // Type check the expression on the RHS
-    let expr_type = type_check_expression(interner, &rhs_expr, errors);
-
-    // First check if the LHS is unspecified
-    // If so, then we give it the same type as the expression
-    if annotated_type != Type::Error {
-        // Now check if LHS is the same type as the RHS
-        // Importantly, we do not coerce any types implicitly
-        let expr_span = interner.expr_span(&rhs_expr);
-        expr_type.make_subtype_of(&annotated_type, expr_span, errors, || {
-            TypeCheckError::TypeMismatch {
-                expected_typ: annotated_type.to_string(),
-                expr_typ: expr_type.to_string(),
-                expr_span,
-            }
         });
-        annotated_type
-    } else {
-        expr_type
+    }
+
+    /// All declaration statements check that the user specified type(UST) is equal to the
+    /// expression on the RHS, unless the UST is unspecified in which case
+    /// the type of the declaration is inferred to match the RHS.
+    fn check_declaration(&mut self, rhs_expr: ExprId, annotated_type: Type) -> Type {
+        // Type check the expression on the RHS
+        let expr_type = self.check_expression(&rhs_expr);
+
+        // First check if the LHS is unspecified
+        // If so, then we give it the same type as the expression
+        if annotated_type != Type::Error {
+            // Now check if LHS is the same type as the RHS
+            // Importantly, we do not coerce any types implicitly
+            let expr_span = self.interner.expr_span(&rhs_expr);
+            self.make_subtype_of(&expr_type, &annotated_type, expr_span, || {
+                TypeCheckError::TypeMismatch {
+                    expected_typ: annotated_type.to_string(),
+                    expr_typ: expr_type.to_string(),
+                    expr_span,
+                }
+            });
+            annotated_type
+        } else {
+            expr_type
+        }
     }
 }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1049 

# Description

## Summary of changes

Allows loops over any field values (not just comptime Fields) in unconstrained functions.

The diff is quite large to account for the change of the type checker from free functions to methods of a new TypeChecker struct (to hold the current_function id used to check if the current function is unconstrained).

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
