### PR TITLE
chore(ci): add cache for Nix workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/nix-cache
-          key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}
+          key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
 
       # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
       - name: Copy cache into nix store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,32 @@ jobs:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: cachix/cachix-action@v12
+        with:
+          name: barretenberg
+
+      - name: Restore nix store cache
+        id: nix-store-cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/nix-cache
+          key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock') }}
+
+      # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
+      - name: Copy cache into nix store
+        if: steps.nix-store-cache.outputs.cache-hit == 'true'
+        # We don't check the signature because we're the one that created the cache
+        run: |
+          for narinfo in /tmp/nix-cache/*.narinfo; do
+            path=$(head -n 1 "$narinfo" | awk '{print $2}')
+            nix copy --no-check-sigs --from "file:///tmp/nix-cache" "$path"
+          done
+
       - name: Run `nix flake check`
         run: |
-          nix flake check
+          nix flake check -L
+
+      - name: Export cache from nix store
+        if: steps.nix-store-cache.outputs.cache-hit != 'true'
+        run: |
+          nix copy --to "file:///tmp/nix-cache?compression=zstd&parallel-compression=true" .#cargo-artifacts

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682019675,
-        "narHash": "sha256-KZ/VL/u81z2sFTdwfxvUFR+ftqf3+2AA0gR9kkgKxe4=",
+        "lastModified": 1682345890,
+        "narHash": "sha256-ZsInK9Iy81MaCugouU3ifa5Vw2GKlJK9MxCU/LF8bIw=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "a38e3611590e085e5f25c322757871fb048aa3d7",
+        "rev": "87aeb375d7b434e0faf47abb79f97753ab760987",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681680516,
-        "narHash": "sha256-EB8Adaeg4zgcYDJn9sR6UMjN/OHdIiMMK19+3LmmXQY=",
+        "lastModified": 1681177078,
+        "narHash": "sha256-ZNIjBDou2GOabcpctiQykEQVkI8BDwk7TyvlWlI4myE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "54b63c8eae4c50172cb50b612946ff1d2bc1c75c",
+        "rev": "0c9f468ff00576577d83f5019a66c557ede5acf6",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681932375,
-        "narHash": "sha256-tSXbYmpnKSSWpzOrs27ie8X3I0yqKA6AuCzCYNtwbCU=",
+        "lastModified": 1681269223,
+        "narHash": "sha256-i6OeI2f7qGvmLfD07l1Az5iBL+bFeP0RHixisWtpUGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d302c67ab8647327dba84fbdb443cdbf0e82744",
+        "rev": "87edbd74246ccdfa64503f334ed86fa04010bab9",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681957132,
-        "narHash": "sha256-52GaHyeLyyiT0u4OL3uGbo0vsUMKm33Z3zLkPyK/ZRY=",
+        "lastModified": 1681352318,
+        "narHash": "sha256-+kwy7bTsuW8GYrRqWRQ8T5hg6duZb5IJiHlKo1J+v9g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4771640d46c214d702512a8ece591f582ae507fa",
+        "rev": "aeaa11c65a5c5cebaa51652353ab3c497b9a7bbf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,9 @@
 
       packages.default = noir;
 
+      # We expose the `cargo-artifacts` derivation so we can cache our cargo dependencies in CI
+      packages.cargo-artifacts = cargoArtifacts;
+
       # TODO(#1197): Look into installable apps with Nix flakes
       # apps.default = flake-utils.lib.mkApp { drv = nargo; };
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->
This adds cache logic to the Nix CI workflow. It uses a `cachix` binary store to load barretenberg & barretenberg.wasm and it exports all cargo dependencies from the Nix store after a successful run, which it can then re-use on subsequent runs.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
