### PR TITLE
chore(ssa refactor): Remove extra 'enable_side_effects' instructions

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/dfg.rs
@@ -139,7 +139,7 @@ impl DataFlowGraph {
         ctrl_typevars: Option<Vec<Type>>,
     ) -> InsertInstructionResult {
         use InsertInstructionResult::*;
-        match instruction.simplify(self) {
+        match instruction.simplify(self, block) {
             SimplifyResult::SimplifiedTo(simplification) => SimplifiedTo(simplification),
             SimplifyResult::Remove => InstructionRemoved,
             SimplifyResult::None => {
@@ -371,6 +371,12 @@ impl std::ops::Index<InstructionId> for DataFlowGraph {
     }
 }
 
+impl std::ops::IndexMut<InstructionId> for DataFlowGraph {
+    fn index_mut(&mut self, id: InstructionId) -> &mut Self::Output {
+        &mut self.instructions[id]
+    }
+}
+
 impl std::ops::Index<ValueId> for DataFlowGraph {
     type Output = Value;
     fn index(&self, id: ValueId) -> &Self::Output {
@@ -387,7 +393,7 @@ impl std::ops::Index<BasicBlockId> for DataFlowGraph {
 
 impl std::ops::IndexMut<BasicBlockId> for DataFlowGraph {
     /// Get a mutable reference to a function's basic block for the given id.
-    fn index_mut(&mut self, id: BasicBlockId) -> &mut BasicBlock {
+    fn index_mut(&mut self, id: BasicBlockId) -> &mut Self::Output {
         &mut self.blocks[id]
     }
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -237,7 +237,10 @@ impl Instruction {
 
     /// Try to simplify this instruction. If the instruction can be simplified to a known value,
     /// that value is returned. Otherwise None is returned.
-    pub(crate) fn simplify(&self, dfg: &mut DataFlowGraph) -> SimplifyResult {
+    ///
+    /// The `block` parameter indicates the block this new instruction will be inserted into
+    /// after this call.
+    pub(crate) fn simplify(&self, dfg: &mut DataFlowGraph, block: BasicBlockId) -> SimplifyResult {
         use SimplifyResult::*;
         match self {
             Instruction::Binary(binary) => binary.simplify(dfg),
@@ -309,10 +312,19 @@ impl Instruction {
                 }
             }
             Instruction::Call { func, arguments } => simplify_call(*func, arguments, dfg),
+            Instruction::EnableSideEffects { condition } => {
+                if let Some(last) = dfg[block].instructions().last().copied() {
+                    let last = &mut dfg[last];
+                    if matches!(last, Instruction::EnableSideEffects { .. }) {
+                        *last = Instruction::EnableSideEffects { condition: *condition };
+                        return Remove;
+                    }
+                }
+                None
+            }
             Instruction::Allocate { .. } => None,
             Instruction::Load { .. } => None,
             Instruction::Store { .. } => None,
-            Instruction::EnableSideEffects { .. } => None,
         }
     }
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

When running larger programs with several `if` statements the ssa refactor can often spit out code such as:

```
...
enable_side_effects_if v0
enable_side_effects_if u1 0
enable_side_effects_if u1 1
enable_side_effects_if u1 1
...
```

In which only the last instruction is useful since `enable_side_effects` overrides any previous calls of itself.

## Summary\*

This PR adds a check in `Instruction::simplify` to check if the last instruction inserted was also a `enable_side_effects_if` instruction, and if so, replace it with the new instruction instead of inserting another.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
