### PR TITLE
fix: Add Result to acir gen

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -32,7 +32,7 @@ pub(crate) fn optimize_into_acir(
     program: Program,
     allow_log_ops: bool,
     print_ssa_passes: bool,
-) -> GeneratedAcir {
+) -> Result<GeneratedAcir, RuntimeError> {
     let abi_distinctness = program.return_distinctness;
     let mut ssa = ssa_gen::generate_ssa(program)
         .print(print_ssa_passes, "Initial SSA:")
@@ -71,7 +71,7 @@ pub fn experimental_create_circuit(
 ) -> Result<(Circuit, DebugInfo, Abi), RuntimeError> {
     let func_sig = program.main_function_signature.clone();
     let GeneratedAcir { current_witness_index, opcodes, return_witnesses, locations, .. } =
-        optimize_into_acir(program, show_output, enable_logging);
+        optimize_into_acir(program, show_output, enable_logging)?;
 
     let abi = gen_abi(func_sig, return_witnesses.clone());
     let public_abi = abi.clone().public_abi();

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -124,6 +124,10 @@ impl AcirContext {
         self.add_data(var_data)
     }
 
+    pub(crate) fn get_location(&mut self) -> Option<Location> {
+        self.acir_ir.current_location
+    }
+
     pub(crate) fn set_location(&mut self, location: Option<Location>) {
         self.acir_ir.current_location = location;
     }
@@ -271,7 +275,11 @@ impl AcirContext {
                 Ok(())
             } else {
                 // Constraint is always false - this program is unprovable
-                Err(AcirGenError::BadConstantEquality { lhs: *lhs_const, rhs: *rhs_const })
+                Err(AcirGenError::BadConstantEquality {
+                    lhs: *lhs_const,
+                    rhs: *rhs_const,
+                    location: self.get_location(),
+                })
             }
         } else {
             self.acir_ir.assert_is_zero(

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/errors.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/errors.rs
@@ -1,29 +1,68 @@
 use acvm::FieldElement;
+use noirc_errors::Location;
+
+use crate::errors::{RuntimeError, RuntimeErrorKind};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) enum AcirGenError {
-    InvalidRangeConstraint { num_bits: u32 },
-    IndexOutOfBounds { index: usize, array_size: usize },
-    UnsupportedIntegerSize { num_bits: u32, max_num_bits: u32 },
-    BadConstantEquality { lhs: FieldElement, rhs: FieldElement },
+    InvalidRangeConstraint { num_bits: u32, location: Option<Location> },
+    IndexOutOfBounds { index: usize, array_size: usize, location: Option<Location> },
+    UnsupportedIntegerSize { num_bits: u32, max_num_bits: u32, location: Option<Location> },
+    BadConstantEquality { lhs: FieldElement, rhs: FieldElement, location: Option<Location> },
 }
 
 impl AcirGenError {
     pub(crate) fn message(&self) -> String {
         match self {
-            AcirGenError::InvalidRangeConstraint { num_bits } => {
+            AcirGenError::InvalidRangeConstraint { num_bits, .. } => {
                 // Don't apply any constraints if the range is for the maximum number of bits or more.
                 format!(
              "All Witnesses are by default u{num_bits} Applying this type does not apply any constraints.\n We also currently do not allow integers of size more than {num_bits}, this will be handled by BigIntegers.")
             }
-            AcirGenError::IndexOutOfBounds { index, array_size } => {
+            AcirGenError::IndexOutOfBounds { index, array_size, .. } => {
                 format!("Index out of bounds, array has size {array_size}, but index was {index}")
             }
-            AcirGenError::UnsupportedIntegerSize { num_bits, max_num_bits } => {
+            AcirGenError::UnsupportedIntegerSize { num_bits, max_num_bits, .. } => {
                 format!("Integer sized {num_bits} is over the max supported size of {max_num_bits}")
             }
-            AcirGenError::BadConstantEquality { lhs, rhs } => {
+            AcirGenError::BadConstantEquality { lhs, rhs, .. } => {
                 format!("{lhs} and {rhs} constrained to be equal though they never can be")
+            }
+        }
+    }
+}
+
+impl From<AcirGenError> for RuntimeError {
+    fn from(error: AcirGenError) -> Self {
+        match error {
+            AcirGenError::InvalidRangeConstraint { num_bits, location } => {
+                let kind = RuntimeErrorKind::UnstructuredError {
+                    message: format!(
+                        "Failed range constraint when constraining to {num_bits} bits"
+                    ),
+                };
+                RuntimeError::new(kind, location)
+            }
+            AcirGenError::IndexOutOfBounds { index, array_size, location } => {
+                let kind = RuntimeErrorKind::ArrayOutOfBounds {
+                    index: index as u128,
+                    bound: array_size as u128,
+                };
+                RuntimeError::new(kind, location)
+            }
+            AcirGenError::UnsupportedIntegerSize { num_bits, max_num_bits, location } => {
+                let kind = RuntimeErrorKind::UnstructuredError {
+                    message: format!("Unsupported integer size of {num_bits} bits. The maximum supported size is {max_num_bits} bits.")
+                };
+                RuntimeError::new(kind, location)
+            }
+            AcirGenError::BadConstantEquality { lhs: _, rhs: _, location } => {
+                // We avoid showing the actual lhs and rhs since most of the time they are just 0
+                // and 1 respectively. This would confuse users if a constraint such as
+                // assert(foo < bar) fails with "failed constraint: 0 = 1."
+                let kind =
+                    RuntimeErrorKind::UnstructuredError { message: "Failed constraint".into() };
+                RuntimeError::new(kind, location)
             }
         }
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -662,6 +662,7 @@ impl GeneratedAcir {
         if num_bits >= FieldElement::max_num_bits() {
             return Err(AcirGenError::InvalidRangeConstraint {
                 num_bits: FieldElement::max_num_bits(),
+                location: self.current_location,
             });
         };
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1918 

## Summary\*

Adds `Result` pervasively to AcirGen. I've also added `Location`s to each `AcirGenError` to improve the error messages.

Now, when running on the example code from the linked issue the compiler no longer crashes and instead issues an error message:

```
error: 
   ┌─ /.../aztec-packages/yarn-project/noir-contracts/src/libs/noir-aztec/src/types/vec.nr:18:16
   │
18 │         assert(self.len as u64 < MaxLen as u64);
   │                ------------------------------- Failed constraint

Error: Aborting due to 1 previous error
```

This error message could still be nicer (in a future PR):
- It is in a library function rather than the original contract, so a stack trace would be very helpful (but difficult).
- We could interpolate failing asserts more precisely. So the error could be `Failed constraint: 75 < 74` (for example).

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
