### PR TITLE
fix(nargo): Indicate which TOML file is missing package name

### DIFF
--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -142,4 +142,7 @@ pub(crate) enum ManifestError {
 
     #[error("Package `{0}` has type `bin` but you cannot depend on binary packages")]
     BinaryDependency(CrateName),
+
+    #[error("Missing `name` field in {toml}")]
+    MissingNameField { toml: PathBuf },
 }

--- a/crates/nargo_cli/src/manifest.rs
+++ b/crates/nargo_cli/src/manifest.rs
@@ -22,7 +22,11 @@ struct PackageConfig {
 
 impl PackageConfig {
     fn resolve_to_package(&self, root_dir: &Path) -> Result<Package, ManifestError> {
-        let name = self.package.name.parse().map_err(|_| ManifestError::InvalidPackageName)?;
+        let name = if let Some(name) = &self.package.name {
+            name.parse().map_err(|_| ManifestError::InvalidPackageName)?
+        } else {
+            return Err(ManifestError::MissingNameField { toml: root_dir.join("Nargo.toml") });
+        };
 
         let mut dependencies: BTreeMap<CrateName, Dependency> = BTreeMap::new();
         for (name, dep_config) in self.dependencies.iter() {
@@ -113,8 +117,7 @@ struct WorkspaceConfig {
 #[allow(dead_code)]
 #[derive(Default, Debug, Deserialize, Clone)]
 struct PackageMetadata {
-    #[serde(default = "panic_missing_name")]
-    name: String,
+    name: Option<String>,
     #[serde(alias = "type")]
     package_type: Option<String>,
     description: Option<String>,
@@ -127,26 +130,6 @@ struct PackageMetadata {
     compiler_version: Option<String>,
     backend: Option<String>,
     license: Option<String>,
-}
-
-// TODO: Remove this after a couple of breaking releases (added in 0.10.0)
-fn panic_missing_name() -> String {
-    panic!(
-        r#"
-
-Failed to parse `Nargo.toml`.
-
-`Nargo.toml` now requires a "name" field for Noir packages.
-
-```toml
-[package]
-name = "package_name"
-```
-
-Modify your `Nargo.toml` similarly to above and rerun the command.
-
-"#
-    )
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2086

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

Recreation of #2159

This relaxes the TOML parsing around package name and moves validation into resolve_to_package to provide better error messages to the user that contain the toml file missing the name field.

I also removed the TODO since we should just keep this validation logic going forward.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
