### PR TITLE
chore: add validation for 'pub' keyword on non-entry point functions

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/value.rs
@@ -64,7 +64,9 @@ impl Value {
             Value::Instruction { typ, .. } => typ.clone(),
             Value::Param { typ, .. } => typ.clone(),
             Value::NumericConstant { typ, .. } => typ.clone(),
-            Value::Array { element_type, array } => Type::Array(element_type.clone(), array.len() / element_type.len()),
+            Value::Array { element_type, array } => {
+                Type::Array(element_type.clone(), array.len() / element_type.len())
+            }
             Value::Function { .. } => Type::Function,
             Value::Intrinsic { .. } => Type::Function,
             Value::ForeignFunction { .. } => Type::Function,

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -6,9 +6,11 @@ use crate::{parser::ParserError, Ident, Type};
 
 use super::import::PathResolutionError;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum PubPosition {
+    #[error("parameter")]
     Parameter,
+    #[error("return type")]
     ReturnType,
 }
 
@@ -169,13 +171,9 @@ impl From<ResolverError> for Diagnostic {
             ResolverError::UnnecessaryPub { ident, position } => {
                 let name = &ident.0.contents;
 
-                let kind = match position {
-                    PubPosition::Parameter => "parameter",
-                    PubPosition::ReturnType => "return type",
-                };
                 let mut diag = Diagnostic::simple_error(
-                    format!("unnecessary pub keyword on {kind} for function {name}"),
-                    format!("unnecessary pub {kind}"),
+                    format!("unnecessary pub keyword on {position} for function {name}"),
+                    format!("unnecessary pub {position}"),
                     ident.0.span(),
                 );
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -623,9 +623,7 @@ impl<'a> Resolver<'a> {
 
         self.declare_numeric_generics(&parameter_types, &return_type);
 
-        if !self.in_contract()
-            && !self.pub_allowed(func)
-            && func.def.return_visibility == noirc_abi::AbiVisibility::Public
+        if !self.pub_allowed(func) && func.def.return_visibility == noirc_abi::AbiVisibility::Public
         {
             self.push_err(ResolverError::UnnecessaryPub {
                 ident: func.name_ident().clone(),
@@ -680,7 +678,7 @@ impl<'a> Resolver<'a> {
     /// True if the 'pub' keyword is allowed on parameters in this function
     fn pub_allowed(&self, func: &NoirFunction) -> bool {
         if self.in_contract() {
-            !func.def.is_unconstrained && !func.def.is_open
+            !func.def.is_unconstrained
         } else {
             func.name() == MAIN_FUNCTION
         }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -623,7 +623,9 @@ impl<'a> Resolver<'a> {
 
         self.declare_numeric_generics(&parameter_types, &return_type);
 
-        if !self.pub_allowed(func) && func.def.return_visibility == noirc_abi::AbiVisibility::Public
+        if !self.in_contract()
+            && !self.pub_allowed(func)
+            && func.def.return_visibility == noirc_abi::AbiVisibility::Public
         {
             self.push_err(ResolverError::UnnecessaryPub {
                 ident: func.name_ident().clone(),

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -49,7 +49,7 @@ use crate::hir_def::{
     stmt::{HirConstrainStatement, HirLetStatement, HirStatement},
 };
 
-use super::errors::ResolverError;
+use super::errors::{PubPosition, ResolverError};
 
 const SELF_TYPE_NAME: &str = "Self";
 
@@ -606,7 +606,10 @@ impl<'a> Resolver<'a> {
 
         for (pattern, typ, visibility) in func.parameters().iter().cloned() {
             if visibility == noirc_abi::AbiVisibility::Public && !self.pub_allowed(func) {
-                self.push_err(ResolverError::UnnecessaryPub { ident: func.name_ident().clone() });
+                self.push_err(ResolverError::UnnecessaryPub {
+                    ident: func.name_ident().clone(),
+                    position: PubPosition::Parameter,
+                });
             }
 
             let pattern = self.resolve_pattern(pattern, DefinitionKind::Local(None));
@@ -619,6 +622,14 @@ impl<'a> Resolver<'a> {
         let return_type = Box::new(self.resolve_type(func.return_type()));
 
         self.declare_numeric_generics(&parameter_types, &return_type);
+
+        if !self.pub_allowed(func) && func.def.return_visibility == noirc_abi::AbiVisibility::Public
+        {
+            self.push_err(ResolverError::UnnecessaryPub {
+                ident: func.name_ident().clone(),
+                position: PubPosition::ReturnType,
+            });
+        }
 
         // 'pub_allowed' also implies 'pub' is required on return types
         if self.pub_allowed(func)


### PR DESCRIPTION
# Description

Add validation for 'pub' keyword on non-entry point functions

## Problem

Resolves #1220 

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
