### PR TITLE
chore!: Update to acvm 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ name = "nargo"
 version = "0.5.1"
 dependencies = [
  "acvm",
+ "iter-extended",
  "noirc_abi",
  "noirc_driver",
  "rustc_version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,6 @@ name = "nargo"
 version = "0.5.1"
 dependencies = [
  "acvm 0.11.0",
- "iter-extended",
  "noirc_abi",
  "noirc_driver",
  "rustc_version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.0.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=0aa72dec1367b4f546ba96a83894b8ae062240f4#0aa72dec1367b4f546ba96a83894b8ae062240f4"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=7d249806afec2c33471e74624e8f6ac11c39fb7c#7d249806afec2c33471e74624e8f6ac11c39fb7c"
 dependencies = [
  "acvm",
  "barretenberg-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,8 +49,8 @@ dependencies = [
 
 [[package]]
 name = "acvm-backend-barretenberg"
-version = "0.0.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=7d249806afec2c33471e74624e8f6ac11c39fb7c#7d249806afec2c33471e74624e8f6ac11c39fb7c"
+version = "0.1.0"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=a26215db10e9e2d382078cc045c32467ca1cb278#a26215db10e9e2d382078cc045c32467ca1cb278"
 dependencies = [
  "acvm",
  "barretenberg-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.0.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=7af612c8542a41901c6744f7cf33d704ba7d2ea3#7af612c8542a41901c6744f7cf33d704ba7d2ea3"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=0aa72dec1367b4f546ba96a83894b8ae062240f4#0aa72dec1367b4f546ba96a83894b8ae062240f4"
 dependencies = [
  "acvm",
  "barretenberg-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,8 +49,9 @@ dependencies = [
 
 [[package]]
 name = "acvm-backend-barretenberg"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=a26215db10e9e2d382078cc045c32467ca1cb278#a26215db10e9e2d382078cc045c32467ca1cb278"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf493c97da8c528c21353452aa10f7972f4870a3aab90919bcc08ba56a8cd8"
 dependencies = [
  "acvm",
  "barretenberg-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,39 +4,13 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510b65efd4d20bf266185ce0a5dc7d29bcdd196a6a1835c20908fd88040de76c"
-dependencies = [
- "acir_field 0.10.3",
- "flate2",
- "rmp-serde",
- "serde",
-]
-
-[[package]]
-name = "acir"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084577e67b44c72d1cdfabe286d48adac6f5e0ad441ef134c5c467f4b6eee291"
 dependencies = [
- "acir_field 0.11.0",
+ "acir_field",
  "flate2",
  "rmp-serde",
- "serde",
-]
-
-[[package]]
-name = "acir_field"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f032e710c67fd146caedc8fe1dea6e95f01ab59453e42d59b604a51fef3dfe"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "cfg-if 1.0.0",
- "hex",
- "num-bigint",
  "serde",
 ]
 
@@ -56,30 +30,12 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2611266039740ffd1978f23258bd6ce3166c22cf15b8227685c2f3bb20ae2ee0"
-dependencies = [
- "acir 0.10.3",
- "acvm_stdlib 0.10.3",
- "blake2",
- "crc32fast",
- "indexmap",
- "k256",
- "num-bigint",
- "num-traits",
- "sha2 0.9.9",
- "thiserror",
-]
-
-[[package]]
-name = "acvm"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e1d6795105b50b13fa0dd1779b5191c4d8e9cd98b357b0b9a0b04a847baacf0"
 dependencies = [
- "acir 0.11.0",
- "acvm_stdlib 0.11.0",
+ "acir",
+ "acvm_stdlib",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -94,9 +50,9 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.0.0"
-source = "git+https://github.com/noir-lang/aztec_backend?rev=677f10e07011849f8aa0d75fe80390bb3081b1e5#677f10e07011849f8aa0d75fe80390bb3081b1e5"
+source = "git+https://github.com/noir-lang/aztec_backend?rev=7af612c8542a41901c6744f7cf33d704ba7d2ea3#7af612c8542a41901c6744f7cf33d704ba7d2ea3"
 dependencies = [
- "acvm 0.10.3",
+ "acvm",
  "barretenberg-sys",
  "blake2",
  "dirs 3.0.2",
@@ -106,18 +62,9 @@ dependencies = [
  "pkg-config",
  "reqwest",
  "rust-embed",
- "sha3",
+ "thiserror",
  "tokio",
  "wasmer",
-]
-
-[[package]]
-name = "acvm_stdlib"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ec51160c66eba75dc15a028a2391675386fd395b3897478d89a386c64a48dd"
-dependencies = [
- "acir 0.10.3",
 ]
 
 [[package]]
@@ -126,7 +73,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3131af53d17ac12340c0ff50f8555d8e040321f8078b8ee3cd8846560b6a44a9"
 dependencies = [
- "acir 0.11.0",
+ "acir",
 ]
 
 [[package]]
@@ -1911,7 +1858,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0",
+ "acvm",
  "noirc_abi",
  "noirc_driver",
  "rustc_version",
@@ -1924,7 +1871,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0",
+ "acvm",
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
@@ -1955,7 +1902,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0",
+ "acvm",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -1971,7 +1918,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0",
+ "acvm",
  "iter-extended",
  "serde",
  "serde_json",
@@ -1983,7 +1930,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0",
+ "acvm",
  "clap",
  "fm",
  "iter-extended",
@@ -2009,7 +1956,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0",
+ "acvm",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -2025,7 +1972,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0",
+ "acvm",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,19 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510b65efd4d20bf266185ce0a5dc7d29bcdd196a6a1835c20908fd88040de76c"
 dependencies = [
- "acir_field",
+ "acir_field 0.10.3",
+ "flate2",
+ "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "acir"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084577e67b44c72d1cdfabe286d48adac6f5e0ad441ef134c5c467f4b6eee291"
+dependencies = [
+ "acir_field 0.11.0",
  "flate2",
  "rmp-serde",
  "serde",
@@ -29,13 +41,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "acir_field"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a267ef529f4b132293199ecdf8c232ade817f01d916039f2d34562cab39e75e9"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "cfg-if 1.0.0",
+ "hex",
+ "num-bigint",
+ "serde",
+]
+
+[[package]]
 name = "acvm"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2611266039740ffd1978f23258bd6ce3166c22cf15b8227685c2f3bb20ae2ee0"
 dependencies = [
- "acir",
- "acvm_stdlib",
+ "acir 0.10.3",
+ "acvm_stdlib 0.10.3",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -47,11 +73,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "acvm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1d6795105b50b13fa0dd1779b5191c4d8e9cd98b357b0b9a0b04a847baacf0"
+dependencies = [
+ "acir 0.11.0",
+ "acvm_stdlib 0.11.0",
+ "blake2",
+ "crc32fast",
+ "indexmap",
+ "k256",
+ "num-bigint",
+ "num-traits",
+ "sha2 0.9.9",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
 name = "acvm-backend-barretenberg"
 version = "0.0.0"
 source = "git+https://github.com/noir-lang/aztec_backend?rev=677f10e07011849f8aa0d75fe80390bb3081b1e5#677f10e07011849f8aa0d75fe80390bb3081b1e5"
 dependencies = [
- "acvm",
+ "acvm 0.10.3",
  "barretenberg-sys",
  "blake2",
  "dirs 3.0.2",
@@ -72,7 +117,16 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ec51160c66eba75dc15a028a2391675386fd395b3897478d89a386c64a48dd"
 dependencies = [
- "acir",
+ "acir 0.10.3",
+]
+
+[[package]]
+name = "acvm_stdlib"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3131af53d17ac12340c0ff50f8555d8e040321f8078b8ee3cd8846560b6a44a9"
+dependencies = [
+ "acir 0.11.0",
 ]
 
 [[package]]
@@ -1857,7 +1911,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0",
  "iter-extended",
  "noirc_abi",
  "noirc_driver",
@@ -1871,7 +1925,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0",
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
@@ -1902,7 +1956,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -1918,7 +1972,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0",
  "iter-extended",
  "serde",
  "serde_json",
@@ -1930,7 +1984,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0",
  "clap",
  "fm",
  "iter-extended",
@@ -1956,7 +2010,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -1972,7 +2026,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 rust-version = "1.66"
 
 [workspace.dependencies]
-acvm = "0.10.3"
+acvm = "0.11.0"
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -14,7 +14,6 @@ rustc_version = "0.4.0"
 acvm.workspace = true
 noirc_abi.workspace = true
 noirc_driver.workspace = true
-iter-extended.workspace = true
 toml.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -14,6 +14,7 @@ rustc_version = "0.4.0"
 acvm.workspace = true
 noirc_abi.workspace = true
 noirc_driver.workspace = true
+iter-extended.workspace = true
 toml.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/nargo/src/ops/codegen_verifier.rs
+++ b/crates/nargo/src/ops/codegen_verifier.rs
@@ -1,7 +1,7 @@
 use acvm::SmartContract;
 
 pub fn codegen_verifier<B: SmartContract>(
-    backend: B,
+    backend: &B,
     verification_key: &[u8],
 ) -> Result<String, B::Error> {
     backend.eth_contract_from_vk(verification_key)

--- a/crates/nargo/src/ops/codegen_verifier.rs
+++ b/crates/nargo/src/ops/codegen_verifier.rs
@@ -1,10 +1,8 @@
 use acvm::SmartContract;
 
-use crate::NargoError;
-
-pub fn codegen_verifier(
-    backend: &impl SmartContract,
+pub fn codegen_verifier<Backend: SmartContract>(
+    backend: &Backend,
     verification_key: &[u8],
-) -> Result<String, NargoError> {
-    Ok(backend.eth_contract_from_vk(verification_key))
+) -> Result<String, Backend::Error> {
+    backend.eth_contract_from_vk(verification_key)
 }

--- a/crates/nargo/src/ops/codegen_verifier.rs
+++ b/crates/nargo/src/ops/codegen_verifier.rs
@@ -1,8 +1,8 @@
 use acvm::SmartContract;
 
-pub fn codegen_verifier<Backend: SmartContract>(
-    backend: &Backend,
+pub fn codegen_verifier<B: SmartContract>(
+    backend: B,
     verification_key: &[u8],
-) -> Result<String, Backend::Error> {
+) -> Result<String, B::Error> {
     backend.eth_contract_from_vk(verification_key)
 }

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -9,10 +9,10 @@ use crate::artifacts::{
 // TODO: pull this from backend.
 const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
 
-pub fn preprocess_program<Backend: ProofSystemCompiler>(
-    backend: &Backend,
+pub fn preprocess_program<B: ProofSystemCompiler>(
+    backend: &B,
     compiled_program: CompiledProgram,
-) -> Result<PreprocessedProgram, Backend::Error> {
+) -> Result<PreprocessedProgram, B::Error> {
     // TODO: currently `compiled_program`'s bytecode is already optimized for the backend.
     // In future we'll need to apply those optimizations here.
     let optimized_bytecode = compiled_program.circuit;
@@ -27,10 +27,10 @@ pub fn preprocess_program<Backend: ProofSystemCompiler>(
     })
 }
 
-pub fn preprocess_contract<Backend: ProofSystemCompiler>(
-    backend: &Backend,
+pub fn preprocess_contract<B: ProofSystemCompiler>(
+    backend: &B,
     compiled_contract: CompiledContract,
-) -> Result<PreprocessedContract, Backend::Error> {
+) -> Result<PreprocessedContract, B::Error> {
     let mut preprocessed_contract_functions = vec![];
     for func in compiled_contract.functions.into_iter() {
         // TODO: currently `func`'s bytecode is already optimized for the backend.

--- a/crates/nargo/src/ops/prove.rs
+++ b/crates/nargo/src/ops/prove.rs
@@ -2,11 +2,11 @@ use acvm::acir::circuit::Circuit;
 use acvm::ProofSystemCompiler;
 use noirc_abi::WitnessMap;
 
-pub fn prove_execution<Backend: ProofSystemCompiler>(
-    backend: &Backend,
+pub fn prove_execution<B: ProofSystemCompiler>(
+    backend: &B,
     circuit: &Circuit,
     solved_witness: WitnessMap,
     proving_key: &[u8],
-) -> Result<Vec<u8>, Backend::Error> {
+) -> Result<Vec<u8>, B::Error> {
     backend.prove_with_pk(circuit, solved_witness, proving_key)
 }

--- a/crates/nargo/src/ops/prove.rs
+++ b/crates/nargo/src/ops/prove.rs
@@ -2,15 +2,11 @@ use acvm::acir::circuit::Circuit;
 use acvm::ProofSystemCompiler;
 use noirc_abi::WitnessMap;
 
-use crate::NargoError;
-
-pub fn prove_execution(
-    backend: &impl ProofSystemCompiler,
+pub fn prove_execution<Backend: ProofSystemCompiler>(
+    backend: &Backend,
     circuit: &Circuit,
     solved_witness: WitnessMap,
     proving_key: &[u8],
-) -> Result<Vec<u8>, NargoError> {
-    let proof = backend.prove_with_pk(circuit, solved_witness, proving_key);
-
-    Ok(proof)
+) -> Result<Vec<u8>, Backend::Error> {
+    backend.prove_with_pk(circuit, solved_witness, proving_key)
 }

--- a/crates/nargo/src/ops/verify.rs
+++ b/crates/nargo/src/ops/verify.rs
@@ -2,16 +2,12 @@ use acvm::acir::circuit::Circuit;
 use acvm::ProofSystemCompiler;
 use noirc_abi::WitnessMap;
 
-use crate::NargoError;
-
-pub fn verify_proof(
-    backend: &impl ProofSystemCompiler,
+pub fn verify_proof<Backend: ProofSystemCompiler>(
+    backend: &Backend,
     circuit: &Circuit,
     proof: &[u8],
     public_inputs: WitnessMap,
     verification_key: &[u8],
-) -> Result<bool, NargoError> {
-    let valid_proof = backend.verify_with_vk(proof, public_inputs, circuit, verification_key);
-
-    Ok(valid_proof)
+) -> Result<bool, Backend::Error> {
+    backend.verify_with_vk(proof, public_inputs, circuit, verification_key)
 }

--- a/crates/nargo/src/ops/verify.rs
+++ b/crates/nargo/src/ops/verify.rs
@@ -2,12 +2,12 @@ use acvm::acir::circuit::Circuit;
 use acvm::ProofSystemCompiler;
 use noirc_abi::WitnessMap;
 
-pub fn verify_proof<Backend: ProofSystemCompiler>(
-    backend: &Backend,
+pub fn verify_proof<B: ProofSystemCompiler>(
+    backend: &B,
     circuit: &Circuit,
     proof: &[u8],
     public_inputs: WitnessMap,
     verification_key: &[u8],
-) -> Result<bool, Backend::Error> {
+) -> Result<bool, B::Error> {
     backend.verify_with_vk(proof, public_inputs, circuit, verification_key)
 }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -37,7 +37,7 @@ termcolor = "1.1.2"
 color-eyre = "0.6.2"
 
 # Backends
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "a26215db10e9e2d382078cc045c32467ca1cb278", default-features = false }
+acvm-backend-barretenberg = { version = "0.1.2", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -37,7 +37,7 @@ termcolor = "1.1.2"
 color-eyre = "0.6.2"
 
 # Backends
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "677f10e07011849f8aa0d75fe80390bb3081b1e5", default-features = false }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "7af612c8542a41901c6744f7cf33d704ba7d2ea3", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -37,7 +37,7 @@ termcolor = "1.1.2"
 color-eyre = "0.6.2"
 
 # Backends
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "0aa72dec1367b4f546ba96a83894b8ae062240f4", default-features = false }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "7d249806afec2c33471e74624e8f6ac11c39fb7c", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -37,7 +37,7 @@ termcolor = "1.1.2"
 color-eyre = "0.6.2"
 
 # Backends
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "7d249806afec2c33471e74624e8f6ac11c39fb7c", default-features = false }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "a26215db10e9e2d382078cc045c32467ca1cb278", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -37,7 +37,7 @@ termcolor = "1.1.2"
 color-eyre = "0.6.2"
 
 # Backends
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "7af612c8542a41901c6744f7cf33d704ba7d2ea3", default-features = false }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/aztec_backend", rev = "0aa72dec1367b4f546ba96a83894b8ae062240f4", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -17,21 +17,21 @@ pub(crate) struct CheckCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: CheckCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     check_from_path(backend, config.program_dir, &args.compile_options)?;
     println!("Constraint system successfully built!");
     Ok(())
 }
 
-fn check_from_path<ConcreteBackend: Backend, P: AsRef<Path>>(
-    backend: &ConcreteBackend,
+fn check_from_path<B: Backend, P: AsRef<Path>>(
+    backend: &B,
     p: P,
     compile_options: &CompileOptions,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let mut driver = Resolver::resolve_root_manifest(p.as_ref(), backend.np_language())?;
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
@@ -154,7 +154,7 @@ d2 = ["", "", ""]
         let pass_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/pass"));
 
-        let backend = crate::backends::ConcreteBackend::default();
+        let backend = crate::backends::B::default();
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(pass_dir).unwrap();
         for path in paths.flatten() {
@@ -173,7 +173,7 @@ d2 = ["", "", ""]
         let fail_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/fail"));
 
-        let backend = crate::backends::ConcreteBackend::default();
+        let backend = crate::backends::B::default();
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(fail_dir).unwrap();
         for path in paths.flatten() {
@@ -191,7 +191,7 @@ d2 = ["", "", ""]
         let pass_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join(format!("{TEST_DATA_DIR}/pass_dev_mode"));
 
-        let backend = crate::backends::ConcreteBackend::default();
+        let backend = crate::backends::B::default();
         let config = CompileOptions { allow_warnings: true, ..Default::default() };
 
         let paths = std::fs::read_dir(pass_dir).unwrap();

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -1,5 +1,5 @@
 use crate::{errors::CliError, resolver::Resolver};
-use acvm::ProofSystemCompiler;
+use acvm::Backend;
 use clap::Args;
 use iter_extended::btree_map;
 use noirc_abi::{AbiParameter, AbiType, MAIN_RETURN_NAME};
@@ -17,15 +17,21 @@ pub(crate) struct CheckCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run(args: CheckCommand, config: NargoConfig) -> Result<(), CliError> {
-    check_from_path(config.program_dir, &args.compile_options)?;
+pub(crate) fn run<ConcreteBackend: Backend>(
+    backend: &ConcreteBackend,
+    args: CheckCommand,
+    config: NargoConfig,
+) -> Result<(), CliError<ConcreteBackend>> {
+    check_from_path(backend, config.program_dir, &args.compile_options)?;
     println!("Constraint system successfully built!");
     Ok(())
 }
 
-fn check_from_path<P: AsRef<Path>>(p: P, compile_options: &CompileOptions) -> Result<(), CliError> {
-    let backend = crate::backends::ConcreteBackend::default();
-
+fn check_from_path<ConcreteBackend: Backend, P: AsRef<Path>>(
+    backend: &ConcreteBackend,
+    p: P,
+    compile_options: &CompileOptions,
+) -> Result<(), CliError<ConcreteBackend>> {
     let mut driver = Resolver::resolve_root_manifest(p.as_ref(), backend.np_language())?;
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
@@ -148,12 +154,13 @@ d2 = ["", "", ""]
         let pass_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/pass"));
 
+        let backend = crate::backends::ConcreteBackend::default();
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(pass_dir).unwrap();
         for path in paths.flatten() {
             let path = path.path();
             assert!(
-                super::check_from_path(path.clone(), &config).is_ok(),
+                super::check_from_path(&backend, path.clone(), &config).is_ok(),
                 "path: {}",
                 path.display()
             );
@@ -166,12 +173,13 @@ d2 = ["", "", ""]
         let fail_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/fail"));
 
+        let backend = crate::backends::ConcreteBackend::default();
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(fail_dir).unwrap();
         for path in paths.flatten() {
             let path = path.path();
             assert!(
-                super::check_from_path(path.clone(), &config).is_err(),
+                super::check_from_path(&backend, path.clone(), &config).is_err(),
                 "path: {}",
                 path.display()
             );
@@ -183,13 +191,14 @@ d2 = ["", "", ""]
         let pass_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join(format!("{TEST_DATA_DIR}/pass_dev_mode"));
 
+        let backend = crate::backends::ConcreteBackend::default();
         let config = CompileOptions { allow_warnings: true, ..Default::default() };
 
         let paths = std::fs::read_dir(pass_dir).unwrap();
         for path in paths.flatten() {
             let path = path.path();
             assert!(
-                super::check_from_path(path.clone(), &config).is_ok(),
+                super::check_from_path(&backend, path.clone(), &config).is_ok(),
                 "path: {}",
                 path.display()
             );

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -154,7 +154,7 @@ d2 = ["", "", ""]
         let pass_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/pass"));
 
-        let backend = crate::backends::B::default();
+        let backend = crate::backends::ConcreteBackend::default();
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(pass_dir).unwrap();
         for path in paths.flatten() {
@@ -173,7 +173,7 @@ d2 = ["", "", ""]
         let fail_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("{TEST_DATA_DIR}/fail"));
 
-        let backend = crate::backends::B::default();
+        let backend = crate::backends::ConcreteBackend::default();
         let config = CompileOptions::default();
         let paths = std::fs::read_dir(fail_dir).unwrap();
         for path in paths.flatten() {
@@ -191,7 +191,7 @@ d2 = ["", "", ""]
         let pass_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join(format!("{TEST_DATA_DIR}/pass_dev_mode"));
 
-        let backend = crate::backends::B::default();
+        let backend = crate::backends::ConcreteBackend::default();
         let config = CompileOptions { allow_warnings: true, ..Default::default() };
 
         let paths = std::fs::read_dir(pass_dir).unwrap();

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -19,11 +19,11 @@ pub(crate) struct CodegenVerifierCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: CodegenVerifierCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     // TODO(#1201): Should this be a utility function?
     let circuit_build_path = args
         .circuit_name

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -4,6 +4,7 @@ use crate::{
     cli::compile_cmd::compile_circuit, constants::CONTRACT_DIR, constants::TARGET_DIR,
     errors::CliError,
 };
+use acvm::Backend;
 use clap::Args;
 use nargo::ops::{codegen_verifier, preprocess_program};
 use noirc_driver::CompileOptions;
@@ -18,9 +19,11 @@ pub(crate) struct CodegenVerifierCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(), CliError> {
-    let backend = crate::backends::ConcreteBackend::default();
-
+pub(crate) fn run<ConcreteBackend: Backend>(
+    backend: &ConcreteBackend,
+    args: CodegenVerifierCommand,
+    config: NargoConfig,
+) -> Result<(), CliError<ConcreteBackend>> {
     // TODO(#1201): Should this be a utility function?
     let circuit_build_path = args
         .circuit_name
@@ -30,12 +33,14 @@ pub(crate) fn run(args: CodegenVerifierCommand, config: NargoConfig) -> Result<(
         Some(circuit_build_path) => read_program_from_file(circuit_build_path)?,
         None => {
             let compiled_program =
-                compile_circuit(&backend, config.program_dir.as_ref(), &args.compile_options)?;
-            preprocess_program(&backend, compiled_program)?
+                compile_circuit(backend, config.program_dir.as_ref(), &args.compile_options)?;
+            preprocess_program(backend, compiled_program)
+                .map_err(CliError::ProofSystemCompilerError)?
         }
     };
 
-    let smart_contract_string = codegen_verifier(&backend, &preprocessed_program.verification_key)?;
+    let smart_contract_string = codegen_verifier(backend, &preprocessed_program.verification_key)
+        .map_err(CliError::SmartContractError)?;
 
     let contract_dir = config.program_dir.join(CONTRACT_DIR);
     create_named_dir(&contract_dir, "contract");

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -26,11 +26,11 @@ pub(crate) struct CompileCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: CompileCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let circuit_dir = config.program_dir.join(TARGET_DIR);
 
     // If contracts is set we're compiling every function in a 'contract' rather than just 'main'.
@@ -61,18 +61,18 @@ pub(crate) fn run<ConcreteBackend: Backend>(
     Ok(())
 }
 
-fn setup_driver<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+fn setup_driver<B: Backend>(
+    backend: &B,
     program_dir: &Path,
 ) -> Result<Driver, DependencyResolutionError> {
     Resolver::resolve_root_manifest(program_dir, backend.np_language())
 }
 
-pub(crate) fn compile_circuit<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn compile_circuit<B: Backend>(
+    backend: &B,
     program_dir: &Path,
     compile_options: &CompileOptions,
-) -> Result<CompiledProgram, CliError<ConcreteBackend>> {
+) -> Result<CompiledProgram, CliError<B>> {
     let mut driver = setup_driver(backend, program_dir)?;
     driver.compile_main(compile_options).map_err(|_| CliError::CompilationError)
 }

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -42,7 +42,7 @@ pub(crate) fn run<B: Backend>(
             .map_err(|_| CliError::CompilationError)?;
         let preprocessed_contracts = try_vecmap(compiled_contracts, |contract| {
             preprocess_contract(backend, contract).map_err(CliError::ProofSystemCompilerError)
-        });
+        })?;
         for contract in preprocessed_contracts {
             save_contract_to_file(
                 &contract,

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -25,11 +25,11 @@ pub(crate) struct ExecuteCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: ExecuteCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let (return_value, solved_witness) =
         execute_with_path(backend, &config.program_dir, &args.compile_options)?;
 
@@ -47,11 +47,11 @@ pub(crate) fn run<ConcreteBackend: Backend>(
     Ok(())
 }
 
-fn execute_with_path<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+fn execute_with_path<B: Backend>(
+    backend: &B,
     program_dir: &Path,
     compile_options: &CompileOptions,
-) -> Result<(Option<InputValue>, WitnessMap), CliError<ConcreteBackend>> {
+) -> Result<(Option<InputValue>, WitnessMap), CliError<B>> {
     let CompiledProgram { abi, circuit } = compile_circuit(backend, program_dir, compile_options)?;
 
     // Parse the initial witness values from Prover.toml
@@ -66,12 +66,12 @@ fn execute_with_path<ConcreteBackend: Backend>(
     Ok((return_value, solved_witness))
 }
 
-pub(crate) fn execute_program<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn execute_program<B: Backend>(
+    backend: &B,
     circuit: Circuit,
     abi: &Abi,
     inputs_map: &InputMap,
-) -> Result<WitnessMap, CliError<ConcreteBackend>> {
+) -> Result<WitnessMap, CliError<B>> {
     let initial_witness = abi.encode(inputs_map, None)?;
 
     let solved_witness = nargo::ops::execute_circuit(backend, circuit, initial_witness)?;

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use acvm::acir::circuit::Circuit;
-use acvm::PartialWitnessGenerator;
+use acvm::Backend;
 use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
 use noirc_abi::{Abi, InputMap, WitnessMap};
@@ -25,9 +25,13 @@ pub(crate) struct ExecuteCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run(args: ExecuteCommand, config: NargoConfig) -> Result<(), CliError> {
+pub(crate) fn run<ConcreteBackend: Backend>(
+    backend: &ConcreteBackend,
+    args: ExecuteCommand,
+    config: NargoConfig,
+) -> Result<(), CliError<ConcreteBackend>> {
     let (return_value, solved_witness) =
-        execute_with_path(&config.program_dir, &args.compile_options)?;
+        execute_with_path(backend, &config.program_dir, &args.compile_options)?;
 
     println!("Circuit witness successfully solved");
     if let Some(return_value) = return_value {
@@ -43,19 +47,18 @@ pub(crate) fn run(args: ExecuteCommand, config: NargoConfig) -> Result<(), CliEr
     Ok(())
 }
 
-fn execute_with_path(
+fn execute_with_path<ConcreteBackend: Backend>(
+    backend: &ConcreteBackend,
     program_dir: &Path,
     compile_options: &CompileOptions,
-) -> Result<(Option<InputValue>, WitnessMap), CliError> {
-    let backend = crate::backends::ConcreteBackend::default();
-
-    let CompiledProgram { abi, circuit } = compile_circuit(&backend, program_dir, compile_options)?;
+) -> Result<(Option<InputValue>, WitnessMap), CliError<ConcreteBackend>> {
+    let CompiledProgram { abi, circuit } = compile_circuit(backend, program_dir, compile_options)?;
 
     // Parse the initial witness values from Prover.toml
     let (inputs_map, _) =
         read_inputs_from_file(program_dir, PROVER_INPUT_FILE, Format::Toml, &abi)?;
 
-    let solved_witness = execute_program(&backend, circuit, &abi, &inputs_map)?;
+    let solved_witness = execute_program(backend, circuit, &abi, &inputs_map)?;
 
     let public_abi = abi.public_abi();
     let (_, return_value) = public_abi.decode(&solved_witness)?;
@@ -63,12 +66,12 @@ fn execute_with_path(
     Ok((return_value, solved_witness))
 }
 
-pub(crate) fn execute_program(
-    backend: &impl PartialWitnessGenerator,
+pub(crate) fn execute_program<ConcreteBackend: Backend>(
+    backend: &ConcreteBackend,
     circuit: Circuit,
     abi: &Abi,
     inputs_map: &InputMap,
-) -> Result<WitnessMap, CliError> {
+) -> Result<WitnessMap, CliError<ConcreteBackend>> {
     let initial_witness = abi.encode(inputs_map, None)?;
 
     let solved_witness = nargo::ops::execute_circuit(backend, circuit, initial_witness)?;

--- a/crates/nargo_cli/src/cli/fs/inputs.rs
+++ b/crates/nargo_cli/src/cli/fs/inputs.rs
@@ -4,7 +4,7 @@ use noirc_abi::{
 };
 use std::{collections::BTreeMap, path::Path};
 
-use crate::errors::CliError;
+use crate::errors::FilesystemError;
 
 use super::write_to_file;
 
@@ -20,14 +20,14 @@ pub(crate) fn read_inputs_from_file<P: AsRef<Path>>(
     file_name: &str,
     format: Format,
     abi: &Abi,
-) -> Result<(InputMap, Option<InputValue>), CliError> {
+) -> Result<(InputMap, Option<InputValue>), FilesystemError> {
     if abi.is_empty() {
         return Ok((BTreeMap::new(), None));
     }
 
     let file_path = path.as_ref().join(file_name).with_extension(format.ext());
     if !file_path.exists() {
-        return Err(CliError::MissingTomlFile(file_name.to_owned(), file_path));
+        return Err(FilesystemError::MissingTomlFile(file_name.to_owned(), file_path));
     }
 
     let input_string = std::fs::read_to_string(file_path).unwrap();
@@ -43,7 +43,7 @@ pub(crate) fn write_inputs_to_file<P: AsRef<Path>>(
     path: P,
     file_name: &str,
     format: Format,
-) -> Result<(), CliError> {
+) -> Result<(), FilesystemError> {
     let file_path = path.as_ref().join(file_name).with_extension(format.ext());
 
     // We must insert the return value into the `InputMap` in order for it to be written to file.

--- a/crates/nargo_cli/src/cli/fs/mod.rs
+++ b/crates/nargo_cli/src/cli/fs/mod.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::errors::CliError;
+use crate::errors::FilesystemError;
 
 pub(super) mod inputs;
 pub(super) mod program;
@@ -32,11 +32,11 @@ pub(super) fn write_to_file(bytes: &[u8], path: &Path) -> String {
     }
 }
 
-pub(super) fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, CliError> {
-    let hex_data: Vec<_> =
-        std::fs::read(&path).map_err(|_| CliError::PathNotValid(path.as_ref().to_path_buf()))?;
+pub(super) fn load_hex_data<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, FilesystemError> {
+    let hex_data: Vec<_> = std::fs::read(&path)
+        .map_err(|_| FilesystemError::PathNotValid(path.as_ref().to_path_buf()))?;
 
-    let raw_bytes = hex::decode(hex_data).map_err(CliError::HexArtifactNotValid)?;
+    let raw_bytes = hex::decode(hex_data).map_err(FilesystemError::HexArtifactNotValid)?;
 
     Ok(raw_bytes)
 }

--- a/crates/nargo_cli/src/cli/fs/program.rs
+++ b/crates/nargo_cli/src/cli/fs/program.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use nargo::artifacts::{contract::PreprocessedContract, program::PreprocessedProgram};
 
-use crate::errors::CliError;
+use crate::errors::FilesystemError;
 
 use super::{create_named_dir, write_to_file};
 
@@ -35,10 +35,11 @@ fn save_build_artifact_to_file<P: AsRef<Path>, T: ?Sized + serde::Serialize>(
 
 pub(crate) fn read_program_from_file<P: AsRef<Path>>(
     circuit_path: P,
-) -> Result<PreprocessedProgram, CliError> {
+) -> Result<PreprocessedProgram, FilesystemError> {
     let file_path = circuit_path.as_ref().with_extension("json");
 
-    let input_string = std::fs::read(&file_path).map_err(|_| CliError::PathNotValid(file_path))?;
+    let input_string =
+        std::fs::read(&file_path).map_err(|_| FilesystemError::PathNotValid(file_path))?;
 
     let program = serde_json::from_slice(&input_string).expect("could not deserialize program");
 

--- a/crates/nargo_cli/src/cli/fs/proof.rs
+++ b/crates/nargo_cli/src/cli/fs/proof.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::{constants::PROOF_EXT, errors::CliError};
+use crate::{constants::PROOF_EXT, errors::FilesystemError};
 
 use super::{create_named_dir, write_to_file};
 
@@ -8,7 +8,7 @@ pub(crate) fn save_proof_to_dir<P: AsRef<Path>>(
     proof: &[u8],
     proof_name: &str,
     proof_dir: P,
-) -> Result<PathBuf, CliError> {
+) -> Result<PathBuf, FilesystemError> {
     create_named_dir(proof_dir.as_ref(), "proof");
     let proof_path = proof_dir.as_ref().join(proof_name).with_extension(PROOF_EXT);
 

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -4,13 +4,13 @@ use acvm::acir::native_types::Witness;
 use noirc_abi::WitnessMap;
 
 use super::{create_named_dir, write_to_file};
-use crate::{constants::WITNESS_EXT, errors::CliError};
+use crate::{constants::WITNESS_EXT, errors::FilesystemError};
 
 pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     witness: WitnessMap,
     witness_name: &str,
     witness_dir: P,
-) -> Result<PathBuf, CliError> {
+) -> Result<PathBuf, FilesystemError> {
     create_named_dir(witness_dir.as_ref(), "witness");
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 

--- a/crates/nargo_cli/src/cli/gates_cmd.rs
+++ b/crates/nargo_cli/src/cli/gates_cmd.rs
@@ -1,4 +1,4 @@
-use acvm::ProofSystemCompiler;
+use acvm::Backend;
 use clap::Args;
 use noirc_driver::CompileOptions;
 use std::path::Path;
@@ -15,17 +15,20 @@ pub(crate) struct GatesCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run(args: GatesCommand, config: NargoConfig) -> Result<(), CliError> {
-    count_gates_with_path(config.program_dir, &args.compile_options)
+pub(crate) fn run<ConcreteBackend: Backend>(
+    backend: &ConcreteBackend,
+    args: GatesCommand,
+    config: NargoConfig,
+) -> Result<(), CliError<ConcreteBackend>> {
+    count_gates_with_path(backend, config.program_dir, &args.compile_options)
 }
 
-fn count_gates_with_path<P: AsRef<Path>>(
+fn count_gates_with_path<ConcreteBackend: Backend, P: AsRef<Path>>(
+    backend: &ConcreteBackend,
     program_dir: P,
     compile_options: &CompileOptions,
-) -> Result<(), CliError> {
-    let backend = crate::backends::ConcreteBackend::default();
-
-    let compiled_program = compile_circuit(&backend, program_dir.as_ref(), compile_options)?;
+) -> Result<(), CliError<ConcreteBackend>> {
+    let compiled_program = compile_circuit(backend, program_dir.as_ref(), compile_options)?;
     let num_opcodes = compiled_program.circuit.opcodes.len();
 
     println!(
@@ -34,7 +37,9 @@ fn count_gates_with_path<P: AsRef<Path>>(
         num_opcodes
     );
 
-    let exact_circuit_size = backend.get_exact_circuit_size(&compiled_program.circuit);
+    let exact_circuit_size = backend
+        .get_exact_circuit_size(&compiled_program.circuit)
+        .map_err(CliError::ProofSystemCompilerError)?;
     println!("Backend circuit size: {exact_circuit_size}");
 
     Ok(())

--- a/crates/nargo_cli/src/cli/gates_cmd.rs
+++ b/crates/nargo_cli/src/cli/gates_cmd.rs
@@ -15,19 +15,19 @@ pub(crate) struct GatesCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: GatesCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     count_gates_with_path(backend, config.program_dir, &args.compile_options)
 }
 
-fn count_gates_with_path<ConcreteBackend: Backend, P: AsRef<Path>>(
-    backend: &ConcreteBackend,
+fn count_gates_with_path<B: Backend, P: AsRef<Path>>(
+    backend: &B,
     program_dir: P,
     compile_options: &CompileOptions,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let compiled_program = compile_circuit(backend, program_dir.as_ref(), compile_options)?;
     let num_opcodes = compiled_program.circuit.opcodes.len();
 

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -67,17 +67,19 @@ pub fn start_cli() -> eyre::Result<()> {
         config.program_dir = find_package_root(&config.program_dir)?;
     }
 
+    let backend = crate::backends::ConcreteBackend::default();
+
     match command {
-        NargoCommand::New(args) => new_cmd::run(args, config),
-        NargoCommand::Check(args) => check_cmd::run(args, config),
-        NargoCommand::Compile(args) => compile_cmd::run(args, config),
-        NargoCommand::Execute(args) => execute_cmd::run(args, config),
-        NargoCommand::Prove(args) => prove_cmd::run(args, config),
-        NargoCommand::Verify(args) => verify_cmd::run(args, config),
-        NargoCommand::Test(args) => test_cmd::run(args, config),
-        NargoCommand::Gates(args) => gates_cmd::run(args, config),
-        NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(args, config),
-        NargoCommand::PrintAcir(args) => print_acir_cmd::run(args, config),
+        NargoCommand::New(args) => new_cmd::run(&backend, args, config),
+        NargoCommand::Check(args) => check_cmd::run(&backend, args, config),
+        NargoCommand::Compile(args) => compile_cmd::run(&backend, args, config),
+        NargoCommand::Execute(args) => execute_cmd::run(&backend, args, config),
+        NargoCommand::Prove(args) => prove_cmd::run(&backend, args, config),
+        NargoCommand::Verify(args) => verify_cmd::run(&backend, args, config),
+        NargoCommand::Test(args) => test_cmd::run(&backend, args, config),
+        NargoCommand::Gates(args) => gates_cmd::run(&backend, args, config),
+        NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(&backend, args, config),
+        NargoCommand::PrintAcir(args) => print_acir_cmd::run(&backend, args, config),
     }?;
 
     Ok(())
@@ -85,6 +87,8 @@ pub fn start_cli() -> eyre::Result<()> {
 
 // helper function which tests noir programs by trying to generate a proof and verify it
 pub fn prove_and_verify(proof_name: &str, program_dir: &Path, show_ssa: bool) -> bool {
+    let backend = crate::backends::ConcreteBackend::default();
+
     let compile_options = CompileOptions {
         show_ssa,
         allow_warnings: false,
@@ -94,6 +98,7 @@ pub fn prove_and_verify(proof_name: &str, program_dir: &Path, show_ssa: bool) ->
     let proof_dir = program_dir.join(PROOFS_DIR);
 
     match prove_cmd::prove_with_path(
+        &backend,
         Some(proof_name.to_owned()),
         program_dir,
         &proof_dir,

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -5,6 +5,7 @@ use crate::{
 
 use super::fs::{create_named_dir, write_to_file};
 use super::{NargoConfig, CARGO_PKG_VERSION};
+use acvm::Backend;
 use clap::Args;
 use const_format::formatcp;
 use std::path::{Path, PathBuf};
@@ -33,13 +34,18 @@ const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
 #[test]
 fn test_main() {
     main(1, 2);
-    
+
     // Uncomment to make test fail
     // main(1, 1);
 }
 "#;
 
-pub(crate) fn run(args: NewCommand, config: NargoConfig) -> Result<(), CliError> {
+pub(crate) fn run<ConcreteBackend: Backend>(
+    // Backend is currently unused, but we might want to use it to inform the "new" template in the future
+    _backend: &ConcreteBackend,
+    args: NewCommand,
+    config: NargoConfig,
+) -> Result<(), CliError<ConcreteBackend>> {
     let package_dir = config.program_dir.join(args.package_name);
 
     if package_dir.exists() {

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -40,12 +40,12 @@ fn test_main() {
 }
 "#;
 
-pub(crate) fn run<ConcreteBackend: Backend>(
+pub(crate) fn run<B: Backend>(
     // Backend is currently unused, but we might want to use it to inform the "new" template in the future
-    _backend: &ConcreteBackend,
+    _backend: &B,
     args: NewCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let package_dir = config.program_dir.join(args.package_name);
 
     if package_dir.exists() {

--- a/crates/nargo_cli/src/cli/print_acir_cmd.rs
+++ b/crates/nargo_cli/src/cli/print_acir_cmd.rs
@@ -15,19 +15,19 @@ pub(crate) struct PrintAcirCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: PrintAcirCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     print_acir_with_path(backend, config.program_dir, &args.compile_options)
 }
 
-fn print_acir_with_path<ConcreteBackend: Backend, P: AsRef<Path>>(
-    backend: &ConcreteBackend,
+fn print_acir_with_path<B: Backend, P: AsRef<Path>>(
+    backend: &B,
     program_dir: P,
     compile_options: &CompileOptions,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let compiled_program = compile_circuit(backend, program_dir.as_ref(), compile_options)?;
     println!("{}", compiled_program.circuit);
 

--- a/crates/nargo_cli/src/cli/print_acir_cmd.rs
+++ b/crates/nargo_cli/src/cli/print_acir_cmd.rs
@@ -1,3 +1,4 @@
+use acvm::Backend;
 use clap::Args;
 use noirc_driver::CompileOptions;
 use std::path::Path;
@@ -14,17 +15,20 @@ pub(crate) struct PrintAcirCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run(args: PrintAcirCommand, config: NargoConfig) -> Result<(), CliError> {
-    print_acir_with_path(config.program_dir, &args.compile_options)
+pub(crate) fn run<ConcreteBackend: Backend>(
+    backend: &ConcreteBackend,
+    args: PrintAcirCommand,
+    config: NargoConfig,
+) -> Result<(), CliError<ConcreteBackend>> {
+    print_acir_with_path(backend, config.program_dir, &args.compile_options)
 }
 
-fn print_acir_with_path<P: AsRef<Path>>(
+fn print_acir_with_path<ConcreteBackend: Backend, P: AsRef<Path>>(
+    backend: &ConcreteBackend,
     program_dir: P,
     compile_options: &CompileOptions,
-) -> Result<(), CliError> {
-    let backend = crate::backends::ConcreteBackend::default();
-
-    let compiled_program = compile_circuit(&backend, program_dir.as_ref(), compile_options)?;
+) -> Result<(), CliError<ConcreteBackend>> {
+    let compiled_program = compile_circuit(backend, program_dir.as_ref(), compile_options)?;
     println!("{}", compiled_program.circuit);
 
     Ok(())

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -39,11 +39,11 @@ pub(crate) struct ProveCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: ProveCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let proof_dir = config.program_dir.join(PROOFS_DIR);
 
     let circuit_build_path = args
@@ -63,15 +63,15 @@ pub(crate) fn run<ConcreteBackend: Backend>(
     Ok(())
 }
 
-pub(crate) fn prove_with_path<ConcreteBackend: Backend, P: AsRef<Path>>(
-    backend: &ConcreteBackend,
+pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
+    backend: &B,
     proof_name: Option<String>,
     program_dir: P,
     proof_dir: P,
     circuit_build_path: Option<PathBuf>,
     check_proof: bool,
     compile_options: &CompileOptions,
-) -> Result<Option<PathBuf>, CliError<ConcreteBackend>> {
+) -> Result<Option<PathBuf>, CliError<B>> {
     let preprocessed_program = match circuit_build_path {
         Some(circuit_build_path) => read_program_from_file(circuit_build_path)?,
         None => {

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -21,22 +21,22 @@ pub(crate) struct TestCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: TestCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let test_name: String = args.test_name.unwrap_or_else(|| "".to_owned());
 
     run_tests(backend, &config.program_dir, &test_name, &args.compile_options)
 }
 
-fn run_tests<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+fn run_tests<B: Backend>(
+    backend: &B,
     program_dir: &Path,
     test_name: &str,
     compile_options: &CompileOptions,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let mut driver = Resolver::resolve_root_manifest(program_dir, backend.np_language())?;
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
@@ -76,13 +76,13 @@ fn run_tests<ConcreteBackend: Backend>(
     Ok(())
 }
 
-fn run_test<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+fn run_test<B: Backend>(
+    backend: &B,
     test_name: &str,
     main: FuncId,
     driver: &Driver,
     config: &CompileOptions,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let program = driver
         .compile_no_check(config, main)
         .map_err(|_| CliError::Generic(format!("Test '{test_name}' failed to compile")))?;

--- a/crates/nargo_cli/src/cli/verify_cmd.rs
+++ b/crates/nargo_cli/src/cli/verify_cmd.rs
@@ -27,11 +27,11 @@ pub(crate) struct VerifyCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<ConcreteBackend: Backend>(
-    backend: &ConcreteBackend,
+pub(crate) fn run<B: Backend>(
+    backend: &B,
     args: VerifyCommand,
     config: NargoConfig,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let proof_path =
         config.program_dir.join(PROOFS_DIR).join(&args.proof).with_extension(PROOF_EXT);
 
@@ -48,13 +48,13 @@ pub(crate) fn run<ConcreteBackend: Backend>(
     )
 }
 
-fn verify_with_path<ConcreteBackend: Backend, P: AsRef<Path>>(
-    backend: &ConcreteBackend,
+fn verify_with_path<B: Backend, P: AsRef<Path>>(
+    backend: &B,
     program_dir: P,
     proof_path: PathBuf,
     circuit_build_path: Option<P>,
     compile_options: CompileOptions,
-) -> Result<(), CliError<ConcreteBackend>> {
+) -> Result<(), CliError<B>> {
     let preprocessed_program = match circuit_build_path {
         Some(circuit_build_path) => read_program_from_file(circuit_build_path)?,
         None => {

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -2,7 +2,7 @@ use acvm::{Backend, ProofSystemCompiler, SmartContract};
 use hex::FromHexError;
 use nargo::NargoError;
 use noirc_abi::errors::{AbiError, InputParserError};
-use std::{fmt::Debug, path::PathBuf};
+use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::resolver::DependencyResolutionError;

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -1,17 +1,14 @@
+use acvm::{Backend, ProofSystemCompiler, SmartContract};
 use hex::FromHexError;
 use nargo::NargoError;
 use noirc_abi::errors::{AbiError, InputParserError};
-use std::path::PathBuf;
+use std::{fmt::Debug, path::PathBuf};
 use thiserror::Error;
 
 use crate::resolver::DependencyResolutionError;
 
 #[derive(Debug, Error)]
-pub(crate) enum CliError {
-    #[error("{0}")]
-    Generic(String),
-    #[error("Error: destination {} already exists", .0.display())]
-    DestinationAlreadyExists(PathBuf),
+pub(crate) enum FilesystemError {
     #[error("Error: {} is not a valid path\nRun either `nargo compile` to generate missing build artifacts or `nargo prove` to construct a proof", .0.display())]
     PathNotValid(PathBuf),
     #[error("Error: could not parse hex build artifact (proof, proving and/or verification keys, ACIR checksum) ({0})")]
@@ -20,6 +17,18 @@ pub(crate) enum CliError {
         " Error: cannot find {0}.toml file.\n Expected location: {1:?} \n Please generate this file at the expected location."
     )]
     MissingTomlFile(String, PathBuf),
+
+    /// Input parsing error
+    #[error(transparent)]
+    InputParserError(#[from] InputParserError),
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum CliError<B: Backend> {
+    #[error("{0}")]
+    Generic(String),
+    #[error("Error: destination {} already exists", .0.display())]
+    DestinationAlreadyExists(PathBuf),
 
     #[error("Failed to verify proof {}", .0.display())]
     InvalidProof(PathBuf),
@@ -31,15 +40,23 @@ pub(crate) enum CliError {
     #[error("Failed to compile circuit")]
     CompilationError,
 
-    /// Input parsing error
-    #[error(transparent)]
-    InputParserError(#[from] InputParserError),
-
     /// ABI encoding/decoding error
     #[error(transparent)]
     AbiError(#[from] AbiError),
 
+    /// Filesystem errors
+    #[error(transparent)]
+    FilesystemError(#[from] FilesystemError),
+
     /// Error from Nargo
     #[error(transparent)]
     NargoError(#[from] NargoError),
+
+    /// Backend error caused by a function on the SmartContract trait
+    #[error(transparent)]
+    SmartContractError(<B as SmartContract>::Error), // Unfortunately, Rust won't let us `impl From` over an Associated Type on a generic
+
+    /// Backend error caused by a function on the ProofSystemCompiler trait
+    #[error(transparent)]
+    ProofSystemCompilerError(<B as ProofSystemCompiler>::Error), // Unfortunately, Rust won't let us `impl From` over an Associated Type on a generic
 }


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1301 <!-- link to issue -->

# Description

## Summary of changes

<!-- Describe the changes in this PR. Point out breaking changes if any. -->

This updates the project to ACVM 0.11.0

This is the version of ACVM that introduced the Result return type to many of the functions on the Backend trait. This allows us to better surface errors from backends—and as such, aztec_backend has been updated to return results for almost all errors (the only unwraps remaining are in the merkle implementation).

This version of ACVM also introduced keccak into the constraint system, so we needed to upgrade barretenberg also. This may cause the same OOM error that the other Keccak PR is exhibiting.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
