### PR TITLE
fix(ssa refactor): function inlining orphans calls

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -674,7 +674,7 @@ mod test {
     #[test]
     fn displaced_return_mapping() {
         // This test is designed specifically to catch a regression in which the ids of blocks
-        // terminated by a returns are badly tracked. As a result, the continuation of a source
+        // terminated by returns are badly tracked. As a result, the continuation of a source
         // block after a call instruction could but inlined into a block that's already been
         // terminated, producing an incorrect order and orphaning successors.
 

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -280,6 +280,9 @@ impl<'function> PerFunctionContext<'function> {
         let mut function_returns = vec![];
 
         while let Some(source_block_id) = block_queue.pop() {
+            if seen_blocks.contains(&source_block_id) {
+                continue;
+            }
             let translated_block_id = self.translate_block(source_block_id, &mut block_queue);
             self.context.builder.switch_to_block(translated_block_id);
 

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -474,6 +474,7 @@ mod test {
 
     use crate::ssa_refactor::{
         ir::{
+            basic_block::BasicBlockId,
             function::RuntimeType,
             instruction::{BinaryOp, Intrinsic, TerminatorInstruction},
             map::Id,
@@ -637,15 +638,26 @@ mod test {
         //   b0():
         //     jmp b1()
         //   b1():
+        //     jmp b2()
+        //   b2():
+        //     jmp b3()
+        //   b3():
+        //     jmp b4()
+        //   b4():
+        //     jmp b5()
+        //   b5():
+        //     jmp b6()
+        //   b6():
         //     return Field 120
         // }
         let inlined = ssa.inline_functions();
         assert_eq!(inlined.functions.len(), 1);
 
         let main = inlined.main();
-        let b1 = &main.dfg[b1];
+        let b6_id: BasicBlockId = Id::test_new(6);
+        let b6 = &main.dfg[b6_id];
 
-        match b1.terminator() {
+        match b6.terminator() {
             Some(TerminatorInstruction::Return { return_values }) => {
                 assert_eq!(return_values.len(), 1);
                 let value = main

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -284,7 +284,7 @@ impl<'function> PerFunctionContext<'function> {
             self.context.builder.switch_to_block(translated_block_id);
 
             seen_blocks.insert(source_block_id);
-            self.inline_block(ssa, source_block_id);
+            self.inline_block_instructions(ssa, source_block_id);
 
             if let Some((block, values)) =
                 self.handle_terminator_instruction(source_block_id, &mut block_queue)
@@ -329,7 +329,7 @@ impl<'function> PerFunctionContext<'function> {
 
     /// Inline each instruction in the given block into the function being inlined into.
     /// This may recurse if it finds another function to inline if a call instruction is within this block.
-    fn inline_block(&mut self, ssa: &Ssa, block_id: BasicBlockId) {
+    fn inline_block_instructions(&mut self, ssa: &Ssa, block_id: BasicBlockId) {
         let block = &self.source_function.dfg[block_id];
         for id in block.instructions() {
             match &self.source_function.dfg[*id] {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

After inlining the following program:

```rs
use dep::std;

fn main(cond: bool) {
    let res = inner1(cond);
    std::println(res);
}

fn inner1(cond: bool) -> Field {
    inner2(cond)
}

fn inner2(cond: bool) -> Field {
    if cond { 1 } else { 2 }
}
```

it would incorrectly reduce to:
```
fn main f3 {
  b0(v0: u1):
    call println(v3)
    return 
}
```

This was happening because at the close of the call to `inner1`, the block mapping was inappropriately used for identifying the location of the "return terminator", thus the function builder was switching to `b0`, instead of continuing from the end of the last inlined function.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

Annotate the inlined location analogous to a "return terminator" by using the the `current_block` instead of a stale mapping.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
