### PR TITLE
chore(ssa refactor): patch unsigned division and shift right algorithms

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -367,6 +367,48 @@ impl AcirContext {
         self.mul_var(lhs, two_pow_rhs_var)
     }
 
+    /// Returns the quotient and remainder such that lhs = rhs * quotient + remainder
+    fn euclidean_division_var(
+        &mut self,
+        lhs: AcirVar,
+        rhs: AcirVar,
+    ) -> Result<(AcirVar, AcirVar), AcirGenError> {
+        let predicate = Expression::one();
+
+        let lhs_data = &self.data[&lhs];
+        let rhs_data = &self.data[&rhs];
+
+        let lhs_expr = lhs_data.to_expression();
+        let rhs_expr = rhs_data.to_expression();
+
+        let lhs_bit_size = self.variables_to_bit_sizes.get(&lhs).expect("euclidean division cannot be made on variables with no known bit size. This should have been caught by the frontend");
+        let rhs_bit_size = self.variables_to_bit_sizes.get(&lhs).expect("euclidean division cannot be made on variables with no known bit size. This should have been caught by the frontend");
+
+        assert_eq!(
+            lhs_bit_size, rhs_bit_size,
+            // This makes the assumption that the bit size is the last known integer
+            // type for this variable and that we are not getting the smallest range for example.
+            "Euclidean division can only be applied to variables of the same type"
+        );
+
+        let (quotient, remainder) =
+            self.acir_ir.euclidean_division(&lhs_expr, &rhs_expr, *lhs_bit_size, &predicate)?;
+
+        let quotient_var = self.add_data(AcirVarData::Witness(quotient));
+        let remainder_var = self.add_data(AcirVarData::Witness(remainder));
+
+        Ok((quotient_var, remainder_var))
+    }
+
+    /// Returns a variable which is constrained to be `lhs mod rhs`
+    pub(crate) fn modulo_var(
+        &mut self,
+        lhs: AcirVar,
+        rhs: AcirVar,
+    ) -> Result<AcirVar, AcirGenError> {
+        let (_, remainder) = self.euclidean_division_var(lhs, rhs)?;
+        Ok(remainder)
+    }
     /// Returns an `AcirVar` that is constrained to be `lhs >> rhs`.
     ///
     /// We convert right shifts to divisions, so this is equivalent to

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -190,6 +190,151 @@ impl GeneratedAcir {
         Ok(limb_witnesses)
     }
 
