### PR TITLE
chore: Use brillig instead of invert directive

### DIFF
--- a/crates/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -1,4 +1,5 @@
 pub(crate) mod brillig_block;
+pub(crate) mod brillig_directive;
 pub(crate) mod brillig_fn;
 
 use crate::ssa_refactor::ir::{function::Function, post_order::PostOrder};

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -14,7 +14,7 @@ pub(crate) fn directive_invert() -> Vec<BrilligOpcode> {
         BrilligOpcode::JumpIfNot { condition: input, location: 3 },
         // put value one in register (1)
         BrilligOpcode::Const { destination: RegisterIndex::from(1), value: Value::from(1_usize) },
-        // Divide 1 by the input, and set the esult of the division into register (0)
+        // Divide 1 by the input, and set the result of the division into register (0)
         BrilligOpcode::BinaryFieldOp {
             op: BinaryFieldOp::Div,
             lhs: RegisterIndex::from(1),

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -2,13 +2,23 @@ use acvm::acir::brillig_vm::{BinaryFieldOp, Opcode as BrilligOpcode, RegisterInd
 
 /// Generates brillig bytecode which computes the inverse of its input if not null, and zero else.
 pub(crate) fn directive_invert() -> Vec<BrilligOpcode> {
+    //  We generate the following code:
+    // fn invert(x : Field) -> Field {
+    //    1/ x
+    // }
+
+    // The input argument, ie the value that will be inverted.
+    let input = RegisterIndex::from(0);
     vec![
-        BrilligOpcode::JumpIfNot { condition: RegisterIndex::from(0), location: 3 },
+        // If the input is zero, then we jump to the stop opcode
+        BrilligOpcode::JumpIfNot { condition: input, location: 3 },
+        // put value one in register (1)
         BrilligOpcode::Const { destination: RegisterIndex::from(1), value: Value::from(1_usize) },
+        // Divide 1 by the input, and set the esult of the division into register (0)
         BrilligOpcode::BinaryFieldOp {
             op: BinaryFieldOp::Div,
             lhs: RegisterIndex::from(1),
-            rhs: RegisterIndex::from(0),
+            rhs: input,
             destination: RegisterIndex::from(0),
         },
         BrilligOpcode::Stop,

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -1,0 +1,16 @@
+use acvm::acir::brillig_vm::{BinaryFieldOp, Opcode as BrilligOpcode, RegisterIndex, Value};
+
+/// Generates brillig bytecode which computes the inverse of its input if not null, and zero else.
+pub(crate) fn directive_invert() -> Vec<BrilligOpcode> {
+    vec![
+        BrilligOpcode::JumpIfNot { condition: RegisterIndex::from(0), location: 3 },
+        BrilligOpcode::Const { destination: RegisterIndex::from(1), value: Value::from(1_usize) },
+        BrilligOpcode::BinaryFieldOp {
+            op: BinaryFieldOp::Div,
+            lhs: RegisterIndex::from(1),
+            rhs: RegisterIndex::from(0),
+            destination: RegisterIndex::from(0),
+        },
+        BrilligOpcode::Stop,
+    ]
+}

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -8,18 +8,23 @@ pub(crate) fn directive_invert() -> Vec<BrilligOpcode> {
     // }
 
     // The input argument, ie the value that will be inverted.
+    // We store the result in this register too.
     let input = RegisterIndex::from(0);
+    let one_const = RegisterIndex::from(1);
+    // Location of the stop opcode
+    let stop_location = 3;
+
     vec![
         // If the input is zero, then we jump to the stop opcode
-        BrilligOpcode::JumpIfNot { condition: input, location: 3 },
-        // put value one in register (1)
-        BrilligOpcode::Const { destination: RegisterIndex::from(1), value: Value::from(1_usize) },
+        BrilligOpcode::JumpIfNot { condition: input, location: stop_location },
+        // Put value one in register (1)
+        BrilligOpcode::Const { destination: one_const, value: Value::from(1_usize) },
         // Divide 1 by the input, and set the result of the division into register (0)
         BrilligOpcode::BinaryFieldOp {
             op: BinaryFieldOp::Div,
-            lhs: RegisterIndex::from(1),
+            lhs: one_const,
             rhs: input,
-            destination: RegisterIndex::from(0),
+            destination: input,
         },
         BrilligOpcode::Stop,
     ]

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -1,4 +1,5 @@
 use super::{errors::AcirGenError, generated_acir::GeneratedAcir};
+use crate::brillig::brillig_gen::brillig_directive;
 use crate::ssa_refactor::acir_gen::AcirValue;
 use crate::ssa_refactor::ir::types::Type as SsaType;
 use crate::ssa_refactor::ir::{instruction::Endian, map::TwoWayMap, types::NumericType};
@@ -143,8 +144,16 @@ impl AcirContext {
             let result_var = self.add_data(AcirVarData::Const(constant.inverse()));
             return Ok(result_var);
         }
-        let inverted_witness = self.acir_ir.directive_inverse(&var_data.to_expression());
-        let inverted_var = self.add_data(AcirVarData::Witness(inverted_witness));
+
+        // Compute the inverse with brillig code
+        let inverse_code = brillig_directive::directive_invert();
+        let field_type = AcirType::NumericType(NumericType::NativeField);
+        let results = self.brillig(
+            inverse_code,
+            vec![AcirValue::Var(var, field_type.clone())],
+            vec![field_type],
+        );
+        let inverted_var = Self::expect_one_var(results);
 
         let should_be_one = self.mul_var(inverted_var, var)?;
         self.assert_eq_one(should_be_one)?;
@@ -156,6 +165,15 @@ impl AcirContext {
     pub(crate) fn assert_eq_one(&mut self, var: AcirVar) -> Result<(), AcirGenError> {
         let one_var = self.add_constant(FieldElement::one());
         self.assert_eq_var(var, one_var)
+    }
+
+    // Returns the variable from the results, assuming it is the only result
+    fn expect_one_var(results: Vec<AcirValue>) -> AcirVar {
+        assert_eq!(results.len(), 1);
+        match results[0] {
+            AcirValue::Var(var, _) => var,
+            AcirValue::Array(_) => unreachable!("ICE - expected a variable"),
+        }
     }
 
     /// Returns an `AcirVar` that is `1` if `lhs` equals `rhs` and


### PR DESCRIPTION
# Description

Avoid using the invert directive when we generate acir

## Problem\*

Directives are deprecated in favour of brillig opcode, which can replace all directives in theory.

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
