### PR TITLE
fix: Assignment to arrays of structs

### DIFF
--- a/crates/nargo_cli/tests/test_data_ssa_refactor/6_array/src/main.nr
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/6_array/src/main.nr
@@ -50,4 +50,9 @@ fn main(x: [u32; 5], y: [u32; 5], mut z: u32, t: u32) {
             assert(x_elem != y_elem);
         }
     }
+
+    // Test 7: Arrays of tuples/structs
+    let mut tuple_array = [(1, 2), (3, 4), (5, 6)];
+    tuple_array[1] = (7, 8);
+    assert(tuple_array[1].1 == 8);
 }

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
@@ -64,7 +64,7 @@ impl Value {
             Value::Instruction { typ, .. } => typ.clone(),
             Value::Param { typ, .. } => typ.clone(),
             Value::NumericConstant { typ, .. } => typ.clone(),
-            Value::Array { element_type, array } => Type::Array(element_type.clone(), array.len()),
+            Value::Array { element_type, array } => Type::Array(element_type.clone(), array.len() / element_type.len()),
             Value::Function { .. } => Type::Function,
             Value::Intrinsic { .. } => Type::Function,
             Value::ForeignFunction { .. } => Type::Function,


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1997

## Summary\*

Removes a TODO/assumption when assigning to arrays that the element type would be a single element rather than several of them (e.g. a tuple/struct). This only started triggering recently due to the recent println PR which disabled the array of structs to struct of arrays conversion for the ssa refactor.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
