### PR TITLE
fix(ssa refactor): safe to query cfg for single block programs

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/cfg.rs
@@ -27,7 +27,14 @@ pub(crate) struct ControlFlowGraph {
 impl ControlFlowGraph {
     /// Allocate and compute the control flow graph for `func`.
     pub(crate) fn with_function(func: &Function) -> Self {
-        let mut cfg = ControlFlowGraph { data: HashMap::new() };
+        // It is expected to be safe to query the control flow graph for any reachable block,
+        // therefore we must ensure that a node exists from the entry block, regardless of whether
+        // it comes to describe any edges after calling compute.
+        let entry_block = func.entry_block();
+        let empty_node = CfgNode { predecessors: HashSet::new(), successors: HashSet::new() };
+        let data = HashMap::from([(entry_block, empty_node)]);
+
+        let mut cfg = ControlFlowGraph { data };
         cfg.compute(func);
         cfg
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/cfg.rs
@@ -28,8 +28,8 @@ impl ControlFlowGraph {
     /// Allocate and compute the control flow graph for `func`.
     pub(crate) fn with_function(func: &Function) -> Self {
         // It is expected to be safe to query the control flow graph for any reachable block,
-        // therefore we must ensure that a node exists from the entry block, regardless of whether
-        // it comes to describe any edges after calling compute.
+        // therefore we must ensure that a node exists for the entry block, regardless of whether
+        // it later comes to describe any edges after calling compute.
         let entry_block = func.entry_block();
         let empty_node = CfgNode { predecessors: HashSet::new(), successors: HashSet::new() };
         let data = HashMap::from([(entry_block, empty_node)]);


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Loop unrolling was crashing on single block programs due the cfg not holding a node for the entry block (which had no edges)

```
Message:  ICE: Attempted to iterate predecessors of block not found within cfg.
Location: crates/noirc_evaluator/src/ssa_refactor/ir/cfg.rs:102
...
  18: noirc_evaluator::ssa_refactor::ir::cfg::ControlFlowGraph::predecessors::h40675d9252c86030
      at /Users/aztec/Documents/GitHub/noir-lang/noir/crates/noirc_evaluator/src/ssa_refactor/ir/cfg.rs:100
  19: noirc_evaluator::ssa_refactor::opt::unrolling::find_all_loops::h750f7171170cccd7
```

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

Init the cfg with an empty node for the entry block


## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
