### PR TITLE
chore: Reuse workspace target directory in wasm build script

### DIFF
--- a/crates/wasm/build.sh
+++ b/crates/wasm/build.sh
@@ -30,7 +30,7 @@ require_command wasm-opt
 
 self_path=$(dirname "$(readlink -f "$0")")
 export pname=$(toml2json < ${self_path}/Cargo.toml | jq -r .package.name)
-export CARGO_TARGET_DIR=$self_path/target
+export CARGO_TARGET_DIR=$self_path/../../target
 
 rm -rf $self_path/outputs >/dev/null 2>&1
 rm -rf $self_path/result >/dev/null 2>&1

--- a/crates/wasm/buildPhaseCargoCommand.sh
+++ b/crates/wasm/buildPhaseCargoCommand.sh
@@ -25,7 +25,7 @@ fi
 
 # TODO: Handle the wasm target being built in release mode
 TARGET=wasm32-unknown-unknown
-WASM_BINARY=${self_path}/../../target/${TARGET}/release/${pname}.wasm
+WASM_BINARY=${CARGO_TARGET_DIR}/${TARGET}/release/${pname}.wasm
 
 NODE_DIR=${self_path}/pkg/nodejs/
 BROWSER_DIR=${self_path}/pkg/web/

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
         BARRETENBERG_BIN_DIR = "${pkgs.barretenberg-wasm}/bin";
       };
 
-      testEnvironment = sharedEnvironment // {};
+      testEnvironment = sharedEnvironment // { };
 
       # The `self.rev` property is only available when the working tree is not dirty
       GIT_COMMIT = if (self ? rev) then self.rev else "unknown";
@@ -295,6 +295,7 @@
         COMMIT_SHORT = builtins.substring 0 7 GIT_COMMIT;
         VERSION_APPENDIX = if GIT_DIRTY == "true" then "-dirty" else "";
         PKG_PATH = "./pkg";
+        CARGO_TARGET_DIR = "./target";
 
         nativeBuildInputs = with pkgs; [
           which


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the build scripts for the `wasm` crate so that it reuses the workspace's `target` directory rather than creating a new one at `crates/wasm/target`.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
