### PR TITLE
fix: Fix nargo not showing compiler errors or warnings

### DIFF
--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -2,7 +2,6 @@ use acvm::Backend;
 use iter_extended::try_vecmap;
 use nargo::artifacts::contract::PreprocessedContract;
 use noirc_driver::{CompileOptions, CompiledProgram, Driver};
-use noirc_errors::reporter;
 use std::path::Path;
 
 use clap::Args;
@@ -50,11 +49,10 @@ pub(crate) fn run<B: Backend>(
     // If contracts is set we're compiling every function in a 'contract' rather than just 'main'.
     if args.contracts {
         let mut driver = setup_driver(backend, &config.program_dir)?;
+
+        let result = driver.compile_contracts(&args.compile_options);
         let compiled_contracts =
-            driver.compile_contracts(&args.compile_options).map_err(|errors| {
-                reporter::report_all(driver.file_manager(), &errors, false);
-                CliError::CompilationError
-            })?;
+            driver.report_errors(result, args.compile_options.deny_warnings)?;
 
         // TODO(#1389): I wonder if it is incorrect for nargo-core to know anything about contracts.
         // As can be seen here, It seems like a leaky abstraction where ContractFunctions (essentially CompiledPrograms)
@@ -121,8 +119,6 @@ pub(crate) fn compile_circuit<B: Backend>(
     compile_options: &CompileOptions,
 ) -> Result<CompiledProgram, CliError<B>> {
     let mut driver = setup_driver(backend, program_dir)?;
-    driver.compile_main(compile_options).map_err(|errors| {
-        reporter::report_all(driver.file_manager(), &errors, false);
-        CliError::CompilationError
-    })
+    let result = driver.compile_main(compile_options);
+    driver.report_errors(result, compile_options.deny_warnings).map_err(Into::into)
 }

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -1,7 +1,8 @@
 use acvm::Backend;
 use iter_extended::try_vecmap;
 use nargo::artifacts::contract::PreprocessedContract;
-use noirc_driver::{CompileOptions, CompiledProgram, Driver};
+use noirc_driver::{CompileOptions, CompiledProgram, Driver, ErrorsAndWarnings, Warnings};
+use noirc_errors::reporter::ReportedErrors;
 use std::path::Path;
 
 use clap::Args;
@@ -51,15 +52,14 @@ pub(crate) fn run<B: Backend>(
         let mut driver = setup_driver(backend, &config.program_dir)?;
 
         let result = driver.compile_contracts(&args.compile_options);
-        let compiled_contracts =
-            driver.report_errors(result, args.compile_options.deny_warnings)?;
+        let contracts = report_errors(result, &driver, args.compile_options.deny_warnings)?;
 
         // TODO(#1389): I wonder if it is incorrect for nargo-core to know anything about contracts.
         // As can be seen here, It seems like a leaky abstraction where ContractFunctions (essentially CompiledPrograms)
         // are compiled via nargo-core and then the PreprocessedContract is constructed here.
         // This is due to EACH function needing it's own CRS, PKey, and VKey from the backend.
         let preprocessed_contracts: Result<Vec<PreprocessedContract>, CliError<B>> =
-            try_vecmap(compiled_contracts, |contract| {
+            try_vecmap(contracts, |contract| {
                 let preprocessed_contract_functions = try_vecmap(contract.functions, |func| {
                     common_reference_string = update_common_reference_string(
                         backend,
@@ -120,5 +120,20 @@ pub(crate) fn compile_circuit<B: Backend>(
 ) -> Result<CompiledProgram, CliError<B>> {
     let mut driver = setup_driver(backend, program_dir)?;
     let result = driver.compile_main(compile_options);
-    driver.report_errors(result, compile_options.deny_warnings).map_err(Into::into)
+    report_errors(result, &driver, compile_options.deny_warnings).map_err(Into::into)
+}
+
+/// Helper function for reporting any errors in a Result<(T, Warnings), ErrorsAndWarnings>
+/// structure that is commonly used as a return result in this file.
+pub(crate) fn report_errors<T>(
+    result: Result<(T, Warnings), ErrorsAndWarnings>,
+    driver: &Driver,
+    deny_warnings: bool,
+) -> Result<T, ReportedErrors> {
+    let (t, warnings) = result.map_err(|errors| {
+        noirc_errors::reporter::report_all(driver.file_manager(), &errors, deny_warnings)
+    })?;
+
+    noirc_errors::reporter::report_all(driver.file_manager(), &warnings, deny_warnings);
+    Ok(t)
 }

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -167,6 +167,7 @@ pub fn prove_and_verify(program_dir: &Path, experimental_ssa: bool) -> bool {
 #[cfg(test)]
 mod tests {
     use noirc_driver::Driver;
+    use noirc_errors::reporter;
     use noirc_frontend::graph::CrateType;
 
     use std::path::{Path, PathBuf};
@@ -184,7 +185,17 @@ mod tests {
         );
         driver.create_local_crate(&root_file, CrateType::Binary);
         crate::resolver::add_std_lib(&mut driver);
-        driver.file_compiles()
+
+        let result = driver.check_crate(false);
+        let success = result.is_ok();
+
+        let errors = match result {
+            Ok(warnings) => warnings,
+            Err(errors) => errors,
+        };
+
+        reporter::report_all(driver.file_manager(), &errors, false);
+        success
     }
 
     #[test]

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -7,7 +7,10 @@ use noirc_driver::{CompileOptions, Driver};
 use noirc_frontend::node_interner::FuncId;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use crate::{cli::compile_cmd::setup_driver, errors::CliError};
+use crate::{
+    cli::{check_cmd::check_crate_and_report_errors, compile_cmd::setup_driver},
+    errors::CliError,
+};
 
 use super::NargoConfig;
 
@@ -38,8 +41,7 @@ fn run_tests<B: Backend>(
     compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
     let mut driver = setup_driver(backend, program_dir)?;
-
-    driver.check_crate_and_report_errors(compile_options.deny_warnings)?;
+    check_crate_and_report_errors(&mut driver, compile_options.deny_warnings)?;
 
     let test_functions = driver.get_all_test_functions_in_crate_matching(test_name);
     println!("Running {} test functions...", test_functions.len());

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -4,7 +4,6 @@ use acvm::{acir::native_types::WitnessMap, Backend};
 use clap::Args;
 use nargo::ops::execute_circuit;
 use noirc_driver::{CompileOptions, Driver};
-use noirc_errors::reporter;
 use noirc_frontend::node_interner::FuncId;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
@@ -40,15 +39,7 @@ fn run_tests<B: Backend>(
 ) -> Result<(), CliError<B>> {
     let mut driver = setup_driver(backend, program_dir)?;
 
-    let result = driver.check_crate();
-    if let Err(errs) = result {
-        let file_manager = driver.file_manager();
-        let error_count = reporter::report_all(file_manager, &errs, compile_options.deny_warnings);
-        if error_count != 0 {
-            reporter::finish_report(error_count);
-            return Err(CliError::CompilationError);
-        }
-    }
+    driver.check_crate_and_report_errors(compile_options.deny_warnings)?;
 
     let test_functions = driver.get_all_test_functions_in_crate_matching(test_name);
     println!("Running {} test functions...", test_functions.len());

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -5,6 +5,7 @@ use acvm::{
 use hex::FromHexError;
 use nargo::NargoError;
 use noirc_abi::errors::{AbiError, InputParserError};
+use noirc_errors::reporter::ReportedErrors;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -43,9 +44,10 @@ pub(crate) enum CliError<B: Backend> {
     #[error(transparent)]
     ResolutionError(#[from] DependencyResolutionError),
 
-    /// Error while compiling Noir into ACIR.
-    #[error("Failed to compile circuit")]
-    CompilationError,
+    /// Errors encountered while compiling the noir program.
+    /// These errors are already written to stderr.
+    #[error("Aborting due to {} previous error{}", .0.error_count, if .0.error_count == 1 { "" } else { "s" })]
+    ReportedErrors(ReportedErrors),
 
     /// ABI encoding/decoding error
     #[error(transparent)]
@@ -73,4 +75,10 @@ pub(crate) enum CliError<B: Backend> {
     /// Backend error caused by a function on the CommonReferenceString trait
     #[error(transparent)]
     CommonReferenceStringError(<B as CommonReferenceString>::Error), // Unfortunately, Rust won't let us `impl From` over an Associated Type on a generic
+}
+
+impl<B: Backend> From<ReportedErrors> for CliError<B> {
+    fn from(errors: ReportedErrors) -> Self {
+        Self::ReportedErrors(errors)
+    }
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -8,7 +8,6 @@ use acvm::Language;
 use clap::Args;
 use fm::{FileId, FileManager, FileType};
 use noirc_abi::FunctionSignature;
-use noirc_errors::reporter::ReportedErrors;
 use noirc_errors::{CustomDiagnostic, FileDiagnostic};
 use noirc_evaluator::{create_circuit, ssa_refactor::experimental_create_circuit};
 use noirc_frontend::graph::{CrateId, CrateName, CrateType, LOCAL_CRATE};
@@ -179,31 +178,6 @@ impl Driver {
         } else {
             Ok(errors)
         }
-    }
-
-    /// Run the lexing, parsing, name resolution, and type checking passes and report any warnings
-    /// and errors found.
-    pub fn check_crate_and_report_errors(
-        &mut self,
-        deny_warnings: bool,
-    ) -> Result<(), ReportedErrors> {
-        let result = self.check_crate(deny_warnings).map(|warnings| ((), warnings));
-        self.report_errors(result, deny_warnings)
-    }
-
-    /// Helper function for reporting any errors in a Result<(T, Warnings), ErrorsAndWarnings>
-    /// structure that is commonly used as a return result in this file.
-    pub fn report_errors<T>(
-        &self,
-        result: Result<(T, Warnings), ErrorsAndWarnings>,
-        deny_warnings: bool,
-    ) -> Result<T, ReportedErrors> {
-        let (t, warnings) = result.map_err(|errors| {
-            noirc_errors::reporter::report_all(self.file_manager(), &errors, deny_warnings)
-        })?;
-
-        noirc_errors::reporter::report_all(self.file_manager(), &warnings, deny_warnings);
-        Ok(t)
     }
 
     pub fn compute_function_signature(&self) -> Option<FunctionSignature> {

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -263,7 +263,7 @@ impl<'function> PerFunctionContext<'function> {
             _ => {
                 self.context.failed_to_inline_a_call = true;
                 None
-            },
+            }
         }
     }
 

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -91,12 +91,13 @@ pub fn compile(args: JsValue) -> JsValue {
     // We are always adding std lib implicitly. It comes bundled with binary.
     add_noir_lib(&mut driver, "std");
 
-    driver.check_crate().expect("Crate check failed");
+    driver.check_crate(false).expect("Crate check failed");
 
     if options.contracts {
         let compiled_contracts = driver
             .compile_contracts(&options.compile_options)
-            .expect("Contract compilation failed");
+            .expect("Contract compilation failed")
+            .0;
 
         <JsValue as JsValueSerdeExt>::from_serde(&compiled_contracts).unwrap()
     } else {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Fixes an issue where if there are any compiler errors or warnings Nargo would map them into a CompilationError without reporting them first, leading to no errors being reported.

Resolves #1645

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
