### PR TITLE
fix(nargo): Make dependencies section optional in TOML

### DIFF
--- a/crates/nargo_cli/src/manifest.rs
+++ b/crates/nargo_cli/src/manifest.rs
@@ -15,6 +15,7 @@ use crate::{errors::ManifestError, git::clone_git_repo};
 #[derive(Debug, Deserialize, Clone)]
 struct PackageConfig {
     package: PackageMetadata,
+    #[serde(default)]
     dependencies: BTreeMap<String, DependencyConfig>,
 }
 
@@ -254,6 +255,19 @@ fn parse_standard_toml() {
         rand = { tag = "next", git = "https://github.com/rust-lang-nursery/rand"}
         cool = { tag = "next", git = "https://github.com/rust-lang-nursery/rand"}
         hello = {path = "./noir_driver"}
+    "#;
+
+    assert!(Config::try_from(String::from(src)).is_ok());
+    assert!(Config::try_from(src).is_ok());
+}
+
+#[test]
+fn parse_package_toml_no_deps() {
+    let src = r#"
+        [package]
+        name = "test"
+        authors = ["kev", "foo"]
+        compiler_version = "0.1"
     "#;
 
     assert!(Config::try_from(String::from(src)).is_ok());


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2114 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This makes the `[dependencies]` section of the Nargo.toml optional because it is weird that we'd require the section if we have no dependencies.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
