### PR TITLE
fix(ssa refactor): Expand PR #1535 to resolve ValueIds in all SSA passes

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -325,6 +325,7 @@ impl Context {
     /// involving such values are evaluated via a separate path and stored in
     /// `ssa_value_to_array_address` instead.
     fn convert_value(&mut self, value_id: ValueId, dfg: &DataFlowGraph) -> AcirValue {
+        let value_id = dfg.resolve(value_id);
         let value = &dfg[value_id];
         if let Some(acir_value) = self.ssa_values.get(&value_id) {
             return acir_value.clone();

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
@@ -157,24 +157,22 @@ impl DataFlowGraph {
     /// values since other instructions referring to the same ValueId need
     /// not be modified to refer to a new ValueId.
     pub(crate) fn set_value_from_id(&mut self, value_to_replace: ValueId, new_value: ValueId) {
-        // Replaced `ValueId`s are tracked purely for debugging purposes.
-        // We first call `resolve_replaced_value_id(new_value)` in case `new_value` is also a
-        // `ValueId` that has previously had its corresponding `Value` substituted.
-        self.replaced_value_ids.insert(value_to_replace, self.resolve_replaced_value_id(new_value));
-
-        let new_value = self.values[new_value].clone();
-        self.values[value_to_replace] = new_value;
+        if value_to_replace != new_value {
+            self.replaced_value_ids.insert(value_to_replace, self.resolve(new_value));
+            let new_value = self.values[new_value].clone();
+            self.values[value_to_replace] = new_value;
+        }
     }
 
     /// If `original_value_id`'s underlying `Value` has been substituted for that of another
     /// `ValueId`, this function will return the `ValueId` from which the substitution was taken.
     /// If `original_value_id`'s underlying `Value` has not been substituted, the same `ValueId`
     /// is returned.
-    ///
-    /// The function exists purely for debugging purposes. Only the SSA printer is concerned with
-    /// this information.
-    pub(crate) fn resolve_replaced_value_id(&self, original_value_id: ValueId) -> ValueId {
-        *self.replaced_value_ids.get(&original_value_id).unwrap_or(&original_value_id)
+    pub(crate) fn resolve(&self, original_value_id: ValueId) -> ValueId {
+        match self.replaced_value_ids.get(&original_value_id) {
+            Some(id) => self.resolve(*id),
+            None => original_value_id,
+        }
     }
 
     /// Creates a new constant value, or returns the Id to an existing one if

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/printer.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/printer.rs
@@ -61,6 +61,7 @@ pub(crate) fn display_block(
 /// constant or a function we print those directly.
 fn value(function: &Function, id: ValueId) -> String {
     use super::value::Value;
+    let id = function.dfg.resolve(id);
     match &function.dfg[id] {
         Value::NumericConstant { constant, typ } => {
             format!("{typ} {constant}")
@@ -71,9 +72,7 @@ fn value(function: &Function, id: ValueId) -> String {
             let elements = vecmap(array, |element| value(function, *element));
             format!("[{}]", elements.join(", "))
         }
-        Value::Param { .. } | Value::Instruction { .. } => {
-            function.dfg.resolve_replaced_value_id(id).to_string()
-        }
+        Value::Param { .. } | Value::Instruction { .. } => id.to_string(),
     }
 }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
@@ -56,9 +56,9 @@ impl Context {
         for instruction in instructions {
             self.push_instruction(function, block, instruction);
         }
-
-        let terminator =
-            function.dfg[block].unwrap_terminator().map_values(|value| self.get_value(value));
+        let terminator = function.dfg[block]
+            .unwrap_terminator()
+            .map_values(|value| self.get_value(function.dfg.resolve(value)));
 
         function.dfg.set_block_terminator(block, terminator);
         self.block_queue.extend(function.dfg[block].successors());

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
@@ -74,7 +74,8 @@ impl Context {
         block: BasicBlockId,
         id: InstructionId,
     ) {
-        let instruction = function.dfg[id].map_values(|id| self.get_value(id));
+        let instruction =
+            function.dfg[id].map_values(|id| self.get_value(function.dfg.resolve(id)));
         let results = vecmap(function.dfg.instruction_results(id), |id| function.dfg.resolve(*id));
 
         let ctrl_typevars = instruction

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
@@ -75,7 +75,7 @@ impl Context {
         id: InstructionId,
     ) {
         let instruction = function.dfg[id].map_values(|id| self.get_value(id));
-        let results = function.dfg.instruction_results(id).to_vec();
+        let results = vecmap(function.dfg.instruction_results(id), |id| function.dfg.resolve(*id));
 
         let ctrl_typevars = instruction
             .requires_ctrl_typevars()

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -534,7 +534,8 @@ impl<'f> Context<'f> {
     fn push_instruction(&mut self, id: InstructionId) {
         let instruction = self.function.dfg[id].map_values(|id| self.translate_value(id));
         let instruction = self.handle_instruction_side_effects(instruction);
-        let results = self.function.dfg.instruction_results(id).to_vec();
+        let results = self.function.dfg.instruction_results(id);
+        let results = vecmap(results, |id| self.function.dfg.resolve(*id));
 
         let ctrl_typevars = instruction
             .requires_ctrl_typevars()

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -362,13 +362,14 @@ impl<'function> PerFunctionContext<'function> {
     fn push_instruction(&mut self, id: InstructionId) {
         let instruction = self.source_function.dfg[id].map_values(|id| self.translate_value(id));
         let results = self.source_function.dfg.instruction_results(id);
+        let results = vecmap(results, |id| self.source_function.dfg.resolve(*id));
 
         let ctrl_typevars = instruction
             .requires_ctrl_typevars()
-            .then(|| vecmap(results, |result| self.source_function.dfg.type_of_value(*result)));
+            .then(|| vecmap(&results, |result| self.source_function.dfg.type_of_value(*result)));
 
         let new_results = self.context.builder.insert_instruction(instruction, ctrl_typevars);
-        Self::insert_new_instruction_results(&mut self.values, results, new_results);
+        Self::insert_new_instruction_results(&mut self.values, &results, new_results);
     }
 
     /// Modify the values HashMap to remember the mapping between an instruction result's previous

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/unrolling.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/unrolling.rs
@@ -441,7 +441,8 @@ impl<'f> LoopIteration<'f> {
 
     fn push_instruction(&mut self, id: InstructionId) {
         let instruction = self.function.dfg[id].map_values(|id| self.get_value(id));
-        let results = self.function.dfg.instruction_results(id).to_vec();
+        let results = self.function.dfg.instruction_results(id);
+        let results = vecmap(results, |id| self.function.dfg.resolve(*id));
 
         let ctrl_typevars = instruction
             .requires_ctrl_typevars()


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Expands the HashMap solution of the existing PR to resolve any updated ValueIds in every pass instead of just the SSA printer.

Resolves #1451

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
