### PR TITLE
feat(nargo): Allow user-specified file for prover inputs instead of `Prover.toml`

### DIFF
--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -21,6 +21,10 @@ pub(crate) struct ExecuteCommand {
     /// Write the execution witness to named file
     witness_name: Option<String>,
 
+    /// The name of the toml file which contains the inputs for the prover
+    #[clap(long, short, default_value = PROVER_INPUT_FILE)]
+    prover_name: String,
+
     #[clap(flatten)]
     compile_options: CompileOptions,
 }
@@ -31,7 +35,7 @@ pub(crate) fn run<B: Backend>(
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
     let (return_value, solved_witness) =
-        execute_with_path(backend, &config.program_dir, &args.compile_options)?;
+        execute_with_path(backend, &config.program_dir, args.prover_name, &args.compile_options)?;
 
     println!("Circuit witness successfully solved");
     if let Some(return_value) = return_value {
@@ -50,13 +54,14 @@ pub(crate) fn run<B: Backend>(
 fn execute_with_path<B: Backend>(
     backend: &B,
     program_dir: &Path,
+    prover_name: String,
     compile_options: &CompileOptions,
 ) -> Result<(Option<InputValue>, WitnessMap), CliError<B>> {
     let CompiledProgram { abi, circuit } = compile_circuit(backend, program_dir, compile_options)?;
 
     // Parse the initial witness values from Prover.toml
     let (inputs_map, _) =
-        read_inputs_from_file(program_dir, PROVER_INPUT_FILE, Format::Toml, &abi)?;
+        read_inputs_from_file(program_dir, prover_name.as_str(), Format::Toml, &abi)?;
 
     let solved_witness = execute_program(backend, circuit, &abi, &inputs_map)?;
 

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -35,6 +35,10 @@ pub(crate) struct ProveCommand {
     /// The name of the circuit build files (ACIR, proving and verification keys)
     circuit_name: Option<String>,
 
+    /// The name of the toml file which contains the inputs for the prover
+    #[clap(long, short, default_value = PROVER_INPUT_FILE)]
+    prover_name: Option<String>,
+
     /// Verify proof after proving
     #[arg(short, long)]
     verify: bool,
@@ -57,6 +61,7 @@ pub(crate) fn run<B: Backend>(
     prove_with_path(
         backend,
         args.proof_name,
+        args.prover_name,
         config.program_dir,
         proof_dir,
         circuit_build_path,
@@ -70,6 +75,7 @@ pub(crate) fn run<B: Backend>(
 pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
     backend: &B,
     proof_name: Option<String>,
+    prover_name: Option<String>,
     program_dir: P,
     proof_dir: P,
     circuit_build_path: Option<PathBuf>,
@@ -107,7 +113,7 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
 
     // Parse the initial witness values from Prover.toml
     let (inputs_map, _) =
-        read_inputs_from_file(&program_dir, PROVER_INPUT_FILE, Format::Toml, &abi)?;
+        read_inputs_from_file(&program_dir, prover_name.as_deref().unwrap_or(PROVER_INPUT_FILE), Format::Toml, &abi)?;
 
     let solved_witness = execute_program(backend, bytecode.clone(), &abi, &inputs_map)?;
 

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -72,6 +72,7 @@ pub(crate) fn run<B: Backend>(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
     backend: &B,
     proof_name: Option<String>,

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -113,8 +113,12 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
         preprocessed_program;
 
     // Parse the initial witness values from Prover.toml
-    let (inputs_map, _) =
-        read_inputs_from_file(&program_dir, prover_name.as_deref().unwrap_or(PROVER_INPUT_FILE), Format::Toml, &abi)?;
+    let (inputs_map, _) = read_inputs_from_file(
+        &program_dir,
+        prover_name.as_deref().unwrap_or(PROVER_INPUT_FILE),
+        Format::Toml,
+        &abi,
+    )?;
 
     let solved_witness = execute_program(backend, bytecode.clone(), &abi, &inputs_map)?;
 

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -113,12 +113,8 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
         preprocessed_program;
 
     // Parse the initial witness values from Prover.toml
-    let (inputs_map, _) = read_inputs_from_file(
-        &program_dir,
-        prover_name.as_str(),
-        Format::Toml,
-        &abi,
-    )?;
+    let (inputs_map, _) =
+        read_inputs_from_file(&program_dir, prover_name.as_str(), Format::Toml, &abi)?;
 
     let solved_witness = execute_program(backend, bytecode.clone(), &abi, &inputs_map)?;
 

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -39,6 +39,10 @@ pub(crate) struct ProveCommand {
     #[clap(long, short, default_value = PROVER_INPUT_FILE)]
     prover_name: String,
 
+    /// The name of the toml file which contains the inputs for the verifier
+    #[clap(long, short, default_value = VERIFIER_INPUT_FILE)]
+    verifier_name: String,
+
     /// Verify proof after proving
     #[arg(short, long)]
     verify: bool,
@@ -62,6 +66,7 @@ pub(crate) fn run<B: Backend>(
         backend,
         args.proof_name,
         args.prover_name,
+        args.verifier_name,
         config.program_dir,
         proof_dir,
         circuit_build_path,
@@ -77,6 +82,7 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
     backend: &B,
     proof_name: Option<String>,
     prover_name: String,
+    verifier_name: String,
     program_dir: P,
     proof_dir: P,
     circuit_build_path: Option<PathBuf>,
@@ -126,7 +132,7 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
         &public_inputs,
         &return_value,
         &program_dir,
-        VERIFIER_INPUT_FILE,
+        verifier_name.as_str(),
         Format::Toml,
     )?;
 

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -37,7 +37,7 @@ pub(crate) struct ProveCommand {
 
     /// The name of the toml file which contains the inputs for the prover
     #[clap(long, short, default_value = PROVER_INPUT_FILE)]
-    prover_name: Option<String>,
+    prover_name: String,
 
     /// Verify proof after proving
     #[arg(short, long)]
@@ -76,7 +76,7 @@ pub(crate) fn run<B: Backend>(
 pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
     backend: &B,
     proof_name: Option<String>,
-    prover_name: Option<String>,
+    prover_name: String,
     program_dir: P,
     proof_dir: P,
     circuit_build_path: Option<PathBuf>,
@@ -115,7 +115,7 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
     // Parse the initial witness values from Prover.toml
     let (inputs_map, _) = read_inputs_from_file(
         &program_dir,
-        prover_name.as_deref().unwrap_or(PROVER_INPUT_FILE),
+        prover_name.as_str(),
         Format::Toml,
         &abi,
     )?;

--- a/crates/nargo_cli/src/cli/verify_cmd.rs
+++ b/crates/nargo_cli/src/cli/verify_cmd.rs
@@ -31,6 +31,10 @@ pub(crate) struct VerifyCommand {
     /// The name of the circuit build files (ACIR, proving and verification keys)
     circuit_name: Option<String>,
 
+    /// The name of the toml file which contains the inputs for the verifier
+    #[clap(long, short, default_value = VERIFIER_INPUT_FILE)]
+    verifier_name: String,
+
     #[clap(flatten)]
     compile_options: CompileOptions,
 }
@@ -52,6 +56,7 @@ pub(crate) fn run<B: Backend>(
         &config.program_dir,
         proof_path,
         circuit_build_path.as_ref(),
+        args.verifier_name,
         &args.compile_options,
     )
 }
@@ -61,6 +66,7 @@ fn verify_with_path<B: Backend, P: AsRef<Path>>(
     program_dir: P,
     proof_path: PathBuf,
     circuit_build_path: Option<P>,
+    verifier_name: String,
     compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
     let common_reference_string = read_cached_common_reference_string();
@@ -91,10 +97,10 @@ fn verify_with_path<B: Backend, P: AsRef<Path>>(
 
     let PreprocessedProgram { abi, bytecode, verification_key, .. } = preprocessed_program;
 
-    // Load public inputs (if any) from `VERIFIER_INPUT_FILE`.
+    // Load public inputs (if any) from `verifier_name`.
     let public_abi = abi.public_abi();
     let (public_inputs_map, return_value) =
-        read_inputs_from_file(program_dir, VERIFIER_INPUT_FILE, Format::Toml, &public_abi)?;
+        read_inputs_from_file(program_dir, verifier_name.as_str(), Format::Toml, &public_abi)?;
 
     let public_inputs = public_abi.encode(&public_inputs_map, return_value)?;
     let proof = load_hex_data(&proof_path)?;


### PR DESCRIPTION
# Description

A short modification of `nargo_cli` to allow the user to specify which `.toml` file to use when generating a proof instead of being forced to use `Prover.toml`.

## Problem\*

The user had no choice but to use `Prover.toml` when generating a proof.
This is leading to race conditions when running forge tests (which run in parallel), in particular when these tests use on-the-fly proof generation.

## Summary\*

Allows the user to optionnally specify which `.toml` file to use with the `-p` or `--prover-name` flag.

This PR sets out to

### Example

Before:

```
nargo prove p
```

After:

```
nargo prove -p OtherProver pp 
```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
