### PR TITLE
fix: Set location before cast instructions in SSA

### DIFF
--- a/crates/noirc_evaluator/src/errors.rs
+++ b/crates/noirc_evaluator/src/errors.rs
@@ -22,7 +22,7 @@ pub enum RuntimeError {
     InternalError(#[from] InternalError),
     #[error("Index out of bounds, array has size {index:?}, but index was {array_size:?}")]
     IndexOutOfBounds { index: usize, array_size: usize, location: Option<Location> },
-    #[error("All Witnesses are by default u{num_bits:?} Applying this type does not apply any constraints.\n We also currently do not allow integers of size more than {num_bits:?}, this will be handled by BigIntegers.")]
+    #[error("Range constraint of {num_bits} bits is too large for the Field size")]
     InvalidRangeConstraint { num_bits: u32, location: Option<Location> },
     #[error("Expected array index to fit into a u64")]
     TypeConversion { from: String, into: String, location: Option<Location> },

--- a/crates/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -268,6 +268,7 @@ impl<'a> FunctionContext<'a> {
     fn codegen_cast(&mut self, cast: &ast::Cast) -> Values {
         let lhs = self.codegen_non_tuple_expression(&cast.lhs);
         let typ = Self::convert_non_tuple_type(&cast.r#type);
+        self.builder.set_location(cast.location);
         self.builder.insert_cast(lhs, typ).into()
     }
 

--- a/crates/noirc_frontend/src/monomorphization/ast.rs
+++ b/crates/noirc_frontend/src/monomorphization/ast.rs
@@ -120,6 +120,7 @@ pub struct If {
 pub struct Cast {
     pub lhs: Box<Expression>,
     pub r#type: Type,
+    pub location: Location,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -319,6 +319,7 @@ impl<'interner> Monomorphizer<'interner> {
             HirExpression::Cast(cast) => ast::Expression::Cast(ast::Cast {
                 lhs: Box::new(self.expr(cast.lhs)),
                 r#type: Self::convert_type(&cast.r#type),
+                location: self.interner.expr_location(&expr),
             }),
 
             HirExpression::For(for_expr) => {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #2193 

## Summary\*

This PR fixes the crash and shortens the error message, but the error message is a bit confusing now for the code snippet from the issue since it is off by one:

```
error: 
  ┌─ /Users/jakefecher/Code/Noir/noir/short/src/main.nr:3:13
  │
3 │     assert((x as u253) < (y as u253));
  │             --------- Range constraint of 254 bits is too large for the Field size
```

Although since we actually do perform a range constraint to 254 bits during a euclidean division call I'm not sure of an obvious solution to make it less confusing.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
