### PR TITLE
chore: add RUST_BACKTRACE environment variable to nix config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,9 @@
         # hidden from the developer - i.e. when they see the command being run via `nix flake check`
         RUST_TEST_THREADS = "1";
 
+        # We enable backtraces on any failure for help with debugging
+        RUST_BACKTRACE = "1";
+
         # We set the environment variable because barretenberg must be compiled in a special way for wasm
         BARRETENBERG_BIN_DIR = "${pkgs.barretenberg-wasm}/bin";
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

This adds `RUST_BACKTRACE=1` to the nix environment. This means it will be set in any direnv shell and any nix commands run. This should help with debugging.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
