### PR TITLE
chore(nargo): Use Display impl for InputValue

### DIFF
--- a/crates/nargo/src/ops/foreign_calls.rs
+++ b/crates/nargo/src/ops/foreign_calls.rs
@@ -3,7 +3,7 @@ use acvm::{
     pwg::ForeignCallWaitInfo,
 };
 use iter_extended::vecmap;
-use noirc_abi::{decode_string_value, decode_value, input_parser::json::JsonTypes, AbiType};
+use noirc_abi::{decode_string_value, input_parser::InputValueDisplay, AbiType};
 
 use crate::errors::ForeignCallError;
 
@@ -68,11 +68,11 @@ impl ForeignCall {
         // We must use a flat map here as each value in a struct will be in a separate input value
         let mut input_values_as_fields =
             input_values.iter().flat_map(|values| values.iter().map(|value| value.to_field()));
-        let decoded_value = decode_value(&mut input_values_as_fields, &abi_type)?;
 
-        let json_value = JsonTypes::try_from_input_value(&decoded_value, &abi_type)?;
+        let input_value_display =
+            InputValueDisplay::try_from_fields(&mut input_values_as_fields, abi_type)?;
 
-        println!("{json_value}");
+        println!("{input_value_display}");
         Ok(())
     }
 }

--- a/crates/noirc_abi/src/input_parser/json.rs
+++ b/crates/noirc_abi/src/input_parser/json.rs
@@ -59,7 +59,7 @@ pub(crate) fn serialize_to_json(
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
-pub enum JsonTypes {
+pub(crate) enum JsonTypes {
     // This is most likely going to be a hex string
     // But it is possible to support UTF-8
     String(String),
@@ -78,7 +78,7 @@ pub enum JsonTypes {
 }
 
 impl JsonTypes {
-    pub fn try_from_input_value(
+    pub(crate) fn try_from_input_value(
         value: &InputValue,
         abi_type: &AbiType,
     ) -> Result<JsonTypes, InputParserError> {

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -1,4 +1,4 @@
-pub mod json;
+mod json;
 mod toml;
 
 use std::collections::BTreeMap;
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 use acvm::FieldElement;
 use serde::Serialize;
 
-use crate::errors::InputParserError;
-use crate::{Abi, AbiType};
+use crate::errors::{AbiError, InputParserError};
+use crate::{decode_value, Abi, AbiType};
 /// This is what all formats eventually transform into
 /// For example, a toml file will parse into TomlTypes
 /// and those TomlTypes will be mapped to Value
@@ -64,6 +64,35 @@ impl InputValue {
             // All other InputValue-AbiType combinations are fundamentally incompatible.
             _ => false,
         }
+    }
+}
+
+/// In order to display an `InputValue` we need an `AbiType` to accurately
+/// convert the value into a human-readable format.
+pub struct InputValueDisplay {
+    input_value: InputValue,
+    abi_type: AbiType,
+}
+
+impl InputValueDisplay {
+    pub fn try_from_fields(
+        field_iterator: &mut impl Iterator<Item = FieldElement>,
+        abi_type: AbiType,
+    ) -> Result<Self, AbiError> {
+        let input_value = decode_value(field_iterator, &abi_type)?;
+        Ok(InputValueDisplay { input_value, abi_type })
+    }
+}
+
+impl std::fmt::Display for InputValueDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // From the docs: https://doc.rust-lang.org/std/fmt/struct.Error.html
+        // This type does not support transmission of an error other than that an error
+        // occurred. Any extra information must be arranged to be transmitted through
+        // some other means.
+        let json_value = json::JsonTypes::try_from_input_value(&self.input_value, &self.abi_type)
+            .map_err(|_| std::fmt::Error)?;
+        write!(f, "{}", serde_json::to_string(&json_value).map_err(|_| std::fmt::Error)?)
     }
 }
 

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -368,7 +368,7 @@ impl Abi {
     }
 }
 
-pub fn decode_value(
+pub(crate) fn decode_value(
     field_iterator: &mut impl Iterator<Item = FieldElement>,
     value_type: &AbiType,
 ) -> Result<InputValue, AbiError> {

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -93,12 +93,12 @@ impl CrateDefMap {
                 .to_str()
                 .expect("expected std path to be convertible to str");
             assert_eq!(path_as_str, "std/lib");
-             // There are 2 printlns in the stdlib. If we are using the experimental SSA, we want to keep
-             // only the unconstrained one. Otherwise we want to keep only the constrained one.
-             ast.functions.retain(|func| {
+            // There are 2 printlns in the stdlib. If we are using the experimental SSA, we want to keep
+            // only the unconstrained one. Otherwise we want to keep only the constrained one.
+            ast.functions.retain(|func| {
                 func.def.name.0.contents.as_str() != "println"
                     || func.def.is_unconstrained == context.def_interner.experimental_ssa
-             });
+            });
 
             if !context.def_interner.experimental_ssa {
                 ast.module_decls.retain(|ident| {

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -778,7 +778,7 @@ impl<'interner> Monomorphizer<'interner> {
             if let Definition::Oracle(name) = &ident.definition {
                 if name.as_str() == "println" {
                     // Oracle calls are required to be wrapped in an unconstrained function
-                    // Thus, the only argument to the `println` oracle is expected to always be an ident 
+                    // Thus, the only argument to the `println` oracle is expected to always be an ident
                     self.append_abi_arg(&hir_arguments[0], &mut arguments);
                 }
             }


### PR DESCRIPTION
# Description

Creates a wrapper around `InputValue` in order to enable using an `AbiType` with a Display impl.

## Problem\*

Resolves #1988 

## Summary\*

Decoding a list of field elements to an `InputValue` and then converting it into a `JsonType` requires an `AbiType`. I made a wrapper around InputValue purely to impl the Display trait. This wrapper will contains the InputValue to display and the AbiType. The wrapper's Display implementation will then does the conversion into JsonTypes inside the noirc_abi crate so that we don't expose format types outside of the Abi crate.

## Documentation

- [] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
