### PR TITLE
feat: add storage access builtins for A3

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -237,6 +237,34 @@ pub(crate) fn evaluate(
                 output_values: vec![],
             }));
         }
+        Opcode::StorageRead => {
+            outputs = vec![evaluator.add_witness_to_cs()];
+            let inputs = vecmap(prepare_inputs(acir_gen, args, ctx, evaluator), |input| {
+                input.witness.into()
+            });
+
+            evaluator.push_opcode(AcirOpcode::Oracle(OracleData {
+                name: "storageRead".into(),
+                inputs,
+                input_values: vec![],
+                outputs: outputs.clone(),
+                output_values: vec![],
+            }));
+        }
+        Opcode::StorageWrite => {
+            outputs = vec![evaluator.add_witness_to_cs()];
+            let inputs = vecmap(prepare_inputs(acir_gen, args, ctx, evaluator), |input| {
+                input.witness.into()
+            });
+
+            evaluator.push_opcode(AcirOpcode::Oracle(OracleData {
+                name: "storageWrite".into(),
+                inputs,
+                input_values: vec![],
+                outputs: outputs.clone(),
+                output_values: vec![],
+            }));
+        }
     }
 
     // If more than witness is returned,

--- a/crates/noirc_evaluator/src/ssa/builtin.rs
+++ b/crates/noirc_evaluator/src/ssa/builtin.rs
@@ -26,6 +26,8 @@ pub(crate) enum Opcode {
     Get2Notes,
     GetNNotes,
     CallPrivateFunction,
+    StorageRead,
+    StorageWrite
 }
 
 impl std::fmt::Display for Opcode {
@@ -55,6 +57,8 @@ impl Opcode {
             "notifyNullifiedNote" => Some(Opcode::NotifyNullifiedNote),
             "getNotes2" => Some(Opcode::GetNotes2),
             "callPrivateFunction" => Some(Opcode::CallPrivateFunction),
+            "storageRead" => Some(Opcode::StorageRead),
+            "storageWrite" => Some(Opcode::StorageWrite),
             "println" => {
                 Some(Opcode::Println(PrintlnInfo { is_string_output: false, show_output: true }))
             }
@@ -90,6 +94,8 @@ impl Opcode {
             Opcode::NotifyNullifiedNote => "notifyNullifiedNote",
             Opcode::GetNotes2 => "getNotes2",
             Opcode::CallPrivateFunction => "callPrivateFunction",
+            Opcode::StorageRead => "storageRead",
+            Opcode::StorageWrite => "storageWrite",
         }
     }
 
@@ -123,6 +129,8 @@ impl Opcode {
             Opcode::NotifyNullifiedNote => ObjectType::NativeField.max_size(),
             Opcode::GetNotes2 => ObjectType::NativeField.max_size(),
             Opcode::CallPrivateFunction => ObjectType::NativeField.max_size(),
+            Opcode::StorageRead => ObjectType::NativeField.max_size(),
+            Opcode::StorageWrite => ObjectType::NativeField.max_size(),
             Opcode::NotifyCreatedNote
             | Opcode::Get2Notes
             | Opcode::GetNNotes
@@ -171,6 +179,8 @@ impl Opcode {
             Opcode::GetNotes2 => (32, ObjectType::NativeField),
             Opcode::Get2Notes => (32, ObjectType::NativeField),
             Opcode::GetNNotes => (13 * 1024, ObjectType::NativeField),
+            Opcode::StorageRead => (1, ObjectType::NativeField),
+            Opcode::StorageWrite => (1, ObjectType::NativeField),
         }
     }
 }

--- a/crates/noirc_evaluator/src/ssa/builtin.rs
+++ b/crates/noirc_evaluator/src/ssa/builtin.rs
@@ -27,7 +27,7 @@ pub(crate) enum Opcode {
     GetNNotes,
     CallPrivateFunction,
     StorageRead,
-    StorageWrite
+    StorageWrite,
 }
 
 impl std::fmt::Display for Opcode {

--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -534,6 +534,8 @@ fn cse_block_with_anchor(
                     builtin::Opcode::GetNotes2 => (),
                     builtin::Opcode::GetNNotes => (),
                     builtin::Opcode::CallPrivateFunction => (),
+                    builtin::Opcode::StorageRead => (),
+                    builtin::Opcode::StorageWrite => (),
                     _ => {
                         let args = args.iter().map(|arg| {
                             NodeEval::from_id(ctx, *arg).into_const_value().map(|f| f.to_u128())


### PR DESCRIPTION
Adds builtins for read and write of public storage for A3.

- `StorageRead` takes a storage slot as a field, and returns its contents as a field 
- `StorageWrite` takes a storage slot as a field and a new value as a field, and returns the written value

Note that StorageWrite cannot be made to return void since [the acvm expects oracle calls to return _something_](https://github.com/noir-lang/acvm/blob/7352802ca8c4abc9be21ac4f88c8c6b7064d9650/acir/src/circuit/opcodes.rs#L190-L196).