### PR TITLE
fix: Add missing `follow_bindings` when checking if a type can be casted

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -347,6 +347,13 @@ impl<'interner> TypeChecker<'interner> {
                 TypeBinding::Bound(from) => return self.check_cast(from.clone(), to, span),
                 TypeBinding::Unbound(_) => is_comp_time,
             },
+            Type::TypeVariable(binding) => match &*binding.borrow() {
+                TypeBinding::Bound(from) => return self.check_cast(from.clone(), to, span),
+                TypeBinding::Unbound(_) => {
+                    self.errors.push(TypeCheckError::TypeAnnotationsNeeded { span });
+                    return Type::Error;
+                }
+            },
             Type::Bool(is_comp_time) => is_comp_time,
             Type::Error => return Type::Error,
             from => {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -340,20 +340,14 @@ impl<'interner> TypeChecker<'interner> {
     }
 
     fn check_cast(&mut self, from: Type, to: Type, span: Span) -> Type {
-        let is_comp_time = match from {
+        let is_comp_time = match from.follow_bindings() {
             Type::Integer(is_comp_time, ..) => is_comp_time,
             Type::FieldElement(is_comp_time) => is_comp_time,
-            Type::PolymorphicInteger(is_comp_time, binding) => match &*binding.borrow() {
-                TypeBinding::Bound(from) => return self.check_cast(from.clone(), to, span),
-                TypeBinding::Unbound(_) => is_comp_time,
-            },
-            Type::TypeVariable(binding) => match &*binding.borrow() {
-                TypeBinding::Bound(from) => return self.check_cast(from.clone(), to, span),
-                TypeBinding::Unbound(_) => {
-                    self.errors.push(TypeCheckError::TypeAnnotationsNeeded { span });
-                    return Type::Error;
-                }
-            },
+            Type::PolymorphicInteger(is_comp_time, _) => is_comp_time,
+            Type::TypeVariable(_) => {
+                self.errors.push(TypeCheckError::TypeAnnotationsNeeded { span });
+                return Type::Error;
+            }
             Type::Bool(is_comp_time) => is_comp_time,
             Type::Error => return Type::Error,
             from => {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #1875

## Summary\*

Types should generally never be shallowly matched on before calling `follow_bindings`. This adds a missed case to catch the above issue in which a bound TypeVariable was not checked that it was bound to a Field.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
