### PR TITLE
fix: Display warning if last expression of block is unused

### DIFF
--- a/crates/noirc_frontend/src/ast/statement.rs
+++ b/crates/noirc_frontend/src/ast/statement.rs
@@ -78,17 +78,11 @@ impl Statement {
                             Statement::Expression(expr)
                         }
                     }
-
-                    // Don't wrap expressions that are not the last expression in
-                    // a block in a Semi so that we can report errors in the type checker
-                    // for unneeded expressions like { 1 + 2; 3 }
-                    (_, Some(_), false) => Statement::Expression(expr),
                     (_, None, false) => {
                         emit_error(missing_semicolon);
                         Statement::Expression(expr)
                     }
-
-                    (_, Some(_), true) => Statement::Semi(expr),
+                    (_, Some(_), _) => Statement::Semi(expr),
                     (_, None, true) => Statement::Expression(expr),
                 }
             }

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -30,7 +30,7 @@ impl CrateId {
 pub struct CrateName(SmolStr);
 
 impl CrateName {
-   fn is_valid_name(name: &str) -> bool {
+    fn is_valid_name(name: &str) -> bool {
         !name.is_empty() && name.chars().all(|n| !CHARACTER_BLACK_LIST.contains(&n))
     }
 }

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -209,7 +209,7 @@ impl From<TypeCheckError> for Diagnostic {
             }
             TypeCheckError::UnusedResultError { expr_type, expr_span } => {
                 Diagnostic::simple_warning(
-                    format!("Unused expression result (of type {expr_type})"),
+                    format!("Unused expression result of type {expr_type}"),
                     String::new(),
                     expr_span,
                 )

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -92,7 +92,7 @@ pub enum TypeCheckError {
     CallDeprecated { name: String, note: Option<String>, span: Span },
     #[error("{0}")]
     ResolverError(ResolverError),
-    #[error("Unused expression result (of type {expr_type})")]
+    #[error("Unused expression result of type {expr_type}")]
     UnusedResultError { expr_type: Type, expr_span: Span },
 }
 

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -92,6 +92,8 @@ pub enum TypeCheckError {
     CallDeprecated { name: String, note: Option<String>, span: Span },
     #[error("{0}")]
     ResolverError(ResolverError),
+    #[error("Unused expression result (of type {expr_type})")]
+    UnusedResultError { expr_type: Type, expr_span: Span },
 }
 
 impl TypeCheckError {
@@ -204,6 +206,13 @@ impl From<TypeCheckError> for Diagnostic {
                 let secondary_message = note.clone().unwrap_or_default();
 
                 Diagnostic::simple_warning(primary_message, secondary_message, span)
+            }
+            TypeCheckError::UnusedResultError { expr_type, expr_span } => {
+                Diagnostic::simple_warning(
+                    format!("Unused expression result (of type {expr_type})"),
+                    String::new(),
+                    expr_span,
+                )
             }
         }
     }


### PR DESCRIPTION
# Description

We normally throw an error on unused expression:

```rust
fn foo() {
    3 + 2; // error: expected (), got field
    5;
}
```

However we currently fail to catch the case where there's only one expression:
```rust
fn foo() {
    3 + 2; // no error :(
}
```

This PR fixes that, and per suggestion of @jfecher (https://github.com/noir-lang/noir/issues/2304#issuecomment-1677969357) converts that error to a warning. This is probably also needed, since otherwise it breaks a few tests that rely on the old behavior, and potentially user code.


Nicer error message is also provided:

Before:
```
error: Expected type (), found type Field
  ┌─ /home/vitkov/code/repos/metacraft-labs/noir/proj/src/main.nr:3:5
  │
3 │     5;
  │     -
```

After:
```
warning: Unused expression result (of type Field)
  ┌─ /home/vitkov/code/repos/metacraft-labs/noir/proj/src/main.nr:3:5
  │
3 │     5;
  │     -
```




## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/2304

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
