### PR TITLE
chore: full path when running tests

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -201,15 +201,13 @@ fn on_code_lens_request(
     let tests = context.get_all_test_functions_in_crate_matching(&crate_id, "");
 
     let mut lenses: Vec<CodeLens> = vec![];
-    for func_id in tests {
+    for (func_name, func_id) in tests {
         let location = context.function_meta(&func_id).name.location;
         let file_id = location.file;
         // TODO(#1681): This file_id never be 0 because the "path" where it maps is the directory, not a file
         if file_id.as_usize() != 0 {
             continue;
         }
-
-        let func_name = context.function_name(&func_id);
 
         let range =
             byte_span_to_range(files, file_id.as_usize(), location.span.into()).unwrap_or_default();

--- a/crates/lsp/src/lib_hacky.rs
+++ b/crates/lsp/src/lib_hacky.rs
@@ -94,15 +94,13 @@ pub fn on_code_lens_request(
     let tests = context.get_all_test_functions_in_crate_matching(&crate_id, "");
 
     let mut lenses: Vec<CodeLens> = vec![];
-    for func_id in tests {
+    for (func_name, func_id) in tests {
         let location = context.function_meta(&func_id).name.location;
         let file_id = location.file;
         // TODO(#1681): This file_id never be 0 because the "path" where it maps is the directory, not a file
         if file_id.as_usize() != 0 {
             continue;
         }
-
-        let func_name = context.function_name(&func_id);
 
         let range =
             byte_span_to_range(files, file_id.as_usize(), location.span.into()).unwrap_or_default();

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -61,12 +61,11 @@ fn run_tests<B: Backend>(
     let writer = StandardStream::stderr(ColorChoice::Always);
     let mut writer = writer.lock();
 
-    for test_function in test_functions {
-        let test_name = context.function_name(&test_function);
+    for (test_name, test_function) in test_functions {
         writeln!(writer, "Testing {test_name}...").expect("Failed to write to stdout");
         writer.flush().ok();
 
-        match run_test(backend, test_name, test_function, &context, compile_options) {
+        match run_test(backend, &test_name, test_function, &context, compile_options) {
             Ok(_) => {
                 writer.set_color(ColorSpec::new().set_fg(Some(Color::Green))).ok();
                 writeln!(writer, "ok").ok();

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
@@ -64,7 +64,9 @@ impl Value {
             Value::Instruction { typ, .. } => typ.clone(),
             Value::Param { typ, .. } => typ.clone(),
             Value::NumericConstant { typ, .. } => typ.clone(),
-            Value::Array { element_type, array } => Type::Array(element_type.clone(), array.len() / element_type.len()),
+            Value::Array { element_type, array } => {
+                Type::Array(element_type.clone(), array.len() / element_type.len())
+            }
             Value::Function { .. } => Type::Function,
             Value::Intrinsic { .. } => Type::Function,
             Value::ForeignFunction { .. } => Type::Function,

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -450,6 +450,7 @@ fn resolve_function_set(
     let file_id = unresolved_functions.file_id;
 
     vecmap(unresolved_functions.functions, |(mod_id, func_id, func)| {
+        let module_id = ModuleId { krate: crate_id, local_id: mod_id };
         let path_resolver =
             StandardPathResolver::new(ModuleId { local_id: mod_id, krate: crate_id });
 
@@ -460,7 +461,7 @@ fn resolve_function_set(
         resolver.set_generics(impl_generics.clone());
         resolver.set_self_type(self_type.clone());
 
-        let (hir_func, func_meta, errs) = resolver.resolve_function(func, func_id);
+        let (hir_func, func_meta, errs) = resolver.resolve_function(func, func_id, module_id);
         interner.push_fn_meta(func_meta, func_id);
         interner.update_fn(func_id, hir_func);
         extend_errors(errors, file_id, errs);

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -40,6 +40,12 @@ pub struct ModuleId {
 }
 
 impl ModuleId {
+    pub fn dummy_id() -> ModuleId {
+        ModuleId { krate: CrateId::dummy_id(), local_id: LocalModuleId::dummy_id() }
+    }
+}
+
+impl ModuleId {
     pub fn module(self, def_maps: &HashMap<CrateId, CrateDefMap>) -> &ModuleData {
         &def_maps[&self.krate].modules()[self.local_id.0]
     }
@@ -185,7 +191,16 @@ impl CrateDefMap {
 
     /// Find a child module's name by inspecting its parent.
     /// Currently required as modules do not store their own names.
-    fn get_module_path(&self, child_id: Index, parent: Option<LocalModuleId>) -> String {
+    pub fn get_module_path(&self, child_id: Index, parent: Option<LocalModuleId>) -> String {
+        self.get_module_path_inner(child_id, parent, ".")
+    }
+
+    pub fn get_module_path_inner(
+        &self,
+        child_id: Index,
+        parent: Option<LocalModuleId>,
+        sep: &str,
+    ) -> String {
         if let Some(id) = parent {
             let parent = &self.modules[id.0];
             let name = parent
@@ -195,11 +210,11 @@ impl CrateDefMap {
                 .map(|(name, _)| &name.0.contents)
                 .expect("Child module was not a child of the given parent module");
 
-            let parent_name = self.get_module_path(id.0, parent.parent);
+            let parent_name = self.get_module_path_inner(id.0, parent.parent, sep);
             if parent_name.is_empty() {
                 name.to_string()
             } else {
-                format!("{parent_name}.{name}")
+                format!("{parent_name}{sep}{name}")
             }
         } else {
             String::new()

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -87,16 +87,32 @@ impl Context {
         &self,
         crate_id: &CrateId,
         pattern: &str,
-    ) -> Vec<FuncId> {
+    ) -> Vec<(String, FuncId)> {
         let interner = &self.def_interner;
-        self.def_map(crate_id)
-            .expect("The local crate should be analyzed already")
+        let def_map = self.def_map(crate_id).expect("The local crate should be analyzed already");
+
+        def_map
             .get_all_test_functions(interner)
-            .filter_map(|id| interner.function_name(&id).contains(pattern).then_some(id))
+            .filter_map(|id| {
+                let name = interner.function_name(&id);
+
+                let meta = interner.function_meta(&id);
+                let module = self.module(meta.module_id);
+
+                let parent =
+                    def_map.get_module_path_inner(meta.module_id.local_id.0, module.parent, "::");
+                let path =
+                    if parent.is_empty() { name.into() } else { format!("{parent}::{name}") };
+
+                path.contains(pattern).then_some((path, id))
+            })
             .collect()
     }
 
-    pub fn get_all_test_functions_in_workspace_matching(&self, pattern: &str) -> Vec<FuncId> {
+    pub fn get_all_test_functions_in_workspace_matching(
+        &self,
+        pattern: &str,
+    ) -> Vec<(String, FuncId)> {
         let mut tests = Vec::new();
 
         for crate_id in self.crate_graph.iter_keys() {

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -229,6 +229,7 @@ mod test {
         let func_meta = FuncMeta {
             name,
             kind: FunctionKind::Normal,
+            module_id: ModuleId::dummy_id(),
             attributes: None,
             location,
             contract_function_type: None,
@@ -378,7 +379,8 @@ mod test {
 
         let func_meta = vecmap(program.functions, |nf| {
             let resolver = Resolver::new(&mut interner, &path_resolver, &def_maps, file);
-            let (hir_func, func_meta, resolver_errors) = resolver.resolve_function(nf, main_id);
+            let (hir_func, func_meta, resolver_errors) =
+                resolver.resolve_function(nf, main_id, ModuleId::dummy_id());
             assert_eq!(resolver_errors, vec![]);
             (hir_func, func_meta)
         });

--- a/crates/noirc_frontend/src/hir_def/function.rs
+++ b/crates/noirc_frontend/src/hir_def/function.rs
@@ -4,6 +4,7 @@ use noirc_errors::{Location, Span};
 
 use super::expr::{HirBlockExpression, HirExpression, HirIdent};
 use super::stmt::HirPattern;
+use crate::hir::def_map::ModuleId;
 use crate::node_interner::{ExprId, NodeInterner};
 use crate::{token::Attribute, FunctionKind};
 use crate::{ContractFunctionType, Type};
@@ -115,6 +116,8 @@ pub struct FuncMeta {
     pub name: HirIdent,
 
     pub kind: FunctionKind,
+
+    pub module_id: ModuleId,
 
     /// A function's attributes are the `#[...]` items above the function
     /// definition, if any. Currently, this is limited to a maximum of only one


### PR DESCRIPTION
# Description

```
❯ nargo test
Running 4 test functions...
Testing test...
ok
Testing a::test...
ok
Testing a::b::test...
ok
Testing a::b::c::test...
ok
All tests passed

❯ nargo test a::b::test 
Running 1 test functions...
Testing a::b::test...
ok
All tests passed
```

## Problem

Resolves #1836 


# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
