### PR TITLE
chore(ci): Use large mac runner for tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,11 +1,7 @@
 name: Pull Request
 
 on:
-  # merge_group:
-  # The `merge_group` event is currently broken (Feb 9th) so we use `push` and scope the branches
-  push:
-    branches:
-      - gh-readonly-queue/master/*
+  merge_group:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  merge_group:
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
             runner: ubuntu-large
             target: x86_64-linux
           - os: mac
-            runner: macos-latest
+            runner: macos-latest-xl
             target: x86_64-darwin
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,6 +1,8 @@
 name: Wasm
 
-on: [push, pull_request]
+on:
+  pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/flake.nix
+++ b/flake.nix
@@ -170,7 +170,7 @@
       };
 
       # Combine the environmnet with cargo args needed to build wasm package
-      noirWasmArgs = wasmEnvironment // {
+      noirWasmArgs = sharedEnvironment // sharedArgs // {
         pname = "noir_wasm";
 
         src = ./.;


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This updates the mac runner to `macos-latest-xl` which is a 12-core hosted runner. I also removed `push` event from the workflow since `merge_queue` was fixed since we implemented this and it is the more correct event. We'll be timing out tests after 30 minutes to keep costs down.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
