### PR TITLE
fix: Only flatten main

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -157,16 +157,14 @@ use crate::ssa_refactor::{
 mod branch_analysis;
 
 impl Ssa {
-    /// Flattens the control flow graph of each function such that the function is left with a
+    /// Flattens the control flow graph of main such that the function is left with a
     /// single block containing all instructions and no more control-flow.
     ///
     /// This pass will modify any instructions with side effects in particular, often multiplying
     /// them by jump conditions to maintain correctness even when all branches of a jmpif are inlined.
     /// For more information, see the module-level comment at the top of this file.
     pub(crate) fn flatten_cfg(mut self) -> Ssa {
-        for function in self.functions.values_mut() {
-            flatten_function_cfg(function);
-        }
+        flatten_function_cfg(self.main_mut());
         self
     }
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #1978

## Summary\*
Flattening the CFG is only needed for the main function, that is the one which will be converted to ACIR. Doing it in all the functions of the SSA implies that it will try to do it in functions that were compiled to brillig, and some of them are not supported by branch analysis, making it panic.
 
<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
