### PR TITLE
chore(ssa refactor): blackbox array arg support

### DIFF
--- a/crates/nargo_cli/tests/test_data_ssa_refactor/blackbox_func_simple_call/src/main.nr
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/blackbox_func_simple_call/src/main.nr
@@ -1,7 +1,9 @@
 // The feature being tested is a call
 // to a black box function.
+// One with array input, one with a numeric input.
 use dep::std;
 
 fn main(x: Field) {
-    std::scalar_mul::fixed_base(x);
+    let _p1 = std::scalar_mul::fixed_base(x);
+    let _p2 = std::hash::pedersen([x]);
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -16,13 +16,6 @@ use acvm::{
 use iter_extended::vecmap;
 use std::{borrow::Cow, collections::HashMap, hash::Hash};
 
-/// Arguments to blackbox function can be either numerics or arrays. When constructing the input
-/// to a blackbox this enum is used to distinguish between the two.
-pub(crate) enum BlackboxArg {
-    AcirVar(AcirVar),
-    ArrayId(ArrayId),
-}
-
 #[derive(Debug, Default)]
 /// Context object which holds the relationship between
 /// `Variables`(AcirVar) and types such as `Expression` and `Witness`
@@ -148,10 +141,7 @@ impl AcirContext {
             .expect("ICE: XOR applied to field type, this should be caught by the type system");
         assert_eq!(lhs_bit_size, rhs_bit_size, "ICE: Operands to XOR require equal bit size");
 
-        let outputs = self.black_box_function(
-            BlackBoxFunc::XOR,
-            vec![BlackboxArg::AcirVar(lhs), BlackboxArg::AcirVar(rhs)],
-        )?;
+        let outputs = self.black_box_function(BlackBoxFunc::XOR, vec![lhs, rhs])?;
         let result = outputs[0];
         self.variables_to_bit_sizes.insert(result, lhs_bit_size);
         Ok(result)
@@ -169,10 +159,7 @@ impl AcirContext {
             .expect("ICE: AND applied to field type, this should be caught by the type system");
         assert_eq!(lhs_bit_size, rhs_bit_size, "ICE: Operands to AND require equal bit size");
 
-        let outputs = self.black_box_function(
-            BlackBoxFunc::AND,
-            vec![BlackboxArg::AcirVar(lhs), BlackboxArg::AcirVar(rhs)],
-        )?;
+        let outputs = self.black_box_function(BlackBoxFunc::AND, vec![lhs, rhs])?;
         let result = outputs[0];
         self.variables_to_bit_sizes.insert(result, lhs_bit_size);
         Ok(result)
@@ -208,10 +195,7 @@ impl AcirContext {
             // infers them correctly.
             self.variables_to_bit_sizes.insert(a, bit_size);
             self.variables_to_bit_sizes.insert(b, bit_size);
-            let output = self.black_box_function(
-                BlackBoxFunc::AND,
-                vec![BlackboxArg::AcirVar(a), BlackboxArg::AcirVar(b)],
-            )?;
+            let output = self.black_box_function(BlackBoxFunc::AND, vec![a, b])?;
             self.sub_var(max, output[0])
         };
         self.variables_to_bit_sizes.insert(result, bit_size);
@@ -459,7 +443,7 @@ impl AcirContext {
     pub(crate) fn black_box_function(
         &mut self,
         name: BlackBoxFunc,
-        inputs: Vec<BlackboxArg>,
+        inputs: Vec<AcirVar>,
     ) -> Result<Vec<AcirVar>, AcirGenError> {
         // Convert `AcirVar` to `FunctionInput`
         let inputs = self.prepare_inputs_for_black_box_func_call(&inputs)?;
@@ -478,78 +462,58 @@ impl AcirContext {
         Ok(outputs_var)
     }
 
-    /// Flattens the blackbox call's argument list and prepares the flattened list elements into
-    /// the `FunctionInput` format.
-    fn prepare_inputs_for_black_box_func_call(
-        &mut self,
-        arguments: &[BlackboxArg],
-    ) -> Result<Vec<FunctionInput>, AcirGenError> {
-        let mut witnesses = Vec::new();
-        for arg in arguments {
-            match arg {
-                BlackboxArg::AcirVar(acir_var) => {
-                    witnesses.push(self.prepare_input_element_for_black_box_func_call(acir_var)?);
-                }
-                BlackboxArg::ArrayId(array_id) => {
-                    for acir_var in self.memory.constant_get_all(*array_id)? {
-                        witnesses
-                            .push(self.prepare_input_element_for_black_box_func_call(&acir_var)?);
-                    }
-                }
-            }
-        }
-        Ok(witnesses)
-    }
-
     /// Black box function calls expect their inputs to be in a specific data structure (FunctionInput).
     ///
     /// This function will convert `AcirVar` into `FunctionInput` for a blackbox function call.
-    fn prepare_input_element_for_black_box_func_call(
+    fn prepare_inputs_for_black_box_func_call(
         &mut self,
-        input: &AcirVar,
-    ) -> Result<FunctionInput, AcirGenError> {
-        let var_data = &self.data[input];
+        inputs: &[AcirVar],
+    ) -> Result<Vec<FunctionInput>, AcirGenError> {
+        let mut witnesses = Vec::new();
+        for input in inputs {
+            let var_data = &self.data[input];
 
-        // Intrinsics only accept Witnesses. This is not a limitation of the
-        // intrinsics, its just how we have defined things. Ideally, we allow
-        // constants too.
-        let expr = var_data.to_expression();
-        let witness = self.acir_ir.get_or_create_witness(&expr);
+            // Intrinsics only accept Witnesses. This is not a limitation of the
+            // intrinsics, its just how we have defined things. Ideally, we allow
+            // constants too.
+            let expr = var_data.to_expression();
+            let witness = self.acir_ir.get_or_create_witness(&expr);
 
-        // Fetch the number of bits for this variable
-        // If it has never been constrained before, then we will
-        // encounter None, and so we take the max number of bits for a
-        // field element.
-        let num_bits = match self.variables_to_bit_sizes.get(input) {
-            Some(bits) => {
-                // In Noir, we specify the number of bits to take from the input
-                // by doing the following:
-                //
-                // ```
-                // call_intrinsic(x as u8)
-                // ```
-                //
-                // The `as u8` specifies that we want to take 8 bits from the `x`
-                // variable.
-                //
-                // There were discussions about the SSA IR optimizing out range
-                // constraints. We would want to be careful with it here. For example:
-                //
-                // ```
-                // let x : u32 = y as u32
-                // call_intrinsic(x as u64)
-                // ```
-                // The `x as u64` is redundant since we know that `x` fits within a u32.
-                // However, since the `x as u64` line is being used to tell the intrinsic
-                // to take 64 bits, we cannot remove it.
+            // Fetch the number of bits for this variable
+            // If it has never been constrained before, then we will
+            // encounter None, and so we take the max number of bits for a
+            // field element.
+            let num_bits = match self.variables_to_bit_sizes.get(input) {
+                Some(bits) => {
+                    // In Noir, we specify the number of bits to take from the input
+                    // by doing the following:
+                    //
+                    // ```
+                    // call_intrinsic(x as u8)
+                    // ```
+                    //
+                    // The `as u8` specifies that we want to take 8 bits from the `x`
+                    // variable.
+                    //
+                    // There were discussions about the SSA IR optimizing out range
+                    // constraints. We would want to be careful with it here. For example:
+                    //
+                    // ```
+                    // let x : u32 = y as u32
+                    // call_intrinsic(x as u64)
+                    // ```
+                    // The `x as u64` is redundant since we know that `x` fits within a u32.
+                    // However, since the `x as u64` line is being used to tell the intrinsic
+                    // to take 64 bits, we cannot remove it.
 
-                *bits
-            }
-            None => FieldElement::max_num_bits(),
-        };
+                    *bits
+                }
+                None => FieldElement::max_num_bits(),
+            };
 
-        let witness = FunctionInput { witness, num_bits };
-        Ok(witness)
+            witnesses.push(FunctionInput { witness, num_bits });
+        }
+        Ok(witnesses)
     }
 
     /// Terminates the context and takes the resulting `GeneratedAcir`
@@ -581,6 +545,16 @@ impl AcirContext {
         index: usize,
     ) -> Result<AcirVar, AcirGenError> {
         self.memory.constant_get(array_id, index)
+    }
+
+    /// Gets all `AcirVar` elements currently stored at the array.
+    ///
+    /// This errors if nothing was previously stored any element in the array.
+    pub(crate) fn array_load_all(
+        &mut self,
+        array_id: ArrayId,
+    ) -> Result<Vec<AcirVar>, AcirGenError> {
+        self.memory.constant_get_all(array_id)
     }
 
     /// Adds `Data` into the context and assigns it a Variable.

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -148,7 +148,10 @@ impl AcirContext {
             .expect("ICE: XOR applied to field type, this should be caught by the type system");
         assert_eq!(lhs_bit_size, rhs_bit_size, "ICE: Operands to XOR require equal bit size");
 
-        let outputs = self.black_box_function(BlackBoxFunc::XOR, vec![lhs, rhs])?;
+        let outputs = self.black_box_function(
+            BlackBoxFunc::XOR,
+            vec![BlackboxArg::AcirVar(lhs), BlackboxArg::AcirVar(rhs)],
+        )?;
         let result = outputs[0];
         self.variables_to_bit_sizes.insert(result, lhs_bit_size);
         Ok(result)
@@ -166,7 +169,10 @@ impl AcirContext {
             .expect("ICE: AND applied to field type, this should be caught by the type system");
         assert_eq!(lhs_bit_size, rhs_bit_size, "ICE: Operands to AND require equal bit size");
 
-        let outputs = self.black_box_function(BlackBoxFunc::AND, vec![lhs, rhs])?;
+        let outputs = self.black_box_function(
+            BlackBoxFunc::AND,
+            vec![BlackboxArg::AcirVar(lhs), BlackboxArg::AcirVar(rhs)],
+        )?;
         let result = outputs[0];
         self.variables_to_bit_sizes.insert(result, lhs_bit_size);
         Ok(result)
@@ -202,7 +208,10 @@ impl AcirContext {
             // infers them correctly.
             self.variables_to_bit_sizes.insert(a, bit_size);
             self.variables_to_bit_sizes.insert(b, bit_size);
-            let output = self.black_box_function(BlackBoxFunc::AND, vec![a, b])?;
+            let output = self.black_box_function(
+                BlackBoxFunc::AND,
+                vec![BlackboxArg::AcirVar(a), BlackboxArg::AcirVar(b)],
+            )?;
             self.sub_var(max, output[0])
         };
         self.variables_to_bit_sizes.insert(result, bit_size);

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/memory.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/memory.rs
@@ -65,6 +65,18 @@ impl Memory {
         array.elements[index].ok_or(AcirGenError::UninitializedElementInArray { index, array_id })
     }
 
+    /// Gets all elements at the array that `ArrayId` points to.
+    ///
+    /// This requires all elements of the array to have been initialized.
+    pub(crate) fn constant_get_all(&self, array_id: ArrayId) -> Result<Vec<AcirVar>, AcirGenError> {
+        let array = &self.arrays[array_id];
+        let mut elements = Vec::new();
+        for index in 0..array.size() {
+            elements.push(self.constant_get(array_id, index)?);
+        }
+        Ok(elements)
+    }
+
     /// Check if the index is larger than the array size
     fn check_bounds(index: usize, array_size: usize) -> Result<(), AcirGenError> {
         if index < array_size {

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/memory.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/memory.rs
@@ -67,7 +67,7 @@ impl Memory {
 
     /// Gets all elements at the array that `ArrayId` points to.
     ///
-    /// This requires all elements of the array to have been initialized.
+    /// This returns an error if any of the array's elements have not been initialized.
     pub(crate) fn constant_get_all(&self, array_id: ArrayId) -> Result<Vec<AcirVar>, AcirGenError> {
         let array = &self.arrays[array_id];
         let mut elements = Vec::new();

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -184,7 +184,7 @@ impl Context {
                 (vec![result_ids[0]], vec![result_acir_var])
             }
             Instruction::Call { func, arguments } => {
-                let outputs = self.convert_ssa_call(*func, arguments, dfg);
+                let outputs = self.convert_ssa_intrinsic_call(*func, arguments, dfg);
                 let result_ids = dfg.instruction_results(instruction_id);
                 (result_ids.to_vec(), outputs)
             }
@@ -325,10 +325,10 @@ impl Context {
         }
     }
 
-    /// Returns the a vector of `AcirVar`s constrained to be result of the function call.
+    /// Returns a vector of `AcirVar`s constrained to be result of the function call.
     ///
     /// The function being called is required to be intrinsic.
-    fn convert_ssa_call(
+    fn convert_ssa_intrinsic_call(
         &mut self,
         func: ValueId,
         arguments: &[ValueId],
@@ -346,7 +346,7 @@ impl Context {
                     .ssa_value_to_array_address
                     .get(value_id)
                     .expect("ICE: Call argument of undeclared array");
-                assert_eq!(index, &0, "ICE: Call arguments only accept arrays in their entirety");
+                assert_eq!(*index, 0, "ICE: Call arguments only accept arrays in their entirety");
                 let elements = self
                     .acir_context
                     .array_load_all(*array_id)


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

ACIR gen didn't support array arguments to black boxes

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

`acir_gen/mod` Forwards blackbox arguments to `acir_variable` as a mix of `AcirVar` and `ArrayIds`. `acir_variable` they take responsibility for rationalising the arguments

### Example

```rs
use dep::std;

fn main(x: Field) {
    let _p1 = std::scalar_mul::fixed_base(x);
    let _p2 = std::hash::pedersen([x]);
}
```

compiles to

```
current witness index : 6
public parameters indices : []
return value indices : []
BLACKBOX::FIXED_BASE_SCALAR_MUL [(_1, num_bits: 254)] [ _2, _3]
BLACKBOX::PEDERSEN [(_1, num_bits: 254)] [ _4, _5]
```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
