### PR TITLE
chore(ci): Name wasm job more clearly

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -120,7 +120,7 @@ jobs:
 
   test:
     needs: [build-wasm, build-nargo]
-    name: Test wasm
+    name: Test noir_wasm
     runs-on: ubuntu-latest
     steps:
       - name: Checkout noir-lang/noir

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -120,7 +120,7 @@ jobs:
 
   test:
     needs: [build-wasm, build-nargo]
-    name: Test
+    name: Test wasm
     runs-on: ubuntu-latest
     steps:
       - name: Checkout noir-lang/noir
@@ -148,7 +148,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./crates/wasm
         run: yarn install
-      
+
       - name: Install playwright deps
         working-directory: ./crates/wasm
         run: |


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

The wasm test job should be a required check, but it is finding this name in the github required checks UI is hard. This makes it more specific.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
