### PR TITLE
chore: move `allow(dead_code)` to only cover `CyclicDependenciesError`

### DIFF
--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 // This has been taken and modified from the rust-analyzer codebase
 // For the most part, everything is the same, the differences are quite subtle
 // but still present. Moreover, since RA is uses incremental compilation, the usage of this component may differ.
@@ -177,6 +176,7 @@ impl std::ops::Index<CrateId> for CrateGraph {
 /// XXX: This is bare-bone for two reasons:
 // There are no display names currently
 // The error would be better if it showed the full cyclic dependency, including transitives.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct CyclicDependenciesError {
     from: CrateId,


### PR DESCRIPTION
# Related issue(s)

Resolves #119 

# Description

## Summary of changes

I've restricted the lint to only cover `CyclicDependenciesError` as this is the only instance of dead code. We should consolidate the crate graph and resolver code at some point at which we can remove this dead code.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
