### PR TITLE
chore(github): Remove PR template's example section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,25 +11,8 @@ Resolves <!-- Link to GitHub Issue -->
 
 ## Summary\*
 
-<!-- Describe the changes in this PR, particularly breaking changes if any. -->
-
-This PR sets out to
-
-### Example
-
-<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->
-
-Before:
-
-```
-
-```
-
-After:
-
-```
-
-```
+<!-- Describe the changes in this PR. -->
+<!-- Supplement code examples and highlight breaking changes, if applicable. -->
 
 ## Documentation
 


### PR DESCRIPTION
# Description

## Problem\*

The "Example" section is not commonly applicable to PRs and can be distracting.

## Summary\*

This PR removes the section and adds a minor reminder in the template on supplementing examples whenever applicable.

## Documentation

- [ ] This PR requires documentation updates when merged.
  - [ ] I will submit a noir-lang/docs PR.
  - [ ] I will request for and support Dev Rel's help in documenting this PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
