### PR TITLE
fix: Numeric generics with impls error

### DIFF
--- a/crates/nargo_cli/tests/test_data/numeric_generics/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/numeric_generics/src/main.nr
@@ -19,10 +19,21 @@ fn id<I>(x: [Field; I]) -> [Field; I] {
 }
 
 struct MyStruct<S> {
-    data: [Field; S]
+    data: [Field; S],
+}
+
+impl<S> MyStruct<S> {
+    fn insert(mut self: Self, index: comptime Field, elem: Field) -> Self {
+        // Regression test for numeric generics on impls
+        constrain index as u64 < S as u64;
+
+        self.data[index] = elem;
+        self
+    }
 }
 
 fn foo(mut s: MyStruct<2+1>) -> MyStruct<10/2-2> {
     s.data[0] = s.data[0] + 1;
     s
 }
+

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -512,6 +512,9 @@ impl<'interner> TypeChecker<'interner> {
         use crate::BinaryOpKind::{Equal, NotEqual};
         use Type::*;
         match (lhs_type, rhs_type)  {
+            // Avoid reporting errors multiple times
+            (Error, _) | (_,Error) => Ok(Bool(CompTime::Yes(None))),
+
             // Matches on PolymorphicInteger and TypeVariable must be first to follow any type
             // bindings.
             (PolymorphicInteger(comptime, int), other)
@@ -571,9 +574,6 @@ impl<'interner> TypeChecker<'interner> {
                 let comptime = comptime_x.and(comptime_y, op.location.span);
                 Ok(Bool(comptime))
             }
-
-            // Avoid reporting errors multiple times
-            (Error, _) | (_,Error) => Ok(Bool(CompTime::Yes(None))),
 
             // Special-case == and != for arrays
             (Array(x_size, x_type), Array(y_size, y_type)) if matches!(op.kind, Equal | NotEqual) => {
@@ -728,6 +728,9 @@ impl<'interner> TypeChecker<'interner> {
 
         use Type::*;
         match (lhs_type, rhs_type)  {
+            // An error type on either side will always return an error
+            (Error, _) | (_,Error) => Ok(Error),
+
             // Matches on PolymorphicInteger and TypeVariable must be first so that we follow any type
             // bindings.
             (PolymorphicInteger(comptime, int), other)
@@ -793,8 +796,6 @@ impl<'interner> TypeChecker<'interner> {
             (Struct(..), _) | (_, Struct(..)) => Err(make_error("Structs cannot be used in an infix operation".to_string())),
             (Tuple(_), _) | (_, Tuple(_)) => Err(make_error("Tuples cannot be used in an infix operation".to_string())),
 
-            // An error type on either side will always return an error
-            (Error, _) | (_,Error) => Ok(Error),
             (Unit, _) | (_,Unit) => Ok(Unit),
 
             // The result of two Fields is always a witness


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

In `aztec3-packages` we get this error on the vec type in the Noir contracts:

```
error: Integer cannot be used with type error
   ┌─ /Users/aztec/Documents/GitHub/aztec3-packages/yarn-project/noir-contracts/src/contracts/zk_token_contract/../noir-aztec3/src/types/vec.nr:18:19
   │
18 │         constrain self.len as u64 < MaxLen as u64;
   │                   -------------------------------

error: aborting due to 1 previous errors
```

This was due to a mismatched ordering when reporting errors in the type rules. I added a regression test in the `numeric_generics` test under the `nargo_cli`.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
