### PR TITLE
chore: remove unnecessary cloning of package dependencies

### DIFF
--- a/crates/nargo_cli/src/lib.rs
+++ b/crates/nargo_cli/src/lib.rs
@@ -102,14 +102,14 @@ fn list_files_and_folders_in<P: AsRef<Path>>(path: P) -> Option<ReadDir> {
 fn prepare_dependencies(
     context: &mut Context,
     parent_crate: CrateId,
-    dependencies: BTreeMap<CrateName, Dependency>,
+    dependencies: &BTreeMap<CrateName, Dependency>,
 ) {
-    for (dep_name, dep) in dependencies.into_iter() {
+    for (dep_name, dep) in dependencies.iter() {
         match dep {
             Dependency::Remote { package } | Dependency::Local { package } => {
                 let crate_id = prepare_crate(context, &package.entry_path, package.crate_type);
-                add_dep(context, parent_crate, crate_id, dep_name);
-                prepare_dependencies(context, crate_id, package.dependencies.to_owned());
+                add_dep(context, parent_crate, crate_id, dep_name.clone());
+                prepare_dependencies(context, crate_id, &package.dependencies);
             }
         }
     }
@@ -122,7 +122,7 @@ fn prepare_package(package: &Package) -> (Context, CrateId) {
 
     let crate_id = prepare_crate(&mut context, &package.entry_path, package.crate_type);
 
-    prepare_dependencies(&mut context, crate_id, package.dependencies.to_owned());
+    prepare_dependencies(&mut context, crate_id, &package.dependencies);
 
     (context, crate_id)
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes some unnecessary clones which occur in `prepare_dependencies`.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
