### PR TITLE
fix: Emit opcodes for sorting variables in order of execution

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -869,12 +869,14 @@ impl AcirContext {
         let outputs_var = vecmap(&outputs_witness, |witness_index| {
             self.add_data(AcirVarData::Witness(*witness_index))
         });
+
+        // Enforce the outputs to be a permutation of the inputs
+        self.acir_ir.permutation(&inputs_expr, &output_expr);
+
         // Enforce the outputs to be sorted
         for i in 0..(outputs_var.len() - 1) {
             self.less_than_constrain(outputs_var[i], outputs_var[i + 1], bit_size, None)?;
         }
-        // Enforce the outputs to be a permutation of the inputs
-        self.acir_ir.permutation(&inputs_expr, &output_expr);
 
         Ok(outputs_var)
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -795,19 +795,25 @@ impl GeneratedAcir {
     /// n.b. A sorting network is a predetermined set of switches,
     /// the control bits indicate the configuration of each switch: false for pass-through and true for cross-over
     pub(crate) fn permutation(&mut self, in_expr: &[Expression], out_expr: &[Expression]) {
-        let bits = Vec::new();
-        let (w, b) = self.permutation_layer(in_expr, &bits, true);
-        // Constrain the network output to out_expr
-        for (b, o) in b.iter().zip(out_expr) {
-            self.push_opcode(AcirOpcode::Arithmetic(b - o));
+        let mut bits_len = 0;
+        for i in 0..in_expr.len() {
+            bits_len += ((i + 1) as f32).log2().ceil() as u32;
         }
+
+        let bits = vecmap(0..bits_len, |_| self.next_witness_index());
         let inputs = in_expr.iter().map(|a| vec![a.clone()]).collect();
         self.push_opcode(AcirOpcode::Directive(Directive::PermutationSort {
             inputs,
             tuple: 1,
-            bits: w,
+            bits: bits.clone(),
             sort_by: vec![0],
         }));
+        let (_, b) = self.permutation_layer(in_expr, &bits, false);
+
+        // Constrain the network output to out_expr
+        for (b, o) in b.iter().zip(out_expr) {
+            self.push_opcode(AcirOpcode::Arithmetic(b - o));
+        }
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This pulls out the changes from #1929 which don't rely on changes to the ACVM.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
