### PR TITLE
chore: adds inputs to the circuit and update sort for stepwise acir

### DIFF
--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -170,6 +170,10 @@ impl Abi {
         self.parameters.iter().map(|x| &x.name).collect()
     }
 
+    pub fn parameter_witness(&self) -> Vec<Witness> {
+        self.param_witnesses.values().flatten().copied().collect()
+    }
+
     pub fn num_parameters(&self) -> usize {
         self.parameters.len()
     }

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -86,6 +86,7 @@ pub fn create_circuit(
         opcodes,
         public_parameters: PublicInputs(public_parameters),
         return_values: PublicInputs(return_values.iter().copied().collect()),
+        inputs: param_witnesses.values().flatten().copied().collect(),
     };
 
     let (parameters, return_type) = program.main_function_signature;

--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -76,8 +76,9 @@ pub fn experimental_create_circuit(
     let public_parameters =
         PublicInputs(public_abi.param_witnesses.values().flatten().copied().collect());
     let return_values = PublicInputs(return_witnesses.into_iter().collect());
-
-    let circuit = Circuit { current_witness_index, opcodes, public_parameters, return_values };
+    let inputs = abi.parameter_witness();
+    let circuit =
+        Circuit { current_witness_index, opcodes, public_parameters, return_values, inputs };
 
     Ok((circuit, abi))
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -856,13 +856,12 @@ impl AcirContext {
         let outputs_var = vecmap(&outputs_witness, |witness_index| {
             self.add_data(AcirVarData::Witness(*witness_index))
         });
+        // Enforce the outputs to be a permutation of the inputs
+        self.acir_ir.permutation(&inputs_expr, &output_expr);
         // Enforce the outputs to be sorted
         for i in 0..(outputs_var.len() - 1) {
             self.less_than_constrain(outputs_var[i], outputs_var[i + 1], bit_size, None)?;
         }
-        // Enforce the outputs to be a permutation of the inputs
-        self.acir_ir.permutation(&inputs_expr, &output_expr);
-
         Ok(outputs_var)
     }
 

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -781,19 +781,24 @@ impl GeneratedAcir {
     /// n.b. A sorting network is a predetermined set of switches,
     /// the control bits indicate the configuration of each switch: false for pass-through and true for cross-over
     pub(crate) fn permutation(&mut self, in_expr: &[Expression], out_expr: &[Expression]) {
-        let bits = Vec::new();
-        let (w, b) = self.permutation_layer(in_expr, &bits, true);
-        // Constrain the network output to out_expr
-        for (b, o) in b.iter().zip(out_expr) {
-            self.push_opcode(AcirOpcode::Arithmetic(b - o));
+        let mut bits_len = 0;
+        for i in 0..in_expr.len() {
+            bits_len += ((i + 1) as f32).log2().ceil() as u32;
         }
+        let bits = vecmap(0..bits_len, |_| self.next_witness_index());
         let inputs = in_expr.iter().map(|a| vec![a.clone()]).collect();
         self.push_opcode(AcirOpcode::Directive(Directive::PermutationSort {
             inputs,
             tuple: 1,
-            bits: w,
+            bits: bits.clone(),
             sort_by: vec![0],
         }));
+        let (_, b) = self.permutation_layer(in_expr, &bits, false);
+
+        // Constrain the network output to out_expr
+        for (b, o) in b.iter().zip(out_expr) {
+            self.push_opcode(AcirOpcode::Arithmetic(b - o));
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Adapt noir for stepwise acir:
adds inputs witnesses to the circuit, as expected by PR https://github.com/noir-lang/acvm/pull/433
update the 'sort' in order to lay down constraints that are solvable in a stepwise execution.

N.B. CI should pass only when ACVM is updated and includes the ACVM PR 433.

## Problem\*

Related to https://github.com/noir-lang/acvm/pull/433

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
