### PR TITLE
fix: Require package names to be non-empty

### DIFF
--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -1,18 +1,20 @@
 use crate::errors::CliError;
 
 use super::fs::{create_named_dir, write_to_file};
-use super::{crate_name_parser, NargoConfig, CARGO_PKG_VERSION};
+use super::{NargoConfig, CARGO_PKG_VERSION};
 use acvm::Backend;
 use clap::Args;
 use nargo::constants::{PKG_FILE, SRC_DIR};
 use nargo::package::PackageType;
+use noirc_frontend::graph::CrateName;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 /// Create a Noir project in the current directory.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
     /// Name of the package [default: current directory name]
-    #[clap(long, value_parser = crate_name_parser)]
+    #[clap(long, value_parser = CrateName::from_str)]
     name: Option<String>,
 
     /// Use a library template

--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -1,7 +1,7 @@
 use crate::errors::CliError;
 
 use super::fs::{create_named_dir, write_to_file};
-use super::{NargoConfig, CARGO_PKG_VERSION};
+use super::{crate_name_parser, NargoConfig, CARGO_PKG_VERSION};
 use acvm::Backend;
 use clap::Args;
 use nargo::constants::{PKG_FILE, SRC_DIR};
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
     /// Name of the package [default: current directory name]
-    #[clap(long)]
+    #[clap(long, value_parser = crate_name_parser)]
     name: Option<String>,
 
     /// Use a library template

--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -8,14 +8,13 @@ use nargo::constants::{PKG_FILE, SRC_DIR};
 use nargo::package::PackageType;
 use noirc_frontend::graph::CrateName;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 /// Create a Noir project in the current directory.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
     /// Name of the package [default: current directory name]
-    #[clap(long, value_parser = CrateName::from_str)]
-    name: Option<String>,
+    #[clap(long)]
+    name: Option<CrateName>,
 
     /// Use a library template
     #[arg(long, conflicts_with = "bin", conflicts_with = "contract")]
@@ -71,6 +70,7 @@ pub(crate) fn run<B: Backend>(
 ) -> Result<(), CliError<B>> {
     let package_name = args
         .name
+        .map(|name| name.to_string())
         .unwrap_or_else(|| config.program_dir.file_name().unwrap().to_str().unwrap().to_owned());
 
     let package_type = if args.lib {

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -86,13 +86,3 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
 
     Ok(())
 }
-
-fn crate_name_parser(name: &str) -> Result<String, String> {
-    use noirc_frontend::graph::CrateName;
-
-    if CrateName::is_valid_name(name) {
-        Ok(name.into())
-    } else {
-        Err("Package names must be non-empty and cannot contain hyphens".into())
-    }
-}

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -86,3 +86,13 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
 
     Ok(())
 }
+
+fn crate_name_parser(name: &str) -> Result<String, String> {
+    use noirc_frontend::graph::CrateName;
+
+    if CrateName::is_valid_name(name) {
+        Ok(name.into())
+    } else {
+        Err("Package names must be non-empty and cannot contain hyphens".into())
+    }
+}

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -5,7 +5,7 @@ use acvm::Backend;
 use clap::Args;
 use nargo::package::PackageType;
 use noirc_frontend::graph::CrateName;
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 
 /// Create a Noir project in a new directory.
 #[derive(Debug, Clone, Args)]
