### PR TITLE
chore(ssa refactor): Add pass to simplify the control flow graph

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/basic_block.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/basic_block.rs
@@ -40,6 +40,11 @@ impl BasicBlock {
         &self.parameters
     }
 
+    /// Removes all the parameters of this block
+    pub(crate) fn take_parameters(&mut self) -> Vec<ValueId> {
+        std::mem::take(&mut self.parameters)
+    }
+
     /// Adds a parameter to this BasicBlock.
     /// Expects that the ValueId given should refer to a Value::Param
     /// instance with its position equal to self.parameters.len().
@@ -103,5 +108,13 @@ impl BasicBlock {
                 panic!("remove_instruction: No such instruction {instruction:?} in block")
             });
         self.instructions.remove(index);
+    }
+
+    /// Take ownership of this block's terminator, replacing it with an empty return terminator.
+    /// It is expected that this function is only called on blocks that are no longer reachable
+    /// as an optimization to copy over a terminator without cloning.
+    pub(crate) fn take_terminator(&mut self) -> TerminatorInstruction {
+        let terminator = self.terminator.as_mut().expect("Expected block to have a terminator");
+        std::mem::replace(terminator, TerminatorInstruction::Return { return_values: Vec::new() })
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
@@ -123,6 +123,12 @@ impl DataFlowGraph {
         self.values.insert(value)
     }
 
+    /// Set the value of value_to_replace to refer to the value referred to by new_value.
+    pub(crate) fn set_value_from_id(&mut self, value_to_replace: ValueId, new_value: ValueId) {
+        let new_value = self.values[new_value];
+        self.values[value_to_replace] = new_value;
+    }
+
     /// Creates a new constant value, or returns the Id to an existing one if
     /// one already exists.
     pub(crate) fn make_constant(&mut self, value: FieldElement, typ: Type) -> ValueId {

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/function.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/function.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::basic_block::BasicBlockId;
 use super::dfg::DataFlowGraph;
 use super::map::Id;
@@ -60,6 +62,23 @@ impl Function {
     /// The parameters will always match that of this function's entry block.
     pub(crate) fn parameters(&self) -> &[ValueId] {
         self.dfg.block_parameters(self.entry_block)
+    }
+
+    /// Collects all the reachable blocks of this function.
+    ///
+    /// Note that self.dfg.basic_blocks_iter() iterates over all blocks,
+    /// whether reachable or not. This function should be used if you
+    /// want to iterate only reachable blocks.
+    pub(crate) fn reachable_blocks(&self) -> HashSet<BasicBlockId> {
+        let mut blocks = HashSet::new();
+        let mut stack = vec![self.entry_block];
+
+        while let Some(block) = stack.pop() {
+            if blocks.insert(block) {
+                stack.extend(self.dfg[block].successors());
+            }
+        }
+        blocks
     }
 }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/mod.rs
@@ -4,3 +4,4 @@
 //! simpler form until the IR only has a single function remaining with 1 block within it.
 //! Generally, these passes are also expected to minimize the final amount of instructions.
 mod inlining;
+mod simplify_cfg;

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/simplify_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/simplify_cfg.rs
@@ -1,0 +1,172 @@
+//! This file contains the simplify cfg pass of the SSA IR.
+//!
+//! This is a rather simple pass that is expected to be cheap to perform. It:
+//! 1. Removes blocks with no predecessors
+//! 2. Inlines a block into its sole predecessor if that predecessor only has one successor.
+//! 3. Removes any block arguments for blocks with only a single predecessor.
+//! 4. Removes any blocks which have no instructions other than a single terminating jmp.
+//!
+//! Currently, only 2 is implemented.
+use std::collections::HashSet;
+
+use crate::ssa_refactor::{
+    ir::{
+        basic_block::BasicBlockId, cfg::ControlFlowGraph, function::Function,
+        instruction::TerminatorInstruction,
+    },
+    ssa_gen::Ssa,
+};
+
+impl Ssa {
+    /// Simplify each function's control flow graph by:
+    /// 1. Removing blocks with no predecessors
+    /// 2. Inlining a block into its sole predecessor if that predecessor only has one successor.
+    /// 3. Removing any block arguments for blocks with only a single predecessor.
+    /// 4. Removing any blocks which have no instructions other than a single terminating jmp.
+    ///
+    /// Currently, only 2 is implemented.
+    pub(crate) fn simplify_cfg(mut self) -> Self {
+        for function in self.functions.values_mut() {
+            simplify_function(function);
+        }
+        self
+    }
+}
+
+/// Simplify a function's cfg by going through each block to check for any simple blocks that can
+/// be inlined into their predecessor.
+fn simplify_function(function: &mut Function) {
+    let mut cfg = ControlFlowGraph::with_function(function);
+    let mut stack = vec![function.entry_block()];
+    let mut visited = HashSet::new();
+
+    while let Some(block) = stack.pop() {
+        if visited.insert(block) {
+            stack.extend(function.dfg[block].successors().filter(|block| !visited.contains(block)));
+        }
+
+        let mut predecessors = cfg.predecessors(block);
+
+        if predecessors.len() == 1 {
+            let predecessor = predecessors.next().expect("Already checked length of predecessors");
+            drop(predecessors);
+
+            if try_inline_into_predecessor(function, &mut cfg, block, predecessor) {
+                continue;
+            }
+        }
+    }
+}
+
+/// Try to inline a block into its predecessor, returning true if successful.
+///
+/// This will only occur if the predecessor's only successor is the given block.
+/// It is also expected that the given block's only predecessor is the given one.
+fn try_inline_into_predecessor(
+    function: &mut Function,
+    cfg: &mut ControlFlowGraph,
+    block_id: BasicBlockId,
+    predecessor_id: BasicBlockId,
+) -> bool {
+    let mut successors = cfg.successors(predecessor_id);
+    if successors.len() == 1 && successors.next() == Some(block_id) {
+        drop(successors);
+
+        // First remove all the instructions and terminator from the block we're removing
+        let block = &mut function.dfg[block_id];
+        let mut instructions = std::mem::take(block.instructions_mut());
+        let terminator = block.take_terminator();
+
+        // Then append each to the predecessor
+        let predecessor = &mut function.dfg[predecessor_id];
+        predecessor.instructions_mut().append(&mut instructions);
+
+        let jump_args = match predecessor.take_terminator() {
+            TerminatorInstruction::Jmp { arguments, .. } => arguments,
+            _ => unreachable!(
+                "Predecessor was already validated to have only a single jmp destination"
+            ),
+        };
+
+        predecessor.set_terminator(terminator);
+
+        // Finally, replace any block parameters with their values, if there were any.
+        let block_params = function.dfg[block_id].take_parameters();
+        assert_eq!(block_params.len(), jump_args.len());
+
+        for (param, arg) in block_params.iter().zip(jump_args) {
+            function.dfg.set_value_from_id(*param, arg);
+        }
+
+        cfg.recompute_block(function, block_id);
+        cfg.recompute_block(function, predecessor_id);
+
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ssa_refactor::{
+        ir::{instruction::TerminatorInstruction, map::Id, types::Type},
+        ssa_builder::FunctionBuilder,
+    };
+
+    #[test]
+    fn inline_blocks() {
+        // fn main {
+        //   b0():
+        //     jmp b1(Field 7)
+        //   b1(v0: Field):
+        //     jmp b2(v0)
+        //   b2(v1: Field):
+        //     return v1
+        // }
+        let main_id = Id::test_new(0);
+        let mut builder = FunctionBuilder::new("main".into(), main_id);
+
+        let b1 = builder.insert_block();
+        let b2 = builder.insert_block();
+
+        let v0 = builder.add_block_parameter(b1, Type::field());
+        let v1 = builder.add_block_parameter(b2, Type::field());
+
+        let expected_return = 7u128;
+        let seven = builder.field_constant(expected_return);
+        builder.terminate_with_jmp(b1, vec![seven]);
+
+        builder.switch_to_block(b1);
+        builder.terminate_with_jmp(b2, vec![v0]);
+
+        builder.switch_to_block(b2);
+        builder.terminate_with_return(vec![v1]);
+
+        let ssa = builder.finish();
+        assert_eq!(ssa.main().reachable_blocks().len(), 3);
+
+        // Expected output:
+        // fn main {
+        //   b0():
+        //     return Field 7
+        // }
+        let ssa = ssa.simplify_cfg();
+        let main = ssa.main();
+        println!("{}", main);
+        assert_eq!(main.reachable_blocks().len(), 1);
+
+        match main.dfg[main.entry_block()].terminator() {
+            Some(TerminatorInstruction::Return { return_values }) => {
+                assert_eq!(return_values.len(), 1);
+                let return_value = main
+                    .dfg
+                    .get_numeric_constant(return_values[0])
+                    .expect("Expected return value to be constant")
+                    .to_u128();
+                assert_eq!(return_value, expected_return);
+            }
+            other => panic!("Unexpected terminator {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves # <!-- link to issue -->

# Description

## Summary of changes

Adds a simple pass to simplify a function's CFG by inlining a block into its predecessor if that block only has 1 predecessor and that predecessor's only successor is that block. Example before this pass:

```rs
fn main {
  b0():
    jmp b1(Field 7)
  b1(v0: Field):
    jmp b2(v0)
  b2(v1: Field):
    return v1
}
```
And after the pass:
```rs
fn main {
  b0():
    return Field 7
}
```

In the future this pass is expected to perform some other quick tasks like unreachable block elimination. I favored getting this PR out earlier and smaller so that each extra feature could be a separate, easier to review PR.
This pass' name and functionality was inspired by llvm's pass of the same name: https://llvm.org/docs/Passes.html#simplifycfg-simplify-the-cfg.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [ ] This PR requires documentation updates when merged.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
