### PR TITLE
fix(ssa refactor): fix bad constant type caching

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
@@ -42,7 +42,7 @@ pub(crate) struct DataFlowGraph {
 
     /// Each constant is unique, attempting to insert the same constant
     /// twice will return the same ValueId.
-    constants: HashMap<FieldElement, ValueId>,
+    constants: HashMap<(FieldElement, Type), ValueId>,
 
     /// Contains each function that has been imported into the current function.
     /// Each function's Value::Function is uniqued here so any given FunctionId
@@ -164,11 +164,11 @@ impl DataFlowGraph {
     /// Creates a new constant value, or returns the Id to an existing one if
     /// one already exists.
     pub(crate) fn make_constant(&mut self, constant: FieldElement, typ: Type) -> ValueId {
-        if let Some(id) = self.constants.get(&constant) {
+        if let Some(id) = self.constants.get(&(constant, typ)) {
             return *id;
         }
         let id = self.values.insert(Value::NumericConstant { constant, typ });
-        self.constants.insert(constant, id);
+        self.constants.insert((constant, typ), id);
         id
     }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Bad type information was used when creating a constant that matched a previously cached constant without considering its type

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

Cache constants by both numeric value and type

### Example

```rs
fn main(x: u2) -> pub u2 {
    0 - x
}
```

Before:

```
Initial SSA:
fn main f0 {
  b0(v0: u2):
    v2 = sub unit 0, v0
    return v2
}
```

After:

```
Initial SSA:
fn main f0 {
  b0(v0: u2):
    v2 = sub u2 0, v0
    return v2
}
```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
