### PR TITLE
chore(nargo)!: Make proving and verification keys optional

### DIFF
--- a/crates/nargo/src/artifacts/contract.rs
+++ b/crates/nargo/src/artifacts/contract.rs
@@ -36,6 +36,6 @@ pub struct PreprocessedContractFunction {
     )]
     pub bytecode: Circuit,
 
-    pub proving_key: Vec<u8>,
-    pub verification_key: Vec<u8>,
+    pub proving_key: Option<Vec<u8>>,
+    pub verification_key: Option<Vec<u8>>,
 }

--- a/crates/nargo/src/artifacts/program.rs
+++ b/crates/nargo/src/artifacts/program.rs
@@ -18,6 +18,6 @@ pub struct PreprocessedProgram {
     )]
     pub bytecode: Circuit,
 
-    pub proving_key: Vec<u8>,
-    pub verification_key: Vec<u8>,
+    pub proving_key: Option<Vec<u8>>,
+    pub verification_key: Option<Vec<u8>>,
 }

--- a/crates/nargo/src/ops/preprocess.rs
+++ b/crates/nargo/src/ops/preprocess.rs
@@ -8,14 +8,21 @@ const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
 
 pub fn preprocess_program<B: ProofSystemCompiler>(
     backend: &B,
+    include_keys: bool,
     common_reference_string: &[u8],
     compiled_program: CompiledProgram,
 ) -> Result<PreprocessedProgram, B::Error> {
     // TODO: currently `compiled_program`'s bytecode is already optimized for the backend.
     // In future we'll need to apply those optimizations here.
     let optimized_bytecode = compiled_program.circuit;
-    let (proving_key, verification_key) =
-        backend.preprocess(common_reference_string, &optimized_bytecode)?;
+
+    let (proving_key, verification_key) = if include_keys {
+        let (proving_key, verification_key) =
+            backend.preprocess(common_reference_string, &optimized_bytecode)?;
+        (Some(proving_key), Some(verification_key))
+    } else {
+        (None, None)
+    };
 
     Ok(PreprocessedProgram {
         backend: String::from(BACKEND_IDENTIFIER),
@@ -28,14 +35,20 @@ pub fn preprocess_program<B: ProofSystemCompiler>(
 
 pub fn preprocess_contract_function<B: ProofSystemCompiler>(
     backend: &B,
+    include_keys: bool,
     common_reference_string: &[u8],
     func: ContractFunction,
 ) -> Result<PreprocessedContractFunction, B::Error> {
     // TODO: currently `func`'s bytecode is already optimized for the backend.
     // In future we'll need to apply those optimizations here.
     let optimized_bytecode = func.bytecode;
-    let (proving_key, verification_key) =
-        backend.preprocess(common_reference_string, &optimized_bytecode)?;
+    let (proving_key, verification_key) = if include_keys {
+        let (proving_key, verification_key) =
+            backend.preprocess(common_reference_string, &optimized_bytecode)?;
+        (Some(proving_key), Some(verification_key))
+    } else {
+        (None, None)
+    };
 
     Ok(PreprocessedContractFunction {
         name: func.name,

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -56,14 +56,17 @@ pub(crate) fn run<B: Backend>(
             let common_reference_string =
                 update_common_reference_string(backend, &common_reference_string, &program.circuit)
                     .map_err(CliError::CommonReferenceStringError)?;
-            let program = preprocess_program(backend, &common_reference_string, program)
+            let program = preprocess_program(backend, true, &common_reference_string, program)
                 .map_err(CliError::ProofSystemCompilerError)?;
             (common_reference_string, program)
         }
     };
 
+    let verification_key = preprocessed_program
+        .verification_key
+        .expect("Verification key should exist as `true` is passed to `preprocess_program`");
     let smart_contract_string =
-        codegen_verifier(backend, &common_reference_string, &preprocessed_program.verification_key)
+        codegen_verifier(backend, &common_reference_string, &verification_key)
             .map_err(CliError::SmartContractError)?;
 
     write_cached_common_reference_string(&common_reference_string);

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -29,6 +29,10 @@ pub(crate) struct CompileCommand {
     /// The name of the ACIR file
     circuit_name: String,
 
+    /// Include Proving and Verification keys in the build artifacts.
+    #[arg(long)]
+    include_keys: bool,
+
     /// Compile each contract function used within the program
     #[arg(short, long)]
     contracts: bool,
@@ -71,8 +75,13 @@ pub(crate) fn run<B: Backend>(
                     )
                     .map_err(CliError::CommonReferenceStringError)?;
 
-                    preprocess_contract_function(backend, &common_reference_string, func)
-                        .map_err(CliError::ProofSystemCompilerError)
+                    preprocess_contract_function(
+                        backend,
+                        args.include_keys,
+                        &common_reference_string,
+                        func,
+                    )
+                    .map_err(CliError::ProofSystemCompilerError)
                 })?;
 
                 Ok(PreprocessedContract {
@@ -94,8 +103,9 @@ pub(crate) fn run<B: Backend>(
             update_common_reference_string(backend, &common_reference_string, &program.circuit)
                 .map_err(CliError::CommonReferenceStringError)?;
 
-        let preprocessed_program = preprocess_program(backend, &common_reference_string, program)
-            .map_err(CliError::ProofSystemCompilerError)?;
+        let preprocessed_program =
+            preprocess_program(backend, args.include_keys, &common_reference_string, program)
+                .map_err(CliError::ProofSystemCompilerError)?;
         save_program_to_file(&preprocessed_program, &args.circuit_name, circuit_dir);
     }
 

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -110,8 +110,9 @@ pub fn prove_and_verify(program_dir: &Path, experimental_ssa: bool) -> bool {
         &program.circuit,
     )
     .expect("Should fetch CRS");
-    let preprocessed_program = preprocess_program(&backend, &common_reference_string, program)
-        .expect("Preprocess should succeed");
+    let preprocessed_program =
+        preprocess_program(&backend, true, &common_reference_string, program)
+            .expect("Preprocess should succeed");
 
     let nargo::artifacts::program::PreprocessedProgram {
         abi,
@@ -120,6 +121,8 @@ pub fn prove_and_verify(program_dir: &Path, experimental_ssa: bool) -> bool {
         verification_key,
         ..
     } = preprocessed_program;
+    let proving_key = proving_key.unwrap();
+    let verification_key = verification_key.unwrap();
 
     // Parse the initial witness values from Prover.toml
     let (inputs_map, _) = fs::inputs::read_inputs_from_file(

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -107,7 +107,7 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
             let common_reference_string =
                 update_common_reference_string(backend, &common_reference_string, &program.circuit)
                     .map_err(CliError::CommonReferenceStringError)?;
-            let program = preprocess_program(backend, &common_reference_string, program)
+            let program = preprocess_program(backend, true, &common_reference_string, program)
                 .map_err(CliError::ProofSystemCompilerError)?;
             (common_reference_string, program)
         }
@@ -137,12 +137,17 @@ pub(crate) fn prove_with_path<B: Backend, P: AsRef<Path>>(
         Format::Toml,
     )?;
 
+    let proving_key =
+        proving_key.expect("Proving key should exist as `true` is passed to `preprocess_program`");
+
     let proof =
         prove_execution(backend, &common_reference_string, &bytecode, solved_witness, &proving_key)
             .map_err(CliError::ProofSystemCompilerError)?;
 
     if check_proof {
         let public_inputs = public_abi.encode(&public_inputs, return_value)?;
+        let verification_key = verification_key
+            .expect("Verification key should exist as `true` is passed to `preprocess_program`");
         let valid_proof = verify_proof(
             backend,
             &common_reference_string,

--- a/crates/nargo_cli/src/cli/verify_cmd.rs
+++ b/crates/nargo_cli/src/cli/verify_cmd.rs
@@ -87,7 +87,7 @@ fn verify_with_path<B: Backend, P: AsRef<Path>>(
             let common_reference_string =
                 update_common_reference_string(backend, &common_reference_string, &program.circuit)
                     .map_err(CliError::CommonReferenceStringError)?;
-            let program = preprocess_program(backend, &common_reference_string, program)
+            let program = preprocess_program(backend, true, &common_reference_string, program)
                 .map_err(CliError::ProofSystemCompilerError)?;
             (common_reference_string, program)
         }
@@ -105,6 +105,8 @@ fn verify_with_path<B: Backend, P: AsRef<Path>>(
     let public_inputs = public_abi.encode(&public_inputs_map, return_value)?;
     let proof = load_hex_data(&proof_path)?;
 
+    let verification_key = verification_key
+        .expect("Verification key should exist as `true` is passed to `preprocess_program`");
     let valid_proof = verify_proof(
         backend,
         &common_reference_string,


### PR DESCRIPTION
# Description

The proving and verifying keys are quite large, so now we give users the option to include or not include those keys.

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
