### PR TITLE
chore: Re-run build.rs if the tests have changed

### DIFF
--- a/crates/nargo_cli/build.rs
+++ b/crates/nargo_cli/build.rs
@@ -15,6 +15,9 @@ fn check_rustc_version() {
 const GIT_COMMIT: &&str = &"GIT_COMMIT";
 
 fn main() {
+    // Rebuild if the tests have changed
+    println!("cargo:rerun-if-changed=tests");
+
     check_rustc_version();
 
     // Only use build_data if the environment variable isn't set


### PR DESCRIPTION
# Description

This will re-rerun the build.rs script if the test files have changed.

Its main usecase will be:

- If a new test has been added
- If the directory name for a test has changed

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
