### PR TITLE
chore!: Require package names in `Nargo.toml` files

### DIFF
--- a/crates/nargo/src/manifest/mod.rs
+++ b/crates/nargo/src/manifest/mod.rs
@@ -64,6 +64,7 @@ pub struct WorkspaceConfig {
 #[allow(dead_code)]
 #[derive(Default, Debug, Deserialize, Clone)]
 pub struct PackageMetadata {
+    #[serde(default = "panic_missing_name")]
     pub name: String,
     description: Option<String>,
     authors: Vec<String>,
@@ -75,6 +76,26 @@ pub struct PackageMetadata {
     compiler_version: Option<String>,
     backend: Option<String>,
     license: Option<String>,
+}
+
+// TODO: Remove this after a couple of breaking releases (added in 0.10.0)
+fn panic_missing_name() -> String {
+    panic!(
+        r#"
+
+Failed to parse `Nargo.toml`.
+    
+`Nargo.toml` now requires a "name" field for Noir packages.
+
+```toml
+[package]
+name = "package_name"
+```
+
+Modify your `Nargo.toml` similarly to above and rerun the command.
+
+"#
+    )
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/nargo/src/manifest/mod.rs
+++ b/crates/nargo/src/manifest/mod.rs
@@ -64,8 +64,8 @@ pub struct WorkspaceConfig {
 #[allow(dead_code)]
 #[derive(Default, Debug, Deserialize, Clone)]
 pub struct PackageMetadata {
-    pub name: Option<String>,
-    // Note: a package name is not needed unless there is a registry
+    pub name: String,
+    description: Option<String>,
     authors: Vec<String>,
     // If not compiler version is supplied, the latest is used
     // For now, we state that all packages must be compiled under the same
@@ -91,6 +91,7 @@ fn parse_standard_toml() {
     let src = r#"
 
         [package]
+        name = "test"
         authors = ["kev", "foo"]
         compiler_version = "0.1"
 

--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -7,20 +7,11 @@ use super::fs::{create_named_dir, write_to_file};
 use super::{NargoConfig, CARGO_PKG_VERSION};
 use acvm::Backend;
 use clap::Args;
-use const_format::formatcp;
 use std::path::PathBuf;
 
 /// Create a Noir project in the current directory.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand;
-
-const SETTINGS: &str = formatcp!(
-    r#"[package]
-authors = [""]
-compiler_version = "{CARGO_PKG_VERSION}"
-
-[dependencies]"#,
-);
 
 const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
     assert(x != y);
@@ -47,10 +38,21 @@ pub(crate) fn run<B: Backend>(
 
 /// Initializes a new Noir project in `package_dir`.
 pub(crate) fn initialize_project(package_dir: PathBuf) {
+    // TODO: Should this reject if we have non-Unicode filepaths?
+    let package_name = package_dir.file_name().expect("Expected a filename").to_string_lossy();
     let src_dir = package_dir.join(SRC_DIR);
     create_named_dir(&src_dir, "src");
 
-    write_to_file(SETTINGS.as_bytes(), &package_dir.join(PKG_FILE));
+    let toml_contents = format!(
+        r#"[package]
+name = "{package_name}"
+authors = [""]
+compiler_version = "{CARGO_PKG_VERSION}"
+
+[dependencies]"#
+    );
+
+    write_to_file(toml_contents.as_bytes(), &package_dir.join(PKG_FILE));
     write_to_file(EXAMPLE.as_bytes(), &src_dir.join("main.nr"));
     println!("Project successfully created! Binary located at {}", package_dir.display());
 }

--- a/crates/nargo_cli/tests/target_tests_data/fail/basic/Nargo.toml
+++ b/crates/nargo_cli/tests/target_tests_data/fail/basic/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "fail_basic"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/target_tests_data/fail/dup_func/Nargo.toml
+++ b/crates/nargo_cli/tests/target_tests_data/fail/dup_func/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "fail_dup_func"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/target_tests_data/pass/basic/Nargo.toml
+++ b/crates/nargo_cli/tests/target_tests_data/pass/basic/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "pass_basic"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/target_tests_data/pass/import/Nargo.toml
+++ b/crates/nargo_cli/tests/target_tests_data/pass/import/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "pass_import"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/target_tests_data/pass_dev_mode/unused/Nargo.toml
+++ b/crates/nargo_cli/tests/target_tests_data/pass_dev_mode/unused/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "pass_dev_mode_unused"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/1327_concrete_in_generic/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/1327_concrete_in_generic/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "1327_concrete_in_generic"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/1_mul/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/1_mul/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "1_mul"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/2_div/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/2_div/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "2_div"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/3_add/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/3_add/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "3_add"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/4_sub/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/4_sub/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "4_sub"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/5_over/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/5_over/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "5_over"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/6/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/6/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "6"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/6_array/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/6_array/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "6_array"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/7/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/7/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "7"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/7_function/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/7_function/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "7_function"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/8_integration/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/8_integration/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "8_integration"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/9_conditional/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/9_conditional/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "9_conditional"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/arithmetic_binary_operations/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/arithmetic_binary_operations/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "arithmetic_binary_operations"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/array_dynamic/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/array_dynamic/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "array_dynamic"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/array_len/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/array_len/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "array_len"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/array_neq/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/array_neq/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "array_neq"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/array_sort/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/array_sort/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "array_sort"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/assert/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/assert/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "assert"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/assert_statement/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/assert_statement/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "assert_statement"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/assign_ex/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/assign_ex/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "assign_ex"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/bit_and/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/bit_and/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "bit_and"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/bit_shifts_comptime/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/bit_shifts_comptime/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "bit_shifts_comptime"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/blackbox_func_simple_call/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/blackbox_func_simple_call/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "blackbox_func_simple_call"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/bool_not/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/bool_not/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "bool_not"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/bool_or/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/bool_or/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "bool_or"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_acir_as_brillig/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_acir_as_brillig/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_acir_as_brillig"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_arrays/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_arrays/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_arrays"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_assert/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_assert/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_assert"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_assert_fail/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_assert_fail/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_assert_fail"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_blake2s/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_blake2s/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_blake2s"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_calls/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_calls/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_calls"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_calls_array/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_calls_array/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_calls_array"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_calls_conditionals/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_calls_conditionals/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_calls_conditionals"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_cast/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_cast/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_cast"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_conditional/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_conditional/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_conditional"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_ecdsa/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_ecdsa/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_ecdsa"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_field_binary_operations/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_field_binary_operations/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_field_binary_operations"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_fns_as_values/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_fns_as_values/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_fns_as_values"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_hash_to_field/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_hash_to_field/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_hash_to_field"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_identity_function/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_identity_function/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_identity_function"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_integer_binary_operations/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_integer_binary_operations/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_integer_binary_operations"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_keccak/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_keccak/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_keccak"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_loop/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_loop/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_loop"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_modulo/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_modulo/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_modulo"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_nested_arrays/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_nested_arrays/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_nested_arrays"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_not/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_not/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_not"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_oracle/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_oracle/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_oracle"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_pedersen/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_pedersen/Nargo.toml
@@ -1,6 +1,6 @@
 [package]
+name = "brillig_pedersen"
 authors = [""]
 compiler_version = "0.1"
 
 [dependencies]
-    

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_recursion/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_recursion/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_recursion"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_references/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_references/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_references"
 authors = [""]
 compiler_version = "0.5.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_scalar_mul/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_scalar_mul/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_scalar_mul"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_schnorr/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_schnorr/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_schnorr"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_sha256/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_sha256/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_sha256"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_slices/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_slices/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_slices"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_be_bytes/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_be_bytes/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_to_be_bytes"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_bits/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_bits/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_to_bits"
 authors = [""]
 compiler_version = "0.7.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_bytes_integration/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_bytes_integration/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_to_bytes_integration"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_le_bytes/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_to_le_bytes/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_to_le_bytes"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_top_level/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_top_level/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "brillig_top_level"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/cast_bool/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/cast_bool/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "cast_bool"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/comptime_array_access/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/comptime_array_access/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "comptime_array_access"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/comptime_recursion_regression/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/comptime_recursion_regression/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "comptime_recursion_regression"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/constant_return/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/constant_return/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "constant_return"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/contracts/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/contracts/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "contracts"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/debug_logs/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/debug_logs/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "debug_logs"
 authors = [""]
 compiler_version = "0.8.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/diamond_deps_0/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/diamond_deps_0/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "diamond_deps_0"
 authors = [""]
 compiler_version = "0.7.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/distinct_keyword/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/distinct_keyword/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "distinct_keyword"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/ec_baby_jubjub/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/ec_baby_jubjub/Nargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "Baby Jubjub sanity checks"
+name = "ec_baby_jubjub"
+description = "Baby Jubjub sanity checks"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/ecdsa_secp256k1/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/ecdsa_secp256k1/Nargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "ECDSA secp256k1 verification"
+name = "ecdsa_secp256k1"
+description = "ECDSA secp256k1 verification"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/ecdsa_secp256r1/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/ecdsa_secp256r1/Nargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "ECDSA secp256r1 verification"
+name = "ecdsa_secp256r1"
+description = "ECDSA secp256r1 verification"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/generics/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/generics/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "generics"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/global_consts/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/global_consts/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "global_consts"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/hash_to_field/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/hash_to_field/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "hash_to_field"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/if_else_chain/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/if_else_chain/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "if_else_chain"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/integer_array_indexing/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/integer_array_indexing/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "integer_array_indexing"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/keccak256/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/keccak256/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "keccak256"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/let_stmt/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/let_stmt/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "let_stmt"
 authors = [""]
 compiler_version = "0.8.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/main_bool_arg/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/main_bool_arg/Nargo.toml
@@ -1,6 +1,6 @@
 [package]
+name = "main_bool_arg"
 authors = [""]
 compiler_version = "0.1"
 
 [dependencies]
-    

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/main_return/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/main_return/Nargo.toml
@@ -1,6 +1,6 @@
 [package]
+name = "main_return"
 authors = [""]
 compiler_version = "0.1"
 
 [dependencies]
-    

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/merkle_insert/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/merkle_insert/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "merkle_insert"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/modules/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/modules/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "modules"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/modules_more/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/modules_more/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "modules_more"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/modulus/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/modulus/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "modulus"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/nested_arrays_from_brillig/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/nested_arrays_from_brillig/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "nested_arrays_from_brillig"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/numeric_generics/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/numeric_generics/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "numeric_generics"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/pedersen_check/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/pedersen_check/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "pedersen_check"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/poseidon_bn254_hash/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/poseidon_bn254_hash/Nargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "Poseidon 254-bit permutation test on 3 elements with alpha = 5"
+name = "poseidon_bn254_hash"
+description = "Poseidon 254-bit permutation test on 3 elements with alpha = 5"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/poseidonsponge_x5_254/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/poseidonsponge_x5_254/Nargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "Variable-length Poseidon-128 sponge test on 7 elements with alpha = 5"
+name = "poseidonsponge_x5_254"
+description = "Variable-length Poseidon-128 sponge test on 7 elements with alpha = 5"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/pred_eq/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/pred_eq/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "pred_eq"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/references/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/references/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "references"
 authors = [""]
 compiler_version = "0.5.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/regression/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/regression/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "regression"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/regression_method_cannot_be_found/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/regression_method_cannot_be_found/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "regression_method_cannot_be_found"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/scalar_mul/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/scalar_mul/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "scalar_mul"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/schnorr/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/schnorr/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "schnorr"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/sha256/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/sha256/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "sha256"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/sha2_blocks/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/sha2_blocks/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "sha2_blocks"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/sha2_byte/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/sha2_byte/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "sha2_byte"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/signed_division/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/signed_division/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "signed_division"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_add_and_ret_arr/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_add_and_ret_arr/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_add_and_ret_arr"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_array_param/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_array_param/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_array_param"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_bitwise/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_bitwise/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_bitwise"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_comparison/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_comparison/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_comparison"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_mut/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_mut/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_mut"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_not/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_not/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_not"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_print/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_print/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_print"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_program_addition/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_program_addition/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_program_addition"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_program_no_body/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_program_no_body/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_program_no_body"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_radix/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_radix/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_radix"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_range/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_range/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_range"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_shield/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_shield/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_shield"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/simple_shift_left_right/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/simple_shift_left_right/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "simple_shift_left_right"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/slices/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/slices/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "slices"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/strings/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/strings/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "strings"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/struct/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/struct/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "struct"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/struct_array_inputs/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/struct_array_inputs/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "struct_array_inputs"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/struct_fields_ordering/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/struct_fields_ordering/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "struct_fields_ordering"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/struct_inputs/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/struct_inputs/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "struct_inputs"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/submodules/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/submodules/Nargo.toml
@@ -1,7 +1,6 @@
+[package]
+name = "submodules"
+authors = [""]
+compiler_version = "0.1"
 
-        [package]
-        authors = [""]
-        compiler_version = "0.1"
-    
-        [dependencies]
-    
+[dependencies]

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/to_be_bytes/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/to_be_bytes/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "to_be_bytes"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/to_bits/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/to_bits/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "to_bits"
 authors = [""]
 compiler_version = "0.7.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/to_bytes_integration/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/to_bytes_integration/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "to_bytes_integration"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/to_le_bytes/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/to_le_bytes/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "to_le_bytes"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/tuples/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/tuples/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "tuples"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/unconstrained_empty/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/unconstrained_empty/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "unconstrained_empty"
 authors = [""]
 compiler_version = "0.6.0"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/unit/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/unit/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "unit"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/vectors/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/vectors/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "vectors"
 authors = [""]
 compiler_version = "0.7.1"
 

--- a/crates/nargo_cli/tests/test_data_ssa_refactor/xor/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/xor/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "xor"
 authors = [""]
 compiler_version = "0.1"
 

--- a/crates/nargo_cli/tests/test_libraries/bad_impl/Nargo.toml
+++ b/crates/nargo_cli/tests/test_libraries/bad_impl/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "bad_impl"
 authors = [""]
 compiler_version = "0.7.1"
 

--- a/crates/nargo_cli/tests/test_libraries/diamond_deps_1/Nargo.toml
+++ b/crates/nargo_cli/tests/test_libraries/diamond_deps_1/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "diamond_deps_1"
 authors = [""]
 compiler_version = "0.7.1"
 

--- a/crates/nargo_cli/tests/test_libraries/diamond_deps_2/Nargo.toml
+++ b/crates/nargo_cli/tests/test_libraries/diamond_deps_2/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "diamond_deps_2"
 authors = [""]
 compiler_version = "0.7.1"
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2053 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This makes the `name` field in Nargo.toml required. By making this required, we can add a `--package` flag to any command to select a package in a workspace. While updating the tests, I found that some `name` fields in Nargo.toml were invalid package names, so I moved the name to a `description` field (which we now parse) and added a proper name.

This is breaking because previous projects will have been generated without a name, but new projects generated by nargo will set the directory name as the package name.

This work fell out of #1992 but should be merged as a prerequisite.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
