### PR TITLE
feat!: Change precedence of bitwise ops to match logical ops

### DIFF
--- a/crates/nargo_cli/tests/test_data/bool_or/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/bool_or/src/main.nr
@@ -1,7 +1,5 @@
-use dep::std;
 fn main(x: u1, y: u1) {
-    constrain x | y == 1;
-
-    constrain x | y | x == 1;
+    constrain (x | y) == 1;
+    constrain (x | y | x) == 1;
 }
     

--- a/crates/nargo_cli/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/global_consts/src/main.nr
@@ -77,7 +77,7 @@ mod mysubmodule {
     global L: Field = 50;
 
     fn my_bool_or(x: u1, y: u1) {
-        constrain x | y == 1;
+        constrain (x | y) == 1;
     }
 
     fn my_helper() -> comptime Field {

--- a/crates/nargo_cli/tests/test_data/submodules/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/submodules/src/main.nr
@@ -9,7 +9,7 @@ mod mysubmodule {
     use dep::std;
 
     fn my_bool_or(x: u1, y: u1) {
-        constrain x | y == 1;
+        constrain (x | y) == 1;
     }
 
     fn my_helper() {}

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -269,11 +269,11 @@ impl ParsedModule {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
 pub enum Precedence {
-    Lowest,
-    Or,
+    Lowest, // == Token::Or
     And,
     Xor,
-    LessGreater,
+    Equal,
+    Comparison,
     Shift,
     Sum,
     Product,
@@ -285,15 +285,15 @@ impl Precedence {
     // XXX: Check the precedence is correct for operators
     fn token_precedence(tok: &Token) -> Option<Precedence> {
         let precedence = match tok {
-            Token::Equal => Precedence::Lowest,
-            Token::NotEqual => Precedence::Lowest,
-            Token::Pipe => Precedence::Or,
+            Token::Pipe => Precedence::Lowest,
             Token::Ampersand => Precedence::And,
             Token::Caret => Precedence::Xor,
-            Token::Less => Precedence::LessGreater,
-            Token::LessEqual => Precedence::LessGreater,
-            Token::Greater => Precedence::LessGreater,
-            Token::GreaterEqual => Precedence::LessGreater,
+            Token::Equal => Precedence::Equal,
+            Token::NotEqual => Precedence::Equal,
+            Token::Less => Precedence::Comparison,
+            Token::LessEqual => Precedence::Comparison,
+            Token::Greater => Precedence::Comparison,
+            Token::GreaterEqual => Precedence::Comparison,
             Token::ShiftLeft => Precedence::Shift,
             Token::ShiftRight => Precedence::Shift,
             Token::Plus => Precedence::Sum,
@@ -312,11 +312,11 @@ impl Precedence {
     fn next(self) -> Self {
         use Precedence::*;
         match self {
-            Lowest => Or,
-            Or => Xor,
-            Xor => And,
-            And => LessGreater,
-            LessGreater => Shift,
+            Lowest => And,
+            And => Xor,
+            Xor => Equal,
+            Equal => Comparison,
+            Comparison => Shift,
             Shift => Sum,
             Sum => Product,
             Product => Highest,


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1191 

# Description

## Summary of changes

Fixes the common error of trying `a == b & c == d` (or some variant) without realizing the precedence of `&` previously parsed this as `a == (b & c) == d`. This PR lowers the precedence of &, |, and ^ (for completeness) so that it is now parsed as `(a == b) & (c == d)`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

Updated tests that used the old precedence to add parenthesis where needed

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
