### PR TITLE
fix: Perform `occurs` check before binding function types

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -775,8 +775,10 @@ impl<'interner> TypeChecker<'interner> {
                 let ret = self.interner.next_type_variable();
                 let args = vecmap(args, |(arg, _)| arg);
                 let expected = Type::Function(args, Box::new(ret.clone()));
-                *binding.borrow_mut() = TypeBinding::Bound(expected);
 
+                if let Err(error) = binding.borrow_mut().bind_to(expected, span) {
+                    self.errors.push(error);
+                }
                 ret
             }
             Type::Function(parameters, ret) => {

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -294,6 +294,20 @@ impl TypeBinding {
     pub fn is_unbound(&self) -> bool {
         matches!(self, TypeBinding::Unbound(_))
     }
+
+    pub fn bind_to(&mut self, binding: Type, span: Span) -> Result<(), TypeCheckError> {
+        match self {
+            TypeBinding::Bound(_) => panic!("Tried to bind an already bound type variable!"),
+            TypeBinding::Unbound(id) => {
+                if binding.occurs(*id) {
+                    Err(TypeCheckError::TypeAnnotationsNeeded { span })
+                } else {
+                    *self = TypeBinding::Bound(binding);
+                    Ok(())
+                }
+            }
+        }
+    }
 }
 
 /// A unique ID used to differentiate different type variables


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #2009

## Summary\*

Previously when type checking function calls if the function was an unbound type variable we'd bind the type variable without performing an `occurs` check first. This lead to us creating infinitely recursive types such as `a = (fn(a) -> ())` as in the issue above. Since we should never bind without performing an occurs check in general, I've made a helper function to help avoid this in the future.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
