### PR TITLE
feat!: remove concept of noir fallbacks for foreign functions

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -29,6 +29,9 @@ pub use program::CompiledProgram;
 pub struct Driver {
     context: Context,
     language: Language,
+    // We retain this as we need to pass this into `create_circuit` once signature is updated to allow.
+    #[allow(dead_code)]
+    is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
 }
 
 #[derive(Args, Clone, Debug, Serialize, Deserialize)]
@@ -68,9 +71,7 @@ impl Default for CompileOptions {
 
 impl Driver {
     pub fn new(language: &Language, is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>) -> Self {
-        let mut driver = Driver { context: Context::default(), language: language.clone() };
-        driver.context.def_interner.set_opcode_support(is_opcode_supported);
-        driver
+        Driver { context: Context::default(), language: language.clone(), is_opcode_supported }
     }
 
     // This is here for backwards compatibility

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -76,7 +76,6 @@ impl From<FunctionDefinition> for NoirFunction {
         let kind = match fd.attribute {
             Some(Attribute::Builtin(_)) => FunctionKind::Builtin,
             Some(Attribute::Foreign(_)) => FunctionKind::LowLevel,
-            Some(Attribute::Alternative(_)) => FunctionKind::Normal,
             Some(Attribute::Test) => FunctionKind::Normal,
             None => FunctionKind::Normal,
         };

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -6,7 +6,6 @@ pub mod type_check;
 
 use crate::graph::{CrateGraph, CrateId};
 use crate::node_interner::NodeInterner;
-use acvm::acir::circuit::Opcode;
 use def_map::CrateDefMap;
 use fm::FileManager;
 use std::collections::HashMap;
@@ -29,20 +28,14 @@ pub struct Context {
 pub type StorageSlot = u32;
 
 impl Context {
-    pub fn new(
-        file_manager: FileManager,
-        crate_graph: CrateGraph,
-        is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
-    ) -> Context {
-        let mut ctx = Context {
+    pub fn new(file_manager: FileManager, crate_graph: CrateGraph) -> Context {
+        Context {
             def_interner: NodeInterner::default(),
             def_maps: HashMap::new(),
             crate_graph,
             file_manager,
             storage_slots: HashMap::new(),
-        };
-        ctx.def_interner.set_opcode_support(is_opcode_supported);
-        ctx
+        }
     }
 
     /// Returns the CrateDefMap for a given CrateId.

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1149,23 +1149,7 @@ impl<'a> Resolver<'a> {
         let span = path.span();
         let id = self.resolve_path(path)?;
 
-        if let Some(mut function) = TryFromModuleDefId::try_from(id) {
-            // Check if this is an unsupported low level opcode. If so, replace it with
-            // an alternative in the stdlib.
-            if let Some(meta) = self.interner.try_function_meta(&function) {
-                if meta.kind == crate::FunctionKind::LowLevel {
-                    let attribute = meta.attributes.expect("all low level functions must contain an attribute which contains the opcode which it links to");
-                    let opcode = attribute.foreign().expect(
-                        "ice: function marked as foreign, but attribute kind does not match this",
-                    );
-                    if !self.interner.foreign(&opcode) {
-                        if let Some(new_id) = self.interner.get_alt(opcode) {
-                            function = new_id;
-                        }
-                    }
-                }
-            }
-
+        if let Some(function) = TryFromModuleDefId::try_from(id) {
             return Ok(self.interner.function_definition_id(function));
         }
 

--- a/crates/noirc_frontend/src/lexer/token.rs
+++ b/crates/noirc_frontend/src/lexer/token.rs
@@ -324,7 +324,6 @@ impl IntType {
 pub enum Attribute {
     Foreign(String),
     Builtin(String),
-    Alternative(String),
     Test,
 }
 
@@ -333,7 +332,6 @@ impl fmt::Display for Attribute {
         match *self {
             Attribute::Foreign(ref k) => write!(f, "#[foreign({k})]"),
             Attribute::Builtin(ref k) => write!(f, "#[builtin({k})]"),
-            Attribute::Alternative(ref k) => write!(f, "#[alternative({k})]"),
             Attribute::Test => write!(f, "#[test]"),
         }
     }
@@ -365,7 +363,6 @@ impl Attribute {
         let tok = match attribute_type {
             "foreign" => Token::Attribute(Attribute::Foreign(attribute_name.to_string())),
             "builtin" => Token::Attribute(Attribute::Builtin(attribute_name.to_string())),
-            "alternative" => Token::Attribute(Attribute::Alternative(attribute_name.to_string())),
             _ => {
                 return Err(LexerErrorKind::MalformedFuncAttribute { span, found: word.to_owned() })
             }
@@ -401,7 +398,6 @@ impl AsRef<str> for Attribute {
         match self {
             Attribute::Foreign(string) => string,
             Attribute::Builtin(string) => string,
-            Attribute::Alternative(string) => string,
             Attribute::Test => "",
         }
     }

--- a/crates/noirc_frontend/src/main.rs
+++ b/crates/noirc_frontend/src/main.rs
@@ -27,12 +27,7 @@ fn main() {
     let crate_id = crate_graph.add_crate_root(CrateType::Library, root_file_id);
 
     // initiate context with file manager and crate graph
-    let mut context = Context::new(
-        fm,
-        crate_graph,
-        #[allow(deprecated)]
-        Box::new(acvm::default_is_opcode_supported(acvm::Language::R1CS)),
-    );
+    let mut context = Context::new(fm, crate_graph);
 
     // Now create the CrateDefMap
     // This is preamble for analysis

--- a/noir_stdlib/src/merkle.nr
+++ b/noir_stdlib/src/merkle.nr
@@ -13,7 +13,6 @@ fn check_membership(_root : Field, _leaf : Field, _index : Field, _hash_path: [F
 fn compute_merkle_root(_leaf : Field, _index : Field, _hash_path: [Field]) -> Field {}
 
 // Returns the root of the tree from the provided leaf and its hashpath, using pedersen hash
-#[alternative(compute_merkle_root)]
 fn compute_root_from_leaf(leaf : Field, index : Field, hash_path: [Field]) -> Field {
     let n = hash_path.len();
     let index_bits = index.to_le_bits(n as u32);

--- a/noir_stdlib/src/sha256.nr
+++ b/noir_stdlib/src/sha256.nr
@@ -99,7 +99,6 @@ fn msg_u8_to_u32(msg: [u8; 64]) -> [u32; 16]
 }
 
 // SHA-256 hash function
-#[alternative(sha256)]
 fn digest<N>(msg: [u8; N]) -> [u8; 32] {
     let mut msg_block: [u8; 64] = [0; 64];
     let mut h: [u32; 8] = [1779033703,3144134277,1013904242,2773480762,1359893119,2600822924,528734635,1541459225]; // Intermediate hash, starting with the canonical initial value


### PR DESCRIPTION
# Related issue(s)

Removes blocker for #1102 

# Description

## Summary of changes

This PR removes the concept of fallback functions inside the stdlib instead the blackbox function opcodes will always be generated.

This can be reintroduced in future using some form of https://github.com/noir-lang/noir/issues/1258#issuecomment-1529134163 or alternatively a fallback can be implemented inside ACVM.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.



# Additional context

<!-- If applicable. -->
