### PR TITLE
chore: Revert "chore(ssa refactor): Make mapping from the instruction results to AcirVar more explicit/mandatory"

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -98,31 +98,24 @@ impl Context {
     /// Converts an SSA instruction into its ACIR representation
     fn convert_ssa_instruction(&mut self, instruction_id: InstructionId, dfg: &DataFlowGraph) {
         let instruction = &dfg[instruction_id];
-
-        let (results_id, results_vars) = match instruction {
+        match instruction {
             Instruction::Binary(binary) => {
                 let result_acir_var = self.convert_ssa_binary(binary, dfg);
                 let result_ids = dfg.instruction_results(instruction_id);
                 assert_eq!(result_ids.len(), 1, "Binary ops have a single result");
-                (vec![result_ids[0]], vec![result_acir_var])
+                self.ssa_value_to_acir_var.insert(result_ids[0], result_acir_var);
             }
             Instruction::Constrain(value_id) => {
                 let constrain_condition = self.convert_ssa_value(*value_id, dfg);
                 self.acir_context.assert_eq_one(constrain_condition);
-                (Vec::new(), Vec::new())
             }
             Instruction::Cast(value_id, typ) => {
                 let result_acir_var = self.convert_ssa_cast(value_id, typ, dfg);
                 let result_ids = dfg.instruction_results(instruction_id);
                 assert_eq!(result_ids.len(), 1, "Cast ops have a single result");
-                (vec![result_ids[0]], vec![result_acir_var])
+                self.ssa_value_to_acir_var.insert(result_ids[0], result_acir_var);
             }
             _ => todo!("{instruction:?}"),
-        };
-
-        // Map the results of the instructions to Acir variables
-        for (result_id, result_var) in results_id.into_iter().zip(results_vars) {
-            self.ssa_value_to_acir_var.insert(result_id, result_var);
         }
     }
 


### PR DESCRIPTION
Reverts noir-lang/noir#1436

Very weird that this is breaking the CI