### PR TITLE
feat(nargo): Add `lsp` command to start server that reports no capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lsp"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73395fba7765010f2a98d007d601bd47e0d31ada90cd82f40c7eab753eba0870"
+dependencies = [
+ "either",
+ "futures",
+ "libc",
+ "lsp-types",
+ "pin-project-lite",
+ "rustix",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,12 +1248,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1240,6 +1276,23 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1259,10 +1312,16 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1759,6 +1818,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsp-types"
+version = "0.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +1940,7 @@ dependencies = [
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
+ "async-lsp",
  "build-data",
  "cfg-if",
  "clap",
@@ -1877,6 +1950,7 @@ dependencies = [
  "hex",
  "iter-extended",
  "nargo",
+ "nargo_lsp",
  "noirc_abi",
  "noirc_driver",
  "noirc_frontend",
@@ -1889,7 +1963,19 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tower",
  "url",
+]
+
+[[package]]
+name = "nargo_lsp"
+version = "0.6.0"
+dependencies = [
+ "async-lsp",
+ "lsp-types",
+ "serde_json",
+ "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -2801,6 +2887,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,7 +3231,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3194,6 +3303,23 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -3316,6 +3442,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }
 nargo = { path = "crates/nargo" }
 nargo_cli = { path = "crates/nargo_cli" }
+nargo_lsp = { path = "crates/nargo_lsp" }
 noirc_abi = { path = "crates/noirc_abi" }
 noirc_driver = { path = "crates/noirc_driver" }
 noirc_errors = { path = "crates/noirc_errors" }
@@ -37,6 +38,7 @@ noirc_evaluator = { path = "crates/noirc_evaluator" }
 noirc_frontend = { path = "crates/noirc_frontend" }
 noir_wasm = { path = "crates/wasm" }
 
+async-lsp = { version = "0.0.4", default-features = false, features = ["omni-trait"] }
 cfg-if = "1.0.0"
 clap = { version = "4.1.4", features = ["derive"]}
 codespan = "0.9.5"
@@ -44,9 +46,11 @@ codespan-reporting = "0.9.5"
 chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
 dirs = "4"
 serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0"
 smol_str = "0.1.17"
 thiserror = "1.0.21"
 toml = "0.7.2"
+tower = "0.4"
 url = "2.2.0"
 wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -18,22 +18,25 @@ build-data = "0.1.3"
 toml.workspace = true
 
 [dependencies]
+async-lsp.workspace = true
 cfg-if.workspace = true
 clap.workspace = true
 dirs.workspace = true
 url.workspace = true
 iter-extended.workspace = true
 nargo.workspace = true
+nargo_lsp.workspace = true
 noirc_driver.workspace = true
 noirc_frontend.workspace = true
 noirc_abi.workspace = true
 acvm.workspace = true
 toml.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
+tower.workspace = true
 const_format = "0.2.30"
 hex = "0.4.2"
-serde_json = "1.0"
 termcolor = "1.1.2"
 color-eyre = "0.6.2"
 tokio = "1.0"
@@ -50,5 +53,15 @@ predicates = "2.1.5"
 [features]
 default = ["plonk_bn254"]
 # The plonk backend can only use bn254, so we do not specify the field
-plonk_bn254 = ["acvm-backend-barretenberg/native"]
-plonk_bn254_wasm = ["acvm-backend-barretenberg/wasm"]
+plonk_bn254 = [
+    "acvm-backend-barretenberg/native",
+    "async-lsp/client-monitor",
+    "async-lsp/stdio",
+    "async-lsp/tracing"
+]
+plonk_bn254_wasm = [
+    "acvm-backend-barretenberg/wasm",
+    "async-lsp/client-monitor",
+    "async-lsp/stdio",
+    "async-lsp/tracing"
+]

--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -1,0 +1,48 @@
+use acvm::Backend;
+use async_lsp::{
+    client_monitor::ClientProcessMonitorLayer, concurrency::ConcurrencyLayer,
+    panic::CatchUnwindLayer, server::LifecycleLayer, stdio::PipeStdin, tracing::TracingLayer,
+};
+use clap::Args;
+use nargo_lsp::NargoLspService;
+use noirc_driver::CompileOptions;
+use tokio::io::BufReader;
+use tower::ServiceBuilder;
+
+use super::NargoConfig;
+use crate::errors::CliError;
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct LspCommand {
+    #[clap(flatten)]
+    compile_options: CompileOptions,
+}
+
+pub(crate) fn run<B: Backend>(
+    // Backend is currently unused, but we might want to use it to inform the lsp in the future
+    _backend: &B,
+    _args: LspCommand,
+    _config: NargoConfig,
+) -> Result<(), CliError<B>> {
+    use tokio::runtime::Builder;
+
+    let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+
+    let (server, _) = async_lsp::Frontend::new_server(|client| {
+        let router = NargoLspService::new();
+
+        ServiceBuilder::new()
+            .layer(TracingLayer::default())
+            .layer(LifecycleLayer::default())
+            .layer(CatchUnwindLayer::default())
+            .layer(ConcurrencyLayer::default())
+            .layer(ClientProcessMonitorLayer::new(client))
+            .service(router)
+    });
+
+    runtime.block_on(async {
+        let stdin = BufReader::new(PipeStdin::lock().unwrap());
+        let stdout = async_lsp::stdio::PipeStdout::lock().unwrap();
+        server.run(stdin, stdout).await.map_err(CliError::LspError)
+    })
+}

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -14,6 +14,7 @@ mod codegen_verifier_cmd;
 mod compile_cmd;
 mod execute_cmd;
 mod gates_cmd;
+mod lsp_cmd;
 mod new_cmd;
 mod prove_cmd;
 mod test_cmd;
@@ -55,13 +56,14 @@ enum NargoCommand {
     Verify(verify_cmd::VerifyCommand),
     Test(test_cmd::TestCommand),
     Gates(gates_cmd::GatesCommand),
+    Lsp(lsp_cmd::LspCommand),
 }
 
 pub fn start_cli() -> eyre::Result<()> {
     let NargoCli { command, mut config } = NargoCli::parse();
 
     // Search through parent directories to find package root if necessary.
-    if !matches!(command, NargoCommand::New(_)) {
+    if !matches!(command, NargoCommand::New(_)) && !matches!(command, NargoCommand::Lsp(_)) {
         config.program_dir = find_package_root(&config.program_dir)?;
     }
 
@@ -77,6 +79,7 @@ pub fn start_cli() -> eyre::Result<()> {
         NargoCommand::Test(args) => test_cmd::run(&backend, args, config),
         NargoCommand::Gates(args) => gates_cmd::run(&backend, args, config),
         NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(&backend, args, config),
+        NargoCommand::Lsp(args) => lsp_cmd::run(&backend, args, config),
     }?;
 
     Ok(())

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -55,6 +55,9 @@ pub(crate) enum CliError<B: Backend> {
     #[error(transparent)]
     FilesystemError(#[from] FilesystemError),
 
+    #[error(transparent)]
+    LspError(#[from] async_lsp::Error),
+
     /// Error from Nargo
     #[error(transparent)]
     NargoError(#[from] NargoError),

--- a/crates/nargo_lsp/Cargo.toml
+++ b/crates/nargo_lsp/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "nargo_lsp"
+description = "Language server for Noir"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-lsp.workspace = true
+serde_json.workspace = true
+tower.workspace = true
+lsp-types = "0.94"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["macros"] }

--- a/crates/nargo_lsp/src/lib.rs
+++ b/crates/nargo_lsp/src/lib.rs
@@ -1,0 +1,150 @@
+use std::{
+    future::Future,
+    ops::ControlFlow,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use async_lsp::{
+    router::Router, AnyEvent, AnyNotification, AnyRequest, Error, LspService, ResponseError,
+};
+use lsp_types::{
+    notification, request, DidChangeConfigurationParams, DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, InitializeParams, InitializeResult,
+    InitializedParams, ServerCapabilities,
+};
+use serde_json::Value as JsonValue;
+use tower::Service;
+
+// State for the LSP gets implemented on this struct and is internal to the implementation
+#[derive(Debug, Default)]
+struct LspState;
+
+pub struct NargoLspService {
+    router: Router<LspState>,
+}
+
+impl NargoLspService {
+    pub fn new() -> Self {
+        let state = LspState::default();
+        let mut router = Router::new(state);
+        router
+            .request::<request::Initialize, _>(on_initialize)
+            .notification::<notification::Initialized>(on_initialized)
+            .notification::<notification::DidChangeConfiguration>(on_did_change_configuration)
+            .notification::<notification::DidOpenTextDocument>(on_did_open_text_document)
+            .notification::<notification::DidChangeTextDocument>(on_did_change_text_document)
+            .notification::<notification::DidCloseTextDocument>(on_did_close_text_document);
+        Self { router }
+    }
+}
+
+impl Default for NargoLspService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// This trait implemented as a passthrough to the router, which makes
+// our `NargoLspService` a normal Service as far as Tower is concerned.
+impl Service<AnyRequest> for NargoLspService {
+    type Response = JsonValue;
+    type Error = ResponseError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.router.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: AnyRequest) -> Self::Future {
+        self.router.call(req)
+    }
+}
+
+// This trait implemented as a passthrough to the router, which makes
+// our `NargoLspService` able to accept the `async-lsp` middleware.
+impl LspService for NargoLspService {
+    fn notify(&mut self, notif: AnyNotification) -> ControlFlow<Result<(), Error>> {
+        self.router.notify(notif)
+    }
+
+    fn emit(&mut self, event: AnyEvent) -> ControlFlow<Result<(), Error>> {
+        self.router.emit(event)
+    }
+}
+
+// Handlers
+// The handlers for `request` are not `async` because it compiles down to lifetimes that can't be added to
+// the router. To return a future that fits the trait, it is easiest wrap your implementations in an `async {}`
+// block but you can also use `std::future::ready`.
+//
+// Additionally, the handlers for `notification` aren't async at all.
+//
+// They are not attached to the `NargoLspService` struct so they can be unit tested with only `LspState`
+// and params passed in.
+
+fn on_initialize(
+    _state: &mut LspState,
+    _params: InitializeParams,
+) -> impl Future<Output = Result<InitializeResult, ResponseError>> {
+    async {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                // Add capabilities before this spread when adding support for one
+                ..ServerCapabilities::default()
+            },
+            server_info: None,
+        })
+    }
+}
+
+fn on_initialized(
+    _state: &mut LspState,
+    _params: InitializedParams,
+) -> ControlFlow<Result<(), async_lsp::Error>> {
+    ControlFlow::Continue(())
+}
+
+fn on_did_change_configuration(
+    _state: &mut LspState,
+    _params: DidChangeConfigurationParams,
+) -> ControlFlow<Result<(), async_lsp::Error>> {
+    ControlFlow::Continue(())
+}
+
+fn on_did_open_text_document(
+    _state: &mut LspState,
+    _params: DidOpenTextDocumentParams,
+) -> ControlFlow<Result<(), async_lsp::Error>> {
+    ControlFlow::Continue(())
+}
+
+fn on_did_change_text_document(
+    _state: &mut LspState,
+    _params: DidChangeTextDocumentParams,
+) -> ControlFlow<Result<(), async_lsp::Error>> {
+    ControlFlow::Continue(())
+}
+
+fn on_did_close_text_document(
+    _state: &mut LspState,
+    _params: DidCloseTextDocumentParams,
+) -> ControlFlow<Result<(), async_lsp::Error>> {
+    ControlFlow::Continue(())
+}
+
+#[cfg(test)]
+mod lsp_tests {
+    use tokio::test;
+
+    use super::*;
+
+    #[test]
+    async fn test_on_initialize() {
+        let mut state = LspState::default();
+        let params = InitializeParams::default();
+        let response = on_initialize(&mut state, params).await.unwrap();
+        assert_eq!(response.capabilities, ServerCapabilities::default());
+        assert!(response.server_info.is_none());
+    }
+}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR puts in place the scaffolding for the LSP server logic via `nargo_lsp` crate and then constructs a Tower stack via the `lsp` command in `nargo_cli`. The LSP currently reports no capabilities, but serves as the skeleton to prove that https://github.com/noir-lang/vscode-noir/pull/3 can communicate with it (enable tracing in the options).

The choice to use `async-lsp` was made because it sets out to solve a bunch of [tower-lsp problems](https://github.com/oxalica/async-lsp#tower-lsp).

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [x] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

This will add an additional command to the Nargo CLI and we will need to update the docs to mention the VSCode extension that provides the LSP client.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
