### PR TITLE
chore(ssa refactor): Add constant folding pass

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -42,6 +42,8 @@ pub(crate) fn optimize_into_acir(program: Program, allow_log_ops: bool) -> Gener
         .print("After Flattening:")
         .mem2reg()
         .print("After Mem2Reg:")
+        .fold_constants()
+        .print("After Constant Folding:")
         .into_acir(func_signature, brillig, allow_log_ops)
 }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
@@ -25,6 +25,8 @@ impl Ssa {
     }
 }
 
+/// The structure of this pass is simple:
+/// Go through each block and re-insert all instructions.
 fn constant_fold(function: &mut Function) {
     let mut context = Context::default();
     context.block_queue.push(function.entry_block());
@@ -40,11 +42,8 @@ fn constant_fold(function: &mut Function) {
 
 #[derive(Default)]
 struct Context {
-    /// Maps pre-unrolled ValueIds to unrolled ValueIds.
-    /// These will often be the exact same as before, unless the ValueId was
-    /// dependent on the loop induction variable which is changing on each iteration.
+    /// Maps pre-folded ValueIds to the new ValueIds obtained by re-inserting the instruction.
     values: HashMap<ValueId, ValueId>,
-
     visited_blocks: HashSet<BasicBlockId>,
     block_queue: Vec<BasicBlockId>,
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
@@ -1,0 +1,180 @@
+use std::collections::{HashMap, HashSet};
+
+use iter_extended::vecmap;
+
+use crate::ssa_refactor::{
+    ir::{
+        basic_block::BasicBlockId, dfg::InsertInstructionResult, function::Function,
+        instruction::InstructionId, value::ValueId,
+    },
+    ssa_gen::Ssa,
+};
+
+impl Ssa {
+    /// Performs constant folding on each instruction.
+    ///
+    /// This is generally done automatically but this pass can become needed
+    /// if `DataFlowGraph::set_value` or `DataFlowGraph::set_value_from_id` are
+    /// used on a value which enables instructions dependent on the value to
+    /// now be simplified.
+    pub(crate) fn fold_constants(mut self) -> Ssa {
+        for function in self.functions.values_mut() {
+            constant_fold(function);
+        }
+        self
+    }
+}
+
+fn constant_fold(function: &mut Function) {
+    let mut context = Context::default();
+    context.block_queue.push(function.entry_block());
+
+    while let Some(block) = context.block_queue.pop() {
+        if context.visited_blocks.contains(&block) {
+            continue;
+        }
+
+        context.fold_constants_in_block(function, block);
+    }
+}
+
+#[derive(Default)]
+struct Context {
+    /// Maps pre-unrolled ValueIds to unrolled ValueIds.
+    /// These will often be the exact same as before, unless the ValueId was
+    /// dependent on the loop induction variable which is changing on each iteration.
+    values: HashMap<ValueId, ValueId>,
+
+    visited_blocks: HashSet<BasicBlockId>,
+    block_queue: Vec<BasicBlockId>,
+}
+
+impl Context {
+    fn fold_constants_in_block(&mut self, function: &mut Function, block: BasicBlockId) {
+        let instructions = std::mem::take(function.dfg[block].instructions_mut());
+
+        for instruction in instructions {
+            self.push_instruction(function, block, instruction);
+        }
+
+        let terminator =
+            function.dfg[block].unwrap_terminator().map_values(|value| self.get_value(value));
+
+        function.dfg.set_block_terminator(block, terminator);
+        self.block_queue.extend(function.dfg[block].successors());
+    }
+
+    fn get_value(&self, value: ValueId) -> ValueId {
+        self.values.get(&value).copied().unwrap_or(value)
+    }
+
+    fn push_instruction(
+        &mut self,
+        function: &mut Function,
+        block: BasicBlockId,
+        id: InstructionId,
+    ) {
+        let instruction = function.dfg[id].map_values(|id| self.get_value(id));
+        let results = function.dfg.instruction_results(id).to_vec();
+
+        let ctrl_typevars = instruction
+            .requires_ctrl_typevars()
+            .then(|| vecmap(&results, |result| function.dfg.type_of_value(*result)));
+
+        let new_results =
+            function.dfg.insert_instruction_and_results(instruction, block, ctrl_typevars);
+
+        Self::insert_new_instruction_results(&mut self.values, &results, new_results);
+    }
+
+    /// Modify the values HashMap to remember the mapping between an instruction result's previous
+    /// ValueId (from the source_function) and its new ValueId in the destination function.
+    fn insert_new_instruction_results(
+        values: &mut HashMap<ValueId, ValueId>,
+        old_results: &[ValueId],
+        new_results: InsertInstructionResult,
+    ) {
+        assert_eq!(old_results.len(), new_results.len());
+
+        match new_results {
+            InsertInstructionResult::SimplifiedTo(new_result) => {
+                values.insert(old_results[0], new_result);
+            }
+            InsertInstructionResult::Results(new_results) => {
+                for (old_result, new_result) in old_results.iter().zip(new_results) {
+                    values.insert(*old_result, *new_result);
+                }
+            }
+            InsertInstructionResult::InstructionRemoved => (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ssa_refactor::{
+        ir::{
+            function::RuntimeType,
+            instruction::{BinaryOp, TerminatorInstruction},
+            map::Id,
+            types::Type,
+        },
+        ssa_builder::FunctionBuilder,
+    };
+
+    #[test]
+    fn simple_constant_fold() {
+        // fn main f0 {
+        //   b0(v0: Field):
+        //     v1 = add v0, Field 1
+        //     v2 = mul v1, Field 3
+        //     return v2
+        // }
+        //
+        // After constructing this IR, we set the value of v0 to 2.
+        // The expected return afterwards should be 9.
+        let main_id = Id::test_new(0);
+
+        // Compiling main
+        let mut builder = FunctionBuilder::new("main".into(), main_id, RuntimeType::Acir);
+        let v0 = builder.add_parameter(Type::field());
+
+        let one = builder.field_constant(1u128);
+        let two = builder.field_constant(2u128);
+        let three = builder.field_constant(3u128);
+
+        let v1 = builder.insert_binary(v0, BinaryOp::Add, one);
+        let v2 = builder.insert_binary(v1, BinaryOp::Mul, three);
+        builder.terminate_with_return(vec![v2]);
+
+        let mut ssa = builder.finish();
+        let main = ssa.main_mut();
+        let instructions = main.dfg[main.entry_block()].instructions();
+        assert_eq!(instructions.len(), 2); // The final return is not counted
+
+        // Expected output:
+        //
+        // fn main f0 {
+        //   b0(v0: Field):
+        //     return Field 9
+        // }
+        main.dfg.set_value_from_id(v0, two);
+
+        let ssa = ssa.fold_constants();
+        let main = ssa.main();
+        let block = &main.dfg[main.entry_block()];
+        assert_eq!(block.instructions().len(), 0);
+
+        match block.terminator() {
+            Some(TerminatorInstruction::Return { return_values }) => {
+                let value = main
+                    .dfg
+                    .get_numeric_constant(return_values[0])
+                    .expect("Expected constant 9")
+                    .to_u128();
+                assert_eq!(value, 9);
+            }
+            _ => unreachable!("b0 should have a return terminator"),
+        }
+    }
+}

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
@@ -154,7 +154,7 @@ mod test {
         // Expected output:
         //
         // fn main f0 {
-        //   b0(v0: Field):
+        //   b0(Field 2: Field):
         //     return Field 9
         // }
         main.dfg.set_value_from_id(v0, two);

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/mod.rs
@@ -3,6 +3,7 @@
 //! Each pass is generally expected to mutate the SSA IR into a gradually
 //! simpler form until the IR only has a single function remaining with 1 block within it.
 //! Generally, these passes are also expected to minimize the final amount of instructions.
+mod constant_folding;
 mod flatten_cfg;
 mod inlining;
 mod mem2reg;


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Normally constant folding is performed automatically when instructions are inserted via `Instruction::simplify`. A manual pass can, however, become necessary after `DataFlowGraph::set_value` or `DataFlowGraph::set_value_from_id` are called and enable an instruction dependent on the updated value to be simplified.

This pass is added since it was used in a test case for the immutable arrays PR.

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
