### PR TITLE
fix(ssa refactor): Ignore array out of bounds errors when enable_side_effects is false

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -122,10 +122,10 @@ impl AcirContext {
         self.add_data(var_data)
     }
 
-    /// True if the given AcirVar refers to a constant zero value
-    pub(crate) fn is_constant_zero(&self, var: &AcirVar) -> bool {
+    /// True if the given AcirVar refers to a constant one value
+    pub(crate) fn is_constant_one(&self, var: &AcirVar) -> bool {
         match self.vars[var] {
-            AcirVarData::Const(field) => field.is_zero(),
+            AcirVarData::Const(field) => field.is_one(),
             _ => false,
         }
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -123,7 +123,7 @@ impl AcirContext {
     }
 
     /// True if the given AcirVar refers to a constant zero value
-    pub(crate) fn is_constant_zero(&self, var: AcirVar) -> bool {
+    pub(crate) fn is_constant_zero(&self, var: &AcirVar) -> bool {
         match self.vars[var] {
             AcirVarData::Const(field) => field.is_zero(),
             _ => false,

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -121,6 +121,14 @@ impl AcirContext {
         self.add_data(var_data)
     }
 
+    /// True if the given AcirVar refers to a constant zero value
+    pub(crate) fn is_constant_zero(&self, var: AcirVar) -> bool {
+        match self.vars[var] {
+            AcirVarData::Const(field) => field.is_zero(),
+            _ => false,
+        }
+    }
+
     /// Adds a new Variable to context whose value will
     /// be constrained to be the negation of `var`.
     ///

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -287,7 +287,7 @@ impl Context {
         if index >= array.len() {
             // Ignore the error if side effects are disabled.
             if let Some(var) = self.current_side_effects_enabled_var {
-                if self.acir_context.is_constant_zero(var) {
+                if self.acir_context.is_constant_zero(&var) {
                     let result_type = dfg.type_of_value(dfg.instruction_results(instruction)[0]);
                     let value = self.create_default_value(result_type);
                     self.define_result(dfg, instruction, value);

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -105,10 +105,18 @@ impl Context {
     }
 
     fn convert_ssa_block_param(&mut self, param_type: &Type) -> AcirValue {
+        self.create_value_from_type(param_type, |this, typ| this.add_numeric_input_var(&typ))
+    }
+
+    fn create_value_from_type(
+        &mut self,
+        param_type: &Type,
+        mut make_var: impl FnMut(&mut Self, NumericType) -> AcirVar,
+    ) -> AcirValue {
         match param_type {
             Type::Numeric(numeric_type) => {
                 let typ = AcirType::new(*numeric_type);
-                AcirValue::Var(self.add_numeric_input_var(numeric_type), typ)
+                AcirValue::Var(make_var(self, *numeric_type), typ)
             }
             Type::Array(element_types, length) => {
                 let mut elements = im::Vector::new();
@@ -287,15 +295,15 @@ impl Context {
         if index >= array.len() {
             // Ignore the error if side effects are disabled.
             if let Some(var) = self.current_side_effects_enabled_var {
-                if self.acir_context.is_constant_zero(&var) {
-                    let result_type = dfg.type_of_value(dfg.instruction_results(instruction)[0]);
-                    let value = self.create_default_value(result_type);
-                    self.define_result(dfg, instruction, value);
-                    return;
+                if self.acir_context.is_constant_one(&var) {
+                    // TODO: Can we save a source Location for this error?
+                    panic!("Index {} is out of bounds for array of length {}", index, array.len());
                 }
             }
-            // TODO: Can we save a source Location for this error?
-            panic!("Index {} is out of bounds for array of length {}", index, array.len());
+            let result_type = dfg.type_of_value(dfg.instruction_results(instruction)[0]);
+            let value = self.create_default_value(&result_type);
+            self.define_result(dfg, instruction, value);
+            return;
         }
 
         let value = match store_value {
@@ -696,8 +704,10 @@ impl Context {
     }
 
     /// Creates a default, meaningless value meant only to be a valid value of the given type.
-    fn create_default_value(&mut self, result_type: Type) -> AcirValue {
-        self.convert_ssa_block_param(&result_type)
+    fn create_default_value(&mut self, param_type: &Type) -> AcirValue {
+        self.create_value_from_type(param_type, |this, _| {
+            this.acir_context.add_constant(FieldElement::zero())
+        })
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

When `enable_side_effects` is false, we are meant to be in a false branch of an `if` that was not taken, so we should ignore side effects causing the program to fail, such as array out of bounds errors. I've added a check for this to only panic for array index of out of bounds errors if enable side effects is not known to be false.

This fixes the bug in #1629 ~~but means the issue will still appear if the `if` uses a witness as its condition, as it would not be known to be false.~~ I've changed the logic to only panic if `enable_side_effects` is known to be true rather than not known to be false.

Resolves #1629 

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
