### PR TITLE
fix(stdlib): Workaround for Field comparison error in EdDSA signature verification

### DIFF
--- a/noir_stdlib/src/eddsa.nr
+++ b/noir_stdlib/src/eddsa.nr
@@ -10,8 +10,8 @@ fn lt_bytes32(x: Field, y: Field) -> bool {
     let mut done = false;
     for i in 0..32 {
         if (!done) {
-            let x_byte = x_bytes[31 - i];
-            let y_byte = y_bytes[31 - i];
+            let x_byte = x_bytes[31 - i] as u8;
+            let y_byte = y_bytes[31 - i] as u8;
             let bytes_match = x_byte == y_byte;
             if !bytes_match {
                 x_is_lt = x_byte < y_byte;


### PR DESCRIPTION
# Related issue(s)

Related to #1313 

# Description
This PR resolves an error that occurs when generating a proof involving EdDSA signature verification: Calling `eddsa_poseidon_verify` leads to an error on the following example:

```rust
use dep::std::eddsa::eddsa_poseidon_verify;

fn main(data: [Field; 6])
{
	assert(eddsa_poseidon_verify(data[0], data[1], data[2], data[3], data[4], data[5]));
}

#[test]
fn test_main()
{
	let data = [0x1f3581c1eb058355ad574689b0bf37ab4e02433492eac1fbcd9fe5ce9272099e,0x0f72436cb679e0fa77342a92342d271bdd869ac14ce1f13a2afcccc5b6f75714,0x03ec6779f0250bb9852b3bc71cfb3dbb21420294fe8ce16ac6469049171b987e, 0x0b317e5deb2cbbc171f7c70ee5f6634563bb3a23f67d001ed9750380bbaf60cf,0x1cad3257ef27851ebd24587ff64230f3be41dfac3e8170878116190527448373,0x1d7ecd14bf6ec1bf60b655ef74e99bc874c76d179b1adc9a81bb55dd4bbacf46];
    

	main(data);
}
```

`nargo test` passes, but `nargo prove` with the following `Prover.toml` fails with the error `not implemented: Field comparison is not implemented yet, try to cast arguments to integer type`:

```
data = ["0x1f3581c1eb058355ad574689b0bf37ab4e02433492eac1fbcd9fe5ce9272099e","0x0f72436cb679e0fa77342a92342d271bdd869ac14ce1f13a2afcccc5b6f75714","0x03ec6779f0250bb9852b3bc71cfb3dbb21420294fe8ce16ac6469049171b987e", "0x0b317e5deb2cbbc171f7c70ee5f6634563bb3a23f67d001ed9750380bbaf60cf","0x1cad3257ef27851ebd24587ff64230f3be41dfac3e8170878116190527448373","0x1d7ecd14bf6ec1bf60b655ef74e99bc874c76d179b1adc9a81bb55dd4bbacf46"]
```

The problem lies in `lt_bytes32`, where the compiler is not treating the elements of the byte arrays `x_bytes` and `y_bytes` as bytes. This PR adds type casts to force this, which eliminates the above error.

## Summary of changes
Added `u8` type casts.
<!-- Describe the changes in this PR. Point out breaking changes if any. -->

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
