### PR TITLE
chore(ssa): Rename ObjectType::Pointer to ObjectType::ArrayPointer

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/internal_var_cache.rs
@@ -73,7 +73,7 @@ impl InternalVarCache {
                             variable.witness.unwrap_or_else(|| evaluator.add_witness_to_cs());
                         InternalVar::from_witness(witness)
                     }
-                    ObjectType::Pointer(_) | ObjectType::NotAnObject => return None,
+                    ObjectType::ArrayPointer(_) | ObjectType::NotAnObject => return None,
                     ObjectType::Function => {
                         unreachable!("ICE: functions should have been removed by this stage")
                     }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -50,7 +50,7 @@ pub(crate) fn evaluate(
             let l_c =
                 acir_gen.var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
             outputs = to_radix_base(l_c.expression(), 2, bit_size, endianess, evaluator);
-            if let ObjectType::Pointer(a) = res_type {
+            if let ObjectType::ArrayPointer(a) = res_type {
                 acir_gen.memory.map_array(a, &outputs, ctx);
             }
         }
@@ -61,7 +61,7 @@ pub(crate) fn evaluate(
             let l_c =
                 acir_gen.var_cache.get_or_compute_internal_var_unwrap(args[0], evaluator, ctx);
             outputs = to_radix_base(l_c.expression(), radix, limb_size, endianess, evaluator);
-            if let ObjectType::Pointer(a) = res_type {
+            if let ObjectType::ArrayPointer(a) = res_type {
                 acir_gen.memory.map_array(a, &outputs, ctx);
             }
         }
@@ -125,7 +125,7 @@ pub(crate) fn evaluate(
                 bits,
                 sort_by: vec![0],
             }));
