### PR TITLE
fix: Prevent panic when passing relative paths to `--program-dir`

### DIFF
--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -40,7 +40,7 @@ struct NargoCli {
 #[derive(Args, Clone, Debug)]
 pub(crate) struct NargoConfig {
     // REMINDER: Also change this flag in the LSP test lens if renamed
-    #[arg(long, hide=true, global=true, default_value_os_t = std::env::current_dir().unwrap())]
+    #[arg(long, hide = true, global = true, default_value = "./")]
     program_dir: PathBuf,
 }
 
@@ -63,6 +63,11 @@ enum NargoCommand {
 
 pub(crate) fn start_cli() -> eyre::Result<()> {
     let NargoCli { command, mut config } = NargoCli::parse();
+
+    // If the provided `program_dir` is relative, make it absolute by joining it to the current directory.
+    if !config.program_dir.is_absolute() {
+        config.program_dir = std::env::current_dir().unwrap().join(config.program_dir)
+    }
 
     // Search through parent directories to find package root if necessary.
     if !matches!(command, NargoCommand::New(_) | NargoCommand::Init(_) | NargoCommand::Lsp(_)) {

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -66,7 +66,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
 
     // If the provided `program_dir` is relative, make it absolute by joining it to the current directory.
     if !config.program_dir.is_absolute() {
-        config.program_dir = std::env::current_dir().unwrap().join(config.program_dir)
+        config.program_dir = std::env::current_dir().unwrap().join(config.program_dir);
     }
 
     // Search through parent directories to find package root if necessary.


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves comment in https://github.com/noir-lang/noir/pull/2322#pullrequestreview-1578966511

## Summary\*

This PR fixes an issue where using relative paths in the `--program-dir` flag causes nargo to panic. This is done by joining any relative paths to the current working directory.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
