### PR TITLE
feat: Allow calling higher-order functions with closures

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -835,11 +835,13 @@ impl<'interner> TypeChecker<'interner> {
         }
 
         for (param, (arg, _, arg_span)) in fn_params.iter().zip(callsite_args) {
-            self.unify(arg, param, || TypeCheckError::TypeMismatch {
-                expected_typ: param.to_string(),
-                expr_typ: arg.to_string(),
-                expr_span: *arg_span,
-            });
+            if arg.try_unify_allow_incompat_lambdas(param).is_err() {
+                self.errors.push(TypeCheckError::TypeMismatch {
+                    expected_typ: param.to_string(),
+                    expr_typ: arg.to_string(),
+                    expr_span: *arg_span,
+                });
+            }
         }
 
         fn_ret.clone()

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -63,28 +63,33 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
         let (expr_span, empty_function) = function_info(interner, function_body_id);
 
         let func_span = interner.expr_span(function_body_id); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
-        function_last_type.unify_with_coercions(
-            &declared_return_type,
-            *function_body_id,
-            interner,
-            &mut errors,
-            || {
-                let mut error = TypeCheckError::TypeMismatchWithSource {
-                    lhs: declared_return_type.clone(),
-                    rhs: function_last_type.clone(),
-                    span: func_span,
-                    source: Source::Return(meta.return_type, expr_span),
-                };
 
-                if empty_function {
-                    error = error.add_context(
-                        "implicitly returns `()` as its body has no tail or `return` expression",
-                    );
-                }
+        let result = function_last_type.try_unify_allow_incompat_lambdas(&declared_return_type);
 
-                error
-            },
-        );
+        if result.is_err() {
+            function_last_type.unify_with_coercions(
+                &declared_return_type,
+                *function_body_id,
+                interner,
+                &mut errors,
+                || {
+                    let mut error = TypeCheckError::TypeMismatchWithSource {
+                        lhs: declared_return_type.clone(),
+                        rhs: function_last_type.clone(),
+                        span: func_span,
+                        source: Source::Return(meta.return_type, expr_span),
+                    };
+
+                    if empty_function {
+                        error = error.add_context(
+                            "implicitly returns `()` as its body has no tail or `return` expression",
+                        );
+                    }
+
+                    error
+                },
+            );
+        }
     }
 
     errors

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -54,8 +54,7 @@ pub enum Type {
     /// TypeVariables are stand-in variables for some type which is not yet known.
     /// They are not to be confused with NamedGenerics. While the later mostly works
     /// as with normal types (ie. for two NamedGenerics T and U, T != U), TypeVariables
-    /// will be automatically rebound as necessary to satisfy any calls to unify
-    /// and make_subtype_of.
+    /// will be automatically rebound as necessary to satisfy any calls to unify.
     ///
     /// TypeVariables are often created when a generic function is instantiated. This
     /// is a process that replaces each NamedGeneric in a generic function with a TypeVariable.
@@ -885,7 +884,36 @@ impl Type {
         }
     }
 
-    /// Similar to `make_subtype_of` but if the check fails this will attempt to coerce the
+    /// Similar to try_unify() but allows non-matching capture groups for function types
+    pub fn try_unify_allow_incompat_lambdas(&self, other: &Type) -> Result<(), UnificationError> {
+        use Type::*;
+        use TypeVariableKind::*;
+
+        match (self, other) {
+            (TypeVariable(binding, Normal), other) | (other, TypeVariable(binding, Normal)) => {
+                if let TypeBinding::Bound(link) = &*binding.borrow() {
+                    return link.try_unify_allow_incompat_lambdas(other);
+                }
+
+                other.try_bind_to(binding)
+            }
+            (Function(params_a, ret_a, _), Function(params_b, ret_b, _)) => {
+                if params_a.len() == params_b.len() {
+                    for (a, b) in params_a.iter().zip(params_b.iter()) {
+                        a.try_unify_allow_incompat_lambdas(b)?;
+                    }
+
+                    // no check for environments here!
+                    ret_b.try_unify_allow_incompat_lambdas(ret_a)
+                } else {
+                    Err(UnificationError)
+                }
+            }
+            _ => self.try_unify(other),
+        }
+    }
+
+    /// Similar to `unify` but if the check fails this will attempt to coerce the
     /// argument to the target type. When this happens, the given expression is wrapped in
     /// a new expression to convert its type. E.g. `array` -> `array.as_slice()`
     ///
@@ -923,7 +951,7 @@ impl Type {
             // If we have an array and our target is a slice
             if matches!(size1, Type::Constant(_)) && matches!(size2, Type::NotConstant) {
                 // Still have to ensure the element types match.
-                // Don't need to issue an error here if not, it will be done in make_subtype_of_with_coercions
+                // Don't need to issue an error here if not, it will be done in unify_with_coercions
                 if element1.try_unify(element2).is_ok() {
                     convert_array_expression_to_slice(expression, this, target, interner);
                     return true;


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->




## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Initial work towards https://github.com/noir-lang/noir/issues/2334

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This is work towards allowing higher-order functions to be called with closure arguments. The bulk of the work will be done in the monomorphizer in the next PRs, this is a prerequisite that  allows higher-order functions called with closures to pass type-checking.

A method called `try_unify_allow_incompat_lambdas` is added that is used instead of `try_unify` for function arguments. The only difference between it and `try_unify` is that it doesn't check function type capture groups.
This also fixes some comments that reference the removed `make_subtype_of` functions



## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
