### PR TITLE
feat: import core logic in cli from `nargo` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,8 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.3.2"
 dependencies = [
+ "acvm 0.8.0",
+ "noirc_abi",
  "rustc_version 0.4.0",
  "serde",
  "thiserror",

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -11,6 +11,8 @@ edition.workspace = true
 rustc_version = "0.4.0"
 
 [dependencies]
+acvm.workspace = true
+noirc_abi.workspace = true
 toml.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -1,0 +1,13 @@
+use acvm::OpcodeResolutionError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NargoError {
+    /// Error while compiling Noir into ACIR.
+    #[error("Failed to compile circuit")]
+    CompilationError,
+
+    /// ACIR circuit solving error
+    #[error(transparent)]
+    SolvingError(#[from] OpcodeResolutionError),
+}

--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -6,4 +6,8 @@
 //! This name was used because it sounds like `cargo` and
 //! Noir Package Manager abbreviated is npm, which is already taken.
 
+mod errors;
 pub mod manifest;
+pub mod ops;
+
+pub use self::errors::NargoError;

--- a/crates/nargo/src/ops/codegen_verifier.rs
+++ b/crates/nargo/src/ops/codegen_verifier.rs
@@ -1,0 +1,10 @@
+use acvm::SmartContract;
+
+use crate::NargoError;
+
+pub fn codegen_verifier(
+    backend: &impl SmartContract,
+    verification_key: &[u8],
+) -> Result<String, NargoError> {
+    Ok(backend.eth_contract_from_vk(verification_key))
+}

--- a/crates/nargo/src/ops/execute.rs
+++ b/crates/nargo/src/ops/execute.rs
@@ -1,0 +1,20 @@
+use acvm::PartialWitnessGenerator;
+use acvm::{acir::circuit::Circuit, pwg::block::Blocks};
+use noirc_abi::WitnessMap;
+
+use crate::NargoError;
+
+pub fn execute_circuit(
+    backend: &impl PartialWitnessGenerator,
+    circuit: Circuit,
+    mut initial_witness: WitnessMap,
+) -> Result<WitnessMap, NargoError> {
+    let mut blocks = Blocks::default();
+    let (unresolved_opcodes, oracles) =
+        backend.solve(&mut initial_witness, &mut blocks, circuit.opcodes)?;
+    if !unresolved_opcodes.is_empty() || !oracles.is_empty() {
+        todo!("Add oracle support to nargo execute")
+    }
+
+    Ok(initial_witness)
+}

--- a/crates/nargo/src/ops/mod.rs
+++ b/crates/nargo/src/ops/mod.rs
@@ -1,0 +1,11 @@
+pub use self::codegen_verifier::codegen_verifier;
+pub use self::execute::execute_circuit;
+pub use self::preprocess::{checksum_acir, preprocess_circuit, PreprocessedData};
+pub use self::prove::prove;
+pub use self::verify::verify_proof;
+
+mod codegen_verifier;
+mod execute;
+mod preprocess;
+mod prove;
+mod verify;

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -1,0 +1,31 @@
+use acvm::acir::circuit::Circuit;
+use acvm::{checksum_constraint_system, ProofSystemCompiler};
+
+use crate::NargoError;
+
+pub fn checksum_acir(circuit: &Circuit) -> [u8; 4] {
+    checksum_constraint_system(circuit).to_be_bytes()
+}
+
+/// The result of preprocessing the ACIR bytecode.
+/// The proving, verification key and circuit are backend specific.
+///
+/// The circuit is backend specific because at the end of compilation
+/// an optimization pass is applied which will transform the bytecode into
+/// a format that the backend will accept; removing unsupported gates
+/// is one example of this.
+pub struct PreprocessedData {
+    pub proving_key: Vec<u8>,
+    pub verification_key: Vec<u8>,
+    pub program_checksum: [u8; 4],
+}
+
+pub fn preprocess_circuit(
+    backend: &impl ProofSystemCompiler,
+    circuit: &Circuit,
+) -> Result<PreprocessedData, NargoError> {
+    let (proving_key, verification_key) = backend.preprocess(circuit);
+    let program_checksum = checksum_acir(circuit);
+
+    Ok(PreprocessedData { proving_key, verification_key, program_checksum })
+}

--- a/crates/nargo/src/ops/prove.rs
+++ b/crates/nargo/src/ops/prove.rs
@@ -1,0 +1,16 @@
+use acvm::acir::circuit::Circuit;
+use acvm::ProofSystemCompiler;
+use noirc_abi::WitnessMap;
+
+use crate::NargoError;
+
+pub fn prove(
+    backend: &impl ProofSystemCompiler,
+    circuit: &Circuit,
+    solved_witness: WitnessMap,
+    proving_key: &[u8],
+) -> Result<Vec<u8>, NargoError> {
+    let proof = backend.prove_with_pk(circuit, solved_witness, proving_key);
+
+    Ok(proof)
+}

--- a/crates/nargo/src/ops/verify.rs
+++ b/crates/nargo/src/ops/verify.rs
@@ -1,0 +1,17 @@
+use acvm::acir::circuit::Circuit;
+use acvm::ProofSystemCompiler;
+use noirc_abi::WitnessMap;
+
+use crate::NargoError;
+
+pub fn verify_proof(
+    backend: &impl ProofSystemCompiler,
+    circuit: &Circuit,
+    proof: &[u8],
+    public_inputs: WitnessMap,
+    verification_key: &[u8],
+) -> Result<bool, NargoError> {
+    let valid_proof = backend.verify_with_vk(proof, public_inputs, circuit, verification_key);
+
+    Ok(valid_proof)
+}

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -15,6 +15,7 @@ pub(crate) struct CodegenVerifierCommand {
 pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(), CliError> {
     let compiled_program = compile_circuit(&config.program_dir, &args.compile_options)?;
 
+    // TODO: replace with `nargo::ops::codegen_verifier`
     let backend = crate::backends::ConcreteBackend;
     #[allow(deprecated)]
     let smart_contract_string = backend.eth_contract_from_cs(compiled_program.circuit);

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -1,7 +1,5 @@
 use std::path::Path;
 
-use acvm::pwg::block::Blocks;
-use acvm::PartialWitnessGenerator;
 use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
 use noirc_abi::{InputMap, WitnessMap};
@@ -65,18 +63,11 @@ pub(crate) fn execute_program(
     compiled_program: &CompiledProgram,
     inputs_map: &InputMap,
 ) -> Result<WitnessMap, CliError> {
-    let mut solved_witness = compiled_program.abi.encode(inputs_map, None)?;
+    let initial_witness = compiled_program.abi.encode(inputs_map, None)?;
 
     let backend = crate::backends::ConcreteBackend;
-    let mut blocks = Blocks::default();
-    let (unresolved_opcodes, oracles) = backend.solve(
-        &mut solved_witness,
-        &mut blocks,
-        compiled_program.circuit.opcodes.clone(),
-    )?;
-    if !unresolved_opcodes.is_empty() || !oracles.is_empty() {
-        todo!("Add oracle support to nargo execute")
-    }
+    let solved_witness =
+        nargo::ops::execute_circuit(&backend, compiled_program.circuit.clone(), initial_witness)?;
 
     Ok(solved_witness)
 }

--- a/crates/nargo_cli/src/cli/fs/keys.rs
+++ b/crates/nargo_cli/src/cli/fs/keys.rs
@@ -1,9 +1,10 @@
-use super::{create_named_dir, load_hex_data, program::checksum_acir, write_to_file};
+use super::{create_named_dir, load_hex_data, write_to_file};
 use crate::{
     constants::{ACIR_CHECKSUM, PK_EXT, VK_EXT},
     errors::CliError,
 };
 use acvm::acir::circuit::Circuit;
+use nargo::ops::checksum_acir;
 use std::path::{Path, PathBuf};
 
 pub(crate) fn save_key_to_dir<P: AsRef<Path>>(
@@ -61,11 +62,9 @@ pub(crate) fn fetch_pk_and_vk<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::fetch_pk_and_vk;
-    use crate::cli::fs::{
-        keys::save_key_to_dir,
-        program::{checksum_acir, save_acir_checksum_to_dir},
-    };
+    use crate::cli::fs::{keys::save_key_to_dir, program::save_acir_checksum_to_dir};
     use acvm::acir::circuit::Circuit;
+    use nargo::ops::checksum_acir;
     use tempdir::TempDir;
 
     #[test]

--- a/crates/nargo_cli/src/cli/fs/program.rs
+++ b/crates/nargo_cli/src/cli/fs/program.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use acvm::{acir::circuit::Circuit, checksum_constraint_system};
 use noirc_driver::{CompiledContract, CompiledProgram};
 
 use crate::{constants::ACIR_CHECKSUM, errors::CliError};
@@ -34,9 +33,6 @@ fn save_build_artifact_to_file<P: AsRef<Path>, T: ?Sized + serde::Serialize>(
     circuit_path
 }
 
-pub(crate) fn checksum_acir(circuit: &Circuit) -> [u8; 4] {
-    checksum_constraint_system(circuit).to_be_bytes()
-}
 pub(crate) fn save_acir_checksum_to_dir<P: AsRef<Path>>(
     acir_checksum: [u8; 4],
     hash_name: &str,

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, io::Write, path::Path};
 
-use acvm::{pwg::block::Blocks, PartialWitnessGenerator, ProofSystemCompiler};
+use acvm::ProofSystemCompiler;
 use clap::Args;
+use nargo::ops::execute_circuit;
 use noirc_driver::{CompileOptions, Driver};
 use noirc_frontend::node_interner::FuncId;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
@@ -79,23 +80,15 @@ fn run_test(
     config: &CompileOptions,
 ) -> Result<(), CliError> {
     let backend = crate::backends::ConcreteBackend;
-    let mut blocks = Blocks::default();
 
     let program = driver
         .compile_no_check(config, main)
         .map_err(|_| CliError::Generic(format!("Test '{test_name}' failed to compile")))?;
 
-    let mut solved_witness = BTreeMap::new();
-
     // Run the backend to ensure the PWG evaluates functions like std::hash::pedersen,
     // otherwise constraints involving these expressions will not error.
-    match backend.solve(&mut solved_witness, &mut blocks, program.circuit.opcodes) {
-        Ok((unresolved_opcodes, oracles)) => {
-            if !unresolved_opcodes.is_empty() || !oracles.is_empty() {
-                todo!("Add oracle support to nargo test")
-            }
-            Ok(())
-        }
+    match execute_circuit(&backend, program.circuit, BTreeMap::new()) {
+        Ok(_) => Ok(()),
         Err(error) => {
             let writer = StandardStream::stderr(ColorChoice::Always);
             let mut writer = writer.lock();

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -1,5 +1,5 @@
-use acvm::OpcodeResolutionError;
 use hex::FromHexError;
+use nargo::NargoError;
 use noirc_abi::errors::{AbiError, InputParserError};
 use std::path::PathBuf;
 use thiserror::Error;
@@ -40,7 +40,7 @@ pub(crate) enum CliError {
     #[error(transparent)]
     AbiError(#[from] AbiError),
 
-    /// ACIR circuit solving error
+    /// Error from Nargo
     #[error(transparent)]
-    SolvingError(#[from] OpcodeResolutionError),
+    NargoError(#[from] NargoError),
 }


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/noir/issues/1063

# Description

## Summary of changes

This PR adds the concept of "ops" to `nargo` which are going to be the core operations which will be shared between the CLI and TS packages (e.g. compile, execute, prove, verify, preprocess, codegen_verifier and eventually test).

I've pushed this PR up a little early to unblock https://github.com/noir-lang/noir/pull/1126#discussion_r1164093059. Trying to migrate those two functions across to `nargo` would result in a huge number of merge conflicts, etc. (as well as needing a fair amount of boilerplate copied from this PR) where it would be simpler to merge this first and then fixup on that PR.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
