### PR TITLE
fix: Parsing nested generics

### DIFF
--- a/crates/nargo_cli/tests/test_data/generics/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/generics/src/main.nr
@@ -53,5 +53,5 @@ fn main(x: Field, y: Field) {
     let one = x;
     let two = y;
     let nested_generics: Bar<Bar<Field>> = Bar { one, two, other: Bar { one, two, other: 0 } };
-    assert(nested_generics.get_other().get_other() == bar1.get_other());
+    assert(nested_generics.other.other == bar1.get_other());
 }

--- a/crates/nargo_cli/tests/test_data/generics/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/generics/src/main.nr
@@ -49,4 +49,9 @@ fn main(x: Field, y: Field) {
 
     // Expected type error
     // assert(bar2.get_other() == bar2.other);
+
+    let one = x;
+    let two = y;
+    let nested_generics: Bar<Bar<Field>> = Bar { one, two, other: Bar { one, two, other: 0 } };
+    assert(nested_generics.get_other().get_other() == bar1.get_other());
 }

--- a/crates/noirc_driver/src/contract.rs
+++ b/crates/noirc_driver/src/contract.rs
@@ -1,7 +1,7 @@
+use crate::program::{deserialize_circuit, serialize_circuit};
 use acvm::acir::circuit::Circuit;
 use noirc_abi::Abi;
 use serde::{Deserialize, Serialize};
-use crate::program::{serialize_circuit, deserialize_circuit};
 
 /// Describes the types of smart contract functions that are allowed.
 /// Unlike the similar enum in noirc_frontend, 'open' and 'unconstrained'

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -162,9 +162,8 @@ impl<'a> Lexer<'a> {
                 if self.peek_char_is('=') {
                     self.next_char();
                     Ok(Token::GreaterEqual.into_span(start, start + 1))
-                } else if self.peek_char_is('>') {
-                    self.next_char();
-                    Ok(Token::ShiftRight.into_span(start, start + 1))
+                    // Note: There is deliberately now case for RightShift. We always lex >> as
+                    // two separate Greater tokens to help the parser parse nested generic types.
                 } else {
                     Ok(prev_token.into_single_span(start))
                 }

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -386,7 +386,8 @@ fn test_single_double_char() {
         Token::Assign,
         Token::Equal,
         Token::ShiftLeft,
-        Token::ShiftRight,
+        Token::Greater,
+        Token::Greater,
         Token::EOF,
     ];
 

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -147,7 +147,7 @@ impl chumsky::Error<Token> for ParserError {
             self.reason = other.reason;
         }
 
-        // assert_eq!(self.span, other.span);
+        self.span = self.span.merge(other.span);
         self
     }
 }

--- a/crates/noirc_frontend/src/parser/errors.rs
+++ b/crates/noirc_frontend/src/parser/errors.rs
@@ -147,7 +147,7 @@ impl chumsky::Error<Token> for ParserError {
             self.reason = other.reason;
         }
 
-        assert_eq!(self.span, other.span);
+        // assert_eq!(self.span, other.span);
         self
     }
 }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -527,7 +527,7 @@ fn assign_operator() -> impl NoirParser<Token> {
     let shorthand_operators = right_shift_operator().or(one_of(shorthand_operators));
     let shorthand_syntax = shorthand_operators.then_ignore(just(Token::Assign));
 
-    // Since >> is lexed as two separte greater-thans, >>= is lexed as > >=, so
+    // Since >> is lexed as two separate greater-thans, >>= is lexed as > >=, so
     // we need to account for that case here as well.
     let right_shift_fix =
         just(Token::Greater).then(just(Token::GreaterEqual)).map(|_| Token::ShiftRight);


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1316

# Description

## Summary of changes

Generics always expect to end with a `Token::Greater`, however nested generics would use the syntax `A<B<T>>` where the final token(s) would be a `Token::ShiftRight` rather than two separate greater-than tokens.

Changing the type parser to also handle right shifts would be difficult as the shift would have to terminate two levels of nesting in the recursive parser. I opted instead for the other route of changing the lexer to always issue two greater-than tokens rather than combining them. From there I needed to add a few special cases in expression operators and the assign-operator shorthands.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

Added a small regression test line in the generics test.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
