### PR TITLE
feat: Add additional `BinaryOp` simplifications

### DIFF
--- a/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa_refactor/ir/instruction.rs
@@ -733,6 +733,9 @@ impl Binary {
                     let zero = dfg.make_constant(FieldElement::zero(), operand_type);
                     return SimplifyResult::SimplifiedTo(zero);
                 }
+                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
+                    return SimplifyResult::SimplifiedTo(self.lhs);
+                }
             }
             BinaryOp::Or => {
                 if lhs_is_zero {
@@ -741,8 +744,17 @@ impl Binary {
                 if rhs_is_zero {
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }
+                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
+                    return SimplifyResult::SimplifiedTo(self.lhs);
+                }
             }
             BinaryOp::Xor => {
+                if lhs_is_zero {
+                    return SimplifyResult::SimplifiedTo(self.rhs);
+                }
+                if rhs_is_zero {
+                    return SimplifyResult::SimplifiedTo(self.lhs);
+                }
                 if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
                     let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                     return SimplifyResult::SimplifiedTo(zero);


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds additional simplification rules for `BinaryOps` for special cases of the operations where the operation is a no-op.

```rust
fn main(x: u32) -> distinct pub [u32; 3] {
    let mut result : [u32; 3] = [0; 3];
    result[0] = x ^ 0;
    result[1] = x & x;
    result[2] = x | x;
    result
}
```

On the latest nightly this compiles to

```
Compiled ACIR for main (unoptimized):
current witness index : 11
public parameters indices : []
return value indices : [9, 10, 11]
BLACKBOX::RANGE [(_1, num_bits: 32)] [ ]
EXPR [ (-1, _2) 0 ]
BLACKBOX::XOR [(_1, num_bits: 32), (_2, num_bits: 32)] [ _3]
BLACKBOX::AND [(_1, num_bits: 32), (_1, num_bits: 32)] [ _4]
EXPR [ (-1, _1) (-1, _5) 4294967295 ]
EXPR [ (-1, _1) (-1, _6) 4294967295 ]
BLACKBOX::AND [(_5, num_bits: 32), (_6, num_bits: 32)] [ _7]
EXPR [ (-1, _7) (-1, _8) 4294967295 ]
EXPR [ (1, _3) (-1, _9) 0 ]
EXPR [ (1, _4) (-1, _10) 0 ]
EXPR [ (1, _8) (-1, _11) 0 ]
```

With this PR, this is compiled down to

```
Compiled ACIR for main (unoptimized):
current witness index : 4
public parameters indices : []
return value indices : [2, 3, 4]
BLACKBOX::RANGE [(_1, num_bits: 32)] [ ]
EXPR [ (1, _1) (-1, _2) 0 ]
EXPR [ (1, _1) (-1, _3) 0 ]
EXPR [ (1, _1) (-1, _4) 0 ]
```


## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
