### PR TITLE
chore: Parameterize the build mode for noir-wasm

### DIFF
--- a/crates/wasm/build.sh
+++ b/crates/wasm/build.sh
@@ -42,7 +42,7 @@ else
   echo "Will install package to $out"
 fi
 
-run_or_fail ${self_path}/buildPhaseCargoCommand.sh debug
+run_or_fail ${self_path}/buildPhaseCargoCommand.sh release
 run_or_fail ${self_path}/installPhase.sh
 
 ln -s $out $self_path/result

--- a/crates/wasm/build.sh
+++ b/crates/wasm/build.sh
@@ -42,7 +42,7 @@ else
   echo "Will install package to $out"
 fi
 
-run_or_fail ${self_path}/buildPhaseCargoCommand.sh
+run_or_fail ${self_path}/buildPhaseCargoCommand.sh debug
 run_or_fail ${self_path}/installPhase.sh
 
 ln -s $out $self_path/result

--- a/crates/wasm/buildPhaseCargoCommand.sh
+++ b/crates/wasm/buildPhaseCargoCommand.sh
@@ -23,9 +23,26 @@ if [ -d ${self_path}/pkg/ ]; then
     rm -rf ${self_path}/pkg/
 fi
 
-# TODO: Handle the wasm target being built in release mode
+# Check that the user passed in debug or release mode
+# and set the BUILD_FLAG and BUILD_MODE appropriately.
+if [[ -z "$1" ]]; then
+    echo "Build script requires either "debug" or "release" as an argument."
+    exit 1
+fi
+
+BUILD_MODE=$1
+BUILD_FLAG="" # Defaults to debug mode which is an empty string 
+
+if [[ "$1" == "release" ]]; then
+    BUILD_MODE=release
+    BUILD_FLAG="--release"
+elif [[ "$1" != "debug" ]]; then
+    echo "Invalid BUILD_MODE. Accepted values are 'debug' or 'release'."
+    exit 1
+fi
+
 TARGET=wasm32-unknown-unknown
-WASM_BINARY=${CARGO_TARGET_DIR}/${TARGET}/release/${pname}.wasm
+WASM_BINARY=${CARGO_TARGET_DIR}/${TARGET}/${BUILD_MODE}/${pname}.wasm
 
 NODE_DIR=${self_path}/pkg/nodejs/
 BROWSER_DIR=${self_path}/pkg/web/
@@ -33,7 +50,7 @@ NODE_WASM=${NODE_DIR}/${pname}_bg.wasm
 BROWSER_WASM=${BROWSER_DIR}/${pname}_bg.wasm
 
 # Build the new wasm package
-run_or_fail cargo build --lib --release --package noir_wasm --target wasm32-unknown-unknown
+run_or_fail cargo build --lib $BUILD_FLAG --package noir_wasm --target wasm32-unknown-unknown
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $NODE_DIR --typescript --target nodejs
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $BROWSER_DIR --typescript --target web
 run_if_available wasm-opt $NODE_WASM -o $NODE_WASM -O


### PR DESCRIPTION
# Description

This does not change any observable behaviour, though if one wanted to use debug mode then it would involve only changing the parameter passed to the build phase.

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
