### PR TITLE
fix: Assigning to tuple fields

### DIFF
--- a/crates/nargo_cli/tests/test_data/tuples/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/tuples/src/main.nr
@@ -9,11 +9,21 @@ fn main(x: Field, y: Field) {
     assert(a == 0);
     assert(b == 1);
 
-    let (u,v) = if x as u32 <1 {
-        (x,x+1)
+    let (u,v) = if x as u32 < 1 {
+        (x, x + 1)
     } else {
-        (x+1,x)
+        (x + 1, x)
     };
-   assert(u==x+1);
-   assert(v==x);
+    assert(u == x+1);
+    assert(v == x);
+
+    // Test mutating tuples
+    let mut mutable = ((0, 0), 1, 2, 3);
+    mutable.0 = pair;
+    mutable.2 = 7;
+    assert(mutable.0.0 == 1);
+    assert(mutable.0.1 == 0);
+    assert(mutable.1 == 1);
+    assert(mutable.2 == 7);
+    assert(mutable.3 == 3);
 }

--- a/crates/noirc_driver/src/contract.rs
+++ b/crates/noirc_driver/src/contract.rs
@@ -1,7 +1,7 @@
+use crate::program::{deserialize_circuit, serialize_circuit};
 use acvm::acir::circuit::Circuit;
 use noirc_abi::Abi;
 use serde::{Deserialize, Serialize};
-use crate::program::{serialize_circuit, deserialize_circuit};
 
 /// Describes the types of smart contract functions that are allowed.
 /// Unlike the similar enum in noirc_frontend, 'open' and 'unconstrained'

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -505,10 +505,8 @@ impl<'interner> TypeChecker<'interner> {
         if let Type::TypeVariable(..) = &lhs_type {
             self.errors.push(TypeCheckError::TypeAnnotationsNeeded { span });
         } else if lhs_type != Type::Error {
-            self.errors.push(TypeCheckError::Unstructured {
-                msg: format!("Type {lhs_type} has no member named {}", field_name),
-                span,
-            });
+            let msg = format!("Type {lhs_type} has no member named {field_name}");
+            self.errors.push(TypeCheckError::Unstructured { msg, span });
         }
 
         None

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -534,7 +534,7 @@ where
 {
     let l_ident = ident().map(LValue::Ident);
 
-    let l_member_rhs = just(Token::Dot).ignore_then(ident()).map(LValueRhs::MemberAccess);
+    let l_member_rhs = just(Token::Dot).ignore_then(field_name()).map(LValueRhs::MemberAccess);
 
     let l_index = expr_parser
         .delimited_by(just(Token::LeftBracket), just(Token::RightBracket))


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1309 

# Description

## Summary of changes

A parser bug parsing fields using `ident()` instead of `field_name()` (which is an ident or integer literal) lead to assignment to tuple fields not being possible. This was overlooked before, as the relevant code to handle tuple-field assignments was not in the type checker either. To fix this I've merged the code that handles tuple field assignments and tuple field access (a normal a.b expression not in an LValue context) so that this will not happen again. I've also slightly improved the error message if a user accesses a tuple field that is out of bounds.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
