### PR TITLE
feat(brillig_gen): Return slices from foreign calls

### DIFF
--- a/crates/nargo/src/ops/execute.rs
+++ b/crates/nargo/src/ops/execute.rs
@@ -1,4 +1,4 @@
-use acvm::acir::brillig_vm::ForeignCallResult;
+use acvm::acir::brillig_vm::{ForeignCallResult, Value};
 use acvm::pwg::{ACVMStatus, ForeignCallWaitInfo, ACVM};
 use acvm::BlackBoxFunctionSolver;
 use acvm::{acir::circuit::Circuit, acir::native_types::WitnessMap};
@@ -56,6 +56,28 @@ fn execute_foreign_call(foreign_call: &ForeignCallWaitInfo) -> ForeignCallResult
             println!("{output_witnesses_string}");
 
             foreign_call.inputs[0][0].into()
+        }
+        "get_number_sequence" => {
+            let sequence_length: u128 = foreign_call.inputs[0][0].to_field().to_u128();
+            // let mut sequence_length: u128 = 0;
+            // for values in &foreign_call.inputs {
+            //     sequence_length = values[0].to_field().to_u128();
+            // }
+
+            let mut sequence = Vec::new();
+            for i in 0..sequence_length {
+                sequence.push(Value::from(i));
+            }
+            sequence.into()
+        }
+        "get_reverse_number_sequence" => {
+            let sequence_length: u128 = foreign_call.inputs[0][0].to_field().to_u128();
+
+            let mut sequence = Vec::new();
+            for i in (0..sequence_length).rev() {
+                sequence.push(Value::from(i));
+            }
+            sequence.into()
         }
         _ => panic!("unexpected foreign call type"),
     }

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_oracle/src/main.nr
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_oracle/src/main.nr
@@ -5,6 +5,10 @@ fn main(x: Field)  {
 
     // TODO(#1615) Nargo currently only supports resolving one foreign call
     // oracle_print_wrapper(x);
+
+    // let slice = get_number_sequence_wrapper(12);
+    // assert(slice.len() == 12);
+    get_number_sequence_wrapper(20);
 }
 
 #[oracle(oracle_print_impl)]
@@ -19,5 +23,22 @@ unconstrained fn oracle_print_array(_arr : [Field; 2]) -> Field {}
 
 unconstrained fn oracle_print_array_wrapper(arr: [Field; 2]) {
     oracle_print_array(arr);
+}
+
+#[oracle(get_number_sequence)]
+unconstrained fn get_number_sequence(_size: Field) -> [Field] {}
+
+#[oracle(get_reverse_number_sequence)]
+unconstrained fn get_reverse_number_sequence(_size: Field) -> [Field] {}
+
+unconstrained fn get_number_sequence_wrapper(size: Field) {
+    let slice = get_number_sequence(size);
+    assert(slice[19] == 19);
+
+    let reversed_slice = get_reverse_number_sequence(size);
+    // Regression test that we have not overwritten memory
+    assert(slice[19] == 19);
+    assert(reversed_slice[0] == 19);
+    assert(reversed_slice[19] == 0);
 }
 

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -1,5 +1,5 @@
 use crate::brillig::brillig_ir::{
-    BrilligBinaryOp, BrilligContext, BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
+    BrilligBinaryOp, BrilligContext, ReservedRegisters, BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
 };
 use crate::ssa_refactor::ir::function::FunctionId;
 use crate::ssa_refactor::ir::instruction::Intrinsic;
@@ -12,7 +12,7 @@ use crate::ssa_refactor::ir::{
     value::{Value, ValueId},
 };
 use acvm::acir::brillig_vm::{
-    BinaryFieldOp, BinaryIntOp, HeapArray, RegisterIndex, RegisterOrMemory,
+    BinaryFieldOp, BinaryIntOp, HeapArray, HeapVector, RegisterIndex, RegisterOrMemory,
 };
 use acvm::FieldElement;
 use iter_extended::vecmap;
@@ -214,6 +214,23 @@ impl<'block> BrilligBlock<'block> {
                         &input_registers,
                         &output_registers,
                     );
