### PR TITLE
chore: Do not create new memory block when not needed

### DIFF
--- a/crates/noirc_evaluator/src/ssa.rs
+++ b/crates/noirc_evaluator/src/ssa.rs
@@ -62,7 +62,8 @@ pub(crate) fn optimize_into_acir(
             .dead_instruction_elimination()
             .print(print_ssa_passes, "After Dead Instruction Elimination:");
     }
-    ssa.into_acir(brillig, abi_distinctness)
+    let array_use = ssa.array_use();
+    ssa.into_acir(brillig, abi_distinctness, &array_use)
 }
 
 /// Compiles the Program into ACIR and applies optimizations to the arithmetic gates

--- a/crates/noirc_evaluator/src/ssa.rs
+++ b/crates/noirc_evaluator/src/ssa.rs
@@ -62,8 +62,8 @@ pub(crate) fn optimize_into_acir(
             .dead_instruction_elimination()
             .print(print_ssa_passes, "After Dead Instruction Elimination:");
     }
-    let array_use = ssa.array_use();
-    ssa.into_acir(brillig, abi_distinctness, &array_use)
+    let last_array_uses = ssa.find_last_array_uses();
+    ssa.into_acir(brillig, abi_distinctness, &last_array_uses)
 }
 
 /// Compiles the Program into ACIR and applies optimizations to the arithmetic gates

