### PR TITLE
chore(ssa refactor): range constraints for integer params to main

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -9,7 +9,7 @@ use super::{
         dfg::DataFlowGraph,
         instruction::{Binary, BinaryOp, Instruction, InstructionId, TerminatorInstruction},
         map::Id,
-        types::Type,
+        types::{NumericType, Type},
         value::{Value, ValueId},
     },
     ssa_gen::Ssa,
@@ -76,8 +76,14 @@ impl Context {
             _ => unreachable!("ICE: Only Param type values should appear in block parameters"),
         };
         match param_type {
-            Type::Numeric(..) => {
+            Type::Numeric(numeric_type) => {
                 let acir_var = self.acir_context.add_variable();
+                if matches!(numeric_type, NumericType::Signed { .. } | NumericType::Unsigned { .. })
+                {
+                    self.acir_context
+                        .numeric_cast_var(acir_var, &numeric_type)
+                        .expect("invalid range constraint was applied {numeric_type}");
+                }
                 self.ssa_value_to_acir_var.insert(param_id, acir_var);
             }
             Type::Reference => {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

Automatically add range constraints for integers found in the parameters to main

### Example

```rs
fn main(x : u8) -> pub u8 {
    x
}
```

produces:

```
current witness index : 2
public parameters indices : []
return value indices : [1]
BLACKBOX::RANGE [(_1, num_bits: 8)] [ ]
```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
