### PR TITLE
fix: Fix an ICE when reassigning a mutable lambda variable to one with a different environment type

### DIFF
--- a/crates/nargo_cli/tests/compile_tests_data/fail/different-lambda-env-reassign-disallow.nr
+++ b/crates/nargo_cli/tests/compile_tests_data/fail/different-lambda-env-reassign-disallow.nr
@@ -1,0 +1,9 @@
+fn bad()  {
+    let a: i32 = 100;
+    let b: i32 = 200;
+
+    let mut f = || a;
+
+    // this should fail with a type error, since the closures have different environments & types
+    f = || a + b; 
+}

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -117,14 +117,14 @@ impl<'interner> TypeChecker<'interner> {
             }
         });
 
-        if let (Type::Function(_, _, env_a), Type::Function(_, _, env_b)) = (&lvalue_type, &expr_type) {
-            env_a.unify(&env_b, span, &mut self.errors, || {
-                TypeCheckError::TypeMismatchWithSource {
-                    rhs: expr_type.clone(),
-                    lhs: lvalue_type.clone(),
-                    span,
-                    source: Source::Assignment,
-                }
+        if let (Type::Function(_, _, env_a), Type::Function(_, _, env_b)) =
+            (&lvalue_type, &expr_type)
+        {
+            env_a.unify(env_b, span, &mut self.errors, || TypeCheckError::TypeMismatchWithSource {
+                rhs: expr_type.clone(),
+                lhs: lvalue_type.clone(),
+                span,
+                source: Source::Assignment,
             });
         }
     }

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -116,17 +116,6 @@ impl<'interner> TypeChecker<'interner> {
                 source: Source::Assignment,
             }
         });
-
-        if let (Type::Function(_, _, env_a), Type::Function(_, _, env_b)) =
-            (&lvalue_type, &expr_type)
-        {
-            env_a.unify(env_b, span, &mut self.errors, || TypeCheckError::TypeMismatchWithSource {
-                rhs: expr_type.clone(),
-                lhs: lvalue_type.clone(),
-                span,
-                source: Source::Assignment,
-            });
-        }
     }
 
     /// Type check an lvalue - the left hand side of an assignment statement.

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -116,6 +116,17 @@ impl<'interner> TypeChecker<'interner> {
                 source: Source::Assignment,
             }
         });
+
+        if let (Type::Function(_, _, env_a), Type::Function(_, _, env_b)) = (&lvalue_type, &expr_type) {
+            env_a.unify(&env_b, span, &mut self.errors, || {
+                TypeCheckError::TypeMismatchWithSource {
+                    rhs: expr_type.clone(),
+                    lhs: lvalue_type.clone(),
+                    span,
+                    source: Source::Assignment,
+                }
+            });
+        }
     }
 
     /// Type check an lvalue - the left hand side of an assignment statement.

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -1206,11 +1206,13 @@ impl Type {
                 }
             }
 
-            (Function(params_a, ret_a, _env_a), Function(params_b, ret_b, _env_b)) => {
+            (Function(params_a, ret_a, env_a), Function(params_b, ret_b, env_b)) => {
                 if params_a.len() == params_b.len() {
                     for (a, b) in params_a.iter().zip(params_b.iter()) {
                         a.try_unify(b, span)?;
                     }
+
+                    env_a.try_unify(env_b, span)?;
 
                     ret_b.try_unify(ret_a, span)
                 } else {
@@ -1413,11 +1415,13 @@ impl Type {
                 }
             }
 
-            (Function(params_a, ret_a, _env_a), Function(params_b, ret_b, _env_b)) => {
+            (Function(params_a, ret_a, env_a), Function(params_b, ret_b, env_b)) => {
                 if params_a.len() == params_b.len() {
                     for (a, b) in params_a.iter().zip(params_b) {
                         a.is_subtype_of(b, span)?;
                     }
+
+                    env_a.is_subtype_of(env_b, span)?;
 
                     // return types are contravariant, so this must be ret_b <: ret_a instead of the reverse
                     ret_b.is_subtype_of(ret_a, span)


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem

This code type-checks properly, but an assertion fails during SSA generation.
The reassignment is invalid since the two lambdas have different environment types, and should be caught during type-checking.
```
fn main() {
    let a: u32 = 1;
    let b: u32 = 1;

    let mut f = || a;
    f = || a + b;

    f();
}
```

Resolves https://github.com/noir-lang/noir/issues/2139

## Summary

This adds an additional check to assignments, to cover this case and throw an error if an invalid assignment happens.
<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