+
+                    for output_register in output_registers {
+                        match output_register {
+                            // The array size register is only set once an external call is resolved, thus
+                            // allocation of the dynamic sized array should happen after the external call.
+                            RegisterOrMemory::HeapVector(HeapVector { size, .. }) => {
+                                // Update the stack pointer so that we do not overwrite
+                                // dynamic memory returned from other external calls
+                                self.brillig_context.update_stack_pointer(size);
+                            }
+                            // Single values and allocation of fixed sized arrays has already been handled
+                            // inside of `allocate_external_call_result`
+                            RegisterOrMemory::RegisterIndex(_) | RegisterOrMemory::HeapArray(_) => {
+                                ()
+                            }
+                        }
+                    }
                 }
                 Value::Function(func_id) => {
                     let function_arguments: Vec<RegisterIndex> =
@@ -485,6 +502,16 @@ impl<'block> BrilligBlock<'block> {
                 let array_size_in_memory = compute_size_of_type(&typ);
                 self.brillig_context.allocate_fixed_length_array(pointer, array_size_in_memory);
                 RegisterOrMemory::HeapArray(HeapArray { pointer, size: array_size_in_memory })
+            }
+            Type::Slice(_) => {
+                let pointer =
+                    self.function_context.get_or_create_register(self.brillig_context, result);
+                let array_size_register = self.brillig_context.allocate_register();
+                // Set the pointer to the current stack frame
+                // The stack pointer will then be update by the caller of this method
+                // once the external call is resolved and the array size is known
+                self.brillig_context.set_array_pointer(pointer);
+                RegisterOrMemory::HeapVector(HeapVector { pointer, size: array_size_register })
             }
             _ => {
                 unreachable!("ICE: unsupported return type for black box call {typ:?}")

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -146,7 +146,10 @@ impl BrilligContext {
             ReservedRegisters::stack_pointer(),
             size_register,
             ReservedRegisters::stack_pointer(),
-            BinaryIntOp::Add,
+            BrilligBinaryOp::Integer {
+                op: BinaryIntOp::Add,
+                bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
+            },
         );
         self.push_opcode(BrilligOpcode::BinaryIntOp {
             destination: ReservedRegisters::stack_pointer(),

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -129,10 +129,25 @@ impl BrilligContext {
         size_register: RegisterIndex,
     ) {
         debug_show::allocate_array_instruction(pointer_register, size_register);
+        self.set_array_pointer(pointer_register);
+        self.update_stack_pointer(size_register);
+    }
+
+    pub(crate) fn set_array_pointer(&mut self, pointer_register: RegisterIndex) {
+        debug_show::mov_instruction(pointer_register, ReservedRegisters::stack_pointer());
         self.push_opcode(BrilligOpcode::Mov {
             destination: pointer_register,
             source: ReservedRegisters::stack_pointer(),
         });
+    }
+
+    pub(crate) fn update_stack_pointer(&mut self, size_register: RegisterIndex) {
+        debug_show::binary_instruction(
+            ReservedRegisters::stack_pointer(),
+            size_register,
+            ReservedRegisters::stack_pointer(),
+            BinaryIntOp::Add,
+        );
         self.push_opcode(BrilligOpcode::BinaryIntOp {
             destination: ReservedRegisters::stack_pointer(),
             op: BinaryIntOp::Add,
@@ -777,12 +792,12 @@ mod tests {
     fn test_brillig_ir_foreign_call_return_vector() {
         // pseudo-noir:
         //
-        // #[oracle(make_number_sequence)]
-        // unconstrained fn make_number_sequence(size: u32) -> Vec<u32> {
+        // #[oracle(get_number_sequence)]
+        // unconstrained fn get_number_sequence(size: u32) -> Vec<u32> {
         // }
         //
         // unconstrained fn main() -> Vec<u32> {
-        //   let the_sequence = make_number_sequence(12);
+        //   let the_sequence = get_number_sequence(12);
         //   assert(the_sequence.len() == 12);
         // }
         let mut context = BrilligContext::new(vec![], vec![]);


### PR DESCRIPTION
# Description

## Problem\*

Partial works towards #1556 

## Summary\*

Now that slices are implemented on the frontend and in the SSA refactor we need to enable code gen for both Brillig and ACIR. This some partial work towards the Brillig gen for slices that enables us to return a slice from an external call like below:
```
#[oracle(get_number_sequence)]
unconstrained fn get_number_sequence(_size: Field) -> [Field] {}
```
I have also included a test that makes two different foreign calls to verify that memory has not been overwritten and we can iterate over the dynamic slices returned from the foreign call inside Brillig.

Other work is being done in parallel to enable these dynamic slices to be returned from Brillig into ACIR and handled inside of ACIR. 

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
