### PR TITLE
fix(ssa refactor): Fix recursive call to `create_value_from_type`

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -131,13 +131,13 @@ impl Context {
     }
 
     fn convert_ssa_block_param(&mut self, param_type: &Type) -> AcirValue {
-        self.create_value_from_type(param_type, |this, typ| this.add_numeric_input_var(&typ))
+        self.create_value_from_type(param_type, &mut |this, typ| this.add_numeric_input_var(&typ))
     }
 
     fn create_value_from_type(
         &mut self,
         param_type: &Type,
-        mut make_var: impl FnMut(&mut Self, NumericType) -> AcirVar,
+        make_var: &mut impl FnMut(&mut Self, NumericType) -> AcirVar,
     ) -> AcirValue {
         match param_type {
             Type::Numeric(numeric_type) => {
@@ -149,7 +149,7 @@ impl Context {
 
                 for _ in 0..*length {
                     for element in element_types.iter() {
-                        elements.push_back(self.convert_ssa_block_param(element));
+                        elements.push_back(self.create_value_from_type(element, make_var));
                     }
                 }
 
@@ -731,7 +731,7 @@ impl Context {
 
     /// Creates a default, meaningless value meant only to be a valid value of the given type.
     fn create_default_value(&mut self, param_type: &Type) -> AcirValue {
-        self.create_value_from_type(param_type, |this, _| {
+        self.create_value_from_type(param_type, &mut |this, _| {
             this.acir_context.add_constant(FieldElement::zero())
         })
     }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

The "missing assignment for witness index" error was caused by an incorrect call in the array-element case of `create_value_from_type` which should have been a recursive call but instead was still calling `convert_ssa_block_param`. This was an oversight from PR #1797.

Resolves #1799

## Summary\*

With this PR `sha2_byte` and `sha2_block` no longer hit this error and instead run into a "cannot satisfy all constraints" error as in #1800.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
