### PR TITLE
fix(ssa refactor): recursive branch analysis

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -131,7 +131,7 @@
 //!   v11 = mul v4, Field 12
 //!   v12 = add v10, v11
 //!   store v12 at v5         (new store)
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::HashMap;
 
 use acvm::FieldElement;
 use iter_extended::vecmap;
@@ -141,11 +141,9 @@ use crate::ssa_refactor::{
         basic_block::BasicBlockId,
         cfg::ControlFlowGraph,
         dfg::InsertInstructionResult,
-        dom::DominatorTree,
         function::Function,
         function_inserter::FunctionInserter,
         instruction::{BinaryOp, Instruction, InstructionId, TerminatorInstruction},
-        post_order::PostOrder,
         types::Type,
         value::ValueId,
     },
@@ -211,11 +209,13 @@ fn flatten_function_cfg(function: &mut Function) {
     if let crate::ssa_refactor::ir::function::RuntimeType::Brillig = function.runtime() {
         return;
     }
+    let cfg = ControlFlowGraph::with_function(function);
+    let branch_ends = branch_analysis::find_branch_ends(function, &cfg);
     let mut context = Context {
-        cfg: ControlFlowGraph::with_function(function),
         inserter: FunctionInserter::new(function),
+        cfg,
         store_values: HashMap::new(),
-        branch_ends: HashMap::new(),
+        branch_ends,
         conditions: Vec::new(),
     };
     context.flatten();
@@ -223,67 +223,9 @@ fn flatten_function_cfg(function: &mut Function) {
 
 impl<'f> Context<'f> {
     fn flatten(&mut self) {
-        self.analyze_function();
-
         // Start with following the terminator of the entry block since we don't
         // need to flatten the entry block into itself.
         self.handle_terminator(self.inserter.function.entry_block());
-    }
-
-    /// Visits every block in the current function to find all blocks with a jmpif instruction and
-    /// all blocks which terminate the jmpif by having each of its branches as a predecessor.
-    fn analyze_function(&mut self) {
-        let post_order = PostOrder::with_function(self.inserter.function);
-        let dom_tree = DominatorTree::with_cfg_and_post_order(&self.cfg, &post_order);
-        let mut branch_beginnings = Vec::new();
-
-        let mut visited = HashSet::new();
-        let mut queue = VecDeque::new();
-        queue.push_front(self.inserter.function.entry_block());
-
-        while let Some(block_id) = queue.pop_front() {
-            // If multiple blocks branch to the same successor before we visit it we can end up in
-            // situations where the same block occurs multiple times in our queue. This check
-            // prevents visiting the same block twice.
-            if visited.contains(&block_id) {
-                continue;
-            } else {
-                visited.insert(block_id);
-            }
-
-            // If there is more than one predecessor, this must be an end block
-            let mut predecessors = self.cfg.predecessors(block_id);
-            if predecessors.len() > 1 {
-                // If we haven't already visited all of this block's predecessors, delay analyzing
-                // the block until we have. This ensures we analyze the function in evaluation order.
-                if !predecessors.all(|block| visited.contains(&block)) {
-                    queue.push_back(block_id);
-                    visited.remove(&block_id);
-                    continue;
-                }
-
-                // We expect the merging of two branches to be ordered such that only the most
-                // recent jmpif is a candidate for being the start of the two branches merged by
-                // a block with 2 predecessors.
-                let branch_beginning =
-                    branch_beginnings.pop().expect("Expected the beginning of a branch");
-
-                for predecessor in self.cfg.predecessors(block_id) {
-                    assert!(dom_tree.dominates(branch_beginning, predecessor));
-                }
-
-                self.branch_ends.insert(branch_beginning, block_id);
-            }
-
-            let block = &self.inserter.function.dfg[block_id];
-            if let Some(TerminatorInstruction::JmpIf { .. }) = block.terminator() {
-                branch_beginnings.push(block_id);
-            }
-
-            queue.extend(block.successors().filter(|block| !visited.contains(block)));
-        }
-
-        assert!(branch_beginnings.is_empty());
     }
 
     /// Check the terminator of the given block and recursively inline any blocks reachable from
@@ -612,14 +554,11 @@ impl<'f> Context<'f> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
 
     use crate::ssa_refactor::{
         ir::{
-            cfg::ControlFlowGraph,
             dfg::DataFlowGraph,
             function::RuntimeType,
-            function_inserter::FunctionInserter,
             instruction::{BinaryOp, Instruction, Intrinsic, TerminatorInstruction},
             map::Id,
             types::Type,
@@ -873,72 +812,6 @@ mod test {
             .count();
 
         assert_eq!(store_count, 4);
-    }
-
-    #[test]
-    fn nested_branch_analysis() {
-        //         b0
-        //         ↓
-        //         b1
-        //       ↙   ↘
-        //     b2     b3
-        //     ↓      |
-        //     b4     |
-        //   ↙  ↘     |
-        // b5    b6   |
-        //   ↘  ↙     ↓
-        //    b7      b8
-        //      ↘   ↙
-        //       b9
-        let main_id = Id::test_new(0);
-        let mut builder = FunctionBuilder::new("main".into(), main_id, RuntimeType::Acir);
-
-        let b1 = builder.insert_block();
-        let b2 = builder.insert_block();
-        let b3 = builder.insert_block();
-        let b4 = builder.insert_block();
-        let b5 = builder.insert_block();
-        let b6 = builder.insert_block();
-        let b7 = builder.insert_block();
-        let b8 = builder.insert_block();
-        let b9 = builder.insert_block();
-
-        let c1 = builder.add_parameter(Type::bool());
-        let c4 = builder.add_parameter(Type::bool());
-
-        builder.terminate_with_jmp(b1, vec![]);
-        builder.switch_to_block(b1);
-        builder.terminate_with_jmpif(c1, b2, b3);
-        builder.switch_to_block(b2);
-        builder.terminate_with_jmp(b4, vec![]);
-        builder.switch_to_block(b3);
-        builder.terminate_with_jmp(b8, vec![]);
-        builder.switch_to_block(b4);
-        builder.terminate_with_jmpif(c4, b5, b6);
-        builder.switch_to_block(b5);
-        builder.terminate_with_jmp(b7, vec![]);
-        builder.switch_to_block(b6);
-        builder.terminate_with_jmp(b7, vec![]);
-        builder.switch_to_block(b7);
-        builder.terminate_with_jmp(b9, vec![]);
-        builder.switch_to_block(b8);
-        builder.terminate_with_jmp(b9, vec![]);
-        builder.switch_to_block(b9);
-        builder.terminate_with_return(vec![]);
-
-        let mut ssa = builder.finish();
-        let function = ssa.main_mut();
-        let mut context = super::Context {
-            cfg: ControlFlowGraph::with_function(function),
-            inserter: FunctionInserter::new(function),
-            store_values: HashMap::new(),
-            branch_ends: HashMap::new(),
-            conditions: Vec::new(),
-        };
-        context.analyze_function();
-        assert_eq!(context.branch_ends.len(), 2);
-        assert_eq!(context.branch_ends.get(&b1), Some(&b9));
-        assert_eq!(context.branch_ends.get(&b4), Some(&b7));
     }
 
     #[test]

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -152,6 +152,8 @@ use crate::ssa_refactor::{
     ssa_gen::Ssa,
 };
 
+mod branch_analysis;
+
 impl Ssa {
     /// Flattens the control flow graph of each function such that the function is left with a
     /// single block containing all instructions and no more control-flow.

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg/branch_analysis.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg/branch_analysis.rs
@@ -1,0 +1,231 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::ssa_refactor::ir::{
+    basic_block::BasicBlockId, cfg::ControlFlowGraph, dom::DominatorTree, function::Function,
+    post_order::PostOrder,
+};
+
+struct Context<'cfg> {
+    cfg: &'cfg ControlFlowGraph,
+    dom_tree: DominatorTree,
+    // visited: HashSet<BasicBlockId>,
+    branch_ends: HashMap<BasicBlockId, BasicBlockId>,
+}
+
+pub(super) fn analyze_branch_ends(
+    cfg: &ControlFlowGraph,
+    function: &Function,
+) -> HashMap<BasicBlockId, BasicBlockId> {
+    let entry_block = function.entry_block();
+    let mut context = Context::new(cfg, function);
+    let mut visited_by_children = HashSet::new();
+    context.analyze(entry_block, &mut visited_by_children);
+    context.branch_ends
+}
+
+impl<'cfg> Context<'cfg> {
+    fn new(cfg: &'cfg ControlFlowGraph, function: &Function) -> Self {
+        let post_order = PostOrder::with_function(function);
+        let dom_tree = DominatorTree::with_cfg_and_post_order(cfg, &post_order);
+        Context { cfg, dom_tree, branch_ends: HashMap::new() }
+    }
+
+    fn analyze(
+        &mut self,
+        mut active_block: BasicBlockId,
+        visited: &mut HashSet<BasicBlockId>,
+    ) -> Option<BasicBlockId> {
+        loop {
+            if visited.contains(&active_block) {
+                return Some(active_block);
+            }
+            visited.insert(active_block);
+            let mut successors = self.cfg.successors(active_block);
+            match successors.len() {
+                0 => {
+                    // Reached the end without colliding - the collision will happen when
+                    // traversing the other branch.
+                    return None;
+                }
+                1 => {
+                    // Not an interesting block - move on
+                    active_block = successors.next().unwrap();
+                }
+                2 => {
+                    // Branch start - fork the recursion
+                    let mut visited_by_children = HashSet::new();
+                    let left_collision =
+                        self.analyze(successors.next().unwrap(), &mut visited_by_children);
+                    let right_collision =
+                        self.analyze(successors.next().unwrap(), &mut visited_by_children);
+                    let collision = match (left_collision, right_collision) {
+                        (Some(collision), None) | (None, Some(collision)) => collision,
+                        (Some(_),Some(_))=> unreachable!("A collision on both branches indicates a loop"), 
+                        _ => unreachable!(
+                            "Until we support multiple returns, branches always re-converge. Once supported this case should return `None`"
+                        ),
+                    };
+                    for collision_predecessor in self.cfg.predecessors(collision) {
+                        assert!(self.dom_tree.dominates(active_block, collision_predecessor));
+                    }
+                    self.branch_ends.insert(active_block, collision);
+
+                    // Continue forward from child branch end until parent branches reconnect too.
+                    active_block = collision;
+                }
+                _ => unreachable!("A block never has more than two successors"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::ssa_refactor::{
+        ir::{cfg::ControlFlowGraph, function::RuntimeType, map::Id, types::Type},
+        opt::flatten_cfg::branch_analysis::analyze_branch_ends,
+        ssa_builder::FunctionBuilder,
+    };
+
+    #[test]
+    fn nested_branch_analysis() {
+        //         b0
+        //         ↓
+        //         b1
+        //       ↙   ↘
+        //     b2     b3
+        //     ↓      |
+        //     b4     |
+        //   ↙  ↘     |
+        // b5    b6   |
+        //   ↘  ↙     ↓
+        //    b7      b8
+        //      ↘   ↙
+        //       b9
+        let main_id = Id::test_new(0);
+        let mut builder = FunctionBuilder::new("main".into(), main_id, RuntimeType::Acir);
+
+        let b1 = builder.insert_block();
+        let b2 = builder.insert_block();
+        let b3 = builder.insert_block();
+        let b4 = builder.insert_block();
+        let b5 = builder.insert_block();
+        let b6 = builder.insert_block();
+        let b7 = builder.insert_block();
+        let b8 = builder.insert_block();
+        let b9 = builder.insert_block();
+
+        let c1 = builder.add_parameter(Type::bool());
+        let c4 = builder.add_parameter(Type::bool());
+
+        builder.terminate_with_jmp(b1, vec![]);
+        builder.switch_to_block(b1);
+        builder.terminate_with_jmpif(c1, b2, b3);
+        builder.switch_to_block(b2);
+        builder.terminate_with_jmp(b4, vec![]);
+        builder.switch_to_block(b3);
+        builder.terminate_with_jmp(b8, vec![]);
+        builder.switch_to_block(b4);
+        builder.terminate_with_jmpif(c4, b5, b6);
+        builder.switch_to_block(b5);
+        builder.terminate_with_jmp(b7, vec![]);
+        builder.switch_to_block(b6);
+        builder.terminate_with_jmp(b7, vec![]);
+        builder.switch_to_block(b7);
+        builder.terminate_with_jmp(b9, vec![]);
+        builder.switch_to_block(b8);
+        builder.terminate_with_jmp(b9, vec![]);
+        builder.switch_to_block(b9);
+        builder.terminate_with_return(vec![]);
+
+        let mut ssa = builder.finish();
+        let function = ssa.main_mut();
+        let cfg = ControlFlowGraph::with_function(function);
+        let branch_ends = analyze_branch_ends(&cfg, function);
+        assert_eq!(branch_ends.len(), 2);
+        assert_eq!(branch_ends.get(&b1), Some(&b9));
+        assert_eq!(branch_ends.get(&b4), Some(&b7));
+    }
+
+    #[test]
+    fn more_nested_branch_analysis() {
+        // Taken from #1664. The success case is that the internal domination asserts all pass.
+        //          b0
+        //        ↙   ↘
+        //      b1     b10
+        //    ↙  ↓      ↓  ↘
+        // b2 → b3     b12 ← b11
+        //    ↙  ↓      ↓  ↘
+        // b4 → b5     b14 ← b13
+        //    ↙  ↓      |
+        // b6 → b7      |
+        //    ↙  ↓      |
+        // b8 → b9      |
+        //        ↘    ↙
+        //          b15
+        let main_id = Id::test_new(0);
+        let mut builder = FunctionBuilder::new("main".into(), main_id, RuntimeType::Acir);
+
+        let b1 = builder.insert_block();
+        let b2 = builder.insert_block();
+        let b3 = builder.insert_block();
+        let b4 = builder.insert_block();
+        let b5 = builder.insert_block();
+        let b6 = builder.insert_block();
+        let b7 = builder.insert_block();
+        let b8 = builder.insert_block();
+        let b9 = builder.insert_block();
+        let b10 = builder.insert_block();
+        let b11 = builder.insert_block();
+        let b12 = builder.insert_block();
+        let b13 = builder.insert_block();
+        let b14 = builder.insert_block();
+        let b15 = builder.insert_block();
+
+        let c0 = builder.add_parameter(Type::bool());
+        let c1 = builder.add_parameter(Type::bool());
+        let c3 = builder.add_parameter(Type::bool());
+        let c5 = builder.add_parameter(Type::bool());
+        let c7 = builder.add_parameter(Type::bool());
+        let c10 = builder.add_parameter(Type::bool());
+        let c12 = builder.add_parameter(Type::bool());
+
+        builder.terminate_with_jmpif(c0, b1, b10);
+        builder.switch_to_block(b1);
+        builder.terminate_with_jmpif(c1, b2, b3);
+        builder.switch_to_block(b2);
+        builder.terminate_with_jmp(b3, vec![]);
+        builder.switch_to_block(b3);
+        builder.terminate_with_jmpif(c3, b4, b5);
+        builder.switch_to_block(b4);
+        builder.terminate_with_jmp(b5, vec![]);
+        builder.switch_to_block(b5);
+        builder.terminate_with_jmpif(c5, b6, b7);
+        builder.switch_to_block(b6);
+        builder.terminate_with_jmp(b7, vec![]);
+        builder.switch_to_block(b7);
+        builder.terminate_with_jmpif(c7, b8, b9);
+        builder.switch_to_block(b8);
+        builder.terminate_with_jmp(b9, vec![]);
+        builder.switch_to_block(b9);
+        builder.terminate_with_jmp(b15, vec![]);
+        builder.switch_to_block(b10);
+        builder.terminate_with_jmpif(c10, b11, b12);
+        builder.switch_to_block(b11);
+        builder.terminate_with_jmp(b12, vec![]);
+        builder.switch_to_block(b12);
+        builder.terminate_with_jmpif(c12, b14, b13);
+        builder.switch_to_block(b13);
+        builder.terminate_with_jmp(b14, vec![]);
+        builder.switch_to_block(b14);
+        builder.terminate_with_jmp(b15, vec![]);
+        builder.switch_to_block(b15);
+        builder.terminate_with_return(vec![]);
+
+        let mut ssa = builder.finish();
+        let function = ssa.main_mut();
+        let cfg = ControlFlowGraph::with_function(function);
+        analyze_branch_ends(&cfg, function);
+    }
+}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves GH-1664

The existing implementation of `analyze_function` used a queue + stack-based approach to to associating a branch start with an end. I couldn't convince myself that there was a way to make this approach safe, so I've written a recursion-based alternative that passes the failing case surfaced by GH-1664.

## Summary\*

This alternative recursion based-approach associates a branch start to its end at the point that a recursion exits, such that the association is encapsulated. A disadvantage to this approach is that it does result in extra allocations, because `visited` hash sets and `Stepper`s are allocated for each level of recursion.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
