### PR TITLE
chore: `sort_by_key` -> `sort_by_key_ref` to avoid an extraneous clone

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -427,10 +427,10 @@ impl<'interner> TypeChecker<'interner> {
         // Note that we use a Vec to store the original arguments (rather than a BTreeMap) to
         // preserve the evaluation order of the source code.
         let mut args = constructor.fields;
-        args.sort_by_key(|(name, _)| name.clone());
+        sort_by_key_ref(&mut args, |(name, _)| name);
 
         let mut fields = typ.borrow().get_fields(&generics);
-        fields.sort_by_key(|(name, _)| name.clone());
+        sort_by_key_ref(&mut fields, |(name, _)| name);
 
         for ((param_name, param_type), (arg_ident, arg)) in fields.into_iter().zip(args) {
             // This can be false if the user provided an incorrect field count. That error should
@@ -838,4 +838,12 @@ fn prefix_operand_type_rules(op: &crate::UnaryOp, rhs_type: &Type) -> Result<Typ
         }
     }
     Ok(rhs_type.clone())
+}
+
+fn sort_by_key_ref<T, F, K>(xs: &mut [T], key: F)
+where
+    F: Fn(&T) -> &K,
+    K: ?Sized + Ord,
+{
+    xs.sort_by(|x, y| key(x).cmp(key(y)));
 }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -840,6 +840,7 @@ fn prefix_operand_type_rules(op: &crate::UnaryOp, rhs_type: &Type) -> Result<Typ
     Ok(rhs_type.clone())
 }
 
+/// Taken from: https://stackoverflow.com/a/47127500
 fn sort_by_key_ref<T, F, K>(xs: &mut [T], key: F)
 where
     F: Fn(&T) -> &K,


### PR DESCRIPTION
# Description
`sort_by_key` -> `sort_by_key_ref` to avoid an extraneous clone

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
