### PR TITLE
chore: update author email to point to `team@noir-lang.org`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/nargo_cli"]
 # x-release-please-start-version
 version = "0.3.2"
 # x-release-please-end
-authors = ["The Noir Team <kevtheappdev@gmail.com>"]
+authors = ["The Noir Team <team@noir-lang.org>"]
 edition = "2021"
 rust-version = "1.66"
 


### PR DESCRIPTION
I'm seeing that we've got a proper email inbox set up here: https://github.com/noir-lang/barretenberg-sys/blob/79f8ae5dbe95a3d35c145abbd455ee1105f7b8f8/Cargo.toml#L5

This PR updates Cargo.toml to reference this.