### PR TITLE
feat(nargo): Add `--workspace` flag to run commands in every package

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -19,7 +19,7 @@ use lsp_types::{
     PublishDiagnosticsParams, Range, ServerCapabilities, TextDocumentSyncOptions,
 };
 use nargo::prepare_package;
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml};
+use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::check_crate;
 use noirc_errors::{DiagnosticKind, FileDiagnostic};
 use noirc_frontend::hir::FunctionNameMatch;
@@ -156,7 +156,7 @@ fn on_code_lens_request(
             return future::ready(Ok(None));
         }
     };
-    let workspace = match resolve_workspace_from_toml(&toml_path, None) {
+    let workspace = match resolve_workspace_from_toml(&toml_path, PackageSelection::All) {
         Ok(workspace) => workspace,
         Err(err) => {
             // If we found a manifest, but the workspace is invalid, we raise an error about it
@@ -281,7 +281,7 @@ fn on_did_save_text_document(
             return ControlFlow::Continue(());
         }
     };
-    let workspace = match resolve_workspace_from_toml(&toml_path, None) {
+    let workspace = match resolve_workspace_from_toml(&toml_path, PackageSelection::All) {
         Ok(workspace) => workspace,
         Err(err) => {
             // If we found a manifest, but the workspace is invalid, we raise an error about it

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -3,7 +3,7 @@ use acvm::Backend;
 use clap::Args;
 use iter_extended::btree_map;
 use nargo::{package::Package, prepare_package};
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml};
+use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_abi::{AbiParameter, AbiType, MAIN_RETURN_NAME};
 use noirc_driver::{check_crate, compute_function_signature, CompileOptions};
 use noirc_frontend::{
@@ -18,8 +18,12 @@ use super::NargoConfig;
 #[derive(Debug, Clone, Args)]
 pub(crate) struct CheckCommand {
     /// The name of the package to check
-    #[clap(long)]
+    #[clap(long, conflicts_with = "workspace")]
     package: Option<CrateName>,
+
+    /// Check all packages in the workspace
+    #[clap(long, conflicts_with = "package")]
+    workspace: bool,
 
     #[clap(flatten)]
     compile_options: CompileOptions,
@@ -31,7 +35,10 @@ pub(crate) fn run<B: Backend>(
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
     let toml_path = find_package_manifest(&config.program_dir)?;
-    let workspace = resolve_workspace_from_toml(&toml_path, args.package)?;
+    let default_selection =
+        if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
+    let selection = args.package.map_or(default_selection, PackageSelection::Selected);
+    let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
 
     for package in &workspace {
         check_package(package, &args.compile_options)?;

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -20,7 +20,7 @@ use nargo::{
     ops::{codegen_verifier, preprocess_program},
     package::Package,
 };
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml};
+use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::CompileOptions;
 use noirc_frontend::graph::CrateName;
 
@@ -28,8 +28,12 @@ use noirc_frontend::graph::CrateName;
 #[derive(Debug, Clone, Args)]
 pub(crate) struct CodegenVerifierCommand {
     /// The name of the package to codegen
-    #[clap(long)]
+    #[clap(long, conflicts_with = "workspace")]
     package: Option<CrateName>,
+
+    /// Codegen all packages in the workspace
+    #[clap(long, conflicts_with = "package")]
+    workspace: bool,
 
     #[clap(flatten)]
     compile_options: CompileOptions,
@@ -41,7 +45,10 @@ pub(crate) fn run<B: Backend>(
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
     let toml_path = find_package_manifest(&config.program_dir)?;
-    let workspace = resolve_workspace_from_toml(&toml_path, args.package)?;
+    let default_selection =
+        if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
+    let selection = args.package.map_or(default_selection, PackageSelection::Selected);
+    let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
 
     for package in &workspace {
         let circuit_build_path = workspace.package_build_path(package);

--- a/crates/nargo_cli/src/cli/verify_cmd.rs
+++ b/crates/nargo_cli/src/cli/verify_cmd.rs
@@ -18,7 +18,7 @@ use clap::Args;
 use nargo::constants::{PROOF_EXT, VERIFIER_INPUT_FILE};
 use nargo::ops::{preprocess_program, verify_proof};
 use nargo::{artifacts::program::PreprocessedProgram, package::Package};
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml};
+use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_abi::input_parser::Format;
 use noirc_driver::CompileOptions;
 use noirc_frontend::graph::CrateName;
@@ -32,8 +32,12 @@ pub(crate) struct VerifyCommand {
     verifier_name: String,
 
     /// The name of the package verify
-    #[clap(long)]
+    #[clap(long, conflicts_with = "workspace")]
     package: Option<CrateName>,
+
+    /// Verify all packages in the workspace
+    #[clap(long, conflicts_with = "package")]
+    workspace: bool,
 
     #[clap(flatten)]
     compile_options: CompileOptions,
@@ -45,7 +49,10 @@ pub(crate) fn run<B: Backend>(
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
     let toml_path = find_package_manifest(&config.program_dir)?;
-    let workspace = resolve_workspace_from_toml(&toml_path, args.package)?;
+    let default_selection =
+        if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
+    let selection = args.package.map_or(default_selection, PackageSelection::Selected);
+    let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
     let proofs_dir = workspace.proofs_directory_path();
 
     for package in &workspace {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2311  <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This adds the `--workspace` flag to subcommands that process workspace packages. This flag allows users to "opt-out" of running the command against only the `default-member` package and instead run it against all packages in the workspace. It also makes sure the LSP always prepares the entire workspace instead of the default member.

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

The `--workspace` flag needs to be documented for the subcommands that accept it.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
