### PR TITLE
fix: Rename `Option::value` to `Option::_value`

### DIFF
--- a/noir_stdlib/src/option.nr
+++ b/noir_stdlib/src/option.nr
@@ -1,17 +1,17 @@
 struct Option<T> {
     _is_some: bool,
-    value: T,
+    _value: T,
 }
 
 impl<T> Option<T> {
     /// Constructs a None value
     fn none() -> Self {
-        Self { _is_some: false, value: crate::unsafe::zeroed() }
+        Self { _is_some: false, _value: crate::unsafe::zeroed() }
     }
 
     /// Constructs a Some wrapper around the given value
-    fn some(value: T) -> Self {
-        Self { _is_some: true, value }
+    fn some(_value: T) -> Self {
+        Self { _is_some: true, _value }
     }
 
     /// True if this Option is None
@@ -27,13 +27,13 @@ impl<T> Option<T> {
     /// Asserts `self.is_some()` and returns the wrapped value.
     fn unwrap(self) -> T {
         assert(self._is_some);
-        self.value
+        self._value
     }
 
     /// Returns the wrapped value if `self.is_some()`. Otherwise, returns the given default value.
     fn unwrap_or(self, default: T) -> T {
         if self._is_some {
-            self.value
+            self._value
         } else {
             default
         }
@@ -43,7 +43,7 @@ impl<T> Option<T> {
     /// a default value.
     fn unwrap_or_else(self, default: fn() -> T) -> T {
         if self._is_some {
-            self.value
+            self._value
         } else {
             default()
         }
@@ -52,7 +52,7 @@ impl<T> Option<T> {
     /// If self is `Some(x)`, this returns `Some(f(x))`. Otherwise, this returns `None`.
     fn map<U>(self, f: fn(T) -> U) -> Option<U> {
         if self._is_some {
-            Option::some(f(self.value))
+            Option::some(f(self._value))
         } else {
             Option::none()
         }
@@ -61,7 +61,7 @@ impl<T> Option<T> {
     /// If self is `Some(x)`, this returns `f(x)`. Otherwise, this returns the given default value.
     fn map_or<U>(self, default: U, f: fn(T) -> U) -> U {
         if self._is_some {
-            f(self.value)
+            f(self._value)
         } else {
             default
         }
@@ -70,7 +70,7 @@ impl<T> Option<T> {
     /// If self is `Some(x)`, this returns `f(x)`. Otherwise, this returns `default()`.
     fn map_or_else<U>(self, default: fn() -> U, f: fn(T) -> U) -> U {
         if self._is_some {
-            f(self.value)
+            f(self._value)
         } else {
             default()
         }
@@ -91,7 +91,7 @@ impl<T> Option<T> {
     /// In some languages this function is called `flat_map` or `bind`.
     fn and_then<U>(self, f: fn(T) -> Option<U>) -> Option<U> {
         if self._is_some {
-            f(self.value)
+            f(self._value)
         } else {
             Option::none()
         }
@@ -135,7 +135,7 @@ impl<T> Option<T> {
     /// Otherwise, this returns `None`
     fn filter(self, predicate: fn(T) -> bool) -> Self {
         if self._is_some {
-            if predicate(self.value) {
+            if predicate(self._value) {
                 self
             } else {
                 Option::none()
@@ -149,7 +149,7 @@ impl<T> Option<T> {
     /// This returns None if the outer Option is None. Otherwise, this returns the inner Option.
     fn flatten(option: Option<Option<T>>) -> Option<T> {
         if option._is_some {
-            option.value
+            option._value
         } else {
             Option::none()
         }

--- a/noir_stdlib/src/option.nr
+++ b/noir_stdlib/src/option.nr
@@ -30,6 +30,13 @@ impl<T> Option<T> {
         self._value
     }
 
+    /// Returns the inner value without asserting `self.is_some()`
+    /// Note that if `self` is `None`, there is no guarantee what value will be returned,
+    /// only that it will be of type `T`.
+    fn unwrap_unchecked(self) -> T {
+        self._value
+    }
+
     /// Returns the wrapped value if `self.is_some()`. Otherwise, returns the given default value.
     fn unwrap_or(self, default: T) -> T {
         if self._is_some {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Following discussion on #1781

## Summary\*

Renames the pseudo-private `value` field of `Option<T>` to `_value` to make it more difficult for users to accidentally use it.

This also adds an `unwrap_unchecked` to return the inner `_value` without performing an assertion. It is expected that this function is called after checking if `option.is_some()` or similar.

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.
    - There is now a new method on options: `Option::unwrap_unchecked()`
    - This method is similar to `unwrap` but it will not assert `option.is_some()`. This method can be useful within an if condition when we already know that `option.is_some()`. If the option is None, there is no guarantee what value will be returned, only that it will be of type `T` for an `Option<T>`.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
