### PR TITLE
feat(nargo): remove misleading quotes in generated `Prover.toml`

### DIFF
--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -66,12 +66,12 @@ fn check_from_path<P: AsRef<Path>>(p: P, compile_options: &CompileOptions) -> Re
 fn build_placeholder_input_map(
     parameters: Vec<AbiParameter>,
     return_type: Option<AbiType>,
-) -> BTreeMap<String, &'static str> {
-    let default_value = |typ: AbiType| {
+) -> BTreeMap<String, toml::Value> {
+    let default_value = |typ: AbiType| -> toml::Value {
         if matches!(typ, AbiType::Array { .. }) {
-            "[]"
+            toml::Value::Array(Vec::new())
         } else {
-            ""
+            toml::Value::String("".to_owned())
         }
     };
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

Currently running `nargo check` on a new project generates the `Prover.toml` file as below

```toml
x = ""
y = "[]"
```

This isn't ideal as unless users remove the quotes around the array, they'll get the error message `Error: cannot parse a string toml type into Array { length: 2, typ: Field }`.

This PR updates `build_placeholder_input_map` so that we get the generated toml file

```toml
x = ""
y = []
```


## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
