### PR TITLE
chore(ssa): Replace JmpIf with BrIf

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -128,8 +128,8 @@ pub(crate) enum TerminatorInstruction {
     ///
     /// Branch If
     ///
-     /// If the condition is true: jump to the specified `then_destination` with `arguments`.
-     /// Otherwise, jump to the specified `else_destination` with `arguments`.
+    /// If the condition is true: jump to the specified `then_destination` with `arguments`.
+    /// Otherwise, jump to the specified `else_destination` with `arguments`.
     BrIf {
         condition: ValueId,
         then_destination: BasicBlockId,

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -128,8 +128,8 @@ pub(crate) enum TerminatorInstruction {
     ///
     /// Branch If
     ///
-    /// Branches to the specified `then_destination` with `arguments` if the condition is true,
-    /// otherwise branches to the `else_destination` with `arguments`.
+     /// If the condition is true: jump to the specified `then_destination` with `arguments`.
+     /// Otherwise, jump to the specified `else_destination` with `arguments`.
     BrIf {
         condition: ValueId,
         then_destination: BasicBlockId,

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -126,12 +126,16 @@ impl Instruction {
 pub(crate) enum TerminatorInstruction {
     /// Control flow
     ///
-    /// Jump If
+    /// Branch If
     ///
-    /// Jumps to the specified `destination` with
-    /// arguments, if the condition
-    /// if the condition is true.
-    JmpIf { condition: ValueId, destination: BasicBlockId, arguments: BlockArguments },
+    /// Branches to the specified `then_destination` with `arguments` if the condition is true,
+    /// otherwise branches to the `else_destination` with `arguments`.
+    BrIf {
+        condition: ValueId,
+        then_destination: BasicBlockId,
+        else_destination: BasicBlockId,
+        arguments: BlockArguments,
+    },
     /// Unconditional Jump
     ///
     /// Jumps to specified `destination` with `arguments`

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -126,11 +126,11 @@ impl Instruction {
 pub(crate) enum TerminatorInstruction {
     /// Control flow
     ///
-    /// Branch If
+    /// Jump If
     ///
     /// If the condition is true: jump to the specified `then_destination` with `arguments`.
     /// Otherwise, jump to the specified `else_destination` with `arguments`.
-    BrIf {
+    JmpIf {
         condition: ValueId,
         then_destination: BasicBlockId,
         else_destination: BasicBlockId,


### PR DESCRIPTION
`JmpIf` isn't sufficient for encoding block arguments for the fall through successor. It is also more convenient if block terminator instructions describe all successors, such that we do not have to infer fall throughs from some block ordering.

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
