### PR TITLE
chore: move printing errors to `nargo_cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "nargo",
  "noirc_abi",
  "noirc_driver",
+ "noirc_errors",
  "noirc_frontend",
  "predicates 2.1.5",
  "rustc_version",
@@ -1946,6 +1947,7 @@ dependencies = [
  "codespan-reporting",
  "fm",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -24,6 +24,7 @@ dirs.workspace = true
 url.workspace = true
 iter-extended.workspace = true
 nargo.workspace = true
+noirc_errors.workspace = true
 noirc_driver.workspace = true
 noirc_frontend.workspace = true
 noirc_abi.workspace = true

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -34,7 +34,7 @@ fn check_from_path<B: Backend, P: AsRef<Path>>(
 ) -> Result<(), CliError<B>> {
     let mut driver = setup_driver(backend, program_dir.as_ref())?;
 
-    driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
+    driver.check_crate(compile_options).map_err(|err| CliError::CompilationError(err.into()))?;
 
     // XXX: We can have a --overwrite flag to determine if you want to overwrite the Prover/Verifier.toml files
     if let Some((parameters, return_type)) = driver.compute_function_signature() {

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -51,7 +51,7 @@ pub(crate) fn run<B: Backend>(
         let mut driver = setup_driver(backend, &config.program_dir)?;
         let compiled_contracts = driver
             .compile_contracts(&args.compile_options)
-            .map_err(|_| CliError::CompilationError)?;
+            .map_err(|err| CliError::CompilationError(err.into()))?;
 
         // TODO(#1389): I wonder if it is incorrect for nargo-core to know anything about contracts.
         // As can be seen here, It seems like a leaky abstraction where ContractFunctions (essentially CompiledPrograms)
@@ -118,5 +118,5 @@ pub(crate) fn compile_circuit<B: Backend>(
     compile_options: &CompileOptions,
 ) -> Result<CompiledProgram, CliError<B>> {
     let mut driver = setup_driver(backend, program_dir)?;
-    driver.compile_main(compile_options).map_err(|_| CliError::CompilationError)
+    driver.compile_main(compile_options).map_err(CliError::CompilationError)
 }

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -39,7 +39,7 @@ fn run_tests<B: Backend>(
 ) -> Result<(), CliError<B>> {
     let mut driver = setup_driver(backend, program_dir)?;
 
-    driver.check_crate(compile_options).map_err(|_| CliError::CompilationError)?;
+    driver.check_crate(compile_options).map_err(|err| CliError::CompilationError(err.into()))?;
 
     let test_functions = driver.get_all_test_functions_in_crate_matching(test_name);
     println!("Running {} test functions...", test_functions.len());

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -45,7 +45,7 @@ pub(crate) enum CliError<B: Backend> {
 
     /// Error while compiling Noir into ACIR.
     #[error("Failed to compile circuit")]
-    CompilationError,
+    CompilationError(#[from] noirc_errors::Error),
 
     /// ABI encoding/decoding error
     #[error(transparent)]

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -9,7 +9,7 @@ use clap::Args;
 use fm::FileType;
 use iter_extended::try_vecmap;
 use noirc_abi::FunctionSignature;
-use noirc_errors::{reporter, Error, ReportedError};
+use noirc_errors::{reporter, Error, FileDiagnostic, ReportedError};
 use noirc_evaluator::{create_circuit, ssa_refactor::experimental_create_circuit};
 use noirc_frontend::graph::{CrateId, CrateName, CrateType, LOCAL_CRATE};
 use noirc_frontend::hir::def_map::{Contract, CrateDefMap};
@@ -89,8 +89,7 @@ impl Driver {
     pub fn file_compiles(&mut self) -> bool {
         let mut errs = vec![];
         CrateDefMap::collect_defs(LOCAL_CRATE, &mut self.context, &mut errs);
-        reporter::report_all(&self.context.file_manager, &errs, false);
-        errs.is_empty()
+        self.report_errors(&errs)
     }
 
     /// Adds the File with the local crate root to the file system
@@ -335,6 +334,11 @@ impl Driver {
 
     pub fn function_name(&self, id: FuncId) -> &str {
         self.context.def_interner.function_name(&id)
+    }
+
+    pub fn report_errors(&self, errs: &[FileDiagnostic]) -> bool {
+        reporter::report_all(&self.context.file_manager, errs, false);
+        errs.is_empty()
     }
 }
 

--- a/crates/noirc_errors/Cargo.toml
+++ b/crates/noirc_errors/Cargo.toml
@@ -12,3 +12,4 @@ codespan.workspace = true
 fm.workspace = true
 chumsky.workspace = true
 serde.workspace = true
+thiserror.workspace = true

--- a/crates/noirc_errors/src/lib.rs
+++ b/crates/noirc_errors/src/lib.rs
@@ -9,16 +9,26 @@ pub use position::{Location, Position, Span, Spanned};
 pub use reporter::{CustomDiagnostic, DiagnosticKind};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Indicates that the error has already been reported.
     Reported,
     /// Represents a custom diagnostic error.
-    Diagnostic(CustomDiagnostic),
+    Diagnostic(&'static str),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Reported => Ok(()),
+            Error::Diagnostic(diagnostic) => f.write_str(diagnostic),
+        }
+    }
 }
 
 impl Error {
-    pub fn message(msg: &str) -> Error {
-        Error::Diagnostic(CustomDiagnostic::from_message(msg))
+    pub fn message(message: &'static str) -> Error {
+        Error::Diagnostic(message)
     }
 }
 

--- a/crates/noirc_errors/src/lib.rs
+++ b/crates/noirc_errors/src/lib.rs
@@ -9,6 +9,25 @@ pub use position::{Location, Position, Span, Spanned};
 pub use reporter::{CustomDiagnostic, DiagnosticKind};
 use serde::{Deserialize, Serialize};
 
+pub enum Error {
+    /// Indicates that the error has already been reported.
+    Reported,
+    /// Represents a custom diagnostic error.
+    Diagnostic(CustomDiagnostic),
+}
+
+impl Error {
+    pub fn message(msg: &str) -> Error {
+        Error::Diagnostic(CustomDiagnostic::from_message(msg))
+    }
+}
+
+impl From<ReportedError> for Error {
+    fn from(_: ReportedError) -> Self {
+        Error::Reported
+    }
+}
+
 /// Returned when the Reporter finishes after reporting errors
 #[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct ReportedError;


### PR DESCRIPTION
# Description

Move printing errors to `nargo_cli`

## Problem

Resolves #1530 

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
