### PR TITLE
chore: Replace explicit if-elses with `FieldElement::from<bool>()` for boolean fields

### DIFF
--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -115,11 +115,7 @@ impl InputValue {
 
                 InputValue::Field(new_value)
             }
-            TomlTypes::Bool(boolean) => {
-                let new_value = if boolean { FieldElement::one() } else { FieldElement::zero() };
-
-                InputValue::Field(new_value)
-            }
+            TomlTypes::Bool(boolean) => InputValue::Field(FieldElement::from(boolean)),
             TomlTypes::ArrayNum(arr_num) => {
                 let array_elements =
                     vecmap(arr_num, |elem_num| FieldElement::from(i128::from(elem_num)));
@@ -132,13 +128,7 @@ impl InputValue {
                 InputValue::Vec(array_elements)
             }
             TomlTypes::ArrayBool(arr_bool) => {
-                let array_elements = vecmap(arr_bool, |elem_bool| {
-                    if elem_bool {
-                        FieldElement::one()
-                    } else {
-                        FieldElement::zero()
-                    }
-                });
+                let array_elements = vecmap(arr_bool, FieldElement::from);
 
                 InputValue::Vec(array_elements)
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/bitwise.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/bitwise.rs
@@ -40,8 +40,8 @@ pub(super) fn simplify_bitwise(
     let max = FieldElement::from((1_u128 << bit_size) - 1);
 
     let (field, var) = match (lhs.to_const(), rhs.to_const()) {
-        (Some(l_c), None) => (l_c == FieldElement::zero() || l_c == max).then_some((l_c, rhs))?,
-        (None, Some(r_c)) => (r_c == FieldElement::zero() || r_c == max).then_some((r_c, lhs))?,
+        (Some(l_c), None) => (l_c.is_zero() || l_c == max).then_some((l_c, rhs))?,
+        (None, Some(r_c)) => (r_c.is_zero() || r_c == max).then_some((r_c, lhs))?,
         _ => return None,
     };
 

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -918,8 +918,10 @@ impl Binary {
                         !res_type.is_native_field(),
                         "ICE: comparisons are not implemented for field elements"
                     );
-                    let res = if lhs < rhs { FieldElement::one() } else { FieldElement::zero() };
-                    return Ok(NodeEval::Const(res, ObjectType::boolean()));
+                    return Ok(NodeEval::Const(
+                        FieldElement::from(lhs < rhs),
+                        ObjectType::boolean(),
+                    ));
                 }
             }
             BinaryOp::Ule => {
@@ -931,8 +933,10 @@ impl Binary {
                         !res_type.is_native_field(),
                         "ICE: comparisons are not implemented for field elements"
                     );
-                    let res = if lhs <= rhs { FieldElement::one() } else { FieldElement::zero() };
-                    return Ok(NodeEval::Const(res, ObjectType::boolean()));
+                    return Ok(NodeEval::Const(
+                        FieldElement::from(lhs <= rhs),
+                        ObjectType::boolean(),
+                    ));
                 }
             }
             BinaryOp::Slt => (),
@@ -942,8 +946,10 @@ impl Binary {
                     return Ok(NodeEval::Const(FieldElement::zero(), ObjectType::boolean()));
                     //n.b we assume the type of lhs and rhs is unsigned because of the opcode, we could also verify this
                 } else if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
-                    let res = if lhs < rhs { FieldElement::one() } else { FieldElement::zero() };
-                    return Ok(NodeEval::Const(res, ObjectType::boolean()));
+                    return Ok(NodeEval::Const(
+                        FieldElement::from(lhs < rhs),
+                        ObjectType::boolean(),
+                    ));
                 }
             }
             BinaryOp::Lte => {
@@ -951,30 +957,30 @@ impl Binary {
                     return Ok(NodeEval::Const(FieldElement::one(), ObjectType::boolean()));
                     //n.b we assume the type of lhs and rhs is unsigned because of the opcode, we could also verify this
                 } else if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
-                    let res = if lhs <= rhs { FieldElement::one() } else { FieldElement::zero() };
-                    return Ok(NodeEval::Const(res, ObjectType::boolean()));
+                    return Ok(NodeEval::Const(
+                        FieldElement::from(lhs <= rhs),
+                        ObjectType::boolean(),
+                    ));
                 }
             }
             BinaryOp::Eq => {
                 if self.lhs == self.rhs {
                     return Ok(NodeEval::Const(FieldElement::one(), ObjectType::boolean()));
                 } else if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
-                    if lhs == rhs {
-                        return Ok(NodeEval::Const(FieldElement::one(), ObjectType::boolean()));
-                    } else {
-                        return Ok(NodeEval::Const(FieldElement::zero(), ObjectType::boolean()));
-                    }
+                    return Ok(NodeEval::Const(
+                        FieldElement::from(lhs == rhs),
+                        ObjectType::boolean(),
+                    ));
                 }
             }
             BinaryOp::Ne => {
                 if self.lhs == self.rhs {
                     return Ok(NodeEval::Const(FieldElement::zero(), ObjectType::boolean()));
                 } else if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
-                    if lhs != rhs {
-                        return Ok(NodeEval::Const(FieldElement::one(), ObjectType::boolean()));
-                    } else {
-                        return Ok(NodeEval::Const(FieldElement::zero(), ObjectType::boolean()));
-                    }
+                    return Ok(NodeEval::Const(
+                        FieldElement::from(lhs != rhs),
+                        ObjectType::boolean(),
+                    ));
                 }
             }
             BinaryOp::And => {


### PR DESCRIPTION
# Related issue(s)

Resolves # <!-- link to issue -->

# Description

## Summary of changes

This PR makes use of the `FieldElement::from<bool>()` implementation from https://github.com/noir-lang/acvm/pull/203 to simplify some of the code.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
