### PR TITLE
feat: Add aztec3 builtins [DO NOT MERGE]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,11 +16,11 @@ dependencies = [
 
 [[package]]
 name = "acir"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f764b474e341efc3e8ee3d5054840b2fd2ac002f764fc2f4cd3569ce76badd1"
+checksum = "9b76c54a3b9f737aef1188d44aa825aabf7eded7b7b9787f1cd8cf9099d485e9"
 dependencies = [
- "acir_field 0.8.0",
+ "acir_field 0.8.1",
  "flate2",
  "rmp-serde",
  "serde",
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbca7df5192c7823d4108d2c34cadcfd30dca94506b9e9861f85f0ea747ddedc"
+checksum = "af00a72bc396a01827421225c6063ec9037553b6a7396d645ca07245471bb8e5"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.1",
@@ -78,12 +78,12 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5df175b6923bf9bb05ba973b017b0fa1356066be8f0ebadd3d2dbbc48bd5b"
+checksum = "28fcd9df61907de622111ec096070c3f1e89bfad43287e87c656d5841f8ad9ab"
 dependencies = [
- "acir 0.8.0",
- "acvm_stdlib 0.8.0",
+ "acir 0.8.1",
+ "acvm_stdlib 0.8.1",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -106,11 +106,11 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2bbc18fe9732ca3d93a2bf8f1a1ad99a003b565e7bc1ad5c67f69867449e8f"
+checksum = "3603a86990c4c0df1aaed6b957d09124659a92ba97f896e05393e1755baa6ab1"
 dependencies = [
- "acir 0.8.0",
+ "acir 0.8.1",
 ]
 
 [[package]]
@@ -904,7 +904,7 @@ name = "common"
 version = "0.1.0"
 source = "git+https://github.com/noir-lang/aztec_backend?rev=26178359a2251e885f15f0a4d1a686afda04aec9#26178359a2251e885f15f0a4d1a686afda04aec9"
 dependencies = [
- "acvm 0.8.0",
+ "acvm 0.8.1",
  "blake2",
  "dirs 3.0.2",
  "downloader",
@@ -2258,7 +2258,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm 0.8.1",
  "assert_cmd",
  "assert_fs",
  "build-data",
@@ -2287,7 +2287,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm 0.8.1",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -2303,7 +2303,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm 0.8.1",
  "iter-extended",
  "serde",
  "serde_json",
@@ -2315,7 +2315,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm 0.8.1",
  "clap 4.1.8",
  "fm",
  "iter-extended",
@@ -2341,7 +2341,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm 0.8.1",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -2357,7 +2357,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm 0.8.1",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 rust-version = "1.66"
 
 [workspace.dependencies]
-acvm = "0.8.0"
+acvm = "0.8.1"
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
@@ -124,11 +124,24 @@ impl InternalVarCache {
                     return *w;
                 }
             }
+
+            let mut assigned_witness = None;
+            for &id in ids {
+                let cached_var = self.get_or_compute_internal_var_unwrap(id, evaluator, ctx);
+                match cached_var.cached_witness() {
+                    Some(witness) => assigned_witness = Some(*witness),
+                    None => {}
+                }
+            }
+
             // We generate a witness and assigns it
-            let w = evaluator.create_intermediate_variable(Expression::from(value));
+            let w = match assigned_witness {
+                Some(assigned_witness) => assigned_witness,
+                None => evaluator.create_intermediate_variable(Expression::from(value)),
+            };
+
             for &id in ids {
                 let mut cached_var = self.get_or_compute_internal_var_unwrap(id, evaluator, ctx);
-                assert!(cached_var.cached_witness().is_none());
                 cached_var.set_witness(w);
                 self.update(cached_var);
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -164,6 +164,20 @@ pub(crate) fn evaluate(
                 output_values: vec![],
             }));
         }
+        Opcode::NotifyCreatedNote => {
+            outputs = vec![];
+            let inputs = vecmap(prepare_inputs(acir_gen, args, ctx, evaluator), |input| {
+                input.witness.into()
+            });
+
+            evaluator.push_opcode(AcirOpcode::Oracle(OracleData {
+                name: "notify_created_note".into(),
+                inputs,
+                input_values: vec![],
+                outputs: vec![],
+                output_values: vec![],
+            }));
+        },
     }
 
     // If more than witness is returned,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -16,7 +16,7 @@ use acvm::{
     acir::{
         circuit::{
             directives::{Directive, LogInfo},
-            opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode},
+            opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode, OracleData},
         },
         native_types::{Expression, Witness},
     },
@@ -130,6 +130,39 @@ pub(crate) fn evaluate(
             } else {
                 unreachable!();
             }
