### PR TITLE
Issue an error for non-integer array elements

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -244,6 +244,7 @@ impl Driver {
         main_function: FuncId,
     ) -> Result<CompiledProgram, ReportedError> {
         let program = monomorphize(main_function, &self.context.def_interner);
+        println!("{program}");
 
         let np_language = self.language.clone();
         let is_opcode_supported = acvm::default_is_opcode_supported(np_language.clone());

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -25,8 +25,12 @@ use iter_extended::vecmap;
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum UnresolvedType {
     FieldElement(CompTime),
-    Array(Option<UnresolvedTypeExpression>, Box<UnresolvedType>), // [4]Witness = Array(4, Witness)
-    Integer(CompTime, Signedness, u32),                           // u32 = Integer(unsigned, 32)
+
+    /// [Field; 4] = Array(4, Field)
+    /// The Span is for the array element, not the whole array
+    Array(Option<UnresolvedTypeExpression>, Box<UnresolvedType>, Span),
+
+    Integer(CompTime, Signedness, u32), // u32 = Integer(unsigned, 32)
     Bool(CompTime),
     Expression(UnresolvedTypeExpression),
     String(Option<UnresolvedTypeExpression>),
@@ -70,7 +74,7 @@ impl std::fmt::Display for UnresolvedType {
         use UnresolvedType::*;
         match self {
             FieldElement(is_const) => write!(f, "{is_const}Field"),
-            Array(len, typ) => match len {
+            Array(len, typ, _) => match len {
                 None => write!(f, "[{typ}]"),
                 Some(len) => write!(f, "[{typ}; {len}]"),
             },

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -63,6 +63,8 @@ pub enum ResolverError {
     ParserError(ParserError),
     #[error("Function is not defined in a contract yet sets its contract visibility")]
     ContractFunctionTypeInNormalFunction { span: Span },
+    #[error("Type {typ} cannot be used as an array element. Tuples, structs, and functions are currently unsupported as array elements")]
+    InvalidArrayElementType { typ: Type, span: Span },
 }
 
 impl ResolverError {
@@ -247,6 +249,11 @@ impl From<ResolverError> for Diagnostic {
             ResolverError::ContractFunctionTypeInNormalFunction { span } => Diagnostic::simple_error(
                 "Only functions defined within contracts can set their contract function type".into(),
                 "Non-contract functions cannot be 'open'".into(),
+                span,
+            ),
+            ResolverError::InvalidArrayElementType { typ, span } => Diagnostic::simple_error(
+                format!("Type {typ} cannot be used as an array element type"),
+                "Structs, tuples, and functions are currently unsupported as array elements".into(),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -613,10 +613,12 @@ fn generic_type_args(
 
 fn array_type(type_parser: impl NoirParser<UnresolvedType>) -> impl NoirParser<UnresolvedType> {
     just(Token::LeftBracket)
-        .ignore_then(type_parser)
+        .ignore_then(type_parser.map_with_span(|typ, span| (typ, span)))
         .then(just(Token::Semicolon).ignore_then(type_expression()).or_not())
         .then_ignore(just(Token::RightBracket))
-        .map(|(element_type, size)| UnresolvedType::Array(size, Box::new(element_type)))
+        .map(|((element_type, element_span), size)| {
+            UnresolvedType::Array(size, Box::new(element_type), element_span)
+        })
 }
 
 fn type_expression() -> impl NoirParser<UnresolvedTypeExpression> {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

Currently if a user attempts to use a struct or tuple type as an array element (e.g. `[(Field, Field); 2]`), they can be met with a confusing error:

```
The application panicked (crashed).
Message:  not yet implemented: Conversion to ObjectType is unimplemented for tuples
Location: crates/noirc_evaluator/src/ssa/context.rs:1196

This is a bug. Consider opening an issue at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 13 frames hidden ⋮                              
  14: noirc_evaluator::ssa::context::SsaContext::convert_type::h98111a9dd2cafb99
      at /Users/jakefecher/Code/Noir/noir/crates/noirc_evaluator/src/ssa/context.rs:1196
  15: noirc_evaluator::ssa::ssa_gen::IrGenerator::ssa_gen_literal::h04f54d2827620f08
      at /Users/jakefecher/Code/Noir/noir/crates/noirc_evaluator/src/ssa/ssa_gen.rs:588
  16: noirc_evaluator::ssa::ssa_gen::IrGenerator::ssa_gen_expression::ha4e42e0dba23e5f2
      at /Users/jakefecher/Code/Noir/noir/crates/noirc_evaluator/src/ssa/ssa_gen.rs:561
  17: noirc_evaluator::ssa::ssa_gen::IrGenerator::ssa_gen_let::h2a571f4136873395
      at /Users/jakefecher/Code/Noir/noir/crates/noirc_evaluator/src/ssa/ssa_gen.rs:495
...
```

This PR smooths over this a bit by issuing an error in the frontend if a struct or tuple is used as an array element, letting users know it is currently unimplemented. This check is just an approximation however, it will not catch generic array elements that are later resolved to structs or tuples during monomorphization.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
