### PR TITLE
feat: Include struct names in ABIs

### DIFF
--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -88,7 +88,7 @@ fn create_input_toml_template(
                     .collect();
                 toml::Value::Array(default_value_vec)
             }
-            AbiType::Struct { fields } => {
+            AbiType::Struct { fields, .. } => {
                 let default_value_map = toml::map::Map::from_iter(
                     fields.into_iter().map(|(name, typ)| (name, default_value(typ))),
                 );
@@ -128,6 +128,7 @@ mod tests {
             typed_param(
                 "d",
                 AbiType::Struct {
+                    name: String::from("mystruct"),
                     fields: vec![
                         (String::from("d1"), AbiType::Field),
                         (

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -128,7 +128,7 @@ mod tests {
             typed_param(
                 "d",
                 AbiType::Struct {
-                    name: String::from("mystruct"),
+                    name: String::from("MyStruct"),
                     fields: vec![
                         (String::from("d1"), AbiType::Field),
                         (

--- a/crates/noirc_abi/src/input_parser/json.rs
+++ b/crates/noirc_abi/src/input_parser/json.rs
@@ -96,7 +96,7 @@ impl JsonTypes {
 
             (InputValue::String(s), AbiType::String { .. }) => JsonTypes::String(s.to_string()),
 
-            (InputValue::Struct(map), AbiType::Struct { fields }) => {
+            (InputValue::Struct(map), AbiType::Struct { fields, .. }) => {
                 let map_with_json_types = try_btree_map(fields, |(key, field_type)| {
                     JsonTypes::try_from_input_value(&map[key], field_type)
                         .map(|json_value| (key.to_owned(), json_value))
@@ -155,7 +155,7 @@ impl InputValue {
                 InputValue::Vec(array_elements)
             }
 
-            (JsonTypes::Table(table), AbiType::Struct { fields }) => {
+            (JsonTypes::Table(table), AbiType::Struct { fields, .. }) => {
                 let native_table = try_btree_map(fields, |(field_name, abi_type)| {
                     // Check that json contains a value for each field of the struct.
                     let field_id = format!("{arg_name}.{field_name}");

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -162,7 +162,7 @@ mod serialization_tests {
                 AbiParameter {
                     name: "bar".into(),
                     typ: AbiType::Struct {
-                        name: "mystruct".into(),
+                        name: "MyStruct".into(),
                         fields: vec![
                             ("field1".into(), AbiType::Integer { sign: Sign::Unsigned, width: 8 }),
                             (

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -162,6 +162,7 @@ mod serialization_tests {
                 AbiParameter {
                     name: "bar".into(),
                     typ: AbiType::Struct {
+                        name: "mystruct".into(),
                         fields: vec![
                             ("field1".into(), AbiType::Integer { sign: Sign::Unsigned, width: 8 }),
                             (

--- a/crates/noirc_abi/src/input_parser/toml.rs
+++ b/crates/noirc_abi/src/input_parser/toml.rs
@@ -94,7 +94,7 @@ impl TomlTypes {
 
             (InputValue::String(s), AbiType::String { .. }) => TomlTypes::String(s.to_string()),
 
-            (InputValue::Struct(map), AbiType::Struct { fields }) => {
+            (InputValue::Struct(map), AbiType::Struct { fields, .. }) => {
                 let map_with_toml_types = try_btree_map(fields, |(key, field_type)| {
                     TomlTypes::try_from_input_value(&map[key], field_type)
                         .map(|toml_value| (key.to_owned(), toml_value))
@@ -138,7 +138,7 @@ impl InputValue {
                 InputValue::Vec(array_elements)
             }
 
-            (TomlTypes::Table(table), AbiType::Struct { fields }) => {
+            (TomlTypes::Table(table), AbiType::Struct { fields, .. }) => {
                 let native_table = try_btree_map(fields, |(field_name, abi_type)| {
                     // Check that json contains a value for each field of the struct.
                     let field_id = format!("{arg_name}.{field_name}");

--- a/crates/noirc_abi/src/lib.rs
+++ b/crates/noirc_abi/src/lib.rs
@@ -55,6 +55,7 @@ pub enum AbiType {
     },
     Boolean,
     Struct {
+        name: String,
         #[serde(
             serialize_with = "serialization::serialize_struct_fields",
             deserialize_with = "serialization::deserialize_struct_fields"
@@ -308,7 +309,7 @@ impl Abi {
                 encoded_value.extend(str_as_fields);
             }
 
-            (InputValue::Struct(object), AbiType::Struct { fields }) => {
+            (InputValue::Struct(object), AbiType::Struct { fields, .. }) => {
                 for (field, typ) in fields {
                     encoded_value.extend(Self::encode_value(object[field].clone(), typ)?);
                 }

--- a/crates/noirc_abi/src/serialization.rs
+++ b/crates/noirc_abi/src/serialization.rs
@@ -92,6 +92,7 @@ mod tests {
             \"name\":\"thing3\",
             \"type\": {
                 \"kind\":\"struct\",
+                \"name\": \"mystruct\",
                 \"fields\": [
                     {
                         \"name\": \"field1\",
@@ -119,6 +120,7 @@ mod tests {
         let expected_struct = AbiParameter {
             name: "thing3".to_string(),
             typ: AbiType::Struct {
+                name: "mystruct".to_string(),
                 fields: vec![
                     ("field1".to_string(), AbiType::Integer { sign: Sign::Unsigned, width: 3 }),
                     (

--- a/crates/noirc_abi/src/serialization.rs
+++ b/crates/noirc_abi/src/serialization.rs
@@ -92,7 +92,7 @@ mod tests {
             \"name\":\"thing3\",
             \"type\": {
                 \"kind\":\"struct\",
-                \"name\": \"mystruct\",
+                \"name\": \"MyStruct\",
                 \"fields\": [
                     {
                         \"name\": \"field1\",
@@ -120,7 +120,7 @@ mod tests {
         let expected_struct = AbiParameter {
             name: "thing3".to_string(),
             typ: AbiType::Struct {
-                name: "mystruct".to_string(),
+                name: "MyStruct".to_string(),
                 fields: vec![
                     ("field1".to_string(), AbiType::Integer { sign: Sign::Unsigned, width: 3 }),
                     (

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -986,7 +986,7 @@ impl Type {
                 let struct_type = def.borrow();
                 let fields = struct_type.get_fields(args);
                 let fields = vecmap(fields, |(name, typ)| (name, typ.as_abi_type()));
-                AbiType::Struct { fields }
+                AbiType::Struct { fields, name: struct_type.name.to_string() }
             }
             Type::Tuple(_) => todo!("as_abi_type not yet implemented for tuple types"),
             Type::TypeVariable(_, _) => unreachable!(),


### PR DESCRIPTION
Include struct names in the output ABI, which is useful for autogenerating types that follow the same naming. 

Related to #2238. It doesn't fix the issue since it'd need the full path to the struct, which I couldn't find on the `StructType`. My guess is there may be a mapping from `CrateId` (part of the `StructId`) to files somewhere. Any tips on where to get this info from would be appreciated, and I can try including it in a follow up PR or this one.

```diff
    {
      "name": "entrypoint",
      "functionType": "secret",
      "isInternal": false,
      "parameters": [
        {
          "name": "payload",
          "type": {
            "kind": "struct",
+           "name": "EntrypointPayload",
            "fields": [
              {
                "name": "flattened_args_hashes",
                "type": {
                  "kind": "array",
                  "length": 4,
                  "type": {
                    "kind": "field"
                  }
                }
              },
```