### PR TITLE
chore(ssa refactor): Add ValueMap abstraction

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir.rs
@@ -10,3 +10,4 @@ pub(crate) mod post_order;
 pub(crate) mod printer;
 pub(crate) mod types;
 pub(crate) mod value;
+pub(crate) mod value_map;

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value_map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value_map.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use iter_extended::vecmap;
 
 use super::{
+    basic_block::BasicBlockId,
     dfg::{DataFlowGraph, InsertInstructionResult},
     instruction::{Instruction, InstructionId},
     types::Type,
@@ -15,27 +16,34 @@ pub(crate) struct ValueMap {
 }
 
 impl ValueMap {
+    /// Insert a new mapping into this value map, overwriting any previous entry if present
     pub(crate) fn insert(&mut self, old_id: ValueId, new_id: ValueId) {
         self.map.insert(old_id, new_id);
     }
 
-    /// Insert the given old_id -> new_id mapping if old_id isn't already in the map.
+    /// Insert the given old_id -> new_id mapping if old_id isn't already in the map
     pub(crate) fn insert_if_not_present(&mut self, old_id: ValueId, new_id: ValueId) {
         self.map.entry(old_id).or_insert(new_id);
     }
 
+    /// Retrieve the mapped value or return None otherwise
     pub(crate) fn get(&self, value: ValueId) -> Option<ValueId> {
         self.map.get(&value).copied()
     }
 
+    /// Retrieve the mapped value, or if there is none, return the given value.
     pub(crate) fn get_value(&self, value: ValueId) -> ValueId {
         self.get(value).unwrap_or(value)
     }
 
+    /// Extend this value map with each new mapping given from the given iterator
     pub(crate) fn extend(&mut self, iterator: impl Iterator<Item = (ValueId, ValueId)>) {
         self.map.extend(iterator);
     }
 
+    /// Map the instruction's ValueIds to their mapped versions from this ValueMap.
+    /// This will also return the (non-mapped) results of the instruction as well as the control
+    /// type variables if needed.
     pub(crate) fn map_instruction<'dfg>(
         &mut self,
         dfg: &'dfg DataFlowGraph,
@@ -71,5 +79,23 @@ impl ValueMap {
             }
             InsertInstructionResult::InstructionRemoved => (),
         }
+    }
+
+    /// Push an instruction to the given block within the CFG.
+    /// This will handle mapping the instruction's argument ValueIds and
+    /// remembering the new result ValueIds.
+    pub(crate) fn push_instruction(
+        &mut self,
+        id: InstructionId,
+        dfg: &mut DataFlowGraph,
+        block: BasicBlockId,
+    ) {
+        let (instruction, results, ctrl_typevars) = self.map_instruction(dfg, id);
+
+        // We must collect the results into a Vec, otherwise we cannot mutate the dfg afterwards
+        let results = results.to_vec();
+
+        let new_results = dfg.insert_instruction_and_results(instruction, block, ctrl_typevars);
+        self.insert_new_instruction_results(&results, new_results);
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value_map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value_map.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+
+use iter_extended::vecmap;
+
+use super::{
+    dfg::{DataFlowGraph, InsertInstructionResult},
+    instruction::{Instruction, InstructionId},
+    types::Type,
+    value::ValueId,
+};
+
+#[derive(Default)]
+pub(crate) struct ValueMap {
+    map: HashMap<ValueId, ValueId>,
+}
+
+impl ValueMap {
+    pub(crate) fn insert(&mut self, old_id: ValueId, new_id: ValueId) {
+        self.map.insert(old_id, new_id);
+    }
+
+    /// Insert the given old_id -> new_id mapping if old_id isn't already in the map.
+    pub(crate) fn insert_if_not_present(&mut self, old_id: ValueId, new_id: ValueId) {
+        self.map.entry(old_id).or_insert(new_id);
+    }
+
+    pub(crate) fn get(&self, value: ValueId) -> Option<ValueId> {
+        self.map.get(&value).copied()
+    }
+
+    pub(crate) fn get_value(&self, value: ValueId) -> ValueId {
+        self.get(value).unwrap_or(value)
+    }
+
+    pub(crate) fn extend(&mut self, iterator: impl Iterator<Item = (ValueId, ValueId)>) {
+        self.map.extend(iterator);
+    }
+
+    pub(crate) fn map_instruction<'dfg>(
+        &mut self,
+        dfg: &'dfg DataFlowGraph,
+        id: InstructionId,
+    ) -> (Instruction, &'dfg [ValueId], Option<Vec<Type>>) {
+        let instruction = dfg[id].map_values(|id| self.get_value(id));
+        let results = dfg.instruction_results(id);
+
+        let ctrl_typevars = instruction
+            .requires_ctrl_typevars()
+            .then(|| vecmap(results, |result| dfg.type_of_value(*result)));
+
+        (instruction, results, ctrl_typevars)
+    }
+
+    /// Modify the values HashMap to remember the mapping between an instruction result's previous
+    /// ValueId (from the source_function) and its new ValueId in the destination function.
+    pub(crate) fn insert_new_instruction_results(
+        &mut self,
+        old_results: &[ValueId],
+        new_results: InsertInstructionResult,
+    ) {
+        assert_eq!(old_results.len(), new_results.len());
+
+        match new_results {
+            InsertInstructionResult::SimplifiedTo(new_result) => {
+                self.map.insert(old_results[0], new_result);
+            }
+            InsertInstructionResult::Results(new_results) => {
+                for (old_result, new_result) in old_results.iter().zip(new_results) {
+                    self.map.insert(*old_result, *new_result);
+                }
+            }
+            InsertInstructionResult::InstructionRemoved => (),
+        }
+    }
+}

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value_map.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value_map.rs
@@ -10,6 +10,11 @@ use super::{
     value::ValueId,
 };
 
