### PR TITLE
chore: update documentation of `show_output` flag

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -40,7 +40,7 @@ pub struct CompileOptions {
     #[arg(short, long)]
     pub allow_warnings: bool,
 
-    /// Display output of `println` statements during tests
+    /// Display output of `println` statements
     #[arg(long)]
     pub show_output: bool,
 }


### PR DESCRIPTION
# Related issue(s)

Related noir-lang/docs#86 

# Description

## Summary of changes

This flag is not limited to just tests but any time we execute the circuit, i.e. executing/proving. We should then remove references to testing in documentation.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
