### PR TITLE
feat(lsp): Add `Compile` code lens for `main` function and contracts

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -264,7 +264,7 @@ fn on_code_lens_request(
         }
 
         if package.is_contract() {
-            // Currently not looking to dedupe this since we don't have a clear decision on if the Contract stuff is staying
+            // Currently not looking to deduplicate this since we don't have a clear decision on if the Contract stuff is staying
             for contract in context.get_all_contracts(&crate_id) {
                 let location = contract.location;
                 let file_id = location.file;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -27,10 +27,11 @@ use noirc_frontend::hir::FunctionNameMatch;
 use serde_json::Value as JsonValue;
 use tower::Service;
 
+const ARROW: &str = "▶\u{fe0e}";
 const TEST_COMMAND: &str = "nargo.test";
-const TEST_CODELENS_TITLE: &str = "▶\u{fe0e} Run Test";
+const TEST_CODELENS_TITLE: &str = "Run Test";
 const COMPILE_COMMAND: &str = "nargo.compile";
-const COMPILE_CODELENS_TITLE: &str = "▶\u{fe0e} Compile";
+const COMPILE_CODELENS_TITLE: &str = "Compile";
 
 // State for the LSP gets implemented on this struct and is internal to the implementation
 pub struct LspState {
@@ -212,7 +213,7 @@ fn on_code_lens_request(
                 .unwrap_or_default();
 
             let command = Command {
-                title: TEST_CODELENS_TITLE.into(),
+                title: format!("{ARROW} {TEST_CODELENS_TITLE}"),
                 command: TEST_COMMAND.into(),
                 arguments: Some(vec![
                     "--program-dir".into(),
@@ -246,7 +247,7 @@ fn on_code_lens_request(
                     .unwrap_or_default();
 
                 let command = Command {
-                    title: COMPILE_CODELENS_TITLE.into(),
+                    title: format!("{ARROW} {COMPILE_CODELENS_TITLE}"),
                     command: COMPILE_COMMAND.into(),
                     arguments: Some(vec![
                         "--program-dir".into(),
@@ -280,7 +281,7 @@ fn on_code_lens_request(
                     .unwrap_or_default();
 
                 let command = Command {
-                    title: COMPILE_CODELENS_TITLE.into(),
+                    title: format!("{ARROW} {COMPILE_CODELENS_TITLE}"),
                     command: COMPILE_COMMAND.into(),
                     arguments: Some(vec![
                         "--program-dir".into(),

--- a/crates/noirc_frontend/src/hir/def_map/mod.rs
+++ b/crates/noirc_frontend/src/hir/def_map/mod.rs
@@ -148,7 +148,7 @@ impl CrateDefMap {
                     let functions =
                         module.value_definitions().filter_map(|id| id.as_function()).collect();
                     let name = self.get_module_path(id, module.parent);
-                    Some(Contract { name, functions })
+                    Some(Contract { name, location: module.location, functions })
                 } else {
                     None
                 }
@@ -194,6 +194,7 @@ impl CrateDefMap {
 pub struct Contract {
     /// To keep `name` semi-unique, it is prefixed with the names of parent modules via CrateDefMap::get_module_path
     pub name: String,
+    pub location: Location,
     pub functions: Vec<FuncId>,
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Another implementation of #1834  <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This adds a `> Compile` code lens above contracts (in contract packages) and `main` functions (in bin packages). Currently a draft because it relies on #2308 and it outputs the artifacts in each package in a workspace instead of at the workspace root (so I want to solve that problem first).

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
