### PR TITLE
fix: Overflowing assignment will result in an error

### DIFF
--- a/crates/nargo_cli/tests/compile_failure/overflowing_assignment/Nargo.toml
+++ b/crates/nargo_cli/tests/compile_failure/overflowing_assignment/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "overflowing_assignment"
+type = "bin"
+authors = [""]
+compiler_version = "0.9.0"
+
+[dependencies]

--- a/crates/nargo_cli/tests/compile_failure/overflowing_assignment/src/main.nr
+++ b/crates/nargo_cli/tests/compile_failure/overflowing_assignment/src/main.nr
@@ -1,0 +1,5 @@
+fn main() {
+    let x:u8 = -1;
+    let y:u8 = 300;
+    assert(x!=y);
+}

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -275,7 +275,7 @@ impl<'interner> TypeChecker<'interner> {
         let span = self.interner.expr_span(rhs_expr);
         match expr {
             HirExpression::Literal(HirLiteral::Integer(value)) => {
-                let v: u128 = value.to_u128();
+                let v = value.to_u128();
                 if let Type::Integer(_, bit_count) = annotated_type {
                     let max = 1 << bit_count;
                     if v >= max {

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -268,6 +268,8 @@ impl<'interner> TypeChecker<'interner> {
         }
     }
 
+    /// Check if an assignment is overflowing with respect to `annotated_type`
+    /// in a declaration statement where `annotated_type` is an unsigned integer
     fn lint_overflowing_uint(&mut self, rhs_expr: &ExprId, annotated_type: &Type) {
         let expr = self.interner.expression(rhs_expr);
         let span = self.interner.expr_span(rhs_expr);

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -272,32 +272,25 @@ impl<'interner> TypeChecker<'interner> {
         let expr = self.interner.expression(rhs_expr);
         let span = self.interner.expr_span(rhs_expr);
         match expr {
-            crate::hir_def::expr::HirExpression::Literal(literal) => match literal {
-                crate::hir_def::expr::HirLiteral::Integer(value) => {
-                    let v: u128 = value.to_u128();
-                    match annotated_type {
-                        Type::Integer(_, bit) => {
-                            let max = 1 << bit;
-                            if v >= max {
-                                self.errors.push(TypeCheckError::OverflowingAssignment {
-                                    expr: value,
-                                    ty: annotated_type.clone(),
-                                    range: format!("0..={}", max - 1),
-                                    span: span,
-                                })
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                _ => {}
-            },
-            crate::hir_def::expr::HirExpression::Prefix(_) => {
-                self.errors.push(TypeCheckError::InvalidUnaryOp {
-                    kind: annotated_type.to_string(),
-                    span: span,
-                })
+            crate::hir_def::expr::HirExpression::Literal(
+                crate::hir_def::expr::HirLiteral::Integer(value),
+            ) => {
+                let v: u128 = value.to_u128();
+                if let Type::Integer(_, bit) = annotated_type {
+                    let max = 1 << bit;
+                    if v >= max {
+                        self.errors.push(TypeCheckError::OverflowingAssignment {
+                            expr: value,
+                            ty: annotated_type.clone(),
+                            range: format!("0..={}", max - 1),
+                            span,
+                        });
+                    };
+                };
             }
+            crate::hir_def::expr::HirExpression::Prefix(_) => self
+                .errors
+                .push(TypeCheckError::InvalidUnaryOp { kind: annotated_type.to_string(), span }),
             _ => {}
         }
     }

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -1,6 +1,6 @@
 use noirc_errors::{Location, Span};
 
-use crate::hir_def::expr::HirIdent;
+use crate::hir_def::expr::{HirExpression, HirIdent, HirLiteral};
 use crate::hir_def::stmt::{
     HirAssignStatement, HirConstrainStatement, HirLValue, HirLetStatement, HirPattern, HirStatement,
 };
@@ -272,9 +272,7 @@ impl<'interner> TypeChecker<'interner> {
         let expr = self.interner.expression(rhs_expr);
         let span = self.interner.expr_span(rhs_expr);
         match expr {
-            crate::hir_def::expr::HirExpression::Literal(
-                crate::hir_def::expr::HirLiteral::Integer(value),
-            ) => {
+            HirExpression::Literal(HirLiteral::Integer(value)) => {
                 let v: u128 = value.to_u128();
                 if let Type::Integer(_, bit) = annotated_type {
                     let max = 1 << bit;
@@ -288,7 +286,7 @@ impl<'interner> TypeChecker<'interner> {
                     };
                 };
             }
-            crate::hir_def::expr::HirExpression::Prefix(_) => self
+            HirExpression::Prefix(_) => self
                 .errors
                 .push(TypeCheckError::InvalidUnaryOp { kind: annotated_type.to_string(), span }),
             _ => {}

--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -276,8 +276,8 @@ impl<'interner> TypeChecker<'interner> {
         match expr {
             HirExpression::Literal(HirLiteral::Integer(value)) => {
                 let v: u128 = value.to_u128();
-                if let Type::Integer(_, bit) = annotated_type {
-                    let max = 1 << bit;
+                if let Type::Integer(_, bit_count) = annotated_type {
+                    let max = 1 << bit_count;
                     if v >= max {
                         self.errors.push(TypeCheckError::OverflowingAssignment {
                             expr: value,

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -447,6 +447,10 @@ impl Type {
         matches!(self.follow_bindings(), Type::Integer(Signedness::Signed, _))
     }
 
+    pub fn is_unsigned(&self) -> bool {
+        matches!(self.follow_bindings(), Type::Integer(Signedness::Unsigned, _))
+    }
+
     fn contains_numeric_typevar(&self, target_id: TypeVariableId) -> bool {
         // True if the given type is a NamedGeneric with the target_id
         let named_generic_id_matches_target = |typ: &Type| {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/2236

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

`nargo execute` code
```rust
use dep::std;
fn main() {
    let x:u8 = 300;
    std::println(x);
}
```
will result in
```rust
error: The literal `300` cannot fit into `u8` which has range `0..=255`
```

`nargo execute` code
```rust
use dep::std;
fn main() {
    let x:u8 = -1;
    std::println(x);
}
```
will result in
```rust
error: u8 cannot be used in a unary operation
```

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
