### PR TITLE
fix: Don't panic when checking if an undeclared variable is mutable

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -160,11 +160,12 @@ impl<'a> Resolver<'a> {
         }
 
         for unused_var in unused_vars.iter() {
-            let definition_info = self.interner.definition(unused_var.id);
-            let name = &definition_info.name;
-            if name != ERROR_IDENT && !definition_info.is_global() {
-                let ident = Ident(Spanned::from(unused_var.location.span, name.to_owned()));
-                self.push_err(ResolverError::UnusedVariable { ident });
+            if let Some(definition_info) = self.interner.try_definition(unused_var.id) {
+                let name = &definition_info.name;
+                if name != ERROR_IDENT && !definition_info.is_global() {
+                    let ident = Ident(Spanned::from(unused_var.location.span, name.to_owned()));
+                    self.push_err(ResolverError::UnusedVariable { ident });
+                }
             }
         }
     }
@@ -1283,14 +1284,15 @@ pub fn verify_mutable_reference(interner: &NodeInterner, rhs: ExprId) -> Result<
             Err(ResolverError::MutableReferenceToArrayElement { span })
         }
         HirExpression::Ident(ident) => {
-            let definition = interner.definition(ident.id);
-            if !definition.mutable {
-                let span = interner.expr_span(&rhs);
-                let variable = definition.name.clone();
-                Err(ResolverError::MutableReferenceToImmutableVariable { span, variable })
-            } else {
-                Ok(())
+            if let Some(definition) = interner.try_definition(ident.id) {
+                if !definition.mutable {
+                    return Err(ResolverError::MutableReferenceToImmutableVariable {
+                        span: interner.expr_span(&rhs),
+                        variable: definition.name.clone(),
+                    });
+                }
             }
+            Ok(())
         }
         _ => Ok(()),
     }

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -128,15 +128,16 @@ impl<'interner> TypeChecker<'interner> {
                     let typ = self.interner.id_type(ident.id).instantiate(self.interner).0;
                     let typ = typ.follow_bindings();
 
-                    let definition = self.interner.definition(ident.id);
-                    if !definition.mutable && !matches!(typ, Type::MutableReference(_)) {
-                        self.errors.push(TypeCheckError::Unstructured {
-                            msg: format!(
-                                "Variable {} must be mutable to be assigned to",
-                                definition.name
-                            ),
-                            span: ident.location.span,
-                        });
+                    if let Some(definition) = self.interner.try_definition(ident.id) {
+                        if !definition.mutable && !matches!(typ, Type::MutableReference(_)) {
+                            self.errors.push(TypeCheckError::Unstructured {
+                                msg: format!(
+                                    "Variable {} must be mutable to be assigned to",
+                                    definition.name
+                                ),
+                                span: ident.location.span,
+                            });
+                        }
                     }
 
                     typ

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -478,8 +478,18 @@ impl NodeInterner {
         }
     }
 
+    /// Retrieves the definition where the given id was defined.
+    /// This will panic if given DefinitionId::dummy_id. Use try_definition for
+    /// any call with a possibly undefined variable.
     pub fn definition(&self, id: DefinitionId) -> &DefinitionInfo {
         &self.definitions[id.0]
+    }
+
+    /// Tries to retrieve the given id's definition.
+    /// This function should be used during name resolution or type checking when we cannot be sure
+    /// all variables have corresponding definitions (in case of an error in the user's code).
+    pub fn try_definition(&self, id: DefinitionId) -> Option<&DefinitionInfo> {
+        self.definitions.get(id.0)
     }
 
     /// Returns the name of the definition


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1985

## Summary\*

We were trying to grab the definition of a variable that wasn't defined previously, leading to a compiler panic. I've added a `try_definition` function to avoid this and went through and removed any other usage of the panicking `definition` method from name resolution and type inference.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
