### PR TITLE
feat: Allow structs and arrays as globals

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1189,7 +1189,8 @@ impl<'a> Resolver<'a> {
         let stmt = match self.interner.statement(&global) {
             HirStatement::Let(let_expr) => let_expr,
             other => {
-                unreachable!("Expected global while evaluating array length, found {:?}", other)
+                dbg!(other);
+                return 0;
             }
         };
 

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -341,7 +341,10 @@ impl<'interner> Monomorphizer<'interner> {
 
             HirExpression::Lambda(lambda) => self.lambda(lambda),
 
-            HirExpression::MethodCall(_) | HirExpression::Error => unreachable!(),
+            HirExpression::MethodCall(_) => {
+                unreachable!("Encountered HirExpression::MethodCall during monomorphization")
+            }
+            HirExpression::Error => unreachable!("Encountered Error node during monomorphization"),
         }
     }
 

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -119,7 +119,7 @@ fn global_declaration() -> impl NoirParser<TopLevelStatement> {
     );
     let p = then_commit(p, global_type_annotation());
     let p = then_commit_ignore(p, just(Token::Assign));
-    let p = then_commit(p, literal_or_constructor(expression()).map_with_span(Expression::new));
+    let p = then_commit(p, literal_or_collection(expression()).map_with_span(Expression::new));
     p.map(LetStatement::new_let).map(TopLevelStatement::Global)
 }
 
@@ -974,8 +974,8 @@ fn literal() -> impl NoirParser<ExpressionKind> {
     })
 }
 
-fn literal_or_constructor(expr_parser: impl ExprParser) -> impl NoirParser<ExpressionKind> {
-    literal().or(constructor(expr_parser))
+fn literal_or_collection(expr_parser: impl ExprParser) -> impl NoirParser<ExpressionKind> {
+    choice((literal(), constructor(expr_parser.clone()), array_expr(expr_parser)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #439 

# Description

## Summary of changes

Allows non-integers such as structs and arrays to be used as globals, as long as they're initialized as constants. There is nothing verifying the sub-expressions for these are also constants currently though, so it is possible to have unexpected behavior (calling a function which tries to use the uninitialized global internally).

Attempting to use these in an array-length context will not crash the compiler, but will issue a somewhat confusing error that can be improved later.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

We'll need to document that, in addition to integers, arbitrary structs and arrays can also be defined as globals. They must be initialized to struct or array literals however.

We should likely mention the sub-expressions within these struct/array literals should also be literals themselves even though this is not enforced yet.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
