### PR TITLE
feat!: Allow specifying new package name with `--name` flag

### DIFF
--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 /// Create a Noir project in the current directory.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
-    /// Name of the package [default = current directory name]
+    /// Name of the package [default: current directory name]
     #[clap(long)]
     name: Option<String>,
 }

--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 /// Create a Noir project in the current directory.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
-    /// Name of the package (Defaults to current directory name)
+    /// Name of the package [default = current directory name]
     #[clap(long)]
     name: Option<String>,
 }

--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -9,7 +9,11 @@ use std::path::PathBuf;
 
 /// Create a Noir project in the current directory.
 #[derive(Debug, Clone, Args)]
-pub(crate) struct InitCommand;
+pub(crate) struct InitCommand {
+    /// Name of the package (Defaults to current directory name)
+    #[clap(long)]
+    name: Option<String>,
+}
 
 const EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
     assert(x != y);
@@ -27,17 +31,20 @@ fn test_main() {
 pub(crate) fn run<B: Backend>(
     // Backend is currently unused, but we might want to use it to inform the "new" template in the future
     _backend: &B,
-    _args: InitCommand,
+    args: InitCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    initialize_project(config.program_dir);
+    let package_name = args
+        .name
+        .unwrap_or_else(|| config.program_dir.file_name().unwrap().to_str().unwrap().to_owned());
+
+    initialize_project(config.program_dir, &package_name);
     Ok(())
 }
 
 /// Initializes a new Noir project in `package_dir`.
-pub(crate) fn initialize_project(package_dir: PathBuf) {
+pub(crate) fn initialize_project(package_dir: PathBuf, package_name: &str) {
     // TODO: Should this reject if we have non-Unicode filepaths?
-    let package_name = package_dir.file_name().expect("Expected a filename").to_string_lossy();
     let src_dir = package_dir.join(SRC_DIR);
     create_named_dir(&src_dir, "src");
 

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -11,7 +11,7 @@ pub(crate) struct NewCommand {
     /// The path to save the new project
     path: PathBuf,
 
-    /// Name of the package [default = package directory name]
+    /// Name of the package [default: package directory name]
     #[clap(long)]
     name: Option<String>,
 }

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -11,7 +11,7 @@ pub(crate) struct NewCommand {
     /// The path to save the new project
     path: PathBuf,
 
-    /// Name of the package (Defaults to package directory name)
+    /// Name of the package [default = package directory name]
     #[clap(long)]
     name: Option<String>,
 }

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -8,10 +8,12 @@ use std::path::PathBuf;
 /// Create a Noir project in a new directory.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct NewCommand {
-    /// Name of the package
-    package_name: String,
     /// The path to save the new project
-    path: Option<PathBuf>,
+    path: PathBuf,
+
+    /// Name of the package (Defaults to package directory name)
+    #[clap(long)]
+    name: Option<String>,
 }
 
 pub(crate) fn run<B: Backend>(
@@ -20,12 +22,14 @@ pub(crate) fn run<B: Backend>(
     args: NewCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let package_dir = config.program_dir.join(args.package_name);
+    let package_dir = config.program_dir.join(&args.path);
 
     if package_dir.exists() {
         return Err(CliError::DestinationAlreadyExists(package_dir));
     }
 
-    initialize_project(package_dir);
+    let package_name =
+        args.name.unwrap_or_else(|| args.path.file_name().unwrap().to_str().unwrap().to_owned());
+    initialize_project(package_dir, &package_name);
     Ok(())
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2132 

## Summary\*

`package_name` positional argument has been replaced by the `name` option. `name` defaults to the package directory if unspecified.

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->
Arguments to `nargo new` and `nargo init` have changed.
## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