+    /// Computes lhs/rhs by using euclidean division.
+    ///
+    /// Returns `q` for quotient and `r` for remainder such
+    /// that lhs = rhs * q + r
+    pub(crate) fn euclidean_division(
+        &mut self,
+        lhs: &Expression,
+        rhs: &Expression,
+        bit_size: u32,
+        predicate: &Expression,
+    ) -> Result<(Witness, Witness), AcirGenError> {
+        let q_witness = self.next_witness_index();
+        let r_witness = self.next_witness_index();
+
+        let pa = lhs * predicate;
+        self.push_opcode(AcirOpcode::Directive(Directive::Quotient(QuotientDirective {
+            a: lhs.clone(),
+            b: rhs.clone(),
+            q: q_witness,
+            r: r_witness,
+            predicate: Some(predicate.clone()),
+        })));
+
+        //r<b
+        let r_expr = Expression::from(r_witness);
+        self.range_constraint(r_witness, bit_size)?;
+        self.bound_constraint_with_offset(&r_expr, rhs, predicate, bit_size)?;
+        //range check q<=a
+        self.range_constraint(q_witness, bit_size)?;
+        // a-b*q-r = 0
+        let mut d = rhs * &Expression::from(q_witness);
+        d = &d + r_witness;
+        d = &d * predicate;
+        let div_euclidean = &pa - &d;
+
+        self.push_opcode(AcirOpcode::Arithmetic(div_euclidean));
+
+        Ok((q_witness, r_witness))
+    }
+
+    /// Generate constraints that are satisfied iff
+    /// a < b , when offset is 1, or
+    /// a <= b, when offset is 0
+    /// bits is the bit size of a and b (or an upper bound of the bit size)
+    ///
+    /// a<=b is done by constraining b-a to a bit size of 'bits':
+    /// if a<=b, 0 <= b-a <= b < 2^bits
+    /// if a>b, b-a = p+b-a > p-2^bits >= 2^bits  (if log(p) >= bits + 1)
+    /// n.b: we do NOT check here that a and b are indeed 'bits' size
+    /// a < b <=> a+1<=b
+    /// TODO: Consolidate this with bounds_check function.
+    fn bound_constraint_with_offset(
+        &mut self,
+        a: &Expression,
+        b: &Expression,
+        offset: &Expression,
+        bits: u32,
+    ) -> Result<(), AcirGenError> {
+        const fn num_bits<T>() -> usize {
+            std::mem::size_of::<T>() * 8
+        }
+
+        fn bit_size_u128(a: u128) -> u32 where {
+            num_bits::<u128>() as u32 - a.leading_zeros()
+        }
+
+        fn bit_size_u32(a: u32) -> u32 where {
+            num_bits::<u32>() as u32 - a.leading_zeros()
+        }
+
+        assert!(
+            bits < FieldElement::max_num_bits(),
+            "range check with bit size of the prime field is not implemented yet"
+        );
+
+        let mut aof = a + offset;
+
+        if b.is_const() && b.q_c.fits_in_u128() {
+            let f = if *offset == Expression::one() {
+                aof = a.clone();
+                assert!(b.q_c.to_u128() >= 1);
+                b.q_c.to_u128() - 1
+            } else {
+                b.q_c.to_u128()
+            };
+
+            if f < 3 {
+                match f {
+                    0 => self.push_opcode(AcirOpcode::Arithmetic(aof)),
+                    1 => {
+                        let expr = self.boolean_expr(&aof);
+                        self.push_opcode(AcirOpcode::Arithmetic(expr));
+                    }
+                    2 => {
+                        let aof_boolean_expr = self.boolean_expr(&aof);
+                        let y = self.expression_to_witness(&aof_boolean_expr);
+                        let neg_two = -FieldElement::from(2_i128);
+
+                        let aof_witness = self.expression_to_witness(&aof);
+                        let mut eee = Expression::default();
+                        eee.push_multiplication_term(FieldElement::one(), y, aof_witness);
+                        eee.push_addition_term(neg_two, y);
+
+                        self.push_opcode(AcirOpcode::Arithmetic(eee));
+                    }
+                    _ => unreachable!(),
+                }
+                return Ok(());
+            }
+            let bit_size = bit_size_u128(f);
+            if bit_size < 128 {
+                let r = (1_u128 << bit_size) - f - 1;
+                assert!(bits + bit_size < FieldElement::max_num_bits()); //we need to ensure a+r does not overflow
+
+                let mut aor = aof.clone();
+                aor.q_c += FieldElement::from(r);
+
+                let witness = self.expression_to_witness(&aor);
+                self.range_constraint(witness, bit_size)?;
+                return Ok(());
+            }
+        }
+
+        let sub_expression = b - &aof; //b-(a+offset)
+        let w = self.expression_to_witness(&sub_expression);
+        self.range_constraint(w, bits)?;
+
+        Ok(())
+    }
+
+    /// Computes the expression x(x-1)
+    ///
+    /// If the above is constrained to zero, then it can only be
+    /// true, iff x equals zero or one.
+    fn boolean_expr(&mut self, expr: &Expression) -> Expression {
+        let expr_as_witness = self.expression_to_witness(&expr);
+        let mut expr_squared = Expression::default();
+        expr_squared.push_multiplication_term(
+            FieldElement::one(),
+            expr_as_witness,
+            expr_as_witness,
+        );
+        &expr_squared - expr
+    }
+
     /// Adds a log directive to print the provided witnesses.
     ///
     /// Logging of strings is currently unsupported.

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -325,7 +325,7 @@ impl GeneratedAcir {
     /// If the above is constrained to zero, then it can only be
     /// true, iff x equals zero or one.
     fn boolean_expr(&mut self, expr: &Expression) -> Expression {
-        let expr_as_witness = self.expression_to_witness(&expr);
+        let expr_as_witness = self.expression_to_witness(expr);
         let mut expr_squared = Expression::default();
         expr_squared.push_multiplication_term(
             FieldElement::one(),

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -334,11 +334,15 @@ impl Context {
     fn convert_ssa_binary(&mut self, binary: &Binary, dfg: &DataFlowGraph) -> AcirVar {
         let lhs = self.convert_ssa_value(binary.lhs, dfg);
         let rhs = self.convert_ssa_value(binary.rhs, dfg);
+
         match binary.operator {
             BinaryOp::Add => self.acir_context.add_var(lhs, rhs),
             BinaryOp::Sub => self.acir_context.sub_var(lhs, rhs),
             BinaryOp::Mul => self.acir_context.mul_var(lhs, rhs),
-            BinaryOp::Div => self.acir_context.div_var(lhs, rhs),
+            BinaryOp::Div => self
+                .acir_context
+                .div_var(lhs, rhs)
+                .expect("add Result types to all methods so errors bubble up"),
             // Note: that this produces unnecessary constraints when
             // this Eq instruction is being used for a constrain statement
             BinaryOp::Eq => self.acir_context.eq_var(lhs, rhs),
@@ -347,7 +351,10 @@ impl Context {
                 .less_than_var(lhs, rhs)
                 .expect("add Result types to all methods so errors bubble up"),
             BinaryOp::Shl => self.acir_context.shift_left_var(lhs, rhs),
-            BinaryOp::Shr => self.acir_context.shift_right_var(lhs, rhs),
+            BinaryOp::Shr => self
+                .acir_context
+                .shift_right_var(lhs, rhs)
+                .expect("add Result types to all methods so errors bubble up"),
             BinaryOp::Xor => self
                 .acir_context
                 .xor_var(lhs, rhs)

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -360,7 +360,10 @@ impl Context {
                 .acir_context
                 .or_var(lhs, rhs)
                 .expect("add Result types to all methods so errors bubble up"),
-            _ => todo!(),
+            BinaryOp::Mod => self
+                .acir_context
+                .modulo_var(lhs, rhs)
+                .expect("add Result types to all methods so errors bubble up"),
         }
     }
     /// Returns an `AcirVar` that is constrained to be


### PR DESCRIPTION
# Description

Previously unsigned division and Shr were using field division. Since we now have euclidean division, we can patch those algorithms to return the quotient

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
