### PR TITLE
chore: replace usage of `&Vec<T>` with `&[T]` in `noirc_evaluator`

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -12,8 +12,8 @@ use crate::{
 // Generate gates which ensure that out_expr is a permutation of in_expr
 // Returns the control bits of the sorting network used to generate the constrains
 pub(crate) fn evaluate_permutation(
-    in_expr: &Vec<Expression>,
-    out_expr: &Vec<Expression>,
+    in_expr: &[Expression],
+    out_expr: &[Expression],
     evaluator: &mut Evaluator,
 ) -> Vec<Witness> {
     let bits = Vec::new();
@@ -27,9 +27,9 @@ pub(crate) fn evaluate_permutation(
 
 // Same as evaluate_permutation() but uses the provided witness as network control bits
 pub(crate) fn evaluate_permutation_with_witness(
-    in_expr: &Vec<Expression>,
-    out_expr: &Vec<Expression>,
-    bits: &Vec<Witness>,
+    in_expr: &[Expression],
+    out_expr: &[Expression],
+    bits: &[Witness],
     evaluator: &mut Evaluator,
 ) {
     let (w, b) = permutation_layer(in_expr, bits, false, evaluator);
@@ -47,14 +47,14 @@ pub(crate) fn evaluate_permutation_with_witness(
 // in both cases it returns the witness of the network configuration
 // if generate_witness is true, bits is ignored
 fn permutation_layer(
-    in_expr: &Vec<Expression>,
+    in_expr: &[Expression],
     bits: &[Witness],
     generate_witness: bool,
     evaluator: &mut Evaluator,
 ) -> (Vec<Witness>, Vec<Expression>) {
     let n = in_expr.len();
     if n == 1 {
-        return (Vec::new(), in_expr.clone());
+        return (Vec::new(), in_expr.to_vec());
     }
     let n1 = n / 2;
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/printer.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/printer.rs
@@ -64,7 +64,7 @@ fn value(function: &Function, id: ValueId) -> String {
     match &function.dfg[id] {
         Value::NumericConstant { constant, typ } => {
             let value = function.dfg[*constant].value();
-            format!("{} {}", typ, value)
+            format!("{typ} {value}")
         }
         Value::Function(id) => id.to_string(),
         Value::Intrinsic(intrinsic) => intrinsic.to_string(),

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -652,7 +652,7 @@ impl std::fmt::Display for Type {
                 write!(f, "fn({}) -> {}", args.join(", "), ret)
             }
             Type::Vec(element) => {
-                write!(f, "Vec<{}>", element)
+                write!(f, "Vec<{element}>")
             }
         }
     }


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/noir/issues/679.

# Description

## Summary of changes

- updated the function signature to use slices instead of a reference to a vector.
- solved the clippy lint `uninlined_format_args`

## Dependency additions / changes
N/A

## Test additions / changes
N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

# Additional context
