### PR TITLE
chore: Pin `wasm-bindgen` dependency to 0.28.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ thiserror = "1.0.21"
 toml = "0.7.2"
 tower = "0.4"
 url = "2.2.0"
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.86", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 
 [patch.crates-io]


### PR DESCRIPTION
# Description

Dependency changes between even minor versions of wasm-bindgen are surfacing errors in the CI. 

We pin the version of wasm-bindgen in this PR, so that it does not get automatically updated. 
 
<img width="1229" alt="Screenshot 2023-07-10 at 11 19 56" src="https://github.com/noir-lang/noir/assets/37423678/90c051f1-e1ad-4185-a7c1-45bb3b15fc10">

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
