### PR TITLE
fix(lsp): Pass `--program-dir` to test command from codelens

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -199,6 +199,8 @@ fn on_code_lens_request(
                 title: TEST_CODELENS_TITLE.into(),
                 command: TEST_COMMAND.into(),
                 arguments: Some(vec![
+                    "--program-dir".into(),
+                    format!("{}", workspace.root_dir.display()).into(),
                     "--package".into(),
                     format!("{}", package.name).into(),
                     "--exact".into(),

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -39,6 +39,7 @@ struct NargoCli {
 #[non_exhaustive]
 #[derive(Args, Clone, Debug)]
 pub(crate) struct NargoConfig {
+    // REMINDER: Also change this flag in the LSP test lens if renamed
     #[arg(short, long, hide=true, global=true, default_value_os_t = std::env::current_dir().unwrap())]
     program_dir: PathBuf,
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2291  <!-- Link to GitHub Issue -->
Resolves https://github.com/noir-lang/vscode-noir/issues/28

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This passes the `--program-dir` flag when a user runs a test via a codelens. This ensures that the `Run Test` lens will always work, even if there is no Nargo.toml file at the root of the vscode workspace.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