+/// Maps old value ids to a new set of value ids, not necessarily in the same function.
+/// This is useful for optimization passes which rewrite instructions and values.
+/// Notably `map_instruction` and `push_instruction` are useful operations for such
+/// passes so that they need to worry less about remembering to update each ValueId
+/// within each Instruction.
 #[derive(Default)]
 pub(crate) struct ValueMap {
     map: HashMap<ValueId, ValueId>,

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/unrolling.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/unrolling.rs
@@ -16,13 +16,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::ssa_refactor::{
     ir::{
-        basic_block::BasicBlockId,
-        cfg::ControlFlowGraph,
-        dom::DominatorTree,
-        function::Function,
-        instruction::{InstructionId, TerminatorInstruction},
-        post_order::PostOrder,
-        value::ValueId,
+        basic_block::BasicBlockId, cfg::ControlFlowGraph, dom::DominatorTree, function::Function,
+        instruction::TerminatorInstruction, post_order::PostOrder, value::ValueId,
         value_map::ValueMap,
     },
     ssa_gen::Ssa,
@@ -417,7 +412,7 @@ impl<'f> LoopIteration<'f> {
         // instances of the induction variable or any values that were changed as a result
         // of the new induction variable value.
         for instruction in instructions {
-            self.push_instruction(instruction);
+            self.values.push_instruction(instruction, &mut self.function.dfg, self.insert_block);
         }
 
         let mut terminator = self.function.dfg[self.source_block]
@@ -426,18 +421,6 @@ impl<'f> LoopIteration<'f> {
 
         terminator.mutate_blocks(|block| self.get_or_insert_block(block));
         self.function.dfg.set_block_terminator(self.insert_block, terminator);
-    }
-
-    fn push_instruction(&mut self, id: InstructionId) {
-        let (instruction, results, ctrl_typevars) =
-            self.values.map_instruction(&mut self.function.dfg, id);
-        let results = results.to_vec();
-        let new_results = self.function.dfg.insert_instruction_and_results(
-            instruction,
-            self.insert_block,
-            ctrl_typevars,
-        );
-        self.values.insert_new_instruction_results(&results, new_results);
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

A few functions and operations are common across several SSA passes:
- Mapping ValueIds to new optimized versions
- Modifying instructions to map their value ids
- Inserting these instructions and remembering their new result ValueIds in this mapping

## Summary\*

This PR adds `ValueMap` to factor these operations out of the loop unrolling, function inlining, and (once it is merged) the flattening pass. Note that function inlining uses its own `push_instruction` method since it pushes to a separate FunctionBuilder rather than the same DFG.

I'd like to hear opinions on this refactoring, e.g. if it is good or if there is a better idea. In particular, factoring out `push_instruction` does not seem like it should be a responsibility of a struct called `ValueMap`. Perhaps we want something similar to `FunctionBuilder` instead. Like `FunctionInserter`, `FunctionModifier`, etc. Something to wrap the whole function being modified and have a value mapping within.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
