### PR TITLE
fix: avoid potential panic in `two_complement`

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/generated_acir.rs
@@ -248,8 +248,11 @@ impl GeneratedAcir {
     ) -> Expression {
         let max_power_of_two =
             FieldElement::from(2_i128).pow(&FieldElement::from(max_bit_size as i128 - 1));
-        let inter = &(&Expression::from_field(max_power_of_two) - lhs) * &leading.into();
-        lhs.add_mul(FieldElement::from(2_i128), &inter.unwrap())
+
+        let intermediate =
+            self.mul_with_witness(&(&Expression::from(max_power_of_two) - lhs), &leading.into());
+
+        lhs.add_mul(FieldElement::from(2_i128), &intermediate)
     }
 
     /// Returns an expression which represents `lhs * rhs`


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

`GeneratedAcir::two_complement` will currently panic if `lhs` is a degree 2 expression. This PR uses `mul_with_witness` to avoid this potential panic.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
