### PR TITLE
feat: Include full module path to structs in abi

### DIFF
--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -34,7 +34,8 @@ pub fn prepare_dependencies(
     for (dep_name, dep) in dependencies.iter() {
         match dep {
             Dependency::Remote { package } | Dependency::Local { package } => {
-                let crate_id = prepare_crate(context, &package.entry_path);
+                let crate_id =
+                    prepare_crate(context, &package.entry_path, Some(package.name.to_owned()));
                 add_dep(context, parent_crate, crate_id, dep_name.clone());
                 prepare_dependencies(context, crate_id, &package.dependencies);
             }
@@ -48,7 +49,7 @@ pub fn prepare_package(package: &Package) -> (Context, CrateId) {
     let graph = CrateGraph::default();
     let mut context = Context::new(fm, graph);
 
-    let crate_id = prepare_crate(&mut context, &package.entry_path);
+    let crate_id = prepare_crate(&mut context, &package.entry_path, Some(package.name.to_owned()));
 
     prepare_dependencies(&mut context, crate_id, &package.dependencies);
 

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -52,15 +52,19 @@ pub fn compile_file(
     context: &mut Context,
     root_file: &Path,
 ) -> Result<(CompiledProgram, Warnings), ErrorsAndWarnings> {
-    let crate_id = prepare_crate(context, root_file);
+    let crate_id = prepare_crate(context, root_file, None);
     compile_main(context, crate_id, &CompileOptions::default())
 }
 
 /// Adds the file from the file system at `Path` to the crate graph
-pub fn prepare_crate(context: &mut Context, file_name: &Path) -> CrateId {
+pub fn prepare_crate(
+    context: &mut Context,
+    file_name: &Path,
+    package_name: Option<CrateName>,
+) -> CrateId {
     let root_file_id = context.file_manager.add_file(file_name).unwrap();
 
-    context.crate_graph.add_crate_root(root_file_id)
+    context.crate_graph.add_crate_root(root_file_id, package_name)
 }
 
 /// Adds a edge in the crate graph for two crates
@@ -132,7 +136,7 @@ pub fn compute_function_signature(
     let main_function = context.get_main_function(crate_id)?;
 
     let func_meta = context.def_interner.function_meta(&main_function);
-
+    println!("In compute_function_signature");
     Some(func_meta.into_function_signature(&context.def_interner))
 }
 

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -136,7 +136,6 @@ pub fn compute_function_signature(
     let main_function = context.get_main_function(crate_id)?;
 
     let func_meta = context.def_interner.function_meta(&main_function);
-    println!("In compute_function_signature");
     Some(func_meta.into_function_signature(&context.def_interner))
 }
 

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -360,7 +360,19 @@ fn resolve_structs(
     // without resolve_struct_fields non-deterministically unwrapping a value
     // that isn't in the HashMap.
     for (type_id, typ) in &structs {
-        context.def_interner.push_empty_struct(*type_id, typ);
+        let type_index = type_id.0.local_id.0;
+        let module_path = context.def_map(&crate_id).unwrap().get_module_path_with_separator(
+            type_index,
+            Some(typ.module_id),
+            "::",
+        );
+        let crate_name = context
+            .crate_graph
+            .get_crate(crate_id)
+            .and_then(|c| c.name.to_owned())
+            .map_or(String::new(), |n| n.to_string());
+        let full_path = format!("{crate_name}::{module_path}");
+        context.def_interner.push_empty_struct(*type_id, full_path, typ);
     }
 
     for (type_id, typ) in structs {

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -122,6 +122,8 @@ pub struct StructType {
 
     pub generics: Generics,
     pub span: Span,
+
+    pub module_path: String,
 }
 
 /// Corresponds to generic lists such as `<T, U>` in the source
@@ -149,8 +151,9 @@ impl StructType {
         span: Span,
         fields: Vec<(Ident, Type)>,
         generics: Generics,
+        module_path: String,
     ) -> StructType {
-        StructType { id, fields, name, span, generics }
+        StructType { id, fields, name, span, generics, module_path }
     }
 
     /// To account for cyclic references between structs, a struct's
@@ -986,7 +989,7 @@ impl Type {
                 let struct_type = def.borrow();
                 let fields = struct_type.get_fields(args);
                 let fields = vecmap(fields, |(name, typ)| (name, typ.as_abi_type()));
-                AbiType::Struct { fields, name: struct_type.name.to_string() }
+                AbiType::Struct { fields, name: struct_type.module_path.to_string() }
             }
             Type::Tuple(_) => todo!("as_abi_type not yet implemented for tuple types"),
             Type::TypeVariable(_, _) => unreachable!(),

--- a/crates/noirc_frontend/src/node_interner.rs
+++ b/crates/noirc_frontend/src/node_interner.rs
@@ -304,7 +304,12 @@ impl NodeInterner {
         self.id_to_type.insert(expr_id.into(), typ);
     }
 
-    pub fn push_empty_struct(&mut self, type_id: StructId, typ: &UnresolvedStruct) {
+    pub fn push_empty_struct(
+        &mut self,
+        type_id: StructId,
+        module_path: String,
+        typ: &UnresolvedStruct,
+    ) {
         self.structs.insert(
             type_id,
             Shared::new(StructType::new(
@@ -320,6 +325,7 @@ impl NodeInterner {
                     let id = TypeVariableId(0);
                     (id, Shared::new(TypeBinding::Unbound(id)))
                 }),
+                module_path,
             )),
         );
     }

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -6,9 +6,12 @@ use noirc_driver::{
     check_crate, compile_contracts, compile_no_check, prepare_crate, propagate_dep, CompileOptions,
     CompiledContract,
 };
-use noirc_frontend::{graph::CrateGraph, hir::Context};
+use noirc_frontend::{
+    graph::{CrateGraph, CrateName},
+    hir::Context,
+};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::{path::Path, str::FromStr};
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,7 +63,7 @@ impl Default for WASMCompileOptions {
 
 fn add_noir_lib(context: &mut Context, crate_name: &str) {
     let path_to_lib = Path::new(&crate_name).join("lib.nr");
-    let library_crate = prepare_crate(context, &path_to_lib);
+    let library_crate = prepare_crate(context, &path_to_lib, CrateName::from_str(crate_name).ok());
 
     propagate_dep(context, library_crate, &crate_name.parse().unwrap());
 }
@@ -84,7 +87,7 @@ pub fn compile(args: JsValue) -> JsValue {
     let mut context = Context::new(fm, graph);
 
     let path = Path::new(&options.entry_point);
-    let crate_id = prepare_crate(&mut context, path);
+    let crate_id = prepare_crate(&mut context, path, None);
 
     for dependency in options.optional_dependencies_set {
         add_noir_lib(&mut context, dependency.as_str());


### PR DESCRIPTION
Continues the work from #2266 and prepends the full module path to struct type names in the ABI. The name is composed as `package_name::module_1::...::module_N::struct_name`. 

For example:

```
    {
      "name": "entrypoint",
      "functionType": "secret",
      "isInternal": false,
      "parameters": [
        {
          "name": "payload",
          "type": {
            "kind": "struct",
-           "name": "EntrypointPayload",
+           "name": "noir_aztec::entrypoint::EntrypointPayload",
            "fields": [
              {
                "name": "flattened_args_hashes",
                "type": {
                  "kind": "array",
                  "length": 4,
                  "type": {
                    "kind": "field"
                  }
                }
              },
```

Note that the `crate_name` added to `CrateData` is optional, since some instantiations of crates seem to be coming from not-a-package. Also, I was unsure as to emit the name of the package or the name of the dependency as registered in the contract package TOML. I decided to go with the former, since this ABI may be consumed from a location that doesn't know the mapping from dependency names to packages.

Now, if this feels like we're spreading too much data across internal types, I'm fine closing this PR and looking for an alternate solution.

Fixes #2238 