### PR TITLE
fix: crash when typechecking fields that don't exist

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -86,9 +86,11 @@ impl<'interner> TypeChecker<'interner> {
                     let struct_type = struct_type.borrow();
 
                     for (field_name, field_pattern) in pattern_fields {
-                        let type_field =
-                            struct_type.get_field(&field_name.0.contents, generics).unwrap().0;
-                        self.bind_pattern(&field_pattern, type_field);
+                        if let Some((type_field, _)) =
+                            struct_type.get_field(&field_name.0.contents, generics)
+                        {
+                            self.bind_pattern(&field_pattern, type_field);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description

## Summary of changes

Fixes a crash when attempting to type check a field that isn't present. This can happen if the user destructures a struct into a struct pattern in a let statement.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
