### PR TITLE
chore(fm): Remove the concept of FileType

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -7,7 +7,7 @@ use acvm::acir::circuit::Opcode;
 use acvm::compiler::CircuitSimplifier;
 use acvm::Language;
 use clap::Args;
-use fm::{FileId, FileType};
+use fm::FileId;
 use noirc_abi::FunctionSignature;
 use noirc_errors::{CustomDiagnostic, FileDiagnostic};
 use noirc_evaluator::{create_circuit, ssa_refactor::experimental_create_circuit};
@@ -90,7 +90,7 @@ pub fn create_local_crate<P: AsRef<Path>>(
     crate_type: CrateType,
 ) -> CrateId {
     let dir_path = root_file.as_ref().to_path_buf();
-    let root_file_id = context.file_manager.add_file(&dir_path, FileType::Root).unwrap();
+    let root_file_id = context.file_manager.add_file(&dir_path).unwrap();
 
     let crate_id = context.crate_graph.add_crate_root(crate_type, root_file_id);
 
@@ -107,7 +107,7 @@ pub fn create_non_local_crate<P: AsRef<Path>>(
     crate_type: CrateType,
 ) -> CrateId {
     let dir_path = root_file.as_ref().to_path_buf();
-    let root_file_id = context.file_manager.add_file(&dir_path, FileType::Root).unwrap();
+    let root_file_id = context.file_manager.add_file(&dir_path).unwrap();
 
     // The first crate is always the local crate
     assert!(context.crate_graph.number_of_crates() != 0);

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -92,7 +92,7 @@ impl CrateDefMap {
                 .path(root_file_id)
                 .to_str()
                 .expect("expected std path to be convertible to str");
-            assert_eq!(path_as_str, "std");
+            assert_eq!(path_as_str, "std/lib");
             ast.module_decls.retain(|ident| ident.0.contents != "slice");
         }
 

--- a/crates/noirc_frontend/src/main.rs
+++ b/crates/noirc_frontend/src/main.rs
@@ -7,7 +7,7 @@
 //! perform optimizations, convert to ACIR and eventually prove/verify the program.
 use std::path::PathBuf;
 
-use fm::{FileManager, FileType};
+use fm::FileManager;
 use hir::{def_map::CrateDefMap, Context};
 use noirc_frontend::graph::{CrateGraph, CrateType};
 use noirc_frontend::hir::{self, def_map::ModuleDefId};
@@ -19,7 +19,7 @@ fn main() {
     //
     // Add root file to file manager
     let dir_path: PathBuf = PathBuf::from("example_project/lib.nr");
-    let root_file_id = fm.add_file(&dir_path, FileType::Root).unwrap();
+    let root_file_id = fm.add_file(&dir_path).unwrap();
 
     // CrateGraph
     let mut crate_graph = CrateGraph::default();


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Towards #1838  <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This removes the concept of `FileType`. The reason this seemed to exist was an artifact of not creating the correct "candidates" in the `resolve_path` function on FileManager.

We want to store all files as their extensionless filename and then search for a directory with the same name and fallback to the sibling file if the directory structure doesn't exist.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
