### PR TITLE
chore: Use `BlackBoxFunctionSolver` separated from `Backend`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9915f2895792d8d9e4f25d9e026bac35774513a97c564fa7604e80462ac19e04"
+source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
 dependencies = [
  "acir_field",
  "bincode",
@@ -19,8 +18,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a43a2e9419db7a1b046e763154fa67e66039e8fe08b88c13f18f81f9220ebdf"
+source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -33,8 +31,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38362933e2f7fcf6faf6c7c969f4c1ad2370953c35613801686259cdb8b5d194"
+source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -50,8 +47,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48216028c1e503f26e52f85b3888010ee2cedc72d67de629a1318ceaf09dc67c"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=279287850befd45f33bf17230b82d8bf7f942114#279287850befd45f33bf17230b82d8bf7f942114"
 dependencies = [
  "acvm",
  "barretenberg-sys",
@@ -70,23 +66,27 @@ dependencies = [
 [[package]]
 name = "acvm_blackbox_solver"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2d887ed2c7203f08efb6661d8f30ecfd69b453fe2965393d7e99664afc7558"
+source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
 dependencies = [
  "acir",
  "blake2",
+ "getrandom",
+ "js-sys",
  "k256",
  "p256",
+ "pkg-config",
+ "rust-embed",
  "sha2",
  "sha3",
  "thiserror",
+ "wasm-bindgen-futures",
+ "wasmer",
 ]
 
 [[package]]
 name = "acvm_stdlib"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7958693ac099e257b1791dc71f0296b0cc5e97764e55d67efc06f25191ecbaf"
+source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
 dependencies = [
  "acir",
 ]
@@ -416,7 +416,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.31.1",
+ "object",
  "rustc-demangle",
 ]
 
@@ -537,8 +537,7 @@ dependencies = [
 [[package]]
 name = "brillig"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d24f35009f581a810c74628ab6bf03eb717b0e55d2c27994694b11ae98ff950"
+source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
 dependencies = [
  "acir_field",
  "serde",
@@ -547,8 +546,7 @@ dependencies = [
 [[package]]
 name = "brillig_vm"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1534e2b03604d08a586ef735fa704f692c468c7e0e6663210fd414bac5382040"
+source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -611,6 +609,12 @@ name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -894,62 +898,86 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+checksum = "2a2ab4512dfd3a6f4be184403a195f76e81a8a9f9e6c898e19d2dc3ce20e0115"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+checksum = "98b022ed2a5913a38839dfbafe6cf135342661293b08049843362df4301261dc"
 dependencies = [
+ "arrayvec",
+ "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
+ "cranelift-egraph",
  "cranelift-entity",
+ "cranelift-isle",
  "gimli 0.26.2",
  "log",
- "regalloc",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+checksum = "639307b45434ad112a98f8300c0f0ab085cbefcd767efcdef9ef19d4c0756e74"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+checksum = "278e52e29c53fcf32431ef08406c295699a70306d05a0715c5b1bf50e33a9ab7"
+
+[[package]]
+name = "cranelift-egraph"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624b54323b06e675293939311943ba82d323bb340468ce1889be5da7932c8d73"
+dependencies = [
+ "cranelift-entity",
+ "fxhash",
+ "hashbrown 0.12.3",
+ "indexmap 1.9.3",
+ "log",
+ "smallvec",
+]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+checksum = "9a59bcbca89c3f1b70b93ab3cbba5e5e0cbf3e63dadb23c7525cb142e21a9d4c"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+checksum = "0d70abacb8cfef3dc8ff7e8836e9c1d70f7967dfdac824a4cd5e30223415aca6"
 dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "393bc73c451830ff8dbb3a07f61843d6cb41a084f9996319917c0b291ed785bb"
 
 [[package]]
 name = "crc32fast"
@@ -1114,6 +1142,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.26",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1515,6 +1556,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generational-arena"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +1914,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2053,27 +2102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
-name = "loupe"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
-dependencies = [
- "indexmap 1.9.3",
- "loupe-derive",
- "rustversion",
-]
-
-[[package]]
-name = "loupe-derive"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "lsp-types"
 version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -2445,18 +2473,6 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "crc32fast",
- "hashbrown 0.11.2",
- "indexmap 1.9.3",
- "memchr",
 ]
 
 [[package]]
@@ -2891,13 +2907,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.34"
+name = "regalloc2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
+checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
 dependencies = [
+ "fxhash",
  "log",
- "rustc-hash",
+ "slice-group-by",
  "smallvec",
 ]
 
@@ -3043,6 +3060,7 @@ dependencies = [
  "bitvec",
  "bytecheck",
  "hashbrown 0.12.3",
+ "indexmap 1.9.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -3312,12 +3330,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.12"
+name = "serde-wasm-bindgen"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
 dependencies = [
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3453,6 +3473,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "small-ord-set"
@@ -4069,6 +4095,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-downcast"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dac026d43bcca6e7ce1c0956ba68f59edf6403e8e930a5d891be72c31a44340"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "wasm-bindgen-downcast-macros",
+]
+
+[[package]]
+name = "wasm-bindgen-downcast-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5020cfa87c7cecefef118055d44e3c1fc122c7ec25701d528ee458a0b45f38f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,73 +4180,67 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+checksum = "78caedecd8cb71ed47ccca03b68d69414a3d278bb031e6f93f15759344efdd52"
 dependencies = [
+ "bytes",
  "cfg-if",
+ "derivative",
  "indexmap 1.9.3",
  "js-sys",
- "loupe",
  "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde-wasm-bindgen",
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
- "wasmer-artifact",
+ "wasm-bindgen-downcast",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
- "wasmer-engine",
- "wasmer-engine-dylib",
- "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
+ "wasmparser 0.83.0",
+ "wasmparser 0.95.0",
  "wat",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
-dependencies = [
- "enumset",
- "loupe",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-compiler"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
+checksum = "726a8450541af4a57c34af7b6973fdbfc79f896cc7e733429577dfd1d1687180"
 dependencies = [
+ "backtrace",
+ "cfg-if",
+ "enum-iterator",
  "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
+ "lazy_static",
+ "leb128",
+ "memmap2",
+ "more-asserts",
+ "region",
  "smallvec",
- "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmparser",
+ "wasmer-vm",
+ "wasmparser 0.95.0",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
+checksum = "a1e5633f90f372563ebbdf3f9799c7b29ba11c90e56cf9b54017112d2e656c95"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "gimli 0.26.2",
- "loupe",
  "more-asserts",
  "rayon",
  "smallvec",
@@ -4209,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+checksum = "97901fdbaae383dbb90ea162cc3a76a9fa58ac39aec7948b4c0b9bbef9307738"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -4220,142 +4263,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-engine"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
-dependencies = [
- "cfg-if",
- "enum-iterator",
- "enumset",
- "leb128",
- "libloading",
- "loupe",
- "object 0.28.4",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
-]
-
-[[package]]
-name = "wasmer-engine-universal"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
-dependencies = [
- "cfg-if",
- "enumset",
- "leb128",
- "loupe",
- "region",
- "rkyv",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-engine-universal-artifact",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-engine-universal-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
-dependencies = [
- "enum-iterator",
- "enumset",
- "loupe",
- "rkyv",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
-dependencies = [
- "object 0.28.4",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-types"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
+checksum = "67f1f2839f4f61509550e4ddcd0e658e19f3af862b51c79fda15549d735d659b"
 dependencies = [
- "backtrace",
+ "bytecheck",
  "enum-iterator",
+ "enumset",
  "indexmap 1.9.3",
- "loupe",
  "more-asserts",
  "rkyv",
- "serde",
+ "target-lexicon",
  "thiserror",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
+checksum = "043118ec4f16d1714fed3aab758b502b864bd865e1d5188626c9ad290100563f"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
  "corosensei",
+ "dashmap",
+ "derivative",
  "enum-iterator",
+ "fnv",
  "indexmap 1.9.3",
  "lazy_static",
  "libc",
- "loupe",
  "mach",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "more-asserts",
  "region",
- "rkyv",
  "scopeguard",
- "serde",
  "thiserror",
- "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
@@ -4365,6 +4310,16 @@ name = "wasmparser"
 version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wasmparser"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
+dependencies = [
+ "indexmap 1.9.3",
+ "url",
+]
 
 [[package]]
 name = "wast"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.10.0"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=c4af91dd14d704f3f17c93459d1686360e771ea4#c4af91dd14d704f3f17c93459d1686360e771ea4"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=aa6309e486c7b9abb0e46219dae0fbeaf1b0bc0a#aa6309e486c7b9abb0e46219dae0fbeaf1b0bc0a"
 dependencies = [
  "acvm",
  "barretenberg-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
+source = "git+https://github.com/noir-lang/acvm?rev=766d76e1419ba90a2c0e76e8da3c02db10497e35#766d76e1419ba90a2c0e76e8da3c02db10497e35"
 dependencies = [
  "acir_field",
  "bincode",
@@ -18,7 +18,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
+source = "git+https://github.com/noir-lang/acvm?rev=766d76e1419ba90a2c0e76e8da3c02db10497e35#766d76e1419ba90a2c0e76e8da3c02db10497e35"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
+source = "git+https://github.com/noir-lang/acvm?rev=766d76e1419ba90a2c0e76e8da3c02db10497e35#766d76e1419ba90a2c0e76e8da3c02db10497e35"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -47,7 +47,7 @@ dependencies = [
 [[package]]
 name = "acvm-backend-barretenberg"
 version = "0.10.0"
-source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=279287850befd45f33bf17230b82d8bf7f942114#279287850befd45f33bf17230b82d8bf7f942114"
+source = "git+https://github.com/noir-lang/acvm-backend-barretenberg?rev=c4af91dd14d704f3f17c93459d1686360e771ea4#c4af91dd14d704f3f17c93459d1686360e771ea4"
 dependencies = [
  "acvm",
  "barretenberg-sys",
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 name = "acvm_blackbox_solver"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
+source = "git+https://github.com/noir-lang/acvm?rev=766d76e1419ba90a2c0e76e8da3c02db10497e35#766d76e1419ba90a2c0e76e8da3c02db10497e35"
 dependencies = [
  "acir",
  "blake2",
@@ -86,7 +86,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
+source = "git+https://github.com/noir-lang/acvm?rev=766d76e1419ba90a2c0e76e8da3c02db10497e35#766d76e1419ba90a2c0e76e8da3c02db10497e35"
 dependencies = [
  "acir",
 ]
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "brillig"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
+source = "git+https://github.com/noir-lang/acvm?rev=766d76e1419ba90a2c0e76e8da3c02db10497e35#766d76e1419ba90a2c0e76e8da3c02db10497e35"
 dependencies = [
  "acir_field",
  "serde",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "brillig_vm"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm?rev=61266056a0be5c7397ed64ee68b781a21c382cd3#61266056a0be5c7397ed64ee68b781a21c382cd3"
+source = "git+https://github.com/noir-lang/acvm?rev=766d76e1419ba90a2c0e76e8da3c02db10497e35#766d76e1419ba90a2c0e76e8da3c02db10497e35"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/wasm",
 ]
 default-members = ["crates/nargo_cli"]
+resolver = "2"
 
 [workspace.package]
 # x-release-please-start-version
@@ -57,3 +58,7 @@ url = "2.2.0"
 wasm-bindgen = { version = "=0.2.86", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
+
+[patch.crates-io]
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "279287850befd45f33bf17230b82d8bf7f942114" }
+acvm = { git = "https://github.com/noir-lang/acvm", rev = "61266056a0be5c7397ed64ee68b781a21c382cd3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,5 +60,5 @@ wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
 
 [patch.crates-io]
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "279287850befd45f33bf17230b82d8bf7f942114" }
-acvm = { git = "https://github.com/noir-lang/acvm", rev = "61266056a0be5c7397ed64ee68b781a21c382cd3" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "c4af91dd14d704f3f17c93459d1686360e771ea4" }
+acvm = { git = "https://github.com/noir-lang/acvm", rev = "766d76e1419ba90a2c0e76e8da3c02db10497e35" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,5 +60,5 @@ wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
 
 [patch.crates-io]
-acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "c4af91dd14d704f3f17c93459d1686360e771ea4" }
+acvm-backend-barretenberg = { git = "https://github.com/noir-lang/acvm-backend-barretenberg", rev = "aa6309e486c7b9abb0e46219dae0fbeaf1b0bc0a" }
 acvm = { git = "https://github.com/noir-lang/acvm", rev = "766d76e1419ba90a2c0e76e8da3c02db10497e35" }

--- a/crates/nargo/src/ops/execute.rs
+++ b/crates/nargo/src/ops/execute.rs
@@ -1,18 +1,18 @@
 use acvm::pwg::{ACVMStatus, ACVM};
-use acvm::BlackBoxFunctionSolver;
 use acvm::{acir::circuit::Circuit, acir::native_types::WitnessMap};
 
 use crate::NargoError;
 
 use super::foreign_calls::ForeignCall;
 
-pub fn execute_circuit<B: BlackBoxFunctionSolver + Default>(
-    _backend: &B,
+pub fn execute_circuit(
     circuit: Circuit,
     initial_witness: WitnessMap,
     show_output: bool,
 ) -> Result<WitnessMap, NargoError> {
-    let mut acvm = ACVM::new(B::default(), circuit.opcodes, initial_witness);
+    #[allow(deprecated)]
+    let black_box_function_solver = acvm::blackbox_solver::BarretenbergSolver::new();
+    let mut acvm = ACVM::new(black_box_function_solver, circuit.opcodes, initial_witness);
 
     loop {
         let solver_status = acvm.solve();

--- a/crates/nargo/src/ops/execute.rs
+++ b/crates/nargo/src/ops/execute.rs
@@ -1,4 +1,5 @@
 use acvm::pwg::{ACVMStatus, ACVM};
+use acvm::BlackBoxFunctionSolver;
 use acvm::{acir::circuit::Circuit, acir::native_types::WitnessMap};
 
 use crate::NargoError;
@@ -6,12 +7,11 @@ use crate::NargoError;
 use super::foreign_calls::ForeignCall;
 
 pub fn execute_circuit(
+    black_box_function_solver: impl BlackBoxFunctionSolver,
     circuit: Circuit,
     initial_witness: WitnessMap,
     show_output: bool,
 ) -> Result<WitnessMap, NargoError> {
-    #[allow(deprecated)]
-    let black_box_function_solver = acvm::blackbox_solver::BarretenbergSolver::new();
     let mut acvm = ACVM::new(black_box_function_solver, circuit.opcodes, initial_witness);
 
     loop {

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -1,4 +1,14 @@
+use acvm::BlackBoxFunctionSolver;
 pub(crate) use acvm_backend_barretenberg::Barretenberg as ConcreteBackend;
+
+pub(crate) fn get_black_box_solver() -> impl BlackBoxFunctionSolver {
+    #[cfg(feature = "plonk_bn254")]
+    return acvm_backend_barretenberg::BarretenbergBlackBoxSolver;
+
+    #[cfg(not(feature = "plonk_bn254"))]
+    #[allow(deprecated)]
+    return acvm::blackbox_solver::BarretenbergSolver::new();
+}
 
 #[cfg(not(any(feature = "plonk_bn254", feature = "plonk_bn254_wasm")))]
 compile_error!("please specify a backend to compile with");

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -75,8 +75,7 @@ fn execute_package<B: Backend>(
     let (inputs_map, _) =
         read_inputs_from_file(&package.root_dir, prover_name, Format::Toml, &abi)?;
 
-    let solved_witness =
-        execute_program(backend, circuit, &abi, &inputs_map, Some((debug, context)))?;
+    let solved_witness = execute_program(circuit, &abi, &inputs_map, Some((debug, context)))?;
     let public_abi = abi.public_abi();
     let (_, return_value) = public_abi.decode(&solved_witness)?;
 
@@ -123,14 +122,13 @@ fn report_unsatisfied_constraint_error(
 }
 
 pub(crate) fn execute_program<B: Backend>(
-    backend: &B,
     circuit: Circuit,
     abi: &Abi,
     inputs_map: &InputMap,
     debug_data: Option<(DebugInfo, Context)>,
 ) -> Result<WitnessMap, CliError<B>> {
     let initial_witness = abi.encode(inputs_map, None)?;
-    let solved_witness_err = nargo::ops::execute_circuit(backend, circuit, initial_witness, true);
+    let solved_witness_err = nargo::ops::execute_circuit(circuit, initial_witness, true);
     match solved_witness_err {
         Ok(solved_witness) => Ok(solved_witness),
         Err(err) => {

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -16,6 +16,7 @@ use noirc_frontend::hir::Context;
 use super::compile_cmd::compile_package;
 use super::fs::{inputs::read_inputs_from_file, witness::save_witness_to_dir};
 use super::NargoConfig;
+use crate::backends::get_black_box_solver;
 use crate::errors::CliError;
 
 /// Executes a circuit to calculate its return value
@@ -128,7 +129,8 @@ pub(crate) fn execute_program<B: Backend>(
     debug_data: Option<(DebugInfo, Context)>,
 ) -> Result<WitnessMap, CliError<B>> {
     let initial_witness = abi.encode(inputs_map, None)?;
-    let solved_witness_err = nargo::ops::execute_circuit(circuit, initial_witness, true);
+    let solved_witness_err =
+        nargo::ops::execute_circuit(get_black_box_solver(), circuit, initial_witness, true);
     match solved_witness_err {
         Ok(solved_witness) => Ok(solved_witness),
         Err(err) => {

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -113,7 +113,7 @@ pub(crate) fn prove_package<B: Backend>(
     let (inputs_map, _) =
         read_inputs_from_file(&package.root_dir, prover_name, Format::Toml, &abi)?;
 
-    let solved_witness = execute_program(backend, bytecode.clone(), &abi, &inputs_map, debug_data)?;
+    let solved_witness = execute_program(bytecode.clone(), &abi, &inputs_map, debug_data)?;
 
     // Write public inputs into Verifier.toml
     let public_abi = abi.public_abi();

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -12,7 +12,9 @@ use noirc_frontend::{
 };
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use crate::{cli::check_cmd::check_crate_and_report_errors, errors::CliError};
+use crate::{
+    backends::get_black_box_solver, cli::check_cmd::check_crate_and_report_errors, errors::CliError,
+};
 
 use super::{compile_cmd::optimize_circuit, NargoConfig};
 
@@ -131,7 +133,7 @@ fn run_test<B: Backend>(
 
     // Run the backend to ensure the PWG evaluates functions like std::hash::pedersen,
     // otherwise constraints involving these expressions will not error.
-    match execute_circuit(program.circuit, WitnessMap::new(), show_output) {
+    match execute_circuit(get_black_box_solver(), program.circuit, WitnessMap::new(), show_output) {
         Ok(_) => Ok(()),
         Err(error) => {
             let writer = StandardStream::stderr(ColorChoice::Always);

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -131,7 +131,7 @@ fn run_test<B: Backend>(
 
     // Run the backend to ensure the PWG evaluates functions like std::hash::pedersen,
     // otherwise constraints involving these expressions will not error.
-    match execute_circuit(backend, program.circuit, WitnessMap::new(), show_output) {
+    match execute_circuit(program.circuit, WitnessMap::new(), show_output) {
         Ok(_) => Ok(()),
         Err(error) => {
             let writer = StandardStream::stderr(ColorChoice::Always);

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,8 @@
       sharedEnvironment = {
         # We enable backtraces on any failure for help with debugging
         RUST_BACKTRACE = "1";
+        # We set the environment variable because barretenberg must be compiled in a special way for wasm
+        BARRETENBERG_BIN_DIR = "${pkgs.barretenberg-wasm}/bin";
       };
 
       nativeEnvironment = sharedEnvironment // {
@@ -83,12 +85,9 @@
         LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
       };
 
-      wasmEnvironment = sharedEnvironment // {
-        # We set the environment variable because barretenberg must be compiled in a special way for wasm
-        BARRETENBERG_BIN_DIR = "${pkgs.barretenberg-wasm}/bin";
-      };
+      wasmEnvironment = sharedEnvironment // { };
 
-      testEnvironment = sharedEnvironment // {};
+      testEnvironment = sharedEnvironment // { };
 
       # The `self.rev` property is only available when the working tree is not dirty
       GIT_COMMIT = if (self ? rev) then self.rev else "unknown";


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/acvm/issues/492

## Summary\*

This PR switches us over to a version of the ACVM where `Backend`s are not responsible for providing implementations of the remaining 3 black box functions.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