-            if let node::ObjectType::Pointer(a) = res_type {
+            if let node::ObjectType::ArrayPointer(a) = res_type {
                 acir_gen.memory.map_array(a, &outputs, ctx);
             } else {
                 unreachable!();
@@ -167,7 +167,7 @@ fn resolve_node_id(
             match node_obj_type {
                 // If the `Variable` represents a Pointer
                 // Then we know that it is an `Array`
-                node::ObjectType::Pointer(a) => resolve_array(a, acir_gen, cfg, evaluator),
+                node::ObjectType::ArrayPointer(a) => resolve_array(a, acir_gen, cfg, evaluator),
                 // If it is not a pointer, we attempt to fetch the witness associated with it
                 _ => match v.witness {
                     Some(w) => {
@@ -229,7 +229,7 @@ fn prepare_outputs(
     let outputs = vecmap(0..output_nb, |_| evaluator.add_witness_to_cs());
 
     let l_obj = ctx.try_get_node(pointer).unwrap();
-    if let node::ObjectType::Pointer(a) = l_obj.get_type() {
+    if let node::ObjectType::ArrayPointer(a) = l_obj.get_type() {
         memory_map.map_array(a, &outputs, ctx);
     }
     outputs
@@ -251,7 +251,7 @@ fn evaluate_println(
 
     let obj_type = ctx.object_type(node_id);
     match obj_type {
-        ObjectType::Pointer(array_id) => {
+        ObjectType::ArrayPointer(array_id) => {
             let mem_array = &ctx.mem[array_id];
             let mut field_elements = Vec::new();
             for idx in 0..mem_array.len {

--- a/crates/noirc_evaluator/src/ssa/block.rs
+++ b/crates/noirc_evaluator/src/ssa/block.rs
@@ -108,7 +108,7 @@ impl BasicBlock {
                         result.insert(*a);
                     }
                     node::Operation::Intrinsic(..) => {
-                        if let node::ObjectType::Pointer(a) = ins.res_type {
+                        if let node::ObjectType::ArrayPointer(a) = ins.res_type {
                             result.insert(a);
                         }
                     }
@@ -118,7 +118,7 @@ impl BasicBlock {
                         }
                         if let Some(f) = ctx.try_get_ssa_func(*func) {
                             for typ in &f.result_types {
-                                if let node::ObjectType::Pointer(a) = typ {
+                                if let node::ObjectType::ArrayPointer(a) = typ {
                                     result.insert(*a);
                                 }
                             }

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -535,7 +535,7 @@ impl DecisionTree {
                 }
             }
             _ => {
-                if let ObjectType::Pointer(a) = ins1.res_type {
+                if let ObjectType::ArrayPointer(a) = ins1.res_type {
                     stack.new_array(a);
                 }
             }
@@ -666,19 +666,19 @@ impl DecisionTree {
                 Operation::Intrinsic(_, _) => {
                     stack.push(ins_id);
                     if ctx.under_assumption(ass_value) {
-                        if let ObjectType::Pointer(a) = ins.res_type {
+                        if let ObjectType::ArrayPointer(a) = ins.res_type {
                             if stack.created_arrays[&a] != stack.block {
                                 let array = &ctx.mem[a].clone();
                                 let name = array.name.to_string() + DUPLICATED;
                                 ctx.new_array(&name, array.element_type, array.len, None);
                                 let array_dup = ctx.mem.last_id();
                                 let ins2 = ctx.instruction_mut(ins_id);
-                                ins2.res_type = ObjectType::Pointer(array_dup);
+                                ins2.res_type = ObjectType::ArrayPointer(array_dup);
 
                                 let mut memcpy_stack = StackFrame::new(stack.block);
                                 ctx.memcpy_inline(
                                     ins.res_type,
-                                    ObjectType::Pointer(array_dup),
+                                    ObjectType::ArrayPointer(array_dup),
                                     &mut memcpy_stack,
                                 );
                                 self.apply_condition_to_instructions(

--- a/crates/noirc_evaluator/src/ssa/function.rs
+++ b/crates/noirc_evaluator/src/ssa/function.rs
@@ -68,7 +68,7 @@ impl SsaFunction {
         let mut decision = DecisionTree::new(&ir_gen.context);
         let mut builder = TreeBuilder::new(self.entry_block);
         for (arg, _) in &self.arguments {
-            if let ObjectType::Pointer(a) = ir_gen.context.object_type(*arg) {
+            if let ObjectType::ArrayPointer(a) = ir_gen.context.object_type(*arg) {
                 builder.stack.created_arrays.insert(a, self.entry_block);
             }
         }
@@ -164,7 +164,7 @@ impl IrGenerator {
         for typ in return_types {
             func.result_types.push(match typ {
                 Type::Unit => ObjectType::NotAnObject,
-                Type::Array(_, _) => ObjectType::Pointer(crate::ssa::mem::ArrayId::dummy()),
+                Type::Array(_, _) => ObjectType::ArrayPointer(crate::ssa::mem::ArrayId::dummy()),
                 _ => self.context.convert_type(&typ),
             });
         }
@@ -318,7 +318,7 @@ impl IrGenerator {
                     let elem_type = self.context.convert_type(&elem_type);
                     let array_id = self.context.new_array("", elem_type, len as u32, None).1;
                     returned_arrays.push((array_id, i as u32));
-                    ObjectType::Pointer(array_id)
+                    ObjectType::ArrayPointer(array_id)
                 }
                 other => self.context.convert_type(&other),
             };
@@ -338,7 +338,7 @@ impl IrGenerator {
         let result_type = if len > 1 {
             //We create an array that will contain the result and set the res_type to point to that array
             let result_index = self.new_array(&format!("{op}_result"), elem_type, len, None).1;
-            node::ObjectType::Pointer(result_index)
+            node::ObjectType::ArrayPointer(result_index)
         } else {
             elem_type
         };

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -206,7 +206,7 @@ fn inline(
 
     //1. return arrays
     for arg_caller in arrays.iter() {
-        if let node::ObjectType::Pointer(a) = ssa_func.result_types[arg_caller.1 as usize] {
+        if let node::ObjectType::ArrayPointer(a) = ssa_func.result_types[arg_caller.1 as usize] {
             stack_frame.array_map.insert(a, arg_caller.0);
             stack_frame.return_arrays.push(arg_caller.0);
         }
@@ -215,8 +215,8 @@ fn inline(
     //2. by copy parameters:
     for (&arg_caller, &arg_function) in args.iter().zip(&func_arg) {
         //pass by-ref const array arguments
-        if let node::ObjectType::Pointer(x) = ctx.object_type(arg_function.0) {
-            if let node::ObjectType::Pointer(y) = ctx.object_type(arg_caller) {
+        if let node::ObjectType::ArrayPointer(x) = ctx.object_type(arg_function.0) {
+            if let node::ObjectType::ArrayPointer(y) = ctx.object_type(arg_caller) {
                 if !arg_function.1 && !stack_frame.array_map.contains_key(&x) {
                     stack_frame.array_map.insert(x, y);
                     continue;
@@ -276,7 +276,7 @@ fn inline_in_block(
             let mut array_id = None;
             let mut clone = ins.clone();
 
-            if let node::ObjectType::Pointer(id) = ins.res_type {
+            if let node::ObjectType::ArrayPointer(id) = ins.res_type {
                 //We collect data here for potential mapping using the array_map below.
                 array_id = Some(id);
             }
@@ -342,7 +342,7 @@ fn inline_in_block(
                     let mut new_ins = new_cloned_instruction(clone, stack_frame.block);
                     if let Some(id) = array_id {
                         let new_id = stack_frame.get_or_default(id);
-                        new_ins.res_type = node::ObjectType::Pointer(new_id);
+                        new_ins.res_type = node::ObjectType::ArrayPointer(new_id);
                     }
 
                     let err = optimizations::simplify(ctx, &mut new_ins);
@@ -359,7 +359,7 @@ fn inline_in_block(
                     if let Mark::ReplaceWith(replacement) = new_ins.mark {
                         if let Some(id) = array_id {
                             if let Entry::Occupied(mut entry) = stack_frame.array_map.entry(id) {
-                                if let node::ObjectType::Pointer(new_id) =
+                                if let node::ObjectType::ArrayPointer(new_id) =
                                     ctx[replacement].get_type()
                                 {
                                     //we now map the array to rhs array
@@ -437,7 +437,7 @@ impl node::Operation {
                         if b != a {
                             let new_var = node::Variable {
                                 id: NodeId::dummy(),
-                                obj_type: node::ObjectType::Pointer(b),
+                                obj_type: node::ObjectType::ArrayPointer(b),
                                 name: String::new(),
                                 root: None,
                                 def: None,

--- a/crates/noirc_evaluator/src/ssa/mem.rs
+++ b/crates/noirc_evaluator/src/ssa/mem.rs
@@ -71,7 +71,7 @@ impl Memory {
     //dereference a pointer
     pub(super) fn deref(ctx: &SsaContext, id: NodeId) -> Option<ArrayId> {
         ctx.try_get_node(id).and_then(|var| match var.get_type() {
-            node::ObjectType::Pointer(a) => Some(a),
+            node::ObjectType::ArrayPointer(a) => Some(a),
             _ => None,
         })
     }

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -181,7 +181,7 @@ pub(crate) enum ObjectType {
     Boolean,
     Unsigned(u32), //bit size
     Signed(u32),   //bit size
-    Pointer(ArrayId),
+    ArrayPointer(ArrayId),
     Function,
     NotAnObject, //not an object
 }
@@ -212,7 +212,7 @@ impl ObjectType {
             ObjectType::NotAnObject => 0,
             ObjectType::Signed(c) => *c,
             ObjectType::Unsigned(c) => *c,
-            ObjectType::Pointer(_) => 0,
+            ObjectType::ArrayPointer(_) => 0,
             ObjectType::Function => 0,
         }
     }
@@ -229,7 +229,7 @@ impl ObjectType {
 
     pub(crate) fn field_to_type(&self, f: FieldElement) -> FieldElement {
         match self {
-            ObjectType::NotAnObject | ObjectType::Pointer(_) => {
+            ObjectType::NotAnObject | ObjectType::ArrayPointer(_) => {
                 unreachable!()
             }
             ObjectType::NativeField => f,

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -83,7 +83,7 @@ fn evaluate_intrinsic(
             let bit_count = args[1] as u32;
             let mut result = Vec::new();
 
-            if let ObjectType::Pointer(a) = res_type {
+            if let ObjectType::ArrayPointer(a) = res_type {
                 for i in 0..bit_count {
                     let index = ctx.get_or_create_const(
                         FieldElement::from(i as i128),
@@ -132,7 +132,7 @@ fn evaluate_intrinsic(
             }
             let mut result = Vec::new();
 
-            if let ObjectType::Pointer(a) = res_type {
+            if let ObjectType::ArrayPointer(a) = res_type {
                 for (i, item) in element.iter().enumerate() {
                     let index = ctx.get_or_create_const(
                         FieldElement::from(i as i128),
@@ -280,13 +280,13 @@ fn cse_block_with_anchor(
 
             match &operator {
                 Operation::Binary(binary) => {
-                    if let ObjectType::Pointer(a) = ctx.object_type(binary.lhs) {
+                    if let ObjectType::ArrayPointer(a) = ctx.object_type(binary.lhs) {
                         //No CSE for arrays because they are not in SSA form
                         //We could improve this in future by checking if the arrays are immutable or not modified in-between
                         let id = ctx.get_dummy_load(a);
                         anchor.push_mem_instruction(ctx, id)?;
 
-                        if let ObjectType::Pointer(a) = ctx.object_type(binary.rhs) {
+                        if let ObjectType::ArrayPointer(a) = ctx.object_type(binary.rhs) {
                             let id = ctx.get_dummy_load(a);
                             anchor.push_mem_instruction(ctx, id)?;
                         }
@@ -446,7 +446,7 @@ fn cse_block_with_anchor(
                     }
                     if let Some(f) = ctx.try_get_ssa_func(*func) {
                         for typ in &f.result_types {
-                            if let ObjectType::Pointer(a) = typ {
+                            if let ObjectType::ArrayPointer(a) = typ {
                                 let id = ctx.get_dummy_store(*a);
                                 anchor.push_mem_instruction(ctx, id)?;
                             }
@@ -455,7 +455,7 @@ fn cse_block_with_anchor(
                     //Add dummy load for function arguments:
                     for arg in arguments {
                         if let Some(obj) = ctx.try_get_node(*arg) {
-                            if let ObjectType::Pointer(a) = obj.get_type() {
+                            if let ObjectType::ArrayPointer(a) = obj.get_type() {
                                 let id = ctx.get_dummy_load(a);
                                 anchor.push_mem_instruction(ctx, id)?;
                             }
@@ -474,14 +474,14 @@ fn cse_block_with_anchor(
 
                     for arg in args {
                         if let Some(obj) = ctx.try_get_node(*arg) {
-                            if let ObjectType::Pointer(a) = obj.get_type() {
+                            if let ObjectType::ArrayPointer(a) = obj.get_type() {
                                 let id = ctx.get_dummy_load(a);
                                 anchor.push_mem_instruction(ctx, id)?;
                                 activate_cse = false;
                             }
                         }
                     }
-                    if let ObjectType::Pointer(a) = ins.res_type {
+                    if let ObjectType::ArrayPointer(a) = ins.res_type {
                         let id = ctx.get_dummy_store(a);
                         anchor.push_mem_instruction(ctx, id)?;
                         activate_cse = false;

--- a/crates/noirc_evaluator/src/ssa/ssa_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen.rs
@@ -414,7 +414,7 @@ impl IrGenerator {
         obj_type: node::ObjectType,
         value_id: NodeId,
     ) -> Result<Value, RuntimeError> {
-        let id = if let node::ObjectType::Pointer(a) = obj_type {
+        let id = if let node::ObjectType::ArrayPointer(a) = obj_type {
             let len = self.context.mem[a].len;
             let el_type = self.context.mem[a].element_type;
             self.context.new_array(&variable_name, el_type, len, definition_id).0
@@ -533,7 +533,7 @@ impl IrGenerator {
                 // Evaluate the 'array' expression
                 let expr_node = self.ssa_gen_expression(&indexed_expr.collection)?.unwrap_id();
                 let array = match self.context.object_type(expr_node) {
-                    ObjectType::Pointer(array_id) => &self.context.mem[array_id],
+                    ObjectType::ArrayPointer(array_id) => &self.context.mem[array_id],
                     other => unreachable!("Expected Pointer type, found {:?}", other),
                 };
                 let array_id = array.id;


### PR DESCRIPTION
# Related issue(s)

Resolves #757

# Description

## Summary of changes

Renames `ObjectType::Pointer` to more explicit `ObjectType::ArrayPointer`

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
