### PR TITLE
fix(nargo): Allow `--program-dir` flag anywhere in a command

### DIFF
--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -39,7 +39,7 @@ struct NargoCli {
 #[non_exhaustive]
 #[derive(Args, Clone, Debug)]
 pub(crate) struct NargoConfig {
-    #[arg(short, long, hide=true, default_value_os_t = std::env::current_dir().unwrap())]
+    #[arg(short, long, hide=true, global=true, default_value_os_t = std::env::current_dir().unwrap())]
     program_dir: PathBuf,
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2289  <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This allows us to put `--program-dir` anywhere in a command. This enables me to work on https://github.com/noir-lang/vscode-noir/issues/28 easily.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
