### PR TITLE
fix: to-bits and to-radix for > 128 bits

### DIFF
--- a/crates/noirc_driver/src/contract.rs
+++ b/crates/noirc_driver/src/contract.rs
@@ -1,7 +1,7 @@
+use crate::program::{deserialize_circuit, serialize_circuit};
 use acvm::acir::circuit::Circuit;
 use noirc_abi::Abi;
 use serde::{Deserialize, Serialize};
-use crate::program::{serialize_circuit, deserialize_circuit};
 
 /// Describes the types of smart contract functions that are allowed.
 /// Unlike the similar enum in noirc_frontend, 'open' and 'unconstrained'

--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -405,9 +405,10 @@ pub(crate) fn to_radix_base(
     evaluator: &mut Evaluator,
 ) -> Vec<Witness> {
     // ensure there is no overflow
-    let mut max = BigUint::from(radix);
-    max = max.pow(limb_size) - BigUint::one();
-    assert!(max < FieldElement::modulus());
+    let mut min = BigUint::from(radix);
+    min = min.pow(limb_size - 1);
+    // minimum value that can be represented with limb_size limbs should be less than the modulus
+    assert!(min < FieldElement::modulus());
 
     let (mut result, bytes) = to_radix_little(radix, limb_size, evaluator);
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1311 

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

- Avoid casting of opcode arguments to `u128` before converting to bits or bytes

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
