### PR TITLE
fix: allow comptime or non comptime fields in unconstrained for loops

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -155,7 +155,7 @@ impl<'interner> TypeChecker<'interner> {
 
                 let mut unify_loop_range = |actual_type, span| {
                     let expected_type = if self.is_unconstrained() {
-                        Type::field(Some(span))
+                        Type::FieldElement(CompTime::new(self.interner))
                     } else {
                         Type::comp_time(Some(span))
                     };


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

The previous check for type checking unconstrained for loops erroneously always unified with a non-comptime Field which produced type errors when used with a comptime one.

This wasn't caught previously since numeric literals are polymorphically comptime and would just bind to CompTime::No previously. It would only trigger if using a variable which was explicitly declared with a comptime type like `let a: comptime Field = 2;`.

## Summary of changes

Fixes the above check by unifying against a polymorphically comptime field instead of a non-comptime one.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
