### PR TITLE
feat(acir_gen): RecursiveAggregation opcode and updates to black box func call generation

### DIFF
--- a/crates/nargo_cli/tests/test_data/config.toml
+++ b/crates/nargo_cli/tests/test_data/config.toml
@@ -2,4 +2,4 @@ exclude = []
 
 
 # List of tests (as their directory name) expecting to fail: if the test pass, we report an error.
-fail = ["brillig_assert_fail", "dep_impl_primitive"]
+fail = ["brillig_assert_fail", "dep_impl_primitive", "recursive_aggregation"]

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/acir_ir/acir_variable.rs
@@ -240,7 +240,7 @@ impl AcirContext {
         typ: AcirType,
     ) -> Result<AcirVar, AcirGenError> {
         let inputs = vec![AcirValue::Var(lhs, typ.clone()), AcirValue::Var(rhs, typ)];
-        let outputs = self.black_box_function(BlackBoxFunc::XOR, inputs)?;
+        let outputs = self.black_box_function(BlackBoxFunc::XOR, inputs, 1)?;
         Ok(outputs[0])
     }
 
@@ -252,7 +252,7 @@ impl AcirContext {
         typ: AcirType,
     ) -> Result<AcirVar, AcirGenError> {
         let inputs = vec![AcirValue::Var(lhs, typ.clone()), AcirValue::Var(rhs, typ)];
-        let outputs = self.black_box_function(BlackBoxFunc::AND, inputs)?;
+        let outputs = self.black_box_function(BlackBoxFunc::AND, inputs, 1)?;
         Ok(outputs[0])
     }
 
@@ -279,7 +279,7 @@ impl AcirContext {
             let a = self.sub_var(max, lhs)?;
             let b = self.sub_var(max, rhs)?;
             let inputs = vec![AcirValue::Var(a, typ.clone()), AcirValue::Var(b, typ)];
-            let outputs = self.black_box_function(BlackBoxFunc::AND, inputs)?;
+            let outputs = self.black_box_function(BlackBoxFunc::AND, inputs, 1)?;
             self.sub_var(max, outputs[0])
         }
     }
@@ -653,6 +653,7 @@ impl AcirContext {
         &mut self,
         name: BlackBoxFunc,
         mut inputs: Vec<AcirValue>,
+        output_count: usize,
     ) -> Result<Vec<AcirVar>, AcirGenError> {
         // Separate out any arguments that should be constants
         let constants = match name {
@@ -674,7 +675,7 @@ impl AcirContext {
         let inputs = self.prepare_inputs_for_black_box_func_call(inputs)?;
 
         // Call Black box with `FunctionInput`
-        let outputs = self.acir_ir.call_black_box(name, inputs, constants);
+        let outputs = self.acir_ir.call_black_box(name, &inputs, constants, output_count);
 
         // Convert `Witness` values which are now constrained to be the output of the
         // black box function call into `AcirVar`s.
@@ -690,9 +691,10 @@ impl AcirContext {
     fn prepare_inputs_for_black_box_func_call(
         &mut self,
         inputs: Vec<AcirValue>,
-    ) -> Result<Vec<FunctionInput>, AcirGenError> {
+    ) -> Result<Vec<Vec<FunctionInput>>, AcirGenError> {
         let mut witnesses = Vec::new();
         for input in inputs {
+            let mut single_val_witnesses = Vec::new();
             for (input, typ) in input.flatten() {
                 let var_data = &self.vars[&input];
 
@@ -702,8 +704,9 @@ impl AcirContext {
                 let expr = var_data.to_expression();
                 let witness = self.acir_ir.get_or_create_witness(&expr);
                 let num_bits = typ.bit_size();
-                witnesses.push(FunctionInput { witness, num_bits });
+                single_val_witnesses.push(FunctionInput { witness, num_bits });
             }
+            witnesses.push(single_val_witnesses);
         }
         Ok(witnesses)
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -880,7 +880,11 @@ impl Context {
             Intrinsic::BlackBox(black_box) => {
                 let inputs = vecmap(arguments, |arg| self.convert_value(*arg, dfg));
 
-                let vars = self.acir_context.black_box_function(black_box, inputs)?;
+                let output_count = result_ids.iter().fold(0usize, |sum, result_id| {
+                    sum + dfg.try_get_array_length(*result_id).unwrap_or(1)
+                });
+
+                let vars = self.acir_context.black_box_function(black_box, inputs, output_count)?;
 
                 Ok(Self::convert_vars_to_values(vars, dfg, result_ids))
             }

--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -18,11 +18,11 @@ mod compat;
 // Oracle calls are required to be wrapped in an unconstrained function
 // Thus, the only argument to the `println` oracle is expected to always be an ident 
 #[oracle(println)]
-unconstrained fn println_oracle<T, A>(_input: T) {}
+unconstrained fn println_oracle<T>(_input: T) {}
 
 unconstrained fn println<T>(input: T) {
     println_oracle(input);
 }
 
 #[foreign(recursive_aggregation)]
-fn verify_proof(_verification_key : [Field], _proof : [Field], _public_inputs : [Field], _key_hash : Field, _input_aggregation_object : [Field]) -> [Field] {}
+fn verify_proof<N>(_verification_key : [Field], _proof : [Field], _public_inputs : [Field], _key_hash : Field, _input_aggregation_object : [Field; N]) -> [Field; N] {}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #1570

## Summary\*

This PR generates the `BlackBoxFuncCall::RecursiveAggregation` opcode. Due to the opcode being more complex some updates had to be done to how we generate black box func calls. 
1. We supported variable black box func inputs, but only for a singular value. This has been updated to handle multiple inputs that can all be variable
2. We fetch the output count before generating a black box function. This is used for generating the output witnesses in case we have variable outputs and cannot check against a hardcoded output count.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
