### PR TITLE
feat(lsp): Add a codelens that runs test when clicked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "acvm",
  "async-lsp",
  "codespan-lsp",
+ "codespan-reporting",
  "lsp-types 0.94.0",
  "noirc_driver",
  "noirc_errors",

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 [dependencies]
 acvm.workspace = true
 codespan-lsp.workspace = true
+codespan-reporting.workspace = true
 lsp-types.workspace = true
 noirc_driver.workspace = true
 noirc_errors.workspace = true

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -13,6 +13,7 @@ use noirc_evaluator::{create_circuit, ssa_refactor::experimental_create_circuit}
 use noirc_frontend::graph::{CrateId, CrateName, CrateType, LOCAL_CRATE};
 use noirc_frontend::hir::def_map::{Contract, CrateDefMap};
 use noirc_frontend::hir::Context;
+use noirc_frontend::hir_def::function::FuncMeta;
 use noirc_frontend::monomorphization::monomorphize;
 use noirc_frontend::node_interner::FuncId;
 use serde::{Deserialize, Serialize};
@@ -388,6 +389,10 @@ impl Driver {
 
     pub fn function_name(&self, id: FuncId) -> &str {
         self.context.def_interner.function_name(&id)
+    }
+
+    pub fn function_meta(&self, func_id: &FuncId) -> FuncMeta {
+        self.context.def_interner.function_meta(func_id)
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

First implementation of #1834 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This adds the infrastructure to display codelenses via the LSP. The first codelens that we support is the `> Run Test` action above functions marked via `#[test]`. The lens will display in any version of the vscode extension, but there is no command registered for `nargo.test` in the currently released version. We are adding the `nargo.test` command in https://github.com/noir-lang/vscode-noir/pull/25 (you can package it into a vsix and install manually to try).

<img width="358" alt="Screenshot 2023-06-28 at 4 00 05 PM" src="https://github.com/noir-lang/noir/assets/992373/3329788a-e115-4f8d-aba6-9748d54c0926">

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [x] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
