### PR TITLE
fix(nargo): Indicate which TOML file is missing package name

### DIFF
--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -147,4 +147,7 @@ pub(crate) enum ManifestError {
 
     #[error("Package `{0}` has type `bin` but you cannot depend on binary packages")]
     BinaryDependency(CrateName),
+
+    #[error("Missing `name` field in {toml}")]
+    MissingNameField { toml: PathBuf },
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2086 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This relaxes the TOML parsing around package name and moves validation into `resolve_to_package` to provide better error messages to the user that contain the toml file missing the `name` field.

I also removed the TODO since we should just keep this validation logic going forward.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
