### PR TITLE
chore: implement arrayLen in acir_gen

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -996,6 +996,19 @@ impl Context {
 
                 Ok(Self::convert_vars_to_values(out_vars, dfg, result_ids))
             }
+            Intrinsic::ArrayLen => {
+                let argument = arguments.first().expect("arraylen must have one argument");
+                let value = self.convert_value(dfg.resolve(*argument), dfg);
+                let len = match value {
+                    AcirValue::Var(_, _) => unreachable!("ICE - expected an array"),
+                    AcirValue::Array(values) => values.len(),
+                    AcirValue::DynamicArray(array) => array.len,
+                };
+                Ok(vec![AcirValue::Var(
+                    self.acir_context.add_constant(FieldElement::from(len as u128)),
+                    AcirType::NumericType(NumericType::NativeField),
+                )])
+            }
             _ => todo!("expected a black box function"),
         }
     }


### PR DESCRIPTION
# Description

Implement arrayLen in acir_gen

## Problem\*
When the length of the array cannot be resolved , we still have arrayLen intrinsic calls in acir_gen 


Resolves #1023 

## Summary\*

I add handling of arrayLen intrinsic during acir_gen.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
