### PR TITLE
feat!: Change CLI to default to new SSA code for compilation

### DIFF
--- a/crates/nargo_cli/build.rs
+++ b/crates/nargo_cli/build.rs
@@ -54,15 +54,15 @@ fn load_conf(conf_path: &Path) -> BTreeMap<String, Vec<String>> {
     conf_data
 }
 
-fn generate_tests(test_file: &mut File, experimental_ssa: bool) {
+fn generate_tests(test_file: &mut File, legacy_ssa: bool) {
     // Try to find the directory that Cargo sets when it is running; otherwise fallback to assuming the CWD
     // is the root of the repository and append the crate path
     let manifest_dir = match std::env::var("CARGO_MANIFEST_DIR") {
         Ok(dir) => PathBuf::from(dir),
         Err(_) => std::env::current_dir().unwrap().join("crates").join("nargo_cli"),
     };
-    // Choose the test directory depending on whether we are in the SSA refactor module or not
-    let test_sub_dir = if experimental_ssa { "test_data_ssa_refactor" } else { "test_data" };
+    // Choose the test directory depending on whether we are in the legacy SSA module or not
+    let test_sub_dir = if legacy_ssa { "test_data" } else { "test_data_ssa_refactor" };
     let test_data_dir = manifest_dir.join("tests").join(test_sub_dir);
     let config_path = test_data_dir.join("config.toml");
 
@@ -99,8 +99,8 @@ fn prove_and_verify_{test_sub_dir}_{test_name}() {{
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg(if {is_workspace} {{ "test" }} else {{ "execute" }});
-    if {experimental_ssa} {{
-        cmd.arg("--experimental-ssa");
+    if {legacy_ssa} {{
+        cmd.arg("--legacy-ssa");
     }};
 
 

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -41,7 +41,7 @@ fn check_from_path<B: Backend>(
         &mut context,
         crate_id,
         compile_options.deny_warnings,
-        compile_options.experimental_ssa,
+        compile_options.legacy_ssa,
     )?;
 
     // XXX: We can have a --overwrite flag to determine if you want to overwrite the Prover/Verifier.toml files
@@ -220,9 +220,9 @@ pub(crate) fn check_crate_and_report_errors(
     context: &mut Context,
     crate_id: CrateId,
     deny_warnings: bool,
-    experimental_ssa: bool,
+    legacy_ssa: bool,
 ) -> Result<(), ReportedErrors> {
-    let result = check_crate(context, crate_id, deny_warnings, experimental_ssa)
-        .map(|warnings| ((), warnings));
+    let result =
+        check_crate(context, crate_id, deny_warnings, legacy_ssa).map(|warnings| ((), warnings));
     super::compile_cmd::report_errors(result, context, deny_warnings)
 }

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -50,7 +50,7 @@ fn run_tests<B: Backend>(
         &mut context,
         crate_id,
         compile_options.deny_warnings,
-        compile_options.experimental_ssa,
+        compile_options.legacy_ssa,
     )?;
 
     let test_functions = match context.crate_graph.crate_type(crate_id) {

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/rebuild.sh
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/rebuild.sh
@@ -21,7 +21,7 @@ for dir in ./*; do
   dir_name=$(basename "$dir")
   if [[ ! " ${exclude_fail_dirs[@]} " =~ " ${dir_name} " ]]; then
       cd $dir
-      nargo compile --experimental-ssa main && nargo execute --experimental-ssa witness
+      nargo compile main && nargo execute witness
       cd ..
   fi
 done

--- a/crates/noirc_evaluator/src/lib.rs
+++ b/crates/noirc_evaluator/src/lib.rs
@@ -65,7 +65,7 @@ pub struct Evaluator {
 // Some of these could have been removed due to optimizations. We need this number because the
 // Standard format requires the number of witnesses. The max number is also fine.
 // If we had a composer object, we would not need it
-pub fn create_circuit(
+pub fn legacy_create_circuit(
     program: Program,
     enable_logging: bool,
     show_output: bool,

--- a/crates/noirc_evaluator/src/ssa_refactor.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor.rs
@@ -65,7 +65,7 @@ pub(crate) fn optimize_into_acir(
 /// This is analogous to `ssa:create_circuit` and this method is called when one wants
 /// to use the new ssa module to process Noir code.
 // TODO: This no longer needs to return a result, but it is kept to match the signature of `create_circuit`
-pub fn experimental_create_circuit(
+pub fn create_circuit(
     program: Program,
     enable_ssa_logging: bool,
     enable_brillig_logging: bool,

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -103,10 +103,10 @@ impl CrateDefMap {
             // only the unconstrained one. Otherwise we want to keep only the constrained one.
             ast.functions.retain(|func| {
                 func.def.name.0.contents.as_str() != "println"
-                    || func.def.is_unconstrained == context.def_interner.experimental_ssa
+                    || func.def.is_unconstrained != context.def_interner.legacy_ssa
             });
 
-            if !context.def_interner.experimental_ssa {
+            if context.def_interner.legacy_ssa {
                 ast.module_decls.retain(|ident| {
                     ident.0.contents != "slice" && ident.0.contents != "collections"
                 });

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -333,7 +333,7 @@ impl<'a> Resolver<'a> {
             UnresolvedType::FieldElement(comp_time) => Type::FieldElement(comp_time),
             UnresolvedType::Array(size, elem) => {
                 let elem = Box::new(self.resolve_type_inner(*elem, new_variables));
-                if self.interner.experimental_ssa && size.is_none() {
+                if !self.interner.legacy_ssa && size.is_none() {
                     return Type::Slice(elem);
                 }
                 let resolved_size = self.resolve_array_size(size, new_variables);

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -384,7 +384,7 @@ impl<'interner> Monomorphizer<'interner> {
         array_contents: Vec<ast::Expression>,
         element_type: ast::Type,
     ) -> ast::Expression {
-        if self.interner.experimental_ssa {
+        if !self.interner.legacy_ssa {
             return ast::Expression::Literal(ast::Literal::Array(ast::ArrayLiteral {
                 contents: array_contents,
                 element_type,
@@ -438,7 +438,7 @@ impl<'interner> Monomorphizer<'interner> {
         element_type: ast::Type,
         location: Location,
     ) -> ast::Expression {
-        if self.interner.experimental_ssa {
+        if !self.interner.legacy_ssa {
             return ast::Expression::Index(ast::Index {
                 collection,
                 index,
@@ -680,7 +680,7 @@ impl<'interner> Monomorphizer<'interner> {
             HirType::Array(length, element) => {
                 let length = length.evaluate_to_u64().unwrap_or(0);
                 let element = self.convert_type(element.as_ref());
-                if self.interner.experimental_ssa {
+                if !self.interner.legacy_ssa {
                     return ast::Type::Array(length, Box::new(element));
                 }
                 self.aos_to_soa_type(length, element)
@@ -741,7 +741,7 @@ impl<'interner> Monomorphizer<'interner> {
     /// Converts arrays of structs (AOS) into structs of arrays (SOA).
     /// This is required since our SSA pass does not support arrays of structs.
     fn aos_to_soa_type(&self, length: u64, element: ast::Type) -> ast::Type {
-        if self.interner.experimental_ssa {
+        if !self.interner.legacy_ssa {
             return ast::Type::Array(length, Box::new(element));
         }
         match element {
@@ -980,7 +980,7 @@ impl<'interner> Monomorphizer<'interner> {
         typ: ast::Type,
         location: Location,
     ) -> ast::Expression {
-        if self.interner.experimental_ssa {
+        if !self.interner.legacy_ssa {
             let lvalue = ast::LValue::Index { array: lvalue, index, element_type: typ, location };
             return ast::Expression::Assign(ast::Assign { lvalue, expression });
         }

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -74,7 +74,7 @@ pub struct NodeInterner {
     /// TODO(#1850): This is technical debt that should be removed once we fully move over
     /// to the new SSA pass which has certain frontend features enabled
     /// such as slices and the removal of aos_to_soa
-    pub experimental_ssa: bool,
+    pub legacy_ssa: bool,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -254,7 +254,7 @@ impl Default for NodeInterner {
             globals: HashMap::new(),
             struct_methods: HashMap::new(),
             primitive_methods: HashMap::new(),
-            experimental_ssa: false,
+            legacy_ssa: false,
         };
 
         // An empty block expression is used often, we add this into the `node` on startup


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR does the minimal changes to move `nargo` over to use the new SSA code by default. You can continue to use the old SSA by using the `legacy-ssa` flag (which replaces `experimental-ssa`) although this should be removed soon.

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.
  
References to `experimental-ssa` should be removed. I would leave `legacy-ssa` undocumented as it will be removed soon.
## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
