### PR TITLE
feat: Make for-loop range be a polymorphic integer instead of just Field in unconstrained functions

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/mod.rs
@@ -243,7 +243,8 @@ impl<'a> FunctionContext<'a> {
         let loop_end = self.builder.insert_block();
 
         // this is the 'i' in `for i in start .. end { block }`
-        let loop_index = self.builder.add_block_parameter(loop_entry, Type::field());
+        let index_type = Self::convert_non_tuple_type(&for_expr.index_type);
+        let loop_index = self.builder.add_block_parameter(loop_entry, index_type);
 
         let start_index = self.codegen_non_tuple_expression(&for_expr.start_range);
         let end_index = self.codegen_non_tuple_expression(&for_expr.end_range);

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -153,9 +153,12 @@ impl<'interner> TypeChecker<'interner> {
                 let start_span = self.interner.expr_span(&for_expr.start_range);
                 let end_span = self.interner.expr_span(&for_expr.end_range);
 
-                let mut unify_loop_range = |actual_type, span| {
+                let mut unify_loop_range = |actual_type: &Type, span: Span| {
                     let expected_type = if self.is_unconstrained() {
-                        Type::FieldElement(CompTime::new(self.interner))
+                        Type::PolymorphicInteger(
+                            CompTime::new(self.interner),
+                            Shared::new(TypeBinding::Bound(actual_type.clone())),
+                        )
                     } else {
                         Type::comp_time(Some(span))
                     };

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -163,17 +163,14 @@ impl<'interner> TypeChecker<'interner> {
                     }
                 });
 
-                let expected_type = if self.is_unconstrained() {
-                    Type::PolymorphicInteger(
-                        CompTime::new(self.interner),
-                        Shared::new(TypeBinding::Bound(start_range_type.clone())),
-                    )
+                let expected_comptime = if self.is_unconstrained() {
+                    CompTime::new(self.interner)
                 } else {
-                    Type::PolymorphicInteger(
-                        CompTime::Yes(Some(range_span)),
-                        Shared::new(TypeBinding::Bound(start_range_type.clone())),
-                    )
+                    CompTime::Yes(Some(range_span))
                 };
+                let fresh_id = self.interner.next_type_variable_id();
+                let type_variable = Shared::new(TypeBinding::Unbound(fresh_id));
+                let expected_type = Type::PolymorphicInteger(expected_comptime, type_variable);
 
                 self.unify(&start_range_type, &expected_type, range_span, || {
                     TypeCheckError::TypeCannotBeUsed {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -160,12 +160,15 @@ impl<'interner> TypeChecker<'interner> {
                             Shared::new(TypeBinding::Bound(actual_type.clone())),
                         )
                     } else {
-                        Type::comp_time(Some(span))
+                        Type::PolymorphicInteger(
+                            CompTime::Yes(Some(span)),
+                            Shared::new(TypeBinding::Bound(actual_type.clone())),
+                        )
                     };
 
                     self.unify(actual_type, &expected_type, span, || {
                         TypeCheckError::TypeCannotBeUsed {
-                            typ: start_range_type.clone(),
+                            typ: actual_type.clone(),
                             place: "for loop",
                             span,
                         }
@@ -175,6 +178,16 @@ impl<'interner> TypeChecker<'interner> {
 
                 unify_loop_range(&start_range_type, start_span);
                 unify_loop_range(&end_range_type, end_span);
+
+                // Check that start range and end range have the same types
+                let range_span = start_span.merge(end_span);
+                self.unify(&start_range_type, &end_range_type, range_span, || {
+                    TypeCheckError::TypeMismatch {
+                        expected_typ: start_range_type.to_string(),
+                        expr_typ: end_range_type.to_string(),
+                        expr_span: range_span,
+                    }
+                });
 
                 self.interner.push_definition_type(for_expr.identifier.id, start_range_type);
 

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -153,32 +153,6 @@ impl<'interner> TypeChecker<'interner> {
                 let start_span = self.interner.expr_span(&for_expr.start_range);
                 let end_span = self.interner.expr_span(&for_expr.end_range);
 
-                let mut unify_loop_range = |actual_type: &Type, span: Span| {
-                    let expected_type = if self.is_unconstrained() {
-                        Type::PolymorphicInteger(
-                            CompTime::new(self.interner),
-                            Shared::new(TypeBinding::Bound(actual_type.clone())),
-                        )
-                    } else {
-                        Type::PolymorphicInteger(
-                            CompTime::Yes(Some(span)),
-                            Shared::new(TypeBinding::Bound(actual_type.clone())),
-                        )
-                    };
-
-                    self.unify(actual_type, &expected_type, span, || {
-                        TypeCheckError::TypeCannotBeUsed {
-                            typ: actual_type.clone(),
-                            place: "for loop",
-                            span,
-                        }
-                        .add_context("The range of a loop must be known at compile-time")
-                    });
-                };
-
-                unify_loop_range(&start_range_type, start_span);
-                unify_loop_range(&end_range_type, end_span);
-
                 // Check that start range and end range have the same types
                 let range_span = start_span.merge(end_span);
                 self.unify(&start_range_type, &end_range_type, range_span, || {
@@ -187,6 +161,27 @@ impl<'interner> TypeChecker<'interner> {
                         expr_typ: end_range_type.to_string(),
                         expr_span: range_span,
                     }
+                });
+
+                let expected_type = if self.is_unconstrained() {
+                    Type::PolymorphicInteger(
+                        CompTime::new(self.interner),
+                        Shared::new(TypeBinding::Bound(start_range_type.clone())),
+                    )
+                } else {
+                    Type::PolymorphicInteger(
+                        CompTime::Yes(Some(range_span)),
+                        Shared::new(TypeBinding::Bound(start_range_type.clone())),
+                    )
+                };
+
+                self.unify(&start_range_type, &expected_type, range_span, || {
+                    TypeCheckError::TypeCannotBeUsed {
+                        typ: start_range_type.clone(),
+                        place: "for loop",
+                        span: range_span,
+                    }
+                    .add_context("The range of a loop must be known at compile-time")
                 });
 
                 self.interner.push_definition_type(for_expr.identifier.id, start_range_type);


### PR DESCRIPTION
# Description


This means that for loop ranges can be either a Field or an integer. Currently we only allow Field. 
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
