### PR TITLE
chore: move backends to `nargo_cli` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,10 +2244,6 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.3.2"
 dependencies = [
- "barretenberg_static_lib",
- "barretenberg_wasm",
- "cfg-if 1.0.0",
- "marlin_arkworks_backend",
  "rustc_version 0.4.0",
  "serde",
  "thiserror",
@@ -2261,13 +2257,17 @@ dependencies = [
  "acvm 0.8.0",
  "assert_cmd",
  "assert_fs",
+ "barretenberg_static_lib",
+ "barretenberg_wasm",
  "build-data",
+ "cfg-if 1.0.0",
  "clap 4.1.8",
  "color-eyre",
  "const_format",
  "dirs 4.0.0",
  "hex",
  "iter-extended",
+ "marlin_arkworks_backend",
  "nargo",
  "noirc_abi",
  "noirc_driver",

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -11,19 +11,7 @@ edition.workspace = true
 rustc_version = "0.4.0"
 
 [dependencies]
-cfg-if.workspace = true
 toml.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 
-# Backends
-aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "26178359a2251e885f15f0a4d1a686afda04aec9" }
-aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "26178359a2251e885f15f0a4d1a686afda04aec9" }
-marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
-
-[features]
-default = ["plonk_bn254"]
-# The plonk backend can only use bn254, so we do not specify the field
-plonk_bn254 = ["aztec_backend"]
-marlin = ["marlin_arkworks_backend/bls12_381"]
-plonk_bn254_wasm = ["aztec_wasm_backend"]

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -6,5 +6,4 @@
 //! This name was used because it sounds like `cargo` and
 //! Noir Package Manager abbreviated is npm, which is already taken.
 
-pub mod backends;
 pub mod manifest;

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -17,6 +17,7 @@ rustc_version = "0.4.0"
 build-data = "0.1.3"
 
 [dependencies]
+cfg-if.workspace = true
 clap.workspace = true
 dirs.workspace = true
 url.workspace = true
@@ -36,11 +37,20 @@ termcolor = "1.1.2"
 tempdir = "0.3.7"
 color-eyre = "0.6.2"
 
+# Backends
+aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "26178359a2251e885f15f0a4d1a686afda04aec9" }
+aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "26178359a2251e885f15f0a4d1a686afda04aec9" }
+marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
+
 [dev-dependencies]
 assert_cmd = "2.0.8"
 assert_fs = "1.0.10"
 predicates = "2.1.5"
 
 [features]
-default = ["nargo/plonk_bn254"]
+default = ["plonk_bn254"]
+# The plonk backend can only use bn254, so we do not specify the field
+plonk_bn254 = ["aztec_backend"]
+marlin = ["marlin_arkworks_backend/bls12_381"]
+plonk_bn254_wasm = ["aztec_wasm_backend"]
 

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -1,11 +1,11 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "plonk_bn254")] {
-        pub use aztec_backend::Plonk as ConcreteBackend;
+        pub(crate) use aztec_backend::Plonk as ConcreteBackend;
     } else if #[cfg(feature = "plonk_bn254_wasm")] {
-        pub use aztec_wasm_backend::Plonk as ConcreteBackend;
+        pub(crate) use aztec_wasm_backend::Plonk as ConcreteBackend;
     } else if #[cfg(feature = "marlin")] {
         // R1CS_MARLIN_ARKWORKS
