### PR TITLE
chore: borrow instead of cloning witness vectors in IR gen

### DIFF
--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -175,7 +175,7 @@ impl Evaluator {
             AbiType::Array { length, typ } => {
                 let witnesses = self.generate_array_witnesses(length, typ)?;
 
-                ir_gen.abi_array(name, Some(def), typ.as_ref(), *length, witnesses.clone());
+                ir_gen.abi_array(name, Some(def), typ.as_ref(), *length, &witnesses);
                 witnesses
             }
             AbiType::Integer { sign: _, width } => {
@@ -203,13 +203,13 @@ impl Evaluator {
                 let mut struct_witnesses: BTreeMap<String, Vec<Witness>> = BTreeMap::new();
                 self.generate_struct_witnesses(&mut struct_witnesses, &new_fields)?;
 
-                ir_gen.abi_struct(name, Some(def), fields, struct_witnesses.clone());
-                struct_witnesses.values().flatten().cloned().collect()
+                ir_gen.abi_struct(name, Some(def), fields, &struct_witnesses);
+                struct_witnesses.values().flatten().copied().collect()
             }
             AbiType::String { length } => {
                 let typ = AbiType::Integer { sign: noirc_abi::Sign::Unsigned, width: 8 };
                 let witnesses = self.generate_array_witnesses(length, &typ)?;
-                ir_gen.abi_array(name, Some(def), &typ, *length, witnesses.clone());
+                ir_gen.abi_array(name, Some(def), &typ, *length, &witnesses);
                 witnesses
             }
         };


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

We don't actually require ownership of the witnesses in `abi_array` and `abi_struct` so I've changed these to take references which allows us to avoid some clones.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
