### PR TITLE
chore(driver): Remove backend dependence from driver construction

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -5,7 +5,6 @@ use std::{
     task::{Context, Poll},
 };
 
-use acvm::Language;
 use async_lsp::{
     router::Router, AnyEvent, AnyNotification, AnyRequest, ClientSocket, Error, LanguageClient,
     LspService, ResponseError,
@@ -134,9 +133,7 @@ fn on_code_lens_request(
     params: CodeLensParams,
 ) -> impl Future<Output = Result<Option<Vec<CodeLens>>, ResponseError>> {
     async move {
-        // TODO: Requiring `Language` and `is_opcode_supported` to construct a driver makes for some real stinky code
-        // The driver should not require knowledge of the backend; instead should be implemented as an independent pass (in nargo?)
-        let mut driver = Driver::new(&Language::R1CS, Box::new(|_op| false));
+        let mut driver = Driver::new();
 
         let file_path = &params.text_document.uri.to_file_path().unwrap();
 
@@ -222,9 +219,7 @@ fn on_did_save_text_document(
     state: &mut LspState,
     params: DidSaveTextDocumentParams,
 ) -> ControlFlow<Result<(), async_lsp::Error>> {
-    // TODO: Requiring `Language` and `is_opcode_supported` to construct a driver makes for some real stinky code
-    // The driver should not require knowledge of the backend; instead should be implemented as an independent pass (in nargo?)
-    let mut driver = Driver::new(&Language::R1CS, Box::new(|_op| false));
+    let mut driver = Driver::new();
 
     let file_path = &params.text_document.uri.to_file_path().unwrap();
 

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -178,11 +178,7 @@ mod tests {
     ///
     /// This is used for tests.
     fn file_compiles<P: AsRef<Path>>(root_file: P) -> bool {
-        let mut driver = Driver::new(
-            &acvm::Language::R1CS,
-            #[allow(deprecated)]
-            Box::new(acvm::pwg::default_is_opcode_supported(acvm::Language::R1CS)),
-        );
+        let mut driver = Driver::new();
         driver.create_local_crate(&root_file, CrateType::Binary);
         crate::resolver::add_std_lib(&mut driver);
 

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -7,10 +7,7 @@ use noirc_driver::{CompileOptions, Driver};
 use noirc_frontend::node_interner::FuncId;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use crate::{
-    cli::{check_cmd::check_crate_and_report_errors, compile_cmd::setup_driver},
-    errors::CliError,
-};
+use crate::{cli::check_cmd::check_crate_and_report_errors, errors::CliError, resolver::Resolver};
 
 use super::NargoConfig;
 
@@ -40,7 +37,7 @@ fn run_tests<B: Backend>(
     test_name: &str,
     compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
-    let mut driver = setup_driver(backend, program_dir)?;
+    let mut driver = Resolver::resolve_root_manifest(program_dir)?;
     check_crate_and_report_errors(&mut driver, compile_options.deny_warnings)?;
 
     let test_functions = driver.get_all_test_functions_in_crate_matching(test_name);
@@ -86,7 +83,7 @@ fn run_test<B: Backend>(
     config: &CompileOptions,
 ) -> Result<(), CliError<B>> {
     let program = driver
-        .compile_no_check(config, main)
+        .compile_no_check(config, main, backend.np_language(), &|op| backend.supports_opcode(op))
         .map_err(|_| CliError::Generic(format!("Test '{test_name}' failed to compile")))?;
 
     // Run the backend to ensure the PWG evaluates functions like std::hash::pedersen,

--- a/crates/nargo_cli/src/resolver.rs
+++ b/crates/nargo_cli/src/resolver.rs
@@ -3,7 +3,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use acvm::{acir::circuit::Opcode, Language};
 use nargo::manifest::{Dependency, PackageManifest};
 use noirc_driver::Driver;
 use noirc_frontend::graph::{CrateId, CrateName, CrateType};
@@ -70,10 +69,8 @@ impl<'a> Resolver<'a> {
     /// XXX: Need to handle when a local package changes!
     pub(crate) fn resolve_root_manifest(
         dir_path: &std::path::Path,
-        np_language: Language,
-        is_opcode_supported: Box<dyn Fn(&Opcode) -> bool>,
     ) -> Result<Driver, DependencyResolutionError> {
-        let mut driver = Driver::new(&np_language, is_opcode_supported);
+        let mut driver = Driver::new();
         let (entry_path, crate_type) = super::lib_or_bin(dir_path)?;
 
         let manifest_path = super::find_package_manifest(dir_path)?;

--- a/crates/noirc_driver/src/main.rs
+++ b/crates/noirc_driver/src/main.rs
@@ -6,11 +6,7 @@ fn main() {
     const EXTERNAL_DIR2: &str = "dep_a/lib.nr";
     const ROOT_DIR_MAIN: &str = "example_real_project/main.nr";
 
-    let mut driver = Driver::new(
-        &Language::R1CS,
-        #[allow(deprecated)]
-        Box::new(acvm::pwg::default_is_opcode_supported(Language::R1CS)),
-    );
+    let mut driver = Driver::new();
 
     // Add local crate to dep graph
     driver.create_local_crate(ROOT_DIR_MAIN, CrateType::Binary);
@@ -23,5 +19,12 @@ fn main() {
     driver.add_dep(LOCAL_CRATE, crate_id1, "coo4");
     driver.add_dep(LOCAL_CRATE, crate_id2, "coo3");
 
-    driver.compile_main(&CompileOptions::default()).ok();
+    driver
+        .compile_main(
+            Language::R1CS,
+            #[allow(deprecated)]
+            &acvm::pwg::default_is_opcode_supported(Language::R1CS),
+            &CompileOptions::default(),
+        )
+        .ok();
 }

--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -8,10 +8,7 @@
 #![allow(dead_code)]
 
 use crate::errors::RuntimeError;
-use acvm::{
-    acir::circuit::{Circuit, Opcode as AcirOpcode, PublicInputs},
-    Language,
-};
+use acvm::acir::circuit::{Circuit, PublicInputs};
 use noirc_abi::Abi;
 
 use noirc_frontend::monomorphization::ast::Program;
@@ -56,10 +53,9 @@ pub(crate) fn optimize_into_acir(
 /// Compiles the Program into ACIR and applies optimizations to the arithmetic gates
 /// This is analogous to `ssa:create_circuit` and this method is called when one wants
 /// to use the new ssa module to process Noir code.
+// TODO: This no longer needs to return a result, but it is kept to match the signature of `create_circuit`
 pub fn experimental_create_circuit(
     program: Program,
-    np_language: Language,
-    is_opcode_supported: &impl Fn(&AcirOpcode) -> bool,
     enable_logging: bool,
     show_output: bool,
 ) -> Result<(Circuit, Abi), RuntimeError> {
@@ -74,26 +70,9 @@ pub fn experimental_create_circuit(
         PublicInputs(public_abi.param_witnesses.values().flatten().copied().collect());
     let return_values = PublicInputs(return_witnesses.into_iter().collect());
 
-    // This region of code will optimize the ACIR bytecode for a particular backend
-    // it will be removed in the near future and we will subsequently only return the
-    // unoptimized backend-agnostic bytecode here
-    let optimized_circuit = {
-        use crate::errors::RuntimeErrorKind;
-        use acvm::compiler::CircuitSimplifier;
+    let circuit = Circuit { current_witness_index, opcodes, public_parameters, return_values };
 
-        let abi_len = abi.field_count();
-
-        let simplifier = CircuitSimplifier::new(abi_len);
-        acvm::compiler::compile(
-            Circuit { current_witness_index, opcodes, public_parameters, return_values },
-            np_language,
-            is_opcode_supported,
-            &simplifier,
-        )
-        .map_err(|_| RuntimeErrorKind::Spanless(String::from("produced an acvm compile error")))?
-    };
-
-    Ok((optimized_circuit, abi))
+    Ok((circuit, abi))
 }
 
 impl Ssa {

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -75,11 +75,7 @@ pub fn compile(args: JsValue) -> JsValue {
 
     // For now we default to plonk width = 3, though we can add it as a parameter
     let language = acvm::Language::PLONKCSat { width: 3 };
-    let mut driver = noirc_driver::Driver::new(
-        &language,
-        #[allow(deprecated)]
-        Box::new(acvm::pwg::default_is_opcode_supported(language.clone())),
-    );
+    let mut driver = noirc_driver::Driver::new();
 
     let path = PathBuf::from(&options.entry_point);
     driver.create_local_crate(path, CrateType::Binary);
@@ -95,15 +91,29 @@ pub fn compile(args: JsValue) -> JsValue {
 
     if options.contracts {
         let compiled_contracts = driver
-            .compile_contracts(&options.compile_options)
+            .compile_contracts(
+                // TODO: Remove clone when it implements Copy
+                language.clone(),
+                #[allow(deprecated)]
+                &acvm::pwg::default_is_opcode_supported(language),
+                &options.compile_options,
+            )
             .expect("Contract compilation failed")
             .0;
 
         <JsValue as JsValueSerdeExt>::from_serde(&compiled_contracts).unwrap()
     } else {
         let main = driver.main_function().expect("Could not find main function!");
-        let compiled_program =
-            driver.compile_no_check(&options.compile_options, main).expect("Compilation failed");
+        let compiled_program = driver
+            .compile_no_check(
+                &options.compile_options,
+                main,
+                // TODO: Remove clone when it implements Copy
+                language.clone(),
+                #[allow(deprecated)]
+                &acvm::pwg::default_is_opcode_supported(language),
+            )
+            .expect("Compilation failed");
 
         <JsValue as JsValueSerdeExt>::from_serde(&compiled_program).unwrap()
     }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #1680 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This removes `language` and `is_opcode_supported` arguments from the construction of the `Driver`. This is a half-measure while #1394 is outstanding. I tried to update that PR with upstream changes and all the tests were failing, so we should merge this intermediate step so I can continue moving forwards on fixing dependency resolution inside the LSP.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

While working on this, I noticed that we should be implementing Copy on the Language enum. See https://github.com/noir-lang/acvm/pull/406

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
