### PR TITLE
feat: introduce codegen-verifier section to Nargo.toml

### DIFF
--- a/crates/nargo/src/manifest/mod.rs
+++ b/crates/nargo/src/manifest/mod.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::PathBuf};
 
 mod errors;
 pub use self::errors::InvalidPackageError;
@@ -8,6 +8,8 @@ pub use self::errors::InvalidPackageError;
 pub struct PackageManifest {
     pub package: PackageMetadata,
     pub dependencies: BTreeMap<String, Dependency>,
+    #[serde(rename(deserialize = "codegen-verifier"))]
+    pub codegen_verifier: Option<CodegenVerifierMetadata>,
 }
 
 impl PackageManifest {
@@ -39,6 +41,15 @@ pub struct PackageMetadata {
     license: Option<String>,
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, Clone)]
+pub struct CodegenVerifierMetadata {
+    /// Path to the directory in which to save the generated verifier.
+    ///
+    /// This path is assumed to be relative to the package root.
+    pub out: PathBuf,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 /// Enum representing the different types of ways to
@@ -60,6 +71,9 @@ fn parse_standard_toml() {
         rand = { tag = "next", git = "https://github.com/rust-lang-nursery/rand"}
         cool = { tag = "next", git = "https://github.com/rust-lang-nursery/rand"}
         hello = {path = "./noir_driver"}
+
+        [codegen-verifier]
+        out = "../hardhat_project/contracts/verifier"
     "#;
 
     assert!(PackageManifest::from_toml_str(src).is_ok());

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -1,12 +1,13 @@
 use super::fs::{create_named_dir, program::read_program_from_file, write_to_file};
 use super::NargoConfig;
-use crate::{
-    cli::compile_cmd::compile_circuit, constants::CONTRACT_DIR, constants::TARGET_DIR,
-    errors::CliError,
-};
+use crate::constants::{PKG_FILE, TARGET_DIR};
+use crate::manifest::parse;
+use crate::{cli::compile_cmd::compile_circuit, errors::CliError};
 use clap::Args;
+use nargo::manifest::PackageManifest;
 use nargo::ops::{codegen_verifier, preprocess_program};
 use noirc_driver::CompileOptions;
+use std::path::PathBuf;
 
 /// Generates a Solidity verifier smart contract for the program
 #[derive(Debug, Clone, Args)]
@@ -37,11 +38,22 @@ pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(
 
     let smart_contract_string = codegen_verifier(&backend, &preprocessed_program.verification_key)?;
 
-    let contract_dir = config.program_dir.join(CONTRACT_DIR);
-    create_named_dir(&contract_dir, "contract");
+    let manifest_path = config.program_dir.join(PKG_FILE);
+    let manifest = parse(manifest_path)?;
+    let contract_dir = verifier_out_dir(manifest, config.program_dir);
+    create_named_dir(&contract_dir, contract_dir.file_name().unwrap().to_str().unwrap());
     let contract_path = contract_dir.join("plonk_vk").with_extension("sol");
 
     let path = write_to_file(smart_contract_string.as_bytes(), &contract_path);
     println!("Contract successfully created and located at {path}");
     Ok(())
+}
+
+/// TODO: Move this function to `PackageManifest` after tracking the root directory.
+/// See also: https://github.com/noir-lang/noir/pull/1138#discussion_r1165351237
+fn verifier_out_dir(manifest: PackageManifest, package_root: PathBuf) -> PathBuf {
+    package_root.join(match manifest.codegen_verifier {
+        Some(cv) => cv.out,
+        None => "verifier.".into(),
+    })
 }

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -54,6 +54,6 @@ pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(
 fn verifier_out_dir(manifest: PackageManifest, package_root: PathBuf) -> PathBuf {
     package_root.join(match manifest.codegen_verifier {
         Some(cv) => cv.out,
-        None => "verifier.".into(),
+        None => "contract.".into(),
     })
 }

--- a/crates/nargo_cli/src/constants.rs
+++ b/crates/nargo_cli/src/constants.rs
@@ -1,6 +1,4 @@
 // Directories
-/// The directory for the `nargo contract` command output
-pub(crate) const CONTRACT_DIR: &str = "contract";
 /// The directory to store serialized circuit proofs.
 pub(crate) const PROOFS_DIR: &str = "proofs";
 /// The directory to store Noir source files

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -1,5 +1,5 @@
 use hex::FromHexError;
-use nargo::NargoError;
+use nargo::{manifest::InvalidPackageError, NargoError};
 use noirc_abi::errors::{AbiError, InputParserError};
 use std::path::PathBuf;
 use thiserror::Error;
@@ -42,4 +42,8 @@ pub(crate) enum CliError {
     /// Error from Nargo
     #[error(transparent)]
     NargoError(#[from] NargoError),
+
+    /// Error while loading package manifest.
+    #[error(transparent)]
+    InvalidManifest(#[from] InvalidPackageError),
 }


### PR DESCRIPTION
# Related issue(s)

Resolves #1009

# Description

## Summary of changes

Added `codegen-verifier` section to `Nargo.toml`, to enable to config the output directory for `nargo codegen-verifier` command.

## Dependency additions / changes

N/A (maybe 😅 )

## Test additions / changes



# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
