### PR TITLE
fix(frontend): Avoid panic if dependency cannot be resolved

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/import.rs
+++ b/crates/noirc_frontend/src/hir/resolution/import.rs
@@ -192,11 +192,11 @@ fn resolve_external_dep(
     let path = &directive.path.segments;
     //
     // Fetch the root module from the prelude
-    let crate_name = path.first().unwrap().0.contents.clone();
+    let crate_name = path.first().unwrap();
     let dep_module = current_def_map
         .extern_prelude
-        .get(&crate_name)
-        .unwrap_or_else(|| panic!("error reporter: could not find crate {crate_name}"));
+        .get(&crate_name.0.contents)
+        .ok_or_else(|| PathResolutionError::Unresolved(crate_name.to_owned()))?;
 
     // Create an import directive for the dependency crate
     let path_without_crate_name = &path[1..]; // XXX: This will panic if the path is of the form `use dep::std` Ideal algorithm will not distinguish between crate and module


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #1718 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This resolves a panic in dependency resolution. When I make this change, I can get error diagnostics for unresolved deps (and the rest of the file) because it no longer crashes the LSP.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
