### PR TITLE
chore: fix lexer errors for unexpected characters

### DIFF
--- a/crates/noirc_frontend/src/lexer/errors.rs
+++ b/crates/noirc_frontend/src/lexer/errors.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum LexerErrorKind {
     #[error("An unexpected character {:?} was found.", found)]
-    UnexpectedCharacter { span: Span, expected: String, found: char },
+    UnexpectedCharacter { span: Span, expected: String, found: Option<char> },
     #[error("NotADoubleChar : {:?} is not a double char token", found)]
     NotADoubleChar { span: Span, found: Token },
     #[error("InvalidIntegerLiteral : {:?} is not a integer", found)]
@@ -39,11 +39,15 @@ impl LexerErrorKind {
                 span,
                 expected,
                 found,
-            } => (
-                "an unexpected character was found".to_string(),
-                format!(" expected {expected} , but got {found}"),
-                *span,
-            ),
+            } => {
+                let found: String = found.map(Into::into).unwrap_or_else(|| "<eof>".into());
+
+                (
+                    "an unexpected character was found".to_string(),
+                    format!(" expected {expected} , but got {}", found),
+                    *span,
+                )
+            },
             LexerErrorKind::NotADoubleChar { span, found } => (
                 format!("tried to parse {found} as double char"),
                 format!(

--- a/crates/noirc_frontend/src/lexer/lexer.rs
+++ b/crates/noirc_frontend/src/lexer/lexer.rs
@@ -244,7 +244,7 @@ impl<'a> Lexer<'a> {
             '0'..='9' => self.eat_digit(initial_char),
             _ => Err(LexerErrorKind::UnexpectedCharacter {
                 span: Span::single_char(self.position),
-                found: initial_char,
+                found: initial_char.into(),
                 expected: "an alpha numeric character".to_owned(),
             }),
         }
@@ -254,7 +254,7 @@ impl<'a> Lexer<'a> {
         if !self.peek_char_is('[') {
             return Err(LexerErrorKind::UnexpectedCharacter {
                 span: Span::single_char(self.position),
-                found: self.next_char().unwrap(),
+                found: self.next_char(),
                 expected: "[".to_owned(),
             });
         }
@@ -269,7 +269,7 @@ impl<'a> Lexer<'a> {
             return Err(LexerErrorKind::UnexpectedCharacter {
                 span: Span::single_char(self.position),
                 expected: "]".to_owned(),
-                found: self.next_char().unwrap(),
+                found: self.next_char(),
             });
         }
         self.next_char();
@@ -425,6 +425,15 @@ fn test_single_double_char() {
         let got = lexer.next_token().unwrap();
         assert_eq!(got, token);
     }
+}
+
+#[test]
+fn invalid_attribute() {
+    let input = "#";
+    let mut lexer = Lexer::new(input);
+
+    let token = lexer.next().unwrap();
+    assert!(token.is_err());
 }
 
 #[test]


### PR DESCRIPTION
# Description

fix lexer errors for unexpected characters and attribute parsing

## Problem

Resolves #1943 

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
