### PR TITLE
fix(nargo): Update acvm-backend-barretenberg to allow wasm backend compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,8 +52,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90594c6d8107569d2ba337a3e1ff2c440cf5ba3f7bc2d3b07af5a405d769584d"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=3043e9f69f25c48027d95fae7ecbb8d576b3a82f#3043e9f69f25c48027d95fae7ecbb8d576b3a82f"
 dependencies = [
  "acvm",
  "barretenberg-sys",
@@ -1405,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-utils"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
 dependencies = [
  "js-sys",
  "serde",
@@ -3677,7 +3676,6 @@ dependencies = [
  "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser",
  "wat",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,8 +51,9 @@ dependencies = [
 
 [[package]]
 name = "acvm-backend-barretenberg"
-version = "0.5.0"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=3043e9f69f25c48027d95fae7ecbb8d576b3a82f#3043e9f69f25c48027d95fae7ecbb8d576b3a82f"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a378e1d68ed47b4ed1af4533b455e01836d21bf27bde482e977edea0869f0b21"
 dependencies = [
  "acvm",
  "barretenberg-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,3 @@ wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
 async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "9fc2db84ddcda291a864f044657f68d4377557f7" }
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "3043e9f69f25c48027d95fae7ecbb8d576b3a82f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
 async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "9fc2db84ddcda291a864f044657f68d4377557f7" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "3043e9f69f25c48027d95fae7ecbb8d576b3a82f" }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -43,7 +43,7 @@ color-eyre = "0.6.2"
 tokio = "1.0"
 
 # Backends
-acvm-backend-barretenberg = { version = "0.5.0", default-features = false }
+acvm-backend-barretenberg = { version = "0.5.1", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"


### PR DESCRIPTION

# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This updates acvm-backend-barretenberg to a version that removes the wasm32 target. There seems to be conflicting dependencies between the backend and the `noir_wasm` crate. Since we aren't going to target wasm32 target with the backend, we can just remove it.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
