### PR TITLE
feat: pass in closure to `Driver` to signal backend opcode support

### DIFF
--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -32,7 +32,12 @@ fn check_from_path<B: Backend, P: AsRef<Path>>(
     p: P,
     compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
-    let mut driver = Resolver::resolve_root_manifest(p.as_ref(), backend.np_language())?;
+    let mut driver = Resolver::resolve_root_manifest(
+        p.as_ref(),
+        backend.np_language(),
+        #[allow(deprecated)]
+        Box::new(acvm::default_is_opcode_supported(backend.np_language())),
+    )?;
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -63,7 +63,12 @@ fn setup_driver<B: Backend>(
     backend: &B,
     program_dir: &Path,
 ) -> Result<Driver, DependencyResolutionError> {
-    Resolver::resolve_root_manifest(program_dir, backend.np_language())
+    Resolver::resolve_root_manifest(
+        program_dir,
+        backend.np_language(),
+        #[allow(deprecated)]
+        Box::new(acvm::default_is_opcode_supported(backend.np_language())),
+    )
 }
 
 pub(crate) fn compile_circuit<B: Backend>(

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -128,7 +128,11 @@ mod tests {
     ///
     /// This is used for tests.
     fn file_compiles<P: AsRef<Path>>(root_file: P) -> bool {
-        let mut driver = Driver::new(&acvm::Language::R1CS);
+        let mut driver = Driver::new(
+            &acvm::Language::R1CS,
+            #[allow(deprecated)]
+            Box::new(acvm::default_is_opcode_supported(acvm::Language::R1CS)),
+        );
         driver.create_local_crate(&root_file, CrateType::Binary);
         crate::resolver::add_std_lib(&mut driver);
         driver.file_compiles()

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -37,7 +37,12 @@ fn run_tests<B: Backend>(
     test_name: &str,
     compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
-    let mut driver = Resolver::resolve_root_manifest(program_dir, backend.np_language())?;
+    let mut driver = Resolver::resolve_root_manifest(
+        program_dir,
+        backend.np_language(),
+        #[allow(deprecated)]
+        Box::new(acvm::default_is_opcode_supported(backend.np_language())),
+    )?;
 
     driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
 

--- a/crates/nargo_cli/src/resolver.rs
+++ b/crates/nargo_cli/src/resolver.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use acvm::Language;
+use acvm::{acir::circuit::Opcode, Language};
 use nargo::manifest::{Dependency, PackageManifest};
 use noirc_driver::Driver;
 use noirc_frontend::graph::{CrateId, CrateName, CrateType};
@@ -71,8 +71,9 @@ impl<'a> Resolver<'a> {
     pub(crate) fn resolve_root_manifest(
         dir_path: &std::path::Path,
         np_language: Language,
+        is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
     ) -> Result<Driver, DependencyResolutionError> {
-        let mut driver = Driver::new(&np_language);
+        let mut driver = Driver::new(&np_language, is_opcode_supported);
         let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;
 
         let manifest_path = super::find_package_manifest(dir_path)?;

--- a/crates/nargo_cli/src/resolver.rs
+++ b/crates/nargo_cli/src/resolver.rs
@@ -71,7 +71,7 @@ impl<'a> Resolver<'a> {
     pub(crate) fn resolve_root_manifest(
         dir_path: &std::path::Path,
         np_language: Language,
-        is_opcode_supported: Box<impl Fn(&Opcode) -> bool>,
+        is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
     ) -> Result<Driver, DependencyResolutionError> {
         let mut driver = Driver::new(&np_language, is_opcode_supported);
         let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;

--- a/crates/nargo_cli/src/resolver.rs
+++ b/crates/nargo_cli/src/resolver.rs
@@ -71,7 +71,7 @@ impl<'a> Resolver<'a> {
     pub(crate) fn resolve_root_manifest(
         dir_path: &std::path::Path,
         np_language: Language,
-        is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
+        is_opcode_supported: Box<impl Fn(&Opcode) -> bool>,
     ) -> Result<Driver, DependencyResolutionError> {
         let mut driver = Driver::new(&np_language, is_opcode_supported);
         let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -59,7 +59,6 @@ impl Default for CompileOptions {
 impl Driver {
     pub fn new(language: &Language, is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>) -> Self {
         let mut driver = Driver { context: Context::default(), language: language.clone() };
-        driver.context.def_interner.set_language(language);
         driver.context.def_interner.set_opcode_support(is_opcode_supported);
         driver
     }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(unreachable_pub)]
 #![warn(clippy::semicolon_if_nothing_returned)]
 
+use acvm::acir::circuit::Opcode;
 use acvm::Language;
 use clap::Args;
 use contract::ContractFunction;
@@ -56,9 +57,10 @@ impl Default for CompileOptions {
 }
 
 impl Driver {
-    pub fn new(np_language: &Language) -> Self {
-        let mut driver = Driver { context: Context::default(), language: np_language.clone() };
-        driver.context.def_interner.set_language(np_language);
+    pub fn new(language: &Language, is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>) -> Self {
+        let mut driver = Driver { context: Context::default(), language: language.clone() };
+        driver.context.def_interner.set_language(language);
+        driver.context.def_interner.set_opcode_support(is_opcode_supported);
         driver
     }
 
@@ -66,9 +68,10 @@ impl Driver {
     // with the restricted version which only uses one file
     pub fn compile_file(
         root_file: PathBuf,
-        np_language: acvm::Language,
+        language: &Language,
+        is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
     ) -> Result<CompiledProgram, ReportedError> {
-        let mut driver = Driver::new(&np_language);
+        let mut driver = Driver::new(language, is_opcode_supported);
         driver.create_local_crate(root_file, CrateType::Binary);
         driver.compile_main(&CompileOptions::default())
     }
@@ -318,6 +321,6 @@ impl Driver {
 
 impl Default for Driver {
     fn default() -> Self {
-        Self::new(&Language::R1CS)
+        Self::new(&Language::R1CS, Box::new(|opcode| matches!(opcode, Opcode::Arithmetic(_))))
     }
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -258,6 +258,7 @@ impl Driver {
         let program = monomorphize(main_function, &self.context.def_interner);
 
         let np_language = self.language.clone();
+        // TODO: use proper `is_opcode_supported` implementation.
         let is_opcode_supported = acvm::default_is_opcode_supported(np_language.clone());
 
         let circuit_abi = if options.experimental_ssa {
@@ -320,6 +321,7 @@ impl Driver {
 
 impl Default for Driver {
     fn default() -> Self {
-        Self::new(&Language::R1CS, Box::new(|opcode| matches!(opcode, Opcode::Arithmetic(_))))
+        #[allow(deprecated)]
+        Self::new(&Language::R1CS, Box::new(acvm::default_is_opcode_supported(Language::R1CS)))
     }
 }

--- a/crates/noirc_driver/src/main.rs
+++ b/crates/noirc_driver/src/main.rs
@@ -1,3 +1,4 @@
+use acvm::acir::circuit::Opcode;
 use noirc_driver::{CompileOptions, Driver};
 use noirc_frontend::graph::{CrateType, LOCAL_CRATE};
 fn main() {
@@ -5,7 +6,10 @@ fn main() {
     const EXTERNAL_DIR2: &str = "dep_a/lib.nr";
     const ROOT_DIR_MAIN: &str = "example_real_project/main.nr";
 
-    let mut driver = Driver::new(&acvm::Language::R1CS);
+    let mut driver = Driver::new(
+        &acvm::Language::R1CS,
+        Box::new(|opcode| matches!(opcode, Opcode::Arithmetic(_))),
+    );
 
     // Add local crate to dep graph
     driver.create_local_crate(ROOT_DIR_MAIN, CrateType::Binary);

--- a/crates/noirc_driver/src/main.rs
+++ b/crates/noirc_driver/src/main.rs
@@ -1,4 +1,4 @@
-use acvm::acir::circuit::Opcode;
+use acvm::Language;
 use noirc_driver::{CompileOptions, Driver};
 use noirc_frontend::graph::{CrateType, LOCAL_CRATE};
 fn main() {
@@ -7,8 +7,9 @@ fn main() {
     const ROOT_DIR_MAIN: &str = "example_real_project/main.nr";
 
     let mut driver = Driver::new(
-        &acvm::Language::R1CS,
-        Box::new(|opcode| matches!(opcode, Opcode::Arithmetic(_))),
+        &Language::R1CS,
+        #[allow(deprecated)]
+        Box::new(acvm::default_is_opcode_supported(Language::R1CS)),
     );
 
     // Add local crate to dep graph

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -6,7 +6,7 @@ pub mod type_check;
 
 use crate::graph::{CrateGraph, CrateId};
 use crate::node_interner::NodeInterner;
-use acvm::Language;
+use acvm::acir::circuit::Opcode;
 use def_map::CrateDefMap;
 use fm::FileManager;
 use std::collections::HashMap;
@@ -29,7 +29,11 @@ pub struct Context {
 pub type StorageSlot = u32;
 
 impl Context {
-    pub fn new(file_manager: FileManager, crate_graph: CrateGraph, language: Language) -> Context {
+    pub fn new(
+        file_manager: FileManager,
+        crate_graph: CrateGraph,
+        is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
+    ) -> Context {
         let mut ctx = Context {
             def_interner: NodeInterner::default(),
             def_maps: HashMap::new(),
@@ -37,7 +41,7 @@ impl Context {
             file_manager,
             storage_slots: HashMap::new(),
         };
-        ctx.def_interner.set_language(&language);
+        ctx.def_interner.set_opcode_support(is_opcode_supported);
         ctx
     }
 

--- a/crates/noirc_frontend/src/main.rs
+++ b/crates/noirc_frontend/src/main.rs
@@ -27,7 +27,12 @@ fn main() {
     let crate_id = crate_graph.add_crate_root(CrateType::Library, root_file_id);
 
     // initiate context with file manager and crate graph
-    let mut context = Context::new(fm, crate_graph, acvm::Language::R1CS);
+    let mut context = Context::new(
+        fm,
+        crate_graph,
+        #[allow(deprecated)]
+        Box::new(acvm::default_is_opcode_supported(acvm::Language::R1CS)),
+    );
 
     // Now create the CrateDefMap
     // This is preamble for analysis

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -70,7 +70,6 @@ pub struct NodeInterner {
     next_type_variable_id: usize,
 
     //used for fallback mechanism
-    language: Language,
     is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
 
     delayed_type_checks: Vec<TypeCheckFn>,
@@ -259,7 +258,6 @@ impl Default for NodeInterner {
             field_indices: HashMap::new(),
             next_type_variable_id: 0,
             globals: HashMap::new(),
-            language: Language::R1CS,
             #[allow(deprecated)]
             is_opcode_supported: Box::new(acvm::default_is_opcode_supported(Language::R1CS)),
             delayed_type_checks: vec![],
@@ -580,10 +578,6 @@ impl NodeInterner {
 
     pub fn function_definition_id(&self, function: FuncId) -> DefinitionId {
         self.function_definition_ids[&function]
-    }
-
-    pub fn set_language(&mut self, language: &Language) {
-        self.language = language.clone();
     }
 
     pub fn set_opcode_support(&mut self, is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>) {

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -76,7 +76,11 @@ pub fn compile(args: JsValue) -> JsValue {
 
     // For now we default to plonk width = 3, though we can add it as a parameter
     let language = acvm::Language::PLONKCSat { width: 3 };
-    let mut driver = noirc_driver::Driver::new(&language);
+    let mut driver = noirc_driver::Driver::new(
+        &language,
+        #[allow(deprecated)]
+        Box::new(acvm::default_is_opcode_supported(language.clone())),
+    );
 
     let path = PathBuf::from(&options.entry_point);
     driver.create_local_crate(path, CrateType::Binary);


### PR DESCRIPTION
# Related issue(s)

Related to #1102 as it makes the backend dependency explicit.

# Description

## Summary of changes

This PR makes the Noir compiler frontend's dependency on a backend explicit as we now pass in a closure to describe which opcodes it supports to use when dealing with foreign functions.

For now this still uses the default support function but should be updated once https://github.com/noir-lang/acvm/pull/273 makes its way into this repository. Once this is done then we can remove those functions for the 0.13.0 release of ACVM.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context