### PR TITLE
fix: Slice initialization

### DIFF
--- a/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_slices/src/main.nr
+++ b/crates/nargo_cli/tests/test_data_ssa_refactor/brillig_slices/src/main.nr
@@ -2,71 +2,75 @@ use dep::std::slice;
 use dep::std;
 
 unconstrained fn main(x: Field, y: Field) {
-    // Mark it as mut so the compiler doesn't simplify the following operations
-    // But don't reuse the mut slice variable until this is fixed https://github.com/noir-lang/noir/issues/1931
-    let slice: [Field] = [y, x];
+    let mut slice: [Field] = [y, x];
     assert(slice.len() == 2);
 
-    let mut pushed_back_slice = slice.push_back(7);
-    assert(pushed_back_slice.len() == 3);
-    assert(pushed_back_slice[0] == y);
-    assert(pushed_back_slice[1] == x);
-    assert(pushed_back_slice[2] == 7);
+    slice = slice.push_back(7);
+    assert(slice.len() == 3);
+    assert(slice[0] == y);
+    assert(slice[1] == x);
+    assert(slice[2] == 7);
 
     // Array set on slice target
-    pushed_back_slice[0] = x;
-    pushed_back_slice[1] = y;
-    pushed_back_slice[2] = 1;
+    slice[0] = x;
+    slice[1] = y;
+    slice[2] = 1;
 
-    assert(pushed_back_slice[0] == x);
-    assert(pushed_back_slice[1] == y);
-    assert(pushed_back_slice[2] == 1);
+    assert(slice[0] == x);
+    assert(slice[1] == y);
+    assert(slice[2] == 1);
 
-    assert(slice.len() == 2);
+    slice = push_front_to_slice(slice, 2);
+    assert(slice.len() == 4);
+    assert(slice[0] == 2);
+    assert(slice[1] == x);
+    assert(slice[2] == y);
+    assert(slice[3] == 1);
 
-    let pushed_front_slice = pushed_back_slice.push_front(2);
-    assert(pushed_front_slice.len() == 4);
-    assert(pushed_front_slice[0] == 2);
-    assert(pushed_front_slice[1] == x);
-    assert(pushed_front_slice[2] == y);
-    assert(pushed_front_slice[3] == 1);
-
-    let (item, popped_front_slice) = pushed_front_slice.pop_front();
+    let (item, popped_front_slice) = slice.pop_front();
+    slice = popped_front_slice;
     assert(item == 2);
 
-    assert(popped_front_slice.len() == 3);
-    assert(popped_front_slice[0] == x);
-    assert(popped_front_slice[1] == y);
-    assert(popped_front_slice[2] == 1);
+    assert(slice.len() == 3);
+    assert(slice[0] == x);
+    assert(slice[1] == y);
+    assert(slice[2] == 1);
 
-    let (popped_back_slice, another_item) = popped_front_slice.pop_back();
+    let (popped_back_slice, another_item) = slice.pop_back();
+    slice = popped_back_slice;
     assert(another_item == 1);
 
-    assert(popped_back_slice.len() == 2);
-    assert(popped_back_slice[0] == x);
-    assert(popped_back_slice[1] == y);
+    assert(slice.len() == 2);
+    assert(slice[0] == x);
+    assert(slice[1] == y);
 
-    let inserted_slice = popped_back_slice.insert(1, 2);
-    assert(inserted_slice.len() == 3);
-    assert(inserted_slice[0] == x);
-    assert(inserted_slice[1] == 2);
-    assert(inserted_slice[2] == y);
+    slice = slice.insert(1, 2);
+    assert(slice.len() == 3);
+    assert(slice[0] == x);
+    assert(slice[1] == 2);
+    assert(slice[2] == y);
 
-    let (removed_slice, should_be_2) = inserted_slice.remove(1);
+    let (removed_slice, should_be_2) = slice.remove(1);
+    slice = removed_slice;
     assert(should_be_2 == 2);
 
-    assert(removed_slice.len() == 2);
-    assert(removed_slice[0] == x);
-    assert(removed_slice[1] == y);
+    assert(slice.len() == 2);
+    assert(slice[0] == x);
+    assert(slice[1] == y);
 
-    let (slice_with_only_x, should_be_y) = removed_slice.remove(1);
+    let (slice_with_only_x, should_be_y) = slice.remove(1);
+    slice = slice_with_only_x;
     assert(should_be_y == y);
 
-    assert(slice_with_only_x.len() == 1);
-    assert(removed_slice[0] == x);
+    assert(slice.len() == 1);
+    assert(slice[0] == x);
 
-    let (empty_slice, should_be_x) = slice_with_only_x.remove(0);
+    let (empty_slice, should_be_x) = slice.remove(0);
     assert(should_be_x == x);
     assert(empty_slice.len() == 0);
 }
 
+// Tests slice passing to/from functions
+unconstrained fn push_front_to_slice<T>(slice: [T], item: T) -> [T] {
+    slice.push_front(item)
+}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

After @jfecher PR https://github.com/noir-lang/noir/pull/2070 now Value::Array can have Type::Slice. This PR tries to handle it appropiately.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
