### PR TITLE
chore!: remove unused flags on LSP command

### DIFF
--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -5,7 +5,6 @@ use async_lsp::{
 };
 use clap::Args;
 use noir_lsp::NargoLspService;
-use noirc_driver::CompileOptions;
 use tokio::io::BufReader;
 use tower::ServiceBuilder;
 
@@ -13,10 +12,7 @@ use super::NargoConfig;
 use crate::errors::CliError;
 
 #[derive(Debug, Clone, Args)]
-pub(crate) struct LspCommand {
-    #[clap(flatten)]
-    compile_options: CompileOptions,
-}
+pub(crate) struct LspCommand;
 
 pub(crate) fn run<B: Backend>(
     // Backend is currently unused, but we might want to use it to inform the lsp in the future


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The LSP command does not use any arguments yet we are providing it with all the flags in `CompileOptions`. This PR removes these unused flags.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
