### PR TITLE
fix(brillig_gen): Pass correct size of complex types input for brillig foreign calls

### DIFF
--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -471,9 +471,10 @@ impl<'block> BrilligBlock<'block> {
         let typ = dfg[value_id].get_type();
         match typ {
             Type::Numeric(_) => RegisterOrMemory::RegisterIndex(register_index),
-            Type::Array(_, size) => {
-                RegisterOrMemory::HeapArray(HeapArray { pointer: register_index, size })
-            }
+            Type::Array(..) => RegisterOrMemory::HeapArray(HeapArray {
+                pointer: register_index,
+                size: compute_size_of_type(&typ),
+            }),
             _ => {
                 unreachable!("type not supported for conversion into brillig register")
             }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -188,7 +188,7 @@ fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunction> {
         })
 }
 
-/// function_modifiers: 'unconstrained'? 'open'? 'internal'? 
+/// function_modifiers: 'unconstrained'? 'open'? 'internal'?
 ///
 /// returns (is_unconstrained, is_open, is_internal) for whether each keyword was present
 fn function_modifiers() -> impl NoirParser<(bool, bool, bool)> {


### PR DESCRIPTION
# Description

We were passing the size of an array from `Type::Array` directly when generating the inputs for a brillig foreign call. This wouldn't break for normal arrays or singular structs, but breaks in the case of an array of structs. For example if we have an array of two structs with two fields each, only the first two fields would be passed to the foreign call as the entire array is of size 2.

## Problem\*

Quick issue found while doing logging PR

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
I held off on adding a struct test directly as my println PR will have much more comprehensive tests that deserialize arrays of structs. 

- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
