### PR TITLE
chore(ssa refactor): Add DenseMap and SparseMap types

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir.rs
@@ -1,5 +1,6 @@
 pub(crate) mod extfunc;
 mod function;
 pub(crate) mod instruction;
+pub(crate) mod map;
 pub(crate) mod types;
 pub(crate) mod value;

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/extfunc.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/extfunc.rs
@@ -1,23 +1,20 @@
 //! Like Crane-lift all functions outside of the current function is seen as
 //! external.
-//! To reference external functions, one uses
+//! To reference external functions, one must first import the function signature
+//! into the current function's context.
 
-use super::types::Typ;
+use super::types::Type;
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct Signature {
-    pub(crate) params: Vec<Typ>,
-    pub(crate) returns: Vec<Typ>,
+    pub(crate) params: Vec<Type>,
+    pub(crate) returns: Vec<Type>,
 }
-/// Reference to a `Signature` in a map inside of
-/// a functions DFG.
-#[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct SigRef(pub(crate) u32);
 
 #[test]
 fn sign_smoke() {
     let mut signature = Signature::default();
 
-    signature.params.push(Typ::Numeric(super::types::NumericType::NativeField));
-    signature.returns.push(Typ::Numeric(super::types::NumericType::Unsigned { bit_size: 32 }));
+    signature.params.push(Type::Numeric(super::types::NumericType::NativeField));
+    signature.returns.push(Type::Numeric(super::types::NumericType::Unsigned { bit_size: 32 }));
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -32,7 +32,7 @@ pub(crate) enum Instruction {
     Binary(Binary),
 
     /// Converts `Value` into Typ
-    Cast(ValueId, Typ),
+    Cast(ValueId, Type),
 
     /// Computes a bit wise not
     Not(ValueId),

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -189,7 +189,7 @@ pub(crate) enum BinaryOp {
 
 #[test]
 fn smoke_instructions_map_duplicate() {
-    let id = Id::make_id_for_testing_only(0);
+    let id = Id::test_new(0);
 
     let ins = Instruction::Not(id);
     let same_ins = Instruction::Not(id);
@@ -211,7 +211,7 @@ fn num_instructions_smoke() {
 
     let mut ins_map = Instructions::default();
     for i in 0..n {
-        let ins = Instruction::Not(Id::make_id_for_testing_only(i));
+        let ins = Instruction::Not(Id::test_new(i));
         ins_map.push(ins);
     }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -28,47 +28,35 @@ pub(crate) struct IntrinsicOpcodes;
 /// Instructions are used to perform tasks.
 /// The instructions that the IR is able to specify are listed below.
 pub(crate) enum Instruction {
-    // Binary Operations
+    /// Binary Operations like +, -, *, /, ==, !=
     Binary(Binary),
+
+    /// Converts `Value` into Typ
+    Cast(ValueId, Typ),
 
     /// Computes a bit wise not
     Not(ValueId),
 
     /// Truncates `value` to `bit_size`
-    Truncate {
-        value: ValueId,
-        bit_size: u32,
-        max_bit_size: u32,
-    },
+    Truncate { value: ValueId, bit_size: u32, max_bit_size: u32 },
 
     /// Constrains a value to be equal to true
     Constrain(ValueId),
 
     /// Performs a function call with a list of its arguments.
-    Call {
-        func: FunctionId,
-        arguments: Vec<ValueId>,
-    },
+    Call { func: FunctionId, arguments: Vec<ValueId> },
     /// Performs a call to an intrinsic function and stores the
     /// results in `return_arguments`.
-    Intrinsic {
-        func: IntrinsicOpcodes,
-        arguments: Vec<ValueId>,
-    },
+    Intrinsic { func: IntrinsicOpcodes, arguments: Vec<ValueId> },
 
     /// Loads a value from memory.
     Load(ValueId),
 
     /// Writes a value to memory.
-    Store {
-        destination: ValueId,
-        value: ValueId,
-    },
+    Store { destination: ValueId, value: ValueId },
 
     /// Stores an Immediate value
-    Immediate {
-        value: FieldElement,
-    },
+    Immediate { value: FieldElement },
 }
 
 impl Instruction {
@@ -77,6 +65,7 @@ impl Instruction {
     pub(crate) fn num_fixed_results(&self) -> usize {
         match self {
             Instruction::Binary(_) => 1,
+            Instruction::Cast(..) => 0,
             Instruction::Not(_) => 1,
             Instruction::Truncate { .. } => 1,
             Instruction::Constrain(_) => 0,
@@ -95,6 +84,7 @@ impl Instruction {
     pub(crate) fn num_fixed_arguments(&self) -> usize {
         match self {
             Instruction::Binary(_) => 2,
+            Instruction::Cast(..) => 1,
             Instruction::Not(_) => 1,
             Instruction::Truncate { .. } => 1,
             Instruction::Constrain(_) => 1,
@@ -113,6 +103,7 @@ impl Instruction {
     pub(crate) fn return_types(&self, ctrl_typevar: Type) -> Vec<Type> {
         match self {
             Instruction::Binary(_) => vec![ctrl_typevar],
+            Instruction::Cast(_, typ) => vec![*typ],
             Instruction::Not(_) => vec![ctrl_typevar],
             Instruction::Truncate { .. } => vec![ctrl_typevar],
             Instruction::Constrain(_) => vec![],

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
@@ -26,7 +26,8 @@ impl<T> Id<T> {
     /// be used for testing. Obtaining Ids in this way should be avoided
     /// as unlike DenseMap::push and SparseMap::push, the Ids created
     /// here are likely invalid for any particularly map.
-    pub(crate) fn make_id_for_testing_only(index: usize) -> Self {
+    #[cfg(test)]
+    pub(crate) fn test_new(index: usize) -> Self {
         Self::new(index)
     }
 }
@@ -79,8 +80,8 @@ impl<T> DenseMap<T> {
     pub(crate) fn len(&self) -> usize {
         self.storage.len()
     }
-/// Adds an element to the map.
-/// Returns the identifier/reference to that element.
+    /// Adds an element to the map.
+    /// Returns the identifier/reference to that element.
     pub(crate) fn push(&mut self, element: T) -> Id<T> {
         let id = Id::new(self.storage.len());
         self.storage.push(element);
@@ -128,8 +129,9 @@ impl<T> SparseMap<T> {
     pub(crate) fn len(&self) -> usize {
         self.storage.len()
     }
-/// Adds an element to the map.
-/// Returns the identifier/reference to that element.
+
+    /// Adds an element to the map.
+    /// Returns the identifier/reference to that element.
     pub(crate) fn push(&mut self, element: T) -> Id<T> {
         let id = Id::new(self.storage.len());
         self.storage.insert(id, element);

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
@@ -124,10 +124,12 @@ pub(crate) struct SparseMap<T> {
 }
 
 impl<T> SparseMap<T> {
+    /// Returns the number of elements in the map.
     pub(crate) fn len(&self) -> usize {
         self.storage.len()
     }
-
+/// Adds an element to the map.
+/// Returns the identifier/reference to that element.
     pub(crate) fn push(&mut self, element: T) -> Id<T> {
         let id = Id::new(self.storage.len());
         self.storage.insert(id, element);

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
@@ -1,0 +1,161 @@
+use std::collections::HashMap;
+
+/// A unique ID corresponding to a value of type T.
+/// This type can be used to retrieve a value of type T from
+/// either a DenseMap<T> or SparseMap<T>.
+///
+/// Note that there is nothing in an Id binding it to a particular
+/// DenseMap or SparseMap. If an Id was created to correspond to one
+/// particular map type, users need to take care not to use it with
+/// another map where it will likely be invalid.
+pub(crate) struct Id<T> {
+    index: usize,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Id<T> {
+    /// Constructs a new Id for the given index.
+    /// This constructor is deliberately private to prevent
+    /// constructing invalid IDs.
+    fn new(index: usize) -> Self {
+        Self { index, _marker: std::marker::PhantomData }
+    }
+
+    /// Creates a test Id with the given index.
+    /// The name of this function makes it apparent it should only
+    /// be used for testing. Obtaining Ids in this way should be avoided
+    /// as unlike DenseMap::push and SparseMap::push, the Ids created
+    /// here are likely invalid for any particularly map.
+    pub(crate) fn make_id_for_testing_only(index: usize) -> Self {
+        Self::new(index)
+    }
+}
+
+// Need to manually implement most impls on Id.
+// Otherwise rust assumes that Id<T>: Hash only if T: Hash,
+// which isn't true since the T is not used internally.
+impl<T> std::hash::Hash for Id<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
+}
+
+impl<T> Eq for Id<T> {}
+
+impl<T> PartialEq for Id<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl<T> Copy for Id<T> {}
+
+impl<T> Clone for Id<T> {
+    fn clone(&self) -> Self {
+        Self { index: self.index, _marker: self._marker }
+    }
+}
+
+impl<T> std::fmt::Debug for Id<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately formatting as a tuple with 1 element here and omitting
+        // the _marker: PhantomData field which would just clutter output
+        f.debug_tuple("Id").field(&self.index).finish()
+    }
+}
+
+/// A DenseMap is a Vec wrapper where each element corresponds
+/// to a unique ID that can be used to access the element. No direct
+/// access to indices is provided. Since IDs must be stable and correspond
+/// to indices in the internal Vec, operations that would change element
+/// ordering like pop, remove, swap_remove, etc, are not possible.
+#[derive(Debug)]
+pub(crate) struct DenseMap<T> {
+    storage: Vec<T>,
+}
+
+impl<T> DenseMap<T> {
+    pub(crate) fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub(crate) fn push(&mut self, element: T) -> Id<T> {
+        let id = Id::new(self.storage.len());
+        self.storage.push(element);
+        id
+    }
+}
+
+impl<T> Default for DenseMap<T> {
+    fn default() -> Self {
+        Self { storage: Vec::new() }
+    }
+}
+
+impl<T> std::ops::Index<Id<T>> for DenseMap<T> {
+    type Output = T;
+
+    fn index(&self, id: Id<T>) -> &Self::Output {
+        &self.storage[id.index]
+    }
+}
+
+impl<T> std::ops::IndexMut<Id<T>> for DenseMap<T> {
+    fn index_mut(&mut self, id: Id<T>) -> &mut Self::Output {
+        &mut self.storage[id.index]
+    }
+}
+
+/// A SparseMap is a HashMap wrapper where each element corresponds
+/// to a unique ID that can be used to access the element. No direct
+/// access to indices is provided.
+///
+/// Unlike DenseMap, SparseMap's IDs are stored within the structure
+/// and are thus stable after element removal.
+///
+/// Note that unlike DenseMap, it is possible to panic when retrieving
+/// an element if the element's Id has been invalidated by a previous
+/// call to .remove().
+#[derive(Debug)]
+pub(crate) struct SparseMap<T> {
+    storage: HashMap<Id<T>, T>,
+}
+
+impl<T> SparseMap<T> {
+    pub(crate) fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub(crate) fn push(&mut self, element: T) -> Id<T> {
+        let id = Id::new(self.storage.len());
+        self.storage.insert(id, element);
+        id
+    }
+
+    /// Remove an element from the map and return it.
+    /// This may return None if the element was already
+    /// previously removed from the map.
+    pub(crate) fn remove(&mut self, id: Id<T>) -> Option<T> {
+        self.storage.remove(&id)
+    }
+}
+
+impl<T> Default for SparseMap<T> {
+    fn default() -> Self {
+        Self { storage: HashMap::new() }
+    }
+}
+
+impl<T> std::ops::Index<Id<T>> for SparseMap<T> {
+    type Output = T;
+
+    fn index(&self, id: Id<T>) -> &Self::Output {
+        &self.storage[&id]
+    }
+}
+
+impl<T> std::ops::IndexMut<Id<T>> for SparseMap<T> {
+    fn index_mut(&mut self, id: Id<T>) -> &mut Self::Output {
+        self.storage.get_mut(&id).expect("Invalid id used in SparseMap::index_mut")
+    }
+}

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
@@ -75,6 +75,7 @@ pub(crate) struct DenseMap<T> {
 }
 
 impl<T> DenseMap<T> {
+    /// Returns the number of elements in the map.
     pub(crate) fn len(&self) -> usize {
         self.storage.len()
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/map.rs
@@ -79,7 +79,8 @@ impl<T> DenseMap<T> {
     pub(crate) fn len(&self) -> usize {
         self.storage.len()
     }
-
+/// Adds an element to the map.
+/// Returns the identifier/reference to that element.
     pub(crate) fn push(&mut self, element: T) -> Id<T> {
         let id = Id::new(self.storage.len());
         self.storage.push(element);

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/types.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/types.rs
@@ -13,12 +13,11 @@ pub(crate) enum NumericType {
     NativeField,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 /// All types representable in the IR.
-pub(crate) enum Typ {
-    /// Represents numeric types in the IR
-    /// including field elements
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum Type {
+    /// Represents numeric types in the IR, including field elements
     Numeric(NumericType),
-    /// Represents the absence of a Type.
+    /// The Unit type with a single value
     Unit,
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
@@ -1,10 +1,9 @@
-use super::{instruction::InstructionId, types::Typ};
+use super::{instruction::InstructionId, map::Id, types::Type};
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub(crate) type ValueId = Id<Value>;
+
 /// Value is the most basic type allowed in the IR.
-/// Transition Note: This is similar to `NodeId` in our previous IR.
-pub(crate) struct ValueId(pub(crate) u32);
-
+/// Transition Note: A Id<Value> is similar to `NodeId` in our previous IR.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum Value {
     /// This value was created due to an instruction
@@ -16,5 +15,5 @@ pub(crate) enum Value {
     /// Example, if you add two numbers together, then the resulting
     /// value would have position `0`, the typ would be the type
     /// of the operands, and the instruction would map to an add instruction.
-    Instruction { typ: Typ, position: u16, instruction: InstructionId },
+    Instruction { typ: Type, position: u16, instruction: InstructionId },
 }


### PR DESCRIPTION
# Description

Refactors a common pattern of having:
- `HashMap<MyStructId, MyStruct>` into a `SparseMap<MyStruct>`
- `Vec<MyStruct>` which also returns and is acccessed by unique Ids into a `DenseMap<MyStruct>`.
- Instead of having a different type for each Id type, there is now a single `Id<T>`. So for example a ValueId is now a `Id<Value>` or a "Id that can be used to retrieve a Value." Type aliases are provided to keep the familiar ValueId name though.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

This is a PR for the SSA Refactoring only, it shouldn't cause any observable changes and only touches the ssa-refactor folder.
