### PR TITLE
chore(noirc_driver): Unify crate preparation

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -22,7 +22,7 @@ use lsp_types::{
     InitializeParams, InitializeResult, InitializedParams, Position, PublishDiagnosticsParams,
     Range, ServerCapabilities, TextDocumentSyncOptions,
 };
-use noirc_driver::{check_crate, create_local_crate};
+use noirc_driver::{check_crate, prepare_crate};
 use noirc_errors::{DiagnosticKind, FileDiagnostic};
 use noirc_frontend::{
     graph::{CrateGraph, CrateType},
@@ -190,7 +190,7 @@ fn on_code_lens_request(
         }
     };
 
-    let crate_id = create_local_crate(&mut context, file_path, CrateType::Binary);
+    let crate_id = prepare_crate(&mut context, file_path, CrateType::Binary);
 
     // We ignore the warnings and errors produced by compilation for producing codelenses
     // because we can still get the test functions even if compilation fails
@@ -283,7 +283,7 @@ fn on_did_save_text_document(
         }
     };
 
-    let crate_id = create_local_crate(&mut context, file_path, CrateType::Binary);
+    let crate_id = prepare_crate(&mut context, file_path, CrateType::Binary);
 
     let mut diagnostics = Vec::new();
 

--- a/crates/lsp/src/lib_hacky.rs
+++ b/crates/lsp/src/lib_hacky.rs
@@ -19,7 +19,7 @@ use lsp_types::{
     InitializedParams, Position, PublishDiagnosticsParams, Range, ServerCapabilities,
     TextDocumentSyncOptions,
 };
