### PR TITLE
chore: change 'unnecessary pub' error to a warning

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -171,7 +171,7 @@ impl From<ResolverError> for Diagnostic {
             ResolverError::UnnecessaryPub { ident, position } => {
                 let name = &ident.0.contents;
 
-                let mut diag = Diagnostic::simple_error(
+                let mut diag = Diagnostic::simple_warning(
                     format!("unnecessary pub keyword on {position} for function {name}"),
                     format!("unnecessary pub {position}"),
                     ident.0.span(),


### PR DESCRIPTION
# Description

Change unnecessary pub error to a warning 

## Problem

Resolves #2059 

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
