### PR TITLE
chore(frontend): Replace `ModuleOrigin` with `Location` on `ModuleData`

### DIFF
--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -137,7 +137,7 @@ impl DefCollector {
         let current_def_map = context.def_maps.get(&crate_id).unwrap();
 
         errors.extend(vecmap(unresolved_imports, |(error, module_id)| {
-            let file_id = current_def_map.modules[module_id.0].origin.file_id();
+            let file_id = current_def_map.file_id(module_id);
             let error = DefCollectorErrorKind::PathResolutionError(error);
             error.into_file_diagnostic(file_id)
         }));
@@ -229,7 +229,7 @@ fn collect_impls(
         let path_resolver =
             StandardPathResolver::new(ModuleId { local_id: *module_id, krate: crate_id });
 
-        let file = def_maps[&crate_id].module_file_id(*module_id);
+        let file = def_maps[&crate_id].file_id(*module_id);
 
         for (generics, span, unresolved) in methods {
             let mut resolver = Resolver::new(interner, &path_resolver, def_maps, file);
@@ -425,7 +425,7 @@ fn resolve_impls(
         let path_resolver =
             StandardPathResolver::new(ModuleId { local_id: module_id, krate: crate_id });
 
-        let file = def_maps[&crate_id].module_file_id(module_id);
+        let file = def_maps[&crate_id].file_id(module_id);
 
         for (generics, _, functions) in methods {
             let mut resolver = Resolver::new(interner, &path_resolver, def_maps, file);

--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1,5 +1,5 @@
 use fm::FileId;
-use noirc_errors::FileDiagnostic;
+use noirc_errors::{FileDiagnostic, Location};
 
 use crate::{
     graph::CrateId, hir::def_collector::dc_crate::UnresolvedStruct, node_interner::StructId,
@@ -11,7 +11,7 @@ use super::{
     dc_crate::{DefCollector, UnresolvedFunctions, UnresolvedGlobal, UnresolvedTypeAlias},
     errors::{DefCollectorErrorKind, DuplicateType},
 };
-use crate::hir::def_map::{parse_file, LocalModuleId, ModuleData, ModuleId, ModuleOrigin};
+use crate::hir::def_map::{parse_file, LocalModuleId, ModuleData, ModuleId};
 use crate::hir::resolution::import::ImportDirective;
 use crate::hir::Context;
 
@@ -315,7 +315,8 @@ impl<'a> ModCollector<'a> {
         errors: &mut Vec<FileDiagnostic>,
     ) -> Option<LocalModuleId> {
         let parent = Some(self.module_id);
-        let new_module = ModuleData::new(parent, ModuleOrigin::File(file_id), is_contract);
+        let location = Location::new(mod_name.span(), file_id);
+        let new_module = ModuleData::new(parent, location, is_contract);
         let module_id = self.def_collector.def_map.modules.insert(new_module);
 
         let modules = &mut self.def_collector.def_map.modules;

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -6,7 +6,7 @@ use crate::parser::{parse_program, ParsedModule};
 use crate::token::Attribute;
 use arena::{Arena, Index};
 use fm::{FileId, FileManager};
-use noirc_errors::FileDiagnostic;
+use noirc_errors::{FileDiagnostic, Location};
 use std::collections::HashMap;
 
 mod module_def;
@@ -87,8 +87,8 @@ impl CrateDefMap {
 
         // Allocate a default Module for the root, giving it a ModuleId
         let mut modules: Arena<ModuleData> = Arena::default();
-        let origin = ModuleOrigin::CrateRoot(root_file_id);
-        let root = modules.insert(ModuleData::new(None, origin, false));
+        let location = Location::new(Default::default(), root_file_id);
+        let root = modules.insert(ModuleData::new(None, location, false));
 
         let def_map = CrateDefMap {
             root: LocalModuleId(root),
@@ -120,13 +120,8 @@ impl CrateDefMap {
         root_module.find_func_with_name(&MAIN_FUNCTION.into())
     }
 
-    pub fn root_file_id(&self) -> FileId {
-        let root_module = &self.modules()[self.root.0];
-        root_module.origin.into()
-    }
-
-    pub fn module_file_id(&self, module_id: LocalModuleId) -> FileId {
-        self.modules[module_id.0].origin.file_id()
+    pub fn file_id(&self, module_id: LocalModuleId) -> FileId {
+        self.modules[module_id.0].location.file
     }
 
     /// Go through all modules in this crate, and find all functions in

--- a/crates/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/crates/noirc_frontend/src/hir/def_map/module_data.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use fm::FileId;
+use noirc_errors::Location;
 
 use crate::{
     node_interner::{FuncId, StmtId, StructId, TypeAliasId},
@@ -23,24 +23,20 @@ pub struct ModuleData {
     /// Contains only the definitions directly defined in the current module
     definitions: ItemScope,
 
-    pub origin: ModuleOrigin,
+    pub location: Location,
 
     /// True if this module is a `contract Foo { ... }` module containing contract functions
     pub is_contract: bool,
 }
 
 impl ModuleData {
-    pub fn new(
-        parent: Option<LocalModuleId>,
-        origin: ModuleOrigin,
-        is_contract: bool,
-    ) -> ModuleData {
+    pub fn new(parent: Option<LocalModuleId>, location: Location, is_contract: bool) -> ModuleData {
         ModuleData {
             parent,
             children: HashMap::new(),
             scope: ItemScope::default(),
             definitions: ItemScope::default(),
-            origin,
+            location,
             is_contract,
         }
     }
@@ -97,32 +93,5 @@ impl ModuleData {
     /// excluding any type definitions.
     pub fn value_definitions(&self) -> impl Iterator<Item = ModuleDefId> + '_ {
         self.definitions.values().values().map(|(id, _)| *id)
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum ModuleOrigin {
-    CrateRoot(FileId),
-    File(FileId),
-}
-
-impl ModuleOrigin {
-    pub fn file_id(&self) -> FileId {
-        match self {
-            ModuleOrigin::CrateRoot(file_id) => *file_id,
-            ModuleOrigin::File(file_id) => *file_id,
-        }
-    }
-}
-
-impl From<ModuleOrigin> for FileId {
-    fn from(origin: ModuleOrigin) -> Self {
-        origin.file_id()
-    }
-}
-
-impl Default for ModuleOrigin {
-    fn default() -> Self {
-        ModuleOrigin::CrateRoot(FileId::default())
     }
 }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1485,8 +1485,9 @@ mod test {
 
     use fm::FileId;
     use iter_extended::vecmap;
+    use noirc_errors::Location;
 
-    use crate::hir::def_map::{ModuleData, ModuleId, ModuleOrigin};
+    use crate::hir::def_map::{ModuleData, ModuleId};
     use crate::hir::resolution::errors::ResolverError;
     use crate::hir::resolution::import::PathResolutionError;
     use crate::hir::resolution::resolver::StmtId;
@@ -1520,7 +1521,8 @@ mod test {
         let file = FileId::default();
 
         let mut modules = arena::Arena::new();
-        modules.insert(ModuleData::new(None, ModuleOrigin::File(file), false));
+        let location = Location::new(Default::default(), file);
+        modules.insert(ModuleData::new(None, location, false));
 
         let path_resolver = TestPathResolver(HashMap::new());
 
@@ -1924,7 +1926,7 @@ mod test {
             fn main() {
                 let string = f"this is i: {i}";
                 println(string);
-                
+
                 println(f"I want to print {0}");
 
                 let new_val = 10;

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -137,7 +137,7 @@ mod test {
     use noirc_errors::{Location, Span};
 
     use crate::graph::CrateId;
-    use crate::hir::def_map::{ModuleData, ModuleId, ModuleOrigin};
+    use crate::hir::def_map::{ModuleData, ModuleId};
     use crate::hir::resolution::import::PathResolutionError;
     use crate::hir_def::expr::HirIdent;
     use crate::hir_def::stmt::HirLetStatement;
@@ -380,7 +380,8 @@ mod test {
         let file = FileId::default();
 
         let mut modules = arena::Arena::new();
-        modules.insert(ModuleData::new(None, ModuleOrigin::File(file), false));
+        let location = Location::new(Default::default(), file);
+        modules.insert(ModuleData::new(None, location, false));
 
         def_maps.insert(
             CrateId::dummy_id(),

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -1303,13 +1303,12 @@ mod tests {
 
     use fm::FileId;
     use iter_extended::vecmap;
+    use noirc_errors::Location;
 
     use crate::{
         graph::CrateId,
         hir::{
-            def_map::{
-                CrateDefMap, LocalModuleId, ModuleData, ModuleDefId, ModuleId, ModuleOrigin,
-            },
+            def_map::{CrateDefMap, LocalModuleId, ModuleData, ModuleDefId, ModuleId},
             resolution::{
                 import::PathResolutionError, path_resolver::PathResolver, resolver::Resolver,
             },
@@ -1349,7 +1348,8 @@ mod tests {
         let file = FileId::default();
 
         let mut modules = arena::Arena::new();
-        modules.insert(ModuleData::new(None, ModuleOrigin::File(file), false));
+        let location = Location::new(Default::default(), file);
+        modules.insert(ModuleData::new(None, location, false));
 
         def_maps.insert(
             CrateId::dummy_id(),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

As discussed with @jfecher today, I removed `ModuleOrigin` from the `ModuleData` struct and replaced it with the `Location` instead.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
