### PR TITLE
chore: pull backend identifier from backend rather than relying on hardcoded values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084577e67b44c72d1cdfabe286d48adac6f5e0ad441ef134c5c467f4b6eee291"
+source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,8 +16,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a267ef529f4b132293199ecdf8c232ade817f01d916039f2d34562cab39e75e9"
+source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -31,8 +29,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1d6795105b50b13fa0dd1779b5191c4d8e9cd98b357b0b9a0b04a847baacf0"
+source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -42,7 +39,7 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-traits",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sha3",
  "thiserror",
 ]
@@ -50,12 +47,10 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf493c97da8c528c21353452aa10f7972f4870a3aab90919bcc08ba56a8cd8"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=98d0148c71ef59549bca7082b0180c6cc20fb7e6#98d0148c71ef59549bca7082b0180c6cc20fb7e6"
 dependencies = [
  "acvm",
  "barretenberg-sys",
- "blake2",
  "dirs 3.0.2",
  "futures-util",
  "getrandom",
@@ -71,8 +66,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3131af53d17ac12340c0ff50f8555d8e040321f8078b8ee3cd8846560b6a44a9"
+source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
 dependencies = [
  "acir",
 ]
@@ -374,13 +368,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -389,7 +381,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -401,12 +392,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
@@ -826,16 +811,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
@@ -965,6 +940,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1448,7 +1424,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.10.1",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -2844,14 +2820,12 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "digest 0.10.6",
  "keccak",
- "opaque-debug",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
+source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
 dependencies = [
- "acir_field 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acir_field 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "flate2",
  "rmp-serde",
  "serde",
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
+source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -53,10 +53,10 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
+source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
 dependencies = [
- "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
- "acvm_stdlib 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm_stdlib 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -108,9 +108,9 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
+source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
 dependencies = [
- "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
 ]
 
 [[package]]
@@ -1885,7 +1885,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "iter-extended",
  "noirc_abi",
  "noirc_driver",
@@ -1899,7 +1899,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
@@ -1930,7 +1930,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -1946,7 +1946,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "iter-extended",
  "serde",
  "serde_json",
@@ -1960,7 +1960,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "clap",
  "fm",
  "iter-extended",
@@ -1986,7 +1986,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -2002,7 +2002,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
+source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
+source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -30,7 +30,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
+source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -49,7 +49,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.1.2"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=5647a7f329865ec4c12e468f40d6cdb38fb921a2#5647a7f329865ec4c12e468f40d6cdb38fb921a2"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=04c9d0f6b5e0f3625fd7d1e2bb5bacb020ae279d#04c9d0f6b5e0f3625fd7d1e2bb5bacb020ae279d"
 dependencies = [
  "acvm",
  "barretenberg-sys",
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
+source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
 dependencies = [
  "acir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
+source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
+source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -30,7 +30,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
+source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -49,7 +49,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.1.2"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=04c9d0f6b5e0f3625fd7d1e2bb5bacb020ae279d#04c9d0f6b5e0f3625fd7d1e2bb5bacb020ae279d"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=968f1eecaedb52aa6f8da0fd2b3c48b3c32f2c4c#968f1eecaedb52aa6f8da0fd2b3c48b3c32f2c4c"
 dependencies = [
  "acvm",
  "barretenberg-sys",
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=eeddcf179880f246383f7f67a11e589269c4e3ff#eeddcf179880f246383f7f67a11e589269c4e3ff"
+source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
 dependencies = [
  "acir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
+source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
+source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -30,10 +30,11 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
+source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
 dependencies = [
  "acir",
  "acvm_stdlib",
+ "async-trait",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -48,26 +49,27 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.1.2"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=4f622b58144330ebc53d8458bd9e456a8efb147c#4f622b58144330ebc53d8458bd9e456a8efb147c"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=5647a7f329865ec4c12e468f40d6cdb38fb921a2#5647a7f329865ec4c12e468f40d6cdb38fb921a2"
 dependencies = [
  "acvm",
  "barretenberg-sys",
- "dirs 3.0.2",
+ "bincode",
+ "bytes",
  "futures-util",
  "getrandom",
  "indicatif",
  "pkg-config",
  "reqwest",
  "rust-embed",
+ "serde",
  "thiserror",
- "tokio",
  "wasmer",
 ]
 
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
+source = "git+https://github.com/noir-lang/acvm?rev=44604f872126602787e38794026d86345380f2bb#44604f872126602787e38794026d86345380f2bb"
 dependencies = [
  "acir",
 ]
@@ -195,7 +197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6873aaba7959593d89babed381d33e2329453368f1bf3c67e07686a1c1056f"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -208,7 +210,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -244,7 +246,7 @@ checksum = "fd34f0920d995d2c932f38861c416f70de89a6de9875876b012557079603e6cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -285,6 +287,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "tempfile",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -329,6 +342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +368,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
  "which",
 ]
 
@@ -442,7 +464,7 @@ checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -544,7 +566,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -844,7 +866,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -861,7 +883,7 @@ checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -884,7 +906,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -895,7 +917,7 @@ checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -915,7 +937,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -942,15 +964,6 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
-dependencies = [
- "dirs-sys",
 ]
 
 [[package]]
@@ -1046,7 +1059,7 @@ checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1067,7 +1080,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1213,7 +1226,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1748,7 +1761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1837,7 +1850,6 @@ name = "nargo"
 version = "0.5.1"
 dependencies = [
  "acvm",
- "iter-extended",
  "noirc_abi",
  "noirc_driver",
  "rustc_version",
@@ -1859,7 +1871,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "const_format",
- "dirs 4.0.0",
+ "dirs",
  "hex",
  "iter-extended",
  "nargo",
@@ -1873,6 +1885,7 @@ dependencies = [
  "tempdir",
  "termcolor",
  "thiserror",
+ "tokio",
  "toml",
  "url",
 ]
@@ -2184,7 +2197,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2234,7 +2247,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2509,7 +2522,7 @@ checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2555,7 +2568,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn",
+ "syn 1.0.109",
  "walkdir",
 ]
 
@@ -2760,7 +2773,7 @@ checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2844,7 +2857,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
 dependencies = [
- "dirs 4.0.0",
+ "dirs",
 ]
 
 [[package]]
@@ -2959,7 +2972,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2980,6 +2993,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,7 +3011,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -3052,7 +3076,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3193,7 +3217,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3366,7 +3390,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -3400,7 +3424,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3531,7 +3555,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3938,6 +3962,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,76 +5,35 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
+source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
 dependencies = [
- "acir_field 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acir_field",
  "flate2",
  "rmp-serde",
  "serde",
-]
-
-[[package]]
-name = "acir"
-version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
-dependencies = [
- "acir_field 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
- "flate2",
- "rmp-serde",
- "serde",
-]
-
-[[package]]
-name = "acir_field"
-version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "cfg-if 1.0.0",
- "hex",
- "num-bigint",
- "serde",
-]
-
-[[package]]
-name = "acir_field"
-version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "cfg-if 1.0.0",
- "hex",
- "num-bigint",
- "serde",
-]
-
-[[package]]
-name = "acvm"
-version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
-dependencies = [
- "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
- "acvm_stdlib 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
- "blake2",
- "crc32fast",
- "indexmap",
- "k256",
- "num-bigint",
- "num-traits",
- "sha2 0.10.6",
- "sha3",
  "thiserror",
 ]
 
 [[package]]
+name = "acir_field"
+version = "0.11.0"
+source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "cfg-if 1.0.0",
+ "hex",
+ "num-bigint",
+ "serde",
+]
+
+[[package]]
 name = "acvm"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
+source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
 dependencies = [
- "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
- "acvm_stdlib 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
+ "acir",
+ "acvm_stdlib",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -89,9 +48,9 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.1.2"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=a97dc35affc33db015a0f84f7e0e22dd143ac558#a97dc35affc33db015a0f84f7e0e22dd143ac558"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=4f622b58144330ebc53d8458bd9e456a8efb147c#4f622b58144330ebc53d8458bd9e456a8efb147c"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
+ "acvm",
  "barretenberg-sys",
  "dirs 3.0.2",
  "futures-util",
@@ -108,17 +67,9 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310#018d6865e03ddd09ed409b383f38971ec9ec3310"
+source = "git+https://github.com/noir-lang/acvm?rev=bbd9ab7ca5be3fb31f3e141fee2522704852f5de#bbd9ab7ca5be3fb31f3e141fee2522704852f5de"
 dependencies = [
- "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
-]
-
-[[package]]
-name = "acvm_stdlib"
-version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
-dependencies = [
- "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
+ "acir",
 ]
 
 [[package]]
@@ -1885,7 +1836,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm",
  "iter-extended",
  "noirc_abi",
  "noirc_driver",
@@ -1899,7 +1850,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm",
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
@@ -1930,7 +1881,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -1946,7 +1897,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm",
  "iter-extended",
  "serde",
  "serde_json",
@@ -1960,7 +1911,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm",
  "clap",
  "fm",
  "iter-extended",
@@ -1986,7 +1937,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -2002,7 +1953,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.5.1"
 dependencies = [
- "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=018d6865e03ddd09ed409b383f38971ec9ec3310)",
+ "acvm",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,11 +5,35 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
+source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
 dependencies = [
- "acir_field",
+ "acir_field 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "flate2",
  "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "acir"
+version = "0.11.0"
+source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
+dependencies = [
+ "acir_field 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
+ "flate2",
+ "rmp-serde",
+ "serde",
+]
+
+[[package]]
+name = "acir_field"
+version = "0.11.0"
+source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "cfg-if 1.0.0",
+ "hex",
+ "num-bigint",
  "serde",
 ]
 
@@ -29,10 +53,28 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.11.0"
+source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
+dependencies = [
+ "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "acvm_stdlib 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+ "blake2",
+ "crc32fast",
+ "indexmap",
+ "k256",
+ "num-bigint",
+ "num-traits",
+ "sha2 0.10.6",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "acvm"
+version = "0.11.0"
 source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
 dependencies = [
- "acir",
- "acvm_stdlib",
+ "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
+ "acvm_stdlib 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
  "blake2",
  "crc32fast",
  "indexmap",
@@ -49,7 +91,7 @@ name = "acvm-backend-barretenberg"
 version = "0.1.2"
 source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=98d0148c71ef59549bca7082b0180c6cc20fb7e6#98d0148c71ef59549bca7082b0180c6cc20fb7e6"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
  "barretenberg-sys",
  "dirs 3.0.2",
  "futures-util",
@@ -66,9 +108,17 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
+source = "git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876#045e18ae13f2228171ce9e37da6e3e9691da2876"
+dependencies = [
+ "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
+]
+
+[[package]]
+name = "acvm_stdlib"
+version = "0.11.0"
 source = "git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4#a83333b9e270dfcfd40a36271896840ec0201bc4"
 dependencies = [
- "acir",
+ "acir 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
 ]
 
 [[package]]
@@ -1835,7 +1885,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "iter-extended",
  "noirc_abi",
  "noirc_driver",
@@ -1849,7 +1899,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
@@ -1880,7 +1930,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "build-data",
  "console_error_panic_hook",
  "gloo-utils",
@@ -1896,7 +1946,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "iter-extended",
  "serde",
  "serde_json",
@@ -1910,7 +1960,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "clap",
  "fm",
  "iter-extended",
@@ -1936,7 +1986,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "arena",
  "iter-extended",
  "noirc_abi",
@@ -1952,7 +2002,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.5.1"
 dependencies = [
- "acvm",
+ "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=045e18ae13f2228171ce9e37da6e3e9691da2876)",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.1.2"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=98d0148c71ef59549bca7082b0180c6cc20fb7e6#98d0148c71ef59549bca7082b0180c6cc20fb7e6"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=a97dc35affc33db015a0f84f7e0e22dd143ac558#a97dc35affc33db015a0f84f7e0e22dd143ac558"
 dependencies = [
  "acvm 0.11.0 (git+https://github.com/noir-lang/acvm?rev=a83333b9e270dfcfd40a36271896840ec0201bc4)",
  "barretenberg-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
+source = "git+https://github.com/noir-lang/acvm?rev=1bfb108dd8fcd139a8f9f2832139a93b6378082a#1bfb108dd8fcd139a8f9f2832139a93b6378082a"
 dependencies = [
  "acir_field",
  "flate2",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
+source = "git+https://github.com/noir-lang/acvm?rev=1bfb108dd8fcd139a8f9f2832139a93b6378082a#1bfb108dd8fcd139a8f9f2832139a93b6378082a"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -30,7 +30,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
+source = "git+https://github.com/noir-lang/acvm?rev=1bfb108dd8fcd139a8f9f2832139a93b6378082a#1bfb108dd8fcd139a8f9f2832139a93b6378082a"
 dependencies = [
  "acir",
  "acvm_stdlib",
@@ -49,7 +49,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.1.2"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=968f1eecaedb52aa6f8da0fd2b3c48b3c32f2c4c#968f1eecaedb52aa6f8da0fd2b3c48b3c32f2c4c"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=5854b5b2dff1182e005bd9d5e3273f8a4a03c476#5854b5b2dff1182e005bd9d5e3273f8a4a03c476"
 dependencies = [
  "acvm",
  "barretenberg-sys",
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.11.0"
-source = "git+https://github.com/noir-lang/acvm?rev=650473a6a04df79c3d758c28984dba1d8e119518#650473a6a04df79c3d758c28984dba1d8e119518"
+source = "git+https://github.com/noir-lang/acvm?rev=1bfb108dd8fcd139a8f9f2832139a93b6378082a#1bfb108dd8fcd139a8f9f2832139a93b6378082a"
 dependencies = [
  "acir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,5 @@ wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
-acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "650473a6a04df79c3d758c28984dba1d8e119518" }
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "968f1eecaedb52aa6f8da0fd2b3c48b3c32f2c4c" }
+acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "1bfb108dd8fcd139a8f9f2832139a93b6378082a" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "5854b5b2dff1182e005bd9d5e3273f8a4a03c476" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ edition = "2021"
 rust-version = "1.66"
 
 [workspace.dependencies]
-acvm = "0.11.0"
+#acvm = "0.11.0"
+acvm = { git = "https://github.com/noir-lang/acvm", rev = "045e18ae13f2228171ce9e37da6e3e9691da2876" }
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,5 @@ wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
-acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "eeddcf179880f246383f7f67a11e589269c4e3ff" }
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "04c9d0f6b5e0f3625fd7d1e2bb5bacb020ae279d" }
+acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "650473a6a04df79c3d758c28984dba1d8e119518" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "968f1eecaedb52aa6f8da0fd2b3c48b3c32f2c4c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,5 @@ wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
-acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "bbd9ab7ca5be3fb31f3e141fee2522704852f5de" }
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "4f622b58144330ebc53d8458bd9e456a8efb147c" }
+acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "44604f872126602787e38794026d86345380f2bb" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "5647a7f329865ec4c12e468f40d6cdb38fb921a2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,5 @@ wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
-acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "44604f872126602787e38794026d86345380f2bb" }
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "5647a7f329865ec4c12e468f40d6cdb38fb921a2" }
+acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "eeddcf179880f246383f7f67a11e589269c4e3ff" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "04c9d0f6b5e0f3625fd7d1e2bb5bacb020ae279d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
 acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "a83333b9e270dfcfd40a36271896840ec0201bc4" }
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "98d0148c71ef59549bca7082b0180c6cc20fb7e6" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "a97dc35affc33db015a0f84f7e0e22dd143ac558" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,7 @@ toml = "0.7.2"
 url = "2.2.0"
 wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
+
+[patch.crates-io]
+acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "a83333b9e270dfcfd40a36271896840ec0201bc4" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "98d0148c71ef59549bca7082b0180c6cc20fb7e6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ edition = "2021"
 rust-version = "1.66"
 
 [workspace.dependencies]
-#acvm = "0.11.0"
-acvm = { git = "https://github.com/noir-lang/acvm", rev = "018d6865e03ddd09ed409b383f38971ec9ec3310" }
+acvm = "0.11.0"
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }
@@ -53,5 +52,5 @@ wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
-acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "a83333b9e270dfcfd40a36271896840ec0201bc4" }
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "a97dc35affc33db015a0f84f7e0e22dd143ac558" }
+acvm = { package = "acvm", git = "https://github.com/noir-lang/acvm", rev = "bbd9ab7ca5be3fb31f3e141fee2522704852f5de" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "4f622b58144330ebc53d8458bd9e456a8efb147c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 #acvm = "0.11.0"
-acvm = { git = "https://github.com/noir-lang/acvm", rev = "045e18ae13f2228171ce9e37da6e3e9691da2876" }
+acvm = { git = "https://github.com/noir-lang/acvm", rev = "018d6865e03ddd09ed409b383f38971ec9ec3310" }
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }

--- a/crates/nargo/Cargo.toml
+++ b/crates/nargo/Cargo.toml
@@ -14,7 +14,6 @@ rustc_version = "0.4.0"
 acvm.workspace = true
 noirc_abi.workspace = true
 noirc_driver.workspace = true
-iter-extended.workspace = true
 toml.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/nargo/src/ops/codegen_verifier.rs
+++ b/crates/nargo/src/ops/codegen_verifier.rs
@@ -2,7 +2,8 @@ use acvm::SmartContract;
 
 pub fn codegen_verifier<B: SmartContract>(
     backend: &B,
+    common_reference_string: &[u8],
     verification_key: &[u8],
 ) -> Result<String, B::Error> {
-    backend.eth_contract_from_vk(verification_key)
+    backend.eth_contract_from_vk(common_reference_string, verification_key)
 }

--- a/crates/nargo/src/ops/execute.rs
+++ b/crates/nargo/src/ops/execute.rs
@@ -1,5 +1,6 @@
+use acvm::pwg::{solve, PartialWitnessGeneratorStatus};
+use acvm::PartialWitnessGenerator;
 use acvm::{acir::circuit::Circuit, pwg::block::Blocks};
-use acvm::{PartialWitnessGenerator, PartialWitnessGeneratorStatus};
 use noirc_abi::WitnessMap;
 
 use crate::NargoError;
@@ -10,7 +11,7 @@ pub fn execute_circuit(
     mut initial_witness: WitnessMap,
 ) -> Result<WitnessMap, NargoError> {
     let mut blocks = Blocks::default();
-    let solver_status = backend.solve(&mut initial_witness, &mut blocks, circuit.opcodes)?;
+    let solver_status = solve(backend, &mut initial_witness, &mut blocks, circuit.opcodes)?;
     if matches!(solver_status, PartialWitnessGeneratorStatus::RequiresOracleData { .. }) {
         todo!("Add oracle support to nargo execute")
     }

--- a/crates/nargo/src/ops/execute.rs
+++ b/crates/nargo/src/ops/execute.rs
@@ -1,7 +1,6 @@
 use acvm::pwg::{solve, PartialWitnessGeneratorStatus};
 use acvm::PartialWitnessGenerator;
-use acvm::{acir::circuit::Circuit, pwg::block::Blocks};
-use noirc_abi::WitnessMap;
+use acvm::{acir::circuit::Circuit, acir::native_types::WitnessMap, pwg::block::Blocks};
 
 use crate::NargoError;
 

--- a/crates/nargo/src/ops/mod.rs
+++ b/crates/nargo/src/ops/mod.rs
@@ -1,6 +1,6 @@
 pub use self::codegen_verifier::codegen_verifier;
 pub use self::execute::execute_circuit;
-pub use self::preprocess::{preprocess_contract, preprocess_program};
+pub use self::preprocess::{preprocess_contract_function, preprocess_program};
 pub use self::prove::prove_execution;
 pub use self::verify::verify_proof;
 

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -3,9 +3,6 @@ use noirc_driver::{CompiledProgram, ContractFunction};
 
 use crate::artifacts::{contract::PreprocessedContractFunction, program::PreprocessedProgram};
 
-// TODO: pull this from backend.
-const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
-
 pub fn preprocess_program<B: ProofSystemCompiler>(
     backend: &B,
     common_reference_string: &[u8],
@@ -18,7 +15,7 @@ pub fn preprocess_program<B: ProofSystemCompiler>(
         backend.preprocess(common_reference_string, &optimized_bytecode)?;
 
     Ok(PreprocessedProgram {
-        backend: String::from(BACKEND_IDENTIFIER),
+        backend: backend.backend_identifier(),
         abi: compiled_program.abi,
         bytecode: optimized_bytecode,
         proving_key,

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -15,7 +15,7 @@ pub fn preprocess_program<B: ProofSystemCompiler>(
         backend.preprocess(common_reference_string, &optimized_bytecode)?;
 
     Ok(PreprocessedProgram {
-        backend: backend.backend_identifier(),
+        backend: backend.identifier(),
         abi: compiled_program.abi,
         bytecode: optimized_bytecode,
         proving_key,

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -1,23 +1,21 @@
 use acvm::ProofSystemCompiler;
-use iter_extended::try_vecmap;
-use noirc_driver::{CompiledContract, CompiledProgram};
+use noirc_driver::{CompiledProgram, ContractFunction};
 
-use crate::artifacts::{
-    contract::{PreprocessedContract, PreprocessedContractFunction},
-    program::PreprocessedProgram,
-};
+use crate::artifacts::{contract::PreprocessedContractFunction, program::PreprocessedProgram};
 
 // TODO: pull this from backend.
 const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
 
 pub fn preprocess_program<B: ProofSystemCompiler>(
     backend: &B,
+    common_reference_string: &[u8],
     compiled_program: CompiledProgram,
 ) -> Result<PreprocessedProgram, B::Error> {
     // TODO: currently `compiled_program`'s bytecode is already optimized for the backend.
     // In future we'll need to apply those optimizations here.
     let optimized_bytecode = compiled_program.circuit;
-    let (proving_key, verification_key) = backend.preprocess(&optimized_bytecode)?;
+    let (proving_key, verification_key) =
+        backend.preprocess(common_reference_string, &optimized_bytecode)?;
 
     Ok(PreprocessedProgram {
         backend: String::from(BACKEND_IDENTIFIER),
@@ -28,30 +26,24 @@ pub fn preprocess_program<B: ProofSystemCompiler>(
     })
 }
 
-pub fn preprocess_contract<B: ProofSystemCompiler>(
+pub fn preprocess_contract_function<B: ProofSystemCompiler>(
     backend: &B,
-    compiled_contract: CompiledContract,
-) -> Result<PreprocessedContract, B::Error> {
-    let preprocessed_contract_functions = try_vecmap(compiled_contract.functions, |func| {
-        // TODO: currently `func`'s bytecode is already optimized for the backend.
-        // In future we'll need to apply those optimizations here.
-        let optimized_bytecode = func.bytecode;
-        let (proving_key, verification_key) = backend.preprocess(&optimized_bytecode)?;
+    common_reference_string: &[u8],
+    func: ContractFunction,
+) -> Result<PreprocessedContractFunction, B::Error> {
+    // TODO: currently `func`'s bytecode is already optimized for the backend.
+    // In future we'll need to apply those optimizations here.
+    let optimized_bytecode = func.bytecode;
+    let (proving_key, verification_key) =
+        backend.preprocess(common_reference_string, &optimized_bytecode)?;
 
-        Ok(PreprocessedContractFunction {
-            name: func.name,
-            function_type: func.function_type,
-            abi: func.abi,
+    Ok(PreprocessedContractFunction {
+        name: func.name,
+        function_type: func.function_type,
+        abi: func.abi,
 
-            bytecode: optimized_bytecode,
-            proving_key,
-            verification_key,
-        })
-    })?;
-
-    Ok(PreprocessedContract {
-        name: compiled_contract.name,
-        backend: String::from(BACKEND_IDENTIFIER),
-        functions: preprocessed_contract_functions,
+        bytecode: optimized_bytecode,
+        proving_key,
+        verification_key,
     })
 }

--- a/crates/nargo/src/ops/prove.rs
+++ b/crates/nargo/src/ops/prove.rs
@@ -3,9 +3,10 @@ use acvm::ProofSystemCompiler;
 
 pub fn prove_execution<B: ProofSystemCompiler>(
     backend: &B,
+    common_reference_string: &[u8],
     circuit: &Circuit,
     solved_witness: WitnessMap,
     proving_key: &[u8],
 ) -> Result<Vec<u8>, B::Error> {
-    backend.prove_with_pk(circuit, solved_witness, proving_key)
+    backend.prove_with_pk(common_reference_string, circuit, solved_witness, proving_key)
 }

--- a/crates/nargo/src/ops/prove.rs
+++ b/crates/nargo/src/ops/prove.rs
@@ -1,6 +1,5 @@
-use acvm::acir::circuit::Circuit;
+use acvm::acir::{circuit::Circuit, native_types::WitnessMap};
 use acvm::ProofSystemCompiler;
-use noirc_abi::WitnessMap;
 
 pub fn prove_execution<B: ProofSystemCompiler>(
     backend: &B,

--- a/crates/nargo/src/ops/verify.rs
+++ b/crates/nargo/src/ops/verify.rs
@@ -3,10 +3,11 @@ use acvm::ProofSystemCompiler;
 
 pub fn verify_proof<B: ProofSystemCompiler>(
     backend: &B,
+    common_reference_string: &[u8],
     circuit: &Circuit,
     proof: &[u8],
     public_inputs: WitnessMap,
     verification_key: &[u8],
 ) -> Result<bool, B::Error> {
-    backend.verify_with_vk(proof, public_inputs, circuit, verification_key)
+    backend.verify_with_vk(common_reference_string, proof, public_inputs, circuit, verification_key)
 }

--- a/crates/nargo/src/ops/verify.rs
+++ b/crates/nargo/src/ops/verify.rs
@@ -1,6 +1,5 @@
-use acvm::acir::circuit::Circuit;
+use acvm::acir::{circuit::Circuit, native_types::WitnessMap};
 use acvm::ProofSystemCompiler;
-use noirc_abi::WitnessMap;
 
 pub fn verify_proof<B: ProofSystemCompiler>(
     backend: &B,

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -35,6 +35,7 @@ hex = "0.4.2"
 serde_json = "1.0"
 termcolor = "1.1.2"
 color-eyre = "0.6.2"
+tokio = "1.0"
 
 # Backends
 acvm-backend-barretenberg = { version = "0.1.2", default-features = false }

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -1,4 +1,7 @@
-use super::fs::{create_named_dir, program::read_program_from_file, write_to_file};
+use super::fs::{
+    common_reference_string::get_common_reference_string, create_named_dir,
+    program::read_program_from_file, write_to_file,
+};
 use super::NargoConfig;
 use crate::{
     cli::compile_cmd::compile_circuit, constants::CONTRACT_DIR, constants::TARGET_DIR,
@@ -29,18 +32,27 @@ pub(crate) fn run<B: Backend>(
         .circuit_name
         .map(|circuit_name| config.program_dir.join(TARGET_DIR).join(circuit_name));
 
-    let preprocessed_program = match circuit_build_path {
-        Some(circuit_build_path) => read_program_from_file(circuit_build_path)?,
+    let (common_reference_string, preprocessed_program) = match circuit_build_path {
+        Some(circuit_build_path) => {
+            let program = read_program_from_file(circuit_build_path)?;
+            let common_reference_string = get_common_reference_string(backend, &program.bytecode)
+                .map_err(CliError::CommonReferenceStringError)?;
+            (common_reference_string, program)
+        }
         None => {
-            let compiled_program =
+            let program =
                 compile_circuit(backend, config.program_dir.as_ref(), &args.compile_options)?;
-            preprocess_program(backend, compiled_program)
-                .map_err(CliError::ProofSystemCompilerError)?
+            let common_reference_string = get_common_reference_string(backend, &program.circuit)
+                .map_err(CliError::CommonReferenceStringError)?;
+            let program = preprocess_program(backend, &common_reference_string, program)
+                .map_err(CliError::ProofSystemCompilerError)?;
+            (common_reference_string, program)
         }
     };
 
-    let smart_contract_string = codegen_verifier(backend, &preprocessed_program.verification_key)
-        .map_err(CliError::SmartContractError)?;
+    let smart_contract_string =
+        codegen_verifier(backend, &common_reference_string, &preprocessed_program.verification_key)
+            .map_err(CliError::SmartContractError)?;
 
     let contract_dir = config.program_dir.join(CONTRACT_DIR);
     create_named_dir(&contract_dir, "contract");

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -17,9 +17,6 @@ use super::fs::{
 };
 use super::NargoConfig;
 
-// TODO: pull this from backend.
-const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
-
 /// Compile the program and its secret execution trace into ACIR format
 #[derive(Debug, Clone, Args)]
 pub(crate) struct CompileCommand {
@@ -63,7 +60,7 @@ pub(crate) fn run<B: Backend>(
 
                 Ok(PreprocessedContract {
                     name: contract.name,
-                    backend: String::from(BACKEND_IDENTIFIER),
+                    backend: backend.backend_identifier(),
                     functions: preprocessed_contract_functions,
                 })
             });

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -1,17 +1,24 @@
 use acvm::Backend;
 use iter_extended::try_vecmap;
+use nargo::artifacts::contract::PreprocessedContract;
 use noirc_driver::{CompileOptions, CompiledProgram, Driver};
 use std::path::Path;
 
 use clap::Args;
 
-use nargo::ops::{preprocess_contract, preprocess_program};
+use nargo::ops::{preprocess_contract_function, preprocess_program};
 
 use crate::resolver::DependencyResolutionError;
 use crate::{constants::TARGET_DIR, errors::CliError, resolver::Resolver};
 
-use super::fs::program::{save_contract_to_file, save_program_to_file};
+use super::fs::{
+    common_reference_string::get_common_reference_string,
+    program::{save_contract_to_file, save_program_to_file},
+};
 use super::NargoConfig;
+
+// TODO: pull this from backend.
+const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
 
 /// Compile the program and its secret execution trace into ACIR format
 #[derive(Debug, Clone, Args)]
@@ -40,10 +47,27 @@ pub(crate) fn run<B: Backend>(
         let compiled_contracts = driver
             .compile_contracts(&args.compile_options)
             .map_err(|_| CliError::CompilationError)?;
-        let preprocessed_contracts = try_vecmap(compiled_contracts, |contract| {
-            preprocess_contract(backend, contract).map_err(CliError::ProofSystemCompilerError)
-        })?;
-        for contract in preprocessed_contracts {
+        // TODO: I wonder if it is incorrect for nargo-core to know anything about contracts.
+        // As can be seen here, It seems like a leaky abstraction where ContractFunctions (essentially CompiledPrograms)
+        // are compiled via nargo-core and then the PreprocessedContract is constructed here.
+        // This is due to EACH function needing it's own CRS, PKey, and VKey from the backend.
+        let preprocessed_contracts: Result<Vec<PreprocessedContract>, CliError<B>> =
+            try_vecmap(compiled_contracts, |contract| {
+                let preprocessed_contract_functions = try_vecmap(contract.functions, |func| {
+                    let common_reference_string =
+                        get_common_reference_string(backend, &func.bytecode)
+                            .map_err(CliError::CommonReferenceStringError)?;
+                    preprocess_contract_function(backend, &common_reference_string, func)
+                        .map_err(CliError::ProofSystemCompilerError)
+                })?;
+
+                Ok(PreprocessedContract {
+                    name: contract.name,
+                    backend: String::from(BACKEND_IDENTIFIER),
+                    functions: preprocessed_contract_functions,
+                })
+            });
+        for contract in preprocessed_contracts? {
             save_contract_to_file(
                 &contract,
                 &format!("{}-{}", &args.circuit_name, contract.name),
@@ -52,8 +76,10 @@ pub(crate) fn run<B: Backend>(
         }
     } else {
         let program = compile_circuit(backend, &config.program_dir, &args.compile_options)?;
-        let preprocessed_program =
-            preprocess_program(backend, program).map_err(CliError::ProofSystemCompilerError)?;
+        let common_reference_string = get_common_reference_string(backend, &program.circuit)
+            .map_err(CliError::CommonReferenceStringError)?;
+        let preprocessed_program = preprocess_program(backend, &common_reference_string, program)
+            .map_err(CliError::ProofSystemCompilerError)?;
         save_program_to_file(&preprocessed_program, &args.circuit_name, circuit_dir);
     }
     Ok(())

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -60,7 +60,7 @@ pub(crate) fn run<B: Backend>(
 
                 Ok(PreprocessedContract {
                     name: contract.name,
-                    backend: backend.backend_identifier(),
+                    backend: backend.identifier(),
                     functions: preprocessed_contract_functions,
                 })
             });

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
-use acvm::acir::circuit::Circuit;
+use acvm::acir::{circuit::Circuit, native_types::WitnessMap};
 use acvm::Backend;
 use clap::Args;
 use noirc_abi::input_parser::{Format, InputValue};
-use noirc_abi::{Abi, InputMap, WitnessMap};
+use noirc_abi::{Abi, InputMap};
 use noirc_driver::{CompileOptions, CompiledProgram};
 
 use super::fs::{inputs::read_inputs_from_file, witness::save_witness_to_dir};

--- a/crates/nargo_cli/src/cli/fs/common_reference_string.rs
+++ b/crates/nargo_cli/src/cli/fs/common_reference_string.rs
@@ -1,12 +1,12 @@
 use std::{env, path::PathBuf};
 
-use acvm::{acir::circuit::Circuit, CommonReferenceString, ProofSystemCompiler};
+use acvm::{acir::circuit::Circuit, Backend, CommonReferenceString, ProofSystemCompiler};
 
 use super::{create_named_dir, write_to_file};
 
 const TRANSCRIPT_NAME: &str = "common-reference-string.bin";
 
-fn common_reference_string_location(backend: &ProofSystemCompiler) -> PathBuf {
+fn common_reference_string_location(backend: &impl ProofSystemCompiler) -> PathBuf {
     let cache_dir = match env::var("BACKEND_CACHE_DIR") {
         Ok(cache_dir) => PathBuf::from(cache_dir),
         Err(_) => dirs::home_dir().unwrap().join(".nargo").join("backends"),
@@ -14,10 +14,10 @@ fn common_reference_string_location(backend: &ProofSystemCompiler) -> PathBuf {
     cache_dir.join(backend.backend_identifier()).join(TRANSCRIPT_NAME)
 }
 
-pub(crate) fn get_common_reference_string<Backend: CommonReferenceString>(
-    backend: &Backend,
+pub(crate) fn get_common_reference_string<B: Backend>(
+    backend: &B,
     circuit: &Circuit,
-) -> Result<Vec<u8>, Backend::Error> {
+) -> Result<Vec<u8>, <B as CommonReferenceString>::Error> {
     use tokio::runtime::Builder;
 
     let crs_path = common_reference_string_location(backend);

--- a/crates/nargo_cli/src/cli/fs/common_reference_string.rs
+++ b/crates/nargo_cli/src/cli/fs/common_reference_string.rs
@@ -1,23 +1,23 @@
 use std::{env, path::PathBuf};
 
-use acvm::{acir::circuit::Circuit, Backend, CommonReferenceString, ProofSystemCompiler};
+use acvm::{acir::circuit::Circuit, BackendInfo, CommonReferenceString};
 
 use super::{create_named_dir, write_to_file};
 
 const TRANSCRIPT_NAME: &str = "common-reference-string.bin";
 
-fn common_reference_string_location(backend: &impl ProofSystemCompiler) -> PathBuf {
+fn common_reference_string_location(backend: &impl BackendInfo) -> PathBuf {
     let cache_dir = match env::var("BACKEND_CACHE_DIR") {
         Ok(cache_dir) => PathBuf::from(cache_dir),
         Err(_) => dirs::home_dir().unwrap().join(".nargo").join("backends"),
     };
-    cache_dir.join(backend.backend_identifier()).join(TRANSCRIPT_NAME)
+    cache_dir.join(backend.identifier()).join(TRANSCRIPT_NAME)
 }
 
-pub(crate) fn get_common_reference_string<B: Backend>(
+pub(crate) fn get_common_reference_string<B: CommonReferenceString>(
     backend: &B,
     circuit: &Circuit,
-) -> Result<Vec<u8>, <B as CommonReferenceString>::Error> {
+) -> Result<Vec<u8>, B::Error> {
     use tokio::runtime::Builder;
 
     let crs_path = common_reference_string_location(backend);

--- a/crates/nargo_cli/src/cli/fs/common_reference_string.rs
+++ b/crates/nargo_cli/src/cli/fs/common_reference_string.rs
@@ -1,0 +1,42 @@
+use std::{env, path::PathBuf};
+
+use acvm::{acir::circuit::Circuit, CommonReferenceString};
+
+use super::{create_named_dir, write_to_file};
+
+// TODO: pull this from backend.
+const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
+const TRANSCRIPT_NAME: &str = "common-reference-string.bin";
+
+fn common_reference_string_location() -> PathBuf {
+    let cache_dir = match env::var("BACKEND_CACHE_DIR") {
+        Ok(cache_dir) => PathBuf::from(cache_dir),
+        Err(_) => dirs::home_dir().unwrap().join(".nargo").join("backends"),
+    };
+    cache_dir.join(BACKEND_IDENTIFIER).join(TRANSCRIPT_NAME)
+}
+
+pub(crate) fn get_common_reference_string<Backend: CommonReferenceString>(
+    backend: &Backend,
+    circuit: &Circuit,
+) -> Result<Vec<u8>, Backend::Error> {
+    use tokio::runtime::Builder;
+
+    let crs_path = common_reference_string_location();
+
+    let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+
+    // TODO: Implement retries
+    let crs = match std::fs::read(&crs_path) {
+        // If the read data is empty, we don't have a CRS and need to generate one
+        Ok(common_reference_string) if !common_reference_string.is_empty() => runtime
+            .block_on(backend.update_common_reference_string(common_reference_string, circuit))?,
+        Ok(_) | Err(_) => runtime.block_on(backend.generate_common_reference_string(circuit))?,
+    };
+
+    create_named_dir(crs_path.parent().unwrap(), "crs");
+
+    write_to_file(crs.as_slice(), &crs_path);
+
+    Ok(crs)
+}

--- a/crates/nargo_cli/src/cli/fs/common_reference_string.rs
+++ b/crates/nargo_cli/src/cli/fs/common_reference_string.rs
@@ -1,19 +1,17 @@
 use std::{env, path::PathBuf};
 
-use acvm::{acir::circuit::Circuit, CommonReferenceString};
+use acvm::{acir::circuit::Circuit, CommonReferenceString, ProofSystemCompiler};
 
 use super::{create_named_dir, write_to_file};
 
-// TODO: pull this from backend.
-const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
 const TRANSCRIPT_NAME: &str = "common-reference-string.bin";
 
-fn common_reference_string_location() -> PathBuf {
+fn common_reference_string_location(backend: &ProofSystemCompiler) -> PathBuf {
     let cache_dir = match env::var("BACKEND_CACHE_DIR") {
         Ok(cache_dir) => PathBuf::from(cache_dir),
         Err(_) => dirs::home_dir().unwrap().join(".nargo").join("backends"),
     };
-    cache_dir.join(BACKEND_IDENTIFIER).join(TRANSCRIPT_NAME)
+    cache_dir.join(backend.backend_identifier()).join(TRANSCRIPT_NAME)
 }
 
 pub(crate) fn get_common_reference_string<Backend: CommonReferenceString>(
@@ -22,7 +20,7 @@ pub(crate) fn get_common_reference_string<Backend: CommonReferenceString>(
 ) -> Result<Vec<u8>, Backend::Error> {
     use tokio::runtime::Builder;
 
-    let crs_path = common_reference_string_location();
+    let crs_path = common_reference_string_location(backend);
 
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();
 

--- a/crates/nargo_cli/src/cli/fs/mod.rs
+++ b/crates/nargo_cli/src/cli/fs/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::errors::FilesystemError;
 
+pub(super) mod common_reference_string;
 pub(super) mod inputs;
 pub(super) mod program;
 pub(super) mod proof;

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use acvm::acir::native_types::Witness;
-use noirc_abi::WitnessMap;
+use acvm::acir::native_types::WitnessMap;
 
 use super::{create_named_dir, write_to_file};
 use crate::{constants::WITNESS_EXT, errors::FilesystemError};
@@ -14,7 +13,7 @@ pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     create_named_dir(witness_dir.as_ref(), "witness");
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
-    let buf = Witness::to_bytes(&witness);
+    let buf: Vec<u8> = witness.try_into()?;
 
     write_to_file(buf.as_slice(), &witness_path);
 

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -11,6 +11,7 @@ use super::NargoConfig;
 use super::{
     compile_cmd::compile_circuit,
     fs::{
+        common_reference_string::get_common_reference_string,
         inputs::{read_inputs_from_file, write_inputs_to_file},
         program::read_program_from_file,
         proof::save_proof_to_dir,
@@ -72,12 +73,20 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
     check_proof: bool,
     compile_options: &CompileOptions,
 ) -> Result<Option<PathBuf>, CliError<B>> {
-    let preprocessed_program = match circuit_build_path {
-        Some(circuit_build_path) => read_program_from_file(circuit_build_path)?,
+    let (common_reference_string, preprocessed_program) = match circuit_build_path {
+        Some(circuit_build_path) => {
+            let program = read_program_from_file(circuit_build_path)?;
+            let common_reference_string = get_common_reference_string(backend, &program.bytecode)
+                .map_err(CliError::CommonReferenceStringError)?;
+            (common_reference_string, program)
+        }
         None => {
-            let compiled_program = compile_circuit(backend, program_dir.as_ref(), compile_options)?;
-            preprocess_program(backend, compiled_program)
-                .map_err(CliError::ProofSystemCompilerError)?
+            let program = compile_circuit(backend, program_dir.as_ref(), compile_options)?;
+            let common_reference_string = get_common_reference_string(backend, &program.circuit)
+                .map_err(CliError::CommonReferenceStringError)?;
+            let program = preprocess_program(backend, &common_reference_string, program)
+                .map_err(CliError::ProofSystemCompilerError)?;
+            (common_reference_string, program)
         }
     };
 
@@ -102,14 +111,21 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
         Format::Toml,
     )?;
 
-    let proof = prove_execution(backend, &bytecode, solved_witness, &proving_key)
-        .map_err(CliError::ProofSystemCompilerError)?;
+    let proof =
+        prove_execution(backend, &common_reference_string, &bytecode, solved_witness, &proving_key)
+            .map_err(CliError::ProofSystemCompilerError)?;
 
     if check_proof {
         let public_inputs = public_abi.encode(&public_inputs, return_value)?;
-        let valid_proof =
-            verify_proof(backend, &bytecode, &proof, public_inputs, &verification_key)
-                .map_err(CliError::ProofSystemCompilerError)?;
+        let valid_proof = verify_proof(
+            backend,
+            &common_reference_string,
+            &bytecode,
+            &proof,
+            public_inputs,
+            &verification_key,
+        )
+        .map_err(CliError::ProofSystemCompilerError)?;
 
         if !valid_proof {
             return Err(CliError::InvalidProof("".into()));

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -1,6 +1,6 @@
-use std::{collections::BTreeMap, io::Write, path::Path};
+use std::{io::Write, path::Path};
 
-use acvm::Backend;
+use acvm::{acir::native_types::WitnessMap, Backend};
 use clap::Args;
 use nargo::ops::execute_circuit;
 use noirc_driver::{CompileOptions, Driver};
@@ -89,7 +89,7 @@ fn run_test<B: Backend>(
 
     // Run the backend to ensure the PWG evaluates functions like std::hash::pedersen,
     // otherwise constraints involving these expressions will not error.
-    match execute_circuit(backend, program.circuit, BTreeMap::new()) {
+    match execute_circuit(backend, program.circuit, WitnessMap::new()) {
         Ok(_) => Ok(()),
         Err(error) => {
             let writer = StandardStream::stderr(ColorChoice::Always);

--- a/crates/nargo_cli/src/cli/verify_cmd.rs
+++ b/crates/nargo_cli/src/cli/verify_cmd.rs
@@ -1,5 +1,8 @@
 use super::compile_cmd::compile_circuit;
-use super::fs::{inputs::read_inputs_from_file, load_hex_data, program::read_program_from_file};
+use super::fs::{
+    common_reference_string::get_common_reference_string, inputs::read_inputs_from_file,
+    load_hex_data, program::read_program_from_file,
+};
 use super::NargoConfig;
 use crate::{
     constants::{PROOFS_DIR, PROOF_EXT, TARGET_DIR, VERIFIER_INPUT_FILE},
@@ -9,7 +12,7 @@ use crate::{
 use acvm::Backend;
 use clap::Args;
 use nargo::artifacts::program::PreprocessedProgram;
-use nargo::ops::preprocess_program;
+use nargo::ops::{preprocess_program, verify_proof};
 use noirc_abi::input_parser::Format;
 use noirc_driver::CompileOptions;
 use std::path::{Path, PathBuf};
@@ -44,7 +47,7 @@ pub(crate) fn run<B: Backend>(
         &config.program_dir,
         proof_path,
         circuit_build_path.as_ref(),
-        args.compile_options,
+        &args.compile_options,
     )
 }
 
@@ -53,15 +56,22 @@ fn verify_with_path<B: Backend, P: AsRef<Path>>(
     program_dir: P,
     proof_path: PathBuf,
     circuit_build_path: Option<P>,
-    compile_options: CompileOptions,
+    compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
-    let preprocessed_program = match circuit_build_path {
-        Some(circuit_build_path) => read_program_from_file(circuit_build_path)?,
+    let (common_reference_string, preprocessed_program) = match circuit_build_path {
+        Some(circuit_build_path) => {
+            let program = read_program_from_file(circuit_build_path)?;
+            let common_reference_string = get_common_reference_string(backend, &program.bytecode)
+                .map_err(CliError::CommonReferenceStringError)?;
+            (common_reference_string, program)
+        }
         None => {
-            let compiled_program =
-                compile_circuit(backend, program_dir.as_ref(), &compile_options)?;
-            preprocess_program(backend, compiled_program)
-                .map_err(CliError::ProofSystemCompilerError)?
+            let program = compile_circuit(backend, program_dir.as_ref(), compile_options)?;
+            let common_reference_string = get_common_reference_string(backend, &program.circuit)
+                .map_err(CliError::CommonReferenceStringError)?;
+            let program = preprocess_program(backend, &common_reference_string, program)
+                .map_err(CliError::ProofSystemCompilerError)?;
+            (common_reference_string, program)
         }
     };
 
@@ -75,9 +85,15 @@ fn verify_with_path<B: Backend, P: AsRef<Path>>(
     let public_inputs = public_abi.encode(&public_inputs_map, return_value)?;
     let proof = load_hex_data(&proof_path)?;
 
-    let valid_proof =
-        nargo::ops::verify_proof(backend, &bytecode, &proof, public_inputs, &verification_key)
-            .map_err(CliError::ProofSystemCompilerError)?;
+    let valid_proof = verify_proof(
+        backend,
+        &common_reference_string,
+        &bytecode,
+        &proof,
+        public_inputs,
+        &verification_key,
+    )
+    .map_err(CliError::ProofSystemCompilerError)?;
 
     if valid_proof {
         Ok(())

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -1,4 +1,7 @@
-use acvm::{acir::native_types::WitnessMapError, Backend, ProofSystemCompiler, SmartContract};
+use acvm::{
+    acir::native_types::WitnessMapError, Backend, CommonReferenceString, ProofSystemCompiler,
+    SmartContract,
+};
 use hex::FromHexError;
 use nargo::NargoError;
 use noirc_abi::errors::{AbiError, InputParserError};
@@ -63,4 +66,8 @@ pub(crate) enum CliError<B: Backend> {
     /// Backend error caused by a function on the ProofSystemCompiler trait
     #[error(transparent)]
     ProofSystemCompilerError(<B as ProofSystemCompiler>::Error), // Unfortunately, Rust won't let us `impl From` over an Associated Type on a generic
+
+    /// Backend error caused by a function on the CommonReferenceString trait
+    #[error(transparent)]
+    CommonReferenceStringError(<B as CommonReferenceString>::Error), // Unfortunately, Rust won't let us `impl From` over an Associated Type on a generic
 }

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -1,4 +1,4 @@
-use acvm::{Backend, ProofSystemCompiler, SmartContract};
+use acvm::{acir::native_types::WitnessMapError, Backend, ProofSystemCompiler, SmartContract};
 use hex::FromHexError;
 use nargo::NargoError;
 use noirc_abi::errors::{AbiError, InputParserError};
@@ -21,6 +21,10 @@ pub(crate) enum FilesystemError {
     /// Input parsing error
     #[error(transparent)]
     InputParserError(#[from] InputParserError),
+
+    /// WitnessMap serialization error
+    #[error(transparent)]
+    WitnessMapSerialization(#[from] WitnessMapError),
 }
 
 #[derive(Debug, Error)]

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -5,7 +5,10 @@
 
 use std::{collections::BTreeMap, str};
 
-use acvm::{acir::native_types::Witness, FieldElement};
+use acvm::{
+    acir::native_types::{Witness, WitnessMap},
+    FieldElement,
+};
 use errors::AbiError;
 use input_parser::InputValue;
 use iter_extended::{try_btree_map, try_vecmap, vecmap};
@@ -21,9 +24,6 @@ mod serialization;
 
 /// A map from the fields in an TOML/JSON file which correspond to some ABI to their values
 pub type InputMap = BTreeMap<String, InputValue>;
-
-/// A map from the witnesses in a constraint system to the field element values
-pub type WitnessMap = BTreeMap<Witness, FieldElement>;
 
 /// A tuple of the arguments to a function along with its return value.
 pub type FunctionSignature = (Vec<AbiParameter>, Option<AbiType>);
@@ -254,7 +254,7 @@ impl Abi {
             .collect::<Result<_, _>>()?;
 
         // Write input field elements into witness indices specified in `self.param_witnesses`.
-        let mut witness_map: WitnessMap = encoded_input_map
+        let mut witness_map: BTreeMap<Witness, FieldElement> = encoded_input_map
             .iter()
             .flat_map(|(param_name, encoded_param_fields)| {
                 let param_witness_indices = &self.param_witnesses[param_name];
@@ -297,7 +297,7 @@ impl Abi {
             (_, None) => {}
         }
 
-        Ok(witness_map)
+        Ok(witness_map.into())
     }
 
     fn encode_value(value: InputValue) -> Result<Vec<FieldElement>, AbiError> {

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -5,7 +5,6 @@
 
 use acvm::Language;
 use clap::Args;
-use contract::ContractFunction;
 use fm::FileType;
 use iter_extended::try_vecmap;
 use noirc_abi::FunctionSignature;
@@ -22,7 +21,7 @@ use std::path::{Path, PathBuf};
 mod contract;
 mod program;
 
-pub use contract::{CompiledContract, ContractFunctionType};
+pub use contract::{CompiledContract, ContractFunction, ContractFunctionType};
 pub use program::CompiledProgram;
 
 pub struct Driver {

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -13,7 +13,7 @@ pub mod ssa_refactor;
 use acvm::{
     acir::circuit::{opcodes::Opcode as AcirOpcode, Circuit, PublicInputs},
     acir::native_types::{Expression, Witness},
-    compiler::transformers::IsOpcodeSupported,
+    compiler::{optimizers::simplify::CircuitSimplifier, transformers::IsOpcodeSupported},
     Language,
 };
 use errors::{RuntimeError, RuntimeErrorKind};
@@ -83,6 +83,7 @@ pub fn create_circuit(
         opcodes,
         ..
     } = evaluator;
+    let simplifier = CircuitSimplifier::new(current_witness_index);
     let optimized_circuit = acvm::compiler::compile(
         Circuit {
             current_witness_index,
@@ -92,6 +93,7 @@ pub fn create_circuit(
         },
         np_language,
         is_opcode_supported,
+        &simplifier,
     )
     .map_err(|_| RuntimeErrorKind::Spanless(String::from("produced an acvm compile error")))?;
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -6,7 +6,7 @@ use crate::{
 use acvm::{
     acir::{
         circuit::{
-            directives::Directive,
+            directives::{Directive, QuotientDirective},
             opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode},
         },
         native_types::{Expression, Witness},
@@ -265,13 +265,13 @@ pub(crate) fn range_constraint(
         let b_witness = evaluator.add_witness_to_cs();
         let exp_big = BigUint::from(2_u128).pow(num_bits - 1);
         let exp = FieldElement::from_be_bytes_reduce(&exp_big.to_bytes_be());
-        evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient {
+        evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient(QuotientDirective {
             a: Expression::from(witness),
             b: Expression::from_field(exp),
             q: b_witness,
             r: r_witness,
             predicate: None,
-        }));
+        })));
 
         try_range_constraint(r_witness, num_bits - 1, evaluator);
         try_range_constraint(b_witness, 1, evaluator);
@@ -283,10 +283,8 @@ pub(crate) fn range_constraint(
         let my_constraint = add(&res, -FieldElement::one(), &witness.into());
         evaluator.push_opcode(AcirOpcode::Arithmetic(my_constraint));
     } else {
-        let gate = AcirOpcode::BlackBoxFuncCall(BlackBoxFuncCall {
-            name: acvm::acir::BlackBoxFunc::RANGE,
-            inputs: vec![FunctionInput { witness, num_bits }],
-            outputs: vec![],
+        let gate = AcirOpcode::BlackBoxFuncCall(BlackBoxFuncCall::RANGE {
+            input: FunctionInput { witness, num_bits },
         });
         evaluator.push_opcode(gate);
     }
@@ -311,13 +309,13 @@ pub(crate) fn bound_check(
     //2^s+a-b=q*2^s +r
     let expr = add(&r_witness.into(), two_s, &q_witness.into());
     evaluator.push_opcode(AcirOpcode::Arithmetic(subtract(&sub, FieldElement::one(), &expr)));
-    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient {
+    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient(QuotientDirective {
         a: sub,
         b: Expression::from_field(two_s),
         q: q_witness,
         r: r_witness,
         predicate: None,
-    }));
+    })));
     try_range_constraint(r_witness, max_bits, evaluator);
     evaluator.push_opcode(AcirOpcode::Arithmetic(boolean(q_witness)));
     q_witness
@@ -522,13 +520,13 @@ pub(crate) fn evaluate_truncate(
     //1. Generate witnesses a,b,c
     let b_witness = evaluator.add_witness_to_cs();
     let c_witness = evaluator.add_witness_to_cs();
-    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient {
+    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient(QuotientDirective {
         a: lhs.clone(),
         b: Expression::from_field(exp),
         q: c_witness,
         r: b_witness,
         predicate: None,
-    }));
+    })));
 
     try_range_constraint(b_witness, rhs, evaluator); //TODO propagate the error using ?
     try_range_constraint(c_witness, max_bits - rhs, evaluator);
@@ -608,13 +606,13 @@ pub(crate) fn evaluate_udiv(
     let q_witness = evaluator.add_witness_to_cs();
     let r_witness = evaluator.add_witness_to_cs();
     let pa = mul_with_witness(evaluator, lhs, predicate);
-    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient {
+    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient(QuotientDirective {
         a: lhs.clone(),
         b: rhs.clone(),
         q: q_witness,
         r: r_witness,
         predicate: Some(predicate.clone()),
-    }));
+    })));
 
     //r<b
     let r_expr = Expression::from(r_witness);

--- a/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/constraints.rs
@@ -565,13 +565,13 @@ pub(crate) fn evaluate_constant_modulo(
     //1. Generate witnesses b,c
     let b_witness = evaluator.add_witness_to_cs();
     let c_witness = evaluator.add_witness_to_cs();
-    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient {
+    evaluator.push_opcode(AcirOpcode::Directive(Directive::Quotient(QuotientDirective {
         a: lhs.clone(),
         b: modulus_exp.clone(),
         q: c_witness,
         r: b_witness,
         predicate: None,
-    }));
+    })));
     bound_constraint_with_offset(
         &Expression::from(b_witness),
         &modulus_exp,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/bitwise.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/bitwise.rs
@@ -121,9 +121,17 @@ pub(super) fn evaluate_bitwise(
     let bit_size = if bit_size % 2 == 1 { bit_size + 1 } else { bit_size };
     assert!(bit_size < FieldElement::max_num_bits() - 1);
     let max = FieldElement::from((1_u128 << bit_size) - 1);
-    let bit_gate = match opcode {
-        BinaryOp::And => acvm::acir::BlackBoxFunc::AND,
-        BinaryOp::Xor => acvm::acir::BlackBoxFunc::XOR,
+    let gate = match opcode {
+        BinaryOp::And => AcirOpcode::BlackBoxFuncCall(BlackBoxFuncCall::AND {
+            lhs: FunctionInput { witness: a_witness, num_bits: bit_size },
+            rhs: FunctionInput { witness: b_witness, num_bits: bit_size },
+            output: result,
+        }),
+        BinaryOp::Xor => AcirOpcode::BlackBoxFuncCall(BlackBoxFuncCall::XOR {
+            lhs: FunctionInput { witness: a_witness, num_bits: bit_size },
+            rhs: FunctionInput { witness: b_witness, num_bits: bit_size },
+            output: result,
+        }),
         BinaryOp::Or => {
             a_witness = evaluator.create_intermediate_variable(constraints::subtract(
                 &Expression::from_field(max),
@@ -136,19 +144,15 @@ pub(super) fn evaluate_bitwise(
                 &Expression::from(b_witness),
             ));
             // We do not have an OR gate yet, so we use the AND gate
-            acvm::acir::BlackBoxFunc::AND
+            AcirOpcode::BlackBoxFuncCall(BlackBoxFuncCall::AND {
+                lhs: FunctionInput { witness: a_witness, num_bits: bit_size },
+                rhs: FunctionInput { witness: b_witness, num_bits: bit_size },
+                output: result,
+            })
         }
         _ => unreachable!("ICE: expected a bitwise operation"),
     };
 
-    let gate = AcirOpcode::BlackBoxFuncCall(BlackBoxFuncCall {
-        name: bit_gate,
-        inputs: vec![
-            FunctionInput { witness: a_witness, num_bits: bit_size },
-            FunctionInput { witness: b_witness, num_bits: bit_size },
-        ],
-        outputs: vec![result],
-    });
     evaluator.opcodes.push(gate);
 
     if opcode == BinaryOp::Or {

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -7,7 +7,7 @@ use crate::{
         },
         builtin,
         context::SsaContext,
-        mem::{ArrayId, Memory},
+        mem::Memory,
         node::{self, Instruction, Node, NodeId, ObjectType},
     },
     Evaluator,
@@ -19,6 +19,7 @@ use acvm::{
             opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode},
         },
         native_types::{Expression, Witness},
+        BlackBoxFunc,
     },
     FieldElement,
 };
@@ -79,15 +80,70 @@ pub(crate) fn evaluate(
             }
         }
         Opcode::LowLevel(op) => {
-            let inputs = prepare_inputs(acir_gen, args, ctx, evaluator);
-            let output_count = op.definition().output_size.0 as u32;
-            outputs =
-                prepare_outputs(&mut acir_gen.memory, instruction_id, output_count, ctx, evaluator);
-
-            let func_call = BlackBoxFuncCall {
-                name: op,
-                inputs,                   //witness + bit size
-                outputs: outputs.clone(), //witness
+            outputs = match op {
+                BlackBoxFunc::SHA256 | BlackBoxFunc::Blake2s => {
+                    prepare_outputs(&mut acir_gen.memory, instruction_id, 32, ctx, evaluator)
+                }
+                BlackBoxFunc::Keccak256 => {
+                    prepare_outputs(&mut acir_gen.memory, instruction_id, 32, ctx, evaluator)
+                }
+                BlackBoxFunc::Pedersen | BlackBoxFunc::FixedBaseScalarMul => {
+                    prepare_outputs(&mut acir_gen.memory, instruction_id, 2, ctx, evaluator)
+                }
+                BlackBoxFunc::SchnorrVerify
+                | BlackBoxFunc::EcdsaSecp256k1
+                | BlackBoxFunc::ComputeMerkleRoot
+                | BlackBoxFunc::HashToField128Security => {
+                    prepare_outputs(&mut acir_gen.memory, instruction_id, 1, ctx, evaluator)
+                }
+                _ => panic!("Unsupported low level function {:?}", op),
+            };
+            let func_call = match op {
+                BlackBoxFunc::SHA256 => BlackBoxFuncCall::SHA256 {
+                    inputs: resolve_array(&args[0], acir_gen, ctx, evaluator),
+                    outputs: outputs.to_vec(),
+                },
+                BlackBoxFunc::Blake2s => BlackBoxFuncCall::Blake2s {
+                    inputs: resolve_array(&args[0], acir_gen, ctx, evaluator),
+                    outputs: outputs.to_vec(),
+                },
+                BlackBoxFunc::Keccak256 => BlackBoxFuncCall::Keccak256 {
+                    inputs: resolve_array(&args[0], acir_gen, ctx, evaluator),
+                    outputs: outputs.to_vec(),
+                },
+                BlackBoxFunc::Pedersen => BlackBoxFuncCall::Pedersen {
+                    inputs: resolve_array(&args[0], acir_gen, ctx, evaluator),
+                    outputs: outputs.to_vec(),
+                },
+                BlackBoxFunc::FixedBaseScalarMul => BlackBoxFuncCall::FixedBaseScalarMul {
+                    input: resolve_variable(&args[0], acir_gen, ctx, evaluator).unwrap(),
+                    outputs: outputs.to_vec(),
+                },
+                BlackBoxFunc::SchnorrVerify => BlackBoxFuncCall::SchnorrVerify {
+                    public_key_x: resolve_variable(&args[0], acir_gen, ctx, evaluator).unwrap(),
+                    public_key_y: resolve_variable(&args[1], acir_gen, ctx, evaluator).unwrap(),
+                    signature: resolve_array(&args[2], acir_gen, ctx, evaluator),
+                    message: resolve_array(&args[3], acir_gen, ctx, evaluator),
+                    output: outputs[0],
+                },
+                BlackBoxFunc::EcdsaSecp256k1 => BlackBoxFuncCall::EcdsaSecp256k1 {
+                    public_key_x: resolve_array(&args[0], acir_gen, ctx, evaluator),
+                    public_key_y: resolve_array(&args[1], acir_gen, ctx, evaluator),
+                    signature: resolve_array(&args[2], acir_gen, ctx, evaluator),
+                    hashed_message: resolve_array(&args[3], acir_gen, ctx, evaluator),
+                    output: outputs[0],
+                },
+                BlackBoxFunc::ComputeMerkleRoot => BlackBoxFuncCall::ComputeMerkleRoot {
+                    leaf: resolve_variable(&args[0], acir_gen, ctx, evaluator).unwrap(),
+                    index: resolve_variable(&args[1], acir_gen, ctx, evaluator).unwrap(),
+                    hash_path: resolve_array(&args[2], acir_gen, ctx, evaluator),
+                    output: outputs[0],
+                },
+                BlackBoxFunc::HashToField128Security => BlackBoxFuncCall::HashToField128Security {
+                    inputs: resolve_array(&args[0], acir_gen, ctx, evaluator),
+                    output: outputs[0],
+                },
+                _ => panic!("Unsupported low level function {:?}", op),
             };
             evaluator.opcodes.push(AcirOpcode::BlackBoxFuncCall(func_call));
         }
@@ -139,27 +195,12 @@ pub(crate) fn evaluate(
     (outputs.len() == 1).then(|| InternalVar::from(outputs[0]))
 }
 
-// Transform the arguments of intrinsic functions into witnesses
-fn prepare_inputs(
-    acir_gen: &mut Acir,
-    arguments: &[NodeId],
-    cfg: &SsaContext,
-    evaluator: &mut Evaluator,
-) -> Vec<FunctionInput> {
-    let mut inputs: Vec<FunctionInput> = Vec::new();
-
-    for argument in arguments {
-        inputs.extend(resolve_node_id(argument, acir_gen, cfg, evaluator));
-    }
-    inputs
-}
-
-fn resolve_node_id(
+fn resolve_variable(
     node_id: &NodeId,
     acir_gen: &mut Acir,
     cfg: &SsaContext,
     evaluator: &mut Evaluator,
-) -> Vec<FunctionInput> {
+) -> Option<FunctionInput> {
     let node_object = cfg.try_get_node(*node_id).expect("could not find node for {node_id}");
     match node_object {
         node::NodeObject::Variable(v) => {
@@ -167,14 +208,12 @@ fn resolve_node_id(
             match node_obj_type {
                 // If the `Variable` represents a Pointer
                 // Then we know that it is an `Array`
-                node::ObjectType::ArrayPointer(a) => resolve_array(a, acir_gen, cfg, evaluator),
+                node::ObjectType::ArrayPointer(_) => None,
                 // If it is not a pointer, we attempt to fetch the witness associated with it
-                _ => match v.witness {
-                    Some(w) => {
-                        vec![FunctionInput { witness: w, num_bits: v.size_in_bits() }]
-                    }
-                    None => todo!("generate a witness"),
-                },
+                _ => {
+                    let witness = v.witness?;
+                    Some(FunctionInput { witness, num_bits: v.size_in_bits() })
+                }
             }
         }
         _ => {
@@ -182,21 +221,30 @@ fn resolve_node_id(
             // we attempt to fetch an associated `InternalVar`.
             // Otherwise, this is a internal compiler error.
             let internal_var = acir_gen.var_cache.get(node_id).expect("invalid input").clone();
-            let witness = acir_gen
-                .var_cache
-                .get_or_compute_witness(internal_var, evaluator)
-                .expect("unexpected constant expression");
-            vec![FunctionInput { witness, num_bits: node_object.size_in_bits() }]
+            let witness = acir_gen.var_cache.get_or_compute_witness(internal_var, evaluator)?;
+            Some(FunctionInput { witness, num_bits: node_object.size_in_bits() })
         }
     }
 }
 
 fn resolve_array(
-    array_id: ArrayId,
+    node_id: &NodeId,
     acir_gen: &mut Acir,
     cfg: &SsaContext,
     evaluator: &mut Evaluator,
 ) -> Vec<FunctionInput> {
+    let node_object = cfg.try_get_node(*node_id).expect("could not find node for {node_id}");
+    let array_id = match node_object {
+        node::NodeObject::Variable(_) => {
+            let node_obj_type = node_object.get_type();
+            match node_obj_type {
+                node::ObjectType::ArrayPointer(a) => a,
+                _ => unreachable!(),
+            }
+        }
+        _ => todo!("generate a witness"),
+    };
+
     let mut inputs = Vec::new();
 
     let array = &cfg.mem[array_id];

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/intrinsics.rs
@@ -204,17 +204,7 @@ fn resolve_variable(
     let node_object = cfg.try_get_node(*node_id).expect("could not find node for {node_id}");
     match node_object {
         node::NodeObject::Variable(v) => {
-            let node_obj_type = node_object.get_type();
-            match node_obj_type {
-                // If the `Variable` represents a Pointer
-                // Then we know that it is an `Array`
-                node::ObjectType::ArrayPointer(_) => None,
-                // If it is not a pointer, we attempt to fetch the witness associated with it
-                _ => {
-                    let witness = v.witness?;
-                    Some(FunctionInput { witness, num_bits: v.size_in_bits() })
-                }
-            }
+            Some(FunctionInput { witness: v.witness?, num_bits: v.size_in_bits() })
         }
         _ => {
             // Upon the case that the `NodeObject` is not a `Variable`,
@@ -244,7 +234,6 @@ fn resolve_array(
         }
         _ => todo!("generate a witness"),
     };
-
     let mut inputs = Vec::new();
 
     let array = &cfg.mem[array_id];

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -113,10 +113,8 @@ fn permutation_layer(
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
-
     use acvm::{
-        acir::{circuit::opcodes::FunctionInput, native_types::Witness},
+        acir::{circuit::opcodes::FunctionInput, native_types::Witness, native_types::WitnessMap},
         pwg::{block::Blocks, solve, OpcodeResolution, PartialWitnessGeneratorStatus},
         FieldElement, OpcodeResolutionError, PartialWitnessGenerator,
     };
@@ -131,7 +129,7 @@ mod test {
     impl PartialWitnessGenerator for MockBackend {
         fn aes(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
@@ -139,7 +137,7 @@ mod test {
         }
         fn and(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _lhs: &FunctionInput,
             _rhs: &FunctionInput,
             _output: &Witness,
@@ -148,7 +146,7 @@ mod test {
         }
         fn xor(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _lhs: &FunctionInput,
             _rhs: &FunctionInput,
             _output: &Witness,
@@ -157,14 +155,14 @@ mod test {
         }
         fn range(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _input: &FunctionInput,
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             panic!("Path not trodden by this test")
         }
         fn sha256(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
@@ -172,7 +170,7 @@ mod test {
         }
         fn blake2s(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
@@ -180,7 +178,7 @@ mod test {
         }
         fn compute_merkle_root(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _leaf: &FunctionInput,
             _index: &FunctionInput,
             _hash_path: &[FunctionInput],
@@ -190,7 +188,7 @@ mod test {
         }
         fn schnorr_verify(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _public_key_x: &FunctionInput,
             _public_key_y: &FunctionInput,
             _signature: &[FunctionInput],
@@ -201,7 +199,7 @@ mod test {
         }
         fn pedersen(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
@@ -209,7 +207,7 @@ mod test {
         }
         fn hash_to_field_128_security(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _inputs: &[FunctionInput],
             _output: &Witness,
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
@@ -217,7 +215,7 @@ mod test {
         }
         fn ecdsa_secp256k1(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _public_key_x: &[FunctionInput],
             _public_key_y: &[FunctionInput],
             _signature: &[FunctionInput],
@@ -228,7 +226,7 @@ mod test {
         }
         fn fixed_base_scalar_mul(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _input: &FunctionInput,
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
@@ -236,7 +234,7 @@ mod test {
         }
         fn keccak256(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _initial_witness: &mut WitnessMap,
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
@@ -255,7 +253,7 @@ mod test {
             let mut input = Vec::new();
             let mut a_val = Vec::new();
             let mut b_wit = Vec::new();
-            let mut solved_witness: BTreeMap<Witness, FieldElement> = BTreeMap::new();
+            let mut solved_witness = WitnessMap::new();
             for i in 0..n {
                 let w = eval.add_witness_to_cs();
                 input.push(w.into());

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -111,88 +111,193 @@ fn permutation_layer(
     (conf, out_expr)
 }
 
-// #[cfg(test)]
-// mod test {
-//     use std::collections::BTreeMap;
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
 
-//     use acvm::{
-//         acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness},
-//         pwg::block::Blocks,
-//         FieldElement, OpcodeResolution, OpcodeResolutionError, PartialWitnessGenerator,
-//         PartialWitnessGeneratorStatus,
-//     };
+    use acvm::{
+        acir::{circuit::opcodes::FunctionInput, native_types::Witness},
+        pwg::{block::Blocks, solve, OpcodeResolution, PartialWitnessGeneratorStatus},
+        FieldElement, OpcodeResolutionError, PartialWitnessGenerator,
+    };
 
-//     use crate::{
-//         ssa::acir_gen::operations::sort::{evaluate_permutation, permutation_layer},
-//         Evaluator,
-//     };
-//     use rand::prelude::*;
+    use crate::{
+        ssa::acir_gen::operations::sort::{evaluate_permutation, permutation_layer},
+        Evaluator,
+    };
+    use rand::prelude::*;
 
-//     struct MockBackend {}
-//     impl PartialWitnessGenerator for MockBackend {
-//         fn solve_black_box_function_call(
-//             &self,
-//             _initial_witness: &mut BTreeMap<Witness, FieldElement>,
-//             _func_call: &BlackBoxFuncCall,
-//         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-//             unreachable!();
-//         }
-//     }
+    struct MockBackend {}
+    impl PartialWitnessGenerator for MockBackend {
+        fn aes(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn and(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _lhs: &FunctionInput,
+            _rhs: &FunctionInput,
+            _output: &Witness,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn xor(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _lhs: &FunctionInput,
+            _rhs: &FunctionInput,
+            _output: &Witness,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn range(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _input: &FunctionInput,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn sha256(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn blake2s(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn compute_merkle_root(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _leaf: &FunctionInput,
+            _index: &FunctionInput,
+            _hash_path: &[FunctionInput],
+            _output: &Witness,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn schnorr_verify(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _public_key_x: &FunctionInput,
+            _public_key_y: &FunctionInput,
+            _signature: &[FunctionInput],
+            _message: &[FunctionInput],
+            _output: &Witness,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn pedersen(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn hash_to_field_128_security(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _output: &Witness,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn ecdsa_secp256k1(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _public_key_x: &[FunctionInput],
+            _public_key_y: &[FunctionInput],
+            _signature: &[FunctionInput],
+            _message: &[FunctionInput],
+            _output: &Witness,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn fixed_base_scalar_mul(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _input: &FunctionInput,
+            _outputs: &[Witness],
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+        fn keccak256(
+            &self,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            panic!("Path not trodden by this test")
+        }
+    }
 
-//     // Check that a random network constrains its output to be a permutation of any random input
-//     #[test]
-//     fn test_permutation() {
-//         let mut rng = rand::thread_rng();
-//         for n in 2..50 {
-//             let mut eval = Evaluator::default();
+    // Check that a random network constrains its output to be a permutation of any random input
+    #[test]
+    fn test_permutation() {
+        let mut rng = rand::thread_rng();
+        for n in 2..50 {
+            let mut eval = Evaluator::default();
 
-//             //we generate random inputs
-//             let mut input = Vec::new();
-//             let mut a_val = Vec::new();
-//             let mut b_wit = Vec::new();
-//             let mut solved_witness: BTreeMap<Witness, FieldElement> = BTreeMap::new();
-//             for i in 0..n {
-//                 let w = eval.add_witness_to_cs();
-//                 input.push(w.into());
-//                 a_val.push(FieldElement::from(rng.next_u32() as i128));
-//                 solved_witness.insert(w, a_val[i]);
-//             }
+            //we generate random inputs
+            let mut input = Vec::new();
+            let mut a_val = Vec::new();
+            let mut b_wit = Vec::new();
+            let mut solved_witness: BTreeMap<Witness, FieldElement> = BTreeMap::new();
+            for i in 0..n {
+                let w = eval.add_witness_to_cs();
+                input.push(w.into());
+                a_val.push(FieldElement::from(rng.next_u32() as i128));
+                solved_witness.insert(w, a_val[i]);
+            }
 
-//             let mut output = Vec::new();
-//             for _i in 0..n {
-//                 let w = eval.add_witness_to_cs();
-//                 b_wit.push(w);
-//                 output.push(w.into());
-//             }
-//             //generate constraints for the inputs
-//             let w = evaluate_permutation(&input, &output, &mut eval);
-//             //checks that it generate the same witness
-//             let (w1, _) = permutation_layer(&input, &w, false, &mut eval);
-//             assert_eq!(w, w1);
-//             //we generate random network
-//             let mut c = Vec::new();
-//             for _i in 0..w.len() {
-//                 c.push(rng.next_u32() % 2 != 0);
-//             }
-//             // initialize bits
-//             for i in 0..w.len() {
-//                 solved_witness.insert(w[i], FieldElement::from(c[i] as i128));
-//             }
-//             // compute the network output by solving the constraints
-//             let backend = MockBackend {};
-//             let mut blocks = Blocks::default();
-//             let solver_status = backend
-//                 .solve(&mut solved_witness, &mut blocks, eval.opcodes.clone())
-//                 .expect("Could not solve permutation constraints");
-//             assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "Incomplete solution");
-//             let mut b_val = Vec::new();
-//             for i in 0..output.len() {
-//                 b_val.push(solved_witness[&b_wit[i]]);
-//             }
-//             // ensure the outputs are a permutation of the inputs
-//             a_val.sort();
-//             b_val.sort();
-//             assert_eq!(a_val, b_val);
-//         }
-//     }
-// }
+            let mut output = Vec::new();
+            for _i in 0..n {
+                let w = eval.add_witness_to_cs();
+                b_wit.push(w);
+                output.push(w.into());
+            }
+            //generate constraints for the inputs
+            let w = evaluate_permutation(&input, &output, &mut eval);
+            //checks that it generate the same witness
+            let (w1, _) = permutation_layer(&input, &w, false, &mut eval);
+            assert_eq!(w, w1);
+            //we generate random network
+            let mut c = Vec::new();
+            for _i in 0..w.len() {
+                c.push(rng.next_u32() % 2 != 0);
+            }
+            // initialize bits
+            for i in 0..w.len() {
+                solved_witness.insert(w[i], FieldElement::from(c[i] as i128));
+            }
+            // compute the network output by solving the constraints
+            let backend = MockBackend {};
+            let mut blocks = Blocks::default();
+            let solver_status =
+                solve(&backend, &mut solved_witness, &mut blocks, eval.opcodes.clone())
+                    .expect("Could not solve permutation constraints");
+            assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "Incomplete solution");
+            let mut b_val = Vec::new();
+            for i in 0..output.len() {
+                b_val.push(solved_witness[&b_wit[i]]);
+            }
+            // ensure the outputs are a permutation of the inputs
+            a_val.sort();
+            b_val.sort();
+            assert_eq!(a_val, b_val);
+        }
+    }
+}

--- a/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/operations/sort.rs
@@ -111,88 +111,88 @@ fn permutation_layer(
     (conf, out_expr)
 }
 
-#[cfg(test)]
-mod test {
-    use std::collections::BTreeMap;
+// #[cfg(test)]
+// mod test {
+//     use std::collections::BTreeMap;
 
-    use acvm::{
-        acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness},
-        pwg::block::Blocks,
-        FieldElement, OpcodeResolution, OpcodeResolutionError, PartialWitnessGenerator,
-        PartialWitnessGeneratorStatus,
-    };
+//     use acvm::{
+//         acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness},
+//         pwg::block::Blocks,
+//         FieldElement, OpcodeResolution, OpcodeResolutionError, PartialWitnessGenerator,
+//         PartialWitnessGeneratorStatus,
+//     };
 
-    use crate::{
-        ssa::acir_gen::operations::sort::{evaluate_permutation, permutation_layer},
-        Evaluator,
-    };
-    use rand::prelude::*;
+//     use crate::{
+//         ssa::acir_gen::operations::sort::{evaluate_permutation, permutation_layer},
+//         Evaluator,
+//     };
+//     use rand::prelude::*;
 
-    struct MockBackend {}
-    impl PartialWitnessGenerator for MockBackend {
-        fn solve_black_box_function_call(
-            &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            _func_call: &BlackBoxFuncCall,
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            unreachable!();
-        }
-    }
+//     struct MockBackend {}
+//     impl PartialWitnessGenerator for MockBackend {
+//         fn solve_black_box_function_call(
+//             &self,
+//             _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+//             _func_call: &BlackBoxFuncCall,
+//         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+//             unreachable!();
+//         }
+//     }
 
-    // Check that a random network constrains its output to be a permutation of any random input
-    #[test]
-    fn test_permutation() {
-        let mut rng = rand::thread_rng();
-        for n in 2..50 {
-            let mut eval = Evaluator::default();
+//     // Check that a random network constrains its output to be a permutation of any random input
+//     #[test]
+//     fn test_permutation() {
+//         let mut rng = rand::thread_rng();
+//         for n in 2..50 {
+//             let mut eval = Evaluator::default();
 
-            //we generate random inputs
-            let mut input = Vec::new();
-            let mut a_val = Vec::new();
-            let mut b_wit = Vec::new();
-            let mut solved_witness: BTreeMap<Witness, FieldElement> = BTreeMap::new();
-            for i in 0..n {
-                let w = eval.add_witness_to_cs();
-                input.push(w.into());
-                a_val.push(FieldElement::from(rng.next_u32() as i128));
-                solved_witness.insert(w, a_val[i]);
-            }
+//             //we generate random inputs
+//             let mut input = Vec::new();
+//             let mut a_val = Vec::new();
+//             let mut b_wit = Vec::new();
+//             let mut solved_witness: BTreeMap<Witness, FieldElement> = BTreeMap::new();
+//             for i in 0..n {
+//                 let w = eval.add_witness_to_cs();
+//                 input.push(w.into());
+//                 a_val.push(FieldElement::from(rng.next_u32() as i128));
+//                 solved_witness.insert(w, a_val[i]);
+//             }
 
-            let mut output = Vec::new();
-            for _i in 0..n {
-                let w = eval.add_witness_to_cs();
-                b_wit.push(w);
-                output.push(w.into());
-            }
-            //generate constraints for the inputs
-            let w = evaluate_permutation(&input, &output, &mut eval);
-            //checks that it generate the same witness
-            let (w1, _) = permutation_layer(&input, &w, false, &mut eval);
-            assert_eq!(w, w1);
-            //we generate random network
-            let mut c = Vec::new();
-            for _i in 0..w.len() {
-                c.push(rng.next_u32() % 2 != 0);
-            }
-            // initialize bits
-            for i in 0..w.len() {
-                solved_witness.insert(w[i], FieldElement::from(c[i] as i128));
-            }
-            // compute the network output by solving the constraints
-            let backend = MockBackend {};
-            let mut blocks = Blocks::default();
-            let solver_status = backend
-                .solve(&mut solved_witness, &mut blocks, eval.opcodes.clone())
-                .expect("Could not solve permutation constraints");
-            assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "Incomplete solution");
-            let mut b_val = Vec::new();
-            for i in 0..output.len() {
-                b_val.push(solved_witness[&b_wit[i]]);
-            }
-            // ensure the outputs are a permutation of the inputs
-            a_val.sort();
-            b_val.sort();
-            assert_eq!(a_val, b_val);
-        }
-    }
-}
+//             let mut output = Vec::new();
+//             for _i in 0..n {
+//                 let w = eval.add_witness_to_cs();
+//                 b_wit.push(w);
+//                 output.push(w.into());
+//             }
+//             //generate constraints for the inputs
+//             let w = evaluate_permutation(&input, &output, &mut eval);
+//             //checks that it generate the same witness
+//             let (w1, _) = permutation_layer(&input, &w, false, &mut eval);
+//             assert_eq!(w, w1);
+//             //we generate random network
+//             let mut c = Vec::new();
+//             for _i in 0..w.len() {
+//                 c.push(rng.next_u32() % 2 != 0);
+//             }
+//             // initialize bits
+//             for i in 0..w.len() {
+//                 solved_witness.insert(w[i], FieldElement::from(c[i] as i128));
+//             }
+//             // compute the network output by solving the constraints
+//             let backend = MockBackend {};
+//             let mut blocks = Blocks::default();
+//             let solver_status = backend
+//                 .solve(&mut solved_witness, &mut blocks, eval.opcodes.clone())
+//                 .expect("Could not solve permutation constraints");
+//             assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "Incomplete solution");
+//             let mut b_val = Vec::new();
+//             for i in 0..output.len() {
+//                 b_val.push(solved_witness[&b_wit[i]]);
+//             }
+//             // ensure the outputs are a permutation of the inputs
+//             a_val.sort();
+//             b_val.sort();
+//             assert_eq!(a_val, b_val);
+//         }
+//     }
+// }

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
+use acvm::acir::circuit::opcodes::BlackBoxFuncCall;
+use acvm::acir::circuit::Opcode;
 use acvm::Language;
 use arena::{Arena, Index};
 use fm::FileId;
@@ -581,13 +583,14 @@ impl NodeInterner {
         self.language = language.clone();
     }
 
+    #[allow(deprecated)]
     pub fn foreign(&self, opcode: &str) -> bool {
-        let is_supported = acvm::default_is_bb_supported(self.language.clone());
-        let black_box_func = match acvm::acir::BlackBoxFunc::lookup(opcode) {
-            Some(black_box_func) => black_box_func,
+        let is_supported = acvm::default_is_opcode_supported(self.language.clone());
+        let black_box_func_call = match acvm::acir::BlackBoxFunc::lookup(opcode) {
+            Some(black_box_func) => BlackBoxFuncCall::dummy(black_box_func),
             None => return false,
         };
-        is_supported(black_box_func)
+        is_supported(&Opcode::BlackBoxFuncCall(black_box_func_call))
     }
 
     pub fn push_delayed_type_check(&mut self, f: TypeCheckFn) {

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -1,7 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
 
-use acvm::acir::circuit::opcodes::BlackBoxFuncCall;
-use acvm::acir::circuit::Opcode;
 use acvm::Language;
 use arena::{Arena, Index};
 use fm::FileId;
@@ -583,18 +581,13 @@ impl NodeInterner {
         self.language = language.clone();
     }
 
-    #[allow(deprecated)]
     pub fn foreign(&self, opcode: &str) -> bool {
-        let is_supported = acvm::default_is_opcode_supported(self.language.clone());
+        let is_supported = acvm::default_is_bb_supported(self.language.clone());
         let black_box_func = match acvm::acir::BlackBoxFunc::lookup(opcode) {
             Some(black_box_func) => black_box_func,
             None => return false,
         };
-        is_supported(&Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
-            name: black_box_func,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-        }))
+        is_supported(black_box_func)
     }
 
     pub fn push_delayed_type_check(&mut self, f: TypeCheckFn) {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683839119,
-        "narHash": "sha256-pVoW3C5Ek9/878PBzvXqnt51KpIDrxPt5HVtNwdErnE=",
+        "lastModified": 1683909802,
+        "narHash": "sha256-2CL8NYKLYwwy6n0RyldvH86ULgrSvfzHrgq2Qf0ZUkE=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "223b9dee2542145d67126cc8a5aa0e9b9d82c244",
+        "rev": "97c9bc72aebab850b4a647d6e6cc50085226eafb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Related issue(s)

Related to https://github.com/noir-lang/acvm/issues/196

# Description

## Summary of changes

This PR updates us to pull the value of `BACKEND_IDENTIFIER` from the backend in question to ensure that it is correct for backends other than `acvm-backend-barretenberg`.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
