### PR TITLE
chore: move `delayed_type_checks` field from `NodeInterner` to `TypeChecker`

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -763,7 +763,7 @@ impl<'interner> TypeChecker<'interner> {
                     // This will be an error if these types later resolve to a Field, or stay
                     // polymorphic as the bit size will be unknown. Delay this error until the function
                     // finishes resolving so we can still allow cases like `let x: u8 = 1 << 2;`.
-                    self.interner.push_delayed_type_check(Box::new(move || {
+                    self.push_delayed_type_check(Box::new(move || {
                         if other.is_field() {
                             Err(make_error("Bitwise operations are invalid on Field types. Try casting the operands to a sized integer type first".into()))
                         } else if other.is_bindable() {

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -89,10 +89,6 @@ impl<'interner> TypeChecker<'interner> {
         self.delayed_type_checks.push(f);
     }
 
-    pub fn take_delayed_type_check_functions(&mut self) -> Vec<TypeCheckFn> {
-        std::mem::take(&mut self.delayed_type_checks)
-    }
-
     fn check_function_body(
         mut self,
         body: &ExprId,

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -22,7 +22,10 @@ use crate::{
     Type,
 };
 
+type TypeCheckFn = Box<dyn FnOnce() -> Result<(), TypeCheckError>>;
+
 pub struct TypeChecker<'interner> {
+    delayed_type_checks: Vec<TypeCheckFn>,
     current_function: Option<FuncId>,
     interner: &'interner mut NodeInterner,
     errors: Vec<TypeCheckError>,
@@ -47,10 +50,11 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
         type_checker.bind_pattern(&param.0, param.1);
     }
 
-    let (function_last_type, mut errors) = type_checker.check_function_body(function_body_id);
+    let (function_last_type, delayed_type_check_functions, mut errors) =
+        type_checker.check_function_body(function_body_id);
 
     // Go through any delayed type checking errors to see if they are resolved, or error otherwise.
-    for type_check_fn in interner.take_delayed_type_check_functions() {
+    for type_check_fn in delayed_type_check_functions {
         if let Err(error) = type_check_fn() {
             errors.push(error);
         }
@@ -73,16 +77,37 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
 
 impl<'interner> TypeChecker<'interner> {
     fn new(current_function: FuncId, interner: &'interner mut NodeInterner) -> Self {
-        Self { current_function: Some(current_function), interner, errors: vec![] }
+        Self {
+            delayed_type_checks: Vec::new(),
+            current_function: Some(current_function),
+            interner,
+            errors: vec![],
+        }
     }
 
-    fn check_function_body(mut self, body: &ExprId) -> (Type, Vec<TypeCheckError>) {
+    pub fn push_delayed_type_check(&mut self, f: TypeCheckFn) {
+        self.delayed_type_checks.push(f);
+    }
+
+    pub fn take_delayed_type_check_functions(&mut self) -> Vec<TypeCheckFn> {
+        std::mem::take(&mut self.delayed_type_checks)
+    }
+
+    fn check_function_body(
+        mut self,
+        body: &ExprId,
+    ) -> (Type, Vec<TypeCheckFn>, Vec<TypeCheckError>) {
         let body_type = self.check_expression(body);
-        (body_type, self.errors)
+        (body_type, self.delayed_type_checks, self.errors)
     }
 
     pub fn check_global(id: &StmtId, interner: &'interner mut NodeInterner) -> Vec<TypeCheckError> {
-        let mut this = Self { current_function: None, interner, errors: vec![] };
+        let mut this = Self {
+            delayed_type_checks: Vec::new(),
+            current_function: None,
+            interner,
+            errors: vec![],
+        };
         this.check_statement(id);
         this.errors
     }


### PR DESCRIPTION
## Problem

The current implementation of the node interner in the codebase appears to be handling multiple responsibilities and exhibiting signs of complexity. 

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