@@ -14,8 +14,8 @@ pub(crate) struct NewCommand {
     path: PathBuf,
 
     /// Name of the package [default: package directory name]
-    #[clap(long, value_parser = CrateName::from_str)]
-    name: Option<String>,
+    #[clap(long)]
+    name: Option<CrateName>,
 
     /// Use a library template
     #[arg(long, conflicts_with = "bin", conflicts_with = "contract")]
@@ -42,8 +42,10 @@ pub(crate) fn run<B: Backend>(
         return Err(CliError::DestinationAlreadyExists(package_dir));
     }
 
-    let package_name =
-        args.name.unwrap_or_else(|| args.path.file_name().unwrap().to_str().unwrap().to_owned());
+    let package_name = args
+        .name
+        .map(|name| name.to_string())
+        .unwrap_or_else(|| args.path.file_name().unwrap().to_str().unwrap().to_owned());
     let package_type = if args.lib {
         PackageType::Library
     } else if args.contract {

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -1,10 +1,11 @@
 use crate::errors::CliError;
 
-use super::{crate_name_parser, init_cmd::initialize_project, NargoConfig};
+use super::{init_cmd::initialize_project, NargoConfig};
 use acvm::Backend;
 use clap::Args;
 use nargo::package::PackageType;
-use std::path::PathBuf;
+use noirc_frontend::graph::CrateName;
+use std::{path::PathBuf, str::FromStr};
 
 /// Create a Noir project in a new directory.
 #[derive(Debug, Clone, Args)]
@@ -13,7 +14,7 @@ pub(crate) struct NewCommand {
     path: PathBuf,
 
     /// Name of the package [default: package directory name]
-    #[clap(long, value_parser = crate_name_parser)]
+    #[clap(long, value_parser = CrateName::from_str)]
     name: Option<String>,
 
     /// Use a library template

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -42,10 +42,13 @@ pub(crate) fn run<B: Backend>(
         return Err(CliError::DestinationAlreadyExists(package_dir));
     }
 
-    let package_name = args
-        .name
-        .map(|name| name.to_string())
-        .unwrap_or_else(|| args.path.file_name().unwrap().to_str().unwrap().to_owned());
+    let package_name = match args.name {
+        Some(name) => name,
+        None => {
+            let name = args.path.file_name().unwrap().to_str().unwrap();
+            name.parse().map_err(|_| CliError::InvalidPackageName(name.into()))?
+        }
+    };
     let package_type = if args.lib {
         PackageType::Library
     } else if args.contract {
@@ -53,6 +56,6 @@ pub(crate) fn run<B: Backend>(
     } else {
         PackageType::Binary
     };
-    initialize_project(package_dir, &package_name, package_type);
+    initialize_project(package_dir, package_name, package_type);
     Ok(())
 }

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -1,6 +1,6 @@
 use crate::errors::CliError;
 
-use super::{init_cmd::initialize_project, NargoConfig};
+use super::{crate_name_parser, init_cmd::initialize_project, NargoConfig};
 use acvm::Backend;
 use clap::Args;
 use nargo::package::PackageType;
@@ -13,7 +13,7 @@ pub(crate) struct NewCommand {
     path: PathBuf,
 
     /// Name of the package [default: package directory name]
-    #[clap(long)]
+    #[clap(long, value_parser = crate_name_parser)]
     name: Option<String>,
 
     /// Use a library template

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -41,6 +41,9 @@ pub(crate) enum CliError<B: Backend> {
     #[error("Failed to verify proof {}", .0.display())]
     InvalidProof(PathBuf),
 
+    #[error("Invalid package name {0}. Did you mean to use `--name`?")]
+    InvalidPackageName(String),
+
     /// ABI encoding/decoding error
     #[error(transparent)]
     AbiError(#[from] AbiError),

--- a/crates/nargo_cli/tests/compile_failure/invalid_dependency_name/Nargo.toml
+++ b/crates/nargo_cli/tests/compile_failure/invalid_dependency_name/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "invalid_dependency_name"
+type = "bin"
+authors = [""]
+compiler_version = "0.9.0"
+
+[dependencies]
+bad_name = { path = "../../test_libraries/bad_name" }

--- a/crates/nargo_cli/tests/compile_failure/invalid_dependency_name/src/main.nr
+++ b/crates/nargo_cli/tests/compile_failure/invalid_dependency_name/src/main.nr
@@ -1,0 +1,1 @@
+fn main(x: Field) { }

--- a/crates/nargo_cli/tests/compile_failure/package_name_empty/Nargo.toml
+++ b/crates/nargo_cli/tests/compile_failure/package_name_empty/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = ""
+type = "bin"
+authors = [""]
+compiler_version = "0.9.0"
+
+[dependencies]

--- a/crates/nargo_cli/tests/compile_failure/package_name_empty/src/main.nr
+++ b/crates/nargo_cli/tests/compile_failure/package_name_empty/src/main.nr
@@ -1,0 +1,1 @@
+fn main(x: Field) { }

--- a/crates/nargo_cli/tests/compile_failure/package_name_hyphen/Nargo.toml
+++ b/crates/nargo_cli/tests/compile_failure/package_name_hyphen/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "hyphenated-name"
+type = "bin"
+authors = [""]
+compiler_version = "0.9.0"
+
+[dependencies]

--- a/crates/nargo_cli/tests/compile_failure/package_name_hyphen/src/main.nr
+++ b/crates/nargo_cli/tests/compile_failure/package_name_hyphen/src/main.nr
@@ -1,0 +1,1 @@
+fn main(x: Field) { }

--- a/crates/nargo_cli/tests/test_libraries/bad_name/Nargo.toml
+++ b/crates/nargo_cli/tests/test_libraries/bad_name/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bad-name"
+type = "lib"
+authors = [""]
+compiler_version = "0.7.1"
+
+[dependencies]

--- a/crates/nargo_toml/src/errors.rs
+++ b/crates/nargo_toml/src/errors.rs
@@ -38,9 +38,11 @@ pub enum ManifestError {
     )]
     MissingDefaultEntryFile { toml: PathBuf, entry: PathBuf, package_type: PackageType },
 
-    /// Invalid character `-` in package name
-    #[error("invalid character `-` in package name")]
-    InvalidPackageName,
+    #[error("{} found in {toml}", if name.is_empty() { "Empty package name".into() } else { format!("Invalid package name `{name}`") })]
+    InvalidPackageName { toml: PathBuf, name: String },
+
+    #[error("{} found in {toml}", if name.is_empty() { "Empty dependency name".into() } else { format!("Invalid dependency name `{name}`") })]
+    InvalidDependencyName { toml: PathBuf, name: String },
 
     /// Encountered error while downloading git repository.
     #[error("{0}")]

--- a/crates/nargo_toml/src/lib.rs
+++ b/crates/nargo_toml/src/lib.rs
@@ -72,14 +72,20 @@ struct PackageConfig {
 impl PackageConfig {
     fn resolve_to_package(&self, root_dir: &Path) -> Result<Package, ManifestError> {
         let name = if let Some(name) = &self.package.name {
-            name.parse().map_err(|_| ManifestError::InvalidPackageName)?
+            name.parse().map_err(|_| ManifestError::InvalidPackageName {
+                toml: root_dir.join("Nargo.toml"),
+                name: name.into(),
+            })?
         } else {
             return Err(ManifestError::MissingNameField { toml: root_dir.join("Nargo.toml") });
         };
 
         let mut dependencies: BTreeMap<CrateName, Dependency> = BTreeMap::new();
         for (name, dep_config) in self.dependencies.iter() {
-            let name = name.parse().map_err(|_| ManifestError::InvalidPackageName)?;
+            let name = name.parse().map_err(|_| ManifestError::InvalidDependencyName {
+                toml: root_dir.join("Nargo.toml"),
+                name: name.into(),
+            })?;
             let resolved_dep = dep_config.resolve_to_dependency(root_dir)?;
 
             dependencies.insert(name, resolved_dep);

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -30,7 +30,7 @@ impl CrateId {
 pub struct CrateName(SmolStr);
 
 impl CrateName {
-    pub fn is_valid_name(name: &str) -> bool {
+   fn is_valid_name(name: &str) -> bool {
         !name.is_empty() && name.chars().all(|n| !CHARACTER_BLACK_LIST.contains(&n))
     }
 }

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -29,6 +29,12 @@ impl CrateId {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct CrateName(SmolStr);
 
+impl CrateName {
+    pub fn is_valid_name(name: &str) -> bool {
+        !name.is_empty() && name.chars().all(|n| !CHARACTER_BLACK_LIST.contains(&n))
+    }
+}
+
 impl Display for CrateName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
@@ -54,11 +60,28 @@ impl FromStr for CrateName {
     type Err = String;
 
     fn from_str(name: &str) -> Result<Self, Self::Err> {
-        let is_invalid = name.chars().any(|n| CHARACTER_BLACK_LIST.contains(&n));
-        if is_invalid {
-            Err(name.into())
-        } else {
+        if Self::is_valid_name(name) {
             Ok(Self(SmolStr::new(name)))
+        } else {
+            Err(name.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod crate_name {
+    use super::{CrateName, CHARACTER_BLACK_LIST};
+
+    #[test]
+    fn it_rejects_empty_string() {
+        assert!(!CrateName::is_valid_name(""));
+    }
+
+    #[test]
+    fn it_rejects_blacklisted_chars() {
+        for bad_char in CHARACTER_BLACK_LIST {
+            let bad_char_string = bad_char.to_string();
+            assert!(!CrateName::is_valid_name(&bad_char_string));
         }
     }
 }

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -63,7 +63,7 @@ impl FromStr for CrateName {
         if Self::is_valid_name(name) {
             Ok(Self(SmolStr::new(name)))
         } else {
-            Err(name.into())
+            Err("Package names must be non-empty and cannot contain hyphens".into())
         }
     }
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2287 

## Summary\*

This PR requires that `CrateNames` must have a non-empty string to avoid the issue described in #2287 

We also weren't validating these on package creation, so I've added a custom value parser to clap in order to error on invalid user input as soon as possible so we don't get `nargo new` half-creating the new package.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


BEGIN_COMMIT_OVERRIDE
fix: Require package names to be non-empty (#2293)
feat: Perform input validation on user's package names (#2293)
END_COMMIT_OVERRIDE