### PR TITLE
fix(nargo): restore `nargo codegen-verifier` functionality

### DIFF
--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -1,8 +1,9 @@
 use super::fs::{create_named_dir, write_to_file};
 use super::NargoConfig;
 use crate::{cli::compile_cmd::compile_circuit, constants::CONTRACT_DIR, errors::CliError};
+use acvm::SmartContract;
 use clap::Args;
-use nargo::ops::{codegen_verifier, preprocess_program};
+use nargo::ops::preprocess_program;
 use noirc_driver::CompileOptions;
 
 /// Generates a Solidity verifier smart contract for the program
@@ -18,7 +19,8 @@ pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(
     let compiled_program = compile_circuit(&backend, &config.program_dir, &args.compile_options)?;
     let preprocessed_program = preprocess_program(&backend, compiled_program)?;
 
-    let smart_contract_string = codegen_verifier(&backend, &preprocessed_program.verification_key)?;
+    #[allow(deprecated)]
+    let smart_contract_string = backend.eth_contract_from_cs(preprocessed_program.bytecode);
 
     let contract_dir = config.program_dir.join(CONTRACT_DIR);
     create_named_dir(&contract_dir, "contract");

--- a/crates/nargo_cli/tests/codegen-verifier.rs
+++ b/crates/nargo_cli/tests/codegen-verifier.rs
@@ -1,0 +1,33 @@
+//! This integration test aims to check that the `nargo codegen-verifier` will successfully create a
+//! file containing a verifier for a simple program.
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use assert_fs::prelude::{PathAssert, PathChild};
+
+#[test]
+fn simple_verifier_codegen() {
+    let test_dir = assert_fs::TempDir::new().unwrap();
+    std::env::set_current_dir(&test_dir).unwrap();
+
+    // Create trivial program
+    let project_name = "hello_world";
+    let project_dir = test_dir.child(project_name);
+
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("new").arg(project_name);
+    cmd.assert().success();
+
+    std::env::set_current_dir(&project_dir).unwrap();
+
+    // Run `nargo codegen-verifier`
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("codegen-verifier");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Contract successfully created and located at"));
+
+    project_dir.child("contract").child("plonk_vk.sol").assert(predicate::path::is_file());
+}


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

Looks like we got a bit ahead of ourselves and started using `eth_contract_from_vk` against a commit of `aztec_backend` where that isn't implemented yet. If you run `nargo codegen-verifier` on v0.4.0 you get

```shell
$ nargo codegen-verifier
The application panicked (crashed).
Message:  not yet implemented: use `eth_contract_from_cs` for now
Location: /home/tom/.cargo/git/checkouts/aztec_backend-a697fb631cbad807/2617835/barretenberg_static_lib/src/acvm_interop/smart_contract.rs:10

This is a bug. Consider opening an issue at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml
```

This PR reverts to `eth_contract_from_cs` and adds an integration test that if you run `codegen-verifier` the command succeeds and you get *some* file created.

I haven't made any change to `nargo::ops::codegen_verifier` as that's backend agnostic and I don't want to make a breaking change to fix this.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
