### PR TITLE
Add formal grammar

### DIFF
--- a/crates/noirc_frontend/src/parser/grammar.bnf
+++ b/crates/noirc_frontend/src/parser/grammar.bnf
@@ -1,0 +1,227 @@
+// Our BNF syntax used in the specification below works as follows:
+// 
+// foo ::= bar baz
+// Foo derives bar followed by baz.
+// 
+// foo ::= bar | baz
+// Foo derives either bar or baz.
+// 
+// bar ::= baz*
+// Bar derives a sequence of zero or more baz.
+// 
+// bar ::= baz+
+// Bar derives a sequence of one or more baz.
+// 
+// bar ::= foo? baz?
+// Bar derives optional foo followed by optional baz.
+// 
+// bar ::= baz%','+
+// Bar derives a sequence of one or more baz where consecutive baz's are separated by a comma
+// without a trailing comma.
+//
+// baz ::= ()
+// Baz has a nulling rule (derives an epsilon string).
+// 
+// foo ::= zero_width(bar baz)
+// Foo makes a zero-width assertion that bar and baz are present ahead.
+//
+// #start foo
+// Declare start symbol.
+//
+// #token bar
+// Declare token.
+//
+// foo(true) ::= bar
+// foo(false) ::= baz
+// Rules with parameters.
+
+#start program
+program ::= module
+
+module ::= top_level_statement*
+
+top_level_statement ::= function_definition(false)
+                      | struct_definition
+                      | implementation
+                      | submodule
+                      | module_declaration
+                      | use_statement
+                      | global_declaration
+
+global_declaration ::= 'global' ident global_type_annotation '=' literal
+
+submodule ::= 'mod' ident '{' module '}'
+
+contract ::= 'contract' ident '{' module '}'
+
+function_definition(allow_self) ::= attribute? function_modifiers 'fn' ident generics '(' function_parameters(allow_self) ')' function_return_type block
+
+function_modifiers ::= 'unconstrained'? 'open'?
+
+generics ::= '<' ident%','* '>' | ()
+
+'struct' ident generics '{' struct_fields '}'
+
+lambda_return_type ::= ('->' type)?
+
+function_return_type ::= ('->' optional_visibility type)?
+
+#token attribute
+
+struct_fields ::= (ident ':' type)%','*
+
+lambda_parameters ::= pattern%','*
+
+function_parameters(false) ::= (pattern ':' optional_visibility type)%','+
+function_parameters(true) ::= (self_parameter | pattern ':' optional_visibility type)%','+
+
+nothing ::= !()
+
+self_parameter ::= 'self'
+
+implementation ::= 'impl' generics type '{' function_definition(true)* '}'
+
+block_expr ::= block(expr_parser)
+
+block ::= '{' (statement (';' statement)*)? ';'? '}'
+
+global_type_annotation ::= (':' type)?
+
+optional_type_annotation ::= (':' type)?
+
+module_declaration ::= 'mod' ident
+
+use_statement ::= 'use' path ('as' ident)?
+
+path ::= 'crate' idents | 'dep' idents | idents
+idents ::= ident%'::'+
+
+#token ident
+
+statement ::= constrain | declaration | assignment | expression
+
+constrain ::= 'constrain' expression
+
+declaration ::= 'let' pattern optional_type_annotation '=' expression
+
+pattern ::= ident | 'mut' pattern | '(' pattern%','* ')' | path '{' (ident | ident ':' pattern)%','* '}'
+
+assignment ::= lvalue assign_operator expression
+
+assign_operator ::= ('+' | '-' | '*' | '/' | '%' | '&' | '^' | '<<' | '>>' | '|') '='
+
+lvalue ::= ident ('.' ident | '[' expression ']')*
+
+type ::= type_inner
+type_inner ::= field_type | int_type | bool_type
+               | string_type | named_type | array_type
+               | tuple_type | vec_type | function_type
+
+optional_visibility ::= 'pub'?
+
+maybe_comp_time ::= 'comptime'?
+
+field_type ::= maybe_comp_time 'Field'?
+
+bool_type ::= maybe_comp_time 'bool'
+
+string_type ::= 'str' ('<' type_expression '>')?
+
+int_type ::= maybe_comp_time IntType
+
+named_type ::= path generic_type_args
+
+vec_type ::= 'Vec' generic_type_args
+
+generic_type_args ::= ('<' (type zero_width(',' | '>') | type_expression)%','+ ','? '>')?
+
+array_type ::= '[' type (':' type_expression)? ']'
+
+type_expression ::= expression_with_precedence(lowest_type_precedence, type_expression, true)
+
+tuple_type ::= '(' (type%','+ ','?)? ')'
+
+function_type ::= 'fn' '(' (type%','+ ','?)? ')' '->' type
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// expression ::= expression_with_precedence(Lowest, expression, false)
+
+/// expression_with_precedence(Highest, ExprParser, true) ::= type_expression_term
+/// expression_with_precedence(Highest, ExprParser, false) ::= term
+/// expression_with_precedence(precedence, ExprParser, true) ::= expression_with_precedence(precedence.next_type_precedence(), ExprParser, true)
+///                                                              (
+///                                                                 operator_with_precedence(precedence)
+///                                                                 expression_with_precedence(precedence.next_type_precedence(), ExprParser, true)
+///                                                              )*
+/// expression_with_precedence(precedence, ExprParser, false) ::= expression_with_precedence(precedence.next(), ExprParser, false)
+///                                                              (
+///                                                                 operator_with_precedence(precedence)
+///                                                                 expression_with_precedence(precedence.next(), ExprParser, false)
+///                                                              )*
+
+/// EQUIVALENT TO:
+
+expression ::= eq_expr
+eq_expr ::= eq_expr ('=' | '!=') or_expr | or_expr
+or_expr ::= or_expr '|' xor_expr | xor_expr
+xor_expr ::= xor_expr '^' and_expr | and_expr
+and_expr ::= and_expr '&' less_greater_expr | less_greater_expr
+less_greater_expr :;= less_greater_expr ('<' | '<=' | '>' | '>=') shift_expr
+shift_expr ::= shift_expr ('<<' | '>>') sum_expr | sum_expr
+sum_expr ::= sum_expr ('+' | '-') product_expr | product_expr
+product_expr ::= product_expr ('/' | '*') term | term
+
+type_expression ::= type_eq_expr
+type_eq_expr ::= type_eq_expr ('=' | '!=') type_sum_expr | type_sum_expr
+type_sum_expr ::= type_sum_expr ('+' | '-') type_product_expr | type_product_expr
+type_product_expr ::= type_product_expr ('/' | '*') type_expression_term | type_expression_term
+
+////////////////////////////////////////////////////////////////////////////////
+
+term ::= not | negation | atom_or_right_unary
+
+atom_or_right_unary ::= atom (call_rhs | array_rhs | cast_rhs | member_rhs)*
+call_rhs ::= '(' expression_list ')'
+array_rhs ::= '[' expression ']'
+cast_rhs ::= 'as' type
+member_rhs ::= '.' field_name ('(' expression_list ')')?
+
+if_expr ::= 'if' expression block_expr ('else' (block_expr | if_expr))? 
+
+lambda ::= '|' lambda_parameters '|' lambda_return_type expression
+
+for_expr ::= 'for' ident 'in' for_range block_expr 
+
+for_range ::= expression '..' expression | expression
+
+array_expr ::= standard_array | array_sugar
+
+standard_array ::= '[' expression ']'
+
+array_sugar ::= '[' expression ';' expression ']' 
+
+expression_list ::= (expression%','+ ','?)?
+
+not ::= '!' term 
+
+negation ::= '-' term
+
+atom ::= '(' expression ')' | tuple | if_expr | for_expr | array_expr | constructor | lambda | block | variable | literal
+
+type_expression_atom ::= variable | literal | '(' type_expression ')'
+
+tuple ::= '(' expression_list ')'
+
+field_name ::= ident | int
+#token int
+
+constructor ::= path '{' constructor_field%','+ ','? '}'
+
+constructor_field ::= ident (':' expression)?
+
+variable ::= path
+
+literal ::= int | bool | str
+
+literal_or_collection ::= literal | constructor | array_expr


### PR DESCRIPTION
# Related issue(s)

Tracking Issue: Parser fuzzing #816 

# Description

## Summary of changes

Adds a formal grammar in the BNF format in a separate file: adds a file `noirc_frontend/parser/grammar.bnf`.

Moves existing formal rules to `grammar.bnf`: makes small changes to comments in `parser/parser.rs`.

## Test additions / changes

None.

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.