### PR TITLE
feat: add `nargo init` command

### DIFF
--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -1,0 +1,56 @@
+use crate::{
+    constants::{PKG_FILE, SRC_DIR},
+    errors::CliError,
+};
+
+use super::fs::{create_named_dir, write_to_file};
+use super::{NargoConfig, CARGO_PKG_VERSION};
+use acvm::Backend;
+use clap::Args;
+use const_format::formatcp;
+use std::path::PathBuf;
+
+/// Create a Noir project in the current directory.
+#[derive(Debug, Clone, Args)]
+pub(crate) struct InitCommand;
+
+const SETTINGS: &str = formatcp!(
+    r#"[package]
+authors = [""]
+compiler_version = "{CARGO_PKG_VERSION}"
+
+[dependencies]"#,
+);
+
+const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
+    assert(x != y);
+}
+
+#[test]
+fn test_main() {
+    main(1, 2);
+
+    // Uncomment to make test fail
+    // main(1, 1);
+}
+"#;
+
+pub(crate) fn run<B: Backend>(
+    // Backend is currently unused, but we might want to use it to inform the "new" template in the future
+    _backend: &B,
+    _args: InitCommand,
+    config: NargoConfig,
+) -> Result<(), CliError<B>> {
+    initialize_project(config.program_dir);
+    Ok(())
+}
+
+/// Initializes a new Noir project in `package_dir`.
+pub(crate) fn initialize_project(package_dir: PathBuf) {
+    let src_dir = package_dir.join(SRC_DIR);
+    create_named_dir(&src_dir, "src");
+
+    write_to_file(SETTINGS.as_bytes(), &package_dir.join(PKG_FILE));
+    write_to_file(EXAMPLE.as_bytes(), &src_dir.join("main.nr"));
+    println!("Project successfully created! Binary located at {}", package_dir.display());
+}

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -14,6 +14,7 @@ mod codegen_verifier_cmd;
 mod compile_cmd;
 mod execute_cmd;
 mod gates_cmd;
+mod init_cmd;
 mod lsp_cmd;
 mod new_cmd;
 mod prove_cmd;
@@ -51,6 +52,7 @@ enum NargoCommand {
     CodegenVerifier(codegen_verifier_cmd::CodegenVerifierCommand),
     Compile(compile_cmd::CompileCommand),
     New(new_cmd::NewCommand),
+    Init(init_cmd::InitCommand),
     Execute(execute_cmd::ExecuteCommand),
     Prove(prove_cmd::ProveCommand),
     Verify(verify_cmd::VerifyCommand),
@@ -63,7 +65,7 @@ pub fn start_cli() -> eyre::Result<()> {
     let NargoCli { command, mut config } = NargoCli::parse();
 
     // Search through parent directories to find package root if necessary.
-    if !matches!(command, NargoCommand::New(_) | NargoCommand::Lsp(_)) {
+    if !matches!(command, NargoCommand::New(_) | NargoCommand::Init(_) | NargoCommand::Lsp(_)) {
         config.program_dir = find_package_root(&config.program_dir)?;
     }
 
@@ -71,6 +73,7 @@ pub fn start_cli() -> eyre::Result<()> {
 
     match command {
         NargoCommand::New(args) => new_cmd::run(&backend, args, config),
+        NargoCommand::Init(args) => init_cmd::run(&backend, args, config),
         NargoCommand::Check(args) => check_cmd::run(&backend, args, config),
         NargoCommand::Compile(args) => compile_cmd::run(&backend, args, config),
         NargoCommand::Execute(args) => execute_cmd::run(&backend, args, config),

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -1,16 +1,11 @@
-use crate::{
-    constants::{PKG_FILE, SRC_DIR},
-    errors::CliError,
-};
+use crate::errors::CliError;
 
-use super::fs::{create_named_dir, write_to_file};
-use super::{NargoConfig, CARGO_PKG_VERSION};
+use super::{init_cmd::initialize_project, NargoConfig};
 use acvm::Backend;
 use clap::Args;
-use const_format::formatcp;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-/// Create a new binary project
+/// Create a Noir project in a new directory.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct NewCommand {
     /// Name of the package
@@ -18,27 +13,6 @@ pub(crate) struct NewCommand {
     /// The path to save the new project
     path: Option<PathBuf>,
 }
-
-const SETTINGS: &str = formatcp!(
-    r#"[package]
-authors = [""]
-compiler_version = "{CARGO_PKG_VERSION}"
-
-[dependencies]"#,
-);
-
-const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
-    assert(x != y);
-}
-
-#[test]
-fn test_main() {
-    main(1, 2);
-
-    // Uncomment to make test fail
-    // main(1, 1);
-}
-"#;
 
 pub(crate) fn run<B: Backend>(
     // Backend is currently unused, but we might want to use it to inform the "new" template in the future
@@ -52,11 +26,6 @@ pub(crate) fn run<B: Backend>(
         return Err(CliError::DestinationAlreadyExists(package_dir));
     }
 
-    let src_dir = package_dir.join(Path::new(SRC_DIR));
-    create_named_dir(&src_dir, "src");
-
-    write_to_file(SETTINGS.as_bytes(), &package_dir.join(PKG_FILE));
-    write_to_file(EXAMPLE.as_bytes(), &src_dir.join("main.nr"));
-    println!("Project successfully created! Binary located at {}", package_dir.display());
+    initialize_project(package_dir);
     Ok(())
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1852 

## Summary\*

This PR adds the `nargo init` command. Marking this as draft for the time being as I want to test some edge cases.

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.
      - Nargo will have a new `nargo init` command which will create a new project in the current directory.
 
## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
