### PR TITLE
chore: enforce `clippy::semicolon_if_nothing_returned` linting rule

### DIFF
--- a/crates/arena/src/lib.rs
+++ b/crates/arena/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 // For now we use a wrapper around generational-arena
 pub use generational_arena::{Arena, Index};

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -137,7 +137,7 @@ mod tests {
 
         let file_id = fm.add_file(&file_path, FileType::Normal).unwrap();
 
-        assert!(fm.path(file_id).ends_with("foo"))
+        assert!(fm.path(file_id).ends_with("foo"));
     }
     #[test]
     fn path_resolve_sub_module() {

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 mod file_map;
 mod file_reader;

--- a/crates/iter-extended/src/lib.rs
+++ b/crates/iter-extended/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 use std::collections::BTreeMap;
 

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 //! Nargo is the package manager for Noir
 //! This name was used because it sounds like `cargo` and

--- a/crates/nargo_cli/src/lib.rs
+++ b/crates/nargo_cli/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 //! Nargo is the package manager for Noir
 //! This name was used because it sounds like `cargo` and

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 use std::{collections::BTreeMap, str};
 

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -284,11 +284,11 @@ impl Abi {
             InputValue::String(string) => {
                 let str_as_fields =
                     string.bytes().map(|byte| FieldElement::from_be_bytes_reduce(&[byte]));
-                encoded_value.extend(str_as_fields)
+                encoded_value.extend(str_as_fields);
             }
             InputValue::Struct(object) => {
                 for value in object.into_values() {
-                    encoded_value.extend(Self::encode_value(value)?)
+                    encoded_value.extend(Self::encode_value(value)?);
                 }
             }
         }
@@ -443,6 +443,6 @@ mod test {
         }
 
         // We also decode the return value (we can do this immediately as we know it shares a witness with an input).
-        assert_eq!(return_value.unwrap(), reconstructed_inputs["thing2"])
+        assert_eq!(return_value.unwrap(), reconstructed_inputs["thing2"]);
     }
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 use acvm::Language;
 use clap::Args;

--- a/crates/noirc_errors/src/lib.rs
+++ b/crates/noirc_errors/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 mod position;
 pub mod reporter;

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 mod errors;
 mod ssa;

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -254,7 +254,7 @@ impl Evaluator {
                         let new_name = format!("{name}.{inner_name}");
                         new_fields.insert(new_name, value.clone());
                     }
