### PR TITLE
chore(ssa refactor): Rename `expression_to_witness` to `create_witness_for_expression` to make purpose clearer.

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -52,38 +52,40 @@ impl GeneratedAcir {
         Witness(self.current_witness_index)
     }
 
-    /// Converts an [`Expression`] into a [`Witness`].
+    /// Converts [`Expression`] `expr` into a [`Witness`].
     ///
-    /// This is done by creating a new Witness and creating an opcode which
-    /// sets the Witness to be equal to the Expression.
+    /// If `expr` can be represented as a `Witness` then this function will return it,
+    /// else a new opcode will be added to create a `Witness` that is equal to `expr`.
+    pub(crate) fn get_or_create_witness(&mut self, expr: &Expression) -> Witness {
+        match expr.to_witness() {
+            Some(witness) => witness,
+            None => self.create_witness_for_expression(expr),
+        }
+    }
+
+    /// Creates a new [`Witness`] which is constrained to be equal to the passed [`Expression`].
     ///
     /// The reason we do this is because _constraints_ in ACIR have a degree limit
-    /// This means you cannot multiply an infinite amount of Expressions together.
-    /// Once the expression goes over degree-2, then it needs to be reduced to a Witness
+    /// This means you cannot multiply an infinite amount of `Expression`s together.
+    /// Once the `Expression` goes over degree-2, then it needs to be reduced to a `Witness`
     /// which has degree-1 in order to be able to continue the multiplication chain.
-    fn expression_to_witness(&mut self, expression: &Expression) -> Witness {
-        if let Some(witness) = expression.to_witness() {
-            // If `expression` consists of a single witness then we can perform a simple coercion.
-            witness
-        } else {
-            // Otherwise we must create a new witness and constrain it to be equal to `expression`.
-            let fresh_witness = self.next_witness_index();
+    fn create_witness_for_expression(&mut self, expression: &Expression) -> Witness {
+        let fresh_witness = self.next_witness_index();
 
-            // Create a constraint that sets them to be equal to each other
-            // Then return the witness as this can now be used in places
-            // where we would have used the `Expression`.
-            let constraint = expression - fresh_witness;
-            // This assertion means that verification of this
-            // program will fail if expression != witness.
-            //
-            // This is because we have:
-            //  => constraint == 0
-            //  => expression - fresh_witness == 0
-            //  => expression == fresh_witness
-            self.assert_is_zero(constraint);
+        // Create a constraint that sets them to be equal to each other
+        // Then return the witness as this can now be used in places
+        // where we would have used the `Expression`.
+        let constraint = expression - fresh_witness;
+        // This assertion means that verification of this
+        // program will fail if expression != witness.
+        //
+        // This is because we have:
+        //  => constraint == 0
+        //  => expression - fresh_witness == 0
+        //  => expression == fresh_witness
+        self.assert_is_zero(constraint);
 
-            fresh_witness
-        }
+        fresh_witness
     }
 
     /// Adds a witness index to the program's return witnesses.
@@ -257,15 +259,6 @@ impl GeneratedAcir {
         self.push_opcode(AcirOpcode::Directive(Directive::Log(LogInfo::WitnessOutput(witnesses))));
     }
 
-    /// If `expr` can be represented as a `Witness` this function will
-    /// return it, else a new opcode will be added to create a Witness
-    /// that is equal to `expr`.
-    pub(crate) fn get_or_create_witness(&mut self, expr: &Expression) -> Witness {
-        match expr.to_witness() {
-            Some(witness) => witness,
-            None => self.expression_to_witness(expr),
-        }
-    }
     /// Adds an inversion directive.
     ///
     /// This directive will invert `expr` without applying constraints

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -71,7 +71,7 @@ impl GeneratedAcir {
 
             // Create a constraint that sets them to be equal to each other
             // Then return the witness as this can now be used in places
-            // where we would have used the Witness.
+            // where we would have used the `Expression`.
             let constraint = expression - fresh_witness;
             // This assertion means that verification of this
             // program will fail if expression != witness.

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -64,7 +64,7 @@ impl GeneratedAcir {
     fn expression_to_witness(&mut self, expression: &Expression) -> Witness {
         if let Some(witness) = expression.to_witness() {
             // If `expression` consists of a single witness then we can perform a simple coercion.
-            return witness;
+            witness
         } else {
             // Otherwise we must create a new witness and constrain it to be equal to `expression`.
             let fresh_witness = self.next_witness_index();

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -62,22 +62,28 @@ impl GeneratedAcir {
     /// Once the expression goes over degree-2, then it needs to be reduced to a Witness
     /// which has degree-1 in order to be able to continue the multiplication chain.
     fn expression_to_witness(&mut self, expression: &Expression) -> Witness {
-        let fresh_witness = self.next_witness_index();
+        if let Some(witness) = expression.to_witness() {
+            // If `expression` consists of a single witness then we can perform a simple coercion.
+            return witness;
+        } else {
+            // Otherwise we must create a new witness and constrain it to be equal to `expression`.
+            let fresh_witness = self.next_witness_index();
 
-        // Create a constraint that sets them to be equal to each other
-        // Then return the witness as this can now be used in places
-        // where we would have used the Witness.
-        let constraint = expression - fresh_witness;
-        // This assertion means that verification of this
-        // program will fail if expression != witness.
-        //
-        // This is because we have:
-        //  => constraint == 0
-        //  => expression - fresh_witness == 0
-        //  => expression == fresh_witness
-        self.assert_is_zero(constraint);
+            // Create a constraint that sets them to be equal to each other
+            // Then return the witness as this can now be used in places
+            // where we would have used the Witness.
+            let constraint = expression - fresh_witness;
+            // This assertion means that verification of this
+            // program will fail if expression != witness.
+            //
+            // This is because we have:
+            //  => constraint == 0
+            //  => expression - fresh_witness == 0
+            //  => expression == fresh_witness
+            self.assert_is_zero(constraint);
 
-        fresh_witness
+            fresh_witness
+        }
     }
 
     /// Adds a witness index to the program's return witnesses.

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -52,10 +52,10 @@ impl GeneratedAcir {
         Witness(self.current_witness_index)
     }
 
-    /// Converts an expression into a Witness.
+    /// Converts an [`Expression`] into a [`Witness`].
     ///
     /// This is done by creating a new Witness and creating an opcode which
-    /// sets the Witness to be equal to the expression.
+    /// sets the Witness to be equal to the Expression.
     ///
     /// The reason we do this is because _constraints_ in ACIR have a degree limit
     /// This means you cannot multiply an infinite amount of Expressions together.


### PR DESCRIPTION
# Description

## Problem

Resolves #1524 

## Summary\*

This PR sets out to prevent extra witnesses by checking to see if we can unwrap the expression into a witness before creating a new one and constraining its value to the expression.

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
