### PR TITLE
fix(nargo): prevent -p arg clash

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -38,7 +38,7 @@ pub struct CompileOptions {
     pub show_ssa: bool,
 
     /// Display the ACIR for compiled circuit
-    #[arg(short, long)]
+    #[arg(long)]
     pub print_acir: bool,
 
     /// Treat all warnings as errors


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

The introduction on `--prover-name` causes `nargo execute` to crash because the argument's short form clashes with `--print-acirs`'s.

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

Prevent the clash, by removing the short form for `--print-acir`. 

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```
The application panicked (crashed).
Message:  Command execute: Short option names must be unique for each argument, but '-p' is in use by both 'prover_name' and 'print_acir'
Location: /Users/aztec/.cargo/registry/src/github.com-1ecc6299db9ec823/clap_builder-4.3.0/src/builder/debug_asserts.rs:115

```

After:

(Now runs correctly)

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
