### PR TITLE
chore(ssa refactor): Remove unit values from SSA IR

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -294,14 +294,6 @@ impl Context {
             _ => unreachable!("ICE: Program must have a singular return"),
         };
 
-        // Check if the program returns the `Unit/None` type.
-        // This type signifies that the program returns nothing.
-        let is_return_unit_type =
-            return_values.len() == 1 && dfg.type_of_value(return_values[0]) == Type::Unit;
-        if is_return_unit_type {
-            return;
-        }
-
         // The return value may or may not be an array reference. Calling `flatten_value_list`
         // will expand the array if there is one.
         let return_acir_vars = self.flatten_value_list(return_values, dfg);
@@ -444,9 +436,6 @@ impl Context {
             (_, Type::Array(..)) | (Type::Array(..), _) => {
                 unreachable!("Arrays are invalid in binary operations")
             }
-            // Unit type currently can mean a 0 constant, so we return the
-            // other type.
-            (typ, Type::Unit) | (Type::Unit, typ) => typ,
             // If either side is a Field constant then, we coerce into the type
             // of the other operand
             (Type::Numeric(NumericType::NativeField), typ)

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/types.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/types.rs
@@ -31,9 +31,6 @@ pub(crate) enum Type {
 
     /// A function that may be called directly
     Function,
-
-    /// The Unit type with a single value
-    Unit,
 }
 
 impl Type {
@@ -78,7 +75,6 @@ impl std::fmt::Display for Type {
                 write!(f, "[{}; {length}]", elements.join(", "))
             }
             Type::Function => write!(f, "function"),
-            Type::Unit => write!(f, "unit"),
         }
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
@@ -170,6 +170,7 @@ impl<'a> FunctionContext<'a> {
             ast::Type::Tuple(fields) => {
                 Tree::Branch(vecmap(fields, |field| Self::map_type_helper(field, f)))
             }
+            ast::Type::Unit => Tree::empty(),
             other => Tree::Leaf(f(Self::convert_non_tuple_type(other))),
         }
     }
@@ -197,7 +198,7 @@ impl<'a> FunctionContext<'a> {
             ast::Type::Integer(Signedness::Unsigned, bits) => Type::unsigned(*bits),
             ast::Type::Bool => Type::unsigned(1),
             ast::Type::String(_) => Type::Reference,
-            ast::Type::Unit => Type::Unit,
+            ast::Type::Unit => panic!("convert_non_tuple_type called on a unit type"),
             ast::Type::Tuple(_) => panic!("convert_non_tuple_type called on a tuple: {typ}"),
             ast::Type::Function(_, _) => Type::Function,
 
@@ -210,8 +211,8 @@ impl<'a> FunctionContext<'a> {
 
     /// Insert a unit constant into the current function if not already
     /// present, and return its value
-    pub(super) fn unit_value(&mut self) -> Values {
-        self.builder.numeric_constant(0u128, Type::Unit).into()
+    pub(super) fn unit_value() -> Values {
+        Values::empty()
     }
 
     /// Insert a binary instruction at the end of the current block.

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/mod.rs
@@ -151,7 +151,7 @@ impl<'a> FunctionContext<'a> {
     }
 
     fn codegen_block(&mut self, block: &[Expression]) -> Values {
-        let mut result = self.unit_value();
+        let mut result = Self::unit_value();
         for expr in block {
             result = self.codegen_expression(expr);
         }
@@ -258,7 +258,7 @@ impl<'a> FunctionContext<'a> {
 
         // Finish by switching back to the end of the loop
         self.builder.switch_to_block(loop_end);
-        self.unit_value()
+        Self::unit_value()
     }
 
     /// Codegens an if expression, handling the case of what to do if there is no 'else'.
@@ -296,7 +296,7 @@ impl<'a> FunctionContext<'a> {
         self.builder.switch_to_block(then_block);
         let then_value = self.codegen_expression(&if_expr.consequence);
 
-        let mut result = self.unit_value();
+        let mut result = Self::unit_value();
 
         if let Some(alternative) = &if_expr.alternative {
             let end_block = self.builder.insert_block();
@@ -363,13 +363,13 @@ impl<'a> FunctionContext<'a> {
         }
 
         self.define(let_expr.id, values);
-        self.unit_value()
+        Self::unit_value()
     }
 
     fn codegen_constrain(&mut self, expr: &Expression, _location: Location) -> Values {
         let boolean = self.codegen_non_tuple_expression(expr);
         self.builder.insert_constrain(boolean);
-        self.unit_value()
+        Self::unit_value()
     }
 
     fn codegen_assign(&mut self, assign: &ast::Assign) -> Values {
@@ -377,11 +377,11 @@ impl<'a> FunctionContext<'a> {
         let rhs = self.codegen_expression(&assign.expression);
 
         self.assign_new_value(lhs, rhs);
-        self.unit_value()
+        Self::unit_value()
     }
 
     fn codegen_semi(&mut self, expr: &Expression) -> Values {
         self.codegen_expression(expr);
-        self.unit_value()
+        Self::unit_value()
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/value.rs
@@ -63,6 +63,11 @@ impl Value {
 pub(super) type Values = Tree<Value>;
 
 impl<T> Tree<T> {
+    /// Returns an empty tree node represented by a Branch with no branches
+    pub(super) fn empty() -> Self {
+        Tree::Branch(vec![])
+    }
+
     /// Flattens the tree into a vector of each leaf value
     pub(super) fn flatten(self) -> Vec<T> {
         match self {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Leaving unit values in the code can lead to issues such as #1614 and #1541 since functions that return no values are instead compiled as functions which return a unit value. Filtering out these values also enables acir_gen to be cleaner by not requiring it to check for a unit return type manually.

Resolves #1614 and #1541

## Summary\*

This PR will filter _all_ unit values out of the program, not just functions returning a single unit value. So functions returning a pair of unit values, or functions which take parameters which may contain nested unit values, and even arrays which may have heterogeneous element types containing a unit value, will all be filtered out. This is essentially equivalent to the Zero-Sized Type (ZST) optimization in rust.

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

Given:
```rs
fn main() {
    let x = f1();
    f2(x, x)
}

fn f1(){}

fn f2<T>(x: T, y: T) -> T { x }
```

```
v0 = call f1()
v1 = call f2(v0)
return v1
```

After:

```
call f1()
call f2()
return
```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
