### PR TITLE
fix(ssa refactor): Do not remove enable_side_effects instructions in die pass

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/die.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/die.rs
@@ -90,7 +90,10 @@ impl Context {
         let instruction = &function.dfg[instruction_id];
 
         // These instruction types cannot be removed
-        if matches!(instruction, Constrain(_) | Call { .. } | Store { .. }) {
+        if matches!(
+            instruction,
+            Constrain(_) | Call { .. } | Store { .. } | EnableSideEffects { .. }
+        ) {
             return false;
         }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

The Dead Instruction Elimination (DIE) pass was removing the enable_side_effects instructions previously as they had no result values, and thus all results were unused. This is problematic because these instructions are side-effectful so we want them to stay around.

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
