### PR TITLE
chore(parser)!: deprecate constrain

### DIFF
--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -16,7 +16,11 @@ use noirc_errors::Span;
 pub use statement::*;
 pub use structure::*;
 
-use crate::{parser::ParserError, token::IntType, BinaryTypeOperator, CompTime};
+use crate::{
+    parser::{ParserError, ParserErrorReason},
+    token::IntType,
+    BinaryTypeOperator, CompTime,
+};
 use iter_extended::vecmap;
 
 /// The parser parses types as 'UnresolvedType's which
@@ -152,9 +156,9 @@ impl UnresolvedTypeExpression {
         expr: Expression,
         span: Span,
     ) -> Result<UnresolvedTypeExpression, ParserError> {
-        Self::from_expr_helper(expr).map_err(|err| {
+        Self::from_expr_helper(expr).map_err(|err_expr| {
             ParserError::with_reason(
-                format!("Expression is invalid in an array-length type: '{err}'. Only unsigned integer constants, globals, generics, +, -, *, /, and % may be used in this context."),
+                ParserErrorReason::InvalidArrayLengthExpression(err_expr),
                 span,
             )
         })

--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::lexer::token::SpannedToken;
-use crate::parser::ParserError;
+use crate::parser::{ParserError, ParserErrorReason};
 use crate::token::Token;
 use crate::{Expression, ExpressionKind, IndexExpression, MemberAccessExpression, UnresolvedType};
 use iter_extended::vecmap;
@@ -59,8 +59,10 @@ impl Statement {
             | Statement::Error => {
                 // To match rust, statements always require a semicolon, even at the end of a block
                 if semi.is_none() {
-                    let reason = "Expected a ; separating these two statements".to_string();
-                    emit_error(ParserError::with_reason(reason, span));
+                    emit_error(ParserError::with_reason(
+                        ParserErrorReason::MissingSeparatingSemi,
+                        span,
+                    ));
                 }
                 self
             }
@@ -83,8 +85,10 @@ impl Statement {
                     // for unneeded expressions like { 1 + 2; 3 }
                     (_, Some(_), false) => Statement::Expression(expr),
                     (_, None, false) => {
-                        let reason = "Expected a ; separating these two statements".to_string();
-                        emit_error(ParserError::with_reason(reason, span));
+                        emit_error(ParserError::with_reason(
+                            ParserErrorReason::MissingSeparatingSemi,
+                            span,
+                        ));
                         Statement::Expression(expr)
                     }
 

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -1,18 +1,33 @@
 use std::collections::BTreeSet;
 
 use crate::lexer::token::Token;
-use crate::BinaryOp;
+use crate::Expression;
+use thiserror::Error;
 
 use iter_extended::vecmap;
 use noirc_errors::CustomDiagnostic as Diagnostic;
 use noirc_errors::Span;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ParserErrorReason {
+    #[error("Arrays must have at least one element")]
+    ZeroSizedArray,
+    #[error("Unexpected '{0}', expected a field name")]
+    ExpectedFieldName(Token),
+    #[error("Expected a ; separating these two statements")]
+    MissingSeparatingSemi,
+    #[error("constrain keyword is deprecated")]
+    ConstrainDeprecated,
+    #[error("Expression is invalid in an array-length type: '{0}'. Only unsigned integer constants, globals, generics, +, -, *, /, and % may be used in this context.")]
+    InvalidArrayLengthExpression(Expression),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParserError {
     expected_tokens: BTreeSet<Token>,
     expected_labels: BTreeSet<String>,
     found: Token,
-    reason: Option<String>,
+    reason: Option<ParserErrorReason>,
     span: Span,
 }
 
@@ -39,19 +54,9 @@ impl ParserError {
         error
     }
 
-    pub fn with_reason(reason: String, span: Span) -> ParserError {
-        let mut error = ParserError::empty(Token::EOF, span);
+    pub fn with_reason(reason: ParserErrorReason, span: Span) -> ParserError {
+        let mut error: ParserError = ParserError::empty(Token::EOF, span);
         error.reason = Some(reason);
-        error
-    }
-
-    pub fn invalid_constrain_operator(operator: BinaryOp) -> ParserError {
-        let message = format!(
-            "Cannot use the {} operator in a constraint statement.",
-            operator.contents.as_string()
-        );
-        let mut error = ParserError::empty(operator.contents.as_token(), operator.span());
-        error.reason = Some(message);
         error
     }
 }
@@ -84,7 +89,19 @@ impl std::fmt::Display for ParserError {
 impl From<ParserError> for Diagnostic {
     fn from(error: ParserError) -> Diagnostic {
         match &error.reason {
-            Some(reason) => Diagnostic::simple_error(reason.clone(), String::new(), error.span),
+            Some(reason) => {
+                match reason {
+                    ParserErrorReason::ConstrainDeprecated => Diagnostic::simple_warning(
+                        "The 'constrain' keyword has been depreciated in favour of 'assert'".into(),
+                        "The 'constrain' keyword has been depreciated, and it is now recommended to instead write constraints in the form of assertions, i.e. 'assert(some_condition);'. This depreciation can be ignored for the time being by compiling with the '--allow-warnings' flag.".into(),
+                        error.span,
+                    ),
+                    other => {
+
+                        Diagnostic::simple_error(format!("{other}"), String::new(), error.span)
+                    }
+                }
+            }
             None => {
                 let primary = error.to_string();
                 Diagnostic::simple_error(primary, String::new(), error.span)

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -24,6 +24,7 @@ use acvm::FieldElement;
 use chumsky::prelude::*;
 use chumsky::primitive::Container;
 pub use errors::ParserError;
+pub use errors::ParserErrorReason;
 use noirc_errors::Span;
 pub use parser::parse_program;
 
@@ -176,7 +177,7 @@ where
         .try_map(move |peek, span| {
             if too_far.get_iter().any(|t| t == peek) {
                 // This error will never be shown to the user
-                Err(ParserError::with_reason(String::new(), span))
+                Err(ParserError::empty(Token::EOF, span))
             } else {
                 Ok(Recoverable::error(span))
             }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1228

# Description

## Summary of changes

- Add warning message for `constrain` keyword
- Change parser error reason field to an enum for more convenient diagnostic conversion

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
