### PR TITLE
fix(ssa refactor): truncate when simplifying constant casts

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -246,6 +246,10 @@ impl Instruction {
                         (
                             Type::Numeric(NumericType::Unsigned { bit_size }),
                             Type::Numeric(NumericType::Unsigned { .. }),
+                        )
+                        | (
+                            Type::Numeric(NumericType::Unsigned { bit_size }),
+                            Type::Numeric(NumericType::NativeField),
                         ) => {
                             let integer_modulus = BigUint::from(2u128).pow(*bit_size);
                             let constant: BigUint = BigUint::from_bytes_be(&constant.to_be_bytes());


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

The behaviour of cast was inconsistent between ACIR gen and SSA instruction simplicifcation.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

- Simplification of cast now only simplifies a constant if both the src and dst are unsigned integers
- The simplification of such constants now truncates by the integer modulus

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
