### PR TITLE
chore(parser): return statements unsupported

### DIFF
--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -18,6 +18,8 @@ pub enum ParserErrorReason {
     MissingSeparatingSemi,
     #[error("constrain keyword is deprecated")]
     ConstrainDeprecated,
+    #[error("early return unsupported")]
+    EarlyReturnUnsupported,
     #[error("Expression is invalid in an array-length type: '{0}'. Only unsigned integer constants, globals, generics, +, -, *, /, and % may be used in this context.")]
     InvalidArrayLengthExpression(Expression),
 }
@@ -96,6 +98,7 @@ impl From<ParserError> for Diagnostic {
                         "The 'constrain' keyword has been deprecated. Please use the 'assert' function instead.".into(),
                         error.span,
                     ),
+                    ParserErrorReason::EarlyReturnUnsupported =>Diagnostic::simple_error("early return unsupported".into(), "Noir doesn't support return statements. The return value of a function is instead inferred from the function body's final expression.".into(), error.span),
                     other => {
 
                         Diagnostic::simple_error(format!("{other}"), String::new(), error.span)

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -468,13 +468,12 @@ fn early_return<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a
 where
     P: ExprParser + 'a,
 {
-    ignore_then_commit(keyword(Keyword::Return), expr_parser)
-        .labelled("statement")
-        .map(|_| Statement::Error)
-        .validate(|expr, span, emit| {
+    ignore_then_commit(keyword(Keyword::Return), expr_parser).labelled("statement").validate(
+        |_, span, emit| {
             emit(ParserError::with_reason(ParserErrorReason::EarlyReturnUnsupported, span));
-            expr
-        })
+            Statement::Error
+        },
+    )
 }
 
 fn declaration<'a, P>(expr_parser: P) -> impl NoirParser<Statement> + 'a


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1190

# Description

## Summary of changes

Adds a parsing rule for return statements, such that users are shown a more informative error when they attempt to use it.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