-        pub use marlin_arkworks_backend::Marlin as ConcreteBackend;
+        pub(crate) use marlin_arkworks_backend::Marlin as ConcreteBackend;
     } else {
         compile_error!("please specify a backend to compile with");
     }

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -27,7 +27,7 @@ pub(crate) fn run(args: CheckCommand, config: NargoConfig) -> Result<(), CliErro
 }
 
 fn check_from_path<P: AsRef<Path>>(p: P, compile_options: &CompileOptions) -> Result<(), CliError> {
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
 
     let mut driver = Resolver::resolve_root_manifest(p.as_ref(), backend.np_language())?;
 

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -15,7 +15,7 @@ pub(crate) struct CodegenVerifierCommand {
 pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(), CliError> {
     let compiled_program = compile_circuit(&config.program_dir, &args.compile_options)?;
 
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
     #[allow(deprecated)]
     let smart_contract_string = backend.eth_contract_from_cs(compiled_program.circuit);
 

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -42,7 +42,7 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
 }
 
 fn setup_driver(program_dir: &Path) -> Result<Driver, DependencyResolutionError> {
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
     Resolver::resolve_root_manifest(program_dir, backend.np_language())
 }
 

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -67,7 +67,7 @@ pub(crate) fn execute_program(
 ) -> Result<WitnessMap, CliError> {
     let mut solved_witness = compiled_program.abi.encode(inputs_map, None)?;
 
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
     let mut blocks = Blocks::default();
     let (unresolved_opcodes, oracles) = backend.solve(
         &mut solved_witness,

--- a/crates/nargo_cli/src/cli/gates_cmd.rs
+++ b/crates/nargo_cli/src/cli/gates_cmd.rs
@@ -25,7 +25,7 @@ fn count_gates_with_path<P: AsRef<Path>>(
 ) -> Result<(), CliError> {
     let compiled_program = compile_circuit(program_dir.as_ref(), compile_options)?;
     let num_opcodes = compiled_program.circuit.opcodes.len();
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
 
     println!(
         "Total ACIR opcodes generated for language {:?}: {}",

--- a/crates/nargo_cli/src/cli/preprocess_cmd.rs
+++ b/crates/nargo_cli/src/cli/preprocess_cmd.rs
@@ -34,7 +34,7 @@ pub(crate) fn preprocess_with_path<P: AsRef<Path>>(
     preprocess_dir: P,
     circuit: &Circuit,
 ) -> Result<(PathBuf, PathBuf), CliError> {
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
     let (proving_key, verification_key) = backend.preprocess(circuit);
 
     // Save a checksum of the circuit to compare against during proving and verification.

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -74,7 +74,7 @@ pub(crate) fn prove_with_path<P: AsRef<Path>>(
             let compiled_program =
                 super::compile_cmd::compile_circuit(program_dir.as_ref(), compile_options)?;
 
-            let backend = nargo::backends::ConcreteBackend;
+            let backend = crate::backends::ConcreteBackend;
             let (proving_key, verification_key) = backend.preprocess(&compiled_program.circuit);
             (compiled_program, proving_key, verification_key)
         }
@@ -102,7 +102,7 @@ pub(crate) fn prove_with_path<P: AsRef<Path>>(
         Format::Toml,
     )?;
 
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
     let proof = backend.prove_with_pk(&compiled_program.circuit, solved_witness, &proving_key);
 
     if check_proof {

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -31,7 +31,7 @@ fn run_tests(
     test_name: &str,
     compile_options: &CompileOptions,
 ) -> Result<(), CliError> {
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
 
     let mut driver = Resolver::resolve_root_manifest(program_dir, backend.np_language())?;
 
@@ -78,7 +78,7 @@ fn run_test(
     driver: &Driver,
     config: &CompileOptions,
 ) -> Result<(), CliError> {
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
     let mut blocks = Blocks::default();
 
     let program = driver

--- a/crates/nargo_cli/src/cli/verify_cmd.rs
+++ b/crates/nargo_cli/src/cli/verify_cmd.rs
@@ -54,7 +54,7 @@ fn verify_with_path<P: AsRef<Path>>(
         None => {
             let compiled_program = compile_circuit(program_dir.as_ref(), &compile_options)?;
 
-            let backend = nargo::backends::ConcreteBackend;
+            let backend = crate::backends::ConcreteBackend;
             let (_, verification_key) = backend.preprocess(&compiled_program.circuit);
             (compiled_program, verification_key)
         }
@@ -86,7 +86,7 @@ pub(crate) fn verify_proof(
     let public_abi = compiled_program.abi.clone().public_abi();
     let public_inputs = public_abi.encode(&public_inputs_map, return_value)?;
 
-    let backend = nargo::backends::ConcreteBackend;
+    let backend = crate::backends::ConcreteBackend;
     let valid_proof =
         backend.verify_with_vk(proof, public_inputs, &compiled_program.circuit, verification_key);
 

--- a/crates/nargo_cli/src/lib.rs
+++ b/crates/nargo_cli/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod backends;
 pub mod cli;
 mod constants;
 mod errors;


### PR DESCRIPTION
# Related issue(s)

Followup to https://github.com/noir-lang/noir/pull/1085#issuecomment-1494618926

# Description

## Summary of changes

This PR moves all logic related to selection of proving backends from `nargo` to `nargo_cli`. This is necessary as we'll be wanting to build multiple crates within the workspace with different backends which all use `nargo` so this must be generic (as otherwise it will have mutually exclusive feature flags set).

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
