### PR TITLE
fix(ssa): set correct predecessors of IF join

### DIFF
--- a/crates/nargo_cli/tests/test_data/regression/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/regression/src/main.nr
@@ -41,16 +41,61 @@ fn compact_decode<N>(input: [u8; N], length: Field) -> ([u4; NIBBLE_LENGTH], Fie
     out
 }
 
+fn enc<N>(value: [u8; N], value_length: Field) -> ([u8; 32], Field)
+{
+    constrain value.len() as u8 >= value_length as u8;
+    let mut out_value = [0; 32];
+    if value_length == 0
+    {
+    	let out = (out_value, value_length);
+		out
+    }
+    else { if value_length as u8 < 31
+    {
+	out_value[0] = 0x80 + value_length as u8;
+	
+		for i in 1..value.len()
+		{
+			out_value[i] = value[i-1];
+		}
+		
+		let out = (out_value, value_length + 1);
+
+	out
+    }
+    else
+    {
+		let out = (out_value, 32);
+		out
+    }
+	}
+}
+
 fn main(x: [u8; 5], z: Field)
 {
     //Issue 1144
 	let (nib, len) = compact_decode(x,z);
 	constrain len == 5;
 	constrain [nib[0], nib[1], nib[2], nib[3], nib[4]] == [15, 1, 12, 11, 8];
+
+
 }
 
 #[test]
+// Issue 1144
 fn test_1144()
 {
     main([0x3f, 0x1c, 0xb8, 0x99, 0xab], 3);
+}
+
+// Issue 1169
+fn enc_test()
+{
+    let val1 = [0xb8,0x8f,0x61,0xe6,0xfb,0xda,0x83,0xfb,0xff,0xfa,0xbe,0x36,0x41,0x12,0x13,0x74,0x80,0x39,0x80,0x18,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00];
+    let val1_length = 20;
+
+    let enc_val1 = enc(val1,val1_length);
+
+    constrain enc_val1.0 == [0x94,0xb8,0x8f,0x61,0xe6,0xfb,0xda,0x83,0xfb,0xff,0xfa,0xbe,0x36,0x41,0x12,0x13,0x74,0x80,0x39,0x80,0x18,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00];
+    constrain enc_val1.1 == 21;
 }

--- a/crates/noirc_evaluator/src/ssa/ssa_gen.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen.rs
@@ -790,6 +790,7 @@ impl IrGenerator {
         self.context.get_current_block_mut().left = Some(exit_block);
 
         //Exit block plumbing
+        let block2 = self.context.current_block;
         self.context.current_block = exit_block;
         self.context.get_current_block_mut().predecessor.push(block2);
         ssa_form::seal_block(&mut self.context, exit_block, entry_block);


### PR DESCRIPTION
# Related issue(s)


Resolves #1169

# Description

## Summary of changes

Set the proper predecessor block for IF joins


## Test additions / changes

Test case added in regression integration test

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

