### PR TITLE
fix: Fix 3 parser test cases in parsing

### DIFF
--- a/crates/noirc_errors/src/reporter.rs
+++ b/crates/noirc_errors/src/reporter.rs
@@ -75,7 +75,7 @@ impl CustomDiagnostic {
         matches!(self.kind, DiagnosticKind::Error)
     }
 
-    pub fn is_warrning(&self) -> bool {
+    pub fn is_warning(&self) -> bool {
         matches!(self.kind, DiagnosticKind::Warning)
     }
 }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -1487,9 +1487,9 @@ mod test {
             .into_iter()
             .flat_map(|program| {
                 let (_expr, diagnostics) = parse_recover(&parser, program);
-                if diagnostics.iter().any(|diagnostic| diagnostic.is_error()) {
+                diagnostics.iter().for_each(|diagnostic| if diagnostic.is_error() {
                     unreachable!("Expected this input to pass with warning:\n{program}\nYet it failed with error:\n{diagnostic}")
-                };
+                });
                 diagnostics
             })
             .collect()


### PR DESCRIPTION
 # Description
Fixed some test code in parser. The biggest change is 

* parse_all_failing test function is now satisfied by errors only ( previous version treated warning as errors )
* Fix 3 parser test cases from failing to passing
* Fix typo in is_warning

## Problem\*

Prior to this PR this test cases triggered errors by in the parser
```
trait GenericTrait<T> { fn elem(&mut self, index: Field) -> T; }

trait GenericTraitWithConstraints<T> where T: SomeTrait { fn elem(self, index: Field) -> T; }

trait TraitWithMultipleGenericParams<A, B, C> where A: SomeTrait, B: AnotherTrait<C> { let Size: Field; fn zero() -> Self; }
```

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
