### PR TITLE
chore(stdlib)!: remove unnecessary merkle functions from stdlib

### DIFF
--- a/crates/nargo_cli/tests/test_data/merkle_insert/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/merkle_insert/src/main.nr
@@ -9,9 +9,8 @@ fn main(
     index: Field,
     mimc_input: [Field; 4],
 ) {
-    let old_leaf_exists = std::merkle::check_membership(old_root, old_leaf, index, old_hash_path);
-    assert(old_leaf_exists);
-    assert(old_root == std::merkle::compute_root_from_leaf(old_leaf, index, old_hash_path));
+    assert(old_root == std::merkle::compute_merkle_root(old_leaf, index, old_hash_path));
+    
     let calculated_root = std::merkle::compute_merkle_root(leaf, index, old_hash_path);
     assert(new_root == calculated_root);
 

--- a/crates/nargo_cli/tests/test_data/merkle_insert/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/merkle_insert/src/main.nr
@@ -10,7 +10,7 @@ fn main(
     mimc_input: [Field; 4],
 ) {
     assert(old_root == std::merkle::compute_merkle_root(old_leaf, index, old_hash_path));
-    
+
     let calculated_root = std::merkle::compute_merkle_root(leaf, index, old_hash_path);
     assert(new_root == calculated_root);
 

--- a/crates/nargo_cli/tests/test_data/simple_shield/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/simple_shield/src/main.nr
@@ -29,8 +29,7 @@ fn main(
     let receiver_note_commitment = std::hash::pedersen([to_pubkey_x, to_pubkey_y]);
 
     // Check that the input note nullifier is in the root
-    let is_member = std::merkle::check_membership(note_root, note_commitment[0], index, note_hash_path);
-    assert(is_member);
+    assert(note_root == std::merkle::compute_merkle_root(note_commitment[0], index, note_hash_path));
 
     [nullifier[0], receiver_note_commitment[0]]
 }

--- a/noir_stdlib/src/merkle.nr
+++ b/noir_stdlib/src/merkle.nr
@@ -1,19 +1,9 @@
 // Regular merkle tree means a append-only merkle tree (Explain why this is the only way to have privacy and alternatives if you don't want it)
-
-// Returns one if the leaf is in the tree 
-// and it is at the given index 
-// and the hashpath proves this
 // Currently we assume that it is a binary tree, so depth k implies a width of 2^k
 // XXX: In the future we can add an arity parameter
-fn check_membership(_root : Field, _leaf : Field, _index : Field, _hash_path: [Field]) -> bool {
-    compute_merkle_root(_leaf, _index, _hash_path) == _root
-}
 
-#[foreign(compute_merkle_root)]
-fn compute_merkle_root(_leaf : Field, _index : Field, _hash_path: [Field]) -> Field {}
-
-// Returns the root of the tree from the provided leaf and its hashpath, using pedersen hash
-fn compute_root_from_leaf(leaf : Field, index : Field, hash_path: [Field]) -> Field {
+// Returns the merkle root of the tree from the provided leaf, its hashpath, using a pedersen hash function.
+fn compute_merkle_root(leaf: Field, index: Field, hash_path: [Field]) -> Field {
     let n = hash_path.len();
     let index_bits = index.to_le_bits(n as u32);
     let mut current = leaf;


### PR DESCRIPTION
# Description

## Problem\*

Related to #1258 and https://github.com/noir-lang/acvm/issues/295

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR removes the unnecessary functions from the `merkle` module in the stdlib (`check_membership` and `compute_root_from_leaf`).

We no longer use the black box version of `compute_merkle_root` in preparation for the opcode being removed and just use the noir implementation (which has been shown to be more efficient anyway). `compute_root_from_leaf` is then removed/renamed to `compute_merkle_root`


## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
