### PR TITLE
fix: Optimize contracts built by `nargo info`

### DIFF
--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -7,7 +7,8 @@ use nargo::prepare_package;
 use nargo::{artifacts::contract::PreprocessedContract, NargoError};
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml};
 use noirc_driver::{
-    compile_contracts, compile_main, CompileOptions, CompiledProgram, ErrorsAndWarnings, Warnings,
+    compile_contracts, compile_main, CompileOptions, CompiledContract, CompiledProgram,
+    ContractFunction, ErrorsAndWarnings, Warnings,
 };
 use noirc_frontend::graph::CrateName;
 use noirc_frontend::hir::Context;
@@ -62,31 +63,31 @@ pub(crate) fn run<B: Backend>(
         if package.is_contract() {
             let result = compile_contracts(&mut context, crate_id, &args.compile_options);
             let contracts = report_errors(result, &context, args.compile_options.deny_warnings)?;
+            let optimized_contracts =
+                try_vecmap(contracts, |contract| optimize_contract(backend, contract))?;
 
             // TODO(#1389): I wonder if it is incorrect for nargo-core to know anything about contracts.
             // As can be seen here, It seems like a leaky abstraction where ContractFunctions (essentially CompiledPrograms)
             // are compiled via nargo-core and then the PreprocessedContract is constructed here.
             // This is due to EACH function needing it's own CRS, PKey, and VKey from the backend.
             let preprocessed_contracts: Result<Vec<PreprocessedContract>, CliError<B>> =
-                try_vecmap(contracts, |contract| {
-                    let preprocessed_contract_functions =
-                        try_vecmap(contract.functions, |mut func| {
-                            func.bytecode = optimize_circuit(backend, func.bytecode)?.0;
-                            common_reference_string = update_common_reference_string(
-                                backend,
-                                &common_reference_string,
-                                &func.bytecode,
-                            )
-                            .map_err(CliError::CommonReferenceStringError)?;
+                try_vecmap(optimized_contracts, |contract| {
+                    let preprocessed_contract_functions = try_vecmap(contract.functions, |func| {
+                        common_reference_string = update_common_reference_string(
+                            backend,
+                            &common_reference_string,
+                            &func.bytecode,
+                        )
+                        .map_err(CliError::CommonReferenceStringError)?;
 
-                            preprocess_contract_function(
-                                backend,
-                                args.include_keys,
-                                &common_reference_string,
-                                func,
-                            )
-                            .map_err(CliError::ProofSystemCompilerError)
-                        })?;
+                        preprocess_contract_function(
+                            backend,
+                            args.include_keys,
+                            &common_reference_string,
+                            func,
+                        )
+                        .map_err(CliError::ProofSystemCompilerError)
+                    })?;
 
                     Ok(PreprocessedContract {
                         name: contract.name,
@@ -160,6 +161,18 @@ pub(super) fn optimize_circuit<B: Backend>(
     .map_err(|_| NargoError::CompilationError)?;
 
     Ok(result)
+}
+
+pub(super) fn optimize_contract<B: Backend>(
+    backend: &B,
+    contract: CompiledContract,
+) -> Result<CompiledContract, CliError<B>> {
+    let functions = try_vecmap(contract.functions, |func| {
+        let optimized_bytecode = optimize_circuit(backend, func.bytecode)?.0;
+        Ok::<_, CliError<B>>(ContractFunction { bytecode: optimized_bytecode, ..func })
+    })?;
+
+    Ok(CompiledContract { functions, ..contract })
 }
 
 /// Helper function for reporting any errors in a Result<(T, Warnings), ErrorsAndWarnings>


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2256 

## Summary\*

This PR ensures that we optimize contracts before querying the number of gates they result in in `nargo info`.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
