### PR TITLE
Parse unit types

### DIFF
--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -788,6 +788,7 @@ fn parse_type_inner(
         string_type(),
         named_type(recursive_type_parser.clone()),
         array_type(recursive_type_parser.clone()),
+        parenthesized(recursive_type_parser.clone()),
         tuple_type(recursive_type_parser.clone()),
         function_type(recursive_type_parser.clone()),
         mutable_reference_type(recursive_type_parser),
@@ -893,7 +894,13 @@ where
     T: NoirParser<UnresolvedType>,
 {
     let fields = type_parser.separated_by(just(Token::Comma)).allow_trailing();
-    parenthesized(fields).map(UnresolvedType::Tuple)
+    parenthesized(fields).map(|fields| {
+        if fields.is_empty() {
+            UnresolvedType::Unit
+        } else {
+            UnresolvedType::Tuple(fields)
+        }
+    })
 }
 
 fn function_type<T>(type_parser: T) -> impl NoirParser<UnresolvedType>


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1933, succeeds #1956

## Summary\*

Previously all parenthesized types were parsed as tuple types. I've fixed this to have:
- parenthesized singular types (with no trailing comma) parsed as the parenthesized type. So `(Field)` = `Field`.
- tuple types with 0 elements are always parsed as `Type::Unit`.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
