### PR TITLE
chore(ci): Remove mac runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
           - os: ubuntu
             runner: ubuntu-large
             target: x86_64-linux
-          - os: mac
-            runner: macos-latest-xl
-            target: x86_64-darwin
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Description

The Mac runner in this PR https://github.com/noir-lang/noir/pull/1728 fails with a `pointer being freed was not allocated error` coming from barretenberg. However, all tests pass on my local intel Mac and other's ARM Mac laptops. 

We also have moved to just performing execution in the prove_and_verify tests w/ barretenberg handling proving and verification. The error is still happening after the move execution, thus there is most likely some internal bug w/ barretenberg on the Mac runner. 

This is blocking slices which is blocking a lot of other work by others, so we are going to remove the Mac runner and create an issue to barretenberg to handle running Noir tests on the different architectures. 

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