+        }
+        Opcode::Rand => {
+            outputs = vec![evaluator.add_witness_to_cs()];
+
+            evaluator.push_opcode(AcirOpcode::Oracle(OracleData {
+                name: "rand".into(),
+                inputs: vec![],
+                input_values: vec![],
+                outputs: outputs.clone(),
+                output_values: vec![],
+            }));
+        }
+        Opcode::Get2Notes => {
+            outputs = prepare_outputs(&mut acir_gen.memory, instruction_id, 26, ctx, evaluator);
+
+            evaluator.push_opcode(AcirOpcode::Oracle(OracleData {
+                name: "get_2_notes".into(),
+                inputs: vec![],
+                input_values: vec![],
+                outputs: outputs.clone(),
+                output_values: vec![],
+            }));
+        }
+        Opcode::GetNNotes => {
+            outputs = prepare_outputs(&mut acir_gen.memory, instruction_id, 26, ctx, evaluator);
+
+            evaluator.push_opcode(AcirOpcode::Oracle(OracleData {
+                name: "get_n_notes".into(),
+                inputs: vec![],
+                input_values: vec![],
+                outputs: outputs.clone(),
+                output_values: vec![],
+            }));
         }
     }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -1,4 +1,4 @@
-use acvm::acir::native_types::Witness;
+use acvm::acir::native_types::{Expression, Witness};
 use noirc_abi::MAIN_RETURN_NAME;
 
 use crate::{
@@ -50,7 +50,7 @@ pub(crate) fn evaluate(
                     "we do not allow private ABI inputs to be returned as public outputs",
                 )));
             }
-            witnesses.push(witness);
+            witnesses.push(evaluator.create_intermediate_variable(Expression::from(witness)));
         }
         evaluator.public_inputs.extend(witnesses.clone());
         evaluator

--- a/crates/noirc_evaluator/src/ssa/builtin.rs
+++ b/crates/noirc_evaluator/src/ssa/builtin.rs
@@ -19,6 +19,7 @@ pub(crate) enum Opcode {
     Sort,
 
     Rand,
+    NotifyCreatedNote,
     Get2Notes,
     GetNNotes,
 }
@@ -44,6 +45,7 @@ impl Opcode {
             "rand" => Some(Opcode::Rand),
             "get_2_notes" => Some(Opcode::Get2Notes),
             "get_n_notes" => Some(Opcode::GetNNotes),
+            "notify_created_note" => Some(Opcode::NotifyCreatedNote),
             "println" => {
                 Some(Opcode::Println(PrintlnInfo { is_string_output: false, show_output: true }))
             }
@@ -74,6 +76,7 @@ impl Opcode {
             Opcode::Rand => "rand",
             Opcode::Get2Notes => "get_2_notes",
             Opcode::GetNNotes => "get_n_notes",
+            Opcode::NotifyCreatedNote => "notify_created_note",
         }
     }
 
@@ -108,6 +111,7 @@ impl Opcode {
             | Opcode::ToBits(_)
             | Opcode::ToRadix(_)
             | Opcode::Println(_)
+            | Opcode::NotifyCreatedNote
             | Opcode::Sort => BigUint::zero(), //pointers do not overflow
         }
     }
@@ -145,6 +149,7 @@ impl Opcode {
             Opcode::Rand => (1, ObjectType::NativeField),
             Opcode::Get2Notes => (26, ObjectType::NativeField),
             Opcode::GetNNotes => (13 * 1024, ObjectType::NativeField),
+            Opcode::NotifyCreatedNote => (0, ObjectType::NotAnObject),
         }
     }
 }

--- a/crates/noirc_evaluator/src/ssa/builtin.rs
+++ b/crates/noirc_evaluator/src/ssa/builtin.rs
@@ -143,8 +143,8 @@ impl Opcode {
                 (ctx.mem[a].len, ctx.mem[a].element_type)
             }
             Opcode::Rand => (1, ObjectType::NativeField),
-            Opcode::Get2Notes => (1, ObjectType::NotAnObject),
-            Opcode::GetNNotes => (1, ObjectType::NotAnObject),
+            Opcode::Get2Notes => (26, ObjectType::NativeField),
+            Opcode::GetNNotes => (13 * 1024, ObjectType::NativeField),
         }
     }
 }

--- a/crates/noirc_evaluator/src/ssa/builtin.rs
+++ b/crates/noirc_evaluator/src/ssa/builtin.rs
@@ -17,6 +17,10 @@ pub(crate) enum Opcode {
     ToRadix(Endian),
     Println(PrintlnInfo),
     Sort,
+
+    Rand,
+    Get2Notes,
+    GetNNotes,
 }
 
 impl std::fmt::Display for Opcode {
@@ -37,6 +41,9 @@ impl Opcode {
             "to_be_bits" => Some(Opcode::ToBits(Endian::Big)),
             "to_le_radix" => Some(Opcode::ToRadix(Endian::Little)),
             "to_be_radix" => Some(Opcode::ToRadix(Endian::Big)),
+            "rand" => Some(Opcode::Rand),
+            "get_2_notes" => Some(Opcode::Get2Notes),
+            "get_n_notes" => Some(Opcode::GetNNotes),
             "println" => {
                 Some(Opcode::Println(PrintlnInfo { is_string_output: false, show_output: true }))
             }
@@ -64,6 +71,9 @@ impl Opcode {
             }
             Opcode::Println(_) => "println",
             Opcode::Sort => "arraysort",
+            Opcode::Rand => "rand",
+            Opcode::Get2Notes => "get_2_notes",
+            Opcode::GetNNotes => "get_n_notes",
         }
     }
 
