### PR TITLE
chore(ssa refactor): generalize store instruction removal

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/mem2reg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/mem2reg.rs
@@ -1,7 +1,9 @@
 //! mem2reg implements a pass for promoting values stored in memory to values in registers where
 //! possible. This is particularly important for converting our memory-based representation of
 //! mutable variables into values that are easier to manipulate.
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use iter_extended::vecmap;
 
 use crate::ssa_refactor::{
     ir::{
@@ -14,30 +16,25 @@ use crate::ssa_refactor::{
 };
 
 impl Ssa {
-    /// Attempts to remove any load instructions that recover values that already available in
+    /// Attempts to remove any load instructions that recover values that are already available in
     /// scope, and attempts to remove store that are subsequently redundant, as long as they are
-    /// not stores on memory that will be passed into a function call.
-    ///
-    /// This pass also assumes that constant folding has been run, such that all addresses given
-    /// as input to store/load instructions are represented as one of:
-    /// - a value that directly resolves to an allocate instruction
-    /// - a value that directly resolves to a binary add instruction which has a allocate
-    /// instruction and a numeric constant as its operands
+    /// not stores on memory that will be passed into a function call or returned.
     pub(crate) fn mem2reg(mut self) -> Ssa {
-        let mut first_context = None;
-
         for function in self.functions.values_mut() {
-            for block in function.reachable_blocks() {
+            let mut all_protected_allocations = HashSet::new();
+            let contexts = vecmap(function.reachable_blocks(), |block| {
                 let mut context = PerBlockContext::new(block);
-                context.eliminate_known_loads(&mut function.dfg);
-                first_context = Some(context);
+                let allocations_protected_by_block =
+                    context.analyze_allocations_and_eliminate_known_loads(&mut function.dfg);
+                all_protected_allocations.extend(allocations_protected_by_block.into_iter());
+                context
+            });
+            // Now that we have a comprehensive list of used allocations across all the
+            // function's blocks, it is safe to remove any stores that do not touch such
+            // allocations.
+            for context in contexts {
+                context.remove_unused_stores(&mut function.dfg, &all_protected_allocations);
             }
-        }
-
-        // If there is only one block in total, remove any unused stores as well since we
-        // know there is no other block they can impact.
-        if self.functions.len() == 1 && self.main().reachable_blocks().len() == 1 {
-            first_context.unwrap().remove_unused_stores(&mut self.main_mut().dfg);
         }
 
         self
@@ -48,8 +45,6 @@ struct PerBlockContext {
     block_id: BasicBlockId,
     last_stores: BTreeMap<AllocId, ValueId>,
     store_ids: Vec<InstructionId>,
-    failed_substitutes: BTreeSet<AllocId>,
-    alloc_ids_used_externally: BTreeSet<AllocId>,
 }
 
 /// An AllocId is the ValueId returned from an allocate instruction. E.g. v0 in v0 = allocate.
@@ -59,18 +54,16 @@ type AllocId = ValueId;
 
 impl PerBlockContext {
     fn new(block_id: BasicBlockId) -> Self {
-        PerBlockContext {
-            block_id,
-            last_stores: BTreeMap::new(),
-            store_ids: Vec::new(),
-            failed_substitutes: BTreeSet::new(),
-            alloc_ids_used_externally: BTreeSet::new(),
-        }
+        PerBlockContext { block_id, last_stores: BTreeMap::new(), store_ids: Vec::new() }
     }
 
     // Attempts to remove load instructions for which the result is already known from previous
     // store instructions to the same address in the same block.
-    fn eliminate_known_loads(&mut self, dfg: &mut DataFlowGraph) {
+    fn analyze_allocations_and_eliminate_known_loads(
+        &mut self,
+        dfg: &mut DataFlowGraph,
+    ) -> HashSet<AllocId> {
+        let mut protected_allocations = HashSet::new();
         let mut loads_to_substitute = HashMap::new();
         let block = &dfg[self.block_id];
 
@@ -84,13 +77,13 @@ impl PerBlockContext {
                     if let Some(last_value) = self.last_stores.get(address) {
                         loads_to_substitute.insert(*instruction_id, *last_value);
                     } else {
-                        self.failed_substitutes.insert(*address);
+                        protected_allocations.insert(*address);
                     }
                 }
                 Instruction::Call { arguments, .. } => {
                     for arg in arguments {
                         if Self::value_is_from_allocation(*arg, dfg) {
-                            self.alloc_ids_used_externally.insert(*arg);
+                            protected_allocations.insert(*arg);
                         }
                     }
                 }
@@ -104,7 +97,7 @@ impl PerBlockContext {
         if let TerminatorInstruction::Return { return_values } = block.unwrap_terminator() {
             for value in return_values {
                 if Self::value_is_from_allocation(*value, dfg) {
-                    self.alloc_ids_used_externally.insert(*value);
+                    protected_allocations.insert(*value);
                 }
             }
         }
@@ -119,12 +112,16 @@ impl PerBlockContext {
         }
 
         // Delete load instructions
-        // TODO: should we let DCE do this instead?
+        // Even though we could let DIE handle this, doing it here makes the debug output easier
+        // to read.
         dfg[self.block_id]
             .instructions_mut()
             .retain(|instruction| !loads_to_substitute.contains_key(instruction));
+
+        protected_allocations
     }
 
+    /// Checks whether the given value id refers to an allocation.
     fn value_is_from_allocation(value: ValueId, dfg: &DataFlowGraph) -> bool {
         match &dfg[value] {
             Value::Instruction { instruction, .. } => {
@@ -134,7 +131,13 @@ impl PerBlockContext {
         }
     }
 
-    fn remove_unused_stores(self, dfg: &mut DataFlowGraph) {
+    /// Removes all store instructions identified during analysis that aren't present in the
+    /// provided `protected_allocations` `HashSet`.
+    fn remove_unused_stores(
+        self,
+        dfg: &mut DataFlowGraph,
+        protected_allocations: &HashSet<AllocId>,
+    ) {
         // Scan for unused stores
         let mut stores_to_remove = HashSet::new();
 
@@ -144,9 +147,7 @@ impl PerBlockContext {
                 _ => unreachable!("store_ids should contain only store instructions"),
             };
 
-            if !self.failed_substitutes.contains(&address)
-                && !self.alloc_ids_used_externally.contains(&address)
-            {
+            if !protected_allocations.contains(&address) {
                 stores_to_remove.insert(*instruction_id);
             }
         }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves GH-1756

The existing test for whether or not it is safe to remove store instructions is sufficient in the presence of unconstrained functions.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This PR generalises store instruction removal such that it can be done safely regardless of the use case. This is done by amassing a set of all protected allocations across all blocks, which is subsequently queried when removing stores in each individual block.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
