### PR TITLE
fix(lsp): Ensure stdlib is always added before the `check_crate` phase

### DIFF
--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -184,7 +184,6 @@ mod tests {
             Box::new(acvm::pwg::default_is_opcode_supported(acvm::Language::R1CS)),
         );
         driver.create_local_crate(&root_file, CrateType::Binary);
-        crate::resolver::add_std_lib(&mut driver);
 
         let result = driver.check_crate(false);
         let success = result.is_ok();

--- a/crates/nargo_cli/src/resolver.rs
+++ b/crates/nargo_cli/src/resolver.rs
@@ -6,7 +6,7 @@ use std::{
 use acvm::{acir::circuit::Opcode, Language};
 use nargo::manifest::{Dependency, PackageManifest};
 use noirc_driver::Driver;
-use noirc_frontend::graph::{CrateId, CrateName, CrateType};
+use noirc_frontend::graph::{CrateId, CrateType};
 use thiserror::Error;
 
 use crate::{git::clone_git_repo, InvalidPackageError};
@@ -85,7 +85,6 @@ impl<'a> Resolver<'a> {
         let pkg_root = manifest_path.parent().expect("Every manifest path has a parent.");
         resolver.resolve_manifest(crate_id, manifest, pkg_root)?;
 
-        add_std_lib(&mut driver);
         Ok(driver)
     }
 
@@ -166,12 +165,4 @@ impl<'a> Resolver<'a> {
             }
         }
     }
-}
-
-// This needs to be public to support the tests in `cli/mod.rs`.
-pub(crate) fn add_std_lib(driver: &mut Driver) {
-    let std_crate_name = "std";
-    let path_to_std_lib_file = PathBuf::from(std_crate_name).join("lib.nr");
-    let std_crate = driver.create_non_local_crate(path_to_std_lib_file, CrateType::Library);
-    driver.propagate_dep(std_crate, &CrateName::new(std_crate_name).unwrap());
 }

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -88,9 +88,6 @@ pub fn compile(args: JsValue) -> JsValue {
         add_noir_lib(&mut driver, dependency.as_str());
     }
 
-    // We are always adding std lib implicitly. It comes bundled with binary.
-    add_noir_lib(&mut driver, "std");
-
     driver.check_crate(false).expect("Crate check failed");
 
     if options.contracts {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #1833  <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This moves the addition of the stdlib to the dependency graph into `Driver::check_crate`, which is the point we know the root is configured and all other dependencies have been added to the driver. This ensures that no matter how or when you call `driver.check_crate` (e.g. `nargo_cli`, `lsp`, or `noir_wasm`), the stdlib will always be available.

This solution is sub-optimal because the stdlib should probably be the first crate added to the dependency graph and then it should be propagated to each new dep as it is added, but that seemed like a much larger refactor because a lot of the code in the compiler expects `FileId(0)` to be the crate root.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

In making this change I also discovered #1839 

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
