### PR TITLE
chore: Ensure that CLI and wasm compilers are sync in `noir_wasm_testing`

### DIFF
--- a/.github/Cross.toml
+++ b/.github/Cross.toml
@@ -1,0 +1,15 @@
+[build]
+# pre-build = [
+#     "dpkg --add-architecture $CROSS_DEB_ARCH",
+#     "apt-get update && apt-get install --assume-yes xz-utils pkgconfig build-essential cmake openssl libssl-dev libomp-dev libssl-dev:$CROSS_DEB_ARCH libomp-dev:$CROSS_DEB_ARCH",
+# ]
+
+[build.env]
+passthrough = [
+    "HOME",
+    "RUST_BACKTRACE",
+    "BARRETENBERG_BIN_DIR"
+]
+volumes = [
+    "HOME",
+]

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Print noir contents
         run: |
           echo "Contents of noir directory:"
-          ls -l noir
+          ls -l .
 
       - name: Print build-nargo contents
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -47,6 +47,27 @@ jobs:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: cachix/cachix-action@v12
+        with:
+          name: barretenberg
+
+      - name: Restore nix store cache
+        id: nix-store-cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/nix-cache
+          key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
+
+      # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
+      - name: Copy cache into nix store
+        if: steps.nix-store-cache.outputs.cache-hit == 'true'
+        # We don't check the signature because we're the one that created the cache
+        run: |
+          for narinfo in /tmp/nix-cache/*.narinfo; do
+            path=$(head -n 1 "$narinfo" | awk '{print $2}')
+            nix copy --no-check-sigs --from "file:///tmp/nix-cache" "$path"
+          done
+
       - name: Build nargo
         run: |
           nix build -L .

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           ls -R
           nargo_binary=$(find . -name "nargo")
+          nargo_binary=$(realpath $nargo_binary)
           chmod +x $nargo_binary
           if [ -f "$nargo_binary" ]; then
             echo "nargo binary found at $nargo_binary."

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -24,9 +24,20 @@ jobs:
           path: build-nargo
           ref: ${{ inputs.build-nargo-ref || 'master' }}
 
+      - name: Print noir contents
+        run: |
+          echo "Contents of noir directory:"
+          ls -l noir
+
+      - name: Print build-nargo contents
+        run: |
+          echo "Contents of build-nargo directory:"
+          ls -l build-nargo
+
       - name: Collect locked barretenberg rev
         run: |
           echo "BB_REV=$(jq -r .nodes.barretenberg.locked.rev ./noir/flake.lock)" >> $GITHUB_ENV
+          echo "BB_REV is ${{ env.BB_REV }}"
 
       - uses: cachix/install-nix-action@v20
         with:
@@ -42,6 +53,7 @@ jobs:
       # https://github.com/actions/upload-artifact/issues/92#issuecomment-1080347032
       - name: Build barretenberg as libbarretenberg-wasm32
         run: |
+          echo "BB_REV is ${{ env.BB_REV }}"
           nix build "github:AztecProtocol/barretenberg/${{ env.BB_REV }}#wasm32"
           echo "ARTIFACT_UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -109,11 +109,19 @@ jobs:
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: nargo-${{ matrix.target }}
+          path: ./dist/*
+          retention-days: 3
+
       # You can access the artifacts directly from ./dist/* here
       - name: Test built artifact
         if: startsWith(matrix.target, 'x86_64-unknown-linux')
         run: |
           cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+          ls -R
           npm install
           npm test
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -87,15 +87,22 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
       - name: Checkout noir-wasm-testing
         uses: actions/checkout@v3
         with:
           repository: noir-lang/noir-wasm-testing
           ref: use-injected-nargo
-          path: noir-wasm-testing
+
+      - name: Download wasm package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: noir_wasm
+          path: ./@noir-lang_noir_wasm
+
+      - name: Inject built wasm into noir-wasm-testing
+        run: |
+          jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./package.json > ./package.json.tmp
+          mv ./package.json.tmp ./package.json
 
       - name: Download nargo binary
         uses: actions/download-artifact@v3
@@ -103,29 +110,17 @@ jobs:
           name: nargo
           path: ./nargo
 
-      - name: Download wasm package artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: noir_wasm
-          path: ./noir-wasm-testing/@noir-lang_noir_wasm
-
-      - name: Inject built wasm into noir-wasm-testing
-        run: |
-          jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./noir-wasm-testing/package.json > ./noir-wasm-testing/package.json.tmp
-          mv ./noir-wasm-testing/package.json.tmp ./noir-wasm-testing/package.json
-
       - name: Run noir-wasm-testing program 
         run: |
           ls -l
           ls -l ./nargo
           ls -l ./nargo/bin
           chmod +x ./nargo/bin/nargo
-          ./nargo/bin/nargo -p "./noir-wasm-testing/src/noir-script" compile noir-wasm-testing
+          ls -l ./nargo/bin
+          ./nargo/bin/nargo -p "./src/noir-script" compile noir-wasm-testing
 
       - name: Install dependencies
-        working-directory: ./noir-wasm-testing
         run: npm install
 
       - name: Run tests
-        working-directory: ./noir-wasm-testing
         run: npm test

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -35,17 +35,17 @@ jobs:
           ref: use-injected-nargo
           path: noir-wasm-testing
 
-      - name: Install nargo
-        run: | 
-          curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-          $HOME/.nargo/bin/noirup -p ./
-
       - name: Inject built wasm into noir-wasm-testing
         run: |
           mkdir ./noir-wasm-testing/@noir-lang_noir_wasm
           cp -r -L ./result/* ./noir-wasm-testing/@noir-lang_noir_wasm
           jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./noir-wasm-testing/package.json > ./noir-wasm-testing/package.json.tmp
           mv ./noir-wasm-testing/package.json.tmp ./noir-wasm-testing/package.json
+
+      - name: Install nargo
+        run: | 
+          nix build .
+          echo ./result/bin" >> $GITHUB_PATH
 
       - name: Run build.sh in noir-wasm-testing
         working-directory: ./noir-wasm-testing

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -113,11 +113,16 @@ jobs:
           ls -R
           nargo_binary=$(find $(pwd) -name "nargo" -type f)
           echo "nargo binary found at $nargo_binary."
-          chmod +x $nargo_binary
+          echo "Initial file permissions:"
+          ls -l $nargo_binary
+          echo "Attempting to make nargo binary executable:"
+          chmod +x $nargo_binary || echo "chmod failed with exit code $?"
+          echo "File permissions after chmod:"
+          ls -l $nargo_binary
           if [ -x "$nargo_binary" ]; then
             $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
           else
-            echo "nargo binary NOT found."
+            echo "nargo binary NOT found or is not executable."
             exit 1
           fi
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -65,12 +65,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          [
+        target: [
             x86_64-unknown-linux-gnu,
-            x86_64-unknown-linux-musl,
-            aarch64-unknown-linux-gnu,
-            aarch64-unknown-linux-musl,
+            # x86_64-unknown-linux-musl,
+            # aarch64-unknown-linux-gnu,
+            # aarch64-unknown-linux-musl,
           ]
 
     steps:
@@ -100,7 +99,6 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build Nargo
-        working-directory: noir
         env:
           BARRETENBERG_BIN_DIR: ${{ github.workspace }}/libbarretenberg-wasm32/bin
         run: |
@@ -108,7 +106,6 @@ jobs:
           cross build --package nargo_cli --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
-        working-directory: noir
         run: |
           mkdir dist
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -112,9 +112,9 @@ jobs:
         run: |
           ls -R
           nargo_binary=$(find $(pwd) -name "nargo")
-          chmod +x $nargo_binary
+          echo "nargo binary found at $nargo_binary."
           if [ -x "$nargo_binary" ]; then
-            echo "nargo binary found at $nargo_binary."
+            chmod +x $nargo_binary
             $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
           else
             echo "nargo binary NOT found."

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -103,11 +103,6 @@ jobs:
           name: nargo
           path: ./nargo
 
-      - name: Add nargo to path
-        run: |
-          chmod +x ./nargo/bin
-          echo "./nargo/bin" >> $GITHUB_PATH
-
       - name: Download wasm package artifact
         uses: actions/download-artifact@v3
         with:
@@ -119,9 +114,8 @@ jobs:
           jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./noir-wasm-testing/package.json > ./noir-wasm-testing/package.json.tmp
           mv ./noir-wasm-testing/package.json.tmp ./noir-wasm-testing/package.json
 
-      - name: Run noir-wasm-testing program
-        working-directory: ./noir-wasm-testing/src/noir-script
-        run: nargo compile noir-wasm-testing
+      - name: Run noir-wasm-testing program 
+        run: ./nargo/bin/nargo -p "./noir-wasm-testing/src/noir-script" compile noir-wasm-testing
 
       - name: Install dependencies
         working-directory: ./noir-wasm-testing

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -119,11 +119,9 @@ jobs:
           jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./noir-wasm-testing/package.json > ./noir-wasm-testing/package.json.tmp
           mv ./noir-wasm-testing/package.json.tmp ./noir-wasm-testing/package.json
 
-      - name: Run build.sh in noir-wasm-testing
-        working-directory: ./noir-wasm-testing
-        run: |
-          chmod +x build.sh
-          ./build.sh
+      - name: Run noir-wasm-testing program
+        working-directory: ./noir-wasm-testing/src/noir-script
+        run: nargo compile noir-wasm-testing
 
       - name: Install dependencies
         working-directory: ./noir-wasm-testing

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build wasm package
         run: |
           nix build -L .#wasm
-      
+
       - name: Dereference symlink
         run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
 
@@ -58,10 +58,8 @@ jobs:
           path: /tmp/nix-cache
           key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
 
-      # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
       - name: Copy cache into nix store
         if: steps.nix-store-cache.outputs.cache-hit == 'true'
-        # We don't check the signature because we're the one that created the cache
         run: |
           for narinfo in /tmp/nix-cache/*.narinfo; do
             path=$(head -n 1 "$narinfo" | awk '{print $2}')
@@ -71,7 +69,7 @@ jobs:
       - name: Build nargo
         run: |
           nix build -L .
-      
+
       - name: Dereference symlink
         run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
 
@@ -108,16 +106,15 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: nargo
-          path: ./src/noir-script
+          path: ./nargo
 
-      - name: Run noir-wasm-testing program 
-        working-directory: ./src/noir-script/
+      - name: Run noir-wasm-testing program
         run: |
           ls -l
-          ls -l ./bin
-          chmod +x ./bin/nargo
-          ls -l ./bin
-          ./bin/nargo compile noir-wasm-testing
+          ls -l ./nargo
+          chmod +x ./nargo/nargo
+          ls -l ./nargo
+          ${{ github.workspace }}/nargo/nargo -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -108,6 +108,11 @@ jobs:
           name: nargo
           path: ./nargo
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libomp-dev
+
       - name: Run noir-wasm-testing program
         run: |
           ls -R

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -104,7 +104,9 @@ jobs:
           path: ./nargo
 
       - name: Add nargo to path
-        run: echo "./nargo" >> $GITHUB_PATH
+        run: |
+          chmod +x ./nargo/bin
+          echo "./nargo/bin" >> $GITHUB_PATH
 
       - name: Download wasm package artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -108,16 +108,13 @@ jobs:
           name: nargo
           path: ./nargo
 
-      - name: Install dependencies
+      - name: Install dependencies and Run noir-wasm-testing program
         run: |
           sudo apt-get update
           sudo apt-get install -y libomp-dev
           echo "Locating libomp.so"
           libomp_path=$(find /usr/ -name libomp.so*)
           echo "libomp.so located at $libomp_path"
-
-      - name: Run noir-wasm-testing program
-        run: |
           ls -R
           nargo_binary=$(find $(pwd) -name "nargo" -type f)
           echo "nargo binary found at $nargo_binary."

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -113,7 +113,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libomp-dev
           echo "Locating libomp.so"
-          libomp_path=$(locate libomp.so)
+          libomp_path=$(find /usr/ -name libomp.so*)
           echo "libomp.so located at $libomp_path"
 
       - name: Run noir-wasm-testing program
@@ -128,7 +128,7 @@ jobs:
           echo "File permissions after chmod:"
           ls -l $nargo_binary
           echo "Updating LD_LIBRARY_PATH"
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname ${{ env.libomp_path }})
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname $libomp_path)
           echo "Library dependencies of nargo binary:"
           ldd $nargo_binary
           if [ -x "$nargo_binary" ]; then

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -116,16 +116,6 @@ jobs:
           path: ./dist/*
           retention-days: 3
 
-      # You can access the artifacts directly from ./dist/* here
-      - name: Test built artifact
-        if: startsWith(matrix.target, 'x86_64-unknown-linux')
-        run: |
-          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
-          cd ./build-nargo
-          npm install
-          ls -R
-          npm test
-
   build-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -121,7 +121,7 @@ jobs:
         if: startsWith(matrix.target, 'x86_64-unknown-linux')
         run: |
           cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
-          ls -R
+          cd ./build-nargo
           npm install
           npm test
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -117,7 +117,7 @@ jobs:
           ls -l ./nargo/bin
           chmod +x ./nargo/bin/nargo
           ls -l ./nargo/bin
-          ./nargo/bin/nargo -p "./src/noir-script" compile noir-wasm-testing
+          ${{ github.workspace }}/nargo/bin/nargo -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -24,16 +24,6 @@ jobs:
           path: build-nargo
           ref: ${{ inputs.build-nargo-ref || 'master' }}
 
-      - name: Print noir contents
-        run: |
-          echo "Contents of noir directory:"
-          ls -l .
-
-      - name: Print build-nargo contents
-        run: |
-          echo "Contents of build-nargo directory:"
-          ls -l build-nargo
-
       - name: Collect locked barretenberg rev
         run: |
           echo "BB_REV=$(jq -r .nodes.barretenberg.locked.rev ./flake.lock)" >> $GITHUB_ENV
@@ -57,6 +47,13 @@ jobs:
           nix build "github:AztecProtocol/barretenberg/${{ env.BB_REV }}#wasm32"
           echo "ARTIFACT_UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: libbarretenberg-wasm32
+          path: ${{ env.ARTIFACT_UPLOAD_PATH }}
+          retention-days: 3
+
   build-linux:
     needs: [build-barretenberg]
     runs-on: ubuntu-22.04
@@ -65,12 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [
-            x86_64-unknown-linux-gnu,
-            # x86_64-unknown-linux-musl,
-            # aarch64-unknown-linux-gnu,
-            # aarch64-unknown-linux-musl,
-          ]
+        target: [x86_64-unknown-linux-gnu]
 
     steps:
       - name: Checkout Noir repo
@@ -92,6 +84,12 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: libbarretenberg-wasm32
+          path: ${{ github.workspace }}/libbarretenberg-wasm32
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.66.0

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -113,7 +113,7 @@ jobs:
           ls -R
           nargo_binary=$(find $(pwd) -name "nargo")
           chmod +x $nargo_binary
-          if [ -f "$nargo_binary" ]; then
+          if [ -x "$nargo_binary" ]; then
             echo "nargo binary found at $nargo_binary."
             $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
           else

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Collect locked barretenberg rev
         run: |
-          echo "BB_REV=$(jq -r .nodes.barretenberg.locked.rev ./noir/flake.lock)" >> $GITHUB_ENV
+          echo "BB_REV=$(jq -r .nodes.barretenberg.locked.rev ./flake.lock)" >> $GITHUB_ENV
           echo "BB_REV is ${{ env.BB_REV }}"
 
       - uses: cachix/install-nix-action@v20
@@ -114,11 +114,11 @@ jobs:
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
-      # You can access the artifacts directly from ./noir/dist/* here
+      # You can access the artifacts directly from ./dist/* here
       - name: Test built artifact
         if: startsWith(matrix.target, 'x86_64-unknown-linux')
         run: |
-          cp ./noir/target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
           npm install
           npm test
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -11,8 +11,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build Wasm
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build wasm package
+        run: |
+          nix build -L .#wasm
+      
+      - name: Dereference symlink
+        run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: noir_wasm
+          path: ${{ env.UPLOAD_PATH }}
+          retention-days: 3
+
+  build-nargo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build nargo
+        run: |
+          nix build -L .
+      
+      - name: Dereference symlink
+        run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: nargo
+          path: ${{ env.UPLOAD_PATH }}
+          retention-days: 3
+
+  test:
+    needs: [build-wasm, build-nargo]
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -24,10 +75,6 @@ jobs:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build wasm package
-        run: |
-          nix build -L .#wasm
-
       - name: Checkout noir-wasm-testing
         uses: actions/checkout@v3
         with:
@@ -35,17 +82,25 @@ jobs:
           ref: use-injected-nargo
           path: noir-wasm-testing
 
+      - name: Download nargo binary
+        uses: actions/download-artifact@v3
+        with:
+          name: nargo
+          path: ./nargo
+
+      - name: Add nargo to path
+        run: echo "./nargo" >> $GITHUB_PATH
+
+      - name: Download wasm package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: noir_wasm
+          path: ./noir-wasm-testing/@noir-lang_noir_wasm
+
       - name: Inject built wasm into noir-wasm-testing
         run: |
-          mkdir ./noir-wasm-testing/@noir-lang_noir_wasm
-          cp -r -L ./result/* ./noir-wasm-testing/@noir-lang_noir_wasm
           jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./noir-wasm-testing/package.json > ./noir-wasm-testing/package.json.tmp
           mv ./noir-wasm-testing/package.json.tmp ./noir-wasm-testing/package.json
-
-      - name: Install nargo
-        run: | 
-          nix build .
-          echo ./result/bin" >> $GITHUB_PATH
 
       - name: Run build.sh in noir-wasm-testing
         working-directory: ./noir-wasm-testing

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run noir-wasm-testing program
         run: |
           ls -R
-          nargo_binary=$(find $(pwd) -name "nargo")
+          nargo_binary=$(find $(pwd) -name "nargo" -type f)
           echo "nargo binary found at $nargo_binary."
           if [ -x "$nargo_binary" ]; then
             chmod +x $nargo_binary

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -11,36 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-wasm:
+  build-barretenberg:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
+      - name: Checkout Noir repo
         uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v20
+      - name: Checkout Build Nargo repo
+        uses: actions/checkout@v3
         with:
-          nix_path: nixpkgs=channel:nixos-22.11
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          repository: noir-lang/build-nargo
+          path: build-nargo
+          ref: ${{ inputs.build-nargo-ref || 'master' }}
 
-      - name: Build wasm package
+      - name: Collect locked barretenberg rev
         run: |
-          nix build -L .#wasm
-
-      - name: Dereference symlink
-        run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: noir_wasm
-          path: ${{ env.UPLOAD_PATH }}
-          retention-days: 3
-
-  build-nargo:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
+          echo "BB_REV=$(jq -r .nodes.barretenberg.locked.rev ./noir/flake.lock)" >> $GITHUB_ENV
 
       - uses: cachix/install-nix-action@v20
         with:
@@ -50,95 +36,208 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: barretenberg
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: Restore nix store cache
-        id: nix-store-cache
-        uses: actions/cache@v3
-        with:
-          path: /tmp/nix-cache
-          key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
-
-      - name: Copy cache into nix store
-        if: steps.nix-store-cache.outputs.cache-hit == 'true'
+      # Upload does not work with symlinks, using this workaround:
+      # https://github.com/actions/upload-artifact/issues/92#issuecomment-1080347032
+      - name: Build barretenberg as libbarretenberg-wasm32
         run: |
-          for narinfo in /tmp/nix-cache/*.narinfo; do
-            path=$(head -n 1 "$narinfo" | awk '{print $2}')
-            nix copy --no-check-sigs --from "file:///tmp/nix-cache" "$path"
-          done
+          nix build "github:AztecProtocol/barretenberg/${{ env.BB_REV }}#wasm32"
+          echo "ARTIFACT_UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
 
-      - name: Build nargo
-        run: |
-          nix build -L .
+  build-linux:
+    needs: [build-barretenberg]
+    runs-on: ubuntu-22.04
+    env:
+      CROSS_CONFIG: ${{ github.workspace }}/.github/Cross.toml
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          [
+            x86_64-unknown-linux-gnu,
+            x86_64-unknown-linux-musl,
+            aarch64-unknown-linux-gnu,
+            aarch64-unknown-linux-musl,
+          ]
 
-      - name: Dereference symlink
-        run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: nargo
-          path: ${{ env.UPLOAD_PATH }}
-          retention-days: 3
-
-  test:
-    needs: [build-wasm, build-nargo]
-    name: Test
-    runs-on: ubuntu-latest
     steps:
-      - name: Checkout noir-wasm-testing
+      - name: Checkout Noir repo
+        uses: actions/checkout@v3
+
+      - name: Checkout Build Nargo repo
         uses: actions/checkout@v3
         with:
-          repository: noir-lang/noir-wasm-testing
-          ref: use-injected-nargo
+          repository: noir-lang/build-nargo
+          path: build-nargo
+          ref: ${{ inputs.build-nargo-ref || 'master' }}
 
-      - name: Download wasm package artifact
-        uses: actions/download-artifact@v3
+      - uses: actions/cache@v3
         with:
-          name: noir_wasm
-          path: ./@noir-lang_noir_wasm
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Inject built wasm into noir-wasm-testing
-        run: |
-          jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./package.json > ./package.json.tmp
-          mv ./package.json.tmp ./package.json
-
-      - name: Download nargo binary
-        uses: actions/download-artifact@v3
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@1.66.0
         with:
-          name: nargo
-          path: ./nargo
+          targets: ${{ matrix.target }}
 
-      - name: Install dependencies and Run noir-wasm-testing program
+      - name: Build Nargo
+        working-directory: noir
+        env:
+          BARRETENBERG_BIN_DIR: ${{ github.workspace }}/libbarretenberg-wasm32/bin
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libomp-dev
-          echo "Locating libomp.so"
-          libomp_path=$(find /usr/ -name libomp.so*)
-          echo "libomp.so located at $libomp_path"
-          nargo_binary=$(find $(pwd) -name "nargo" -type f)
-          echo "nargo binary found at $nargo_binary."
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
-          sudo ln -s /usr/lib/x86_64-linux-gnu/libomp.so.5 /usr/lib/x86_64-linux-gnu/libomp.so
+          cargo install cross --force --git https://github.com/cross-rs/cross
+          cross build --package nargo_cli --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
-          echo "Initial file permissions:"
-          ls -l $nargo_binary
-          echo "Attempting to make nargo binary executable:"
-          chmod +x $nargo_binary || echo "chmod failed with exit code $?"
-          echo "File permissions after chmod:"
-          ls -l $nargo_binary
-          echo "Updating LD_LIBRARY_PATH"
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname $libomp_path)
-          echo "Library dependencies of nargo binary:"
-          ldd $nargo_binary
-          if [ -x "$nargo_binary" ]; then
-            $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
-          else
-            echo "nargo binary NOT found or is not executable."
-            exit 1
-          fi
+      - name: Package artifacts
+        working-directory: noir
+        run: |
+          mkdir dist
+          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
+          7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
-      - name: Install dependencies
-        run: npm install
+      # You can access the artifacts directly from ./noir/dist/* here
+      - name: Test built artifact
+        if: startsWith(matrix.target, 'x86_64-unknown-linux')
+        run: |
+          cp ./noir/target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+          npm install
+          npm test
 
-      - name: Run tests
-        run: npm test
+  # build-wasm:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - uses: cachix/install-nix-action@v20
+  #       with:
+  #         nix_path: nixpkgs=channel:nixos-22.11
+  #         github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Build wasm package
+  #       run: |
+  #         nix build -L .#wasm
+
+  #     - name: Dereference symlink
+  #       run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
+
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: noir_wasm
+  #         path: ${{ env.UPLOAD_PATH }}
+  #         retention-days: 3
+
+  # build-nargo:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - uses: cachix/install-nix-action@v20
+  #       with:
+  #         nix_path: nixpkgs=channel:nixos-22.11
+  #         github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - uses: cachix/cachix-action@v12
+  #       with:
+  #         name: barretenberg
+
+  #     - name: Restore nix store cache
+  #       id: nix-store-cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: /tmp/nix-cache
+  #         key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
+
+  #     - name: Copy cache into nix store
+  #       if: steps.nix-store-cache.outputs.cache-hit == 'true'
+  #       run: |
+  #         for narinfo in /tmp/nix-cache/*.narinfo; do
+  #           path=$(head -n 1 "$narinfo" | awk '{print $2}')
+  #           nix copy --no-check-sigs --from "file:///tmp/nix-cache" "$path"
+  #         done
+
+  #     - name: Build nargo
+  #       run: |
+  #         nix build -L .
+
+  #     - name: Dereference symlink
+  #       run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
+
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: nargo
+  #         path: ${{ env.UPLOAD_PATH }}
+  #         retention-days: 3
+
+  # test:
+  #   needs: [build-wasm, build-nargo]
+  #   name: Test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout noir-wasm-testing
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: noir-lang/noir-wasm-testing
+  #         ref: use-injected-nargo
+
+  #     - name: Download wasm package artifact
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: noir_wasm
+  #         path: ./@noir-lang_noir_wasm
+
+  #     - name: Inject built wasm into noir-wasm-testing
+  #       run: |
+  #         jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./package.json > ./package.json.tmp
+  #         mv ./package.json.tmp ./package.json
+
+  #     - name: Download nargo binary
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: nargo
+  #         path: ./nargo
+
+  #     - name: Install dependencies and Run noir-wasm-testing program
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y libomp-dev
+  #         echo "Locating libomp.so"
+  #         libomp_path=$(find /usr/ -name libomp.so*)
+  #         echo "libomp.so located at $libomp_path"
+  #         nargo_binary=$(find $(pwd) -name "nargo" -type f)
+  #         echo "nargo binary found at $nargo_binary."
+  #         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+  #         sudo ln -s /usr/lib/x86_64-linux-gnu/libomp.so.5 /usr/lib/x86_64-linux-gnu/libomp.so
+
+  #         echo "Initial file permissions:"
+  #         ls -l $nargo_binary
+  #         echo "Attempting to make nargo binary executable:"
+  #         chmod +x $nargo_binary || echo "chmod failed with exit code $?"
+  #         echo "File permissions after chmod:"
+  #         ls -l $nargo_binary
+  #         echo "Updating LD_LIBRARY_PATH"
+  #         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname $libomp_path)
+  #         echo "Library dependencies of nargo binary:"
+  #         ldd $nargo_binary
+  #         if [ -x "$nargo_binary" ]; then
+  #           $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
+  #         else
+  #           echo "nargo binary NOT found or is not executable."
+  #           exit 1
+  #         fi
+
+  #     - name: Install dependencies
+  #       run: npm install
+
+  #     - name: Run tests
+  #       run: npm test

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           ls -R
           nargo_binary=$(find . -name "nargo")
-          nargo_binary=$(realpath $nargo_binary)
+          nargo_binary="$(pwd)/$nargo_binary"
           chmod +x $nargo_binary
           if [ -f "$nargo_binary" ]; then
             echo "nargo binary found at $nargo_binary."

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -108,16 +108,16 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: nargo
-          path: ./nargo
+          path: ./src/noir-script
 
       - name: Run noir-wasm-testing program 
+        working-directory: ./src/noir-script/
         run: |
           ls -l
-          ls -l ./nargo
-          ls -l ./nargo/bin
-          chmod +x ./nargo/bin/nargo
-          ls -l ./nargo/bin
-          ${{ github.workspace }}/nargo/bin/nargo -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
+          ls -l ./bin
+          chmod +x ./bin/nargo
+          ls -l ./bin
+          ./bin/nargo compile noir-wasm-testing
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install nargo
         run: | 
           curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-          noirup -p ./
+          $HOME/.nargo/bin/noirup -p ./
 
       - name: Inject built wasm into noir-wasm-testing
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -116,6 +116,9 @@ jobs:
 
       - name: Run noir-wasm-testing program 
         run: |
+          ls -l
+          ls -l ./nargo
+          ls -l ./nargo/bin
           chmod +x ./nargo/bin/nargo
           ./nargo/bin/nargo -p "./noir-wasm-testing/src/noir-script" compile noir-wasm-testing
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -119,6 +119,8 @@ jobs:
           chmod +x $nargo_binary || echo "chmod failed with exit code $?"
           echo "File permissions after chmod:"
           ls -l $nargo_binary
+          echo "Library dependencies of nargo binary:"
+          ldd $nargo_binary
           if [ -x "$nargo_binary" ]; then
             $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
           else

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -54,7 +54,7 @@ jobs:
           path: ${{ env.ARTIFACT_UPLOAD_PATH }}
           retention-days: 3
 
-  build-linux:
+  build-nargo:
     needs: [build-barretenberg]
     runs-on: ubuntu-22.04
     env:
@@ -123,136 +123,82 @@ jobs:
           cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
           cd ./build-nargo
           npm install
+          ls -R
           npm test
 
-  # build-wasm:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - uses: cachix/install-nix-action@v20
-  #       with:
-  #         nix_path: nixpkgs=channel:nixos-22.11
-  #         github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-22.11
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Build wasm package
-  #       run: |
-  #         nix build -L .#wasm
+      - name: Build wasm package
+        run: |
+          nix build -L .#wasm
 
-  #     - name: Dereference symlink
-  #       run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
+      - name: Dereference symlink
+        run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
 
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: noir_wasm
-  #         path: ${{ env.UPLOAD_PATH }}
-  #         retention-days: 3
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: noir_wasm
+          path: ${{ env.UPLOAD_PATH }}
+          retention-days: 3
 
-  # build-nargo:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+  test:
+    needs: [build-wasm, build-nargo]
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout noir-wasm-testing
+        uses: actions/checkout@v3
+        with:
+          repository: noir-lang/noir-wasm-testing
+          ref: use-injected-nargo
 
-  #     - uses: cachix/install-nix-action@v20
-  #       with:
-  #         nix_path: nixpkgs=channel:nixos-22.11
-  #         github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download wasm package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: noir_wasm
+          path: ./@noir-lang_noir_wasm
 
-  #     - uses: cachix/cachix-action@v12
-  #       with:
-  #         name: barretenberg
+      - name: Inject built wasm into noir-wasm-testing
+        run: |
+          jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./package.json > ./package.json.tmp
+          mv ./package.json.tmp ./package.json
 
-  #     - name: Restore nix store cache
-  #       id: nix-store-cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: /tmp/nix-cache
-  #         key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
+      - name: Download nargo binary
+        uses: actions/download-artifact@v3
+        with:
+          name: nargo
+          path: ./nargo
 
-  #     - name: Copy cache into nix store
-  #       if: steps.nix-store-cache.outputs.cache-hit == 'true'
-  #       run: |
-  #         for narinfo in /tmp/nix-cache/*.narinfo; do
-  #           path=$(head -n 1 "$narinfo" | awk '{print $2}')
-  #           nix copy --no-check-sigs --from "file:///tmp/nix-cache" "$path"
-  #         done
+      - name: Install dependencies and Run noir-wasm-testing program
+        run: |
+          nargo_binary=$(find $(pwd) -name "nargo" -type f)
+          echo "nargo binary found at $nargo_binary."
+          ls -l $nargo_binary
+          echo "Attempting to make nargo binary executable:"
+          chmod +x $nargo_binary || echo "chmod failed with exit code $?"
+          echo "File permissions after chmod:"
+          ls -l $nargo_binary
+          echo "Library dependencies of nargo binary:"
+          ldd $nargo_binary
+          if [ -x "$nargo_binary" ]; then
+            $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
+          else
+            echo "nargo binary NOT found or is not executable."
+            exit 1
+          fi
 
-  #     - name: Build nargo
-  #       run: |
-  #         nix build -L .
+      - name: Install dependencies
+        run: npm install
 
-  #     - name: Dereference symlink
-  #       run: echo "UPLOAD_PATH=$(readlink -f result)" >> $GITHUB_ENV
-
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: nargo
-  #         path: ${{ env.UPLOAD_PATH }}
-  #         retention-days: 3
-
-  # test:
-  #   needs: [build-wasm, build-nargo]
-  #   name: Test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout noir-wasm-testing
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: noir-lang/noir-wasm-testing
-  #         ref: use-injected-nargo
-
-  #     - name: Download wasm package artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: noir_wasm
-  #         path: ./@noir-lang_noir_wasm
-
-  #     - name: Inject built wasm into noir-wasm-testing
-  #       run: |
-  #         jq '.dependencies["@noir-lang/noir_wasm"] = "file:./@noir-lang_noir_wasm"' ./package.json > ./package.json.tmp
-  #         mv ./package.json.tmp ./package.json
-
-  #     - name: Download nargo binary
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: nargo
-  #         path: ./nargo
-
-  #     - name: Install dependencies and Run noir-wasm-testing program
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y libomp-dev
-  #         echo "Locating libomp.so"
-  #         libomp_path=$(find /usr/ -name libomp.so*)
-  #         echo "libomp.so located at $libomp_path"
-  #         nargo_binary=$(find $(pwd) -name "nargo" -type f)
-  #         echo "nargo binary found at $nargo_binary."
-  #         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
-  #         sudo ln -s /usr/lib/x86_64-linux-gnu/libomp.so.5 /usr/lib/x86_64-linux-gnu/libomp.so
-
-  #         echo "Initial file permissions:"
-  #         ls -l $nargo_binary
-  #         echo "Attempting to make nargo binary executable:"
-  #         chmod +x $nargo_binary || echo "chmod failed with exit code $?"
-  #         echo "File permissions after chmod:"
-  #         ls -l $nargo_binary
-  #         echo "Updating LD_LIBRARY_PATH"
-  #         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname $libomp_path)
-  #         echo "Library dependencies of nargo binary:"
-  #         ldd $nargo_binary
-  #         if [ -x "$nargo_binary" ]; then
-  #           $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
-  #         else
-  #           echo "nargo binary NOT found or is not executable."
-  #           exit 1
-  #         fi
-
-  #     - name: Install dependencies
-  #       run: npm install
-
-  #     - name: Run tests
-  #       run: npm test
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -115,9 +115,11 @@ jobs:
           echo "Locating libomp.so"
           libomp_path=$(find /usr/ -name libomp.so*)
           echo "libomp.so located at $libomp_path"
-          ls -R
           nargo_binary=$(find $(pwd) -name "nargo" -type f)
           echo "nargo binary found at $nargo_binary."
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+          sudo ln -s /usr/lib/x86_64-linux-gnu/libomp.so.5 /usr/lib/x86_64-linux-gnu/libomp.so
+
           echo "Initial file permissions:"
           ls -l $nargo_binary
           echo "Attempting to make nargo binary executable:"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -112,6 +112,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libomp-dev
+          echo "Locating libomp.so"
+          libomp_path=$(locate libomp.so)
+          echo "libomp.so located at $libomp_path"
 
       - name: Run noir-wasm-testing program
         run: |
@@ -124,6 +127,8 @@ jobs:
           chmod +x $nargo_binary || echo "chmod failed with exit code $?"
           echo "File permissions after chmod:"
           ls -l $nargo_binary
+          echo "Updating LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname ${{ env.libomp_path }})
           echo "Library dependencies of nargo binary:"
           ldd $nargo_binary
           if [ -x "$nargo_binary" ]; then

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -112,9 +112,10 @@ jobs:
         run: |
           ls -l
           ls -l ./nargo
-          chmod +x ./nargo/nargo
-          ls -l ./nargo
-          ${{ github.workspace }}/nargo/nargo -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
+          ls -l ./nargo/bin
+          chmod +x ./nargo/bin/nargo
+          ls -l ./nargo/bin
+          ${{ github.workspace }}/nargo/bin/nargo -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -110,12 +110,16 @@ jobs:
 
       - name: Run noir-wasm-testing program
         run: |
-          ls -l
-          ls -l ./nargo
-          ls -l ./nargo/bin
-          chmod +x ./nargo/bin/nargo
-          ls -l ./nargo/bin
-          ${{ github.workspace }}/nargo/bin/nargo -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
+          ls -R
+          nargo_binary=$(find . -name "nargo")
+          chmod +x $nargo_binary
+          if [ -f "$nargo_binary" ]; then
+            echo "nargo binary found at $nargo_binary."
+            $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
+          else
+            echo "nargo binary NOT found."
+            exit 1
+          fi
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - jb/noir-testing-workflow
+      - tom/noir-wasm-testing
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
@@ -31,7 +32,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: noir-lang/noir-wasm-testing
+          ref: use-injected-nargo
           path: noir-wasm-testing
+
+      - name: Install nargo
+        run: | 
+          curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
+          noirup -p ./
 
       - name: Inject built wasm into noir-wasm-testing
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: nargo-${{ matrix.target }}
+          name: nargo
           path: ./dist/*
           retention-days: 3
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -113,8 +113,8 @@ jobs:
           ls -R
           nargo_binary=$(find $(pwd) -name "nargo" -type f)
           echo "nargo binary found at $nargo_binary."
+          chmod +x $nargo_binary
           if [ -x "$nargo_binary" ]; then
-            chmod +x $nargo_binary
             $nargo_binary -p "${{ github.workspace }}/src/noir-script" compile noir-wasm-testing
           else
             echo "nargo binary NOT found."

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -115,7 +115,9 @@ jobs:
           mv ./noir-wasm-testing/package.json.tmp ./noir-wasm-testing/package.json
 
       - name: Run noir-wasm-testing program 
-        run: ./nargo/bin/nargo -p "./noir-wasm-testing/src/noir-script" compile noir-wasm-testing
+        run: |
+          chmod +x ./nargo/bin/nargo
+          ./nargo/bin/nargo -p "./noir-wasm-testing/src/noir-script" compile noir-wasm-testing
 
       - name: Install dependencies
         working-directory: ./noir-wasm-testing

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -90,12 +90,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Setup Nix
-        uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-22.11
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout noir-wasm-testing
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -111,8 +111,7 @@ jobs:
       - name: Run noir-wasm-testing program
         run: |
           ls -R
-          nargo_binary=$(find . -name "nargo")
-          nargo_binary="$(pwd)/$nargo_binary"
+          nargo_binary=$(find $(pwd) -name "nargo")
           chmod +x $nargo_binary
           if [ -f "$nargo_binary" ]; then
             echo "nargo binary found at $nargo_binary."

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -150,7 +150,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: noir-lang/noir-wasm-testing
-          ref: use-injected-nargo
 
       - name: Download wasm package artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is a pretty hacky solution to the mismatch of noirc versions between CLI and WASM. We should in future get wasm to reuse the build artifacts we have commited.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
