### PR TITLE
feat: Allow warnings by default

### DIFF
--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -197,7 +197,7 @@ d2 = ["", "", ""]
             .join(format!("{TEST_DATA_DIR}/pass_dev_mode"));
 
         let backend = crate::backends::ConcreteBackend::default();
-        let config = CompileOptions { allow_warnings: true, ..Default::default() };
+        let config = CompileOptions { deny_warnings: false, ..Default::default() };
 
         let paths = std::fs::read_dir(pass_dir).unwrap();
         for path in paths.flatten() {

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -89,7 +89,7 @@ pub fn prove_and_verify(proof_name: &str, program_dir: &Path) -> bool {
     let compile_options = CompileOptions {
         show_ssa: false,
         print_acir: false,
-        allow_warnings: false,
+        deny_warnings: false,
         show_output: false,
         experimental_ssa: false,
     };

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -44,9 +44,9 @@ pub struct CompileOptions {
     #[arg(short, long)]
     pub print_acir: bool,
 
-    /// Issue a warning for each unused variable instead of an error
+    /// Treat all warnings as errors
     #[arg(short, long)]
-    pub allow_warnings: bool,
+    pub deny_warnings: bool,
 
     /// Display output of `println` statements
     #[arg(long)]
@@ -62,7 +62,7 @@ impl Default for CompileOptions {
         Self {
             show_ssa: false,
             print_acir: false,
-            allow_warnings: false,
+            deny_warnings: false,
             show_output: true,
             experimental_ssa: false,
         }
@@ -174,7 +174,7 @@ impl Driver {
         let mut errs = vec![];
         CrateDefMap::collect_defs(LOCAL_CRATE, &mut self.context, &mut errs);
         let error_count =
-            reporter::report_all(&self.context.file_manager, &errs, options.allow_warnings);
+            reporter::report_all(&self.context.file_manager, &errs, options.deny_warnings);
         reporter::finish_report(error_count)
     }
 
@@ -315,7 +315,7 @@ impl Driver {
                 // Errors will be shown at the call site without a stacktrace
                 let file = err.location.map(|loc| loc.file);
                 let files = &self.context.file_manager;
-                let error = reporter::report(files, &err.into(), file, options.allow_warnings);
+                let error = reporter::report(files, &err.into(), file, options.deny_warnings);
                 reporter::finish_report(error as u32)?;
                 Err(ReportedError)
             }

--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -106,11 +106,11 @@ impl CustomLabel {
 pub fn report_all(
     files: &fm::FileManager,
     diagnostics: &[FileDiagnostic],
-    allow_warnings: bool,
+    deny_warnings: bool,
 ) -> u32 {
     diagnostics
         .iter()
-        .map(|error| report(files, &error.diagnostic, Some(error.file_id), allow_warnings) as u32)
+        .map(|error| report(files, &error.diagnostic, Some(error.file_id), deny_warnings) as u32)
         .sum()
 }
 
@@ -119,24 +119,24 @@ pub fn report(
     files: &fm::FileManager,
     custom_diagnostic: &CustomDiagnostic,
     file: Option<fm::FileId>,
-    allow_warnings: bool,
+    deny_warnings: bool,
 ) -> bool {
     let writer = StandardStream::stderr(ColorChoice::Always);
     let config = codespan_reporting::term::Config::default();
 
-    let diagnostic = convert_diagnostic(custom_diagnostic, file, allow_warnings);
+    let diagnostic = convert_diagnostic(custom_diagnostic, file, deny_warnings);
     term::emit(&mut writer.lock(), &config, files.as_simple_files(), &diagnostic).unwrap();
 
-    !allow_warnings || custom_diagnostic.is_error()
+    deny_warnings || custom_diagnostic.is_error()
 }
 
 fn convert_diagnostic(
     cd: &CustomDiagnostic,
     file: Option<fm::FileId>,
-    allow_warnings: bool,
+    deny_warnings: bool,
 ) -> Diagnostic<usize> {
-    let diagnostic = match (cd.kind, allow_warnings) {
-        (DiagnosticKind::Warning, true) => Diagnostic::warning(),
+    let diagnostic = match (cd.kind, deny_warnings) {
+        (DiagnosticKind::Warning, false) => Diagnostic::warning(),
         _ => Diagnostic::error(),
     };
 


### PR DESCRIPTION
# Related issue(s)

<!-- If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here. -->

Resolves #1382

# Description

## Summary of changes

Allows warnings by default. The old default behavior of treating warnings like errors is now opt-in with the `--deny-warnings` flag. The old `--allow-warnings` flag has been removed as it is no longer useful.

## Dependency additions / changes

<!-- If applicable. -->

## Test additions / changes

<!-- If applicable. -->

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

## Documentation needs
- [x] This PR requires documentation updates when merged.

We should remove references to `--allow-warnings` in the documentation and add references to `--deny-warnings`. Additionally, we should mention that unused variables are warnings rather than errors if we mention them at all. Deprecated constructs like `constrain` do not need to be mentioned.

<!-- If checked, list / describe what needs to be documented. -->

# Additional context

<!-- If applicable. -->
