### PR TITLE
fix: Fix modulo operator for comptime values

### DIFF
--- a/crates/nargo_cli/tests/test_data/2_div/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/2_div/src/main.nr
@@ -3,4 +3,5 @@ fn main(mut x: u32, y: u32, z: u32) {
     let a = x % y;
     assert(x / y == z);
     assert(a == x - z*y);
+    assert((50 as u64) % (9 as u64) == 5);
 }

--- a/crates/noirc_evaluator/src/ssa/node.rs
+++ b/crates/noirc_evaluator/src/ssa/node.rs
@@ -922,7 +922,10 @@ impl Binary {
                 } else if l_is_zero {
                     return Ok(l_eval); //TODO what is the correct result?
                 } else if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
-                    return Ok(NodeEval::Const(lhs - rhs * (lhs / rhs), res_type));
+                    let lhs = res_type.field_to_type(lhs).to_u128();
+                    let rhs = res_type.field_to_type(rhs).to_u128();
+                    let result = lhs - rhs * (lhs / rhs);
+                    return Ok(NodeEval::Const(FieldElement::from(result), res_type));
                 }
             }
             BinaryOp::Srem(loc) => {


### PR DESCRIPTION
# Related issue(s)

Resolves #1346
Resolves #774 

# Description

## Summary of changes

Use the operands type during modulo simplification

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

regression test added to 2_div

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
