### PR TITLE
chore(ci): use custom caching action to prevent cache writes in merge queue

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,0 +1,38 @@
+name: Cache
+description: 'A wrapper around `actions/cache` which exposes an additional `read-only` input to conditionally write new cache entries'
+
+inputs:
+  path:
+    description: 'A list of files, directories, and wildcard patterns to cache and restore'
+    required: true
+  key:
+    description: 'An explicit key for restoring and saving the cache'
+    required: true
+  read-only:
+    description: 'Do not write cache artifacts in the case of a missed cache'
+    default: 'false'
+    required: false
+
+outputs:
+  cache-hit:
+    description: 'A boolean value to indicate an exact match was found for the primary key'
+    value: ${{ steps.cache.outputs.cache-hit || steps.restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+
+    - id: restore
+      uses: actions/cache/restore@v3
+      if: ${{ inputs.read_only }}
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+
+    - id: cache
+      uses: actions/cache@v3
+      if: ${{ !inputs.read_only }}
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}  
+    

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
           echo "SDKROOT=$(xcrun -sdk macosx$(sw_vers -productVersion) --show-sdk-path)" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx$(sw_vers -productVersion) --show-sdk-platform-version)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/cache
         with:
           path: |
             ~/.cargo/bin/
@@ -88,6 +88,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          read-only: ${{ github.event_name == 'merge_group' }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3
@@ -161,7 +162,7 @@ jobs:
         with:
           ref: ${{ inputs.tag || env.GITHUB_REF }}
 
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/cache
         with:
           path: |
             ~/.cargo/bin/
@@ -170,6 +171,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          read-only: ${{ github.event_name == 'merge_group' }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3
@@ -237,7 +239,7 @@ jobs:
         with:
           ref: ${{ inputs.tag || env.GITHUB_REF }}
 
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/cache
         with:
           path: |
             ~/.cargo/bin/
@@ -246,6 +248,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          read-only: ${{ github.event_name == 'merge_group' }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,11 @@ jobs:
 
       - name: Restore nix store cache
         id: nix-store-cache
-        uses: actions/cache@v3
+        uses: ./.github/actions/cache
         with:
           path: /tmp/nix-cache
           key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
+          read-only: ${{ github.event_name == 'merge_group' }}
 
       # Based on https://github.com/marigold-dev/deku/blob/b5016f0cf4bf6ac48db9111b70dd7fb49b969dfd/.github/workflows/build.yml#L26
       - name: Copy cache into nix store

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout Noir repo
         uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/cache
         with:
           path: |
             ~/.cargo/bin/
@@ -63,6 +63,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          read-only: ${{ github.event_name == 'merge_group' }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
… 

# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/2274

## Summary\*

This PR wraps our usage of the `actions/cache` action with an action which choses between this and `actions/cache/restore` based on a boolean input. We can then perform a read-only cache restore if the workflow was triggered by the `merge_group` trigger.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
