### PR TITLE
feat(ssa refactor): Implement dominator tree

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir.rs
@@ -6,6 +6,7 @@ pub(crate) mod dom;
 pub(crate) mod function;
 pub(crate) mod instruction;
 pub(crate) mod map;
+pub(crate) mod post_order;
 pub(crate) mod printer;
 pub(crate) mod types;
 pub(crate) mod value;

--- a/crates/noirc_evaluator/src/ssa_refactor/ir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir.rs
@@ -2,6 +2,7 @@ pub(crate) mod basic_block;
 pub(crate) mod cfg;
 pub(crate) mod constant;
 pub(crate) mod dfg;
+pub(crate) mod dom;
 pub(crate) mod function;
 pub(crate) mod instruction;
 pub(crate) mod map;

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/basic_block.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/basic_block.rs
@@ -76,7 +76,9 @@ impl BasicBlock {
     /// Iterate over all the successors of the currently block, as determined by
     /// the blocks jumped to in the terminator instruction. If there is no terminator
     /// instruction yet, this will iterate 0 times.
-    pub(crate) fn successors(&self) -> impl ExactSizeIterator<Item = BasicBlockId> {
+    pub(crate) fn successors(
+        &self,
+    ) -> impl ExactSizeIterator<Item = BasicBlockId> + DoubleEndedIterator {
         match &self.terminator {
             Some(TerminatorInstruction::Jmp { destination, .. }) => vec![*destination].into_iter(),
             Some(TerminatorInstruction::JmpIf { then_destination, else_destination, .. }) => {

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
@@ -179,7 +179,7 @@ impl DominatorTree {
         // Get an iterator with just the reachable, already visited predecessors to `block_id`.
         // Note that during the first pass `node` was pre-populated with all reachable blocks.
         let mut reachable_preds =
-            cfg.pred_iter(block_id).filter(|pred_id| self.nodes.contains_key(pred_id));
+            cfg.predecessors(block_id).filter(|pred_id| self.nodes.contains_key(pred_id));
 
         // This function isn't called on unreachable blocks or the entry block, so the reverse
         // post-order will contain at least one predecessor to this block.

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
@@ -109,36 +109,6 @@ impl DominatorTree {
         }
     }
 
-    /// Compute the common dominator of two basic blocks.
-    ///
-    /// Both basic blocks are assumed to be reachable.
-    fn common_dominator(
-        &self,
-        mut block_a_id: BasicBlockId,
-        mut block_b_id: BasicBlockId,
-    ) -> BasicBlockId {
-        loop {
-            match self.reverse_post_order_cmp(block_a_id, block_b_id) {
-                Ordering::Less => {
-                    // "a" comes before "b" in the reverse post-order. Move "b" up.
-                    block_b_id = self.nodes[&block_b_id]
-                        .immediate_dominator
-                        .expect("Unreachable basic block?");
-                }
-                Ordering::Greater => {
-                    // "b" comes before "a" in the reverse post-order. Move "a" up.
-                    block_a_id = self.nodes[&block_a_id]
-                        .immediate_dominator
-                        .expect("Unreachable basic block?");
-                }
-                Ordering::Equal => break,
-            }
-        }
-
-        debug_assert_eq!(block_a_id, block_b_id, "Unreachable block passed to common_dominator?");
-        block_a_id
-    }
-
     /// Allocate and compute a dominator tree.
     pub(crate) fn with_function(func: &Function, cfg: &ControlFlowGraph) -> Self {
         let post_order = compute_post_order(func);
@@ -216,6 +186,36 @@ impl DominatorTree {
         }
 
         immediate_dominator
+    }
+
+    /// Compute the common dominator of two basic blocks.
+    ///
+    /// Both basic blocks are assumed to be reachable.
+    fn common_dominator(
+        &self,
+        mut block_a_id: BasicBlockId,
+        mut block_b_id: BasicBlockId,
+    ) -> BasicBlockId {
+        loop {
+            match self.reverse_post_order_cmp(block_a_id, block_b_id) {
+                Ordering::Less => {
+                    // "a" comes before "b" in the reverse post-order. Move "b" up.
+                    block_b_id = self.nodes[&block_b_id]
+                        .immediate_dominator
+                        .expect("Unreachable basic block?");
+                }
+                Ordering::Greater => {
+                    // "b" comes before "a" in the reverse post-order. Move "a" up.
+                    block_a_id = self.nodes[&block_a_id]
+                        .immediate_dominator
+                        .expect("Unreachable basic block?");
+                }
+                Ordering::Equal => break,
+            }
+        }
+
+        debug_assert_eq!(block_a_id, block_b_id, "Unreachable block passed to common_dominator?");
+        block_a_id
     }
 }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
@@ -285,9 +285,7 @@ mod tests {
         let func = ssa.functions.first().unwrap();
         let block0_id = func.entry_block();
 
-        let cfg = ControlFlowGraph::with_function(func);
-        let post_order = PostOrder::with_function(func);
-        let dt = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
+        let dt = DominatorTree::with_function(func);
         (dt, block0_id, block1_id, block2_id, block3_id)
     }
 
@@ -391,9 +389,7 @@ mod tests {
         let func = ssa.functions.first().unwrap();
         let block0_id = func.entry_block();
 
-        let cfg = ControlFlowGraph::with_function(func);
-        let post_order = PostOrder::with_function(func);
-        let dt = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
+        let dt = DominatorTree::with_function(func);
 
         // Expected dominance tree:
         // block0 {

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
@@ -1,5 +1,8 @@
 //! The dominator tree of a function, represented as a hash map of each reachable block id to its
 //! immediate dominator.
+//!
+//! Dominator trees are useful for tasks such as identifying back-edges in loop analysis or
+//! calculating dominance frontiers.
 
 use std::{cmp::Ordering, collections::HashMap};
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
@@ -162,7 +162,7 @@ impl DominatorTree {
         // Get an iterator with just the reachable, already visited predecessors to `block_id`.
         // Note that during the first pass `node` was pre-populated with all reachable blocks.
         let mut reachable_preds =
-            cfg.pred_iter(block_id).filter(|pred_id| self.nodes.contains_key(&pred_id));
+            cfg.pred_iter(block_id).filter(|pred_id| self.nodes.contains_key(pred_id));
 
         // This function isn't called on unreachable blocks or the entry block, so the reverse
         // post-order will contain at least one predecessor to this block.

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
@@ -1,0 +1,443 @@
+use std::{cmp::Ordering, collections::HashMap};
+
+use self::post_order::compute_post_order;
+
+use super::{basic_block::BasicBlockId, cfg::ControlFlowGraph, function::Function};
+
+mod post_order;
+
+/// Dominator tree node. We keep one of these per reachable block.
+#[derive(Clone, Default)]
+struct DomNode {
+    /// The block's idx in the control flow graph's reverse post-order
+    reverse_post_order_idx: u32,
+
+    /// The block that immediately dominated that of the node in question.
+    ///
+    /// This will be None for the entry block, which has no immediate dominator.
+    immediate_dominator: Option<BasicBlockId>,
+}
+
+impl DomNode {
+    /// Updates the immediate dominator estimate, returning true if it has changed.
+    ///
+    /// This is used internally as a shorthand during `compute_dominator_tree`.
+    pub(self) fn update_estimate(&mut self, immediate_dominator: BasicBlockId) -> bool {
+        let immediate_dominator = Some(immediate_dominator);
+        if self.immediate_dominator == immediate_dominator {
+            false
+        } else {
+            self.immediate_dominator = immediate_dominator;
+            true
+        }
+    }
+}
+
+/// The dominator tree for a single function.
+pub(crate) struct DominatorTree {
+    /// The nodes of the dominator tree
+    ///
+    /// After dominator tree computation has complete, this will contain a node for every
+    /// reachable block, and no nodes for unreachable blocks.
+    nodes: HashMap<BasicBlockId, DomNode>,
+
+    /// CFG post-order of all reachable blocks. This is cached and exposed as it is useful for
+    /// more than just computing the dominator tree.
+    post_order: Vec<BasicBlockId>,
+}
+
+/// Methods for querying the dominator tree.
+impl DominatorTree {
+    /// Is `block_id` reachable from the entry block?
+    pub(crate) fn is_reachable(&self, block_id: BasicBlockId) -> bool {
+        self.nodes.contains_key(&block_id)
+    }
+
+    /// Get the CFG post-order of blocks that was used to compute the dominator tree.
+    pub(crate) fn cfg_post_order(&self) -> &[BasicBlockId] {
+        &self.post_order
+    }
+
+    /// Returns the immediate dominator of `block_id`.
+    ///
+    /// A block is said to *dominate* `block_id` if all control flow paths from the function
+    /// entry to `block_id` must go through the block.
+    ///
+    /// The *immediate dominator* is the dominator that is closest to `block_id`. All other
+    /// dominators also dominate the immediate dominator.
+    ///
+    /// This returns `None` if `block_id` is not reachable from the entry block, or if it is the
+    /// entry block which has no dominators.
+    pub(crate) fn immediate_dominator(&self, block_id: BasicBlockId) -> Option<BasicBlockId> {
+        match self.nodes.get(&block_id) {
+            Some(node) => node.immediate_dominator,
+            _ => None,
+        }
+    }
+
+    /// Compare two blocks relative to the reverse post-order.
+    pub(crate) fn reverse_post_order_cmp(&self, a: BasicBlockId, b: BasicBlockId) -> Ordering {
+        match (self.nodes.get(&a), self.nodes.get(&b)) {
+            (Some(a), Some(b)) => a.reverse_post_order_idx.cmp(&b.reverse_post_order_idx),
+            _ => unreachable!("Post order for unreachable block is undefined"),
+        }
+    }
+
+    /// Returns `true` if `block_a_id` dominates `block_b_id`.
+    ///
+    /// This means that every control-flow path from the function entry to `block_b_id` must go
+    /// through `block_a_id`.
+    ///
+    /// This function panics if either of the blocks are unreachable.
+    ///
+    /// An instruction is considered to dominate itself.
+    pub(crate) fn dominates(&self, block_a_id: BasicBlockId, mut block_b_id: BasicBlockId) -> bool {
+        // Walk up the dominator tree from "b" until we encounter or pass "a". Doing the
+        // comparison on the reverse post-order may allows to test whether we have passed "a"
+        // without waiting until we reach the root of the tree.
+        loop {
+            match self.reverse_post_order_cmp(block_a_id, block_b_id) {
+                Ordering::Less => {
+                    block_b_id = match self.immediate_dominator(block_b_id) {
+                        Some(immediate_dominator) => immediate_dominator,
+                        None => return false, // a is unreachable, so we climbed past the entry
+                    }
+                }
+                Ordering::Greater => return false,
+                Ordering::Equal => return true,
+            }
+        }
+    }
+
+    /// Compute the common dominator of two basic blocks.
+    ///
+    /// Both basic blocks are assumed to be reachable.
+    fn common_dominator(
+        &self,
+        mut block_a_id: BasicBlockId,
+        mut block_b_id: BasicBlockId,
+    ) -> BasicBlockId {
+        loop {
+            match self.reverse_post_order_cmp(block_a_id, block_b_id) {
+                Ordering::Less => {
+                    // "a" comes before "b" in the reverse post-order. Move "b" up.
+                    block_b_id = self.nodes[&block_b_id]
+                        .immediate_dominator
+                        .expect("Unreachable basic block?");
+                }
+                Ordering::Greater => {
+                    // "b" comes before "a" in the reverse post-order. Move "a" up.
+                    block_a_id = self.nodes[&block_a_id]
+                        .immediate_dominator
+                        .expect("Unreachable basic block?");
+                }
+                Ordering::Equal => break,
+            }
+        }
+
+        debug_assert_eq!(block_a_id, block_b_id, "Unreachable block passed to common_dominator?");
+        block_a_id
+    }
+
+    /// Allocate and compute a dominator tree.
+    pub(crate) fn with_function(func: &Function, cfg: &ControlFlowGraph) -> Self {
+        let post_order = compute_post_order(func);
+        let mut domtree = DominatorTree { nodes: HashMap::new(), post_order };
+        domtree.compute_dominator_tree(cfg);
+        domtree
+    }
+
+    /// Build a dominator tree from a control flow graph using Keith D. Cooper's
+    /// "Simple, Fast Dominator Algorithm."
+    fn compute_dominator_tree(&mut self, cfg: &ControlFlowGraph) {
+        // We'll be iterating over a reverse post-order of the CFG, skipping the entry block.
+        let (entry_block_id, entry_free_post_order) = self
+            .post_order
+            .as_slice()
+            .split_last()
+            .expect("ICE: functions always have at least one block");
+
+        // Do a first pass where we assign reverse post-order indices to all reachable nodes. The
+        // entry block will be the only node with no immediate dominator.
+        self.nodes.insert(
+            *entry_block_id,
+            DomNode { reverse_post_order_idx: 0, immediate_dominator: None },
+        );
+        for (i, &block_id) in entry_free_post_order.iter().rev().enumerate() {
+            // Indices have been displaced by 1 by to the removal of the entry node
+            let reverse_post_order_idx = i as u32 + 1;
+
+            // Due to the nature of the post-order traversal, every node we visit will have at
+            // least one predecessor that has previously been assigned during this loop.
+            let immediate_dominator = self.compute_immediate_dominator(block_id, cfg);
+            self.nodes.insert(
+                block_id,
+                DomNode { immediate_dominator: Some(immediate_dominator), reverse_post_order_idx },
+            );
+        }
+
+        // Now that we have reverse post-order indices for everything and initial immediate
+        // dominator estimates, iterate until convergence.
+        //
+        // If the function is free of irreducible control flow, this will exit after one iteration.
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for &block_id in entry_free_post_order.iter().rev() {
+                let immediate_dominator = self.compute_immediate_dominator(block_id, cfg);
+                changed = self
+                    .nodes
+                    .get_mut(&block_id)
+                    .expect("Assigned in first pass")
+                    .update_estimate(immediate_dominator);
+            }
+        }
+    }
+
+    // Compute the immediate dominator for `block_id` using the pre-calculate immediate dominators
+    // of reachable nodes.
+    fn compute_immediate_dominator(
+        &self,
+        block_id: BasicBlockId,
+        cfg: &ControlFlowGraph,
+    ) -> BasicBlockId {
+        // Get an iterator with just the reachable, already visited predecessors to `block_id`.
+        // Note that during the first pass `node` was pre-populated with all reachable blocks.
+        let mut reachable_preds =
+            cfg.pred_iter(block_id).filter(|pred_id| self.nodes.contains_key(&pred_id));
+
+        // This function isn't called on unreachable blocks or the entry block, so the reverse
+        // post-order will contain at least one predecessor to this block.
+        let mut immediate_dominator =
+            reachable_preds.next().expect("block node must have one reachable predecessor");
+
+        for pred in reachable_preds {
+            immediate_dominator = self.common_dominator(immediate_dominator, pred);
+        }
+
+        immediate_dominator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use crate::ssa_refactor::ir::{
+        basic_block::BasicBlockId, cfg::ControlFlowGraph, dom::DominatorTree, function::Function,
+        instruction::TerminatorInstruction, map::Id, types::Type,
+    };
+
+    #[test]
+    fn empty() {
+        let func_id = Id::test_new(0);
+        let mut func = Function::new("func".into(), func_id);
+        let block0_id = func.entry_block();
+        func.dfg.set_block_terminator(
+            block0_id,
+            TerminatorInstruction::Return { return_values: vec![] },
+        );
+        let cfg = ControlFlowGraph::with_function(&func);
+        let dom_tree = DominatorTree::with_function(&func, &cfg);
+        assert_eq!(dom_tree.cfg_post_order(), &[block0_id]);
+    }
+
+    // Testing setup for a function with an unreachable block2
+    fn unreachable_node_setup(
+    ) -> (DominatorTree, BasicBlockId, BasicBlockId, BasicBlockId, BasicBlockId) {
+        // func() {
+        //   block0(cond: u1):
+        //     jmpif v0 block2() block3()
+        //   block1():
+        //     jmp block2()
+        //   block2():
+        //     jmp block3()
+        //   block3():
+        //     return ()
+        // }
+        let func_id = Id::test_new(0);
+        let mut func = Function::new("func".into(), func_id);
+        let block0_id = func.entry_block();
+        let block1_id = func.dfg.make_block();
+        let block2_id = func.dfg.make_block();
+        let block3_id = func.dfg.make_block();
+
+        let cond = func.dfg.add_block_parameter(block0_id, Type::unsigned(1));
+        func.dfg.set_block_terminator(
+            block0_id,
+            TerminatorInstruction::JmpIf {
+                condition: cond,
+                then_destination: block2_id,
+                else_destination: block3_id,
+            },
+        );
+        func.dfg.set_block_terminator(
+            block1_id,
+            TerminatorInstruction::Jmp { destination: block2_id, arguments: vec![] },
+        );
+        func.dfg.set_block_terminator(
+            block2_id,
+            TerminatorInstruction::Jmp { destination: block3_id, arguments: vec![] },
+        );
+        func.dfg.set_block_terminator(
+            block3_id,
+            TerminatorInstruction::Return { return_values: vec![] },
+        );
+
+        let cfg = ControlFlowGraph::with_function(&func);
+        let dt = DominatorTree::with_function(&func, &cfg);
+        (dt, block0_id, block1_id, block2_id, block3_id)
+    }
+
+    // Expected dominator tree
+    // block0 {
+    //   block2
+    //   block3
+    // }
+
+    // Dominance matrix
+    // ✓: Row item dominates column item
+    // !: Querying row item's dominance of column item panics. (i.e. invalid)
+    //    b0  b1  b2  b3
+    // b0 ✓   !   ✓   ✓
+    // b1 !   !   !   !
+    // b2     !   ✓
+    // b3     !       ✓
+    // Note that from a local view block 1 dominates blocks 1,2 & 3, but since this block is
+    // unreachable, performing this query indicates an internal compiler error.
+    #[test]
+    fn unreachable_node_asserts() {
+        let (dt, b0, _b1, b2, b3) = unreachable_node_setup();
+
+        assert_eq!(dt.cfg_post_order(), &[b3, b2, b0]);
+
+        assert_eq!(dt.dominates(b0, b0), true);
+        assert_eq!(dt.dominates(b0, b2), true);
+        assert_eq!(dt.dominates(b0, b3), true);
+
+        assert_eq!(dt.dominates(b2, b0), false);
+        assert_eq!(dt.dominates(b2, b2), true);
+        assert_eq!(dt.dominates(b2, b3), false);
+
+        assert_eq!(dt.dominates(b3, b0), false);
+        assert_eq!(dt.dominates(b3, b2), false);
+        assert_eq!(dt.dominates(b3, b3), true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn unreachable_node_panic_b0_b1() {
+        let (dt, b0, b1, _b2, _b3) = unreachable_node_setup();
+        dt.dominates(b0, b1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn unreachable_node_panic_b1_b0() {
+        let (dt, b0, b1, _b2, _b3) = unreachable_node_setup();
+        dt.dominates(b1, b0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn unreachable_node_panic_b1_b1() {
+        let (dt, _b0, b1, _b2, _b3) = unreachable_node_setup();
+        dt.dominates(b1, b1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn unreachable_node_panic_b1_b2() {
+        let (dt, _b0, b1, b2, _b3) = unreachable_node_setup();
+        dt.dominates(b1, b2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn unreachable_node_panic_b1_b3() {
+        let (dt, _b0, b1, _b2, b3) = unreachable_node_setup();
+        dt.dominates(b1, b3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn unreachable_node_panic_b3_b1() {
+        let (dt, _b0, b1, b2, _b3) = unreachable_node_setup();
+        dt.dominates(b2, b1);
+    }
+
+    #[test]
+    fn backwards_layout() {
+        // func {
+        //   block0():
+        //     jmp block2()
+        //   block1():
+        //     return ()
+        //   block2():
+        //     jump block1()
+        // }
+        let func_id = Id::test_new(0);
+        let mut func = Function::new("func".into(), func_id);
+        let block0_id = func.entry_block();
+        let block1_id = func.dfg.make_block();
+        let block2_id = func.dfg.make_block();
+
+        func.dfg.set_block_terminator(
+            block0_id,
+            TerminatorInstruction::Jmp { destination: block2_id, arguments: vec![] },
+        );
+        func.dfg.set_block_terminator(
+            block1_id,
+            TerminatorInstruction::Return { return_values: vec![] },
+        );
+        func.dfg.set_block_terminator(
+            block2_id,
+            TerminatorInstruction::Jmp { destination: block1_id, arguments: vec![] },
+        );
+
+        let cfg = ControlFlowGraph::with_function(&func);
+        let dt = DominatorTree::with_function(&func, &cfg);
+
+        // Expected dominance tree:
+        // block0 {
+        //   block2 {
+        //     block1
+        //   }
+        // }
+
+        assert_eq!(dt.immediate_dominator(block0_id), None);
+        assert_eq!(dt.immediate_dominator(block1_id), Some(block2_id));
+        assert_eq!(dt.immediate_dominator(block2_id), Some(block0_id));
+
+        assert_eq!(dt.reverse_post_order_cmp(block0_id, block0_id), Ordering::Equal);
+        assert_eq!(dt.reverse_post_order_cmp(block0_id, block1_id), Ordering::Less);
+        assert_eq!(dt.reverse_post_order_cmp(block0_id, block2_id), Ordering::Less);
+
+        assert_eq!(dt.reverse_post_order_cmp(block1_id, block0_id), Ordering::Greater);
+        assert_eq!(dt.reverse_post_order_cmp(block1_id, block1_id), Ordering::Equal);
+        assert_eq!(dt.reverse_post_order_cmp(block1_id, block2_id), Ordering::Greater);
+
+        assert_eq!(dt.reverse_post_order_cmp(block2_id, block0_id), Ordering::Greater);
+        assert_eq!(dt.reverse_post_order_cmp(block2_id, block1_id), Ordering::Less);
+        assert_eq!(dt.reverse_post_order_cmp(block2_id, block2_id), Ordering::Equal);
+
+        // Dominance matrix:
+        // ✓: Row item dominates column item
+        //    b0  b1  b2
+        // b0 ✓   ✓   ✓
+        // b1     ✓
+        // b2     ✓   ✓
+
+        assert_eq!(dt.dominates(block0_id, block0_id), true);
+        assert_eq!(dt.dominates(block0_id, block1_id), true);
+        assert_eq!(dt.dominates(block0_id, block2_id), true);
+
+        assert_eq!(dt.dominates(block1_id, block0_id), false);
+        assert_eq!(dt.dominates(block1_id, block1_id), true);
+        assert_eq!(dt.dominates(block1_id, block2_id), false);
+
+        assert_eq!(dt.dominates(block2_id, block0_id), false);
+        assert_eq!(dt.dominates(block2_id, block1_id), true);
+        assert_eq!(dt.dominates(block2_id, block2_id), true);
+    }
+}

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom.rs
@@ -1,3 +1,6 @@
+//! The dominator tree of a function, represented as a hash map of each reachable block id to its
+//! immediate dominator.
+
 use std::{cmp::Ordering, collections::HashMap};
 
 use super::{basic_block::BasicBlockId, cfg::ControlFlowGraph, post_order::PostOrder};

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dom/post_order.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dom/post_order.rs
@@ -1,0 +1,136 @@
+use std::collections::HashSet;
+
+use crate::ssa_refactor::ir::{basic_block::BasicBlockId, function::Function};
+
+/// DFT stack state marker for computing the cfg postorder.
+enum Visit {
+    First,
+    Last,
+}
+
+// Calculates the post-order of the
+pub(super) fn compute_post_order(func: &Function) -> Vec<BasicBlockId> {
+    let mut stack = vec![(Visit::First, func.entry_block())];
+    let mut visited: HashSet<BasicBlockId> = HashSet::new();
+    let mut post_order: Vec<BasicBlockId> = Vec::new();
+
+    while let Some((visit, block_id)) = stack.pop() {
+        match visit {
+            Visit::First => {
+                if !visited.contains(&block_id) {
+                    // This is the first time we pop the block, so we need to scan its
+                    // successors and then revisit it.
+                    visited.insert(block_id);
+                    stack.push((Visit::Last, block_id));
+                    // Note: cranelift choses to instead iterate successors backwards for reasons
+                    // that aren't yet clearly relevant to us:
+                    // https://github.com/bytecodealliance/wasmtime/commit/8abfe928d6073d76ebd991a2e991bf8268b4e5a2
+                    for successor_id in func.dfg[block_id].successors() {
+                        if !visited.contains(&successor_id) {
+                            // This not visited check would also be cover by the the next
+                            // iteration, but checking here two saves an iteration per successor.
+                            stack.push((Visit::First, successor_id))
+                        }
+                    }
+                }
+            }
+
+            Visit::Last => {
+                // We've finished all this node's successors.
+                post_order.push(block_id);
+            }
+        }
+    }
+    post_order
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ssa_refactor::ir::{
+        function::Function, instruction::TerminatorInstruction, map::Id, types::Type,
+    };
+
+    use super::compute_post_order;
+
+    #[test]
+    fn single_block() {
+        let func_id = Id::test_new(0);
+        let func = Function::new("func".into(), func_id);
+        let post_order = compute_post_order(&func);
+        assert_eq!(post_order, [func.entry_block()]);
+    }
+
+    #[test]
+    fn arb_graph_with_unreachable() {
+        // A → B   C
+        // ↓ ↗ ↓   ↓
+        // D ← E → F
+        // Technically correct post-order:
+        // D, F, E, B, A, C
+        // Post-order for our purposes:
+        // F, E, B, D, A
+        // Differences:
+        // - Since C is unreachable we don't want to include it
+        // - Siblings are traversed "backwards" (i.e. "else" before "then") to simply to save on
+        //   an iterator conversion. We could change this if we find a motivation.
+
+        let func_id = Id::test_new(0);
+        let mut func = Function::new("func".into(), func_id);
+        let block_a_id = func.entry_block();
+        let block_b_id = func.dfg.make_block();
+        let block_c_id = func.dfg.make_block();
+        let block_d_id = func.dfg.make_block();
+        let block_e_id = func.dfg.make_block();
+        let block_f_id = func.dfg.make_block();
+
+        // A → B   •
+        // ↓
+        // D   •   •
+        let cond_a = func.dfg.add_block_parameter(block_a_id, Type::unsigned(1));
+        func.dfg.set_block_terminator(
+            block_a_id,
+            TerminatorInstruction::JmpIf {
+                condition: cond_a,
+                // Ordered backwards for test
+                then_destination: block_b_id,
+                else_destination: block_d_id,
+            },
+        );
+        //  •   B   •
+        //  •   ↓   •
+        //  •   E   •
+        func.dfg.set_block_terminator(
+            block_b_id,
+            TerminatorInstruction::Jmp { destination: block_e_id, arguments: vec![] },
+        );
+        // •   •   •
+        //
+        // D ← E → F
+        let cond_e = func.dfg.add_block_parameter(block_e_id, Type::unsigned(1));
+        func.dfg.set_block_terminator(
+            block_e_id,
+            TerminatorInstruction::JmpIf {
+                condition: cond_e,
+                then_destination: block_d_id,
+                else_destination: block_f_id,
+            },
+        );
+        // •   B   •
+        //   ↗
+        // D   •   •
+        func.dfg.set_block_terminator(
+            block_d_id,
+            TerminatorInstruction::Jmp { destination: block_b_id, arguments: vec![] },
+        );
+        // •   •   C
+        // •   •   ↓
+        // •   •   F
+        func.dfg.set_block_terminator(
+            block_c_id,
+            TerminatorInstruction::Jmp { destination: block_f_id, arguments: vec![] },
+        );
+
+        let post_order = compute_post_order(&func);
+        assert_eq!(post_order, [block_f_id, block_e_id, block_b_id, block_d_id, block_a_id]);
+    }
+}

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use crate::ssa_refactor::ir::{basic_block::BasicBlockId, function::Function};
 
-/// DFT stack state marker for computing the cfg post-order.
+/// Depth-first traversal stack state marker for computing the cfg post-order.
 enum Visit {
     First,
     Last,
@@ -45,9 +45,7 @@ impl PostOrder {
                         stack.push((Visit::Last, block_id));
                         // Stack successors for visiting. Because items are taken from the top of the
                         // stack, we push the item that's due for a visit first to the top.
-                        for successor_id in
-                            func.dfg[block_id].successors().collect::<Vec<_>>().into_iter().rev()
-                        {
+                        for successor_id in func.dfg[block_id].successors().rev() {
                             if !visited.contains(&successor_id) {
                                 // This not visited check would also be cover by the the next
                                 // iteration, but checking here two saves an iteration per successor.
@@ -121,7 +119,6 @@ mod tests {
             block_a_id,
             TerminatorInstruction::JmpIf {
                 condition: cond_a,
-                // Ordered backwards for test
                 then_destination: block_b_id,
                 else_destination: block_d_id,
             },

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
@@ -1,4 +1,7 @@
 //! The post-order for a given function represented as a vector of basic block ids.
+//!
+//! This ordering is beneficial to the efficiency of various algorithms, such as those for dead
+//! code elimination and calculating dominance trees.
 
 use std::collections::HashSet;
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
@@ -48,7 +48,7 @@ impl PostOrder {
                             if !visited.contains(&successor_id) {
                                 // This not visited check would also be cover by the the next
                                 // iteration, but checking here two saves an iteration per successor.
-                                stack.push((Visit::First, successor_id))
+                                stack.push((Visit::First, successor_id));
                             }
                         }
                     }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/post_order.rs
@@ -1,3 +1,5 @@
+//! The post-order for a given function represented as a vector of basic block ids.
+
 use std::collections::HashSet;
 
 use crate::ssa_refactor::ir::{basic_block::BasicBlockId, function::Function};

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/program.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/program.rs
@@ -4,7 +4,7 @@ use crate::ssa_refactor::ir::function::Function;
 
 /// Contains the entire SSA representation of the program.
 pub struct Ssa {
-    functions: Vec<Function>,
+    pub functions: Vec<Function>,
 }
 
 impl Ssa {


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1116

# Description

## Summary of changes

- Add `PostOrder` for calculating the post-order of a function reachable blocks
- Adds `DominatorTree` for querying one block's dominance over another
- Make finished `Ssa`'s function collection accessible so that the `FunctionBuilder` can be used in unit tests

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

Unit test for both of the above

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
