### PR TITLE
fix(nargo): correct name in CLI output from `nargo_cli` to `nargo`

### DIFF
--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -30,7 +30,7 @@ static VERSION_STRING: &str =
     formatcp!("{} (git version hash: {}, is dirty: {})", CARGO_PKG_VERSION, GIT_HASH, IS_DIRTY);
 
 #[derive(Parser, Debug)]
-#[command(author, version=VERSION_STRING, about, long_about = None)]
+#[command(name="nargo", author, version=VERSION_STRING, about, long_about = None)]
 struct NargoCli {
     #[command(subcommand)]
     command: NargoCommand,


### PR DESCRIPTION
# Related issue(s)

Resolves [failing build acceptance test ](https://github.com/noir-lang/build-nargo/actions/runs/4605982988/jobs/8146517196?pr=20)

# Description

## Summary of changes

The CLI tool currently thinks it's called `nargo_cli` rather than `nargo` so I've manually set this value.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
