### PR TITLE
fix: Fix struct or tuple field assignment failing with generics

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -153,7 +153,7 @@ impl<'interner> TypeChecker<'interner> {
                     (Type::Error, None)
                 };
 
-                let (typ, field_index) = match result {
+                let (typ, field_index) = match result.follow_bindings() {
                     Type::Struct(def, args) => {
                         match def.borrow().get_field(&field_name.0.contents, &args) {
                             Some((field, index)) => (field, Some(index)),


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1315 

# Description

## Summary of changes

Fixes an issue where we forgot to call `.follow_bindings()` before matching on a type to see if it was a struct, tuple, or neither. This led to the issue described in #1315 where the compiler did not see the type as a struct and thus thought there was no field of the given name.

## Dependency additions / changes

None

## Test additions / changes

None

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
