### PR TITLE
fix(nargo): give contract artifacts unique names to prevent overwrites

### DIFF
--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -41,7 +41,11 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
         let preprocessed_contracts =
             try_vecmap(compiled_contracts, |contract| preprocess_contract(&backend, contract))?;
         for contract in preprocessed_contracts {
-            save_contract_to_file(&contract, &args.circuit_name, &circuit_dir);
+            save_contract_to_file(
+                &contract,
+                &format!("{}-{}", &args.circuit_name, contract.name),
+                &circuit_dir,
+            );
         }
     } else {
         let program = compile_circuit(&backend, &config.program_dir, &args.compile_options)?;


### PR DESCRIPTION
# Related issue(s)

Resolves #1157 

# Description

## Summary of changes

This PR includes the contract name in the build artifact's file name to allow us to compile multiple contracts from the same crate.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
