### PR TITLE
chore: Move the long line of `nargo info` to `long_about`

### DIFF
--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -53,13 +53,9 @@ enum NargoCommand {
     Compile(compile_cmd::CompileCommand),
     New(new_cmd::NewCommand),
     Init(init_cmd::InitCommand),
-    #[command(aliases = ["run", "r"])]
     Execute(execute_cmd::ExecuteCommand),
-    #[command(alias = "p")]
     Prove(prove_cmd::ProveCommand),
-    #[command(alias = "v")]
     Verify(verify_cmd::VerifyCommand),
-    #[command(alias = "t")]
     Test(test_cmd::TestCommand),
     Info(info_cmd::InfoCommand),
     Lsp(lsp_cmd::LspCommand),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Add some aliasing

`nargo info`  has a about line that look like this which is long

<img width="1057" alt="1" src="https://github.com/noir-lang/noir/assets/70556667/c071ac6f-00b5-4835-91cd-b81e9079859f">

this pr will make it look like this 
<img width="658" alt="3" src="https://github.com/noir-lang/noir/assets/70556667/dd1d2c3d-159c-45f2-be65-47393910d4b2">


and users can still see the details if they run `nargo info --help`

<img width="789" alt="2" src="https://github.com/noir-lang/noir/assets/70556667/3952e882-e76a-4a62-8e1e-863b212db592">


<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
