### PR TITLE
chore!: remove outdated arkworks backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,42 +4,13 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad7977c11d19ae0dd983b50dc5fd9eb96c002072f75643e45daa6dc0c23fba5"
-dependencies = [
- "acir_field 0.3.1",
- "flate2",
- "rmp-serde",
- "serde",
-]
-
-[[package]]
-name = "acir"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f764b474e341efc3e8ee3d5054840b2fd2ac002f764fc2f4cd3569ce76badd1"
 dependencies = [
- "acir_field 0.8.0",
+ "acir_field",
  "flate2",
  "rmp-serde",
- "serde",
-]
-
-[[package]]
-name = "acir_field"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687506e635efa7ce15d6b93ceae14dec1519ed2e54c24298fc8c40e86edbce24"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254 0.3.0",
- "ark-ff 0.3.0",
- "blake2",
- "cfg-if 1.0.0",
- "hex",
- "num-bigint",
- "num-traits",
  "serde",
 ]
 
@@ -49,8 +20,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbca7df5192c7823d4108d2c34cadcfd30dca94506b9e9861f85f0ea747ddedc"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.1",
+ "ark-bn254",
+ "ark-ff",
  "cfg-if 1.0.0",
  "hex",
  "num-bigint",
@@ -59,31 +30,12 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99007127e84602134226eefc2245c59b7fe55853bfeba572714b04c5b3fefdea"
-dependencies = [
- "acir 0.3.1",
- "acir_field 0.3.1",
- "acvm_stdlib 0.3.1",
- "blake2",
- "hex",
- "indexmap",
- "k256",
- "num-bigint",
- "num-traits",
- "sha2 0.9.9",
- "thiserror",
-]
-
-[[package]]
-name = "acvm"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5df175b6923bf9bb05ba973b017b0fa1356066be8f0ebadd3d2dbbc48bd5b"
 dependencies = [
- "acir 0.8.0",
- "acvm_stdlib 0.8.0",
+ "acir",
+ "acvm_stdlib",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -96,21 +48,11 @@ dependencies = [
 
 [[package]]
 name = "acvm_stdlib"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f5ef183f4a10b4a257d25c3a37fd090b9e8fbb7dff0902329fb6606b524114"
-dependencies = [
- "acir 0.3.1",
- "acir_field 0.3.1",
-]
-
-[[package]]
-name = "acvm_stdlib"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2bbc18fe9732ca3d93a2bf8f1a1ad99a003b565e7bc1ad5c67f69867449e8f"
 dependencies = [
- "acir 0.8.0",
+ "acir",
 ]
 
 [[package]]
@@ -182,50 +124,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-bls12-381"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65be532f9dd1e98ad0150b037276cde464c6f371059e6dd02c0222395761f6aa"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-traits",
- "zeroize",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -234,10 +140,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c60370a92f8e1a5f053cad73a862e1b99bc642333cd676fa11c0c39f80f4ac2"
 dependencies = [
- "ark-ff 0.4.1",
- "ark-poly 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
  "itertools",
@@ -247,50 +153,22 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2d42532524bee1da5a4f6f733eb4907301baa480829557adcff5dfaeee1d9a"
 dependencies = [
- "ark-ff-asm 0.4.1",
- "ark-ff-macros 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "digest 0.10.6",
  "itertools",
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version 0.4.0",
+ "rustc_version",
  "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -299,18 +177,6 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6873aaba7959593d89babed381d33e2329453368f1bf3c67e07686a1c1056f"
 dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint",
- "num-traits",
  "quote",
  "syn",
 ]
@@ -329,84 +195,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-marlin"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8510faa8e64f0a6841ee4b58efe2d56f7a80d86fa0ce9891bbb3aa20166d9"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-poly 0.3.0",
- "ark-poly-commit",
- "ark-relations",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "digest 0.9.0",
- "rand_chacha",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "hashbrown 0.11.2",
-]
-
-[[package]]
 name = "ark-poly"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6ec811462cabe265cfe1b102fcfe3df79d7d2929c2425673648ee9abfd0272"
 dependencies = [
- "ark-ff 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-poly-commit"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71ddfa72bad1446cab7bbecb6018dbbdc9abcbc3a0065483ae5186ad2a64dcd"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-poly 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "digest 0.9.0",
- "tracing",
-]
-
-[[package]]
-name = "ark-relations"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cba4c1c99792a6834bd97f7fd76578ec2cd58d2afc5139a17e1d1bec65b38f6"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
- "tracing",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-serialize-derive 0.3.0",
- "ark-std 0.3.0",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -415,21 +213,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e735959bc173ea4baf13327b19c22d452b8e9e8e8f7b7fc34e6bf0e316c33e"
 dependencies = [
- "ark-serialize-derive 0.4.1",
- "ark-std 0.4.0",
+ "ark-serialize-derive",
+ "ark-std",
  "digest 0.10.6",
  "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -445,41 +232,12 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "arkworks_backend"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/arkworks_backend?rev=2f3f0db182004d5c01008c741bf519fe6798e24d#2f3f0db182004d5c01008c741bf519fe6798e24d"
-dependencies = [
- "acvm 0.3.1",
- "ark-bls12-381",
- "ark-bn254 0.3.0",
- "ark-ff 0.3.0",
- "ark-marlin",
- "ark-poly 0.3.0",
- "ark-poly-commit",
- "ark-relations",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "blake2",
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -904,7 +662,7 @@ name = "common"
 version = "0.1.0"
 source = "git+https://github.com/noir-lang/aztec_backend?rev=26178359a2251e885f15f0a4d1a686afda04aec9#26178359a2251e885f15f0a4d1a686afda04aec9"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "blake2",
  "dirs 3.0.2",
  "downloader",
@@ -2160,15 +1918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "marlin_arkworks_backend"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/marlin_arkworks_backend?rev=144378edad821bfaa52bf2cacca8ecc87514a4fc#144378edad821bfaa52bf2cacca8ecc87514a4fc"
-dependencies = [
- "acvm 0.3.1",
- "arkworks_backend",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,11 +1993,11 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "iter-extended",
  "noirc_abi",
  "noirc_driver",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "thiserror",
  "toml",
@@ -2258,7 +2007,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "assert_cmd",
  "assert_fs",
  "barretenberg_static_lib",
@@ -2271,13 +2020,12 @@ dependencies = [
  "dirs 4.0.0",
  "hex",
  "iter-extended",
- "marlin_arkworks_backend",
  "nargo",
  "noirc_abi",
  "noirc_driver",
  "noirc_frontend",
  "predicates 2.1.5",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "serde_json",
  "tempdir",
@@ -2291,7 +2039,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -2307,7 +2055,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "iter-extended",
  "serde",
  "serde_json",
@@ -2319,7 +2067,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "clap 4.1.8",
  "fm",
  "iter-extended",
@@ -2345,7 +2093,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -2361,7 +2109,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.3.2"
 dependencies = [
- "acvm 0.8.0",
+ "acvm",
  "arena",
  "chumsky",
  "fm",
@@ -2534,16 +2282,6 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "pest"
-version = "2.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -3019,20 +2757,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver",
 ]
 
 [[package]]
@@ -3174,27 +2903,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -3695,12 +3406,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -40,7 +40,6 @@ color-eyre = "0.6.2"
 # Backends
 aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "https://github.com/noir-lang/aztec_backend", rev = "26178359a2251e885f15f0a4d1a686afda04aec9" }
 aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "26178359a2251e885f15f0a4d1a686afda04aec9" }
-marlin_arkworks_backend = { optional = true, git = "https://github.com/noir-lang/marlin_arkworks_backend", rev = "144378edad821bfaa52bf2cacca8ecc87514a4fc" }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
@@ -51,6 +50,5 @@ predicates = "2.1.5"
 default = ["plonk_bn254"]
 # The plonk backend can only use bn254, so we do not specify the field
 plonk_bn254 = ["aztec_backend"]
-marlin = ["marlin_arkworks_backend/bls12_381"]
 plonk_bn254_wasm = ["aztec_wasm_backend"]
 

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -3,9 +3,6 @@ cfg_if::cfg_if! {
         pub(crate) use aztec_backend::Plonk as ConcreteBackend;
     } else if #[cfg(feature = "plonk_bn254_wasm")] {
         pub(crate) use aztec_wasm_backend::Plonk as ConcreteBackend;
-    } else if #[cfg(feature = "marlin")] {
-        // R1CS_MARLIN_ARKWORKS
-        pub(crate) use marlin_arkworks_backend::Marlin as ConcreteBackend;
     } else {
         compile_error!("please specify a backend to compile with");
     }
@@ -15,12 +12,4 @@ cfg_if::cfg_if! {
 #[cfg(all(feature = "plonk_bn254", feature = "plonk_bn254_wasm"))]
 compile_error!(
     "feature \"plonk_bn254\"  and feature \"plonk_bn254_wasm\" cannot be enabled at the same time"
-);
-#[cfg(all(feature = "plonk_bn254_wasm", feature = "marlin"))]
-compile_error!(
-    "feature \"plonk_bn254_wasm\"  and feature \"marlin\" cannot be enabled at the same time"
-);
-#[cfg(all(feature = "plonk_bn254", feature = "marlin"))]
-compile_error!(
-    "feature \"plonk_bn254\"  and feature \"marlin\" cannot be enabled at the same time"
 );


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/marlin_arkworks_backend/issues/8

# Description

## Summary of changes

I've removed the marlin backend it's using an extremely outdated interface and pulling in a version of ACVM which is multiple breaking releases behind. We shouldn't be "advertising" this feature if people can't activate this feature flag and have it work.

Once https://github.com/noir-lang/marlin_arkworks_backend/issues/8 has been resolved then we can re-add this optional dependency.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