@@ -92,9 +102,13 @@ impl Opcode {
                     }
                 }
             }
-            Opcode::ToBits(_) | Opcode::ToRadix(_) | Opcode::Println(_) | Opcode::Sort => {
-                BigUint::zero()
-            } //pointers do not overflow
+            Opcode::Rand => ObjectType::NativeField.max_size(),
+            Opcode::Get2Notes
+            | Opcode::GetNNotes
+            | Opcode::ToBits(_)
+            | Opcode::ToRadix(_)
+            | Opcode::Println(_)
+            | Opcode::Sort => BigUint::zero(), //pointers do not overflow
         }
     }
 
@@ -128,6 +142,9 @@ impl Opcode {
                 let a = super::mem::Memory::deref(ctx, args[0]).unwrap();
                 (ctx.mem[a].len, ctx.mem[a].element_type)
             }
+            Opcode::Rand => (1, ObjectType::NativeField),
+            Opcode::Get2Notes => (1, ObjectType::NotAnObject),
+            Opcode::GetNNotes => (1, ObjectType::NotAnObject),
         }
     }
 }

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -888,7 +888,7 @@ impl SsaContext {
                 };
                 return self.new_instruction(op_a, self.mem[a].element_type);
             } else {
-                unreachable!("Index expression must be for an array");
+                unreachable!("Index expression must be for an array, found {lhs_type:?} instead");
             }
         } else if matches!(lhs_type, ObjectType::Pointer(_)) {
             if let Some(Instruction {

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -995,7 +995,7 @@ impl SsaContext {
                 self.new_instruction_inline(op_a, l_type, stack_frame);
             }
         } else {
-            unreachable!("invalid type, expected arrays");
+            unreachable!("invalid type, expected arrays, {l_type:?}, {r_type:?}");
         }
     }
 

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -526,6 +526,9 @@ fn cse_block_with_anchor(
                 match opcode {
                     // We do not simplify print statements
                     builtin::Opcode::Println(_) => (),
+                    builtin::Opcode::Rand => (),
+                    builtin::Opcode::Get2Notes => (),
+                    builtin::Opcode::GetNNotes => (),
                     _ => {
                         let args = args.iter().map(|arg| {
                             NodeEval::from_id(ctx, *arg).into_const_value().map(|f| f.to_u128())

--- a/crates/noirc_evaluator/src/ssa/ssa_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen.rs
@@ -249,8 +249,7 @@ impl IrGenerator {
                 self.find_variable(Self::lvalue_ident_def(array.as_ref())).unwrap()
             }
             LValue::MemberAccess { object, field_index, .. } => {
-                let ident_def = Self::lvalue_ident_def(object.as_ref());
-                let val = self.find_variable(ident_def).unwrap();
+                let val = self.lvalue_to_value(object);
                 val.get_field_member(*field_index)
             }
         }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -512,6 +512,9 @@ impl<'interner> TypeChecker<'interner> {
         use crate::BinaryOpKind::{Equal, NotEqual};
         use Type::*;
         match (lhs_type, rhs_type)  {
+            // Avoid reporting errors multiple times
+            (Error, _) | (_,Error) => Ok(Bool(CompTime::Yes(None))),
+
             // Matches on PolymorphicInteger and TypeVariable must be first to follow any type
             // bindings.
             (PolymorphicInteger(comptime, int), other)
@@ -571,9 +574,6 @@ impl<'interner> TypeChecker<'interner> {
                 let comptime = comptime_x.and(comptime_y, op.location.span);
                 Ok(Bool(comptime))
             }
-
-            // Avoid reporting errors multiple times
-            (Error, _) | (_,Error) => Ok(Bool(CompTime::Yes(None))),
 
             // Special-case == and != for arrays
             (Array(x_size, x_type), Array(y_size, y_type)) if matches!(op.kind, Equal | NotEqual) => {
@@ -728,6 +728,8 @@ impl<'interner> TypeChecker<'interner> {
 
         use Type::*;
         match (lhs_type, rhs_type)  {
+            (Error, _) | (_,Error) => Ok(Error),
+
             // Matches on PolymorphicInteger and TypeVariable must be first so that we follow any type
             // bindings.
             (PolymorphicInteger(comptime, int), other)
@@ -794,7 +796,6 @@ impl<'interner> TypeChecker<'interner> {
             (Tuple(_), _) | (_, Tuple(_)) => Err(make_error("Tuples cannot be used in an infix operation".to_string())),
 
             // An error type on either side will always return an error
-            (Error, _) | (_,Error) => Ok(Error),
             (Unit, _) | (_,Unit) => Ok(Unit),
 
             // The result of two Fields is always a witness


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

Adds `rand`, `get_2_notes`, and `get_n_notes` (stubbed) as builtins which translate to oracle calls in acvm

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
