### PR TITLE
chore: Remove the concept of `CrateType`

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -22,7 +22,7 @@ use lsp_types::{
 };
 use noirc_driver::{check_crate, create_local_crate};
 use noirc_errors::{DiagnosticKind, FileDiagnostic};
-use noirc_frontend::{graph::CrateType, hir::Context};
+use noirc_frontend::hir::Context;
 use serde_json::Value as JsonValue;
 use tower::Service;
 
@@ -167,7 +167,7 @@ fn on_code_lens_request(
 
     let mut context = Context::default();
 
-    let crate_id = create_local_crate(&mut context, file_path, CrateType::Binary);
+    let crate_id = create_local_crate(&mut context, file_path);
 
     // We ignore the warnings and errors produced by compilation for producing codelenses
     // because we can still get the test functions even if compilation fails
@@ -254,7 +254,7 @@ fn on_did_save_text_document(
 
     let mut context = Context::default();
 
-    let crate_id = create_local_crate(&mut context, file_path, CrateType::Binary);
+    let crate_id = create_local_crate(&mut context, file_path);
 
     let mut diagnostics = Vec::new();
 

--- a/crates/lsp/src/lib_hacky.rs
+++ b/crates/lsp/src/lib_hacky.rs
@@ -21,7 +21,7 @@ use lsp_types::{
 use noirc_driver::{check_crate, create_local_crate, create_non_local_crate, propagate_dep};
 use noirc_errors::{DiagnosticKind, FileDiagnostic};
 use noirc_frontend::{
-    graph::{CrateId, CrateName, CrateType},
+    graph::{CrateId, CrateName},
     hir::Context,
 };
 
@@ -268,7 +268,7 @@ fn create_context_at_path(actual_path: PathBuf) -> (Context, CrateId) {
     }
     let nargo_toml_path = find_nearest_parent_file(&file_path, &["Nargo.toml"]);
 
-    let current_crate_id = create_local_crate(&mut context, file_path, CrateType::Binary);
+    let current_crate_id = create_local_crate(&mut context, file_path);
 
     // TODO(AD): undo hacky dependency resolution
     if let Some(nargo_toml_path) = nargo_toml_path {
@@ -279,8 +279,7 @@ fn create_context_at_path(actual_path: PathBuf) -> (Context, CrateId) {
                     .parent()
                     .unwrap() // TODO
                     .join(PathBuf::from(&dependency_path).join("src").join("lib.nr"));
-                let library_crate =
-                    create_non_local_crate(&mut context, path_to_lib, CrateType::Library);
+                let library_crate = create_non_local_crate(&mut context, path_to_lib);
                 propagate_dep(&mut context, library_crate, &CrateName::new(crate_name).unwrap());
             }
         }

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -90,7 +90,7 @@ pub fn start_cli() -> eyre::Result<()> {
 mod tests {
     use noirc_driver::{check_crate, create_local_crate};
     use noirc_errors::reporter;
-    use noirc_frontend::{graph::CrateType, hir::Context};
+    use noirc_frontend::hir::Context;
 
     use std::path::{Path, PathBuf};
 
@@ -101,7 +101,7 @@ mod tests {
     /// This is used for tests.
     fn file_compiles<P: AsRef<Path>>(root_file: P) -> bool {
         let mut context = Context::default();
-        let crate_id = create_local_crate(&mut context, &root_file, CrateType::Binary);
+        let crate_id = create_local_crate(&mut context, &root_file);
 
         let result = check_crate(&mut context, crate_id, false, false);
         let success = result.is_ok();

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -48,12 +48,7 @@ fn run_tests<B: Backend>(
         compile_options.experimental_ssa,
     )?;
 
-    let test_functions = match context.crate_graph.crate_type(crate_id) {
-        noirc_frontend::graph::CrateType::Workspace => {
-            context.get_all_test_functions_in_workspace_matching(test_name)
-        }
-        _ => context.get_all_test_functions_in_crate_matching(&crate_id, test_name),
-    };
+    let test_functions = context.get_all_test_functions_in_crate_matching(&crate_id, test_name);
 
     println!("Running {} test functions...", test_functions.len());
     let mut failing = 0;

--- a/crates/nargo_cli/src/lib.rs
+++ b/crates/nargo_cli/src/lib.rs
@@ -7,7 +7,6 @@
 //! This name was used because it sounds like `cargo` and
 //! Noir Package Manager abbreviated is npm, which is already taken.
 
-use noirc_frontend::graph::CrateType;
 use std::{
     fs::ReadDir,
     path::{Path, PathBuf},
@@ -49,7 +48,7 @@ fn find_package_manifest(current_path: &Path) -> Result<PathBuf, InvalidPackageE
         .ok_or_else(|| InvalidPackageError::MissingManifestFile(current_path.to_path_buf()))
 }
 
-fn lib_or_bin(current_path: impl AsRef<Path>) -> Result<(PathBuf, CrateType), InvalidPackageError> {
+fn lib_or_bin(current_path: impl AsRef<Path>) -> Result<PathBuf, InvalidPackageError> {
     let current_path = current_path.as_ref();
     // A library has a lib.nr and a binary has a main.nr
     // You cannot have both.
@@ -60,8 +59,8 @@ fn lib_or_bin(current_path: impl AsRef<Path>) -> Result<(PathBuf, CrateType), In
     let bin_nr_path = find_file(&src_path, "main", "nr");
     match (lib_nr_path, bin_nr_path) {
         (Some(_), Some(_)) => Err(InvalidPackageError::ContainsMultipleCrates),
-        (None, Some(path)) => Ok((path, CrateType::Binary)),
-        (Some(path), None) => Ok((path, CrateType::Library)),
+        (None, Some(path)) => Ok(path),
+        (Some(path), None) => Ok(path),
         (None, None) => Err(InvalidPackageError::ContainsZeroCrates),
     }
 }

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -66,17 +66,9 @@ impl CrateGraph {
 /// and we do not want names that differ by a hyphen
 pub const CHARACTER_BLACK_LIST: [char; 1] = ['-'];
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum CrateType {
-    Library,
-    Binary,
-    Workspace,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrateData {
     pub root_file_id: FileId,
-    pub crate_type: CrateType,
     pub dependencies: Vec<Dependency>,
 }
 
@@ -95,7 +87,7 @@ impl Dependency {
 }
 
 impl CrateGraph {
-    pub fn add_crate_root(&mut self, crate_type: CrateType, file_id: FileId) -> CrateId {
+    pub fn add_crate_root(&mut self, file_id: FileId) -> CrateId {
         let mut roots_with_file_id =
             self.arena.iter().filter(|(_, crate_data)| crate_data.root_file_id == file_id);
 
@@ -104,14 +96,14 @@ impl CrateGraph {
             return *file_id.0;
         }
 
-        let data = CrateData { root_file_id: file_id, crate_type, dependencies: Vec::new() };
+        let data = CrateData { root_file_id: file_id, dependencies: Vec::new() };
         let crate_id = CrateId::Crate(self.arena.len());
         let prev = self.arena.insert(crate_id, data);
         assert!(prev.is_none());
         crate_id
     }
 
-    pub fn add_stdlib(&mut self, crate_type: CrateType, file_id: FileId) -> CrateId {
+    pub fn add_stdlib(&mut self, file_id: FileId) -> CrateId {
         let mut roots_with_file_id =
             self.arena.iter().filter(|(_, crate_data)| crate_data.root_file_id == file_id);
 
@@ -120,17 +112,12 @@ impl CrateGraph {
             return *file_id.0;
         }
 
-        let data = CrateData { root_file_id: file_id, crate_type, dependencies: Vec::new() };
+        let data = CrateData { root_file_id: file_id, dependencies: Vec::new() };
         let crate_id = CrateId::Stdlib(self.arena.len());
         let prev = self.arena.insert(crate_id, data);
         assert!(prev.is_none());
         crate_id
     }
-
-    pub fn crate_type(&self, crate_id: CrateId) -> CrateType {
-        self.arena.get(&crate_id).unwrap().crate_type
-    }
-
     pub fn iter_keys(&self) -> impl Iterator<Item = CrateId> + '_ {
         self.arena.keys().copied()
     }
@@ -222,7 +209,7 @@ pub struct CyclicDependenciesError {
 mod tests {
     use std::path::PathBuf;
 
-    use super::{CrateGraph, CrateName, CrateType, FileId};
+    use super::{CrateGraph, CrateName, FileId};
 
     fn dummy_file_ids(n: usize) -> Vec<FileId> {
         use fm::{FileMap, FILE_EXTENSION};
@@ -244,9 +231,9 @@ mod tests {
         let file_ids = dummy_file_ids(3);
 
         let mut graph = CrateGraph::default();
-        let crate1 = graph.add_crate_root(CrateType::Library, file_ids[0]);
-        let crate2 = graph.add_crate_root(CrateType::Library, file_ids[1]);
-        let crate3 = graph.add_crate_root(CrateType::Library, file_ids[2]);
+        let crate1 = graph.add_crate_root(file_ids[0]);
+        let crate2 = graph.add_crate_root(file_ids[1]);
+        let crate3 = graph.add_crate_root(file_ids[2]);
 
         assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
         assert!(graph.add_dep(crate2, CrateName::new("crate3").unwrap(), crate3).is_ok());
@@ -260,9 +247,9 @@ mod tests {
         let file_id_1 = file_ids[1];
         let file_id_2 = file_ids[2];
         let mut graph = CrateGraph::default();
-        let crate1 = graph.add_crate_root(CrateType::Library, file_id_0);
-        let crate2 = graph.add_crate_root(CrateType::Library, file_id_1);
-        let crate3 = graph.add_crate_root(CrateType::Library, file_id_2);
+        let crate1 = graph.add_crate_root(file_id_0);
+        let crate2 = graph.add_crate_root(file_id_1);
+        let crate3 = graph.add_crate_root(file_id_2);
         assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
         assert!(graph.add_dep(crate2, CrateName::new("crate3").unwrap(), crate3).is_ok());
     }
@@ -273,12 +260,12 @@ mod tests {
         let file_id_1 = file_ids[1];
         let file_id_2 = file_ids[2];
         let mut graph = CrateGraph::default();
-        let _crate1 = graph.add_crate_root(CrateType::Library, file_id_0);
-        let _crate2 = graph.add_crate_root(CrateType::Library, file_id_1);
+        let _crate1 = graph.add_crate_root(file_id_0);
+        let _crate2 = graph.add_crate_root(file_id_1);
 
         // Adding the same file, so the crate should be the same.
-        let crate3 = graph.add_crate_root(CrateType::Library, file_id_2);
-        let crate3_2 = graph.add_crate_root(CrateType::Library, file_id_2);
+        let crate3 = graph.add_crate_root(file_id_2);
+        let crate3_2 = graph.add_crate_root(file_id_2);
         assert_eq!(crate3, crate3_2);
     }
 }

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -4,7 +4,7 @@ pub mod resolution;
 pub mod scope;
 pub mod type_check;
 
-use crate::graph::{CrateGraph, CrateId, CrateType};
+use crate::graph::{CrateGraph, CrateId};
 use crate::hir_def::function::FuncMeta;
 use crate::node_interner::{FuncId, NodeInterner};
 use def_map::{Contract, CrateDefMap};
@@ -69,17 +69,13 @@ impl Context {
         // Find the local crate, one should always be present
         let local_crate = self.def_map(crate_id).unwrap();
 
-        // Check the crate type
-        // We don't panic here to allow users to `evaluate` libraries which will do nothing
-        if matches!(
-            self.crate_graph[*crate_id].crate_type,
-            CrateType::Binary | CrateType::Workspace
-        ) {
-            // All Binaries should have a main function
-            local_crate.main_function()
-        } else {
-            None
-        }
+        // All Binaries should have a main function
+        local_crate.main_function()
+    }
+
+    pub fn is_binary_crate(&self, crate_id: &CrateId) -> bool {
+        // Currently, anything with a `main` function is a binary crate
+        matches!(self.get_main_function(crate_id), Some(_))
     }
 
     /// Returns a list of all functions in the current crate marked with #[test]

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -5,10 +5,7 @@ use noirc_driver::{
     check_crate, compile_contracts, compile_no_check, create_local_crate, create_non_local_crate,
     propagate_dep, CompileOptions, CompiledContract,
 };
-use noirc_frontend::{
-    graph::{CrateName, CrateType},
-    hir::Context,
-};
+use noirc_frontend::{graph::CrateName, hir::Context};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use wasm_bindgen::prelude::*;
@@ -62,7 +59,7 @@ impl Default for WASMCompileOptions {
 
 fn add_noir_lib(context: &mut Context, crate_name: &str) {
     let path_to_lib = PathBuf::from(&crate_name).join("lib.nr");
-    let library_crate = create_non_local_crate(context, path_to_lib, CrateType::Library);
+    let library_crate = create_non_local_crate(context, path_to_lib);
 
     propagate_dep(context, library_crate, &CrateName::new(crate_name).unwrap());
 }
@@ -83,7 +80,7 @@ pub fn compile(args: JsValue) -> JsValue {
     let mut context = Context::default();
 
     let path = PathBuf::from(&options.entry_point);
-    let crate_id = create_local_crate(&mut context, path, CrateType::Binary);
+    let crate_id = create_local_crate(&mut context, path);
 
     for dependency in options.optional_dependencies_set {
         add_noir_lib(&mut context, dependency.as_str());


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Towards #1838  <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This removes the concept of a `CrateType` as it doesn't really matter except for adding dependencies and doing a "full" compilation (with backend, etc). In the cases where we need to know if something is a "binary crate" we can just check to see if it has a main function.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
