### PR TITLE
chore(ssa refactor) : Research on region labelling [DO NOT MERGE]

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -43,6 +43,7 @@ pub(crate) fn optimize_into_acir(program: Program) -> GeneratedAcir {
         .mem2reg()
         .print("After Mem2Reg:")
         .into_acir(func_signature)
+        .print_acir()
 }
 
 /// Compiles the Program into ACIR and applies optimizations to the arithmetic gates
@@ -56,7 +57,7 @@ pub fn experimental_create_circuit(
     _show_output: bool,
 ) -> Result<(Circuit, Abi), RuntimeError> {
     let func_sig = program.main_function_signature.clone();
-    let GeneratedAcir { current_witness_index, opcodes, return_witnesses } =
+    let GeneratedAcir { current_witness_index, opcodes, return_witnesses, .. } =
         optimize_into_acir(program);
 
     let abi = gen_abi(func_sig, return_witnesses.clone());

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -28,7 +28,7 @@ pub(crate) struct AcirContext {
     /// For example, If one was to add two Variables together,
     /// then the `acir_ir` will be populated to assert this
     /// addition.
-    acir_ir: GeneratedAcir,
+    pub(crate) acir_ir: GeneratedAcir,
 }
 
 impl AcirContext {

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -92,6 +92,7 @@ impl Context {
     /// Converts an SSA instruction into its ACIR representation
     fn convert_ssa_instruction(&mut self, instruction_id: InstructionId, dfg: &DataFlowGraph) {
         let instruction = &dfg[instruction_id];
+        self.acir_context.acir_ir.start_region_label(format!("{instruction:?}"));
         match instruction {
             Instruction::Binary(binary) => {
                 let result_acir_var = self.convert_ssa_binary(binary, dfg);
@@ -101,6 +102,7 @@ impl Context {
             }
             _ => todo!(),
         }
+        self.acir_context.acir_ir.end_label();
     }
 
     /// Converts an SSA terminator's return values into their ACIR representations
@@ -110,7 +112,8 @@ impl Context {
             _ => unreachable!("ICE: Program must have a singular return"),
         };
 
-        let is_return_unit_type = return_values.len() == 1 && dfg.type_of_value(return_values[0]) == Type::Unit;
+        let is_return_unit_type =
+            return_values.len() == 1 && dfg.type_of_value(return_values[0]) == Type::Unit;
         if is_return_unit_type {
             return;
         }


### PR DESCRIPTION
# Description

In this PR I was attempting to add region labelling to the ACIR code, which would allow us to print the GeneratedACIR and it will tell us what SSA instruction created it.

The main problem seems to be that opcodes are laid down lazilly so an add instruction won't necessarilly create an ACIR opcode.  See #1427 for more detail.

Here is an example program:

```
fn main(x : Field, y : pub Field) -> pub Field {
    let z = x + x;
    let t = z - y;
    z / t
}
```

The code will output:

```
region start: Binary(Binary { lhs: Id(0), rhs: Id(0), operator: Add })
region start: Binary(Binary { lhs: Id(2), rhs: Id(1), operator: Sub })
region start: Binary(Binary { lhs: Id(2), rhs: Id(3), operator: Div })
OPCODE : EXPR [ (2, _1) (-1, _2) (-1, _3) 0 ]
region end: Binary(Binary { lhs: Id(0), rhs: Id(0), operator: Add })
region end: Binary(Binary { lhs: Id(2), rhs: Id(1), operator: Sub })
OPCODE : DIR::INVERT (_3, out: _4) 
OPCODE : EXPR [ (2, _1) (-1, _2) (-1, _5) 0 ]
OPCODE : EXPR [ (1, _4, _5) -1 ]
OPCODE : EXPR [ (2, _1) (-1, _6) 0 ]
OPCODE : EXPR [ (1, _4, _6) (-1, _7) 0 ]
region end: Binary(Binary { lhs: Id(2), rhs: Id(3), operator: Div })
```

You can ignore the fact that we are not printing the ssa IR instructions properly. Due to not every SSA IR instruction mapping to an opcode, the region start of each instruction is grouped together unfortunately.

The region_end lines map more closely to what is actually happening, ie:

```
OPCODE : EXPR [ (2, _1) (-1, _2) (-1, _3) 0 ]
region end: Binary(Binary { lhs: Id(0), rhs: Id(0), operator: Add })
region end: Binary(Binary { lhs: Id(2), rhs: Id(1), operator: Sub })
```

This is the region for add and sub, two ssa ir instructions produced one ACIR opcode.

```
OPCODE : DIR::INVERT (_3, out: _4) 
OPCODE : EXPR [ (2, _1) (-1, _2) (-1, _5) 0 ]
OPCODE : EXPR [ (1, _4, _5) -1 ]
OPCODE : EXPR [ (2, _1) (-1, _6) 0 ]
OPCODE : EXPR [ (1, _4, _6) (-1, _7) 0 ]
region end: Binary(Binary { lhs: Id(2), rhs: Id(3), operator: Div })
```

This is the region for div, one ssa div instruction produced five acir opcodes
