### PR TITLE
chore: Improve unary error

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -71,7 +71,7 @@ pub enum TypeCheckError {
     IntegerBitWidth { bit_width_x: u32, bit_width_y: u32, span: Span },
     #[error("{kind} cannot be used in an infix operation")]
     InvalidInfixOp { kind: &'static str, span: Span },
-    #[error("{kind} cannot be used in an unary operation")]
+    #[error("{kind} cannot be used in a unary operation")]
     InvalidUnaryOp { kind: String, span: Span },
     #[error("Bitwise operations are invalid on Field types. Try casting the operands to a sized integer type first.")]
     InvalidBitwiseOperationOnField { span: Span },

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -71,6 +71,8 @@ pub enum TypeCheckError {
     IntegerBitWidth { bit_width_x: u32, bit_width_y: u32, span: Span },
     #[error("{kind} cannot be used in an infix operation")]
     InvalidInfixOp { kind: &'static str, span: Span },
+    #[error("{kind} cannot be used in an unary operation")]
+    InvalidUnaryOp { kind: String, span: Span },
     #[error("Bitwise operations are invalid on Field types. Try casting the operands to a sized integer type first.")]
     InvalidBitwiseOperationOnField { span: Span },
     #[error("Integer cannot be used with type {typ}")]
@@ -174,6 +176,7 @@ impl From<TypeCheckError> for Diagnostic {
             | TypeCheckError::IntegerSignedness { span, .. }
             | TypeCheckError::IntegerBitWidth { span, .. }
             | TypeCheckError::InvalidInfixOp { span, .. }
+            | TypeCheckError::InvalidUnaryOp { span, .. }
             | TypeCheckError::InvalidBitwiseOperationOnField { span, .. }
             | TypeCheckError::IntegerTypeMismatch { span, .. }
             | TypeCheckError::FieldComparison { span, .. }

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -1088,7 +1088,6 @@ impl<'interner> TypeChecker<'interner> {
         };
 
         match op {
-            // crate::UnaryOp::Minus => unify(Type::polymorphic_integer(self.interner)),
             crate::UnaryOp::Minus => {
                 let expected = Type::polymorphic_integer(self.interner);
                 rhs_type.unify(&expected, span, &mut self.errors, || {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -1088,7 +1088,14 @@ impl<'interner> TypeChecker<'interner> {
         };
 
         match op {
-            crate::UnaryOp::Minus => unify(Type::polymorphic_integer(self.interner)),
+            // crate::UnaryOp::Minus => unify(Type::polymorphic_integer(self.interner)),
+            crate::UnaryOp::Minus => {
+                let expected = Type::polymorphic_integer(self.interner);
+                rhs_type.unify(&expected, span, &mut self.errors, || {
+                    TypeCheckError::InvalidUnaryOp { kind: rhs_type.to_string(), span }
+                });
+                expected
+            }
             crate::UnaryOp::Not => {
                 let rhs_type = rhs_type.follow_bindings();
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/2152

## Summary\*

```rust
fn main() {
    let a = -[1,2];
}
```

will now return

```rust
[Field; 2] cannot be used in an unary operation
```

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
