### PR TITLE
chore: Hide the `show_ssa` and `show_brillig` flags

### DIFF
--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -25,10 +25,10 @@ pub use program::CompiledProgram;
 #[derive(Args, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CompileOptions {
     /// Emit debug information for the intermediate SSA IR
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub show_ssa: bool,
 
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub show_brillig: bool,
 
     /// Display the ACIR for compiled circuit


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves partially #2130 

## Summary\*

This PR hides the `show_ssa` and `show_brillig` flags as they're unnecessary for 99.9% of users. I've left `print_acir` as is pending us splitting up this struct.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
