### PR TITLE
fix: Prevent comparisons from being used on `Field`s

### DIFF
--- a/crates/nargo_cli/tests/test_data/higher_order_functions/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/higher_order_functions/src/main.nr
@@ -1,7 +1,7 @@
 use dep::std;
 
 fn main() -> pub Field {
-    let f = if 3 * 7 > 200 { foo } else { bar };
+    let f = if 3 * 7 > 200 as u32 { foo } else { bar };
     assert(f()[1] == 2);
 
     // Lambdas:

--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -198,7 +198,7 @@ impl BinaryOpKind {
     /// Comparator operators return a 0 or 1
     /// When seen in the middle of an infix operator,
     /// they transform the infix expression into a predicate expression
-    pub fn is_comparator(&self) -> bool {
+    pub fn is_comparator(self) -> bool {
         matches!(
             self,
             BinaryOpKind::Equal
@@ -208,6 +208,10 @@ impl BinaryOpKind {
                 | BinaryOpKind::Greater
                 | BinaryOpKind::GreaterEqual
         )
+    }
+
+    pub fn is_valid_for_field_type(self) -> bool {
+        matches!(self, BinaryOpKind::Equal | BinaryOpKind::NotEqual)
     }
 
     pub fn as_string(self) -> &'static str {

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     cell::RefCell,
     collections::{BTreeSet, HashMap},
     rc::Rc,
@@ -592,6 +593,16 @@ impl Type {
                 })
             }
             Type::Vec(element) => element.contains_numeric_typevar(target_id),
+        }
+    }
+
+    pub(crate) fn try_get_comptime(&self) -> Cow<CompTime> {
+        match self {
+            Type::FieldElement(comptime)
+            | Type::Integer(comptime, _, _)
+            | Type::Bool(comptime)
+            | Type::PolymorphicInteger(comptime, _) => Cow::Borrowed(comptime),
+            _ => Cow::Owned(CompTime::No(None)),
         }
     }
 }

--- a/noir_stdlib/src/sha256.nr
+++ b/noir_stdlib/src/sha256.nr
@@ -104,11 +104,11 @@ fn digest<N>(msg: [u8; N]) -> [u8; 32] {
     let mut h: [u32; 8] = [1779033703,3144134277,1013904242,2773480762,1359893119,2600822924,528734635,1541459225]; // Intermediate hash, starting with the canonical initial value
     let mut c: [u32; 8] = [0; 8]; // Compression of current message block as sequence of u32
     let mut out_h: [u8; 32] = [0; 32]; // Digest as sequence of bytes
-    let mut i = 0; // Message byte pointer
+    let mut i: u64 = 0; // Message byte pointer
 
     for k in 0 .. msg.len() {
         // Populate msg_block
-        msg_block[i] = msg[k];
+        msg_block[i as Field] = msg[k];
         i = i + 1;
         if i == 64 { // Enough to hash block
             c = sha_c(msg_u8_to_u32(msg_block), h);
@@ -122,7 +122,7 @@ fn digest<N>(msg: [u8; N]) -> [u8; 32] {
 
     // Pad the rest such that we have a [u32; 2] block at the end representing the length
     // of the message, and a block of 1 0 ... 0 following the message (i.e. [1 << 7, 0, ..., 0]).
-    msg_block[i] = 1 << 7;
+    msg_block[i as Field] = 1 << 7;
     i = i + 1;
 
     // If i >= 57, there aren't enough bits in the current message block to accomplish this, so
@@ -131,7 +131,7 @@ fn digest<N>(msg: [u8; N]) -> [u8; 32] {
         if i < 64 {
             for _i in 57..64 {
                 if i <= 63 {
-                    msg_block[i] = 0;
+                    msg_block[i as Field] = 0;
                     i += 1;
                 }
             }
@@ -147,7 +147,7 @@ fn digest<N>(msg: [u8; N]) -> [u8; 32] {
 
     for _i in 0..64 {// In any case, fill blocks up with zeros until the last 64 (i.e. until i = 56).
         if i < 56 {
-            msg_block[i] = 0;
+            msg_block[i as Field] = 0;
             i = i + 1;
         } else if i < 64 {
             let mut len = 8 * msg.len() as u64;

--- a/noir_stdlib/src/sha512.nr
+++ b/noir_stdlib/src/sha512.nr
@@ -104,11 +104,11 @@ fn digest<N>(msg: [u8; N]) -> [u8; 64]
     let mut h: [u64; 8] = [7640891576956012808, 13503953896175478587, 4354685564936845355, 11912009170470909681, 5840696475078001361, 11170449401992604703, 2270897969802886507, 6620516959819538809]; // Intermediate hash, starting with the canonical initial value
     let mut c: [u64; 8] = [0; 8]; // Compression of current message block as sequence of u64
     let mut out_h: [u8; 64] = [0; 64]; // Digest as sequence of bytes
-    let mut i = 0; // Message byte pointer
+    let mut i: u64 = 0; // Message byte pointer
 
     for k in 0 .. msg.len() {
         // Populate msg_block
-        msg_block[i] = msg[k];
+        msg_block[i as Field] = msg[k];
         i = i + 1;
         if i == 128 { // Enough to hash block
             c = sha_c(msg_u8_to_u64(msg_block), h);
@@ -122,7 +122,7 @@ fn digest<N>(msg: [u8; N]) -> [u8; 64]
 
     // Pad the rest such that we have a [u64; 2] block at the end representing the length
     // of the message, and a block of 1 0 ... 0 following the message (i.e. [1 << 7, 0, ..., 0]).
-    msg_block[i] = 1 << 7;
+    msg_block[i as Field] = 1 << 7;
     i += 1;
     
     // If i >= 113, there aren't enough bits in the current message block to accomplish this, so
@@ -131,7 +131,7 @@ fn digest<N>(msg: [u8; N]) -> [u8; 64]
         if i < 128 {
             for _i in 113..128 {
                 if i <= 127 {
-                    msg_block[i] = 0;
+                    msg_block[i as Field] = 0;
                     i += 1;
                 }
             }
@@ -146,7 +146,7 @@ fn digest<N>(msg: [u8; N]) -> [u8; 64]
 
     for _i in 0..128 {// In any case, fill blocks up with zeros until the last 128 (i.e. until i = 112).
         if i < 112 {
-            msg_block[i] = 0;
+            msg_block[i as Field] = 0;
             i += 1;
         } else if i < 128 {
             let mut len = 8 * msg.len() as u64; // u128 unsupported


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Adds missed checks to the type system to prevent comparison operators (other than `==` and `!=`) from being used on Fields even if at least 1 operand is a type variable. These are implemented the same way we prevent this with bitwise operators - with a delayed type check.

Resolves #1857

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
