### PR TITLE
chore: Emit an error for the 'return' expression

### DIFF
--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -106,6 +106,12 @@ impl Recoverable for Expression {
     }
 }
 
+impl Recoverable for Option<Expression> {
+    fn error(span: Span) -> Self {
+        Some(Expression::new(ExpressionKind::Error, span))
+    }
+}
+
 #[derive(Debug, Eq, Clone)]
 pub struct Expression {
     pub kind: ExpressionKind,

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -803,7 +803,7 @@ impl<'a> Resolver<'a> {
                 let stmt = HirAssignStatement { lvalue: identifier, expression };
                 HirStatement::Assign(stmt)
             }
-            Statement::Error => HirStatement::Error,
+            Statement::Error | Statement::Return { .. } => HirStatement::Error,
         }
     }
 

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -1531,9 +1531,6 @@ mod test {
             result
         });
 
-        assert_eq!(
-            vecmap(&results, |t| t.0.clone()),
-            vecmap(&results, |t| t.1.clone()),
-        );
+        assert_eq!(vecmap(&results, |t| t.0.clone()), vecmap(&results, |t| t.1.clone()),);
     }
 }


### PR DESCRIPTION
# Related issue(s)

Resolves #1190

# Description

Emit the `Early 'return' is unsupported` message for the 'return' expression

## Dependency additions / changes

N/A

## Test additions / changes

Added `return_validation`

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context

N/A
