### PR TITLE
fix: flattening pass no longer overwrites previously mapped condition values

### DIFF
--- a/crates/nargo_cli/tests/test_data/regression_2099/Nargo.toml
+++ b/crates/nargo_cli/tests/test_data/regression_2099/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_2099"
+authors = [""]
+compiler_version = "0.9.0"
+
+[dependencies]

--- a/crates/nargo_cli/tests/test_data/regression_2099/src/main.nr
+++ b/crates/nargo_cli/tests/test_data/regression_2099/src/main.nr
@@ -1,0 +1,37 @@
+use dep::std::ec::tecurve::affine::Curve as AffineCurve;
+use dep::std::ec::tecurve::affine::Point as Gaffine;
+use dep::std::ec::tecurve::curvegroup::Curve;
+use dep::std::ec::tecurve::curvegroup::Point as G;
+
+use dep::std::ec::swcurve::affine::Point as SWGaffine;
+use dep::std::ec::swcurve::curvegroup::Point as SWG;
+
+use dep::std::ec::montcurve::affine::Point as MGaffine;
+use dep::std::ec::montcurve::curvegroup::Point as MG;
+
+fn main() {
+    // Define Baby Jubjub (ERC-2494) parameters in affine representation
+    let bjj_affine = AffineCurve::new(168700, 168696, Gaffine::new(995203441582195749578291179787384436505546430278305826713579947235728471134,5472060717959818805561601436314318772137091100104008585924551046643952123905));
+
+    // Test addition
+    let p1_affine = Gaffine::new(17777552123799933955779906779655732241715742912184938656739573121738514868268, 2626589144620713026669568689430873010625803728049924121243784502389097019475);
+    let p2_affine = Gaffine::new(16540640123574156134436876038791482806971768689494387082833631921987005038935, 20819045374670962167435360035096875258406992893633759881276124905556507972311);      
+    let _p3_affine = bjj_affine.add(p1_affine, p2_affine);
+    
+    // Test SWCurve equivalents of the above
+    // First the affine representation
+    let bjj_swcurve_affine = bjj_affine.into_swcurve();
+
+    let p1_swcurve_affine = bjj_affine.map_into_swcurve(p1_affine);
+    let p2_swcurve_affine = bjj_affine.map_into_swcurve(p2_affine);
+
+    let _p3_swcurve_affine_from_add = bjj_swcurve_affine.add(
+        p1_swcurve_affine,
+        p2_swcurve_affine
+    );
+
+    // Check that these points are on the curve
+    assert(
+        bjj_swcurve_affine.contains(p1_swcurve_affine)
+    );            
+}

--- a/crates/noirc_evaluator/src/ssa_refactor/ir/function_inserter.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/function_inserter.rs
@@ -124,7 +124,6 @@ impl<'f> FunctionInserter<'f> {
         let old_parameters = self.function.dfg.block_parameters(block);
 
         for (param, new_param) in old_parameters.iter().zip(new_values) {
-            // Don't overwrite any existing entries to avoid overwriting the induction variable
             self.values.entry(*param).or_insert(*new_param);
         }
     }

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -274,7 +274,10 @@ impl<'f> Context<'f> {
                 // end, in addition to resetting the value of old_condition since it is set to
                 // known to be true/false within the then/else branch respectively.
                 self.insert_current_side_effects_enabled();
-                self.inserter.map_value(old_condition, old_condition);
+
+                // We must map back to then_condition here. Mapping old_condition to itself would
+                // lose any previous mappings.
+                self.inserter.map_value(old_condition, then_condition);
 
                 // While there is a condition on the stack we don't compile outside the condition
                 // until it is popped. This ensures we inline the full then and else branches

--- a/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/opt/flatten_cfg.rs
@@ -275,7 +275,7 @@ impl<'f> Context<'f> {
                 // known to be true/false within the then/else branch respectively.
                 self.insert_current_side_effects_enabled();
 
-                // We must map back to then_condition here. Mapping old_condition to itself would
+                // We must map back to `then_condition` here. Mapping `old_condition` to itself would
                 // lose any previous mappings.
                 self.inserter.map_value(old_condition, then_condition);
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #2099 and the issue in #1954, although #2099 is now failing with another error that looks to require #2106.

## Summary\*

When resetting the mapping of the condition value during flattening, we were mapping it to its old value directly, rather than the value it was previously mapped to. This had the effect of forgetting any previous mappings which made it possible for (among other things) block parameters of previously deleted blocks to remain in the code.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

CC @TomAFrench since this unblocks his PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
