### PR TITLE
chore: remove `Option` in `predicate: Option<AcirVar>`

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -173,7 +173,7 @@ impl AcirContext {
         let field_type = AcirType::NumericType(NumericType::NativeField);
 
         let results = self.brillig(
-            Some(predicate),
+            predicate,
             inverse_code,
             vec![AcirValue::Var(var, field_type.clone())],
             vec![field_type],
@@ -810,7 +810,7 @@ impl AcirContext {
 
     pub(crate) fn brillig(
         &mut self,
-        predicate: Option<AcirVar>,
+        predicate: AcirVar,
         code: Vec<BrilligOpcode>,
         inputs: Vec<AcirValue>,
         outputs: Vec<AcirType>,
@@ -851,8 +851,8 @@ impl AcirContext {
                 AcirValue::Array(array_values)
             }
         });
-        let predicate = predicate.map(|var| self.vars[&var].to_expression().into_owned());
-        self.acir_ir.brillig(predicate, code, b_inputs, b_outputs);
+        let predicate = self.vars[&predicate].to_expression().into_owned();
+        self.acir_ir.brillig(Some(predicate), code, b_inputs, b_outputs);
 
         outputs_var
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -171,7 +171,8 @@ impl Context {
 
         let code = self.gen_brillig_for(main_func, &brillig);
 
-        let output_values = self.acir_context.brillig(None, code, inputs, outputs);
+        let output_values =
+            self.acir_context.brillig(self.current_side_effects_enabled_var, code, inputs, outputs);
         let output_vars: Vec<_> = output_values
             .iter()
             .flat_map(|value| value.clone().flatten())
@@ -284,7 +285,7 @@ impl Context {
 
                                 let outputs: Vec<AcirType> = vecmap(result_ids, |result_id| dfg.type_of_value(*result_id).into());
 
-                                let output_values = self.acir_context.brillig(Some(self.current_side_effects_enabled_var), code, inputs, outputs);
+                                let output_values = self.acir_context.brillig(self.current_side_effects_enabled_var, code, inputs, outputs);
 
                                 // Compiler sanity check
                                 assert_eq!(result_ids.len(), output_values.len(), "ICE: The number of Brillig output values should match the result ids in SSA");

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
@@ -64,7 +64,9 @@ impl Value {
             Value::Instruction { typ, .. } => typ.clone(),
             Value::Param { typ, .. } => typ.clone(),
             Value::NumericConstant { typ, .. } => typ.clone(),
-            Value::Array { element_type, array } => Type::Array(element_type.clone(), array.len() / element_type.len()),
+            Value::Array { element_type, array } => {
+                Type::Array(element_type.clone(), array.len() / element_type.len())
+            }
             Value::Function { .. } => Type::Function,
             Value::Intrinsic { .. } => Type::Function,
             Value::ForeignFunction { .. } => Type::Function,


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/1972

think `fn brillig` is the only one

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
