### PR TITLE
chore: Bump `async-lsp` to v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,8 +357,9 @@ dependencies = [
 
 [[package]]
 name = "async-lsp"
-version = "0.0.4"
-source = "git+https://github.com/oxalica/async-lsp?rev=0bfc8e4c4a3d875b073a0db3bd7d3710835a5465#0bfc8e4c4a3d875b073a0db3bd7d3710835a5465"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bd600f2652d2cccb0a33ab4f92d163ab3930844c8b0ad3713a5ae3285eeb4e"
 dependencies = [
  "futures",
  "lsp-types 0.94.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,13 +358,12 @@ dependencies = [
 [[package]]
 name = "async-lsp"
 version = "0.0.4"
-source = "git+https://github.com/oxalica/async-lsp?rev=09dbcc11046f7a188a80137f8d36484d86c78c78#09dbcc11046f7a188a80137f8d36484d86c78c78"
+source = "git+https://github.com/oxalica/async-lsp?rev=09ccde114333a71349885e156c896a39480c750f#09ccde114333a71349885e156c896a39480c750f"
 dependencies = [
- "either",
  "futures",
  "lsp-types 0.94.0",
  "pin-project-lite",
- "rustix 0.37.23",
+ "rustix 0.38.4",
  "serde",
  "serde_json",
  "thiserror",
@@ -372,7 +371,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "windows-sys 0.48.0",
+ "waitpid-any",
 ]
 
 [[package]]
@@ -2023,6 +2022,7 @@ dependencies = [
  "termcolor",
  "thiserror",
  "tokio",
+ "tokio-util",
  "toml",
  "tower",
  "url",
@@ -3368,6 +3368,7 @@ checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3580,6 +3581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "waitpid-any"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f8c3c56044fc359f905b72879576a15d49c46d085ed6266a98826716f14033"
+dependencies = [
+ "rustix 0.38.4",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 [[package]]
 name = "async-lsp"
 version = "0.0.4"
-source = "git+https://github.com/oxalica/async-lsp?rev=09ccde114333a71349885e156c896a39480c750f#09ccde114333a71349885e156c896a39480c750f"
+source = "git+https://github.com/oxalica/async-lsp?rev=0bfc8e4c4a3d875b073a0db3bd7d3710835a5465#0bfc8e4c4a3d875b073a0db3bd7d3710835a5465"
 dependencies = [
  "futures",
  "lsp-types 0.94.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,5 @@ wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
 
 [patch.crates-io]
-async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "09ccde114333a71349885e156c896a39480c750f" }
+# We need to use a patched version of async-lsp to use unreleased fixes for Windows (see #2168)
+async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "0bfc8e4c4a3d875b073a0db3bd7d3710835a5465" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,3 @@ url = "2.2.0"
 wasm-bindgen = { version = "=0.2.86", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
-
-[patch.crates-io]
-# We need to use a patched version of async-lsp to use unreleased fixes for Windows (see #2168)
-async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "0bfc8e4c4a3d875b073a0db3bd7d3710835a5465" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,4 @@ wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
 
 [patch.crates-io]
-async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "09dbcc11046f7a188a80137f8d36484d86c78c78" }
+async-lsp = { git = "https://github.com/oxalica/async-lsp", rev = "09ccde114333a71349885e156c896a39480c750f" }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -19,7 +19,7 @@ noirc_frontend.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 tower.workspace = true
-async-lsp = { version = "0.0.4", default-features = false, features = ["omni-trait"] }
+async-lsp = { version = "0.0.5", default-features = false, features = ["omni-trait"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -40,12 +40,14 @@ async-lsp = { version = "0.0.4", default-features = false, features = [
     "client-monitor",
     "stdio",
     "tracing",
+    "tokio"
 ] }
 const_format = "0.2.30"
 hex = "0.4.2"
 termcolor = "1.1.2"
 color-eyre = "0.6.2"
 tokio = { version = "1.0", features = ["io-std"] }
+tokio-util = { version = "0.7.8", features = ["compat"] }
 
 # Backends
 acvm-backend-barretenberg = { version = "0.10.0", default-features = false }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -36,7 +36,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tower.workspace = true
-async-lsp = { version = "0.0.4", default-features = false, features = [
+async-lsp = { version = "0.0.5", default-features = false, features = [
     "client-monitor",
     "stdio",
     "tracing",

--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -5,7 +5,6 @@ use async_lsp::{
 };
 use clap::Args;
 use noir_lsp::NargoLspService;
-use tokio::io::BufReader;
 use tower::ServiceBuilder;
 
 use super::NargoConfig;
@@ -30,7 +29,7 @@ pub(crate) fn run<B: Backend>(
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();
 
     runtime.block_on(async {
-        let (server, _) = async_lsp::Frontend::new_server(|client| {
+        let (server, _) = async_lsp::MainLoop::new_server(|client| {
             let router = NargoLspService::new(&client);
 
             ServiceBuilder::new()
@@ -50,10 +49,11 @@ pub(crate) fn run<B: Backend>(
         );
         // Fallback to spawn blocking read/write otherwise.
         #[cfg(not(unix))]
-        let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
+        let (stdin, stdout) = (
+            tokio_util::compat::TokioAsyncReadCompatExt::compat(tokio::io::stdin()),
+            tokio_util::compat::TokioAsyncWriteCompatExt::compat_write(tokio::io::stdout()),
+        );
 
-        let stdin = BufReader::new(stdin);
-
-        server.run(stdin, stdout).await.map_err(CliError::LspError)
+        server.run_bufferred(stdin, stdout).await.map_err(CliError::LspError)
     })
 }

--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -41,7 +41,7 @@ pub(crate) fn run<B: Backend>(
                 .service(router)
         });
 
-        // Prefer truely asynchronous piped stdin/stdout without blocking tasks.
+        // Prefer truly asynchronous piped stdin/stdout without blocking tasks.
         #[cfg(unix)]
         let (stdin, stdout) = (
             async_lsp::stdio::PipeStdin::lock_tokio().unwrap(),

--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -54,6 +54,6 @@ pub(crate) fn run<B: Backend>(
             tokio_util::compat::TokioAsyncWriteCompatExt::compat_write(tokio::io::stdout()),
         );
 
-        server.run_bufferred(stdin, stdout).await.map_err(CliError::LspError)
+        server.run_buffered(stdin, stdout).await.map_err(CliError::LspError)
     })
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Ref #2168 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

WIP to get us on latest async-lsp changes to make sure they work and then we can request a new official release

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
