### PR TITLE
chore: push recompilation for stdlib changes down to `fm`

### DIFF
--- a/crates/fm/build.rs
+++ b/crates/fm/build.rs
@@ -1,0 +1,20 @@
+use std::path::Path;
+
+/// Expects that the given directory is an existing path
+fn rerun_if_stdlib_changes(directory: &Path) {
+    for entry in std::fs::read_dir(directory).unwrap() {
+        let path = entry.unwrap().path();
+
+        if path.is_dir() {
+            rerun_if_stdlib_changes(&path);
+        } else {
+            // Tell Cargo that if the given file changes, to rerun this build script.
+            println!("cargo:rerun-if-changed={}", path.to_string_lossy());
+        }
+    }
+}
+
+fn main() {
+    let stdlib_src_dir = Path::new("../../noir_stdlib/");
+    rerun_if_stdlib_changes(stdlib_src_dir);
+}

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-dirs.workspace = true
 rustc_version = "0.4.0"
 build-data = "0.1.3"
 

--- a/crates/nargo/build.rs
+++ b/crates/nargo/build.rs
@@ -1,19 +1,4 @@
 use rustc_version::{version, Version};
-use std::path::Path;
-
-/// Expects that the given directory is an existing path
-fn rerun_if_stdlib_changes(directory: &Path) {
-    for entry in std::fs::read_dir(directory).unwrap() {
-        let path = entry.unwrap().path();
-
-        if path.is_dir() {
-            rerun_if_stdlib_changes(&path);
-        } else {
-            // Tell Cargo that if the given file changes, to rerun this build script.
-            println!("cargo:rerun-if-changed={}", path.to_string_lossy());
-        }
-    }
-}
 
 fn check_rustc_version() {
     assert!(
@@ -28,7 +13,4 @@ fn main() {
     build_data::set_GIT_COMMIT();
     build_data::set_GIT_DIRTY();
     build_data::no_debug_rebuilds();
-
-    let stdlib_src_dir = Path::new("../../noir_stdlib/");
-    rerun_if_stdlib_changes(stdlib_src_dir);
 }


### PR DESCRIPTION
# Related issue(s)

Prep work for #1063 

# Description

## Summary of changes

Currently we force a rebuild of `nargo` if the stdlib directory changes. I've pushed this further down the compilation stack so that we rebuild `fm` (which will then trigger a rebuild of `nargo`).

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
