### PR TITLE
chore(ssa refactor): Make abi generation completely deterministic in the function signature

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -59,7 +59,7 @@ pub fn experimental_create_circuit(
     let GeneratedAcir { current_witness_index, opcodes, return_witnesses } =
         optimize_into_acir(program);
 
-    let abi = gen_abi(func_sig, return_witnesses.clone());
+    let abi = gen_abi(func_sig);
     let public_abi = abi.clone().public_abi();
 
     let public_parameters =

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -55,15 +55,17 @@ impl Context {
         let dfg = &main_func.dfg;
         let entry_block = &dfg[main_func.entry_block()];
 
+        // The witnesses produced here should match the witnesses in the
+        // `Abi` struct, since the Abi is a mapping from main parameters
+        // and return type to witness indices.
         for param_id in entry_block.parameters() {
             self.convert_ssa_block_param(*param_id, dfg);
         }
+        self.convert_ssa_return(entry_block.terminator().unwrap(), dfg);
 
         for instruction_id in entry_block.instructions() {
             self.convert_ssa_instruction(*instruction_id, dfg);
         }
-
-        self.convert_ssa_return(entry_block.terminator().unwrap(), dfg);
 
         self.acir_context.finish()
     }
@@ -110,7 +112,8 @@ impl Context {
             _ => unreachable!("ICE: Program must have a singular return"),
         };
 
-        let is_return_unit_type = return_values.len() == 1 && dfg.type_of_value(return_values[0]) == Type::Unit;
+        let is_return_unit_type =
+            return_values.len() == 1 && dfg.type_of_value(return_values[0]) == Type::Unit;
         if is_return_unit_type {
             return;
         }


### PR DESCRIPTION
# Description

Related to #1425 -- This means that Abi generation is completely determinsitic in the function signature. Instead of the return witnesses depending on the body of main.

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
