### PR TITLE
fix: correct test for mutually exclusive feature flags

### DIFF
--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -22,6 +22,7 @@ aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "ht
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
 
 [features]
+default = ["plonk_bn254"]
 # The plonk backend can only use bn254, so we do not specify the field
 plonk_bn254 = ["aztec_backend"]
 marlin = ["marlin_arkworks_backend/bls12_381"]

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -22,7 +22,6 @@ aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "ht
 marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
 
 [features]
-default = ["plonk_bn254"]
 # The plonk backend can only use bn254, so we do not specify the field
 plonk_bn254 = ["aztec_backend"]
 marlin = ["marlin_arkworks_backend/bls12_381"]

--- a/crates/nargo/src/backends.rs
+++ b/crates/nargo/src/backends.rs
@@ -10,6 +10,17 @@ cfg_if::cfg_if! {
         compile_error!("please specify a backend to compile with");
     }
 }
-// XXX: This works  because there are only two features, we want to say only one of these can be enabled. (feature xor)
-#[cfg(all(feature = "plonk", feature = "marlin"))]
-compile_error!("feature \"plonk\"  and feature \"marlin\" cannot be enabled at the same time");
+
+// As we have 3 feature flags we must test all 3 potential pairings to ensure they're mutually exclusive.
+#[cfg(all(feature = "plonk_bn254", feature = "plonk_bn254_wasm"))]
+compile_error!(
+    "feature \"plonk_bn254\"  and feature \"plonk_bn254_wasm\" cannot be enabled at the same time"
+);
+#[cfg(all(feature = "plonk_bn254_wasm", feature = "marlin"))]
+compile_error!(
+    "feature \"plonk_bn254_wasm\"  and feature \"marlin\" cannot be enabled at the same time"
+);
+#[cfg(all(feature = "plonk_bn254", feature = "marlin"))]
+compile_error!(
+    "feature \"plonk_bn254\"  and feature \"marlin\" cannot be enabled at the same time"
+);


### PR DESCRIPTION
# Related issue(s)

Resolves #1084 

# Description

## Summary of changes

I've updated the checks to match the feature flags which are in use.

I've also removed the default feature flag for the `nargo` package. This should be set in the `nargo_cli` crate (and by any direct consumers of `nargo`)

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
