### PR TITLE
fix(ssa refactor): Fix flatten_cfg for ifs with no else

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -441,7 +441,11 @@ impl<'f> Context<'f> {
         new_condition: ValueId,
         condition_value: FieldElement,
     ) -> Branch {
-        if destination != self.branch_ends[&jmpif_block] {
+        if destination == self.branch_ends[&jmpif_block] {
+            // If the branch destination is the same as the end of the branch, this must be the
+            // 'else' case of an if with no else - so there is no else branch.
+            Branch { condition: new_condition, last_block: jmpif_block, store_values: HashMap::new() }
+        } else {
             self.push_condition(jmpif_block, new_condition);
             self.insert_current_side_effects_enabled();
             let old_stores = std::mem::take(&mut self.store_values);
@@ -456,8 +460,6 @@ impl<'f> Context<'f> {
             let stores_in_branch = std::mem::replace(&mut self.store_values, old_stores);
 
             Branch { condition: new_condition, last_block: final_block, store_values: stores_in_branch }
-        } else {
-            Branch { condition: new_condition, last_block: jmpif_block, store_values: HashMap::new() }
         }
     }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1420

## Summary\*

Adds a small check to flatten_cfg to avoid inlining a branch if the branch start matches the branch end.

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