--- a/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -1121,7 +1121,7 @@ impl Context {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
+    use std::{rc::Rc, collections::HashMap};
 
     use acvm::{
         acir::{
@@ -1161,7 +1161,7 @@ mod tests {
         let ssa = builder.finish();
 
         let context = Context::new();
-        let acir = context.convert_ssa(ssa, Brillig::default()).unwrap();
+        let acir = context.convert_ssa(ssa, Brillig::default(), &HashMap::new()).unwrap();
 
         let expected_opcodes =
             vec![Opcode::Arithmetic(&Expression::one() - &Expression::from(Witness(1)))];

--- a/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -112,9 +112,10 @@ impl Ssa {
         self,
         brillig: Brillig,
         abi_distinctness: AbiDistinctness,
+        array_use: &HashMap<ValueId, InstructionId>,
     ) -> Result<GeneratedAcir, RuntimeError> {
         let context = Context::new();
-        let mut generated_acir = context.convert_ssa(self, brillig)?;
+        let mut generated_acir = context.convert_ssa(self, brillig, array_use)?;
 
         match abi_distinctness {
             AbiDistinctness::Distinct => {
@@ -154,10 +155,15 @@ impl Context {
     }
 
     /// Converts SSA into ACIR
-    fn convert_ssa(self, ssa: Ssa, brillig: Brillig) -> Result<GeneratedAcir, RuntimeError> {
+    fn convert_ssa(
+        self,
+        ssa: Ssa,
+        brillig: Brillig,
+        array_use: &HashMap<ValueId, InstructionId>,
+    ) -> Result<GeneratedAcir, RuntimeError> {
         let main_func = ssa.main();
         match main_func.runtime() {
-            RuntimeType::Acir => self.convert_acir_main(main_func, &ssa, brillig),
+            RuntimeType::Acir => self.convert_acir_main(main_func, &ssa, brillig, array_use),
             RuntimeType::Brillig => self.convert_brillig_main(main_func, brillig),
         }
     }
@@ -167,13 +173,14 @@ impl Context {
         main_func: &Function,
         ssa: &Ssa,
         brillig: Brillig,
+        array_use: &HashMap<ValueId, InstructionId>,
     ) -> Result<GeneratedAcir, RuntimeError> {
         let dfg = &main_func.dfg;
         let entry_block = &dfg[main_func.entry_block()];
         let input_witness = self.convert_ssa_block_params(entry_block.parameters(), dfg)?;
 
         for instruction_id in entry_block.instructions() {
-            self.convert_ssa_instruction(*instruction_id, dfg, ssa, &brillig)?;
+            self.convert_ssa_instruction(*instruction_id, dfg, ssa, &brillig, array_use)?;
         }
 
         self.convert_ssa_return(entry_block.unwrap_terminator(), dfg)?;
@@ -310,6 +317,7 @@ impl Context {
         dfg: &DataFlowGraph,
         ssa: &Ssa,
         brillig: &Brillig,
+        array_use: &HashMap<ValueId, InstructionId>,
     ) -> Result<(), RuntimeError> {
         let instruction = &dfg[instruction_id];
         self.acir_context.set_location(dfg.get_location(&instruction_id));
@@ -389,10 +397,17 @@ impl Context {
                 self.current_side_effects_enabled_var = acir_var;
             }
             Instruction::ArrayGet { array, index } => {
-                self.handle_array_operation(instruction_id, *array, *index, None, dfg)?;
+                self.handle_array_operation(instruction_id, *array, *index, None, dfg, array_use)?;
             }
             Instruction::ArraySet { array, index, value } => {
-                self.handle_array_operation(instruction_id, *array, *index, Some(*value), dfg)?;
+                self.handle_array_operation(
+                    instruction_id,
+                    *array,
+                    *index,
+                    Some(*value),
+                    dfg,
+                    array_use,
+                )?;
             }
             Instruction::Allocate => {
                 unreachable!("Expected all allocate instructions to be removed before acir_gen")
@@ -447,6 +462,7 @@ impl Context {
         index: ValueId,
         store_value: Option<ValueId>,
         dfg: &DataFlowGraph,
+        array_use: &HashMap<ValueId, InstructionId>,
     ) -> Result<(), RuntimeError> {
         let index_const = dfg.get_numeric_constant(index);
 
@@ -504,9 +520,10 @@ impl Context {
             }
             AcirValue::DynamicArray(_) => (),
         }
-
+        let resolved_array = dfg.resolve(array);
+        let map_array = array_use.get(&resolved_array) == Some(&instruction);
         if let Some(store) = store_value {
-            self.array_set(instruction, array, index, store, dfg)?;
+            self.array_set(instruction, array, index, store, dfg, map_array)?;
         } else {
             self.array_get(instruction, array, index, dfg)?;
         }
@@ -568,6 +585,7 @@ impl Context {
         index: ValueId,
         store_value: ValueId,
         dfg: &DataFlowGraph,
+        map_array: bool,
     ) -> Result<(), InternalError> {
         // Fetch the internal SSA ID for the array
         let array = dfg.resolve(array);
@@ -602,24 +620,30 @@ impl Context {
         }
 
         // Since array_set creates a new array, we create a new block ID for this
-        // array.
+        // array, unless map_array is true. In that case, we operate directly on block_id
+        // and we do not create a new block ID.
         let result_id = dfg
             .instruction_results(instruction)
             .first()
             .expect("Array set does not have one result");
-        let result_block_id = self.block_id(result_id);
-
-        // Initialize the new array with the values from the old array
-        let init_values = try_vecmap(0..len, |i| {
-            let index = AcirValue::Var(
-                self.acir_context.add_constant(FieldElement::from(i as u128)),
-                AcirType::NumericType(NumericType::NativeField),
-            );
-            let var = index.into_var()?;
-            let read = self.acir_context.read_from_memory(block_id, &var)?;
-            Ok(AcirValue::Var(read, AcirType::NumericType(NumericType::NativeField)))
-        })?;
-        self.initialize_array(result_block_id, len, Some(&init_values))?;
+        let result_block_id;
+        if map_array {
+            self.memory_blocks.insert(*result_id, block_id);
+            result_block_id = block_id;
+        } else {
+            // Initialize the new array with the values from the old array
+            result_block_id = self.block_id(result_id);
+            let init_values = try_vecmap(0..len, |i| {
+                let index = AcirValue::Var(
+                    self.acir_context.add_constant(FieldElement::from(i as u128)),
+                    AcirType::NumericType(NumericType::NativeField),
+                );
+                let var = index.into_var()?;
+                let read = self.acir_context.read_from_memory(block_id, &var)?;
+                Ok(AcirValue::Var(read, AcirType::NumericType(NumericType::NativeField)))
+            })?;
+            self.initialize_array(result_block_id, len, Some(&init_values))?;
+        }
 
         // Write the new value into the new array at the specified index
         let index_var = self.convert_value(index, dfg).into_var()?;

--- a/crates/noirc_evaluator/src/ssa/ir/post_order.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/post_order.rs
@@ -27,6 +27,10 @@ impl PostOrder {
         PostOrder(Self::compute_post_order(func))
     }
 
+    pub(crate) fn into_vec(self) -> Vec<BasicBlockId> {
+        self.0
+    }
+
     // Computes the post-order of the function by doing a depth-first traversal of the
     // function's entry block's previously unvisited children. Each block is sequenced according
     // to when the traversal exits it.

--- a/crates/noirc_evaluator/src/ssa/opt/array_use.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/array_use.rs
@@ -6,7 +6,7 @@ use crate::ssa::{
         dfg::DataFlowGraph,
         instruction::{Instruction, InstructionId},
         post_order::PostOrder,
-        value::ValueId,
+        value::{Value, ValueId},
     },
     ssa_gen::Ssa,
 };
@@ -42,6 +42,14 @@ fn last_use(
             Instruction::ArrayGet { array, .. } | Instruction::ArraySet { array, .. } => {
                 let array = dfg.resolve(*array);
                 array_def.insert(array, *instruction_id);
+            }
+            Instruction::Call { arguments, .. } => {
+                for argument in arguments {
+                    if matches!(dfg[*argument], Value::Array { .. }) {
+                        let array = dfg.resolve(*argument);
+                        array_def.insert(array, *instruction_id);
+                    }
+                }
             }
             _ => {
                 // Nothing to do

--- a/crates/noirc_evaluator/src/ssa/opt/array_use.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/array_use.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+use crate::ssa::{
+    ir::{
+        basic_block::BasicBlockId,
+        dfg::DataFlowGraph,
+        instruction::{Instruction, InstructionId},
+        post_order::PostOrder,
+        value::ValueId,
+    },
+    ssa_gen::Ssa,
+};
+
+impl Ssa {
+    /// Map arrays with the last instruction that uses it
+    /// For this we simply process all the instructions in execution order
+    /// and update the map whenever there is a match
+    pub(crate) fn array_use(&self) -> HashMap<ValueId, InstructionId> {
+        let mut array_use = HashMap::new();
+        for func in self.functions.values() {
+            let mut reverse_post_order = Vec::new();
+            reverse_post_order.extend_from_slice(PostOrder::with_function(func).as_slice());
+            reverse_post_order.reverse();
+
+            for block in reverse_post_order {
+                last_use(block, &func.dfg, &mut array_use);
+            }
+        }
+        array_use
+    }
+}
+
+/// Updates the array_def map when an instructions is using an array
+fn last_use(
+    block_id: BasicBlockId,
+    dfg: &DataFlowGraph,
+    array_def: &mut HashMap<ValueId, InstructionId>,
+) {
+    let block = &dfg[block_id];
+    for instruction_id in block.instructions() {
+        match &dfg[*instruction_id] {
+            Instruction::ArrayGet { array, .. } | Instruction::ArraySet { array, .. } => {
+                let array = dfg.resolve(*array);
+                array_def.insert(array, *instruction_id);
+            }
+            _ => {
+                // Nothing to do
+            }
+        }
+    }
+}

--- a/crates/noirc_evaluator/src/ssa/opt/array_use.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/array_use.rs
@@ -18,10 +18,8 @@ impl Ssa {
     pub(crate) fn array_use(&self) -> HashMap<ValueId, InstructionId> {
         let mut array_use = HashMap::new();
         for func in self.functions.values() {
-            let mut reverse_post_order = Vec::new();
-            reverse_post_order.extend_from_slice(PostOrder::with_function(func).as_slice());
+            let mut reverse_post_order = PostOrder::with_function(func).into_vec();
             reverse_post_order.reverse();
-
             for block in reverse_post_order {
                 last_use(block, &func.dfg, &mut array_use);
             }

--- a/crates/noirc_evaluator/src/ssa/opt/array_use.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/array_use.rs
@@ -15,7 +15,7 @@ impl Ssa {
     /// Map arrays with the last instruction that uses it
     /// For this we simply process all the instructions in execution order
     /// and update the map whenever there is a match
-    pub(crate) fn array_use(&self) -> HashMap<ValueId, InstructionId> {
+    pub(crate) fn find_last_array_uses(&self) -> HashMap<ValueId, InstructionId> {
         let mut array_use = HashMap::new();
         for func in self.functions.values() {
             let mut reverse_post_order = PostOrder::with_function(func).into_vec();

--- a/crates/noirc_evaluator/src/ssa/opt/array_use.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/array_use.rs
@@ -43,9 +43,9 @@ fn last_use(
             }
             Instruction::Call { arguments, .. } => {
                 for argument in arguments {
-                    if matches!(dfg[*argument], Value::Array { .. }) {
-                        let array = dfg.resolve(*argument);
-                        array_def.insert(array, *instruction_id);
+                    let resolved_arg = dfg.resolve(*argument);
+                    if matches!(dfg[resolved_arg], Value::Array { .. }) {
+                        array_def.insert(resolved_arg, *instruction_id);
                     }
                 }
             }

--- a/crates/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/mod.rs
@@ -3,6 +3,7 @@
 //! Each pass is generally expected to mutate the SSA IR into a gradually
 //! simpler form until the IR only has a single function remaining with 1 block within it.
 //! Generally, these passes are also expected to minimize the final amount of instructions.
+mod array_use;
 mod constant_folding;
 mod defunctionalize;
 mod die;


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Array_set was always creating a new copy of an acir MemoryBlock, because it creates a new ssa array

Resolves #2014

## Summary\*

We implement a new ssa pass which maps ssa arrays with their last use.
In acir-gen, when we process the instruction corresponding to the last use of an array, we can avoid to create a new one and copy it, and we can directly operate on that array.
In order to do this, we take benefit from the ssa array-> acir block Id map and map the new ssa array to the block ID of the original ssa array.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
