### PR TITLE
fix: Fix auto-deref operations assigning the wrong result type

### DIFF
--- a/crates/nargo_cli/tests/test_data_ssa_refactor/references/src/main.nr
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/references/src/main.nr
@@ -2,10 +2,9 @@ fn main(mut x: Field) {
     add1(&mut x);
     assert(x == 3);
 
-    // https://github.com/noir-lang/noir/issues/1899
-    // let mut s = S { y: x };
-    // s.add2();
-    // assert(s.y == 5);
+    let mut s = S { y: x };
+    s.add2();
+    assert(s.y == 5);
 
     // Test that normal mutable variables are still copied
     let mut a = 0;

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -524,8 +524,8 @@ impl<'interner> TypeChecker<'interner> {
                 operator: crate::UnaryOp::Dereference,
                 rhs: old_lhs,
             }));
-            this.interner.push_expr_type(access_lhs, lhs_type);
-            this.interner.push_expr_type(&old_lhs, element);
+            this.interner.push_expr_type(&old_lhs, lhs_type);
+            this.interner.push_expr_type(access_lhs, element);
         };
 
         match self.check_field_access(&lhs_type, &access.rhs.0.contents, span, dereference_lhs) {
@@ -939,7 +939,7 @@ impl<'interner> TypeChecker<'interner> {
                 Type::MutableReference(Box::new(rhs_type.follow_bindings()))
             }
             crate::UnaryOp::Dereference => {
-                let element_type = Type::type_variable(self.interner.next_type_variable_id());
+                let element_type = self.interner.next_type_variable();
                 unify(Type::MutableReference(Box::new(element_type.clone())));
                 element_type
             }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1899

## Summary\*

When we encounter `foo.bar` where `foo` is a reference, we automatically dereference foo, transforming the code into `(*foo).bar`. When this happens, we previously accidentally set the type of `foo` to `T` and `*foo` to `&mut T` instead of the reverse. I've switched the two cases.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
