### PR TITLE
chore: Make a more clear error for slices passed to std::println

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/acir_gen/mod.rs
@@ -1002,7 +1002,7 @@ impl Context {
             }
             Intrinsic::ArrayLen => {
                 let len = match self.convert_value(arguments[0], dfg) {
-                    AcirValue::Var(_, _) =>  unreachable!("Non-array passed to array.len() method"),
+                    AcirValue::Var(_, _) => unreachable!("Non-array passed to array.len() method"),
                     AcirValue::Array(values) => (values.len() as u128).into(),
                     AcirValue::DynamicArray(array) => (array.len as u128).into(),
                 };

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -758,7 +758,7 @@ impl<'interner> Monomorphizer<'interner> {
     fn append_abi_arg_inner(typ: &Type, arguments: &mut Vec<ast::Expression>) {
         if let HirType::Array(size, _) = typ {
             if let HirType::NotConstant = **size {
-                unreachable!("Slices are not supported with println. Convert the slice to an array before passing it to println");
+                unreachable!("println does not support slices. Convert the slice to an array before passing it to println");
             }
         }
         let abi_type = typ.as_abi_type();


### PR DESCRIPTION
# Description

## Problem\*

Relates to https://github.com/noir-lang/noir/issues/1344#issuecomment-1656017435 but does not solve the issue.

## Summary\*

Slices cannot be supported for println yet as we do support slices as an entry point for Brillig generation. This is because the Brillig entry point expects a set amount of expressions and it cannot be unknown. Slices will not be supported in Brillig gen until we add another pass or some other context information to track slice sizes. Once slices are enabled for Brillig entry points the linked issue will be able to be fully resolved. 

For now, this PR simply clarifies the error so that the user does not get information about the main func and the ABI:
```
Message:  internal error: entered unreachable code: println does not support slices. Convert the slice to an array before passing it to println
Location: crates/noirc_frontend/src/monomorphization/mod.rs:761

This is a bug. We may have already fixed this in newer versions of Nargo so try searching for similar issues at https://github.com/noir-lang/noir/issues/.
If there isn't an open issue for this bug, consider opening one at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 8 frames hidden ⋮                               
   9: noirc_frontend::monomorphization::Monomorphizer::append_abi_arg_inner::ha447d9002b33ba3c
      at <unknown source file>:<unknown line>
  10: noirc_frontend::monomorphization::Monomorphizer::append_abi_arg::h2cde20c1cb416df2
      at <unknown source file>:<unknown line>
  11: noirc_frontend::monomorphization::Monomorphizer::expr::hafd2e2677c8f0090
      at <unknown source file>:<unknown line>
  12: noirc_frontend::monomorphization::Monomorphizer::statement::ha7146438d1ed7b6f
```

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
