### PR TITLE
fix(nargo)!: Remove `-p` short flag from the `--program-dir` flag

### DIFF
--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -40,7 +40,7 @@ struct NargoCli {
 #[derive(Args, Clone, Debug)]
 pub(crate) struct NargoConfig {
     // REMINDER: Also change this flag in the LSP test lens if renamed
-    #[arg(short, long, hide=true, global=true, default_value_os_t = std::env::current_dir().unwrap())]
+    #[arg(long, hide=true, global=true, default_value_os_t = std::env::current_dir().unwrap())]
     program_dir: PathBuf,
 }
 


### PR DESCRIPTION
# Description

The recently added `--program-name` conflicts with the `--prover-name` argument of `nargo prove`, and `nargo prove` panics with the following error:

```
Message:  Command prove: Short option names must be unique for each argument, but '-p' is in use by both 'prover_name' and 'program_dir'
```
## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue --> https://github.com/noir-lang/noir/issues/2299

## Summary\*

Remove the option to have --program-dir as a short argument so it doesn't conflict with --prover-name
<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
