### PR TITLE
chore(ssa refactor): Fix inlining bug

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -305,7 +305,8 @@ impl<'function> PerFunctionContext<'function> {
         arguments: &[ValueId],
     ) {
         let old_results = self.source_function.dfg.instruction_results(call_id);
-        let new_results = self.context.inline_function(ssa, function, arguments);
+        let arguments = vecmap(arguments, |arg| self.translate_value(*arg));
+        let new_results = self.context.inline_function(ssa, function, &arguments);
         Self::insert_new_instruction_results(&mut self.values, old_results, new_results);
     }
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

I found this bug while working on loop unrolling: we never call `translate_value` on function arguments before during inlining which could cause the functions to be called with the incorrect values. This wasn't obvious because ValueIds are only valid for the function they're created in, so the untranslated ones were being used outside of their function and were referring to different values than they were meant to.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
