### PR TITLE
fix(aztec3-hacky): remove pk / vk verbatim

### DIFF
--- a/crates/nargo/src/artifacts/contract.rs
+++ b/crates/nargo/src/artifacts/contract.rs
@@ -35,7 +35,4 @@ pub struct PreprocessedContractFunction {
         deserialize_with = "super::deserialize_circuit"
     )]
     pub bytecode: Circuit,
-
-    pub proving_key: Vec<u8>,
-    pub verification_key: Vec<u8>,
 }

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -32,14 +32,12 @@ pub fn preprocess_program(
 }
 
 pub fn preprocess_contract(
-    backend: &impl ProofSystemCompiler,
     compiled_contract: CompiledContract,
 ) -> Result<PreprocessedContract, NargoError> {
     let preprocessed_contract_functions = vecmap(compiled_contract.functions, |func| {
         // TODO: currently `func`'s bytecode is already optimized for the backend.
         // In future we'll need to apply those optimizations here.
         let optimized_bytecode = func.bytecode;
-        let (proving_key, verification_key) = backend.preprocess(&optimized_bytecode);
 
         PreprocessedContractFunction {
             name: func.name,
@@ -47,8 +45,6 @@ pub fn preprocess_contract(
             abi: func.abi,
 
             bytecode: optimized_bytecode,
-            proving_key,
-            verification_key,
         }
     });
 

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -39,7 +39,7 @@ pub(crate) fn run(args: CompileCommand, config: NargoConfig) -> Result<(), CliEr
             .compile_contracts(&args.compile_options)
             .map_err(|_| CliError::CompilationError)?;
         let preprocessed_contracts =
-            try_vecmap(compiled_contracts, |contract| preprocess_contract(&backend, contract))?;
+            try_vecmap(compiled_contracts, |contract| preprocess_contract(contract))?;
         for contract in preprocessed_contracts {
             save_contract_to_file(
                 &contract,


### PR DESCRIPTION
# Description

Variation of #1709 that removes the pk / vk from noir contracts entirely

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
