### PR TITLE
chore(ci): mark github releases as pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           package-name: noir
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
+          prerelease: true # Marks GitHub Releases for 0.x.x versions as "Pre-release"
           pull-request-title-pattern: "chore(noir): Release ${version}"
           extra-files: |
             Cargo.toml


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

This marks the GitHub Release that is produced by Release-Please as a "Pre-release" (see https://github.com/phated/phated/releases for an example).

Noirup and our various guides utilize the "latest" release because GitHub provides a handy redirect: https://github.com/noir-lang/noir/releases/latest and sometimes the docs and demos lag behind. This change allows the previous release to be marked as "latest" until we manually update the GitHub Release to be latest (such as when documentation is done).

Note: In the PR that [added this feature](https://github.com/googleapis/release-please/pull/1181) on Release-Please, they restricted it to 0.x.x versions, which would not work for our workflow after 1.0; however, I think this decision was arbitrary and I'll work with them to allow this to be applied to any release versions.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
