### PR TITLE
fix(ssa refactor): ACIR gen NOT integer

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -348,6 +348,9 @@ impl AcirContext {
 
     /// Adds a new variable that is constrained to be the logical NOT of `x`.
     pub(crate) fn not_var(&mut self, x: AcirVar, typ: AcirType) -> Result<AcirVar, AcirGenError> {
+        if typ.is_signed() {
+            todo!("implement NOT for signed integers");
+        }
         let bit_size = typ.bit_size();
         // Subtracting from max flips the bits
         let max = self.add_constant(FieldElement::from((1_u128 << bit_size) - 1));

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -347,11 +347,11 @@ impl AcirContext {
     }
 
     /// Adds a new variable that is constrained to be the logical NOT of `x`.
-    ///
-    /// `x` must be a 1-bit integer (i.e. a boolean)
-    pub(crate) fn not_var(&mut self, x: AcirVar) -> AcirVar {
-        // Since `x` can only be 0 or 1, we can derive NOT as 1 - x
-        self.add_data(AcirVarData::Expr(&Expression::one() - self.vars[x].to_expression().as_ref()))
+    pub(crate) fn not_var(&mut self, x: AcirVar, typ: AcirType) -> Result<AcirVar, AcirGenError> {
+        let bit_size = typ.bit_size();
+        // Subtracting from max flips the bits
+        let max = self.add_constant(FieldElement::from((1_u128 << bit_size) - 1));
+        self.sub_var(max, x)
     }
 
     /// Returns an `AcirVar` that is constrained to be `lhs << rhs`.

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -221,8 +221,14 @@ impl Context {
                 }
             }
             Instruction::Not(value_id) => {
-                let boolean_var = self.convert_numeric_value(*value_id, dfg);
-                let result_acir_var = self.acir_context.not_var(boolean_var);
+                let (acir_var, typ) = match self.convert_value(*value_id, dfg) {
+                    AcirValue::Var(acir_var, typ) => (acir_var, typ),
+                    _ => unreachable!("NOT is only applied to numerics"),
+                };
+                let result_acir_var = self
+                    .acir_context
+                    .not_var(acir_var, typ)
+                    .expect("add Result types to all methods so errors bubble up");
                 self.define_result_var(dfg, instruction_id, result_acir_var);
             }
             Instruction::Truncate { value, bit_size, max_bit_size } => {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

ACIR gen assumed `NOT` to only handle `bool`s.

Resolves GH-1748

## Summary\*

Add `NOT` integer support

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
