### PR TITLE
feat: multiple item imports in use statement

### DIFF
--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -253,7 +253,7 @@ impl ParsedModule {
     }
 
     fn push_import(&mut self, import_stmt: UseTree) {
-        self.imports.extend(import_stmt.desugar());
+        self.imports.extend(import_stmt.desugar(None));
     }
 
     fn push_module_decl(&mut self, mod_name: Ident) {
@@ -446,7 +446,7 @@ impl std::fmt::Display for TopLevelStatement {
         match self {
             TopLevelStatement::Function(fun) => fun.fmt(f),
             TopLevelStatement::Module(m) => write!(f, "mod {m}"),
-            TopLevelStatement::Import(i) => i.fmt(f),
+            TopLevelStatement::Import(tree) => write!(f, "use {tree}"),
             TopLevelStatement::Struct(s) => s.fmt(f),
             TopLevelStatement::Impl(i) => i.fmt(f),
             TopLevelStatement::SubModule(s) => s.fmt(f),

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -18,7 +18,7 @@ use crate::{ast::ImportStatement, Expression, NoirStruct};
 use crate::{
     BlockExpression, ExpressionKind, ForExpression, Ident, IndexExpression, LetStatement,
     MethodCallExpression, NoirFunction, NoirImpl, Path, PathKind, Pattern, Recoverable, Statement,
-    UnresolvedType,
+    UnresolvedType, UseTree,
 };
 
 use acvm::FieldElement;
@@ -38,7 +38,7 @@ static UNIQUE_NAME_COUNTER: AtomicU32 = AtomicU32::new(0);
 pub(crate) enum TopLevelStatement {
     Function(NoirFunction),
     Module(Ident),
-    Import(ImportStatement),
+    Import(UseTree),
     Struct(NoirStruct),
     Impl(NoirImpl),
     SubModule(SubModule),
@@ -252,8 +252,8 @@ impl ParsedModule {
         self.impls.push(r#impl);
     }
 
-    fn push_import(&mut self, import_stmt: ImportStatement) {
-        self.imports.push(import_stmt);
+    fn push_import(&mut self, import_stmt: UseTree) {
+        self.imports.extend(import_stmt.desugar());
     }
 
     fn push_module_decl(&mut self, mod_name: Ident) {

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -446,6 +446,7 @@ fn use_tree() -> impl NoirParser<UseTree> {
             let prefix = path().then_ignore(just(Token::DoubleColon));
             let tree = use_tree
                 .separated_by(just(Token::Comma))
+                .allow_trailing()
                 .delimited_by(just(Token::LeftBrace), just(Token::RightBrace))
                 .map(UseTreeKind::List);
 
@@ -1537,6 +1538,8 @@ mod test {
                 "use std",
                 "use foo::bar as hello",
                 "use bar as bar",
+                "use foo::{}",
+                "use foo::{bar,}",
                 "use foo::{bar, hello}",
                 "use foo::{bar as bar2, hello}",
                 "use foo::{bar as bar2, hello::{foo}, nested::{foo, bar}}",
@@ -1551,6 +1554,7 @@ mod test {
                 "use hello:: as foo;",
                 "use foo bar::baz",
                 "use foo bar::{baz}",
+                "use foo::{,}",
             ],
         );
     }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -433,9 +433,7 @@ fn path() -> impl NoirParser<Path> {
 
 fn empty_path() -> impl NoirParser<Path> {
     let make_path = |kind| move |_| Path { segments: Vec::new(), kind };
-
-    let prefix = |key| keyword(key);
-    let path_kind = |key, kind| prefix(key).map(make_path(kind));
+    let path_kind = |key, kind| keyword(key).map(make_path(kind));
 
     choice((path_kind(Keyword::Crate, PathKind::Crate), path_kind(Keyword::Dep, PathKind::Dep)))
 }


### PR DESCRIPTION
# Description

Implement multiple item imports in use statement: `use foo::{bar, hello}`.

## Summary

Added support for multiple item imports in the use statement, allowing for more flexible and targeted module imports. Updated the parser, AST, and desugaring logic to handle the new syntax.

## Additional Context

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
