### PR TITLE
fix(wasm): add std after dependencies

### DIFF
--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -81,12 +81,12 @@ pub fn compile(args: JsValue) -> JsValue {
     let path = PathBuf::from(&options.entry_point);
     driver.create_local_crate(path, CrateType::Binary);
 
-    // We are always adding std lib implicitly. It comes bundled with binary.
-    add_noir_lib(&mut driver, "std");
-
     for dependency in options.optional_dependencies_set {
         add_noir_lib(&mut driver, dependency.as_str());
     }
+
+    // We are always adding std lib implicitly. It comes bundled with binary.
+    add_noir_lib(&mut driver, "std");
 
     driver.check_crate(&options.compile_options).unwrap_or_else(|_| panic!("Crate check failed"));
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1244

# Description

Adding the std library after all dependencies so all dependencies get the std lib.

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
