### PR TITLE
feat: Add full call stacks to runtime errors

### DIFF
--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -122,7 +122,7 @@ fn run_test<B: Backend>(
     config: &CompileOptions,
 ) -> Result<(), CliError<B>> {
     let mut program = compile_no_check(context, config, main).map_err(|err| {
-        noirc_errors::reporter::report_all(&context.file_manager, &[err], config.deny_warnings);
+        noirc_errors::reporter::report_all(&context.file_manager, &err, config.deny_warnings);
         CliError::Generic(format!("Test '{test_name}' failed to compile"))
     })?;
 

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -226,13 +226,13 @@ fn compile_contract(
     options: &CompileOptions,
 ) -> Result<CompiledContract, Vec<FileDiagnostic>> {
     let mut functions = Vec::new();
-    let mut errs = Vec::new();
+    let mut errors = Vec::new();
     for function_id in &contract.functions {
         let name = context.function_name(function_id).to_owned();
         let function = match compile_no_check(context, options, *function_id) {
             Ok(function) => function,
-            Err(err) => {
-                errs.push(err);
+            Err(mut new_errors) => {
+                errors.append(&mut new_errors);
                 continue;
             }
         };
@@ -252,10 +252,10 @@ fn compile_contract(
         });
     }
 
-    if errs.is_empty() {
+    if errors.is_empty() {
         Ok(CompiledContract { name: contract.name, functions })
     } else {
-        Err(errs)
+        Err(errors)
     }
 }
 
@@ -268,7 +268,7 @@ pub fn compile_no_check(
     context: &Context,
     options: &CompileOptions,
     main_function: FuncId,
-) -> Result<CompiledProgram, FileDiagnostic> {
+) -> Result<CompiledProgram, Vec<FileDiagnostic>> {
     let program = monomorphize(main_function, &context.def_interner);
 
     let (circuit, debug, abi) = create_circuit(program, options.show_ssa, options.show_brillig)?;

--- a/crates/noirc_errors/src/debug_info.rs
+++ b/crates/noirc_errors/src/debug_info.rs
@@ -6,11 +6,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct DebugInfo {
     /// Map opcode index of an ACIR circuit into the source code location
-    pub locations: HashMap<usize, Location>,
+    pub locations: HashMap<usize, Vec<Location>>,
 }
 
 impl DebugInfo {
-    pub fn new(locations: HashMap<usize, Location>) -> Self {
+    pub fn new(locations: HashMap<usize, Vec<Location>>) -> Self {
         DebugInfo { locations }
     }
 
@@ -27,13 +27,13 @@ impl DebugInfo {
         let mut new_locations = HashMap::new();
         for (i, idx) in opcode_indices.iter().enumerate() {
             if self.locations.contains_key(idx) {
-                new_locations.insert(i, self.locations[idx]);
+                new_locations.insert(i, self.locations[idx].clone());
             }
         }
         self.locations = new_locations;
     }
 
-    pub fn opcode_location(&self, idx: usize) -> Option<&Location> {
-        self.locations.get(&idx)
+    pub fn opcode_location(&self, idx: usize) -> Option<Vec<Location>> {
+        self.locations.get(&idx).cloned()
     }
 }

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -109,7 +109,7 @@ impl<'block> BrilligBlock<'block> {
                     self.create_block_label_for_current_function(*else_destination),
                 );
             }
-            TerminatorInstruction::Jmp { destination, arguments, location: _ } => {
+            TerminatorInstruction::Jmp { destination, arguments, call_stack: _ } => {
                 let target = &dfg[*destination];
                 for (src, dest) in arguments.iter().zip(target.parameters()) {
                     // Destination variable might have already been created by another block that jumps to this target

--- a/crates/noirc_evaluator/src/errors.rs
+++ b/crates/noirc_evaluator/src/errors.rs
@@ -8,6 +8,7 @@
 //!
 //! An Error of the latter is an error in the implementation of the compiler
 use acvm::FieldElement;
+use iter_extended::vecmap;
 use noirc_errors::{CustomDiagnostic as Diagnostic, FileDiagnostic, Location};
 use thiserror::Error;
 
@@ -17,45 +18,45 @@ pub enum RuntimeError {
     // and 1 respectively. This would confuse users if a constraint such as
     // assert(foo < bar) fails with "failed constraint: 0 = 1."
     #[error("Failed constraint")]
-    FailedConstraint { lhs: FieldElement, rhs: FieldElement, location: Option<Location> },
+    FailedConstraint { lhs: FieldElement, rhs: FieldElement, location: Vec<Location> },
     #[error(transparent)]
     InternalError(#[from] InternalError),
     #[error("Index out of bounds, array has size {index:?}, but index was {array_size:?}")]
-    IndexOutOfBounds { index: usize, array_size: usize, location: Option<Location> },
+    IndexOutOfBounds { index: usize, array_size: usize, location: Vec<Location> },
     #[error("Range constraint of {num_bits} bits is too large for the Field size")]
-    InvalidRangeConstraint { num_bits: u32, location: Option<Location> },
+    InvalidRangeConstraint { num_bits: u32, location: Vec<Location> },
     #[error("Expected array index to fit into a u64")]
-    TypeConversion { from: String, into: String, location: Option<Location> },
+    TypeConversion { from: String, into: String, location: Vec<Location> },
     #[error("{name:?} is not initialized")]
-    UnInitialized { name: String, location: Option<Location> },
+    UnInitialized { name: String, location: Vec<Location> },
     #[error("Integer sized {num_bits:?} is over the max supported size of {max_num_bits:?}")]
-    UnsupportedIntegerSize { num_bits: u32, max_num_bits: u32, location: Option<Location> },
+    UnsupportedIntegerSize { num_bits: u32, max_num_bits: u32, location: Vec<Location> },
     #[error("Could not determine loop bound at compile-time")]
-    UnknownLoopBound { location: Option<Location> },
+    UnknownLoopBound { location: Vec<Location> },
     #[error("Argument is not constant")]
-    AssertConstantFailed { location: Option<Location> },
+    AssertConstantFailed { location: Vec<Location> },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum InternalError {
     #[error("ICE: Both expressions should have degree<=1")]
-    DegreeNotReduced { location: Option<Location> },
+    DegreeNotReduced { location: Vec<Location> },
     #[error("Try to get element from empty array")]
-    EmptyArray { location: Option<Location> },
+    EmptyArray { location: Vec<Location> },
     #[error("ICE: {message:?}")]
-    General { message: String, location: Option<Location> },
+    General { message: String, location: Vec<Location> },
     #[error("ICE: {name:?} missing {arg:?} arg")]
-    MissingArg { name: String, arg: String, location: Option<Location> },
+    MissingArg { name: String, arg: String, location: Vec<Location> },
     #[error("ICE: {name:?} should be a constant")]
-    NotAConstant { name: String, location: Option<Location> },
+    NotAConstant { name: String, location: Vec<Location> },
     #[error("ICE: Undeclared AcirVar")]
-    UndeclaredAcirVar { location: Option<Location> },
+    UndeclaredAcirVar { location: Vec<Location> },
     #[error("ICE: Expected {expected:?}, found {found:?}")]
-    UnExpected { expected: String, found: String, location: Option<Location> },
+    UnExpected { expected: String, found: String, location: Vec<Location> },
 }
 
 impl RuntimeError {
-    fn location(&self) -> Option<Location> {
+    fn into_location(self) -> Vec<Location> {
         match self {
             RuntimeError::InternalError(
                 InternalError::DegreeNotReduced { location }
@@ -73,30 +74,68 @@ impl RuntimeError {
             | RuntimeError::UnInitialized { location, .. }
             | RuntimeError::UnknownLoopBound { location }
             | RuntimeError::AssertConstantFailed { location }
-            | RuntimeError::UnsupportedIntegerSize { location, .. } => *location,
+            | RuntimeError::UnsupportedIntegerSize { location, .. } => location,
+        }
+    }
+
+    fn location(&self) -> &[Location] {
+        match self {
+            RuntimeError::InternalError(
+                InternalError::DegreeNotReduced { location }
+                | InternalError::EmptyArray { location }
+                | InternalError::General { location, .. }
+                | InternalError::MissingArg { location, .. }
+                | InternalError::NotAConstant { location, .. }
+                | InternalError::UndeclaredAcirVar { location }
+                | InternalError::UnExpected { location, .. },
+            )
+            | RuntimeError::FailedConstraint { location, .. }
+            | RuntimeError::IndexOutOfBounds { location, .. }
+            | RuntimeError::InvalidRangeConstraint { location, .. }
+            | RuntimeError::TypeConversion { location, .. }
+            | RuntimeError::UnInitialized { location, .. }
+            | RuntimeError::UnknownLoopBound { location }
+            | RuntimeError::AssertConstantFailed { location }
+            | RuntimeError::UnsupportedIntegerSize { location, .. } => location,
         }
     }
 }
 
-impl From<RuntimeError> for FileDiagnostic {
-    fn from(error: RuntimeError) -> Self {
-        let file_id = error.location().map(|loc| loc.file).unwrap();
-        FileDiagnostic { file_id, diagnostic: error.into() }
+impl From<RuntimeError> for Vec<FileDiagnostic> {
+    fn from(error: RuntimeError) -> Vec<FileDiagnostic> {
+        let file_ids = vecmap(error.location(), |loc| loc.file);
+        vecmap(error.as_diagnostics().into_iter().zip(file_ids), |(diagnostic, file_id)| {
+            FileDiagnostic { file_id, diagnostic }
+        })
     }
 }
 
-impl From<RuntimeError> for Diagnostic {
-    fn from(error: RuntimeError) -> Diagnostic {
-        match error {
-            RuntimeError::InternalError(_) => Diagnostic::simple_error(
-                "Internal Consistency Evaluators Errors: \n 
-                This is likely a bug. Consider Opening an issue at https://github.com/noir-lang/noir/issues".to_owned(),
-                "".to_string(),
-                noirc_errors::Span::new(0..0)
-            ),
+impl RuntimeError {
+    fn as_diagnostics(self) -> Vec<Diagnostic> {
+        match self {
+            RuntimeError::InternalError(_) => {
+                vec![Diagnostic::simple_error(
+                    "Internal Consistency Evaluators Errors: \n 
+                    This is likely a bug. Consider Opening an issue at https://github.com/noir-lang/noir/issues".to_owned(),
+                    "".to_string(),
+                    noirc_errors::Span::new(0..0)
+                )]
+            }
             _ => {
-                let span = if let Some(loc) = error.location() { loc.span } else { noirc_errors::Span::new(0..0) };
-                Diagnostic::simple_error("".to_owned(), error.to_string(), span)
+                let message = self.to_string();
+                let mut locations = self.into_location();
+                let mut errors = Vec::new();
+
+                if let Some(location) = locations.pop() {
+                    errors.push(Diagnostic::simple_error(message, String::new(), location.span));
+                }
+
+                for location in locations.into_iter().rev() {
+                    let message = "Called from here".into();
+                    errors.push(Diagnostic::simple_error(message, String::new(), location.span));
+                }
+
+                errors
             }
         }
     }

--- a/crates/noirc_evaluator/src/ssa.rs
+++ b/crates/noirc_evaluator/src/ssa.rs
@@ -105,6 +105,9 @@ pub fn create_circuit(
         public_parameters,
         return_values,
     };
+
+    let locations = locations.into_iter().map(|(k, v)| (k, v.into_iter().collect())).collect();
+
     let debug_info = DebugInfo::new(locations);
 
     Ok((circuit, debug_info, abi))

--- a/crates/noirc_evaluator/src/ssa.rs
+++ b/crates/noirc_evaluator/src/ssa.rs
@@ -50,6 +50,7 @@ pub(crate) fn optimize_into_acir(
             .inline_functions()
             .print(print_ssa_passes, "After Inlining:")
             .evaluate_assert_constant()?
+            .print(print_ssa_passes, "After asert cons:")
             .unroll_loops()?
             .print(print_ssa_passes, "After Unrolling:")
             .simplify_cfg()

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -151,11 +151,11 @@ impl AcirContext {
         self.add_data(var_data)
     }
 
-    pub(crate) fn get_location(&self) -> Option<Location> {
-        self.acir_ir.current_location
+    pub(crate) fn get_location(&self) -> Vec<Location> {
+        self.acir_ir.current_location.clone()
     }
 
-    pub(crate) fn set_location(&mut self, location: Option<Location>) {
+    pub(crate) fn set_location(&mut self, location: Vec<Location>) {
         self.acir_ir.current_location = location;
     }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -46,11 +46,11 @@ pub(crate) struct GeneratedAcir {
     pub(crate) input_witnesses: Vec<Witness>,
 
     /// Correspondance between an opcode index (in opcodes) and the source code location which generated it
-    pub(crate) locations: HashMap<usize, Location>,
+    pub(crate) locations: HashMap<usize, Vec<Location>>,
 
     /// Source code location of the current instruction being processed
     /// None if we do not know the location
-    pub(crate) current_location: Option<Location>,
+    pub(crate) current_location: Vec<Location>,
 }
 
 impl GeneratedAcir {
@@ -62,8 +62,8 @@ impl GeneratedAcir {
     /// Adds a new opcode into ACIR.
     fn push_opcode(&mut self, opcode: AcirOpcode) {
         self.opcodes.push(opcode);
-        if let Some(location) = self.current_location {
-            self.locations.insert(self.opcodes.len() - 1, location);
+        if !self.current_location.is_empty() {
+            self.locations.insert(self.opcodes.len() - 1, self.current_location.clone());
         }
     }
 
@@ -195,7 +195,7 @@ impl GeneratedAcir {
                         return Err(InternalError::MissingArg {
                             name: "".to_string(),
                             arg: "message_size".to_string(),
-                            location: self.current_location,
+                            location: self.current_location.clone(),
                         });
                     }
                 };
@@ -706,7 +706,7 @@ impl GeneratedAcir {
         if num_bits >= FieldElement::max_num_bits() {
             return Err(RuntimeError::InvalidRangeConstraint {
                 num_bits: FieldElement::max_num_bits(),
-                location: self.current_location,
+                location: self.current_location.clone(),
             });
         };
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use crate::{
     brillig::brillig_gen::brillig_directive,
     errors::{InternalError, RuntimeError},
+    ssa::ir::dfg::CallStack,
 };
 
 use acvm::acir::{
@@ -22,7 +23,6 @@ use acvm::{
     FieldElement,
 };
 use iter_extended::vecmap;
-use noirc_errors::Location;
 use num_bigint::BigUint;
 
 #[derive(Debug, Default)]
@@ -46,11 +46,11 @@ pub(crate) struct GeneratedAcir {
     pub(crate) input_witnesses: Vec<Witness>,
 
     /// Correspondance between an opcode index (in opcodes) and the source code location which generated it
-    pub(crate) locations: HashMap<usize, Vec<Location>>,
+    pub(crate) locations: HashMap<usize, CallStack>,
 
     /// Source code location of the current instruction being processed
     /// None if we do not know the location
-    pub(crate) current_location: Vec<Location>,
+    pub(crate) call_stack: CallStack,
 }
 
 impl GeneratedAcir {
@@ -62,8 +62,8 @@ impl GeneratedAcir {
     /// Adds a new opcode into ACIR.
     fn push_opcode(&mut self, opcode: AcirOpcode) {
         self.opcodes.push(opcode);
-        if !self.current_location.is_empty() {
-            self.locations.insert(self.opcodes.len() - 1, self.current_location.clone());
+        if !self.call_stack.is_empty() {
+            self.locations.insert(self.opcodes.len() - 1, self.call_stack.clone());
         }
     }
 
@@ -195,7 +195,7 @@ impl GeneratedAcir {
                         return Err(InternalError::MissingArg {
                             name: "".to_string(),
                             arg: "message_size".to_string(),
-                            location: self.current_location.clone(),
+                            call_stack: self.call_stack.clone(),
                         });
                     }
                 };
@@ -706,7 +706,7 @@ impl GeneratedAcir {
         if num_bits >= FieldElement::max_num_bits() {
             return Err(RuntimeError::InvalidRangeConstraint {
                 num_bits: FieldElement::max_num_bits(),
-                location: self.current_location.clone(),
+                call_stack: self.call_stack.clone(),
             });
         };
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/sort.rs
@@ -50,7 +50,11 @@ impl GeneratedAcir {
         if n % 2 == 1 {
             in_sub2.push(match in_expr.last() {
                 Some(in_expr) => in_expr.clone(),
-                None => return Err(InternalError::EmptyArray { location: self.current_location }),
+                None => {
+                    return Err(InternalError::EmptyArray {
+                        location: self.current_location.clone(),
+                    })
+                }
             });
         }
         let mut out_expr = Vec::new();
@@ -70,12 +74,18 @@ impl GeneratedAcir {
         if n % 2 == 0 {
             out_expr.push(match b1.last() {
                 Some(b1) => b1.clone(),
-                None => return Err(InternalError::EmptyArray { location: self.current_location }),
+                None => {
+                    return Err(InternalError::EmptyArray {
+                        location: self.current_location.clone(),
+                    })
+                }
             });
         }
         out_expr.push(match b2.last() {
             Some(b2) => b2.clone(),
-            None => return Err(InternalError::EmptyArray { location: self.current_location }),
+            None => {
+                return Err(InternalError::EmptyArray { location: self.current_location.clone() })
+            }
         });
         conf.extend(w1);
         conf.extend(w2);

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/sort.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/sort.rs
@@ -51,9 +51,7 @@ impl GeneratedAcir {
             in_sub2.push(match in_expr.last() {
                 Some(in_expr) => in_expr.clone(),
                 None => {
-                    return Err(InternalError::EmptyArray {
-                        location: self.current_location.clone(),
-                    })
+                    return Err(InternalError::EmptyArray { call_stack: self.call_stack.clone() })
                 }
             });
         }
@@ -75,17 +73,13 @@ impl GeneratedAcir {
             out_expr.push(match b1.last() {
                 Some(b1) => b1.clone(),
                 None => {
-                    return Err(InternalError::EmptyArray {
-                        location: self.current_location.clone(),
-                    })
+                    return Err(InternalError::EmptyArray { call_stack: self.call_stack.clone() })
                 }
             });
         }
         out_expr.push(match b2.last() {
             Some(b2) => b2.clone(),
-            None => {
-                return Err(InternalError::EmptyArray { location: self.current_location.clone() })
-            }
+            None => return Err(InternalError::EmptyArray { call_stack: self.call_stack.clone() }),
         });
         conf.extend(w1);
         conf.extend(w2);

--- a/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use std::ops::RangeInclusive;
 
 use self::acir_ir::acir_variable::{AcirContext, AcirType, AcirVar};
+use super::ir::dfg::CallStack;
 use super::{
     ir::{
         dfg::DataFlowGraph,
@@ -93,7 +94,7 @@ impl AcirValue {
             AcirValue::Var(var, _) => Ok(var),
             AcirValue::DynamicArray(_) | AcirValue::Array(_) => Err(InternalError::General {
                 message: "Called AcirValue::into_var on an array".to_string(),
-                location: Vec::new(),
+                call_stack: CallStack::new(),
             }),
         }
     }
@@ -320,7 +321,7 @@ impl Context {
         last_array_uses: &HashMap<ValueId, InstructionId>,
     ) -> Result<(), RuntimeError> {
         let instruction = &dfg[instruction_id];
-        self.acir_context.set_location(dfg.get_location(instruction_id));
+        self.acir_context.set_call_stack(dfg.get_call_stack(instruction_id));
         match instruction {
             Instruction::Binary(binary) => {
                 let result_acir_var = self.convert_ssa_binary(binary, dfg)?;
@@ -426,7 +427,7 @@ impl Context {
                 unreachable!("Expected all load instructions to be removed before acir_gen")
             }
         }
-        self.acir_context.set_location(Vec::new());
+        self.acir_context.set_call_stack(CallStack::new());
         Ok(())
     }
 
@@ -449,7 +450,7 @@ impl Context {
                 None => {
                     return Err(InternalError::General {
                         message: format!("Cannot find linked fn {unresolved_fn_label}"),
-                        location: Vec::new(),
+                        call_stack: CallStack::new(),
                     })
                 }
             };
@@ -478,7 +479,7 @@ impl Context {
                 return Err(RuntimeError::InternalError(InternalError::UnExpected {
                     expected: "an array value".to_string(),
                     found: format!("{acir_var:?}"),
-                    location: self.acir_context.get_location(),
+                    call_stack: self.acir_context.get_call_stack(),
                 }))
             }
             AcirValue::Array(array) => {
@@ -487,11 +488,11 @@ impl Context {
                     let index = match index_const.try_to_u64() {
                         Some(index_const) => index_const as usize,
                         None => {
-                            let location = self.acir_context.get_location();
+                            let location = self.acir_context.get_call_stack();
                             return Err(RuntimeError::TypeConversion {
                                 from: "array index".to_string(),
                                 into: "u64".to_string(),
-                                location,
+                                call_stack: location,
                             });
                         }
                     };
@@ -499,11 +500,11 @@ impl Context {
                         // Ignore the error if side effects are disabled.
                         if self.acir_context.is_constant_one(&self.current_side_effects_enabled_var)
                         {
-                            let location = self.acir_context.get_location();
+                            let location = self.acir_context.get_call_stack();
                             return Err(RuntimeError::IndexOutOfBounds {
                                 index,
                                 array_size,
-                                location,
+                                call_stack: location,
                             });
                         }
                         let result_type =
@@ -558,7 +559,7 @@ impl Context {
                 _ => {
                     return Err(RuntimeError::UnInitialized {
                         name: "array".to_string(),
-                        location: self.acir_context.get_location(),
+                        call_stack: self.acir_context.get_call_stack(),
                     })
                 }
             }
@@ -620,7 +621,7 @@ impl Context {
                 _ => {
                     return Err(InternalError::General {
                         message: format!("Array {array} should be initialized"),
-                        location: self.acir_context.get_location(),
+                        call_stack: self.acir_context.get_call_stack(),
                     })
                 }
             }
@@ -770,12 +771,12 @@ impl Context {
             AcirValue::Array(array) => Err(InternalError::UnExpected {
                 expected: "a numeric value".to_string(),
                 found: format!("{array:?}"),
-                location: self.acir_context.get_location(),
+                call_stack: self.acir_context.get_call_stack(),
             }),
             AcirValue::DynamicArray(_) => Err(InternalError::UnExpected {
                 expected: "a numeric value".to_string(),
                 found: "an array".to_string(),
-                location: self.acir_context.get_location(),
+                call_stack: self.acir_context.get_call_stack(),
             }),
         }
     }
@@ -801,7 +802,7 @@ impl Context {
                     return Err(RuntimeError::UnsupportedIntegerSize {
                         num_bits: *bit_size,
                         max_num_bits: max_integer_bit_size,
-                        location: self.acir_context.get_location(),
+                        call_stack: self.acir_context.get_call_stack(),
                     });
                 }
             }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -93,7 +93,7 @@ impl AcirValue {
             AcirValue::Var(var, _) => Ok(var),
             AcirValue::DynamicArray(_) | AcirValue::Array(_) => Err(InternalError::General {
                 message: "Called AcirValue::into_var on an array".to_string(),
-                location: None,
+                location: Vec::new(),
             }),
         }
     }
@@ -320,7 +320,7 @@ impl Context {
         last_array_uses: &HashMap<ValueId, InstructionId>,
     ) -> Result<(), RuntimeError> {
         let instruction = &dfg[instruction_id];
-        self.acir_context.set_location(dfg.get_location(&instruction_id));
+        self.acir_context.set_location(dfg.get_location(instruction_id));
         match instruction {
             Instruction::Binary(binary) => {
                 let result_acir_var = self.convert_ssa_binary(binary, dfg)?;
@@ -426,7 +426,7 @@ impl Context {
                 unreachable!("Expected all load instructions to be removed before acir_gen")
             }
         }
-        self.acir_context.set_location(None);
+        self.acir_context.set_location(Vec::new());
         Ok(())
     }
 
@@ -449,7 +449,7 @@ impl Context {
                 None => {
                     return Err(InternalError::General {
                         message: format!("Cannot find linked fn {unresolved_fn_label}"),
-                        location: None,
+                        location: Vec::new(),
                     })
                 }
             };

--- a/crates/noirc_evaluator/src/ssa/ir/cfg.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/cfg.rs
@@ -220,7 +220,7 @@ mod tests {
         func.dfg[block2_id].set_terminator(TerminatorInstruction::Jmp {
             destination: ret_block_id,
             arguments: vec![],
-            location: None,
+            call_stack: im::Vector::new(),
         });
         func.dfg[block0_id].set_terminator(TerminatorInstruction::JmpIf {
             condition: cond,

--- a/crates/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -72,10 +72,15 @@ pub(crate) struct DataFlowGraph {
     replaced_value_ids: HashMap<ValueId, ValueId>,
 
     /// Source location of each instruction for debugging and issuing errors.
+    /// The Vec here corresponds to the entire callstack of locations. Initially this only
+    /// contains the actual location of the instruction. During inlining, a new location will
+    /// be pushed to each instruction for the location of the function call of the function the
+    /// instruction was originally located in. Once inlining is complete, the locations Vec here
+    /// should contain the entire callstack for each instruction.
     ///
     /// Instructions inserted by internal SSA passes that don't correspond to user code
     /// may not have a corresponding location.
-    locations: HashMap<InstructionId, Location>,
+    locations: HashMap<InstructionId, Vec<Location>>,
 }
 
 impl DataFlowGraph {
@@ -149,7 +154,7 @@ impl DataFlowGraph {
         instruction: Instruction,
         block: BasicBlockId,
         ctrl_typevars: Option<Vec<Type>>,
-        location: Option<Location>,
+        location: Vec<Location>,
     ) -> InsertInstructionResult {
         use InsertInstructionResult::*;
         match instruction.simplify(self, block) {
@@ -162,9 +167,7 @@ impl DataFlowGraph {
                 let instruction = result.instruction().unwrap_or(instruction);
                 let id = self.make_instruction(instruction, ctrl_typevars);
                 self.blocks[block].insert_instruction(id);
-                if let Some(location) = location {
-                    self.locations.insert(id, location);
-                }
+                self.locations.insert(id, location);
                 InsertInstructionResult::Results(self.instruction_results(id))
             }
         }
@@ -407,14 +410,18 @@ impl DataFlowGraph {
         destination.set_terminator(terminator);
     }
 
-    pub(crate) fn get_location(&self, id: &InstructionId) -> Option<Location> {
-        self.locations.get(id).copied()
+    pub(crate) fn get_location(&self, instruction: InstructionId) -> Vec<Location> {
+        self.locations.get(&instruction).cloned().unwrap_or_default()
     }
 
-    pub(crate) fn get_value_location(&self, id: &ValueId) -> Option<Location> {
-        match &self.values[self.resolve(*id)] {
-            Value::Instruction { instruction, .. } => self.get_location(instruction),
-            _ => None,
+    pub(crate) fn add_location(&mut self, instruction: InstructionId, location: Location) {
+        self.locations.entry(instruction).or_default().push(location);
+    }
+
+    pub(crate) fn get_value_location(&self, value: ValueId) -> Vec<Location> {
+        match &self.values[self.resolve(value)] {
+            Value::Instruction { instruction, .. } => self.get_location(*instruction),
+            _ => Vec::new(),
         }
     }
 

--- a/crates/noirc_evaluator/src/ssa/ir/function_inserter.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/function_inserter.rs
@@ -56,10 +56,10 @@ impl<'f> FunctionInserter<'f> {
         self.values.insert(key, value);
     }
 
-    pub(crate) fn map_instruction(&mut self, id: InstructionId) -> (Instruction, Option<Location>) {
+    pub(crate) fn map_instruction(&mut self, id: InstructionId) -> (Instruction, Vec<Location>) {
         (
             self.function.dfg[id].clone().map_values(|id| self.resolve(id)),
-            self.function.dfg.get_location(&id),
+            self.function.dfg.get_location(id),
         )
     }
 
@@ -73,7 +73,7 @@ impl<'f> FunctionInserter<'f> {
         instruction: Instruction,
         id: InstructionId,
         block: BasicBlockId,
-        location: Option<Location>,
+        location: Vec<Location>,
     ) -> InsertInstructionResult {
         let results = self.function.dfg.instruction_results(id);
         let results = vecmap(results, |id| self.function.dfg.resolve(*id));

--- a/crates/noirc_evaluator/src/ssa/ir/function_inserter.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/function_inserter.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
 use iter_extended::vecmap;
-use noirc_errors::Location;
 
 use super::{
     basic_block::BasicBlockId,
-    dfg::InsertInstructionResult,
+    dfg::{CallStack, InsertInstructionResult},
     function::Function,
     instruction::{Instruction, InstructionId},
     value::ValueId,
@@ -56,10 +55,10 @@ impl<'f> FunctionInserter<'f> {
         self.values.insert(key, value);
     }
 
-    pub(crate) fn map_instruction(&mut self, id: InstructionId) -> (Instruction, Vec<Location>) {
+    pub(crate) fn map_instruction(&mut self, id: InstructionId) -> (Instruction, CallStack) {
         (
             self.function.dfg[id].clone().map_values(|id| self.resolve(id)),
-            self.function.dfg.get_location(id),
+            self.function.dfg.get_call_stack(id),
         )
     }
 
@@ -73,7 +72,7 @@ impl<'f> FunctionInserter<'f> {
         instruction: Instruction,
         id: InstructionId,
         block: BasicBlockId,
-        location: Vec<Location>,
+        call_stack: CallStack,
     ) -> InsertInstructionResult {
         let results = self.function.dfg.instruction_results(id);
         let results = vecmap(results, |id| self.function.dfg.resolve(*id));
@@ -86,7 +85,7 @@ impl<'f> FunctionInserter<'f> {
             instruction,
             block,
             ctrl_typevars,
-            location,
+            call_stack,
         );
 
         Self::insert_new_instruction_results(&mut self.values, &results, &new_results);

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -426,7 +426,7 @@ pub(crate) enum TerminatorInstruction {
     /// Jumps to specified `destination` with `arguments`.
     /// The optional Location here is expected to be used to issue an error when the start range of
     /// a for loop cannot be deduced at compile-time.
-    Jmp { destination: BasicBlockId, arguments: Vec<ValueId>, location: Option<Location> },
+    Jmp { destination: BasicBlockId, arguments: Vec<ValueId>, location: Vec<Location> },
 
     /// Return from the current function with the given return values.
     ///
@@ -454,7 +454,7 @@ impl TerminatorInstruction {
             Jmp { destination, arguments, location } => Jmp {
                 destination: *destination,
                 arguments: vecmap(arguments, |value| f(*value)),
-                location: *location,
+                location: location.clone(),
             },
             Return { return_values } => {
                 Return { return_values: vecmap(return_values, |value| f(*value)) }

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -1,11 +1,10 @@
 use acvm::{acir::BlackBoxFunc, FieldElement};
 use iter_extended::vecmap;
-use noirc_errors::Location;
 use num_bigint::BigUint;
 
 use super::{
     basic_block::BasicBlockId,
-    dfg::DataFlowGraph,
+    dfg::{CallStack, DataFlowGraph},
     map::Id,
     types::{NumericType, Type},
     value::{Value, ValueId},
@@ -426,7 +425,7 @@ pub(crate) enum TerminatorInstruction {
     /// Jumps to specified `destination` with `arguments`.
     /// The optional Location here is expected to be used to issue an error when the start range of
     /// a for loop cannot be deduced at compile-time.
-    Jmp { destination: BasicBlockId, arguments: Vec<ValueId>, location: Vec<Location> },
+    Jmp { destination: BasicBlockId, arguments: Vec<ValueId>, call_stack: CallStack },
 
     /// Return from the current function with the given return values.
     ///
@@ -451,10 +450,10 @@ impl TerminatorInstruction {
                 then_destination: *then_destination,
                 else_destination: *else_destination,
             },
-            Jmp { destination, arguments, location } => Jmp {
+            Jmp { destination, arguments, call_stack: location } => Jmp {
                 destination: *destination,
                 arguments: vecmap(arguments, |value| f(*value)),
-                location: location.clone(),
+                call_stack: location.clone(),
             },
             Return { return_values } => {
                 Return { return_values: vecmap(return_values, |value| f(*value)) }

--- a/crates/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/printer.rs
@@ -100,7 +100,7 @@ pub(crate) fn display_terminator(
     f: &mut Formatter,
 ) -> Result {
     match terminator {
-        Some(TerminatorInstruction::Jmp { destination, arguments, location: _ }) => {
+        Some(TerminatorInstruction::Jmp { destination, arguments, call_stack: _ }) => {
             writeln!(f, "    jmp {}({})", destination, value_list(function, arguments))
         }
         Some(TerminatorInstruction::JmpIf { condition, then_destination, else_destination }) => {

--- a/crates/noirc_evaluator/src/ssa/opt/assert_constant.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/assert_constant.rs
@@ -77,7 +77,7 @@ fn evaluate_assert_constant(
     if arguments.iter().all(|arg| function.dfg.is_constant(*arg)) {
         Ok(false)
     } else {
-        let location = function.dfg.get_location(&instruction);
+        let location = function.dfg.get_location(instruction);
         Err(RuntimeError::AssertConstantFailed { location })
     }
 }

--- a/crates/noirc_evaluator/src/ssa/opt/assert_constant.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/assert_constant.rs
@@ -77,7 +77,7 @@ fn evaluate_assert_constant(
     if arguments.iter().all(|arg| function.dfg.is_constant(*arg)) {
         Ok(false)
     } else {
-        let location = function.dfg.get_location(instruction);
-        Err(RuntimeError::AssertConstantFailed { location })
+        let location = function.dfg.get_call_stack(instruction);
+        Err(RuntimeError::AssertConstantFailed { call_stack: location })
     }
 }

--- a/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -71,7 +71,7 @@ impl Context {
             .requires_ctrl_typevars()
             .then(|| vecmap(&old_results, |result| function.dfg.type_of_value(*result)));
 
-        let location = function.dfg.get_location(&id);
+        let location = function.dfg.get_location(id);
         let new_results = match function.dfg.insert_instruction_and_results(
             instruction,
             block,

--- a/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -71,7 +71,7 @@ impl Context {
             .requires_ctrl_typevars()
             .then(|| vecmap(&old_results, |result| function.dfg.type_of_value(*result)));
 
-        let location = function.dfg.get_location(id);
+        let location = function.dfg.get_call_stack(id);
         let new_results = match function.dfg.insert_instruction_and_results(
             instruction,
             block,

--- a/crates/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -260,7 +260,7 @@ impl<'f> Context<'f> {
                     self.inline_branch(block, then_block, old_condition, then_condition, one);
 
                 let else_condition =
-                    self.insert_instruction(Instruction::Not(then_condition), None);
+                    self.insert_instruction(Instruction::Not(then_condition), Vec::new());
                 let zero = FieldElement::zero();
 
                 // Make sure the else branch sees the previous values of each store
@@ -317,7 +317,7 @@ impl<'f> Context<'f> {
 
         if let Some((_, previous_condition)) = self.conditions.last() {
             let and = Instruction::binary(BinaryOp::And, *previous_condition, condition);
-            let new_condition = self.insert_instruction(and, None);
+            let new_condition = self.insert_instruction(and, Vec::new());
             self.conditions.push((end_block, new_condition));
         } else {
             self.conditions.push((end_block, condition));
@@ -327,11 +327,7 @@ impl<'f> Context<'f> {
     /// Insert a new instruction into the function's entry block.
     /// Unlike push_instruction, this function will not map any ValueIds.
     /// within the given instruction, nor will it modify self.values in any way.
-    fn insert_instruction(
-        &mut self,
-        instruction: Instruction,
-        location: Option<Location>,
-    ) -> ValueId {
+    fn insert_instruction(&mut self, instruction: Instruction, location: Vec<Location>) -> ValueId {
         let block = self.inserter.function.entry_block();
         self.inserter
             .function
@@ -354,7 +350,7 @@ impl<'f> Context<'f> {
             instruction,
             block,
             ctrl_typevars,
-            None,
+            Vec::new(),
         )
     }
 
@@ -465,9 +461,11 @@ impl<'f> Context<'f> {
             "Expected values merged to be of the same type but found {then_type} and {else_type}"
         );
 
-        let then_location = self.inserter.function.dfg.get_value_location(&then_value);
-        let else_location = self.inserter.function.dfg.get_value_location(&else_value);
-        let merge_location = then_location.or(else_location);
+        let then_location = self.inserter.function.dfg.get_value_location(then_value);
+        let else_location = self.inserter.function.dfg.get_value_location(else_value);
+
+        let location =
+            if then_location.is_empty() { else_location.clone() } else { then_location.clone() };
 
         // We must cast the bool conditions to the actual numeric type used by each value.
         let then_condition =
@@ -480,7 +478,7 @@ impl<'f> Context<'f> {
             .inserter
             .function
             .dfg
-            .insert_instruction_and_results(mul, block, None, merge_location)
+            .insert_instruction_and_results(mul, block, None, location.clone())
             .first();
 
         let mul = Instruction::binary(BinaryOp::Mul, else_condition, else_value);
@@ -488,14 +486,14 @@ impl<'f> Context<'f> {
             .inserter
             .function
             .dfg
-            .insert_instruction_and_results(mul, block, None, merge_location)
+            .insert_instruction_and_results(mul, block, None, location.clone())
             .first();
 
         let add = Instruction::binary(BinaryOp::Add, then_value, else_value);
         self.inserter
             .function
             .dfg
-            .insert_instruction_and_results(add, block, None, merge_location)
+            .insert_instruction_and_results(add, block, None, location)
             .first()
     }
 
@@ -682,7 +680,7 @@ impl<'f> Context<'f> {
     /// will also be mapped to the results of the new instruction.
     fn push_instruction(&mut self, id: InstructionId) {
         let (instruction, location) = self.inserter.map_instruction(id);
-        let instruction = self.handle_instruction_side_effects(instruction, location);
+        let instruction = self.handle_instruction_side_effects(instruction, location.clone());
         let is_allocate = matches!(instruction, Instruction::Allocate);
 
         let entry = self.inserter.function.entry_block();
@@ -700,14 +698,14 @@ impl<'f> Context<'f> {
     fn handle_instruction_side_effects(
         &mut self,
         instruction: Instruction,
-        location: Option<Location>,
+        location: Vec<Location>,
     ) -> Instruction {
         if let Some((_, condition)) = self.conditions.last().copied() {
             match instruction {
                 Instruction::Constrain(value) => {
                     let mul = self.insert_instruction(
                         Instruction::binary(BinaryOp::Mul, value, condition),
-                        location,
+                        location.clone(),
                     );
                     let eq = self.insert_instruction(
                         Instruction::binary(BinaryOp::Eq, mul, condition),

--- a/crates/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -87,7 +87,7 @@ fn check_for_constant_jmpif(
                 if constant.is_zero() { *else_destination } else { *then_destination };
 
             let arguments = Vec::new();
-            let jmp = TerminatorInstruction::Jmp { destination, arguments, location: None };
+            let jmp = TerminatorInstruction::Jmp { destination, arguments, location: Vec::new() };
             function.dfg[block].set_terminator(jmp);
             cfg.recompute_block(function, block);
         }

--- a/crates/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 
 use crate::ssa::{
     ir::{
-        basic_block::BasicBlockId, cfg::ControlFlowGraph, function::Function,
+        basic_block::BasicBlockId, cfg::ControlFlowGraph, dfg::CallStack, function::Function,
         instruction::TerminatorInstruction,
     },
     ssa_gen::Ssa,
@@ -87,7 +87,8 @@ fn check_for_constant_jmpif(
                 if constant.is_zero() { *else_destination } else { *then_destination };
 
             let arguments = Vec::new();
-            let jmp = TerminatorInstruction::Jmp { destination, arguments, location: Vec::new() };
+            let jmp =
+                TerminatorInstruction::Jmp { destination, arguments, call_stack: CallStack::new() };
             function.dfg[block].set_terminator(jmp);
             cfg.recompute_block(function, block);
         }

--- a/crates/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -14,15 +14,13 @@
 //! program that will need to be removed by a later simplify cfg pass.
 use std::collections::{HashMap, HashSet};
 
-use noirc_errors::Location;
-
 use crate::{
     errors::RuntimeError,
     ssa::{
         ir::{
             basic_block::BasicBlockId,
             cfg::ControlFlowGraph,
-            dfg::DataFlowGraph,
+            dfg::{CallStack, DataFlowGraph},
             dom::DominatorTree,
             function::{Function, RuntimeType},
             function_inserter::FunctionInserter,
@@ -126,8 +124,8 @@ impl Loops {
             if !self.failed_to_unroll.contains(&next_loop.header) {
                 match unroll_loop(function, &self.cfg, &next_loop) {
                     Ok(_) => self.modified_blocks.extend(next_loop.blocks),
-                    Err(location) if abort_on_error => {
-                        return Err(RuntimeError::UnknownLoopBound { location });
+                    Err(call_stack) if abort_on_error => {
+                        return Err(RuntimeError::UnknownLoopBound { call_stack });
                     }
                     Err(_) => {
                         self.failed_to_unroll.insert(next_loop.header);
@@ -176,7 +174,7 @@ fn unroll_loop(
     function: &mut Function,
     cfg: &ControlFlowGraph,
     loop_: &Loop,
-) -> Result<(), Vec<Location>> {
+) -> Result<(), CallStack> {
     let mut unroll_into = get_pre_header(cfg, loop_);
     let mut jump_value = get_induction_variable(function, unroll_into)?;
 
@@ -206,12 +204,9 @@ fn get_pre_header(cfg: &ControlFlowGraph, loop_: &Loop) -> BasicBlockId {
 ///
 /// Expects the current block to terminate in `jmp h(N)` where h is the loop header and N is
 /// a Field value.
-fn get_induction_variable(
-    function: &Function,
-    block: BasicBlockId,
-) -> Result<ValueId, Vec<Location>> {
+fn get_induction_variable(function: &Function, block: BasicBlockId) -> Result<ValueId, CallStack> {
     match function.dfg[block].terminator() {
-        Some(TerminatorInstruction::Jmp { arguments, location, .. }) => {
+        Some(TerminatorInstruction::Jmp { arguments, call_stack: location, .. }) => {
             // This assumption will no longer be valid if e.g. mutable variables are represented as
             // block parameters. If that becomes the case we'll need to figure out which variable
             // is generally constant and increasing to guess which parameter is the induction
@@ -224,7 +219,7 @@ fn get_induction_variable(
                 Err(location.clone())
             }
         }
-        _ => Err(Vec::new()),
+        _ => Err(CallStack::new()),
     }
 }
 
@@ -236,7 +231,7 @@ fn unroll_loop_header<'a>(
     loop_: &'a Loop,
     unroll_into: BasicBlockId,
     induction_value: ValueId,
-) -> Result<Option<LoopIteration<'a>>, Vec<Location>> {
+) -> Result<Option<LoopIteration<'a>>, CallStack> {
     // We insert into a fresh block first and move instructions into the unroll_into block later
     // only once we verify the jmpif instruction has a constant condition. If it does not, we can
     // just discard this fresh block and leave the loop unmodified.
@@ -269,7 +264,7 @@ fn unroll_loop_header<'a>(
             } else {
                 // If this case is reached the loop either uses non-constant indices or we need
                 // another pass, such as mem2reg to resolve them to constants.
-                Err(context.inserter.function.dfg.get_value_location(condition))
+                Err(context.inserter.function.dfg.get_value_call_stack(condition))
             }
         }
         other => unreachable!("Expected loop header to terminate in a JmpIf to the loop body, but found {other:?} instead"),
@@ -361,7 +356,7 @@ impl<'f> LoopIteration<'f> {
             TerminatorInstruction::JmpIf { condition, then_destination, else_destination } => {
                 self.handle_jmpif(*condition, *then_destination, *else_destination)
             }
-            TerminatorInstruction::Jmp { destination, arguments, location: _ } => {
+            TerminatorInstruction::Jmp { destination, arguments, call_stack: _ } => {
                 if self.get_original_block(*destination) == self.loop_.header {
                     assert_eq!(arguments.len(), 1);
                     self.induction_value = Some((self.insert_block, arguments[0]));
@@ -391,8 +386,11 @@ impl<'f> LoopIteration<'f> {
                 self.source_block = self.get_original_block(destination);
 
                 let arguments = Vec::new();
-                let jmp =
-                    TerminatorInstruction::Jmp { destination, arguments, location: Vec::new() };
+                let jmp = TerminatorInstruction::Jmp {
+                    destination,
+                    arguments,
+                    call_stack: CallStack::new(),
+                };
                 self.inserter.function.dfg.set_block_terminator(self.insert_block, jmp);
                 vec![destination]
             }

--- a/crates/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -176,7 +176,7 @@ fn unroll_loop(
     function: &mut Function,
     cfg: &ControlFlowGraph,
     loop_: &Loop,
-) -> Result<(), Option<Location>> {
+) -> Result<(), Vec<Location>> {
     let mut unroll_into = get_pre_header(cfg, loop_);
     let mut jump_value = get_induction_variable(function, unroll_into)?;
 
@@ -209,7 +209,7 @@ fn get_pre_header(cfg: &ControlFlowGraph, loop_: &Loop) -> BasicBlockId {
 fn get_induction_variable(
     function: &Function,
     block: BasicBlockId,
-) -> Result<ValueId, Option<Location>> {
+) -> Result<ValueId, Vec<Location>> {
     match function.dfg[block].terminator() {
         Some(TerminatorInstruction::Jmp { arguments, location, .. }) => {
             // This assumption will no longer be valid if e.g. mutable variables are represented as
@@ -221,10 +221,10 @@ fn get_induction_variable(
             if function.dfg.get_numeric_constant(value).is_some() {
                 Ok(value)
             } else {
-                Err(*location)
+                Err(location.clone())
             }
         }
-        _ => Err(None),
+        _ => Err(Vec::new()),
     }
 }
 
@@ -236,7 +236,7 @@ fn unroll_loop_header<'a>(
     loop_: &'a Loop,
     unroll_into: BasicBlockId,
     induction_value: ValueId,
-) -> Result<Option<LoopIteration<'a>>, Option<Location>> {
+) -> Result<Option<LoopIteration<'a>>, Vec<Location>> {
     // We insert into a fresh block first and move instructions into the unroll_into block later
     // only once we verify the jmpif instruction has a constant condition. If it does not, we can
     // just discard this fresh block and leave the loop unmodified.
@@ -269,7 +269,7 @@ fn unroll_loop_header<'a>(
             } else {
                 // If this case is reached the loop either uses non-constant indices or we need
                 // another pass, such as mem2reg to resolve them to constants.
-                Err(context.inserter.function.dfg.get_value_location(&condition))
+                Err(context.inserter.function.dfg.get_value_location(condition))
             }
         }
         other => unreachable!("Expected loop header to terminate in a JmpIf to the loop body, but found {other:?} instead"),
@@ -391,7 +391,8 @@ impl<'f> LoopIteration<'f> {
                 self.source_block = self.get_original_block(destination);
 
                 let arguments = Vec::new();
-                let jmp = TerminatorInstruction::Jmp { destination, arguments, location: None };
+                let jmp =
+                    TerminatorInstruction::Jmp { destination, arguments, location: Vec::new() };
                 self.inserter.function.dfg.set_block_terminator(self.insert_block, jmp);
                 vec![destination]
             }

--- a/crates/noirc_evaluator/src/ssa/ssa_builder/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_builder/mod.rs
@@ -14,7 +14,7 @@ use crate::ssa::ir::{
 use super::{
     ir::{
         basic_block::BasicBlock,
-        dfg::InsertInstructionResult,
+        dfg::{CallStack, InsertInstructionResult},
         function::RuntimeType,
         instruction::{InstructionId, Intrinsic},
     },
@@ -32,7 +32,7 @@ pub(crate) struct FunctionBuilder {
     pub(super) current_function: Function,
     current_block: BasicBlockId,
     finished_functions: Vec<Function>,
-    current_location: Vec<Location>,
+    call_stack: CallStack,
 }
 
 impl FunctionBuilder {
@@ -53,7 +53,7 @@ impl FunctionBuilder {
             current_function: new_function,
             current_block,
             finished_functions: Vec::new(),
-            current_location: Vec::new(),
+            call_stack: CallStack::new(),
         }
     }
 
@@ -150,7 +150,7 @@ impl FunctionBuilder {
             instruction,
             self.current_block,
             ctrl_typevars,
-            self.current_location.clone(),
+            self.call_stack.clone(),
         )
     }
 
@@ -174,12 +174,12 @@ impl FunctionBuilder {
     }
 
     pub(crate) fn set_location(&mut self, location: Location) -> &mut FunctionBuilder {
-        self.current_location = vec![location];
+        self.call_stack = im::Vector::unit(location);
         self
     }
 
-    pub(crate) fn set_call_stack(&mut self, location: Vec<Location>) -> &mut FunctionBuilder {
-        self.current_location = location;
+    pub(crate) fn set_call_stack(&mut self, call_stack: CallStack) -> &mut FunctionBuilder {
+        self.call_stack = call_stack;
         self
     }
 
@@ -286,8 +286,12 @@ impl FunctionBuilder {
         destination: BasicBlockId,
         arguments: Vec<ValueId>,
     ) {
-        let location = self.current_location.clone();
-        self.terminate_block_with(TerminatorInstruction::Jmp { destination, arguments, location });
+        let call_stack = self.call_stack.clone();
+        self.terminate_block_with(TerminatorInstruction::Jmp {
+            destination,
+            arguments,
+            call_stack,
+        });
     }
 
     /// Terminate the current block with a jmpif instruction to jmp with the given arguments

--- a/crates/noirc_evaluator/src/ssa/ssa_builder/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_builder/mod.rs
@@ -32,7 +32,7 @@ pub(crate) struct FunctionBuilder {
     pub(super) current_function: Function,
     current_block: BasicBlockId,
     finished_functions: Vec<Function>,
-    current_location: Option<Location>,
+    current_location: Vec<Location>,
 }
 
 impl FunctionBuilder {
@@ -53,7 +53,7 @@ impl FunctionBuilder {
             current_function: new_function,
             current_block,
             finished_functions: Vec::new(),
-            current_location: None,
+            current_location: Vec::new(),
         }
     }
 
@@ -150,7 +150,7 @@ impl FunctionBuilder {
             instruction,
             self.current_block,
             ctrl_typevars,
-            self.current_location,
+            self.current_location.clone(),
         )
     }
 
@@ -174,7 +174,12 @@ impl FunctionBuilder {
     }
 
     pub(crate) fn set_location(&mut self, location: Location) -> &mut FunctionBuilder {
-        self.current_location = Some(location);
+        self.current_location = vec![location];
+        self
+    }
+
+    pub(crate) fn set_call_stack(&mut self, location: Vec<Location>) -> &mut FunctionBuilder {
+        self.current_location = location;
         self
     }
 
@@ -281,18 +286,7 @@ impl FunctionBuilder {
         destination: BasicBlockId,
         arguments: Vec<ValueId>,
     ) {
-        self.terminate_with_jmp_with_location(destination, arguments, None);
-    }
-
-    /// Terminate the current block with a jmp instruction to jmp to the given
-    /// block with the given arguments. This version also remembers the Location of the jmp
-    /// for issuing error messages.
-    pub(crate) fn terminate_with_jmp_with_location(
-        &mut self,
-        destination: BasicBlockId,
-        arguments: Vec<ValueId>,
-        location: Option<Location>,
-    ) {
+        let location = self.current_location.clone();
         self.terminate_block_with(TerminatorInstruction::Jmp { destination, arguments, location });
     }
 

--- a/crates/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -314,8 +314,8 @@ impl<'a> FunctionContext<'a> {
 
         // Set the location of the initial jmp instruction to the start range. This is the location
         // used to issue an error if the start range cannot be determined at compile-time.
-        let jmp_location = Some(for_expr.start_range_location);
-        self.builder.terminate_with_jmp_with_location(loop_entry, vec![start_index], jmp_location);
+        self.builder.set_location(for_expr.start_range_location);
+        self.builder.terminate_with_jmp(loop_entry, vec![start_index]);
 
         // Compile the loop entry block
         self.builder.switch_to_block(loop_entry);


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #2214

## Summary\*

Adds full call stacks to runtime errors. I'll update this PR when it is ready to be merged with examples of what the new errors look like.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
