### PR TITLE
Updating label docs workflow

### DIFF
--- a/.github/workflows/label_docs.yml
+++ b/.github/workflows/label_docs.yml
@@ -5,6 +5,10 @@ on:
     types:
       - labeled
       - unlabeled
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
 
 jobs:
   dispatch:


### PR DESCRIPTION
Quick update, as this workflow is apparently only triggered by humans and ignored by github_bot. This commit attempts to fix this

# Description

## Summary of changes

Adds another trigger "pull_request", as apparently "pull_request_target" is excluding github_bot. Pull request is usually labeled by github_bot, making the counterpart issues in the docs not being created

