### PR TITLE
fix(ssa refactor): Implement array equality in SSA-gen

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -263,7 +263,7 @@ impl<'function> PerFunctionContext<'function> {
             _ => {
                 self.context.failed_to_inline_a_call = true;
                 None
-            },
+            }
         }
     }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ssa_gen/context.rs
@@ -291,12 +291,17 @@ impl<'a> FunctionContext<'a> {
         let rhs_type = self.builder.type_of_value(rhs);
 
         let (array_length, element_type) = match (lhs_type, rhs_type) {
-            (Type::Array(lhs_elements, lhs_length), Type::Array(rhs_elements, rhs_length)) => {
-                assert_eq!(lhs_elements.len(), 1, "== is unimplemented for arrays of structs");
-                assert_eq!(rhs_elements.len(), 1, "== is unimplemented for arrays of structs");
-                assert_eq!(lhs_elements[0], rhs_elements[0]);
+            (
+                Type::Array(lhs_composite_type, lhs_length),
+                Type::Array(rhs_composite_type, rhs_length),
+            ) => {
+                assert!(
+                    lhs_composite_type.len() == 1 && rhs_composite_type.len() == 1,
+                    "== is unimplemented for arrays of structs"
+                );
+                assert_eq!(lhs_composite_type[0], rhs_composite_type[0]);
                 assert_eq!(lhs_length, rhs_length, "Expected two arrays of equal length");
-                (lhs_length, lhs_elements[0].clone())
+                (lhs_length, lhs_composite_type[0].clone())
             }
             _ => unreachable!("Expected two array values"),
         };


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #1625

## Summary\*

Implements array equality in ssa-gen. This way we should not need a separate pass in brillig.

We could still improve this code-gen with, e.g. an early exit if any `eq` returns false but I elected for the more straightforward approach for now since this code is temporary.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
