### PR TITLE
chore: simplify setup code in `noir_integration` test

### DIFF
--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -34,7 +34,6 @@ const_format = "0.2.30"
 hex = "0.4.2"
 serde_json = "1.0"
 termcolor = "1.1.2"
-tempdir = "0.3.7"
 color-eyre = "0.6.2"
 
 # Backends
@@ -42,6 +41,7 @@ aztec_backend = { optional = true, package = "barretenberg_static_lib", git = "h
 aztec_wasm_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "26178359a2251e885f15f0a4d1a686afda04aec9" }
 
 [dev-dependencies]
+tempdir = "0.3.7"
 assert_cmd = "2.0.8"
 assert_fs = "1.0.10"
 predicates = "2.1.5"

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use color_eyre::eyre;
 
-use crate::find_package_root;
+use crate::{constants::PROOFS_DIR, find_package_root};
 
 mod fs;
 
@@ -85,16 +85,14 @@ pub fn start_cli() -> eyre::Result<()> {
 }
 
 // helper function which tests noir programs by trying to generate a proof and verify it
-pub fn prove_and_verify(proof_name: &str, prg_dir: &Path, show_ssa: bool) -> bool {
-    use tempdir::TempDir;
-
-    let tmp_dir = TempDir::new("p_and_v_tests").unwrap();
+pub fn prove_and_verify(proof_name: &str, program_dir: &Path, show_ssa: bool) -> bool {
     let compile_options = CompileOptions { show_ssa, allow_warnings: false, show_output: false };
+    let proof_dir = program_dir.join(PROOFS_DIR);
 
     match prove_cmd::prove_with_path(
         Some(proof_name.to_owned()),
-        prg_dir,
-        &tmp_dir.into_path(),
+        program_dir,
+        &proof_dir,
         None,
         true,
         &compile_options,

--- a/crates/nargo_cli/tests/prove_and_verify.rs
+++ b/crates/nargo_cli/tests/prove_and_verify.rs
@@ -15,7 +15,6 @@ mod tests {
     fn load_conf(conf_path: &Path) -> BTreeMap<String, Vec<String>> {
         let config_str = std::fs::read_to_string(conf_path).unwrap();
 
-        // Parse config.toml into a BTreeMap, do not fail if config file does not exist.
         let mut conf_data = match toml::from_str(&config_str) {
             Ok(t) => t,
             Err(_) => BTreeMap::from([


### PR DESCRIPTION
# Related issue(s)

Pulling out code from #1179 to separate it from a more controversial change.

# Description

## Summary of changes

This PR pulls out the code readability improvements from #1179 while maintaining the existing method of proving/verifying. We then get the benefits of this refactoring without increasing CI times.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
