### PR TITLE
fix: maintain ordering of return value witnesses when constructing ABI

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/return.rs
@@ -46,7 +46,7 @@ pub(crate) fn evaluate(
                     "we do not allow private ABI inputs to be returned as public outputs",
                 )));
             }
-            evaluator.return_values.insert(witness);
+            evaluator.return_values.push(witness);
         }
     }
 


### PR DESCRIPTION
# Related issue(s)

Resolves #1174 

# Description

## Summary of changes

This PR switches the evaluator to track the witnesses for the return value in a `Vec<Witness>` rather than a `BTreeSet<Witness>`. While it's correct to store them as a set inside the `Circuit`, we rely on the ordering of these witnesses for proper ABI decoding and so we need to maintain this when we're constructing the ABI.

See #1174 for an example of this causing improper ABI decoding.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