-                    self.generate_struct_witnesses(struct_witnesses, &new_fields)?
+                    self.generate_struct_witnesses(struct_witnesses, &new_fields)?;
                 }
                 AbiType::String { length } => {
                     let typ = AbiType::Integer { sign: noirc_abi::Sign::Unsigned, width: 8 };

--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -361,7 +361,7 @@ pub(crate) fn bound_constraint_with_offset(
                 0 => evaluator.push_opcode(AcirOpcode::Arithmetic(aof)),
                 1 => {
                     let expr = boolean_expr(&aof, evaluator);
-                    evaluator.push_opcode(AcirOpcode::Arithmetic(expr))
+                    evaluator.push_opcode(AcirOpcode::Arithmetic(expr));
                 }
                 2 => {
                     let y = expression_to_witness(boolean_expr(&aof, evaluator), evaluator);

--- a/crates/noirc_evaluator/src/ssa/acir_gen/internal_var.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/internal_var.rs
@@ -36,7 +36,7 @@ impl InternalVar {
         &self.expression
     }
     pub(crate) fn set_id(&mut self, id: NodeId) {
-        self.id = Some(id)
+        self.id = Some(id);
     }
     pub(crate) fn get_id(&self) -> Option<NodeId> {
         self.id

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -149,7 +149,7 @@ fn prepare_inputs(
     let mut inputs: Vec<FunctionInput> = Vec::new();
 
     for argument in arguments {
-        inputs.extend(resolve_node_id(argument, acir_gen, cfg, evaluator))
+        inputs.extend(resolve_node_id(argument, acir_gen, cfg, evaluator));
     }
     inputs
 }
@@ -212,7 +212,7 @@ fn resolve_array(
         arr_element.set_witness(witness);
         acir_gen.memory.insert(array.id, i, arr_element);
 
-        inputs.push(func_input)
+        inputs.push(func_input);
     }
 
     inputs
@@ -329,7 +329,7 @@ fn evaluate_println(
 fn format_field_string(field: FieldElement) -> String {
     let mut trimmed_field = field.to_hex().trim_start_matches('0').to_owned();
     if trimmed_field.len() % 2 != 0 {
-        trimmed_field = "0".to_owned() + &trimmed_field
+        trimmed_field = "0".to_owned() + &trimmed_field;
     };
     "0x".to_owned() + &trimmed_field
 }

--- a/crates/noirc_evaluator/src/ssa/conditional.rs
+++ b/crates/noirc_evaluator/src/ssa/conditional.rs
@@ -855,14 +855,14 @@ impl DecisionTree {
                         && left_arrays.is_empty()
                         && right_arrays.is_empty() =>
                     {
-                        candidates.push(Segment::new(left_node, right_node))
+                        candidates.push(Segment::new(left_node, right_node));
                     }
 
                     (
                         Operation::Store { array_id: left_array, index: left_index, .. },
                         Operation::Store { array_id: right_array, index: right_index, .. },
                     ) if left_array == right_array && left_index == right_index => {
-                        candidates.push(Segment::new(left_node, right_node))
+                        candidates.push(Segment::new(left_node, right_node));
                     }
                     _ => (),
                 }

--- a/crates/noirc_evaluator/src/ssa/context.rs
+++ b/crates/noirc_evaluator/src/ssa/context.rs
@@ -163,7 +163,7 @@ impl SsaContext {
             result = format!("{var}");
         }
         if result.is_empty() {
-            result = format!("unknown {:?}", id.0.into_raw_parts().0)
+            result = format!("unknown {:?}", id.0.into_raw_parts().0);
         }
         result
     }
@@ -250,7 +250,7 @@ impl SsaContext {
 
     pub(crate) fn print_instructions(&self, instructions: &[NodeId]) {
         for id in instructions {
-            self.print_node(*id)
+            self.print_node(*id);
         }
     }
 

--- a/crates/noirc_evaluator/src/ssa/inline.rs
+++ b/crates/noirc_evaluator/src/ssa/inline.rs
@@ -241,7 +241,7 @@ fn inline(
             decision,
         )?;
         if result && nested_call {
-            result = false
+            result = false;
         }
     }
     Ok(result)

--- a/crates/noirc_evaluator/src/ssa/integer.rs
+++ b/crates/noirc_evaluator/src/ssa/integer.rs
@@ -319,7 +319,7 @@ fn block_overflow(
                 if let Some(r_const) = ctx.get_as_constant(rhs) {
                     let r_type = ctx[rhs].get_type();
                     if r_const.to_u128() > r_type.bits() as u128 {
-                        ins.mark = Mark::ReplaceWith(ctx.zero_with_type(ins.res_type))
+                        ins.mark = Mark::ReplaceWith(ctx.zero_with_type(ins.res_type));
                     } else {
                         let rhs = ctx
                             .get_or_create_const(FieldElement::from(2_i128).pow(&r_const), r_type);

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -1225,7 +1225,7 @@ impl Operation {
             Cond { condition, val_true: lhs, val_false: rhs } => {
                 *condition = f(*condition);
                 *lhs = f(*lhs);
-                *rhs = f(*rhs)
+                *rhs = f(*rhs);
             }
             Load { index, .. } => *index = f(*index),
             Store { index, value, predicate, .. } => {
@@ -1291,7 +1291,7 @@ impl Operation {
             Nop => (),
             Call { func, arguments, .. } => {
                 f(*func);
-                arguments.iter().copied().for_each(f)
+                arguments.iter().copied().for_each(f);
             }
             Return(values) => values.iter().copied().for_each(f),
             Result { call_instruction, .. } => {

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -469,7 +469,7 @@ fn cse_block_with_anchor(
                     let mut activate_cse = true;
                     // We do not want to replace any print intrinsics as we want them to remain in order and unchanged
                     if let builtin::Opcode::Println(_) = opcode {
-                        activate_cse = false
+                        activate_cse = false;
                     }
 
                     for arg in args {

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -120,9 +120,9 @@ impl CrateGraph {
                 return;
             }
             for dep in graph[source].dependencies.iter() {
-                go(graph, visited, res, dep.crate_id)
+                go(graph, visited, res, dep.crate_id);
             }
-            res.push(source)
+            res.push(source);
         }
     }
 
@@ -163,7 +163,7 @@ impl CrateGraph {
 }
 impl CrateData {
     fn add_dep(&mut self, name: CrateName, crate_id: CrateId) {
-        self.dependencies.push(Dependency { crate_id, name })
+        self.dependencies.push(Dependency { crate_id, name });
     }
 }
 impl std::ops::Index<CrateId> for CrateGraph {

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -30,7 +30,7 @@ pub struct UnresolvedFunctions {
 
 impl UnresolvedFunctions {
     pub fn push_fn(&mut self, mod_id: LocalModuleId, func_id: FuncId, func: NoirFunction) {
-        self.functions.push((mod_id, func_id, func))
+        self.functions.push((mod_id, func_id, func));
     }
 }
 
@@ -243,7 +243,7 @@ fn collect_impls(
             } else if typ != Type::Error && crate_id == LOCAL_CRATE {
                 let span = *span;
                 let error = DefCollectorErrorKind::NonStructTypeInImpl { span };
-                errors.push(error.into_file_diagnostic(unresolved.file_id))
+                errors.push(error.into_file_diagnostic(unresolved.file_id));
             }
         }
     }
@@ -261,7 +261,7 @@ where
     Errs: IntoIterator<Item = Err>,
     Err: Into<CustomDiagnostic>,
 {
-    errors.extend(new_errors.into_iter().map(|err| err.into().in_file(file)))
+    errors.extend(new_errors.into_iter().map(|err| err.into().in_file(file)));
 }
 
 /// Separate the globals Vec into two. The first element in the tuple will be the
@@ -476,6 +476,6 @@ fn type_check_functions(
     errors: &mut Vec<FileDiagnostic>,
 ) {
     for (file, func) in file_func_ids {
-        extend_errors(errors, file, type_check_func(interner, func))
+        extend_errors(errors, file, type_check_func(interner, func));
     }
 }

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -37,7 +37,7 @@ pub fn collect_defs(
 
     // First resolve the module declarations
     for decl in ast.module_decls {
-        collector.parse_module_declaration(context, &decl, crate_id, errors)
+        collector.parse_module_declaration(context, &decl, crate_id, errors);
     }
 
     collector.collect_submodules(context, crate_id, ast.submodules, file_id, errors);

--- a/crates/noirc_frontend/src/hir/resolution/import.rs
+++ b/crates/noirc_frontend/src/hir/resolution/import.rs
@@ -168,7 +168,7 @@ fn resolve_name_in_module(
             return Err(PathResolutionError::ExternalContractUsed(segment.clone()));
         }
 
-        current_ns = found_ns
+        current_ns = found_ns;
     }
 
     Ok(current_ns)

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -121,7 +121,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn push_err(&mut self, err: ResolverError) {
-        self.errors.push(err)
+        self.errors.push(err);
     }
 
     fn current_lambda_index(&self) -> usize {
@@ -410,7 +410,7 @@ impl<'a> Resolver<'a> {
                     });
 
                     // Fix the generic count so we can continue typechecking
-                    args.resize_with(expected_generic_count, || Type::Error)
+                    args.resize_with(expected_generic_count, || Type::Error);
                 }
 
                 Type::Struct(struct_type, args)
@@ -555,7 +555,7 @@ impl<'a> Resolver<'a> {
                     name: generic.0.contents.clone(),
                     first_span: *first_span,
                     second_span: span,
-                })
+                });
             } else {
                 self.generics.push((name, typevar.clone(), span));
             }
@@ -616,7 +616,7 @@ impl<'a> Resolver<'a> {
 
         for (pattern, typ, visibility) in func.parameters().iter().cloned() {
             if visibility == noirc_abi::AbiVisibility::Public && !self.pub_allowed(func) {
-                self.push_err(ResolverError::UnnecessaryPub { ident: func.name_ident().clone() })
+                self.push_err(ResolverError::UnnecessaryPub { ident: func.name_ident().clone() });
             }
 
             let pattern = self.resolve_pattern(pattern, DefinitionKind::Local(None));
@@ -634,13 +634,13 @@ impl<'a> Resolver<'a> {
             && return_type.as_ref() != &Type::Unit
             && func.def.return_visibility != noirc_abi::AbiVisibility::Public
         {
-            self.push_err(ResolverError::NecessaryPub { ident: func.name_ident().clone() })
+            self.push_err(ResolverError::NecessaryPub { ident: func.name_ident().clone() });
         }
 
         if attributes == Some(Attribute::Test) && !parameters.is_empty() {
             self.push_err(ResolverError::TestFunctionHasParameters {
                 span: func.name_ident().span(),
-            })
+            });
         }
 
         let mut typ = Type::Function(parameter_types, return_type);
@@ -1017,7 +1017,7 @@ impl<'a> Resolver<'a> {
             }
             Pattern::Mutable(pattern, span) => {
                 if let Some(first_mut) = mutable {
-                    self.push_err(ResolverError::UnnecessaryMut { first_mut, second_mut: span })
+                    self.push_err(ResolverError::UnnecessaryMut { first_mut, second_mut: span });
                 }
 
                 let pattern = self.resolve_pattern_mutable(*pattern, Some(span), definition);
@@ -1491,7 +1491,7 @@ mod test {
     fn path_unresolved_error(err: ResolverError, expected_unresolved_path: &str) {
         match err {
             ResolverError::PathResolutionError(PathResolutionError::Unresolved(name)) => {
-                assert_eq!(name.to_string(), expected_unresolved_path)
+                assert_eq!(name.to_string(), expected_unresolved_path);
             }
             _ => unimplemented!("expected an unresolved path"),
         }

--- a/crates/noirc_frontend/src/hir/scope/mod.rs
+++ b/crates/noirc_frontend/src/hir/scope/mod.rs
@@ -90,7 +90,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeTree<K, V> {
     }
 
     pub fn push_scope(&mut self) {
-        self.0.push(Scope::default())
+        self.0.push(Scope::default());
     }
 
     pub fn pop_scope(&mut self) -> Scope<K, V> {
@@ -135,7 +135,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
     }
 
     fn extend_current_scope_tree(&mut self) {
-        self.current_scope_tree().push_scope()
+        self.current_scope_tree().push_scope();
     }
 
     fn remove_scope_tree_extension(&mut self) -> Scope<K, V> {
@@ -145,7 +145,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
     /// Starting a function requires a new scope tree, as you do not want the functions scope to
     /// have access to the scope of the caller
     pub fn start_function(&mut self) {
-        self.0.push(ScopeTree::default())
+        self.0.push(ScopeTree::default());
     }
 
     /// Ending a function requires that we removes it's whole tree of scope
@@ -157,7 +157,7 @@ impl<K: std::hash::Hash + Eq + Clone, V> ScopeForest<K, V> {
     /// The beginning of a scope always correlates with the start of a block {}.
     /// This can be in if expressions, for loops, or functions.
     pub fn start_scope(&mut self) {
-        self.extend_current_scope_tree()
+        self.extend_current_scope_tree();
     }
 
     /// Ends the current scope - this should correspond with the end of a BlockExpression.

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -101,7 +101,7 @@ impl<'interner> TypeChecker<'interner> {
         span: Span,
         make_error: impl FnOnce() -> TypeCheckError,
     ) {
-        actual.unify(expected, span, &mut self.errors, make_error)
+        actual.unify(expected, span, &mut self.errors, make_error);
     }
 
     /// Wrapper of Type::make_subtype_of using self.errors
@@ -112,7 +112,7 @@ impl<'interner> TypeChecker<'interner> {
         span: Span,
         make_error: impl FnOnce() -> TypeCheckError,
     ) {
-        actual.make_subtype_of(expected, span, &mut self.errors, make_error)
+        actual.make_subtype_of(expected, span, &mut self.errors, make_error);
     }
 }
 
@@ -362,7 +362,7 @@ mod test {
 
         for ((hir_func, meta), func_id) in func_meta.into_iter().zip(func_ids.clone()) {
             interner.update_fn(func_id, hir_func);
-            interner.push_fn_meta(meta, func_id)
+            interner.push_fn_meta(meta, func_id);
         }
 
         // Type check section

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -126,7 +126,7 @@ pub type Generics = Vec<(TypeVariableId, TypeVariable)>;
 
 impl std::hash::Hash for StructType {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state)
+        self.id.hash(state);
     }
 }
 
@@ -230,7 +230,7 @@ pub struct Shared<T>(Rc<RefCell<T>>);
 
 impl<T: std::hash::Hash> std::hash::Hash for Shared<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.borrow().hash(state)
+        self.0.borrow().hash(state);
     }
 }
 
@@ -705,7 +705,7 @@ impl Type {
     pub fn set_comp_time_span(&mut self, new_span: Span) {
         match self {
             Type::FieldElement(comptime) | Type::Integer(comptime, _, _) => {
-                comptime.set_span(new_span)
+                comptime.set_span(new_span);
             }
             Type::PolymorphicInteger(span, binding) => {
                 if let TypeBinding::Bound(binding) = &mut *binding.borrow_mut() {
@@ -865,7 +865,7 @@ impl Type {
         make_error: impl FnOnce() -> TypeCheckError,
     ) {
         if let Err(err_span) = self.try_unify(expected, span) {
-            Self::issue_errors(expected, err_span, errors, make_error)
+            Self::issue_errors(expected, err_span, errors, make_error);
         }
     }
 
@@ -1006,7 +1006,7 @@ impl Type {
         make_error: impl FnOnce() -> TypeCheckError,
     ) {
         if let Err(err_span) = self.is_subtype_of(expected, span) {
-            Self::issue_errors(expected, err_span, errors, make_error)
+            Self::issue_errors(expected, err_span, errors, make_error);
         }
     }
 

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -216,7 +216,7 @@ impl<'a> Lexer<'a> {
         // Therefore, the current character which triggered this function will need to be appended
         let mut word = String::new();
         if let Some(init_char) = initial_char {
-            word.push(init_char)
+            word.push(init_char);
         }
 
         // Keep checking that we are not at the EOF

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -539,7 +539,7 @@ mod keywords {
                 resolved_token,
                 Token::Keyword(keyword),
                 "Keyword::lookup_keyword returns unexpected Keyword"
-            )
+            );
         }
     }
 }

--- a/crates/noirc_frontend/src/lib.rs
+++ b/crates/noirc_frontend/src/lib.rs
@@ -8,6 +8,7 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
 
 pub mod ast;
 pub mod graph;

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -320,7 +320,7 @@ impl NodeInterner {
 
     pub fn update_struct(&mut self, type_id: StructId, f: impl FnOnce(&mut StructType)) {
         let mut value = self.structs.get_mut(&type_id).unwrap().borrow_mut();
-        f(&mut value)
+        f(&mut value);
     }
 
     /// Returns the interned statement corresponding to `stmt_id`

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -263,7 +263,7 @@ impl ParsedModule {
     }
 
     fn push_global(&mut self, global: LetStatement) {
-        self.globals.push(global)
+        self.globals.push(global);
     }
 }
 

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -856,7 +856,7 @@ where
                 emit(ParserError::with_reason(
                     "Arrays must have at least one element".to_owned(),
                     span,
-                ))
+                ));
             }
             ExpressionKind::array(elements)
         })
@@ -1135,7 +1135,7 @@ mod test {
             match expr_to_array(expr) {
                 ArrayLiteral::Standard(elements) => assert_eq!(elements.len(), 5),
                 ArrayLiteral::Repeated { length, .. } => {
-                    assert_eq!(length.kind, ExpressionKind::integer(5i128.into()))
+                    assert_eq!(length.kind, ExpressionKind::integer(5i128.into()));
                 }
             }
         }
@@ -1367,7 +1367,7 @@ mod test {
 
         for (src, expected_path_kind) in cases {
             let path = parse_with(path(), src).unwrap();
-            assert_eq!(path.kind, expected_path_kind)
+            assert_eq!(path.kind, expected_path_kind);
         }
 
         parse_all_failing(

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+
 use gloo_utils::format::JsValueSerdeExt;
 use log::Level;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

This PR is a noop. I quite like the visual cue that semicolons give that nothing is being returned, but we're currently inconsistent on this with a mix of including vs omitting these semicolons. I've added a lint to standardise this and addressed any instances of missing semicolons.

https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
