### PR TITLE
chore(nargo)!: use faster hash function for checking preprocessed keys

### DIFF
--- a/crates/nargo_cli/src/cli/fs/keys.rs
+++ b/crates/nargo_cli/src/cli/fs/keys.rs
@@ -1,9 +1,9 @@
-use super::{create_named_dir, load_hex_data, write_to_file};
+use super::{create_named_dir, load_hex_data, program::checksum_acir, write_to_file};
 use crate::{
     constants::{ACIR_CHECKSUM, PK_EXT, VK_EXT},
     errors::CliError,
 };
-use acvm::{acir::circuit::Circuit, checksum_constraint_system};
+use acvm::acir::circuit::Circuit;
 use std::path::{Path, PathBuf};
 
 pub(crate) fn save_key_to_dir<P: AsRef<Path>>(
@@ -31,7 +31,7 @@ pub(crate) fn fetch_pk_and_vk<P: AsRef<Path>>(
     let acir_hash_path = circuit_build_path.as_ref().with_extension(ACIR_CHECKSUM);
 
     let expected_acir_checksum = load_hex_data(acir_hash_path.clone())?;
-    let new_acir_checksum = checksum_constraint_system(circuit).to_be_bytes();
+    let new_acir_checksum = checksum_acir(circuit);
 
     if new_acir_checksum[..] != expected_acir_checksum {
         return Err(CliError::MismatchedAcir(acir_hash_path));

--- a/crates/nargo_cli/src/cli/fs/keys.rs
+++ b/crates/nargo_cli/src/cli/fs/keys.rs
@@ -3,7 +3,7 @@ use crate::{
     constants::{ACIR_CHECKSUM, PK_EXT, VK_EXT},
     errors::CliError,
 };
-use acvm::{acir::circuit::Circuit, hash_constraint_system};
+use acvm::{acir::circuit::Circuit, checksum_constraint_system};
 use std::path::{Path, PathBuf};
 
 pub(crate) fn save_key_to_dir<P: AsRef<Path>>(
@@ -30,11 +30,10 @@ pub(crate) fn fetch_pk_and_vk<P: AsRef<Path>>(
 ) -> Result<(Vec<u8>, Vec<u8>), CliError> {
     let acir_hash_path = circuit_build_path.as_ref().with_extension(ACIR_CHECKSUM);
 
-    let expected_acir_hash = load_hex_data(acir_hash_path.clone())?;
+    let expected_acir_checksum = load_hex_data(acir_hash_path.clone())?;
+    let new_acir_checksum = checksum_constraint_system(circuit).to_be_bytes();
 
-    let new_acir_hash = hash_constraint_system(circuit);
-
-    if new_acir_hash[..] != expected_acir_hash {
+    if new_acir_checksum[..] != expected_acir_checksum {
         return Err(CliError::MismatchedAcir(acir_hash_path));
     }
 
@@ -62,7 +61,7 @@ pub(crate) fn fetch_pk_and_vk<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::fetch_pk_and_vk;
-    use crate::cli::fs::{keys::save_key_to_dir, program::save_acir_hash_to_dir};
+    use crate::cli::fs::{keys::save_key_to_dir, program::save_acir_checksum_to_dir};
     use acvm::acir::circuit::Circuit;
     use tempdir::TempDir;
 
@@ -78,7 +77,7 @@ mod tests {
         save_key_to_dir(&pk, circuit_name, &circuit_build_path, true).unwrap();
         save_key_to_dir(&vk, circuit_name, &circuit_build_path, false).unwrap();
 
-        save_acir_hash_to_dir(&circuit, circuit_name, &circuit_build_path);
+        save_acir_checksum_to_dir(&circuit, circuit_name, &circuit_build_path);
         circuit_build_path.push(circuit_name);
 
         let loaded_keys = fetch_pk_and_vk(&circuit, circuit_build_path, true, true).unwrap();

--- a/crates/nargo_cli/src/cli/fs/program.rs
+++ b/crates/nargo_cli/src/cli/fs/program.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use acvm::{acir::circuit::Circuit, hash_constraint_system};
+use acvm::{acir::circuit::Circuit, checksum_constraint_system};
 use noirc_driver::{CompiledContract, CompiledProgram};
 
 use crate::{constants::ACIR_CHECKSUM, errors::CliError};
@@ -34,14 +34,14 @@ fn save_build_artifact_to_file<P: AsRef<Path>, T: ?Sized + serde::Serialize>(
     circuit_path
 }
 
-pub(crate) fn save_acir_hash_to_dir<P: AsRef<Path>>(
+pub(crate) fn save_acir_checksum_to_dir<P: AsRef<Path>>(
     circuit: &Circuit,
     hash_name: &str,
     hash_dir: P,
 ) -> PathBuf {
-    let acir_hash = hash_constraint_system(circuit);
+    let acir_checksum = checksum_constraint_system(circuit);
     let hash_path = hash_dir.as_ref().join(hash_name).with_extension(ACIR_CHECKSUM);
-    write_to_file(hex::encode(acir_hash).as_bytes(), &hash_path);
+    write_to_file(hex::encode(acir_checksum.to_be_bytes()).as_bytes(), &hash_path);
 
     hash_path
 }

--- a/crates/nargo_cli/src/cli/preprocess_cmd.rs
+++ b/crates/nargo_cli/src/cli/preprocess_cmd.rs
@@ -8,7 +8,7 @@ use crate::{constants::TARGET_DIR, errors::CliError};
 
 use super::fs::{
     keys::save_key_to_dir,
-    program::{read_program_from_file, save_acir_hash_to_dir},
+    program::{read_program_from_file, save_acir_checksum_to_dir},
 };
 use super::NargoConfig;
 
@@ -38,8 +38,8 @@ pub(crate) fn preprocess_with_path<P: AsRef<Path>>(
     let (proving_key, verification_key) = backend.preprocess(circuit);
 
     // Save a checksum of the circuit to compare against during proving and verification.
-    // If hash doesn't match then the circuit has been updated and keys are stale.
-    save_acir_hash_to_dir(circuit, key_name, &preprocess_dir);
+    // If the checksums don't match then the circuit has been updated and keys are stale.
+    save_acir_checksum_to_dir(circuit, key_name, &preprocess_dir);
 
     let pk_path = save_key_to_dir(&proving_key, key_name, &preprocess_dir, true)?;
     let vk_path = save_key_to_dir(&verification_key, key_name, preprocess_dir, false)?;


### PR DESCRIPTION
# Related issue(s)

Resolves https://github.com/noir-lang/noir/issues/870

# Description

## Summary of changes

We now use the faster `checksum_constraint_system` function over `hash_constraint_system` when preprocessing programs to generate their keys.

One important thing to note here is that it means that we'll be using a different hash function when saving programs to disk in comparison to the hash function we'll be using for contract functions in the A3 context. We'll need to ensure that we keep these separate. As part of that, I have updated any references to "hashes" to "checksums".


## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
