### PR TITLE
fix(ci): Labeling `doc needed` PRs with uppercase checkbox `- [X]`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
 # Add/remove 'doc needed' label if issue/PR contains the line '- [x] This PR requires documentation updates when merged.'
 "doc needed":
-  - '- \[x\] This PR requires documentation updates when merged.'
+  - '- \[(x|X)\] This PR requires documentation updates when merged.'


### PR DESCRIPTION
# Description

The `doc needed` labeling CI was able to detect `- [x]` but not `- [X]` documentation checkbox on PRs. (See https://github.com/noir-lang/noir/pull/1271 as an example.)

This PR fixes the labeling CI to label a PR when either a `- [x]` or `- [X]` documentation checkbox is detected.

# Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context

PR in testing repo for reference: https://github.com/noir-lang-test/noir/pull/9
