### PR TITLE
fix: Parse an if followed by a tuple as a block

### DIFF
--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -188,7 +188,7 @@ fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunction> {
         })
 }
 
-/// function_modifiers: 'unconstrained'? 'open'? 'internal'? 
+/// function_modifiers: 'unconstrained'? 'open'? 'internal'?
 ///
 /// returns (is_unconstrained, is_open, is_internal) for whether each keyword was present
 fn function_modifiers() -> impl NoirParser<(bool, bool, bool)> {
@@ -1529,7 +1529,14 @@ mod test {
 
     #[test]
     fn parse_block() {
-        parse_with(block(expression()), "{ [0,1,2,3,4] }").unwrap();
+        parse_all(
+            block(expression()),
+            vec![
+                "{ [0,1,2,3,4] }",
+                // Regression for #1310: this should be parsed as a block and not a function call
+                "{ if true { 1 } else { 2 } (3, 4) }",
+            ],
+        );
 
         parse_all_failing(
             block(expression()),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1310

## Summary\*

Previously an `if` followed by a tuple expression was parsed as a function call, with the return result of the `if` being the function. This is ambiguous with the grammar of an `if` expression sequenced with a tuple. Since the later parse is more desirable (and matches what rust does in this scenario) I've resolved the parse by arbitrarily always taking the later over the former.

Since I've added a check when constructing an `Expression::call` this means unfortunately that any `if` expression surrounded by parenthesis is also affected. So `(if c { f } else { g })(1, 2)` is also parsed as a sequence rather than a function call.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
