### PR TITLE
chore: create a `const` to hold the panic message

### DIFF
--- a/crates/nargo_cli/src/main.rs
+++ b/crates/nargo_cli/src/main.rs
@@ -3,12 +3,12 @@
 use color_eyre::{config::HookBuilder, eyre};
 use nargo_cli::cli::start_cli;
 
+const PANIC_MESSAGE: &str = "This is a bug. We may have already fixed this in newer versions of Nargo so try searching for similar issues at https://github.com/noir-lang/noir/issues/.\nIf there isn't an open issue for this bug, consider opening one at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml";
+
 fn main() -> eyre::Result<()> {
     // Register a panic hook to display more readable panic messages to end-users
-    let (panic_hook, _) = HookBuilder::default()
-        .display_env_section(false)
-        .panic_section("This is a bug. We may have already fixed this in newer versions of Nargo so try searching for similar issues at https://github.com/noir-lang/noir/issues/.\nIf there isn't an open issue for this bug, consider opening one at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml")
-        .into_hooks();
+    let (panic_hook, _) =
+        HookBuilder::default().display_env_section(false).panic_section(PANIC_MESSAGE).into_hooks();
     panic_hook.install();
 
     start_cli()


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Having this large string literal makes diffs a little ugly (see #2118). I've then split it off into a `const` to keep it out of the way.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
