### PR TITLE
chore(ssa refactor): Update how instruction result types are retrieved

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -199,7 +199,7 @@ pub(crate) enum BinaryOp {
     Lt,
     /// Bitwise and (&)
     And,
-    /// Bitiwse or (|)
+    /// Bitwise or (|)
     Or,
     /// Bitwise xor (^)
     Xor,
@@ -207,29 +207,6 @@ pub(crate) enum BinaryOp {
     Shl,
     /// Shift lhs right by rhs bits (>>)
     Shr,
-}
-
-impl From<noirc_frontend::BinaryOpKind> for BinaryOp {
-    fn from(value: noirc_frontend::BinaryOpKind) -> Self {
-        match value {
-            noirc_frontend::BinaryOpKind::Add => todo!(),
-            noirc_frontend::BinaryOpKind::Subtract => todo!(),
-            noirc_frontend::BinaryOpKind::Multiply => todo!(),
-            noirc_frontend::BinaryOpKind::Divide => todo!(),
-            noirc_frontend::BinaryOpKind::Equal => todo!(),
-            noirc_frontend::BinaryOpKind::NotEqual => todo!(),
-            noirc_frontend::BinaryOpKind::Less => todo!(),
-            noirc_frontend::BinaryOpKind::LessEqual => todo!(),
-            noirc_frontend::BinaryOpKind::Greater => todo!(),
-            noirc_frontend::BinaryOpKind::GreaterEqual => todo!(),
-            noirc_frontend::BinaryOpKind::And => todo!(),
-            noirc_frontend::BinaryOpKind::Or => todo!(),
-            noirc_frontend::BinaryOpKind::Xor => todo!(),
-            noirc_frontend::BinaryOpKind::ShiftRight => todo!(),
-            noirc_frontend::BinaryOpKind::ShiftLeft => todo!(),
-            noirc_frontend::BinaryOpKind::Modulo => todo!(),
-        }
-    }
 }
 
 impl std::fmt::Display for BinaryOp {

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -170,32 +170,66 @@ pub(crate) struct Binary {
 }
 
 /// Binary Operations allowed in the IR.
+/// Aside from the comparison operators (Eq and Lt), all operators
+/// will return the same type as their operands.
+/// The operand types must match for all binary operators.
+/// All binary operators are also only for numeric types. To implement
+/// e.g. equality for a compound type like a struct, one must add a
+/// separate Eq operation for each field and combine them later with And.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum BinaryOp {
-    /// Addition of two types.
-    /// The result will have the same type as
-    /// the operands.
+    /// Addition of lhs + rhs.
     Add,
-    /// Subtraction of two types.
-    /// The result will have the same type as
-    /// the operands.
+    /// Subtraction of lhs - rhs.
     Sub,
-    /// Multiplication of two types.
-    /// The result will have the same type as
-    /// the operands.
+    /// Multiplication of lhs * rhs.
     Mul,
-    /// Division of two types.
-    /// The result will have the same type as
-    /// the operands.
+    /// Division of lhs / rhs.
     Div,
+    /// Modulus of lhs % rhs.
+    Mod,
     /// Checks whether two types are equal.
     /// Returns true if the types were equal and
     /// false otherwise.
     Eq,
-    /// Checks whether two types are equal.
-    /// Returns true if the types were not equal and
-    /// false otherwise.
-    Neq,
+    /// Checks whether the lhs is less than the rhs.
+    /// All other comparison operators should be translated
+    /// to less than. For example (a > b) = (b < a) = !(a >= b) = !(b <= a).
+    /// The result will always be a u1.
+    Lt,
+    /// Bitwise and (&)
+    And,
+    /// Bitiwse or (|)
+    Or,
+    /// Bitwise xor (^)
+    Xor,
+    /// Shift lhs left by rhs bits (<<)
+    Shl,
+    /// Shift lhs right by rhs bits (>>)
+    Shr,
+}
+
+impl From<noirc_frontend::BinaryOpKind> for BinaryOp {
+    fn from(value: noirc_frontend::BinaryOpKind) -> Self {
+        match value {
+            noirc_frontend::BinaryOpKind::Add => todo!(),
+            noirc_frontend::BinaryOpKind::Subtract => todo!(),
+            noirc_frontend::BinaryOpKind::Multiply => todo!(),
+            noirc_frontend::BinaryOpKind::Divide => todo!(),
+            noirc_frontend::BinaryOpKind::Equal => todo!(),
+            noirc_frontend::BinaryOpKind::NotEqual => todo!(),
+            noirc_frontend::BinaryOpKind::Less => todo!(),
+            noirc_frontend::BinaryOpKind::LessEqual => todo!(),
+            noirc_frontend::BinaryOpKind::Greater => todo!(),
+            noirc_frontend::BinaryOpKind::GreaterEqual => todo!(),
+            noirc_frontend::BinaryOpKind::And => todo!(),
+            noirc_frontend::BinaryOpKind::Or => todo!(),
+            noirc_frontend::BinaryOpKind::Xor => todo!(),
+            noirc_frontend::BinaryOpKind::ShiftRight => todo!(),
+            noirc_frontend::BinaryOpKind::ShiftLeft => todo!(),
+            noirc_frontend::BinaryOpKind::Modulo => todo!(),
+        }
+    }
 }
 
 impl std::fmt::Display for BinaryOp {
@@ -206,7 +240,13 @@ impl std::fmt::Display for BinaryOp {
             BinaryOp::Mul => write!(f, "mul"),
             BinaryOp::Div => write!(f, "div"),
             BinaryOp::Eq => write!(f, "eq"),
-            BinaryOp::Neq => write!(f, "neq"),
+            BinaryOp::Mod => write!(f, "mod"),
+            BinaryOp::Lt => write!(f, "lt"),
+            BinaryOp::And => write!(f, "and"),
+            BinaryOp::Or => write!(f, "or"),
+            BinaryOp::Xor => write!(f, "xor"),
+            BinaryOp::Shl => write!(f, "shl"),
+            BinaryOp::Shr => write!(f, "shr"),
         }
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/types.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/types.rs
@@ -38,6 +38,10 @@ impl Type {
         Type::Numeric(NumericType::Unsigned { bit_size })
     }
 
+    pub(crate) fn bool() -> Type {
+        Type::unsigned(1)
+    }
+
     pub(crate) fn field() -> Type {
         Type::Numeric(NumericType::NativeField)
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
@@ -28,3 +28,13 @@ pub(crate) enum Value {
     /// This Value originates from a numeric constant
     NumericConstant { constant: NumericConstantId, typ: Type },
 }
+
+impl Value {
+    pub(crate) fn get_type(&self) -> Type {
+        match self {
+            Value::Instruction { typ, .. } => *typ,
+            Value::Param { typ, .. } => *typ,
+            Value::NumericConstant { typ, .. } => *typ,
+        }
+    }
+}

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_builder/function_builder.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_builder/function_builder.rs
@@ -100,12 +100,23 @@ impl<'ssa> FunctionBuilder<'ssa> {
         self.insert_instruction(Instruction::Store { address, value });
     }
 
-    /// Insert a Store instruction at the end of the current block, storing the given element
-    /// at the given address. Expects that the address points to a previous Allocate instruction.
-    /// Returns the result of the add instruction.
-    pub(crate) fn insert_add(&mut self, lhs: ValueId, rhs: ValueId, typ: Type) -> ValueId {
-        let operator = BinaryOp::Add;
+    /// Insert a binary instruction at the end of the current block.
+    /// Returns the result of the binary instruction.
+    pub(crate) fn insert_binary(
+        &mut self,
+        lhs: ValueId,
+        operator: BinaryOp,
+        rhs: ValueId,
+        typ: Type,
+    ) -> ValueId {
         let id = self.insert_instruction(Instruction::Binary(Binary { lhs, rhs, operator }));
+        self.current_function.dfg.make_instruction_results(id, typ)[0]
+    }
+
+    /// Insert a not instruction at the end of the current block.
+    /// Returns the result of the instruction.
+    pub(crate) fn insert_not(&mut self, rhs: ValueId, typ: Type) -> ValueId {
+        let id = self.insert_instruction(Instruction::Not(rhs));
         self.current_function.dfg.make_instruction_results(id, typ)[0]
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_builder/function_builder.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_builder/function_builder.rs
@@ -3,7 +3,7 @@ use acvm::FieldElement;
 use crate::ssa_refactor::ir::{
     basic_block::BasicBlockId,
     function::{Function, FunctionId},
-    instruction::{Binary, BinaryOp, Instruction, InstructionId},
+    instruction::{Binary, BinaryOp, Instruction},
     types::Type,
     value::ValueId,
 };
@@ -71,18 +71,21 @@ impl<'ssa> FunctionBuilder<'ssa> {
         self.numeric_constant(value.into(), Type::field())
     }
 
-    fn insert_instruction(&mut self, instruction: Instruction) -> InstructionId {
-        let id = self.current_function.dfg.make_instruction(instruction);
+    fn insert_instruction(
+        &mut self,
+        instruction: Instruction,
+        ctrl_typevars: Option<Vec<Type>>,
+    ) -> &[ValueId] {
+        let id = self.current_function.dfg.make_instruction(instruction, ctrl_typevars);
         self.current_function.dfg.insert_instruction_in_block(self.current_block, id);
-        id
+        self.current_function.dfg.instruction_results(id)
     }
 
     /// Insert an allocate instruction at the end of the current block, allocating the
     /// given amount of field elements. Returns the result of the allocate instruction,
     /// which is always a Reference to the allocated data.
     pub(crate) fn insert_allocate(&mut self, size_to_allocate: u32) -> ValueId {
-        let id = self.insert_instruction(Instruction::Allocate { size: size_to_allocate });
-        self.current_function.dfg.make_instruction_results(id, None)[0]
+        self.insert_instruction(Instruction::Allocate { size: size_to_allocate }, None)[0]
     }
 
     /// Insert a Load instruction at the end of the current block, loading from the given address
@@ -90,14 +93,13 @@ impl<'ssa> FunctionBuilder<'ssa> {
     /// a single value. Loading multiple values (such as a tuple) will require multiple loads.
     /// Returns the element that was loaded.
     pub(crate) fn insert_load(&mut self, address: ValueId, type_to_load: Type) -> ValueId {
-        let id = self.insert_instruction(Instruction::Load { address });
-        self.current_function.dfg.make_instruction_results(id, Some(vec![type_to_load]))[0]
+        self.insert_instruction(Instruction::Load { address }, Some(vec![type_to_load]))[0]
     }
 
     /// Insert a Store instruction at the end of the current block, storing the given element
     /// at the given address. Expects that the address points to a previous Allocate instruction.
     pub(crate) fn insert_store(&mut self, address: ValueId, value: ValueId) {
-        self.insert_instruction(Instruction::Store { address, value });
+        self.insert_instruction(Instruction::Store { address, value }, None);
     }
 
     /// Insert a binary instruction at the end of the current block.
@@ -108,14 +110,13 @@ impl<'ssa> FunctionBuilder<'ssa> {
         operator: BinaryOp,
         rhs: ValueId,
     ) -> ValueId {
-        let id = self.insert_instruction(Instruction::Binary(Binary { lhs, rhs, operator }));
-        self.current_function.dfg.make_instruction_results(id, None)[0]
+        let instruction = Instruction::Binary(Binary { lhs, rhs, operator });
+        self.insert_instruction(instruction, None)[0]
     }
 
     /// Insert a not instruction at the end of the current block.
     /// Returns the result of the instruction.
     pub(crate) fn insert_not(&mut self, rhs: ValueId) -> ValueId {
-        let id = self.insert_instruction(Instruction::Not(rhs));
-        self.current_function.dfg.make_instruction_results(id, None)[0]
+        self.insert_instruction(Instruction::Not(rhs), None)[0]
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_builder/function_builder.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_builder/function_builder.rs
@@ -82,7 +82,7 @@ impl<'ssa> FunctionBuilder<'ssa> {
     /// which is always a Reference to the allocated data.
     pub(crate) fn insert_allocate(&mut self, size_to_allocate: u32) -> ValueId {
         let id = self.insert_instruction(Instruction::Allocate { size: size_to_allocate });
-        self.current_function.dfg.make_instruction_results(id, Type::Reference)[0]
+        self.current_function.dfg.make_instruction_results(id, None)[0]
     }
 
     /// Insert a Load instruction at the end of the current block, loading from the given address
@@ -91,7 +91,7 @@ impl<'ssa> FunctionBuilder<'ssa> {
     /// Returns the element that was loaded.
     pub(crate) fn insert_load(&mut self, address: ValueId, type_to_load: Type) -> ValueId {
         let id = self.insert_instruction(Instruction::Load { address });
-        self.current_function.dfg.make_instruction_results(id, type_to_load)[0]
+        self.current_function.dfg.make_instruction_results(id, Some(vec![type_to_load]))[0]
     }
 
     /// Insert a Store instruction at the end of the current block, storing the given element
@@ -107,16 +107,15 @@ impl<'ssa> FunctionBuilder<'ssa> {
         lhs: ValueId,
         operator: BinaryOp,
         rhs: ValueId,
-        typ: Type,
     ) -> ValueId {
         let id = self.insert_instruction(Instruction::Binary(Binary { lhs, rhs, operator }));
-        self.current_function.dfg.make_instruction_results(id, typ)[0]
+        self.current_function.dfg.make_instruction_results(id, None)[0]
     }
 
     /// Insert a not instruction at the end of the current block.
     /// Returns the result of the instruction.
-    pub(crate) fn insert_not(&mut self, rhs: ValueId, typ: Type) -> ValueId {
+    pub(crate) fn insert_not(&mut self, rhs: ValueId) -> ValueId {
         let id = self.insert_instruction(Instruction::Not(rhs));
-        self.current_function.dfg.make_instruction_results(id, typ)[0]
+        self.current_function.dfg.make_instruction_results(id, None)[0]
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
@@ -6,7 +6,9 @@ use noirc_frontend::monomorphization::ast::{self, LocalId, Parameters};
 use noirc_frontend::monomorphization::ast::{FuncId, Program};
 use noirc_frontend::Signedness;
 
+use crate::ssa_refactor::ir::instruction::BinaryOp;
 use crate::ssa_refactor::ir::types::Type;
+use crate::ssa_refactor::ir::value::ValueId;
 use crate::ssa_refactor::ssa_builder::SharedBuilderContext;
 use crate::ssa_refactor::{
     ir::function::FunctionId as IrFunctionId, ssa_builder::function_builder::FunctionBuilder,
@@ -122,6 +124,78 @@ impl<'a> FunctionContext<'a> {
             // Or are they just references?
             ast::Type::Vec(_) => Type::Reference,
         }
+    }
+
+    pub(super) fn unit_value(&mut self) -> Values {
+        self.builder.numeric_constant(0u128.into(), Type::Unit).into()
+    }
+
+    /// Insert a binary instruction at the end of the current block.
+    /// Converts the form of the binary instruction as necessary
+    /// (e.g. swapping arguments, inserting a not) to represent it in the IR.
+    /// For example, (a <= b) is represented as !(b < a)
+    pub(super) fn insert_binary(
+        &mut self,
+        mut lhs: ValueId,
+        operator: noirc_frontend::BinaryOpKind,
+        mut rhs: ValueId,
+    ) -> Values {
+        let op = convert_operator(operator);
+
+        if operator_requires_swapped_operands(operator) {
+            std::mem::swap(&mut lhs, &mut rhs);
+        }
+
+        // TODO: Rework how types are stored.
+        // They should be on values rather than on instruction results
+        let typ = Type::field();
+        let mut result = self.builder.insert_binary(lhs, op, rhs, typ);
+
+        if operator_requires_not(operator) {
+            result = self.builder.insert_not(result, typ);
+        }
+        result.into()
+    }
+}
+
+/// True if the given operator cannot be encoded directly and needs
+/// to be represented as !(some other operator)
+fn operator_requires_not(op: noirc_frontend::BinaryOpKind) -> bool {
+    use noirc_frontend::BinaryOpKind::*;
+    matches!(op, NotEqual | LessEqual | GreaterEqual)
+}
+
+/// True if the given operator cannot be encoded directly and needs
+/// to have its lhs and rhs swapped to be represented with another operator.
+/// Example: (a > b) needs to be represented as (b < a)
+fn operator_requires_swapped_operands(op: noirc_frontend::BinaryOpKind) -> bool {
+    use noirc_frontend::BinaryOpKind::*;
+    matches!(op, Greater | LessEqual)
+}
+
+/// Lossily (!) converts the given operator to the appropriate BinaryOp.
+/// Take care when using this to insert a binary instruction: this requires
+/// checking operator_requires_not and operator_requires_swapped_operands
+/// to represent the full operation correctly.
+fn convert_operator(op: noirc_frontend::BinaryOpKind) -> BinaryOp {
+    use noirc_frontend::BinaryOpKind;
+    match op {
+        BinaryOpKind::Add => BinaryOp::Add,
+        BinaryOpKind::Subtract => BinaryOp::Sub,
+        BinaryOpKind::Multiply => BinaryOp::Mul,
+        BinaryOpKind::Divide => BinaryOp::Div,
+        BinaryOpKind::Modulo => BinaryOp::Mod,
+        BinaryOpKind::Equal => BinaryOp::Eq,
+        BinaryOpKind::NotEqual => BinaryOp::Eq, // Requires not
+        BinaryOpKind::Less => BinaryOp::Lt,
+        BinaryOpKind::Greater => BinaryOp::Lt, // Requires operand swap
+        BinaryOpKind::LessEqual => BinaryOp::Lt, // Requires operand swap and not
+        BinaryOpKind::GreaterEqual => BinaryOp::Lt, // Requires not
+        BinaryOpKind::And => BinaryOp::And,
+        BinaryOpKind::Or => BinaryOp::Or,
+        BinaryOpKind::Xor => BinaryOp::Xor,
+        BinaryOpKind::ShiftRight => BinaryOp::Shr,
+        BinaryOpKind::ShiftLeft => BinaryOp::Shl,
     }
 }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
@@ -126,6 +126,8 @@ impl<'a> FunctionContext<'a> {
         }
     }
 
+    /// Insert a unit constant into the current function if not already
+    /// present, and return its value
     pub(super) fn unit_value(&mut self) -> Values {
         self.builder.numeric_constant(0u128.into(), Type::Unit).into()
     }
@@ -173,7 +175,7 @@ fn operator_requires_swapped_operands(op: noirc_frontend::BinaryOpKind) -> bool 
     matches!(op, Greater | LessEqual)
 }
 
-/// Lossily (!) converts the given operator to the appropriate BinaryOp.
+/// Converts the given operator to the appropriate BinaryOp.
 /// Take care when using this to insert a binary instruction: this requires
 /// checking operator_requires_not and operator_requires_swapped_operands
 /// to represent the full operation correctly.

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
@@ -148,13 +148,10 @@ impl<'a> FunctionContext<'a> {
             std::mem::swap(&mut lhs, &mut rhs);
         }
 
-        // TODO: Rework how types are stored.
-        // They should be on values rather than on instruction results
-        let typ = Type::field();
-        let mut result = self.builder.insert_binary(lhs, op, rhs, typ);
+        let mut result = self.builder.insert_binary(lhs, op, rhs);
 
         if operator_requires_not(operator) {
-            result = self.builder.insert_not(result, typ);
+            result = self.builder.insert_not(result);
         }
         result.into()
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/mod.rs
@@ -116,8 +116,8 @@ impl<'a> FunctionContext<'a> {
                 let address = if i == 0 {
                     array
                 } else {
-                    let offset = self.builder.numeric_constant((i as u128).into(), Type::field());
-                    self.builder.insert_binary(array, BinaryOp::Add, offset, Type::field())
+                    let offset = self.builder.field_constant(i as u128);
+                    self.builder.insert_binary(array, BinaryOp::Add, offset)
                 };
                 self.builder.insert_store(address, value.eval());
                 i += 1;

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/value.rs
@@ -2,6 +2,7 @@ use crate::ssa_refactor::ir::function::FunctionId as IrFunctionId;
 use crate::ssa_refactor::ir::types::Type;
 use crate::ssa_refactor::ir::value::ValueId as IrValueId;
 
+#[derive(Debug)]
 pub(super) enum Tree<T> {
     Branch(Vec<Tree<T>>),
     Leaf(T),


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1218 

# Description

## Summary of changes

Result types are already stored in results so I've updated the handling a bit to try to make the API easier to use and less reliant on getting the `ctrl_typevar` correct. Now the `ctrl_typevars` (plural) are only needed for Load, Call, and Intrinsic (although Intrinsic can likely be removed once it is implemented and each variant is known). `ctrl_typevars` is also now taken in as an option so it can be easily omitted. In case it is required but was not specified we panic instead of returning an empty Vec.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
