### PR TITLE
feat: Optimize `x < 0` for unsigned `x` to false

### DIFF
--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -593,6 +593,13 @@ impl Binary {
                     let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                     return SimplifyResult::SimplifiedTo(zero);
                 }
+                if let Type::Numeric(NumericType::Unsigned { .. }) = operand_type {
+                    if rhs_is_zero {
+                        // Unsigned values cannot be less than zero.
+                        let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
+                        return SimplifyResult::SimplifiedTo(zero);
+                    }
+                }
             }
             BinaryOp::And => {
                 if lhs_is_zero || rhs_is_zero {

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -593,12 +593,10 @@ impl Binary {
                     let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                     return SimplifyResult::SimplifiedTo(zero);
                 }
-                if let Type::Numeric(NumericType::Unsigned { .. }) = operand_type {
-                    if rhs_is_zero {
-                        // Unsigned values cannot be less than zero.
-                        let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
-                        return SimplifyResult::SimplifiedTo(zero);
-                    }
+                if operand_type.is_unsigned() && rhs_is_zero {
+                    // Unsigned values cannot be less than zero.
+                    let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
+                    return SimplifyResult::SimplifiedTo(zero);
                 }
             }
             BinaryOp::And => {

--- a/crates/noirc_evaluator/src/ssa/ir/types.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/types.rs
@@ -37,6 +37,11 @@ pub(crate) enum Type {
 }
 
 impl Type {
+    /// Returns whether the `Type` represents an unsigned numeric type.
+    pub(crate) fn is_unsigned(&self) -> bool {
+        matches!(self, Type::Numeric(NumericType::Unsigned { .. }))
+    }
+
     /// Create a new signed integer type with the given amount of bits.
     pub(crate) fn signed(bit_size: u32) -> Type {
         Type::Numeric(NumericType::Signed { bit_size })


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Currently we don't make use of type information when simplifying the `Lt` operator. As we know that unsigned values can't be negative then `x < 0` can be simplified to `false`.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
