### PR TITLE
fix(ssa refactor): Fix stack overflow during loop unrolling

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -237,7 +237,9 @@ impl Instruction {
         match self {
             Instruction::Binary(binary) => binary.simplify(dfg),
             Instruction::Cast(value, typ) => {
-                if let Some(value) = (*typ == dfg.type_of_value(*value)).then_some(*value) {
+                if let Some(constant) = dfg.get_numeric_constant(*value) {
+                    SimplifiedTo(dfg.make_constant(constant, typ.clone()))
+                } else if let Some(value) = (*typ == dfg.type_of_value(*value)).then_some(*value) {
                     SimplifiedTo(value)
                 } else {
                     None


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1650 

## Summary\*

Fixes an issue causing loop unrolling to overflow the stack. Note that this does not fix 9_conditional completely since it runs into issues with the flatten_cfg pass. I believe this may be related to #1420.

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
