### PR TITLE
fix(ssa refactor): Fix failed_to_inline_a_function being set for intrinsics

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -256,8 +256,14 @@ impl<'function> PerFunctionContext<'function> {
         id = self.translate_value(id);
         match self.context.builder[id] {
             Value::Function(id) => Some(id),
+            // We don't set failed_to_inline_a_call for intrinsics since those
+            // don't correspond to actual functions in the SSA program that would
+            // need to be removed afterward.
             Value::Intrinsic(_) => None,
-            _ => None,
+            _ => {
+                self.context.failed_to_inline_a_call = true;
+                None
+            },
         }
     }
 
@@ -332,10 +338,7 @@ impl<'function> PerFunctionContext<'function> {
                             self.push_instruction(*id);
                         }
                     },
-                    None => {
-                        self.context.failed_to_inline_a_call = true;
-                        self.push_instruction(*id);
-                    }
+                    None => self.push_instruction(*id),
                 },
                 _ => self.push_instruction(*id),
             }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

The change to add handling for brillig functions changed `failed_to_inline_a_function` to be true whenever a function failed to inline. We want this not to be set if the function we found is an intrinsic since those do not need to be inlined and added a comment since this is otherwise a subtle difference.

Fixes #1659 

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
