### PR TITLE
fix(lsp): Avoid storing Context until recompiles are possible

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -28,14 +28,12 @@ const TEST_CODELENS_TITLE: &str = "▶\u{fe0e} Run Test";
 
 // State for the LSP gets implemented on this struct and is internal to the implementation
 struct LspState {
-    context: Context,
     client: ClientSocket,
 }
 
 impl LspState {
     fn new(client: &ClientSocket) -> Self {
-        // TODO: Do we want to build the Context here or when we get the initialize message?
-        Self { client: client.clone(), context: Context::default() }
+        Self { client: client.clone() }
     }
 }
 
@@ -130,31 +128,33 @@ fn on_shutdown(
 }
 
 fn on_code_lens_request(
-    state: &mut LspState,
+    _state: &mut LspState,
     params: CodeLensParams,
 ) -> impl Future<Output = Result<Option<Vec<CodeLens>>, ResponseError>> {
     let file_path = &params.text_document.uri.to_file_path().unwrap();
 
-    let crate_id = create_local_crate(&mut state.context, file_path, CrateType::Binary);
+    let mut context = Context::default();
+
+    let crate_id = create_local_crate(&mut context, file_path, CrateType::Binary);
 
     // We ignore the warnings and errors produced by compilation for producing codelenses
     // because we can still get the test functions even if compilation fails
-    let _ = check_crate(&mut state.context, false, false);
+    let _ = check_crate(&mut context, false, false);
 
-    let fm = &state.context.file_manager;
+    let fm = &context.file_manager;
     let files = fm.as_simple_files();
-    let tests = state.context.get_all_test_functions_in_crate_matching(&crate_id, "");
+    let tests = context.get_all_test_functions_in_crate_matching(&crate_id, "");
 
     let mut lenses: Vec<CodeLens> = vec![];
     for func_id in tests {
-        let location = state.context.function_meta(&func_id).name.location;
+        let location = context.function_meta(&func_id).name.location;
         let file_id = location.file;
         // TODO(#1681): This file_id never be 0 because the "path" where it maps is the directory, not a file
         if file_id.as_usize() != 0 {
             continue;
         }
 
-        let func_name = state.context.function_name(&func_id);
+        let func_name = context.function_name(&func_id);
 
         let range =
             byte_span_to_range(files, file_id.as_usize(), location.span.into()).unwrap_or_default();
@@ -220,17 +220,19 @@ fn on_did_save_text_document(
 ) -> ControlFlow<Result<(), async_lsp::Error>> {
     let file_path = &params.text_document.uri.to_file_path().unwrap();
 
-    create_local_crate(&mut state.context, file_path, CrateType::Binary);
+    let mut context = Context::default();
+
+    create_local_crate(&mut context, file_path, CrateType::Binary);
 
     let mut diagnostics = Vec::new();
 
-    let file_diagnostics = match check_crate(&mut state.context, false, false) {
+    let file_diagnostics = match check_crate(&mut context, false, false) {
         Ok(warnings) => warnings,
         Err(errors_and_warnings) => errors_and_warnings,
     };
 
     if !file_diagnostics.is_empty() {
-        let fm = &state.context.file_manager;
+        let fm = &context.file_manager;
         let files = fm.as_simple_files();
 
         for FileDiagnostic { file_id, diagnostic } in file_diagnostics {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

Currently, the compiler doesn't know how to recompile code. Instead if just returns immediately. By storing a context on the LSP state, no diagnostics would be sent because the codelens handler runs first.

We need to create a new Context on each message until we can make the compiler recompile files.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
