### PR TITLE
fix(lsp): Ensure lsp does not crawl past the root specified

### DIFF
--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -3,7 +3,7 @@ use acvm::Backend;
 use clap::Args;
 use iter_extended::btree_map;
 use nargo::{package::Package, prepare_package};
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_abi::{AbiParameter, AbiType, MAIN_RETURN_NAME};
 use noirc_driver::{check_crate, compute_function_signature, CompileOptions};
 use noirc_frontend::{
@@ -34,7 +34,7 @@ pub(crate) fn run<B: Backend>(
     args: CheckCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/crates/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -20,7 +20,7 @@ use nargo::{
     ops::{codegen_verifier, preprocess_program},
     package::Package,
 };
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::CompileOptions;
 use noirc_frontend::graph::CrateName;
 
@@ -44,7 +44,7 @@ pub(crate) fn run<B: Backend>(
     args: CodegenVerifierCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -6,7 +6,7 @@ use nargo::artifacts::debug::DebugArtifact;
 use nargo::package::Package;
 use nargo::prepare_package;
 use nargo::{artifacts::contract::PreprocessedContract, NargoError};
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{
     compile_contracts, compile_main, CompileOptions, CompiledContract, CompiledProgram,
     ErrorsAndWarnings, Warnings,
@@ -62,7 +62,7 @@ pub(crate) fn run<B: Backend>(
     args: CompileCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use nargo::constants::PROVER_INPUT_FILE;
 use nargo::package::Package;
 use nargo::NargoError;
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_abi::input_parser::{Format, InputValue};
 use noirc_abi::{Abi, InputMap};
 use noirc_driver::{CompileOptions, CompiledProgram};
@@ -45,7 +45,7 @@ pub(crate) fn run<B: Backend>(
     args: ExecuteCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_cli/src/cli/info_cmd.rs
+++ b/crates/nargo_cli/src/cli/info_cmd.rs
@@ -2,7 +2,7 @@ use acvm::Backend;
 use clap::Args;
 use iter_extended::try_vecmap;
 use nargo::{package::Package, prepare_package};
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{compile_contracts, CompileOptions};
 use noirc_frontend::graph::CrateName;
 use prettytable::{row, Table};
@@ -38,7 +38,7 @@ pub(crate) fn run<B: Backend>(
     args: InfoCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_cli/src/cli/prove_cmd.rs
+++ b/crates/nargo_cli/src/cli/prove_cmd.rs
@@ -6,7 +6,7 @@ use nargo::artifacts::program::PreprocessedProgram;
 use nargo::constants::{PROVER_INPUT_FILE, VERIFIER_INPUT_FILE};
 use nargo::ops::{preprocess_program, prove_execution, verify_proof};
 use nargo::package::Package;
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_abi::input_parser::Format;
 use noirc_driver::CompileOptions;
 use noirc_frontend::graph::CrateName;
@@ -56,7 +56,7 @@ pub(crate) fn run<B: Backend>(
     args: ProveCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use acvm::{acir::native_types::WitnessMap, Backend};
 use clap::Args;
 use nargo::{ops::execute_circuit, package::Package, prepare_package};
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{compile_no_check, CompileOptions};
 use noirc_frontend::{
     graph::CrateName,
@@ -47,7 +47,7 @@ pub(crate) fn run<B: Backend>(
     args: TestCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_cli/src/cli/verify_cmd.rs
+++ b/crates/nargo_cli/src/cli/verify_cmd.rs
@@ -18,7 +18,7 @@ use clap::Args;
 use nargo::constants::{PROOF_EXT, VERIFIER_INPUT_FILE};
 use nargo::ops::{preprocess_program, verify_proof};
 use nargo::{artifacts::program::PreprocessedProgram, package::Package};
-use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_abi::input_parser::Format;
 use noirc_driver::CompileOptions;
 use noirc_frontend::graph::CrateName;
@@ -48,7 +48,7 @@ pub(crate) fn run<B: Backend>(
     args: VerifyCommand,
     config: NargoConfig,
 ) -> Result<(), CliError<B>> {
-    let toml_path = find_package_manifest(&config.program_dir)?;
+    let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);

--- a/crates/nargo_toml/src/errors.rs
+++ b/crates/nargo_toml/src/errors.rs
@@ -59,4 +59,7 @@ pub enum ManifestError {
 
     #[error("Missing `name` field in {toml}")]
     MissingNameField { toml: PathBuf },
+
+    #[error("No common ancestor between {root} and {current}")]
+    NoCommonAncestor { root: PathBuf, current: PathBuf },
 }

--- a/crates/nargo_toml/src/lib.rs
+++ b/crates/nargo_toml/src/lib.rs
@@ -44,7 +44,7 @@ fn path_root(path: &Path) -> PathBuf {
     }
 }
 
-/// Returns the [Path] of the `Nargo.toml` file by searching from `current_path` and stopping at `root_path`.
+/// Returns the [PathBuf] of the `Nargo.toml` file by searching from `current_path` and stopping at `root_path`.
 ///
 /// Returns a [ManifestError] if no parent directories of `current_path` contain a manifest file.
 pub fn find_package_manifest(
@@ -72,7 +72,7 @@ pub fn find_package_manifest(
         })
     }
 }
-/// Returns the [Path] of the `Nargo.toml` file in the `current_path` directory.
+/// Returns the [PathBuf] of the `Nargo.toml` file in the `current_path` directory.
 ///
 /// Returns a [ManifestError] if `current_path` does not contain a manifest file.
 pub fn get_package_manifest(current_path: &Path) -> Result<PathBuf, ManifestError> {

--- a/crates/nargo_toml/src/lib.rs
+++ b/crates/nargo_toml/src/lib.rs
@@ -17,7 +17,7 @@ mod git;
 pub use errors::ManifestError;
 use git::clone_git_repo;
 
-/// Returns the [Path] of the directory containing the `Nargo.toml` by searching from `current_path` to the root of its [Path].
+/// Returns the [PathBuf] of the directory containing the `Nargo.toml` by searching from `current_path` to the root of its [Path].
 ///
 /// Returns a [ManifestError] if no parent directories of `current_path` contain a manifest file.
 pub fn find_package_root(current_path: &Path) -> Result<PathBuf, ManifestError> {

--- a/crates/nargo_toml/src/lib.rs
+++ b/crates/nargo_toml/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::BTreeMap,
-    fs::ReadDir,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use fm::{NormalizePath, FILE_EXTENSION};
@@ -18,11 +17,12 @@ mod git;
 pub use errors::ManifestError;
 use git::clone_git_repo;
 
-/// Returns the path of the root directory of the package containing `current_path`.
+/// Returns the [Path] of the directory containing the `Nargo.toml` by searching from `current_path` to the root of its [Path].
 ///
-/// Returns a `CliError` if no parent directories of `current_path` contain a manifest file.
+/// Returns a [ManifestError] if no parent directories of `current_path` contain a manifest file.
 pub fn find_package_root(current_path: &Path) -> Result<PathBuf, ManifestError> {
-    let manifest_path = find_package_manifest(current_path)?;
+    let root = path_root(current_path);
+    let manifest_path = find_package_manifest(&root, current_path)?;
 
     let package_root =
         manifest_path.parent().expect("infallible: manifest file path can't be root directory");
@@ -30,36 +30,71 @@ pub fn find_package_root(current_path: &Path) -> Result<PathBuf, ManifestError> 
     Ok(package_root.to_path_buf())
 }
 
-/// Returns the path of the manifest file (`Nargo.toml`) of the package containing `current_path`.
+// TODO: We are probably going to need a "filepath utils" crate soon
+fn path_root(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+
+    // Preserve path prefix if one exists.
+    let mut normalized_path = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!("Path cannot contain multiple prefixes"),
+            Component::RootDir => {
+                normalized_path.push(component.as_os_str());
+            }
+            Component::CurDir | Component::ParentDir | Component::Normal(_) => {
+                break;
+            }
+        }
+    }
+
+    normalized_path
+}
+
+/// Returns the [Path] of the `Nargo.toml` file by searching from `current_path` and stopping at `root_path`.
 ///
-/// Returns a `CliError` if no parent directories of `current_path` contain a manifest file.
-pub fn find_package_manifest(current_path: &Path) -> Result<PathBuf, ManifestError> {
-    current_path
-        .ancestors()
-        .find_map(|dir| find_file(dir, "Nargo", "toml"))
-        .ok_or_else(|| ManifestError::MissingFile(current_path.to_path_buf()))
+/// Returns a [ManifestError] if no parent directories of `current_path` contain a manifest file.
+pub fn find_package_manifest(
+    root_path: &Path,
+    current_path: &Path,
+) -> Result<PathBuf, ManifestError> {
+    if current_path.starts_with(root_path) {
+        let mut found_toml_paths = Vec::new();
+        for path in current_path.ancestors() {
+            if let Ok(toml_path) = get_package_manifest(path) {
+                found_toml_paths.push(toml_path);
+            }
+            // While traversing, break once we process the root specified
+            if path == root_path {
+                break;
+            }
+        }
+
+        // Return the shallowest Nargo.toml, which will be the last in the list
+        found_toml_paths.pop().ok_or_else(|| ManifestError::MissingFile(current_path.to_path_buf()))
+    } else {
+        Err(ManifestError::NoCommonAncestor {
+            root: root_path.to_path_buf(),
+            current: current_path.to_path_buf(),
+        })
+    }
 }
-
-// Looks for file named `file_name` in path
-fn find_file<P: AsRef<Path>>(path: P, file_name: &str, extension: &str) -> Option<PathBuf> {
-    let entries = list_files_and_folders_in(path)?;
-    let file_name = format!("{file_name}.{extension}");
-
-    find_artifact(entries, &file_name)
-}
-
-// There is no distinction between files and folders
-fn find_artifact(entries: ReadDir, artifact_name: &str) -> Option<PathBuf> {
-    let entry = entries
-        .into_iter()
-        .flatten()
-        .find(|entry| entry.file_name().to_str() == Some(artifact_name))?;
-
-    Some(entry.path())
-}
-
-fn list_files_and_folders_in<P: AsRef<Path>>(path: P) -> Option<ReadDir> {
-    std::fs::read_dir(path).ok()
+/// Returns the [Path] of the `Nargo.toml` file in the `current_path` directory.
+///
+/// Returns a [ManifestError] if `current_path` does not contain a manifest file.
+pub fn get_package_manifest(current_path: &Path) -> Result<PathBuf, ManifestError> {
+    let toml_path = current_path.join("Nargo.toml");
+    if toml_path.exists() {
+        Ok(toml_path)
+    } else {
+        Err(ManifestError::MissingFile(current_path.to_path_buf()))
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2261 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This reworks the crawling for Nargo.toml files. When searching for the `program_dir`, we still search to the root using `find_package_root`; however, `find_package_manifest` requires a root where we stop the crawling. Additionally, we now read the `<program_dir>/Nargo.toml` exactly instead of traversing.

These changes allowed me to fix a problem with the LSP where it would crawl past the `root_uri` and find a Nargo.toml outside of the directory you have opened.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
