### PR TITLE
chore(errors): Remove span end offset to surface problems

### DIFF
--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -145,7 +145,7 @@ fn convert_diagnostic(
             .iter()
             .map(|sl| {
                 let start_span = sl.span.start() as usize;
-                let end_span = sl.span.end() as usize + 1;
+                let end_span = sl.span.end() as usize;
                 Label::secondary(file_id.as_usize(), start_span..end_span).with_message(&sl.message)
             })
             .collect()


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This removes the `+ 1` offset on span ends. This will allow us to have a clear understanding of where span start/ends might be wrong in the compiler. I first noticed this off-by-one when outputting diagnostics via the LSP and will open a follow-up issue to fix the spans in the compiler.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
