### PR TITLE
fix(lsp): Ensure LSP can compile on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "async-lsp"
 version = "0.0.4"
-source = "git+https://github.com/oxalica/async-lsp?rev=9fc2db84ddcda291a864f044657f68d4377557f7#9fc2db84ddcda291a864f044657f68d4377557f7"
+source = "git+https://github.com/oxalica/async-lsp?rev=09dbcc11046f7a188a80137f8d36484d86c78c78#09dbcc11046f7a188a80137f8d36484d86c78c78"
 dependencies = [
  "either",
  "futures",
@@ -368,6 +368,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,4 @@ wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
-async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "9fc2db84ddcda291a864f044657f68d4377557f7" }
+async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "09dbcc11046f7a188a80137f8d36484d86c78c78" }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -40,7 +40,7 @@ const_format = "0.2.30"
 hex = "0.4.2"
 termcolor = "1.1.2"
 color-eyre = "0.6.2"
-tokio = "1.0"
+tokio = { version = "1.0", features = ["io-std"] }
 
 # Backends
 acvm-backend-barretenberg = { version = "0.5.1", default-features = false }

--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -1,7 +1,7 @@
 use acvm::Backend;
 use async_lsp::{
     client_monitor::ClientProcessMonitorLayer, concurrency::ConcurrencyLayer,
-    panic::CatchUnwindLayer, server::LifecycleLayer, stdio::PipeStdin, tracing::TracingLayer,
+    panic::CatchUnwindLayer, server::LifecycleLayer, tracing::TracingLayer,
 };
 use clap::Args;
 use noir_lsp::NargoLspService;
@@ -40,8 +40,19 @@ pub(crate) fn run<B: Backend>(
                 .layer(ClientProcessMonitorLayer::new(client))
                 .service(router)
         });
-        let stdin = BufReader::new(PipeStdin::lock().unwrap());
-        let stdout = async_lsp::stdio::PipeStdout::lock().unwrap();
+
+        // Prefer truely asynchronous piped stdin/stdout without blocking tasks.
+        #[cfg(unix)]
+        let (stdin, stdout) = (
+            async_lsp::stdio::PipeStdin::lock_tokio().unwrap(),
+            async_lsp::stdio::PipeStdout::lock_tokio().unwrap(),
+        );
+        // Fallback to spawn blocking read/write otherwise.
+        #[cfg(not(unix))]
+        let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
+
+        let stdin = BufReader::new(stdin);
+
         server.run(stdin, stdout).await.map_err(CliError::LspError)
     })
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This updates async-lsp to support windows. I needed to add a conditional implementation for the stdio stuff because Windows doesn't have non-blocking stdio (this is the same as async-lsp tests).

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
