### PR TITLE
chore: restrict xor optimisation to 128 bits

### DIFF
--- a/crates/noirc_evaluator/src/ssa/optimizations.rs
+++ b/crates/noirc_evaluator/src/ssa/optimizations.rs
@@ -58,7 +58,7 @@ pub(super) fn simplify(ctx: &mut SsaContext, ins: &mut Instruction) -> Result<()
         }
     }
     if let Operation::Binary(binary) = &ins.operation {
-        if binary.operator == BinaryOp::Xor {
+        if binary.operator == BinaryOp::Xor && ins.res_type.bits() < 128 {
             let max = FieldElement::from(2_u128.pow(ins.res_type.bits()) - 1);
             if NodeEval::from_id(ctx, binary.rhs).into_const_value() == Some(max) {
                 ins.operation = Operation::Not(binary.lhs);


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Very small fix to restrict the xor constant folding to 128 bits as the simplification done does not support more than that.

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
