### PR TITLE
chore(ci): Run on macos-13 to avoid nix failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,8 @@ jobs:
             runner: ubuntu-large
             target: x86_64-linux
           - os: mac
-            runner: macos-latest
+            # The nix action doesn't fail on macos-13 according to https://github.com/cachix/install-nix-action/issues/183
+            runner: macos-13
             target: x86_64-darwin
 
     steps:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,7 @@
             }
         }
     },
+    "yaml.schemas": {
+        "https://json.schemastore.org/github-workflow.json": "${workspaceRoot}/.github/workflows/*.yml"
+    },
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

According to https://github.com/cachix/install-nix-action/issues/183, the nix github action doesn't fail on macos-13. Hopefully the stops our CI from flaking on mac.

I also updated the workspace settings to ensure the workflows are validated correctly by the yaml plugin.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
