### PR TITLE
chore: Save witness in correct format that bb.js expects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,8 +52,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6b0dcd4fb93738eeb51a4558247c4dbacea4d3d5fd72842349638688d00ed6"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg.git?rev=0842911beed6c54b7efcd721372fb73431c95bbf#0842911beed6c54b7efcd721372fb73431c95bbf"
 dependencies = [
  "acvm",
  "barretenberg-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]
 async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "09dbcc11046f7a188a80137f8d36484d86c78c78" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg.git", rev = "0842911beed6c54b7efcd721372fb73431c95bbf" }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -56,3 +56,5 @@ default = ["plonk_bn254"]
 # The plonk backend can only use bn254, so we do not specify the field
 plonk_bn254 = ["acvm-backend-barretenberg/native"]
 plonk_bn254_wasm = ["acvm-backend-barretenberg/wasm"]
+plonk_bn254_bb_js = ["acvm-backend-barretenberg/native"]
+plonk_bn254_wasm_bb_js = ["acvm-backend-barretenberg/wasm"]

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -56,5 +56,4 @@ default = ["plonk_bn254"]
 # The plonk backend can only use bn254, so we do not specify the field
 plonk_bn254 = ["acvm-backend-barretenberg/native"]
 plonk_bn254_wasm = ["acvm-backend-barretenberg/wasm"]
-plonk_bn254_bb_js = ["acvm-backend-barretenberg/native"]
-plonk_bn254_wasm_bb_js = ["acvm-backend-barretenberg/wasm"]
+flat_witness = ["acvm-backend-barretenberg/native"]

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -1,6 +1,6 @@
 pub(crate) use acvm_backend_barretenberg::Barretenberg as ConcreteBackend;
 
-#[cfg(not(any(feature = "plonk_bn254", feature = "plonk_bn254_wasm")))]
+#[cfg(not(any(feature = "plonk_bn254", feature = "plonk_bn254_wasm", feature = "flat_witness")))]
 compile_error!("please specify a backend to compile with");
 
 #[cfg(all(feature = "plonk_bn254", feature = "plonk_bn254_wasm"))]

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -14,7 +14,7 @@ pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
     let buf: Vec<u8> = witnesses.try_into()?;
-    #[cfg(any(feature = "plonk_bn254_bb_js", feature = "plonk_bn254_wasm_bb_js"))]
+    #[cfg(feature = "flat_witness")]
     {
         let mut buf = Vec::new();
         for (_, value) in witnesses {

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -13,10 +13,13 @@ pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     create_named_dir(witness_dir.as_ref(), "witness");
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
-    let buf: Vec<u8> = witnesses.try_into()?;
+    let mut buf: Vec<u8> = Vec::new();
+    #[cfg(not(feature = "flat_witness"))]
+    {
+        buf = witnesses.try_into()?;
+    }
     #[cfg(feature = "flat_witness")]
     {
-        let mut buf = Vec::new();
         for (_, value) in witnesses {
             buf.extend_from_slice(&value.to_be_bytes());
         }

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -13,9 +13,13 @@ pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     create_named_dir(witness_dir.as_ref(), "witness");
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
-    let mut buf = Vec::new();
-    for (_, value) in witnesses {
-        buf.extend_from_slice(&value.to_be_bytes());
+    let buf: Vec<u8> = witness.try_into()?;
+    #[cfg(any(feature = "plonk_bn254_bb_js", feature = "plonk_bn254_wasm_bb_js"))]
+    {
+        let mut buf = Vec::new();
+        for (_, value) in witnesses {
+            buf.extend_from_slice(&value.to_be_bytes());
+        }
     }
 
     write_to_file(buf.as_slice(), &witness_path);

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -13,7 +13,7 @@ pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     create_named_dir(witness_dir.as_ref(), "witness");
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
-    let buf: Vec<u8> = witness.try_into()?;
+    let buf: Vec<u8> = witnesses.try_into()?;
     #[cfg(any(feature = "plonk_bn254_bb_js", feature = "plonk_bn254_wasm_bb_js"))]
     {
         let mut buf = Vec::new();

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -13,19 +13,24 @@ pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
     create_named_dir(witness_dir.as_ref(), "witness");
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
-    let mut buf: Vec<u8> = Vec::new();
-    #[cfg(not(feature = "flat_witness"))]
-    {
-        buf = witnesses.try_into()?;
-    }
-    #[cfg(feature = "flat_witness")]
-    {
-        for (_, value) in witnesses {
-            buf.extend_from_slice(&value.to_be_bytes());
-        }
-    }
+    let buf: Vec<u8> = serialize_witness_map(witnesses)?;
 
     write_to_file(buf.as_slice(), &witness_path);
 
     Ok(witness_path)
+}
+
+#[cfg(not(feature = "flat_witness"))]
+fn serialize_witness_map(witnesses: WitnessMap) -> Result<Vec<u8>, FilesystemError> {
+    let buf: Vec<u8> = witnesses.try_into()?;
+    Ok(buf)
+}
+
+#[cfg(feature = "flat_witness")]
+fn serialize_witness_map(witnesses: WitnessMap) -> Result<Vec<u8>, FilesystemError> {
+    let mut buf: Vec<u8> = Vec::new();
+    for (_, value) in witnesses {
+        buf.extend_from_slice(&value.to_be_bytes());
+    }
+    Ok(buf)
 }

--- a/crates/nargo_cli/src/cli/fs/witness.rs
+++ b/crates/nargo_cli/src/cli/fs/witness.rs
@@ -6,14 +6,17 @@ use super::{create_named_dir, write_to_file};
 use crate::{constants::WITNESS_EXT, errors::FilesystemError};
 
 pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
-    witness: WitnessMap,
+    witnesses: WitnessMap,
     witness_name: &str,
     witness_dir: P,
 ) -> Result<PathBuf, FilesystemError> {
     create_named_dir(witness_dir.as_ref(), "witness");
     let witness_path = witness_dir.as_ref().join(witness_name).with_extension(WITNESS_EXT);
 
-    let buf: Vec<u8> = witness.try_into()?;
+    let mut buf = Vec::new();
+    for (_, value) in witnesses {
+        buf.extend_from_slice(&value.to_be_bytes());
+    }
 
     write_to_file(buf.as_slice(), &witness_path);
 


### PR DESCRIPTION

# Description

We are moving to have our ACIR tests run in bb.js for proving and verification while nargo will just handle circuit execution.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR changes the format in which witnesses are saved to file. bberg is currently the only consumer of our witness output however this may be breaking for any old programs that still save the witness to file and use it elsewhere (however I see this as unlikely due to the large divergence in the TS bberg packages and Noir master). 

In order to be in line with bb.js we also need to enable the RecursiveAggregation opcode in acvm-backend-barretenberg as per this PR: https://github.com/noir-lang/acvm-backend-barretenberg/pull/225

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
