### PR TITLE
fix: properly capture lvalues in closure environments (#2120)

### DIFF
--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -919,7 +919,10 @@ impl<'a> Resolver<'a> {
     fn resolve_lvalue(&mut self, lvalue: LValue) -> HirLValue {
         match lvalue {
             LValue::Ident(ident) => {
-                HirLValue::Ident(self.find_variable_or_default(&ident).0, Type::Error)
+                let ident = self.find_variable_or_default(&ident);
+                self.resolve_local_variable(ident.0, ident.1);
+
+                HirLValue::Ident(ident.0, Type::Error)
             }
             LValue::MemberAccess { object, field_name } => {
                 let object = Box::new(self.resolve_lvalue(*object));
@@ -1018,8 +1021,8 @@ impl<'a> Resolver<'a> {
                                 self.interner.push_definition_type(hir_ident.id, typ);
                             }
                         }
-                        // We ignore the above definition kinds because only local variables can be captured by closures.
                         DefinitionKind::Local(_) => {
+                            // only local variables can be captured by closures.
                             self.resolve_local_variable(hir_ident, var_scope_index);
                         }
                     }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Work towards resolving <!-- Link to GitHub Issue --> https://github.com/noir-lang/noir/issues/2120

## Summary\*

Previously LValues weren't scanned & added to closure environments. This PR fixes that.

However, the example given in https://github.com/noir-lang/noir/issues/2120 still doesn't work due to an unrelated codegen issue (https://github.com/noir-lang/noir/issues/2255):
```
fn main() {
    let x1 = &mut 42;
    let set_x1 = |y| { *x1 = y; };

    assert(*x1 == 42);
    set_x1(44);
    assert(*x1 == 44);
    set_x1(*x1);
    assert(*x1 == 44);
}
```
<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
