### PR TITLE
fix(ssa refactor): Add missing calls to resolve in Instruction::simplify

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
@@ -308,7 +308,7 @@ impl DataFlowGraph {
         &self,
         value: ValueId,
     ) -> Option<(FieldElement, Type)> {
-        match &self.values[value] {
+        match &self.values[self.resolve(value)] {
             Value::NumericConstant { constant, typ } => Some((*constant, typ.clone())),
             _ => None,
         }
@@ -320,7 +320,7 @@ impl DataFlowGraph {
         &self,
         value: ValueId,
     ) -> Option<(im::Vector<ValueId>, Rc<CompositeType>)> {
-        match &self.values[value] {
+        match &self.values[self.resolve(value)] {
             // Vectors are shared, so cloning them is cheap
             Value::Array { array, element_type } => Some((array.clone(), element_type.clone())),
             _ => None,

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -244,7 +244,7 @@ impl Instruction {
                 }
             }
             Instruction::Not(value) => {
-                match &dfg[*value] {
+                match &dfg[dfg.resolve(*value)] {
                     // Limit optimizing ! on constants to only booleans. If we tried it on fields,
                     // there is no Not on FieldElement, so we'd need to convert between u128. This
                     // would be incorrect however since the extra bits on the field would not be flipped.
@@ -497,13 +497,13 @@ impl Binary {
                 }
             }
             BinaryOp::Eq => {
-                if self.lhs == self.rhs {
+                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
                     let one = dfg.make_constant(FieldElement::one(), Type::bool());
                     return SimplifyResult::SimplifiedTo(one);
                 }
             }
             BinaryOp::Lt => {
-                if self.lhs == self.rhs {
+                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
                     let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                     return SimplifyResult::SimplifiedTo(zero);
                 }
@@ -523,7 +523,7 @@ impl Binary {
                 }
             }
             BinaryOp::Xor => {
-                if self.lhs == self.rhs {
+                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
                     let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                     return SimplifyResult::SimplifiedTo(zero);
                 }

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -444,7 +444,11 @@ impl<'f> Context<'f> {
         if destination == self.branch_ends[&jmpif_block] {
             // If the branch destination is the same as the end of the branch, this must be the
             // 'else' case of an if with no else - so there is no else branch.
-            Branch { condition: new_condition, last_block: jmpif_block, store_values: HashMap::new() }
+            Branch {
+                condition: new_condition,
+                last_block: jmpif_block,
+                store_values: HashMap::new(),
+            }
         } else {
             self.push_condition(jmpif_block, new_condition);
             self.insert_current_side_effects_enabled();
@@ -459,7 +463,11 @@ impl<'f> Context<'f> {
             self.conditions.pop();
             let stores_in_branch = std::mem::replace(&mut self.store_values, old_stores);
 
-            Branch { condition: new_condition, last_block: final_block, store_values: stores_in_branch }
+            Branch {
+                condition: new_condition,
+                last_block: final_block,
+                store_values: stores_in_branch,
+            }
         }
     }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

The lack of these calls was causing some instructions to fail to simplify.

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
