### PR TITLE
chore: Update `noir-source-resolver` to v1.1.3

### DIFF
--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -14,7 +14,7 @@
   "module": "./web/noir_wasm.js",
   "sideEffects": false,
   "peerDependencies": {
-    "@noir-lang/noir-source-resolver": "1.1.2"
+    "@noir-lang/noir-source-resolver": "1.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating noir-wasm to point to noir-source-resolver version 1.1.3