### PR TITLE
chore: clarify that `verify_signature` takes a hashed message

### DIFF
--- a/noir_stdlib/src/ecdsa_secp256k1.nr
+++ b/noir_stdlib/src/ecdsa_secp256k1.nr
@@ -1,2 +1,2 @@
 #[foreign(ecdsa_secp256k1)]
-fn verify_signature(_public_key_x : [u8; 32], _public_key_y : [u8; 32], _signature: [u8; 64], _message: [u8]) -> Field {}
+fn verify_signature(_public_key_x : [u8; 32], _public_key_y : [u8; 32], _signature: [u8; 64], _message_hash: [u8]) -> Field {}


### PR DESCRIPTION
# Related issue(s)

Motivated by slack messages

# Description

## Summary of changes

This updates the argument name in the `verify_signature` function to specify that it receives the hash of the message rather than the message itself.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
