### PR TITLE
fix: Switch from HashMap to BTreeMap in merge_stores

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -132,7 +132,7 @@
 //!   v12 = add v10, v11
 //!   store v12 at v5         (new store)
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, BTreeMap},
     rc::Rc,
 };
 
@@ -610,7 +610,7 @@ impl<'f> Context<'f> {
     /// this function also needs to be changed to reflect that.
     fn merge_stores(&mut self, then_branch: Branch, else_branch: Branch) {
         // Address -> (then_value, else_value, value_before_the_if)
-        let mut new_map = HashMap::with_capacity(then_branch.store_values.len());
+        let mut new_map = BTreeMap::new();
 
         for (address, store) in then_branch.store_values {
             new_map.insert(address, (store.new_value, store.old_value, store.old_value));


### PR DESCRIPTION
# Description

## Problem\*

Resolves issue with non-deterministic circuit bytecode when using HashMap for `merge_stores`

## Summary\*

Move from HashMap to BTreeMap in merge_stores

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
