### PR TITLE
chore(docs): Replace instructions that exist on the website with link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,69 +53,13 @@ Concretely the following items are on the road map:
 - Recursion
 - Big integers
 
-## Nargo CLI - pre-built
-
-`nargo` - command line interface tool for interacting with Noir programs - allows compiling, proving, verifying, and more. Nightly binary builds can be found [here](https://github.com/noir-lang/noir/releases/tag/nightly). Please refer [noir-lang/build-nargo](https://github.com/noir-lang/build-nargo) to inspect how these are built for various platforms.
-
-## Nargo CLI - install scripts
-
-[noir-lang/noirup](https://github.com/noir-lang/noirup) repository contains install scripts for Linux, macOS, and Windows systems to allow easy installation.
-
 ## Minimum Rust version
 
 This crate's minimum supported rustc version is 1.66.0.
 
 ## Working on this project
 
-Due to the large number of native dependencies, this project uses [Nix](https://nixos.org/) and [direnv](https://direnv.net/) to streamline the development experience.
-
-### Setting up your environment
-
-For the best experience, please follow these instructions to setup your environment:
-1. Install Nix following [their guide](https://nixos.org/download.html) for your operating system
-2. Create the file `~/.config/nix/nix.conf` with the contents:
-```ini
-experimental-features = nix-command
-extra-experimental-features = flakes
-```
-3. Install direnv into your Nix profile by running:
-```sh
-nix profile install nixpkgs#direnv
-```
-4. Add direnv to your shell following [their guide](https://direnv.net/docs/hook.html)
-5. Restart your shell
-
-### Shell & editor experience
-
-Now that your environment is set up, you can get to work on the project.
-
-1. Clone the repository, such as:
-```sh
-git clone git@github.com:noir-lang/noir
-```
-2. Navigate to the directory:
-```sh
-cd noir
-```
-3. You should see a __direnv error__ because projects aren't allowed by default. Make sure you've reviewed and trust our `.envrc` file, then you need to run:
-```sh
-direnv allow
-```
-4. Now, wait awhile for all the native dependencies to be built. This will take some time and direnv will warn you that it is taking a long time, but we just need to let it run.
-5. Once you are presented with your prompt again, you can start your editor within the project directory (we recommend [VSCode](https://code.visualstudio.com/)):
-```sh
-code .
-```
-6. (Recommended) When launching VSCode for the first time, you should be prompted to install our recommended plugins. We highly recommend installing these for the best development experience.
-
-### Building and testing
-
-Assuming you are using `direnv` to populate your environment, building and testing the project can be done
-with the typical `cargo build`, `cargo test`, and `cargo clippy` commands. You'll notice that the `cargo` version matches the version we specify in [flake.nix](./flake.nix), which is 1.66.0 at the time of this writing.
-
-If you want to build the entire project in an isolated sandbox, you can use Nix commands:
-1. `nix build .` (or `nix build . -L` for verbose output) to build the project in a Nix sandbox
-2. `nix flake check` (or `nix flake check -L` for verbose output) to run clippy and tests in a Nix sandbox
+This project uses [Nix](https://nixos.org/) and [direnv](https://direnv.net/) to streamline the development experience. Please follow [our guidelines](https://noir-lang.org/getting_started/nargo_installation/#option-4-compile-from-source) to setup your environment for working on the project.
 
 ### Building against a different local/remote version of Barretenberg
 
@@ -132,13 +76,6 @@ nix flake lock --override-input barretenberg github:username/barretenberg/branch
 ```
 
 __Note:__ You don't want to commit the updated lockfile, as it will fail in CI!
-
-### Without direnv
-
-If you have hesitations with using `direnv`, you can launch a subshell with `nix develop` and then launch your editor
-from within the subshell. However, if VSCode was already launched in the project directory, the environment won't be updated.
-
-__Advanced:__ If you aren't using `direnv` nor launching your editor within the subshell, you can try to install Barretenberg and other global dependencies the package needs. This is an advanced workflow and likely won't receive support!
 
 ## License
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #1199 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This removes the documentation from the readme about building from source and instead links to that documentation on the website.

I also removed the information about nargo because that's on the website too and linked higher up in the readme.

Depends upon my changes in noir-lang/docs#170 

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
