### PR TITLE
chore!(noir): deprecation warning for constrain

### DIFF
--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -27,7 +27,7 @@ compiler_version = "{CARGO_PKG_VERSION}"
 );
 
 const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
-    constrain x != y;
+    assert(x != y);
 }
 
 #[test]

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -21,6 +21,7 @@ pub const ERROR_IDENT: &str = "$error";
 pub enum Statement {
     Let(LetStatement),
     Constrain(ConstrainStatement),
+    Assert(ConstrainStatement),
     Expression(Expression),
     Assign(AssignStatement),
     // This is an expression with a trailing semi-colon
@@ -54,6 +55,7 @@ impl Statement {
         match self {
             Statement::Let(_)
             | Statement::Constrain(_)
+            | Statement::Assert(_)
             | Statement::Assign(_)
             | Statement::Semi(_)
             | Statement::Error => {
@@ -391,6 +393,7 @@ impl Display for Statement {
         match self {
             Statement::Let(let_statement) => let_statement.fmt(f),
             Statement::Constrain(constrain) => constrain.fmt(f),
+            Statement::Assert(constrain) => constrain.fmt(f),
             Statement::Expression(expression) => expression.fmt(f),
             Statement::Assign(assign) => assign.fmt(f),
             Statement::Semi(semi) => write!(f, "{semi};"),

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -262,7 +262,7 @@ impl From<ResolverError> for Diagnostic {
             ),
             ResolverError::ConstrainDepreciated { span } => Diagnostic::simple_warning(
                 "The 'constrain' keyword has been depreciated in favour of 'assert'".into(),
-                "The 'constrain' keyword has been depreciated, and it now recommended to instead write constraints in form of assertions such as 'assert(some_condition);'. This depreciation can be ignored for the time being by compiling with the '--allow-warnings' flag.".into(),
+                "The 'constrain' keyword has been depreciated, and it is now recommended to instead write constraints in the form of assertions, i.e. 'assert(some_condition);'. This depreciation can be ignored for the time being by compiling with the '--allow-warnings' flag.".into(),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -60,6 +60,8 @@ pub enum ResolverError {
     ParserError(ParserError),
     #[error("Function is not defined in a contract yet sets its contract visibility")]
     ContractFunctionTypeInNormalFunction { span: Span },
+    #[error("The 'constrain' keyword has been depreciated in favour of 'assert'")]
+    ConstrainDepreciated { span: Span },
 }
 
 impl ResolverError {
@@ -256,6 +258,11 @@ impl From<ResolverError> for Diagnostic {
             ResolverError::ContractFunctionTypeInNormalFunction { span } => Diagnostic::simple_error(
                 "Only functions defined within contracts can set their contract function type".into(),
                 "Non-contract functions cannot be 'open'".into(),
+                span,
+            ),
+            ResolverError::ConstrainDepreciated { span } => Diagnostic::simple_warning(
+                "The 'constrain' keyword has been depreciated in favour of 'assert'".into(),
+                "The 'constrain' keyword has been depreciated, and it now recommended to instead write constraints in form of assertions such as 'assert(some_condition);'. This depreciation can be ignored for the time being by compiling with the '--allow-warnings' flag.".into(),
                 span,
             ),
         }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -810,6 +810,11 @@ impl<'a> Resolver<'a> {
                 })
             }
             Statement::Constrain(constrain_stmt) => {
+                self.push_err(ResolverError::ConstrainDepreciated { span: constrain_stmt.0.span });
+                let expr_id = self.resolve_expression(constrain_stmt.0);
+                HirStatement::Constrain(HirConstrainStatement(expr_id, self.file))
+            }
+            Statement::Assert(constrain_stmt) => {
                 let expr_id = self.resolve_expression(constrain_stmt.0);
                 HirStatement::Constrain(HirConstrainStatement(expr_id, self.file))
             }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -456,7 +456,7 @@ where
 {
     ignore_then_commit(keyword(Keyword::Assert), parenthesized(expr_parser))
         .labelled("statement")
-        .map(|expr| Statement::Constrain(ConstrainStatement(expr)))
+        .map(|expr| Statement::Assert(ConstrainStatement(expr)))
 }
 
 fn declaration<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -82,13 +82,13 @@ mod affine {
         // Curve constructor
         fn new(j: Field, k: Field, gen: Point) -> Self {
             // Check curve coefficients
-            constrain k != 0;
-            constrain j*j != 4;
+            assert(k != 0);
+            assert(j*j != 4);
 
             let curve = Self {j, k, gen};
 
             // gen should be on the curve
-            constrain curve.contains(curve.gen);
+            assert(curve.contains(curve.gen));
 
             curve
         }
@@ -180,10 +180,10 @@ mod affine {
             let z = ZETA; // Non-square Field element required for map
             
             // Check whether curve is admissible
-            constrain j != 0;
+            assert(j != 0);
             let l = (j*j - 4)/(k*k);
-            constrain l != 0;
-            constrain is_square(l) == false;
+            assert(l != 0);
+            assert(is_square(l) == false);
 
             let x1 = safe_inverse(1+z*u*u)*(0 - (j/k));
             
@@ -284,13 +284,13 @@ mod curvegroup {
         // Curve constructor
         fn new(j: Field, k: Field, gen: Point) -> Self {
             // Check curve coefficients
-            constrain k != 0;
-            constrain j*j != 4;
+            assert(k != 0);
+            assert(j*j != 4);
 
             let curve = Self {j, k, gen};
 
             // gen should be on the curve
-            constrain curve.contains(curve.gen);
+            assert(curve.contains(curve.gen));
 
             curve
         }

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -71,12 +71,12 @@ mod affine {
         // Curve constructor
         fn new(a: Field, b: Field, gen: Point) -> Curve {
             // Check curve coefficients
-            constrain 4*a*a*a + 27*b*b != 0;
+            assert(4*a*a*a + 27*b*b != 0);
             
 	    let curve = Curve { a, b, gen };
 
             // gen should be on the curve
-            constrain curve.contains(curve.gen);
+            assert(curve.contains(curve.gen));
 
             curve
         }
@@ -164,7 +164,7 @@ mod affine {
         // where g(x) = x^3 + a*x + b. swu_map(c,z,.) then maps a Field element to a point on curve c.
         fn swu_map(self, z: Field, u: Field) -> Point {
             // Check whether curve is admissible
-            constrain self.a*self.b != 0;
+            assert(self.a*self.b != 0);
             
             let Curve {a, b, gen: _gen} = self;
             
@@ -248,12 +248,12 @@ mod curvegroup {
         // Curve constructor
         fn new(a: Field, b: Field, gen: Point) -> Curve {
             // Check curve coefficients
-            constrain 4*a*a*a + 27*b*b != 0;
+            assert(4*a*a*a + 27*b*b != 0);
             
 	    let curve = Curve { a, b, gen };
 
             // gen should be on the curve
-            constrain curve.contains(curve.gen);
+            assert(curve.contains(curve.gen));
 
             curve
         }

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -81,12 +81,12 @@ mod affine {
         // Curve constructor
         fn new(a: Field, d: Field, gen: Point) -> Curve {
             // Check curve coefficients
-            constrain a*d*(a-d) != 0;
+            assert(a*d*(a-d) != 0);
             
 	    let curve = Curve {a, d, gen};
 
             // gen should be on the curve
-            constrain curve.contains(curve.gen);
+            assert(curve.contains(curve.gen));
 
             curve
         }
@@ -286,12 +286,12 @@ mod curvegroup {
         // Curve constructor
         fn new(a: Field, d: Field, gen: Point) -> Curve {
             // Check curve coefficients
-            constrain a*d*(a-d) != 0;
+            assert(a*d*(a-d) != 0);
             
 	    let curve = Curve { a, d, gen };
 
             // gen should be on the curve
-            constrain curve.contains(curve.gen);
+            assert(curve.contains(curve.gen));
 
             curve
         }

--- a/noir_stdlib/src/hash/poseidon.nr
+++ b/noir_stdlib/src/hash/poseidon.nr
@@ -20,9 +20,9 @@ fn config<M,N>(
     mds: [Field; N])
     -> PoseidonConfig<M,N> {
     // Input checks
-    constrain t as u8 * (rf + rp) == ark.len() as u8;
-    constrain t * t == mds.len();
-    constrain alpha != 0;
+    assert(t as u8 * (rf + rp) == ark.len() as u8);
+    assert(t * t == mds.len());
+    assert(alpha != 0);
     
     PoseidonConfig {t, rf, rp, alpha, ark, mds}
 }
@@ -34,7 +34,7 @@ fn permute<M,N,O>(
     -> [Field; O] {
     let PoseidonConfig {t, rf, rp, alpha, ark, mds} = pos_conf;
 
-    constrain t == state.len();
+    assert(t == state.len());
     
     let mut count = 0;
 
@@ -68,7 +68,7 @@ fn absorb<M,N,O,P>(
     capacity: comptime Field, // Capacity; usually 1
     msg: [Field; P]) // Arbitrary length message
     -> [Field; O] {
-    constrain pos_conf.t == rate + capacity;
+    assert(pos_conf.t == rate + capacity);
     
     let mut i = 0;
 

--- a/noir_stdlib/src/hash/poseidon/bn254.nr
+++ b/noir_stdlib/src/hash/poseidon/bn254.nr
@@ -15,9 +15,9 @@ fn permute<M,N,O>(
     let rf = 8;
     let rp = [56, 57, 56, 60, 60, 63, 64, 63, 60, 66, 60, 65, 70, 60, 64, 68][state.len() - 2];
 
-    constrain t == state.len();
-    constrain rf == config_rf as Field;
-    constrain rp == config_rp as Field;
+    assert(t == state.len());
+    assert(rf == config_rf as Field);
+    assert(rp == config_rp as Field);
     
     let mut count = 0;
 
@@ -73,7 +73,7 @@ fn absorb<M,N,O,P>(
     msg: [Field; P] // Arbitrary length message
 ) -> [Field; O] {
 
-    constrain pos_conf.t == rate + capacity;
+    assert(pos_conf.t == rate + capacity);
     
     let mut i = 0;
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1228

# Description

## Summary of changes

Emit a depreciation warning when encountering the `constrain` keyword, plus a tip on how to resolve. It was convenient to emit this warning during HIR resolution, hence the distinction between assert/constrain was propagated beyond the parser.

Stdlib usages of `constrain` are now also replaced with `assert`. The `nargo new` template now also uses `assert` instead of constrain.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
