### PR TITLE
chore: Replace `resolve_path` function with a trait that impls normalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ version = "0.9.0"
 dependencies = [
  "cfg-if",
  "codespan-reporting",
+ "iter-extended",
  "rust-embed",
  "serde",
  "tempfile",

--- a/crates/fm/Cargo.toml
+++ b/crates/fm/Cargo.toml
@@ -17,3 +17,4 @@ wasm-bindgen.workspace = true
 
 [dev-dependencies]
 tempfile = "3.2.0"
+iter-extended.workspace = true

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -167,7 +167,7 @@ mod path_normalization {
             [
                 ("/", "/"),                             // Handles root
                 ("/foo/bar/../baz/../bar", "/foo/bar"), // Handles backtracking
-                ("/././././././././baz", "/baz"),       // Removes noops
+                ("/././././././././baz", "/baz"),       // Removes no-ops
             ],
             |(unnormalized, normalized)| (PathBuf::from(unnormalized), PathBuf::from(normalized)),
         );

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -167,7 +167,7 @@ mod path_normalization {
                 ("/", "/"),                             // Handles root
                 ("/foo/bar/../baz/../bar", "/foo/bar"), // Handles backtracking
                 ("/././././././././baz", "/baz"),       // Removes noops
-                (r"C:/foo", "C:/foo"),                  // Retains Windows prefixes
+                ("C:/foo", "C:/foo"),                   // Retains Windows prefixes
             ],
             |(unnormalized, normalized)| (PathBuf::from(unnormalized), PathBuf::from(normalized)),
         );

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -30,7 +30,7 @@ pub struct FileManager {
 impl FileManager {
     pub fn new(root: &Path) -> Self {
         Self {
-            root: root.to_path_buf(),
+            root: root.normalize(),
             file_map: Default::default(),
             id_to_path: Default::default(),
             path_to_id: Default::default(),
@@ -44,7 +44,7 @@ impl FileManager {
             // TODO: The stdlib path should probably be an absolute path rooted in something people would never create
             file_name.to_path_buf()
         } else {
-            self.resolve_path(file_name)
+            self.root.join(file_name).normalize()
         };
 
         // Check that the resolved path already exists in the file map, if it is, we return it.
@@ -99,42 +99,56 @@ impl FileManager {
 
         Err(candidate_files.remove(0).as_os_str().to_str().unwrap().to_owned())
     }
+}
 
-    /// Resolve a path within the FileManager, removing all `.` and `..` segments.
-    /// Additionally, relative paths will be resolved against the FileManager's root.
-    pub fn resolve_path(&self, path: &Path) -> PathBuf {
-        // This is a replacement for `std::fs::canonicalize` that doesn't verify the path exists.
-        //
-        // Plucked from https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
-        // Advice from https://www.reddit.com/r/rust/comments/hkkquy/comment/fwtw53s/
-        let mut components = path.components().peekable();
-        let mut ret = match components.peek().cloned() {
-            Some(c @ Component::Prefix(..)) => {
-                components.next();
-                PathBuf::from(c.as_os_str())
+pub trait NormalizePath {
+    /// Replacement for `std::fs::canonicalize` that doesn't verify the path exists.
+    ///
+    /// Plucked from https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
+    /// Advice from https://www.reddit.com/r/rust/comments/hkkquy/comment/fwtw53s/
+    fn normalize(&self) -> PathBuf;
+}
+
+impl NormalizePath for PathBuf {
+    fn normalize(&self) -> PathBuf {
+        let components = self.components();
+        resolve_components(components)
+    }
+}
+
+impl NormalizePath for &Path {
+    fn normalize(&self) -> PathBuf {
+        let components = self.components();
+        resolve_components(components)
+    }
+}
+
+fn resolve_components<'a>(components: impl Iterator<Item = Component<'a>>) -> PathBuf {
+    let mut components = components.peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
             }
-            Some(Component::RootDir) => PathBuf::new(),
-            // If the first component isn't a RootDir or a Prefix, we know it is relative and needs to be joined to root
-            _ => self.root.clone(),
-        };
-
-        for component in components {
-            match component {
-                Component::Prefix(..) => unreachable!(),
-                Component::RootDir => {
-                    ret.push(component.as_os_str());
-                }
-                Component::CurDir => {}
-                Component::ParentDir => {
-                    ret.pop();
-                }
-                Component::Normal(c) => {
-                    ret.push(c);
-                }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
             }
         }
-        ret
     }
+
+    ret
 }
 
 /// Takes a path to a noir file. This will panic on paths to directories

--- a/crates/fm/src/lib.rs
+++ b/crates/fm/src/lib.rs
@@ -162,12 +162,12 @@ mod path_normalization {
 
     #[test]
     fn normalizes_paths_correctly() {
+        // Note that tests are run on unix so prefix handling can't be tested (as these only exist on Windows)
         let test_cases = vecmap(
             [
                 ("/", "/"),                             // Handles root
                 ("/foo/bar/../baz/../bar", "/foo/bar"), // Handles backtracking
                 ("/././././././././baz", "/baz"),       // Removes noops
-                ("C:/foo", "C:/foo"),                   // Retains Windows prefixes
             ],
             |(unnormalized, normalized)| (PathBuf::from(unnormalized), PathBuf::from(normalized)),
         );

--- a/cspell.json
+++ b/cspell.json
@@ -63,6 +63,7 @@
         "typevars",
         "udiv",
         "uninstantiated",
+        "unnormalized",
         "urem",
         "vecmap",
         "direnv",


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

While trying to integrate #2156 into Nargo CLI toml resolution, I found that it was a bad API due to the current way that Nargo CLI reads from the filesystem.

Instead of using that API, I believe we should implement `normalize` on `PathBuf` and `&Path` so we can import the trait to normalize any paths we have in the codebase.

Sorry for the churn!

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