-use noirc_driver::{check_crate, create_local_crate, create_non_local_crate, propagate_dep};
+use noirc_driver::{check_crate, prepare_crate, propagate_dep};
 use noirc_errors::{DiagnosticKind, FileDiagnostic};
 use noirc_frontend::{
     graph::{CrateGraph, CrateId, CrateType},
@@ -286,7 +286,7 @@ fn create_context_at_path(
     }
     let nargo_toml_path = find_nearest_parent_file(&file_path, &["Nargo.toml"]);
 
-    let current_crate_id = create_local_crate(&mut context, &file_path, CrateType::Binary);
+    let current_crate_id = prepare_crate(&mut context, &file_path, CrateType::Binary);
 
     // TODO(AD): undo hacky dependency resolution
     if let Some(nargo_toml_path) = nargo_toml_path {
@@ -297,8 +297,7 @@ fn create_context_at_path(
                     .parent()
                     .unwrap() // TODO
                     .join(PathBuf::from(&dependency_path).join("src").join("lib.nr"));
-                let library_crate =
-                    create_non_local_crate(&mut context, &path_to_lib, CrateType::Library);
+                let library_crate = prepare_crate(&mut context, &path_to_lib, CrateType::Library);
                 propagate_dep(&mut context, library_crate, &crate_name.parse().unwrap());
             }
         }

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -92,7 +92,7 @@ pub fn start_cli() -> eyre::Result<()> {
 #[cfg(test)]
 mod tests {
     use fm::FileManager;
-    use noirc_driver::{check_crate, create_local_crate};
+    use noirc_driver::{check_crate, prepare_crate};
     use noirc_errors::reporter;
     use noirc_frontend::{
         graph::{CrateGraph, CrateType},
@@ -110,7 +110,7 @@ mod tests {
         let fm = FileManager::new(root_dir);
         let graph = CrateGraph::default();
         let mut context = Context::new(fm, graph);
-        let crate_id = create_local_crate(&mut context, root_file, CrateType::Binary);
+        let crate_id = prepare_crate(&mut context, root_file, CrateType::Binary);
 
         let result = check_crate(&mut context, crate_id, false);
         let success = result.is_ok();

--- a/crates/nargo_cli/src/lib.rs
+++ b/crates/nargo_cli/src/lib.rs
@@ -9,7 +9,7 @@
 
 use fm::FileManager;
 use nargo::package::{Dependency, Package};
-use noirc_driver::{add_dep, create_local_crate, create_non_local_crate};
+use noirc_driver::{add_dep, prepare_crate};
 use noirc_frontend::{
     graph::{CrateGraph, CrateId, CrateName, CrateType},
     hir::Context,
@@ -107,8 +107,7 @@ fn prepare_dependencies(
     for (dep_name, dep) in dependencies.into_iter() {
         match dep {
             Dependency::Remote { package } | Dependency::Local { package } => {
-                let crate_id =
-                    create_non_local_crate(context, &package.entry_path, package.crate_type);
+                let crate_id = prepare_crate(context, &package.entry_path, package.crate_type);
                 add_dep(context, parent_crate, crate_id, dep_name);
                 prepare_dependencies(context, crate_id, package.dependencies.to_owned());
             }
@@ -121,7 +120,7 @@ fn prepare_package(package: &Package) -> (Context, CrateId) {
     let graph = CrateGraph::default();
     let mut context = Context::new(fm, graph);
 
-    let crate_id = create_local_crate(&mut context, &package.entry_path, package.crate_type);
+    let crate_id = prepare_crate(&mut context, &package.entry_path, package.crate_type);
 
     prepare_dependencies(&mut context, crate_id, package.dependencies.to_owned());
 

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -52,37 +52,14 @@ pub fn compile_file(
     context: &mut Context,
     root_file: &Path,
 ) -> Result<(CompiledProgram, Warnings), ErrorsAndWarnings> {
-    let crate_id = create_local_crate(context, root_file, CrateType::Binary);
+    let crate_id = prepare_crate(context, root_file, CrateType::Binary);
     compile_main(context, crate_id, &CompileOptions::default())
 }
 
-/// Adds the File with the local crate root to the file system
-/// and adds the local crate to the graph
-/// XXX: This may pose a problem with workspaces, where you can change the local crate and where
-/// we have multiple binaries in one workspace
-/// A Fix would be for the driver instance to store the local crate id.
-// Granted that this is the only place which relies on the local crate being first
-pub fn create_local_crate(
-    context: &mut Context,
-    file_name: &Path,
-    crate_type: CrateType,
-) -> CrateId {
+/// Adds the file from the file system at `Path` to the crate graph
+pub fn prepare_crate(context: &mut Context, file_name: &Path, crate_type: CrateType) -> CrateId {
     let root_file_id = context.file_manager.add_file(file_name).unwrap();
 
-    context.crate_graph.add_crate_root(crate_type, root_file_id)
-}
-
-/// Creates a Non Local Crate. A Non Local Crate is any crate which is the not the crate that
-/// the compiler is compiling.
-pub fn create_non_local_crate(
-    context: &mut Context,
-    file_name: &Path,
-    crate_type: CrateType,
-) -> CrateId {
-    let root_file_id = context.file_manager.add_file(file_name).unwrap();
-
-    // You can add any crate type to the crate graph
-    // but you cannot depend on Binaries
     context.crate_graph.add_crate_root(crate_type, root_file_id)
 }
 

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -3,8 +3,8 @@ use fm::FileManager;
 use gloo_utils::format::JsValueSerdeExt;
 use log::debug;
 use noirc_driver::{
-    check_crate, compile_contracts, compile_no_check, create_local_crate, create_non_local_crate,
-    propagate_dep, CompileOptions, CompiledContract,
+    check_crate, compile_contracts, compile_no_check, prepare_crate, propagate_dep, CompileOptions,
+    CompiledContract,
 };
 use noirc_frontend::{
     graph::{CrateGraph, CrateType},
@@ -63,7 +63,7 @@ impl Default for WASMCompileOptions {
 
 fn add_noir_lib(context: &mut Context, crate_name: &str) {
     let path_to_lib = Path::new(&crate_name).join("lib.nr");
-    let library_crate = create_non_local_crate(context, &path_to_lib, CrateType::Library);
+    let library_crate = prepare_crate(context, &path_to_lib, CrateType::Library);
 
     propagate_dep(context, library_crate, &crate_name.parse().unwrap());
 }
@@ -87,7 +87,7 @@ pub fn compile(args: JsValue) -> JsValue {
     let mut context = Context::new(fm, graph);
 
     let path = Path::new(&options.entry_point);
-    let crate_id = create_local_crate(&mut context, path, CrateType::Binary);
+    let crate_id = prepare_crate(&mut context, path, CrateType::Binary);
 
     for dependency in options.optional_dependencies_set {
         add_noir_lib(&mut context, dependency.as_str());


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

While working on my CrateType PR, I noticed that these functions are now exactly the same. This can land before the CrateType work is finished.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
