### PR TITLE
fix(aztec3-hacky): Add option for slim abi on the aztec3 branch

### DIFF
--- a/crates/nargo/src/artifacts/contract.rs
+++ b/crates/nargo/src/artifacts/contract.rs
@@ -36,6 +36,6 @@ pub struct PreprocessedContractFunction {
     )]
     pub bytecode: Circuit,
 
-    pub proving_key: Vec<u8>,
-    pub verification_key: Vec<u8>,
+    pub proving_key: Option<Vec<u8>>,
+    pub verification_key: Option<Vec<u8>>,
 }

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -41,14 +41,13 @@ pub fn preprocess_contract(
         // In future we'll need to apply those optimizations here.
         let optimized_bytecode = func.bytecode;
 
+        // If slim_abi is set, we do not generate a proving key or verification key.
         let (proving_key, verification_key) = if slim_abi {
             (None, None)
         } else {
             let (pk, vk) = backend.preprocess(&optimized_bytecode);
             (Some(pk), Some(vk))
         };
-
-        println!("SLIM ABI: {}", slim_abi);
 
         PreprocessedContractFunction {
             name: func.name,

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -34,6 +34,7 @@ pub fn preprocess_program(
 pub fn preprocess_contract(
     backend: &impl ProofSystemCompiler,
     compiled_contract: CompiledContract,
+    slim_abi: bool,
 ) -> Result<PreprocessedContract, NargoError> {
     let preprocessed_contract_functions = vecmap(compiled_contract.functions, |func| {
         // TODO: currently `func`'s bytecode is already optimized for the backend.
@@ -47,8 +48,8 @@ pub fn preprocess_contract(
             abi: func.abi,
 
             bytecode: optimized_bytecode,
-            proving_key,
-            verification_key,
+            proving_key: if slim_abi { None } else { Some(proving_key) },
+            verification_key: if slim_abi { None } else { Some(verification_key) },
         }
     });
 

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -40,7 +40,15 @@ pub fn preprocess_contract(
         // TODO: currently `func`'s bytecode is already optimized for the backend.
         // In future we'll need to apply those optimizations here.
         let optimized_bytecode = func.bytecode;
-        let (proving_key, verification_key) = backend.preprocess(&optimized_bytecode);
+
+        let (proving_key, verification_key) = if slim_abi {
+            (None, None)
+        } else {
+            let (pk, vk) = backend.preprocess(&optimized_bytecode);
+            (Some(pk), Some(vk))
+        };
+
+        println!("SLIM ABI: {}", slim_abi);
 
         PreprocessedContractFunction {
             name: func.name,
@@ -48,8 +56,8 @@ pub fn preprocess_contract(
             abi: func.abi,
 
             bytecode: optimized_bytecode,
-            proving_key: if slim_abi { None } else { Some(proving_key) },
-            verification_key: if slim_abi { None } else { Some(verification_key) },
+            proving_key,
+            verification_key,
         }
     });
 

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -38,8 +38,9 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
         let compiled_contracts = driver
             .compile_contracts(&args.compile_options)
             .map_err(|_| CliError::CompilationError)?;
-        let preprocessed_contracts =
-            try_vecmap(compiled_contracts, |contract| preprocess_contract(&backend, contract))?;
+        let preprocessed_contracts = try_vecmap(compiled_contracts, |contract| {
+            preprocess_contract(&backend, contract, args.compile_options.slim_abi)
+        })?;
         for contract in preprocessed_contracts {
             save_contract_to_file(
                 &contract,

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -89,7 +89,8 @@ pub fn prove_and_verify(proof_name: &str, prg_dir: &Path, show_ssa: bool) -> boo
     use tempdir::TempDir;
 
     let tmp_dir = TempDir::new("p_and_v_tests").unwrap();
-    let compile_options = CompileOptions { show_ssa, allow_warnings: false, show_output: false };
+    let compile_options =
+        CompileOptions { show_ssa, allow_warnings: false, show_output: false, slim_abi: false };
 
     match prove_cmd::prove_with_path(
         Some(proof_name.to_owned()),

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, io::Write, path::Path};
 
 use acvm::{pwg::block::Blocks, PartialWitnessGenerator, ProofSystemCompiler, UnresolvedData};
 use clap::Args;
-use nargo::ops::execute_circuit;
+
 use noirc_driver::{CompileOptions, Driver};
 use noirc_frontend::node_interner::FuncId;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -44,6 +44,7 @@ pub struct CompileOptions {
     #[arg(long)]
     pub show_output: bool,
 
+    /// Outputs abi without the proving or verification key
     #[arg(long)]
     pub slim_abi: bool,
 }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -43,11 +43,14 @@ pub struct CompileOptions {
     /// Display output of `println` statements
     #[arg(long)]
     pub show_output: bool,
+
+    #[arg(long)]
+    pub slim_abi: bool,
 }
 
 impl Default for CompileOptions {
     fn default() -> Self {
-        Self { show_ssa: false, allow_warnings: false, show_output: true }
+        Self { show_ssa: false, allow_warnings: false, show_output: true, slim_abi: false }
     }
 }
 


### PR DESCRIPTION
# Description

Right now compile times are massively impacted by the huge proving key and verification keys that are created for each compiled function. 

They balloon the size of the .json outputs to around 3GB in some cases. In order to consume the json we have to run the files through .jq to remove the pk / vk anyway. 

I propose this fix ONLY lives on the hacky branch until a more premanent solution is found. But it would speed us up massively to have merged in.


<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
