### PR TITLE
chore: add documentation to the `nargo lsp` command

### DIFF
--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -12,6 +12,11 @@ use tower::ServiceBuilder;
 use super::NargoConfig;
 use crate::errors::CliError;
 
+/// Starts the Noir LSP server
+///
+/// Starts an LSP server which allows IDEs such as VS Code to display diagnostics in Noir source.
+///
+/// VS Code Noir Language Support: https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir
 #[derive(Debug, Clone, Args)]
 pub(crate) struct LspCommand {
     #[clap(flatten)]


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We've currently got a very conspicuous blank space next to `lsp` when we run `nargo --help`. If someone were to run the command to find out what it does then they appear to just have the terminal hang until they terminate the program.

My thoughts are that we should either hide the command or add some explanatory documentation.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
