### PR TITLE
fix!: Fix returning of structs in ACIR

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -53,7 +53,9 @@ pub(crate) fn evaluate(
             witnesses.push(witness);
         }
         evaluator.public_inputs.extend(witnesses.clone());
-        evaluator.param_witnesses.entry(MAIN_RETURN_NAME.to_owned())
+        evaluator
+            .param_witnesses
+            .entry(MAIN_RETURN_NAME.to_owned())
             .or_default()
             .append(&mut witnesses);
     }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -53,7 +53,9 @@ pub(crate) fn evaluate(
             witnesses.push(witness);
         }
         evaluator.public_inputs.extend(witnesses.clone());
-        evaluator.param_witnesses.insert(MAIN_RETURN_NAME.to_owned(), witnesses);
+        evaluator.param_witnesses.entry(MAIN_RETURN_NAME.to_owned())
+            .or_default()
+            .append(&mut witnesses);
     }
 
     Ok(None)


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

Previously, the handling of Return instructions in ACIR-gen was incorrect since it would overwrite the "return" param_witness on each loop iteration. This fixes that by appending to it on each iteration instead.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
