### PR TITLE
feat(stdlib): Add multiple slice builtins

### DIFF
--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -37,7 +37,11 @@ fn check_from_path<B: Backend>(
     compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
     let mut context = resolve_root_manifest(program_dir)?;
-    check_crate_and_report_errors(&mut context, compile_options.deny_warnings, compile_options.experimental_ssa)?;
+    check_crate_and_report_errors(
+        &mut context,
+        compile_options.deny_warnings,
+        compile_options.experimental_ssa,
+    )?;
 
     // XXX: We can have a --overwrite flag to determine if you want to overwrite the Prover/Verifier.toml files
     if let Some((parameters, return_type)) = compute_function_signature(&context) {

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -41,7 +41,11 @@ fn run_tests<B: Backend>(
     compile_options: &CompileOptions,
 ) -> Result<(), CliError<B>> {
     let mut context = resolve_root_manifest(program_dir)?;
-    check_crate_and_report_errors(&mut context, compile_options.deny_warnings, compile_options.experimental_ssa)?;
+    check_crate_and_report_errors(
+        &mut context,
+        compile_options.deny_warnings,
+        compile_options.experimental_ssa,
+    )?;
 
     let test_functions = context.get_all_test_functions_in_crate_matching(&LOCAL_CRATE, test_name);
     println!("Running {} test functions...", test_functions.len());

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/slices/src/main.nr
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/slices/src/main.nr
@@ -1,6 +1,8 @@
 use dep::std::slice;
-
+use dep::std;
 fn main(x : Field, y : pub Field) {
+    /// TODO: Using slices in if statements where the condition is a witness
+    /// is not yet supported
 
     let mut slice: [Field] = [0; 2];
 
@@ -19,5 +21,27 @@ fn main(x : Field, y : pub Field) {
         new_slice = new_slice.push_back(i);
     }
     assert(new_slice.len() == 5);
+
+    new_slice = new_slice.push_front(20);
+    assert(new_slice[0] == 20);
+    assert(new_slice.len() == 6);
+
+    let (popped_slice, last_elem) = new_slice.pop_back();
+    assert(last_elem == 4);
+    assert(popped_slice.len() == 5);
+
+    let (first_elem, rest_of_slice) = popped_slice.pop_front();
+    assert(first_elem == 20);
+    assert(rest_of_slice.len() == 4);
+
+    new_slice = rest_of_slice.insert(2, 100);
+    assert(new_slice[2] == 100);
+    assert(new_slice[4] == 3);
+    assert(new_slice.len() == 5);
+
+    let (remove_slice, removed_elem) = new_slice.remove(3);
+    assert(removed_elem == 2);
+    assert(remove_slice[3] == 3);
+    assert(remove_slice.len() == 4);
 }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/function_inserter.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/function_inserter.rs
@@ -97,6 +97,11 @@ impl<'f> FunctionInserter<'f> {
             InsertInstructionResult::SimplifiedTo(new_result) => {
                 values.insert(old_results[0], *new_result);
             }
+            InsertInstructionResult::SimplifiedToMultiple(new_results) => {
+                for (old_result, new_result) in old_results.iter().zip(new_results.clone()) {
+                    values.insert(*old_result, new_result);
+                }
+            }
             InsertInstructionResult::Results(new_results) => {
                 for (old_result, new_result) in old_results.iter().zip(*new_results) {
                     values.insert(*old_result, *new_result);

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -34,6 +34,11 @@ pub(crate) enum Intrinsic {
     Sort,
     ArrayLen,
     SlicePushBack,
+    SlicePushFront,
+    SlicePopBack,
+    SlicePopFront,
+    SliceInsert,
+    SliceRemove,
     Println,
     ToBits(Endian),
     ToRadix(Endian),
@@ -47,6 +52,11 @@ impl std::fmt::Display for Intrinsic {
             Intrinsic::Sort => write!(f, "arraysort"),
             Intrinsic::ArrayLen => write!(f, "array_len"),
             Intrinsic::SlicePushBack => write!(f, "slice_push_back"),
+            Intrinsic::SlicePushFront => write!(f, "slice_push_front"),
+            Intrinsic::SlicePopBack => write!(f, "slice_pop_back"),
+            Intrinsic::SlicePopFront => write!(f, "slice_pop_front"),
+            Intrinsic::SliceInsert => write!(f, "slice_insert"),
+            Intrinsic::SliceRemove => write!(f, "slice_remove"),
             Intrinsic::ToBits(Endian::Big) => write!(f, "to_be_bits"),
             Intrinsic::ToBits(Endian::Little) => write!(f, "to_le_bits"),
             Intrinsic::ToRadix(Endian::Big) => write!(f, "to_be_radix"),
@@ -65,6 +75,11 @@ impl Intrinsic {
             "arraysort" => Some(Intrinsic::Sort),
             "array_len" => Some(Intrinsic::ArrayLen),
             "slice_push_back" => Some(Intrinsic::SlicePushBack),
+            "slice_push_front" => Some(Intrinsic::SlicePushFront),
+            "slice_pop_back" => Some(Intrinsic::SlicePopBack),
+            "slice_pop_front" => Some(Intrinsic::SlicePopFront),
+            "slice_insert" => Some(Intrinsic::SliceInsert),
+            "slice_remove" => Some(Intrinsic::SliceRemove),
             "to_le_radix" => Some(Intrinsic::ToRadix(Endian::Little)),
             "to_be_radix" => Some(Intrinsic::ToRadix(Endian::Big)),
             "to_le_bits" => Some(Intrinsic::ToBits(Endian::Little)),
@@ -425,6 +440,62 @@ fn simplify_call(func: ValueId, arguments: &[ValueId], dfg: &mut DataFlowGraph) 
                 slice.push_back(elem);
                 let new_slice = dfg.make_array(slice, element_type);
                 SimplifiedTo(new_slice)
+            } else {
+                None
+            }
+        }
+        Intrinsic::SlicePushFront => {
+            let slice = dfg.get_array_constant(arguments[0]);
+            if let (Some((mut slice, element_type)), elem) = (slice, arguments[1]) {
+                slice.push_front(elem);
+                let new_slice = dfg.make_array(slice, element_type);
+                SimplifiedTo(new_slice)
+            } else {
+                None
+            }
+        }
+        Intrinsic::SlicePopBack => {
+            let slice = dfg.get_array_constant(arguments[0]);
+            if let Some((mut slice, element_type)) = slice {
+                let elem =
+                    slice.pop_back().expect("There are no elements in this slice to be removed");
+                let new_slice = dfg.make_array(slice, element_type);
+                SimplifiedToMultiple(vec![new_slice, elem])
+            } else {
+                None
+            }
+        }
+        Intrinsic::SlicePopFront => {
+            let slice = dfg.get_array_constant(arguments[0]);
+            if let Some((mut slice, element_type)) = slice {
+                let elem =
+                    slice.pop_front().expect("There are no elements in this slice to be removed");
+                let new_slice = dfg.make_array(slice, element_type);
+                SimplifiedToMultiple(vec![elem, new_slice])
+            } else {
+                None
+            }
+        }
+        Intrinsic::SliceInsert => {
+            let slice = dfg.get_array_constant(arguments[0]);
+            let index = dfg.get_numeric_constant(arguments[1]);
+            if let (Some((mut slice, element_type)), Some(index), value) =
+                (slice, index, arguments[2])
+            {
+                slice.insert(index.to_u128() as usize, value);
+                let new_slice = dfg.make_array(slice, element_type);
+                SimplifiedTo(new_slice)
+            } else {
+                None
+            }
+        }
+        Intrinsic::SliceRemove => {
+            let slice = dfg.get_array_constant(arguments[0]);
+            let index = dfg.get_numeric_constant(arguments[1]);
+            if let (Some((mut slice, element_type)), Some(index)) = (slice, index) {
+                let removed_elem = slice.remove(index.to_u128() as usize);
+                let new_slice = dfg.make_array(slice, element_type);
+                SimplifiedToMultiple(vec![new_slice, removed_elem])
             } else {
                 None
             }
@@ -830,6 +901,11 @@ impl std::fmt::Display for BinaryOp {
 pub(crate) enum SimplifyResult {
     /// Replace this function's result with the given value
     SimplifiedTo(ValueId),
+
+    /// Replace this function's results with the given values
+    /// Used for when there are multiple return values from
+    /// a function such as a tuple
+    SimplifiedToMultiple(Vec<ValueId>),
 
     /// Remove the instruction, it is unnecessary
     Remove,

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/constant_folding.rs
@@ -74,6 +74,7 @@ impl Context {
         let new_results =
             match function.dfg.insert_instruction_and_results(instruction, block, ctrl_typevars) {
                 InsertInstructionResult::SimplifiedTo(new_result) => vec![new_result],
+                InsertInstructionResult::SimplifiedToMultiple(new_results) => new_results,
                 InsertInstructionResult::Results(new_results) => new_results.to_vec(),
                 InsertInstructionResult::InstructionRemoved => vec![],
             };

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/inlining.rs
@@ -403,6 +403,11 @@ impl<'function> PerFunctionContext<'function> {
             InsertInstructionResult::SimplifiedTo(new_result) => {
                 values.insert(old_results[0], new_result);
             }
+            InsertInstructionResult::SimplifiedToMultiple(new_results) => {
+                for (old_result, new_result) in old_results.iter().zip(new_results) {
+                    values.insert(*old_result, new_result);
+                }
+            }
             InsertInstructionResult::Results(new_results) => {
                 for (old_result, new_result) in old_results.iter().zip(new_results) {
                     values.insert(*old_result, *new_result);

--- a/noir_stdlib/src/slice.nr
+++ b/noir_stdlib/src/slice.nr
@@ -6,6 +6,33 @@ impl<T> [T] {
     #[builtin(slice_push_back)]
     fn push_back(_self: Self, _elem: T) -> Self { }
 
+    /// Push a new element to the front of the slice, returning a
+    /// new slice with a length one greater than the 
+    /// original unmodified slice. 
+    #[builtin(slice_push_front)]
+    fn push_front(_self: Self, _elem: T) -> Self { }
+
+    /// Remove the last element of the slice, returning the
+    /// popped slice and the element in a tuple
+    #[builtin(slice_pop_back)]
+    fn pop_back(_self: Self) -> (Self, T) { }
+
+    /// Remove the first element of the slice, returning the
+    /// element and the popped slice in a tuple
+    #[builtin(slice_pop_front)]
+    fn pop_front(_self: Self) -> (T, Self) { }
+
+    /// Insert an element at a specified index, shifting all elements 
+    /// after it to the right
+    #[builtin(slice_insert)]
+    fn insert(_self: Self, _index: Field, _elem: T) -> Self { }
+
+    /// Remove an element at a specified index, shifting all elements
+    /// after it to the left, returning the altered slice and 
+    /// the removed element
+    #[builtin(slice_remove)]
+    fn remove(_self: Self, _index: Field) -> (Self, T) { }
+ 
     #[builtin(array_len)]
     fn len(_self: Self) -> comptime Field {}
 


### PR DESCRIPTION
# Description

This PR adds slice builtins for `push_front`, `pop_back`, `pop_front`, `insert`, and `remove`. 

## Problem\*

This is indirectly related with #1556 and implementing vectors. The original slices PR only included `push_back` and a full Vec type needs more slice builtins like the ones included in this PR. 

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [X] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [X] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [X] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
