### PR TITLE
chore(nargo): Toggle brillig debug trace from CLI

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -28,6 +28,9 @@ pub struct CompileOptions {
     #[arg(short, long)]
     pub show_ssa: bool,
 
+    #[arg(long)]
+    pub show_brillig: bool,
+
     /// Display the ACIR for compiled circuit
     #[arg(long)]
     pub print_acir: bool,
@@ -49,6 +52,7 @@ impl Default for CompileOptions {
     fn default() -> Self {
         Self {
             show_ssa: false,
+            show_brillig: false,
             print_acir: false,
             deny_warnings: false,
             show_output: true,
@@ -322,7 +326,12 @@ pub fn compile_no_check(
     let program = monomorphize(main_function, &context.def_interner);
 
     let (circuit, debug, abi) = if options.experimental_ssa {
-        experimental_create_circuit(program, options.show_ssa, options.show_output)?
+        experimental_create_circuit(
+            program,
+            options.show_ssa,
+            options.show_brillig,
+            options.show_output,
+        )?
     } else {
         create_circuit(program, options.show_ssa, options.show_output)?
     };

--- a/crates/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -13,7 +13,7 @@ use self::{brillig_block::BrilligBlock, brillig_fn::FunctionContext};
 use super::brillig_ir::{artifact::BrilligArtifact, BrilligContext};
 
 /// Converting an SSA function into Brillig bytecode.
-pub(crate) fn convert_ssa_function(func: &Function) -> BrilligArtifact {
+pub(crate) fn convert_ssa_function(func: &Function, enable_debug_trace: bool) -> BrilligArtifact {
     let mut reverse_post_order = Vec::new();
     reverse_post_order.extend_from_slice(PostOrder::with_function(func).as_slice());
     reverse_post_order.reverse();
@@ -24,6 +24,7 @@ pub(crate) fn convert_ssa_function(func: &Function) -> BrilligArtifact {
     let mut brillig_context = BrilligContext::new(
         FunctionContext::parameters(func),
         FunctionContext::return_values(func),
+        enable_debug_trace,
     );
 
     brillig_context.enter_context(FunctionContext::function_id_to_function_label(func.id()));

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
@@ -260,7 +260,7 @@ mod tests {
         arguments: Vec<BrilligParameter>,
         returns: Vec<BrilligParameter>,
     ) -> BrilligContext {
-        let mut context = BrilligContext::new(arguments, returns);
+        let mut context = BrilligContext::new(arguments, returns, true);
         context.enter_context("test");
         context
     }

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -19,6 +19,7 @@ use acvm::{
     },
     FieldElement,
 };
+use debug_show::DebugShow;
 
 /// Integer arithmetic in Brillig is limited to 127 bit
 /// integers.
@@ -83,6 +84,8 @@ pub(crate) struct BrilligContext {
     context_label: String,
     /// Section label, used to separate sections of code
     section_label: usize,
+    /// IR printer
+    debug_show: DebugShow,
 }
 
 impl BrilligContext {
@@ -90,12 +93,14 @@ impl BrilligContext {
     pub(crate) fn new(
         arguments: Vec<BrilligParameter>,
         return_parameters: Vec<BrilligParameter>,
+        enable_debug_trace: bool,
     ) -> BrilligContext {
         BrilligContext {
             obj: BrilligArtifact::new(arguments, return_parameters),
             registers: BrilligRegistersContext::new(),
             context_label: String::default(),
             section_label: 0,
+            debug_show: DebugShow::new(enable_debug_trace),
         }
     }
 
@@ -128,13 +133,13 @@ impl BrilligContext {
         pointer_register: RegisterIndex,
         size_register: RegisterIndex,
     ) {
-        debug_show::allocate_array_instruction(pointer_register, size_register);
+        self.debug_show.allocate_array_instruction(pointer_register, size_register);
         self.set_array_pointer(pointer_register);
         self.update_stack_pointer(size_register);
     }
 
     pub(crate) fn set_array_pointer(&mut self, pointer_register: RegisterIndex) {
-        debug_show::mov_instruction(pointer_register, ReservedRegisters::stack_pointer());
+        self.debug_show.mov_instruction(pointer_register, ReservedRegisters::stack_pointer());
         self.push_opcode(BrilligOpcode::Mov {
             destination: pointer_register,
             source: ReservedRegisters::stack_pointer(),
@@ -153,7 +158,7 @@ impl BrilligContext {
     /// Allocates a variable in memory and stores the
     /// pointer to the array in `pointer_register`
     pub(crate) fn allocate_variable_instruction(&mut self, pointer_register: RegisterIndex) {
-        debug_show::allocate_instruction(pointer_register);
+        self.debug_show.allocate_instruction(pointer_register);
         // A variable can be stored in up to two values, so we reserve two values for that.
         let size_register = self.make_constant(2_u128.into());
         self.push_opcode(BrilligOpcode::Mov {
@@ -175,7 +180,7 @@ impl BrilligContext {
         index: RegisterIndex,
         result: RegisterIndex,
     ) {
-        debug_show::array_get(array_ptr, index, result);
+        self.debug_show.array_get(array_ptr, index, result);
         // Computes array_ptr + index, ie array[index]
         let index_of_element_in_memory = self.allocate_register();
         self.binary_instruction(
@@ -197,7 +202,7 @@ impl BrilligContext {
         index: RegisterIndex,
         value: RegisterIndex,
     ) {
-        debug_show::array_set(array_ptr, index, value);
+        self.debug_show.array_set(array_ptr, index, value);
         // Computes array_ptr + index, ie array[index]
         let index_of_element_in_memory = self.allocate_register();
         self.binary_instruction(
@@ -220,7 +225,7 @@ impl BrilligContext {
         destination_pointer: RegisterIndex,
         num_elements_register: RegisterIndex,
     ) {
-        debug_show::copy_array_instruction(
+        self.debug_show.copy_array_instruction(
             source_pointer,
             destination_pointer,
             num_elements_register,
@@ -266,7 +271,7 @@ impl BrilligContext {
 
     /// Adds a label to the next opcode
     pub(crate) fn enter_context<T: ToString>(&mut self, label: T) {
-        debug_show::enter_context(label.to_string());
+        self.debug_show.enter_context(label.to_string());
         self.context_label = label.to_string();
         self.section_label = 0;
         // Add a context label to the next opcode
@@ -300,7 +305,7 @@ impl BrilligContext {
 
     /// Adds a unresolved `Jump` instruction to the bytecode.
     pub(crate) fn jump_instruction<T: ToString>(&mut self, target_label: T) {
-        debug_show::jump_instruction(target_label.to_string());
+        self.debug_show.jump_instruction(target_label.to_string());
         self.add_unresolved_jump(BrilligOpcode::Jump { location: 0 }, target_label.to_string());
     }
 
@@ -310,7 +315,7 @@ impl BrilligContext {
         condition: RegisterIndex,
         target_label: T,
     ) {
-        debug_show::jump_if_instruction(condition, target_label.to_string());
+        self.debug_show.jump_if_instruction(condition, target_label.to_string());
         self.add_unresolved_jump(
             BrilligOpcode::JumpIf { condition, location: 0 },
             target_label.to_string(),
@@ -343,7 +348,7 @@ impl BrilligContext {
     /// Emits brillig bytecode to jump to a trap condition if `condition`
     /// is false.
     pub(crate) fn constrain_instruction(&mut self, condition: RegisterIndex) {
-        debug_show::constrain_instruction(condition);
+        self.debug_show.constrain_instruction(condition);
         self.add_unresolved_jump(
             BrilligOpcode::JumpIf { condition, location: 0 },
             self.next_section_label(),
@@ -362,7 +367,7 @@ impl BrilligContext {
     /// method will move all register values to the first `N` values in
     /// the VM.
     pub(crate) fn return_instruction(&mut self, return_registers: &[RegisterIndex]) {
-        debug_show::return_instruction(return_registers);
+        self.debug_show.return_instruction(return_registers);
         let mut sources = Vec::with_capacity(return_registers.len());
         let mut destinations = Vec::with_capacity(return_registers.len());
 
@@ -402,7 +407,7 @@ impl BrilligContext {
     ///
     /// Copies the value at `source` into `destination`
     pub(crate) fn mov_instruction(&mut self, destination: RegisterIndex, source: RegisterIndex) {
-        debug_show::mov_instruction(destination, source);
+        self.debug_show.mov_instruction(destination, source);
         self.push_opcode(BrilligOpcode::Mov { destination, source });
     }
 
@@ -417,7 +422,7 @@ impl BrilligContext {
         result: RegisterIndex,
         operation: BrilligBinaryOp,
     ) {
-        debug_show::binary_instruction(lhs, rhs, result, operation.clone());
+        self.debug_show.binary_instruction(lhs, rhs, result, operation.clone());
         match operation {
             BrilligBinaryOp::Field { op } => {
                 let opcode = BrilligOpcode::BinaryFieldOp { op, destination: result, lhs, rhs };
@@ -436,7 +441,7 @@ impl BrilligContext {
 
     /// Stores the value of `constant` in the `result` register
     pub(crate) fn const_instruction(&mut self, result: RegisterIndex, constant: Value) {
-        debug_show::const_instruction(result, constant);
+        self.debug_show.const_instruction(result, constant);
         self.push_opcode(BrilligOpcode::Const { destination: result, value: constant });
     }
 
@@ -450,7 +455,7 @@ impl BrilligContext {
         bit_size: u32,
         result: RegisterIndex,
     ) {
-        debug_show::not_instruction(input, bit_size, result);
+        self.debug_show.not_instruction(input, bit_size, result);
         // Compile !x as ((-1) - x)
         let u_max = FieldElement::from(2_i128).pow(&FieldElement::from(bit_size as i128))
             - FieldElement::one();
@@ -476,7 +481,7 @@ impl BrilligContext {
         inputs: &[RegisterOrMemory],
         outputs: &[RegisterOrMemory],
     ) {
-        debug_show::foreign_call_instruction(func_name.clone(), inputs, outputs);
+        self.debug_show.foreign_call_instruction(func_name.clone(), inputs, outputs);
         let opcode = BrilligOpcode::ForeignCall {
             function: func_name,
             destinations: outputs.to_vec(),
@@ -491,7 +496,7 @@ impl BrilligContext {
         destination: RegisterIndex,
         source_pointer: RegisterIndex,
     ) {
-        debug_show::load_instruction(destination, source_pointer);
+        self.debug_show.load_instruction(destination, source_pointer);
         self.push_opcode(BrilligOpcode::Load { destination, source_pointer });
     }
 
@@ -527,7 +532,7 @@ impl BrilligContext {
         destination_pointer: RegisterIndex,
         source: RegisterIndex,
     ) {
-        debug_show::store_instruction(destination_pointer, source);
+        self.debug_show.store_instruction(destination_pointer, source);
         self.push_opcode(BrilligOpcode::Store { destination_pointer, source });
     }
 
@@ -601,7 +606,7 @@ impl BrilligContext {
 
     /// Emits a stop instruction
     pub(crate) fn stop_instruction(&mut self) {
-        debug_show::stop_instruction();
+        self.debug_show.stop_instruction();
         self.push_opcode(BrilligOpcode::Stop);
     }
 
@@ -678,7 +683,7 @@ impl BrilligContext {
         source: RegisterIndex,
         target_bit_size: u32,
     ) {
-        debug_show::cast_instruction(destination, source, target_bit_size);
+        self.debug_show.cast_instruction(destination, source, target_bit_size);
         assert!(
             target_bit_size <= BRILLIG_INTEGER_ARITHMETIC_BIT_SIZE,
             "tried to cast to a bit size greater than allowed {target_bit_size}"
@@ -700,7 +705,7 @@ impl BrilligContext {
     /// Adds a unresolved external `Call` instruction to the bytecode.
     /// This calls into another function compiled into this brillig artifact.
     pub(crate) fn add_external_call_instruction<T: ToString>(&mut self, func_label: T) {
-        debug_show::add_external_call_instruction(func_label.to_string());
+        self.debug_show.add_external_call_instruction(func_label.to_string());
         self.obj.add_unresolved_external_call(
             BrilligOpcode::Call { location: 0 },
             func_label.to_string(),
@@ -845,7 +850,7 @@ impl BrilligContext {
 
     /// Issues a blackbox operation.
     pub(crate) fn black_box_op_instruction(&mut self, op: BlackBoxOp) {
-        debug_show::black_box_op_instruction(op);
+        self.debug_show.black_box_op_instruction(op);
         self.push_opcode(BrilligOpcode::BlackBox(op));
     }
 }
@@ -915,7 +920,7 @@ mod tests {
         //   let the_sequence = get_number_sequence(12);
         //   assert(the_sequence.len() == 12);
         // }
-        let mut context = BrilligContext::new(vec![], vec![]);
+        let mut context = BrilligContext::new(vec![], vec![], true);
         let r_stack = ReservedRegisters::stack_pointer();
         // Start stack pointer at 0
         context.const_instruction(r_stack, Value::from(0_usize));

--- a/crates/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
@@ -6,9 +6,6 @@ use acvm::acir::brillig::{
     Value,
 };
 
-/// Controls whether debug traces are enabled
-const ENABLE_DEBUG_TRACE: bool = true;
-
 /// Trait for converting values into debug-friendly strings.
 trait DebugToString {
     fn debug_to_string(&self) -> String;
@@ -130,215 +127,313 @@ impl<T: DebugToString> DebugToString for [T] {
 }
 
 macro_rules! debug_println {
-    ( $literal:expr ) => {
-        if ENABLE_DEBUG_TRACE {
-            println!("{}", $literal);
+    ( $enable_debug:expr, $literal:expr ) => {
+        match $enable_debug {
+            true => println!("{}", $literal),
+            false => ()
         }
     };
-    ( $format_message:expr, $( $x:expr ),* ) => {
-        if ENABLE_DEBUG_TRACE {
-            println!($format_message, $( $x.debug_to_string(), )*)
+    ( $enable_debug:expr, $format_message:expr, $( $x:expr ),* ) => {
+        match $enable_debug {
+            true => println!($format_message, $( $x.debug_to_string(), )*),
+            false => ()
         }
     };
 }
 
-/// Emits brillig bytecode to jump to a trap condition if `condition`
-/// is false.
-pub(crate) fn constrain_instruction(condition: RegisterIndex) {
-    debug_println!("  ASSERT {} != 0", condition);
+pub(crate) struct DebugShow {
+    enable_debug_trace: bool,
 }
 
-/// Processes a return instruction.
-pub(crate) fn return_instruction(return_registers: &[RegisterIndex]) {
-    let registers_string = return_registers
-        .iter()
-        .map(RegisterIndex::debug_to_string)
-        .collect::<Vec<String>>()
-        .join(", ");
-
-    debug_println!("  // return {};", registers_string);
-}
-
-/// Emits a `mov` instruction.
-pub(crate) fn mov_instruction(destination: RegisterIndex, source: RegisterIndex) {
-    debug_println!("  MOV {}, {}", destination, source);
-}
-
-/// Processes a binary instruction according `operation`.
-pub(crate) fn binary_instruction(
-    lhs: RegisterIndex,
-    rhs: RegisterIndex,
-    result: RegisterIndex,
-    operation: BrilligBinaryOp,
-) {
-    debug_println!("  {} = {} {} {}", result, lhs, operation, rhs);
-}
-
-/// Stores the value of `constant` in the `result` register
-pub(crate) fn const_instruction(result: RegisterIndex, constant: Value) {
-    debug_println!("  CONST {} = {}", result, constant);
-}
-
-/// Processes a not instruction. Append with "_" as this is a high-level instruction.
-pub(crate) fn not_instruction(condition: RegisterIndex, bit_size: u32, result: RegisterIndex) {
-    debug_println!("  i{}_NOT {} = !{}", bit_size, result, condition);
-}
-
-/// Processes a foreign call instruction.
-pub(crate) fn foreign_call_instruction(
-    func_name: String,
-    inputs: &[RegisterOrMemory],
-    outputs: &[RegisterOrMemory],
-) {
-    debug_println!("  FOREIGN_CALL {} ({}) => {}", func_name, inputs, outputs);
-}
-
-/// Emits a load instruction
-pub(crate) fn load_instruction(destination: RegisterIndex, source_pointer: RegisterIndex) {
-    debug_println!("  LOAD {} = *{}", destination, source_pointer);
-}
-
-/// Emits a store instruction
-pub(crate) fn store_instruction(destination_pointer: RegisterIndex, source: RegisterIndex) {
-    debug_println!("  STORE *{} = {}", destination_pointer, source);
-}
-
-/// Emits a stop instruction
-pub(crate) fn stop_instruction() {
-    debug_println!("  STOP");
-}
-
-/// Debug function for allocate_array_instruction
-pub(crate) fn allocate_array_instruction(
-    pointer_register: RegisterIndex,
-    size_register: RegisterIndex,
-) {
-    debug_println!("  ALLOCATE_ARRAY {} SIZE {}", pointer_register, size_register);
-}
-
-/// Debug function for allocate_instruction
-pub(crate) fn allocate_instruction(pointer_register: RegisterIndex) {
-    debug_println!("  ALLOCATE {} ", pointer_register);
-}
-
-/// Debug function for array_get
-pub(crate) fn array_get(array_ptr: RegisterIndex, index: RegisterIndex, result: RegisterIndex) {
-    debug_println!("  ARRAY_GET {}[{}] -> {}", array_ptr, index, result);
-}
-
-/// Debug function for array_set
-pub(crate) fn array_set(array_ptr: RegisterIndex, index: RegisterIndex, value: RegisterIndex) {
-    debug_println!("  ARRAY_SET {}[{}] = {}", array_ptr, index, value);
-}
-
-/// Debug function for copy_array_instruction
-pub(crate) fn copy_array_instruction(
-    source: RegisterIndex,
-    destination: RegisterIndex,
-    num_elements_register: RegisterIndex,
-) {
-    debug_println!(
-        "  COPY_ARRAY {} -> {} ({} ELEMENTS)",
-        source,
-        destination,
-        num_elements_register
-    );
-}
-
-/// Debug function for enter_context
-pub(crate) fn enter_context(label: String) {
-    if !label.ends_with("-b0") {
-        // Hacky readability fix: don't print labels e.g. f1 then f1-b0 one after another, they mean the same thing
-        debug_println!("{}:", label);
+impl DebugShow {
+    pub(crate) fn new(enable_debug_trace: bool) -> DebugShow {
+        DebugShow { enable_debug_trace }
     }
-}
 
-/// Debug function for jump_instruction
-pub(crate) fn jump_instruction(target_label: String) {
-    debug_println!("  JUMP_TO {}", target_label);
-}
+    /// Emits brillig bytecode to jump to a trap condition if `condition`
+    /// is false.
+    pub(crate) fn constrain_instruction(&self, condition: RegisterIndex) {
+        debug_println!(self.enable_debug_trace, "  ASSERT {} != 0", condition);
+    }
 
-/// Debug function for jump_if_instruction
-pub(crate) fn jump_if_instruction<T: ToString>(condition: RegisterIndex, target_label: T) {
-    debug_println!("  JUMP_IF {} TO {}", condition, target_label.to_string());
-}
+    /// Processes a return instruction.
+    pub(crate) fn return_instruction(&self, return_registers: &[RegisterIndex]) {
+        let registers_string = return_registers
+            .iter()
+            .map(RegisterIndex::debug_to_string)
+            .collect::<Vec<String>>()
+            .join(", ");
 
-/// Debug function for cast_instruction
-pub(crate) fn cast_instruction(
-    destination: RegisterIndex,
-    source: RegisterIndex,
-    target_bit_size: u32,
-) {
-    debug_println!("  CAST {} FROM {} TO {} BITS", destination, source, target_bit_size);
-}
+        debug_println!(self.enable_debug_trace, "  // return {};", registers_string);
+    }
 
-/// Debug function for black_box_op
-pub(crate) fn black_box_op_instruction(op: BlackBoxOp) {
-    match op {
-        BlackBoxOp::Sha256 { message, output } => {
-            debug_println!("  SHA256 {} -> {}", message, output);
+    /// Emits a `mov` instruction.
+    pub(crate) fn mov_instruction(&self, destination: RegisterIndex, source: RegisterIndex) {
+        debug_println!(self.enable_debug_trace, "  MOV {}, {}", destination, source);
+    }
+
+    /// Processes a binary instruction according `operation`.
+    pub(crate) fn binary_instruction(
+        &self,
+        lhs: RegisterIndex,
+        rhs: RegisterIndex,
+        result: RegisterIndex,
+        operation: BrilligBinaryOp,
+    ) {
+        debug_println!(self.enable_debug_trace, "  {} = {} {} {}", result, lhs, operation, rhs);
+    }
+
+    /// Stores the value of `constant` in the `result` register
+    pub(crate) fn const_instruction(&self, result: RegisterIndex, constant: Value) {
+        debug_println!(self.enable_debug_trace, "  CONST {} = {}", result, constant);
+    }
+
+    /// Processes a not instruction. Append with "_" as this is a high-level instruction.
+    pub(crate) fn not_instruction(
+        &self,
+        condition: RegisterIndex,
+        bit_size: u32,
+        result: RegisterIndex,
+    ) {
+        debug_println!(self.enable_debug_trace, "  i{}_NOT {} = !{}", bit_size, result, condition);
+    }
+
+    /// Processes a foreign call instruction.
+    pub(crate) fn foreign_call_instruction(
+        &self,
+        func_name: String,
+        inputs: &[RegisterOrMemory],
+        outputs: &[RegisterOrMemory],
+    ) {
+        debug_println!(
+            self.enable_debug_trace,
+            "  FOREIGN_CALL {} ({}) => {}",
+            func_name,
+            inputs,
+            outputs
+        );
+    }
+
+    /// Emits a load instruction
+    pub(crate) fn load_instruction(
+        &self,
+        destination: RegisterIndex,
+        source_pointer: RegisterIndex,
+    ) {
+        debug_println!(self.enable_debug_trace, "  LOAD {} = *{}", destination, source_pointer);
+    }
+
+    /// Emits a store instruction
+    pub(crate) fn store_instruction(
+        &self,
+        destination_pointer: RegisterIndex,
+        source: RegisterIndex,
+    ) {
+        debug_println!(self.enable_debug_trace, "  STORE *{} = {}", destination_pointer, source);
+    }
+
+    /// Emits a stop instruction
+    pub(crate) fn stop_instruction(&self) {
+        debug_println!(self.enable_debug_trace, "  STOP");
+    }
+
+    /// Debug function for allocate_array_instruction
+    pub(crate) fn allocate_array_instruction(
+        &self,
+        pointer_register: RegisterIndex,
+        size_register: RegisterIndex,
+    ) {
+        debug_println!(
+            self.enable_debug_trace,
+            "  ALLOCATE_ARRAY {} SIZE {}",
+            pointer_register,
+            size_register
+        );
+    }
+
+    /// Debug function for allocate_instruction
+    pub(crate) fn allocate_instruction(&self, pointer_register: RegisterIndex) {
+        debug_println!(self.enable_debug_trace, "  ALLOCATE {} ", pointer_register);
+    }
+
+    /// Debug function for array_get
+    pub(crate) fn array_get(
+        &self,
+        array_ptr: RegisterIndex,
+        index: RegisterIndex,
+        result: RegisterIndex,
+    ) {
+        debug_println!(
+            self.enable_debug_trace,
+            "  ARRAY_GET {}[{}] -> {}",
+            array_ptr,
+            index,
+            result
+        );
+    }
+
+    /// Debug function for array_set
+    pub(crate) fn array_set(
+        &self,
+        array_ptr: RegisterIndex,
+        index: RegisterIndex,
+        value: RegisterIndex,
+    ) {
+        debug_println!(self.enable_debug_trace, "  ARRAY_SET {}[{}] = {}", array_ptr, index, value);
+    }
+
+    /// Debug function for copy_array_instruction
+    pub(crate) fn copy_array_instruction(
+        &self,
+        source: RegisterIndex,
+        destination: RegisterIndex,
+        num_elements_register: RegisterIndex,
+    ) {
+        debug_println!(
+            self.enable_debug_trace,
+            "  COPY_ARRAY {} -> {} ({} ELEMENTS)",
+            source,
+            destination,
+            num_elements_register
+        );
+    }
+
+    /// Debug function for enter_context
+    pub(crate) fn enter_context(&self, label: String) {
+        if !label.ends_with("-b0") {
+            // Hacky readability fix: don't print labels e.g. f1 then f1-b0 one after another, they mean the same thing
+            debug_println!(self.enable_debug_trace, "{}:", label);
         }
-        BlackBoxOp::Keccak256 { message, output } => {
-            debug_println!("  KECCAK256 {} -> {}", message, output);
-        }
-        BlackBoxOp::Blake2s { message, output } => {
-            debug_println!("  BLAKE2S {} -> {}", message, output);
-        }
-        BlackBoxOp::HashToField128Security { message, output } => {
-            debug_println!("  HASH_TO_FIELD_128_SECURITY {} -> {}", message, output);
-        }
-        BlackBoxOp::EcdsaSecp256k1 {
-            hashed_msg,
-            public_key_x,
-            public_key_y,
-            signature,
-            result,
-        } => {
-            debug_println!(
-                "  ECDSA_SECP256K1 {} {} {} {} -> {}",
+    }
+
+    /// Debug function for jump_instruction
+    pub(crate) fn jump_instruction(&self, target_label: String) {
+        debug_println!(self.enable_debug_trace, "  JUMP_TO {}", target_label);
+    }
+
+    /// Debug function for jump_if_instruction
+    pub(crate) fn jump_if_instruction<T: ToString>(
+        &self,
+        condition: RegisterIndex,
+        target_label: T,
+    ) {
+        debug_println!(
+            self.enable_debug_trace,
+            "  JUMP_IF {} TO {}",
+            condition,
+            target_label.to_string()
+        );
+    }
+
+    /// Debug function for cast_instruction
+    pub(crate) fn cast_instruction(
+        &self,
+        destination: RegisterIndex,
+        source: RegisterIndex,
+        target_bit_size: u32,
+    ) {
+        debug_println!(
+            self.enable_debug_trace,
+            "  CAST {} FROM {} TO {} BITS",
+            destination,
+            source,
+            target_bit_size
+        );
+    }
+
+    /// Debug function for black_box_op
+    pub(crate) fn black_box_op_instruction(&self, op: BlackBoxOp) {
+        match op {
+            BlackBoxOp::Sha256 { message, output } => {
+                debug_println!(self.enable_debug_trace, "  SHA256 {} -> {}", message, output);
+            }
+            BlackBoxOp::Keccak256 { message, output } => {
+                debug_println!(self.enable_debug_trace, "  KECCAK256 {} -> {}", message, output);
+            }
+            BlackBoxOp::Blake2s { message, output } => {
+                debug_println!(self.enable_debug_trace, "  BLAKE2S {} -> {}", message, output);
+            }
+            BlackBoxOp::HashToField128Security { message, output } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  HASH_TO_FIELD_128_SECURITY {} -> {}",
+                    message,
+                    output
+                );
+            }
+            BlackBoxOp::EcdsaSecp256k1 {
                 hashed_msg,
                 public_key_x,
                 public_key_y,
                 signature,
-                result
-            );
-        }
-        BlackBoxOp::EcdsaSecp256r1 {
-            hashed_msg,
-            public_key_x,
-            public_key_y,
-            signature,
-            result,
-        } => {
-            debug_println!(
-                "  ECDSA_SECP256R1 {} {} {} {} -> {}",
+                result,
+            } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  ECDSA_SECP256K1 {} {} {} {} -> {}",
+                    hashed_msg,
+                    public_key_x,
+                    public_key_y,
+                    signature,
+                    result
+                );
+            }
+            BlackBoxOp::EcdsaSecp256r1 {
                 hashed_msg,
                 public_key_x,
                 public_key_y,
                 signature,
-                result
-            );
-        }
-        BlackBoxOp::FixedBaseScalarMul { input, result } => {
-            debug_println!("  FIXED_BASE_SCALAR_MUL {} -> {}", input, result);
-        }
-        BlackBoxOp::Pedersen { inputs, domain_separator, output } => {
-            debug_println!("  PEDERSEN {} {} -> {}", inputs, domain_separator, output);
-        }
-        BlackBoxOp::SchnorrVerify { public_key_x, public_key_y, message, signature, result } => {
-            debug_println!(
-                "  SCHNORR_VERIFY {} {} {} {} -> {}",
+                result,
+            } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  ECDSA_SECP256R1 {} {} {} {} -> {}",
+                    hashed_msg,
+                    public_key_x,
+                    public_key_y,
+                    signature,
+                    result
+                );
+            }
+            BlackBoxOp::FixedBaseScalarMul { input, result } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  FIXED_BASE_SCALAR_MUL {} -> {}",
+                    input,
+                    result
+                );
+            }
+            BlackBoxOp::Pedersen { inputs, domain_separator, output } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  PEDERSEN {} {} -> {}",
+                    inputs,
+                    domain_separator,
+                    output
+                );
+            }
+            BlackBoxOp::SchnorrVerify {
                 public_key_x,
                 public_key_y,
                 message,
                 signature,
-                result
-            );
+                result,
+            } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  SCHNORR_VERIFY {} {} {} {} -> {}",
+                    public_key_x,
+                    public_key_y,
+                    message,
+                    signature,
+                    result
+                );
+            }
         }
     }
-}
 
-/// Debug function for cast_instruction
-pub(crate) fn add_external_call_instruction(func_label: String) {
-    debug_println!("  CALL {}", func_label);
+    /// Debug function for cast_instruction
+    pub(crate) fn add_external_call_instruction(&self, func_label: String) {
+        debug_println!(self.enable_debug_trace, "  CALL {}", func_label);
+    }
 }

--- a/crates/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
@@ -128,15 +128,13 @@ impl<T: DebugToString> DebugToString for [T] {
 
 macro_rules! debug_println {
     ( $enable_debug:expr, $literal:expr ) => {
-        match $enable_debug {
-            true => println!("{}", $literal),
-            false => ()
+        if $enable_debug {
+            println!("{}", $literal)
         }
     };
     ( $enable_debug:expr, $format_message:expr, $( $x:expr ),* ) => {
-        match $enable_debug {
-            true => println!($format_message, $( $x.debug_to_string(), )*),
-            false => ()
+        if $enable_debug {
+            println!($format_message, $( $x.debug_to_string(), )*)
         }
     };
 }

--- a/crates/noirc_evaluator/src/brillig/mod.rs
+++ b/crates/noirc_evaluator/src/brillig/mod.rs
@@ -24,8 +24,8 @@ pub struct Brillig {
 
 impl Brillig {
     /// Compiles a function into brillig and store the compilation artifacts
-    pub(crate) fn compile(&mut self, func: &Function) {
-        let obj = convert_ssa_function(func);
+    pub(crate) fn compile(&mut self, func: &Function, enable_debug_trace: bool) {
+        let obj = convert_ssa_function(func, enable_debug_trace);
         self.ssa_function_to_brillig.insert(func.id(), obj);
     }
 
@@ -50,7 +50,7 @@ impl std::ops::Index<FunctionId> for Brillig {
 
 impl Ssa {
     /// Compile to brillig brillig functions and ACIR functions reachable from them
-    pub(crate) fn to_brillig(&self) -> Brillig {
+    pub(crate) fn to_brillig(&self, enable_debug_trace: bool) -> Brillig {
         // Collect all the function ids that are reachable from brillig
         // That means all the functions marked as brillig and ACIR functions called by them
         let mut brillig_reachable_function_ids: HashSet<FunctionId> = HashSet::new();
@@ -96,7 +96,7 @@ impl Ssa {
         let mut brillig = Brillig::default();
         for brillig_function_id in brillig_reachable_function_ids {
             let func = &self.functions[&brillig_function_id];
-            brillig.compile(func);
+            brillig.compile(func, enable_debug_trace);
         }
 
         brillig

--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -32,6 +32,7 @@ pub(crate) fn optimize_into_acir(
     program: Program,
     allow_log_ops: bool,
     print_ssa_passes: bool,
+    print_brillig_trace: bool,
 ) -> Result<GeneratedAcir, RuntimeError> {
     let abi_distinctness = program.return_distinctness;
     let mut ssa = ssa_gen::generate_ssa(program)
@@ -39,7 +40,7 @@ pub(crate) fn optimize_into_acir(
         .defunctionalize()
         .print(print_ssa_passes, "After Defunctionalization:");
 
-    let brillig = ssa.to_brillig();
+    let brillig = ssa.to_brillig(print_brillig_trace);
     if let RuntimeType::Acir = ssa.main().runtime() {
         ssa = ssa
             .inline_functions()
@@ -66,12 +67,13 @@ pub(crate) fn optimize_into_acir(
 // TODO: This no longer needs to return a result, but it is kept to match the signature of `create_circuit`
 pub fn experimental_create_circuit(
     program: Program,
-    enable_logging: bool,
+    enable_ssa_logging: bool,
+    enable_brillig_logging: bool,
     show_output: bool,
 ) -> Result<(Circuit, DebugInfo, Abi), RuntimeError> {
     let func_sig = program.main_function_signature.clone();
     let GeneratedAcir { current_witness_index, opcodes, return_witnesses, locations, .. } =
-        optimize_into_acir(program, show_output, enable_logging)?;
+        optimize_into_acir(program, show_output, enable_ssa_logging, enable_brillig_logging)?;
 
     let abi = gen_abi(func_sig, return_witnesses.clone());
     let public_abi = abi.clone().public_abi();

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -93,12 +93,12 @@ impl CrateDefMap {
                 .to_str()
                 .expect("expected std path to be convertible to str");
             assert_eq!(path_as_str, "std/lib");
-             // There are 2 printlns in the stdlib. If we are using the experimental SSA, we want to keep
-             // only the unconstrained one. Otherwise we want to keep only the constrained one.
-             ast.functions.retain(|func| {
+            // There are 2 printlns in the stdlib. If we are using the experimental SSA, we want to keep
+            // only the unconstrained one. Otherwise we want to keep only the constrained one.
+            ast.functions.retain(|func| {
                 func.def.name.0.contents.as_str() != "println"
                     || func.def.is_unconstrained == context.def_interner.experimental_ssa
-             });
+            });
 
             if !context.def_interner.experimental_ssa {
                 ast.module_decls.retain(|ident| {

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -778,7 +778,7 @@ impl<'interner> Monomorphizer<'interner> {
             if let Definition::Oracle(name) = &ident.definition {
                 if name.as_str() == "println" {
                     // Oracle calls are required to be wrapped in an unconstrained function
-                    // Thus, the only argument to the `println` oracle is expected to always be an ident 
+                    // Thus, the only argument to the `println` oracle is expected to always be an ident
                     self.append_abi_arg(&hir_arguments[0], &mut arguments);
                 }
             }


### PR DESCRIPTION
# Description

## Problem\*

Reference this comment: https://github.com/noir-lang/noir/pull/1755#pullrequestreview-1487752018

## Summary\*

Currently we have a hardcoded constant in the code for whether we display a Brillig debug trace. It is currently set to true which means anytime that a Brillig function is used in a program the trace is printed as well. Now that println has been set to use Brillig it means that every time println is used in a program the full brillig debug trace will be first outputted. 

I have added a flag `--show-brillig` that toggles this feature. I had to thread it further into the Brillig gen module than I would have liked due to how the current Brillig printer is implemented. The Brillig debug trace is more high-level and is more of a Brillig codegen printer than a full Brillig printer. For example, when allocating an array the IR printer will print this:
```
            "  ALLOCATE_ARRAY {} SIZE {}",
            pointer_register,
            size_register
```
but the actual Brillig generate to allocate an array is a MOV (to move the stack pointer to the pointer register), and a BinaryIntOp::Add (to increment the stack pointer). This high-level printing occurs for several instructions. I wanted originally to incorporate usage of the `Display` trait, but that will be a larger refactor is we want to keep this higher-level printer.

The debug_logs test now just prints this:
```
"*** println ***"
"0x05"
["0x05","0x0a"]
{"foo":"0x0f","my_struct":{"x":"0x0a","y":"0x05"}}
```
Rather than:
```
f4:
  CONST R6 = 198
  ALLOCATE_ARRAY R5 SIZE R6
  MOV R5, Stack
  Stack = Stack + R6
  .....
  like 900 lines of Brillig IR
  ......
  STORE *R5 = R12
  R5 = R5 + R6
  CONST R8 = 34
  STORE *R5 = R8
  R5 = R5 + R6
  CONST R26 = 125
  STORE *R5 = R26
  R5 = R5 + R6
  CONST R26 = 125
  STORE *R5 = R26
  R5 = R5 + R6
  FOREIGN_CALL println (R2[0..2], R3[0..51]) => 
  // return ;
  STOP
"*** println ***"
"0x05"
["0x05","0x0a"]
{"foo":"0x0f","my_struct":{"x":"0x0a","y":"0x05"}}
```

## Documentation

- [] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
