### PR TITLE
fix: remove duplicated `name` option in `nargo new`

### DIFF
--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -1,9 +1,6 @@
 use crate::errors::CliError;
 
-use super::{
-    init_cmd::{initialize_project, InitCommand},
-    NargoConfig,
-};
+use super::{init_cmd::initialize_project, NargoConfig};
 use acvm::Backend;
 use clap::Args;
 use nargo::package::PackageType;
@@ -19,8 +16,13 @@ pub(crate) struct NewCommand {
     #[clap(long)]
     name: Option<String>,
 
-    #[clap(flatten)]
-    init_config: InitCommand,
+    /// Use a library template
+    #[arg(long, conflicts_with = "bin")]
+    pub(crate) lib: bool,
+
+    /// Use a binary template [default]
+    #[arg(long, conflicts_with = "lib")]
+    pub(crate) bin: bool,
 }
 
 pub(crate) fn run<B: Backend>(
@@ -37,8 +39,7 @@ pub(crate) fn run<B: Backend>(
 
     let package_name =
         args.name.unwrap_or_else(|| args.path.file_name().unwrap().to_str().unwrap().to_owned());
-    let package_type =
-        if args.init_config.lib { PackageType::Library } else { PackageType::Binary };
+    let package_type = if args.lib { PackageType::Library } else { PackageType::Binary };
     initialize_project(package_dir, &package_name, package_type);
     Ok(())
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2182 

## Summary\*

I've removed the copying across of all `nargo init` arguments into `nargo new` as this was causing panics.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE