### PR TITLE
chore(ssa refactor): Remove dead blackboxes and handle pedersen domain separator

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -496,23 +496,9 @@ impl AcirContext {
                     .expect("ICE: Domain separator must be a constant");
                 vec![domain_constant]
             }
-            BlackBoxFunc::Keccak256 => {
-                // There are two variants of Keccak256 - one for fixed length inputs and one for
-                // variable length inputs. Whether or not the last argument (corresponding to
-                // `message_size` in the stdlib) is a constant determines which variant is used.
-                // If it's not a constant, we'll leave it at the end of the input list to be
-                // ingested as a `FunctionInput`.
-                let message_size_var =
-                    inputs.pop().expect("ICE: Keccak expects a message_size arg");
-                if let AcirVarData::Const(constant) = self.data[&message_size_var] {
-                    vec![constant]
-                } else {
-                    inputs.push(message_size_var);
-                    vec![]
-                }
-            }
             _ => vec![],
         };
+
         // Convert `AcirVar` to `FunctionInput`
         let inputs = self.prepare_inputs_for_black_box_func_call(&inputs)?;
 

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -496,6 +496,21 @@ impl AcirContext {
                     .expect("ICE: Domain separator must be a constant");
                 vec![domain_constant]
             }
+            BlackBoxFunc::Keccak256 => {
+                // There are two variants of Keccak256 - one for fixed length inputs and one for
+                // variable length inputs. Whether or not the last argument (corresponding to
+                // `message_size` in the stdlib) is a constant determines which variant is used.
+                // If it's not a constant, we'll leave it at the end of the input list to be
+                // ingested as a `FunctionInput`.
+                let message_size_var =
+                    inputs.pop().expect("ICE: Keccak expects a message_size arg");
+                if let AcirVarData::Const(constant) = self.data[&message_size_var] {
+                    vec![constant]
+                } else {
+                    inputs.push(message_size_var);
+                    vec![]
+                }
+            }
             _ => vec![],
         };
         // Convert `AcirVar` to `FunctionInput`

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -91,7 +91,7 @@ impl GeneratedAcir {
     pub(crate) fn call_black_box(
         &mut self,
         func_name: BlackBoxFunc,
-        inputs: Vec<FunctionInput>,
+        mut inputs: Vec<FunctionInput>,
         constants: Vec<FieldElement>,
     ) -> Vec<Witness> {
         intrinsics_check_inputs(func_name, &inputs);
@@ -141,7 +141,10 @@ impl GeneratedAcir {
             BlackBoxFunc::FixedBaseScalarMul => {
                 BlackBoxFuncCall::FixedBaseScalarMul { input: inputs[0], outputs }
             }
-            BlackBoxFunc::Keccak256 => BlackBoxFuncCall::Keccak256 { inputs, outputs },
+            BlackBoxFunc::Keccak256 => {
+                let var_message_size = inputs.pop().expect("ICE: Missing message_size arg");
+                BlackBoxFuncCall::Keccak256VariableLength { inputs, var_message_size, outputs }
+            }
         };
 
         self.opcodes.push(AcirOpcode::BlackBoxFuncCall(black_box_func_call));

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -142,21 +142,8 @@ impl GeneratedAcir {
                 BlackBoxFuncCall::FixedBaseScalarMul { input: inputs[0], outputs }
             }
             BlackBoxFunc::Keccak256 => {
-                if constants.len() == 1 {
-                    // This constant has been separated from the other arguments to represent the
-                    // `message_size`, and therefore what remains in the arguments is the message.
-                    let message_size = constants[0].to_u128() as usize;
-                    assert_eq!(
-                        inputs.len(),
-                        message_size,
-                        "ICE: Expected keccak256 message size does not match input"
-                    );
-                    BlackBoxFuncCall::Keccak256 { inputs, outputs }
-                } else {
-                    // The final argument wasn't separated as a constant so needs separating now.
-                    let var_message_size = inputs.pop().expect("ICE: Missing message_size arg");
-                    BlackBoxFuncCall::Keccak256VariableLength { inputs, var_message_size, outputs }
-                }
+                let var_message_size = inputs.pop().expect("ICE: Missing message_size arg");
+                BlackBoxFuncCall::Keccak256VariableLength { inputs, var_message_size, outputs }
             }
         };
 


### PR DESCRIPTION

# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->


## Summary\*

Unbreaks #1475 by removing AES and ComputeMerkleRoot, and by handling pedersen domain separators.

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->


## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
