### PR TITLE
chore(brillig): Fix brillig radix instruction return vector size

### DIFF
--- a/crates/nargo_cli/tests/execution_success/brillig_to_le_bytes/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/brillig_to_le_bytes/src/main.nr
@@ -1,14 +1,13 @@
 use dep::std;
 
-unconstrained fn main(x : Field) -> pub [u8; 4] {
+unconstrained fn main(x : Field) -> pub [u8; 31] {
     // The result of this byte array will be little-endian
     let byte_array = x.to_le_bytes(31);
-    let mut first_four_bytes = [0; 4];
-    for i in 0..4 {
-        first_four_bytes[i] = byte_array[i];
+    assert(byte_array.len() == 31);
+
+    let mut bytes = [0; 31];
+    for i in 0..31 {
+        bytes[i] = byte_array[i];
     }
-    // Issue #617 fix
-    // We were incorrectly mapping our output array from bit decomposition functions during acir generation
-    first_four_bytes[3] = byte_array[31];
-    first_four_bytes
+    bytes
 }

--- a/crates/nargo_cli/tests/execution_success/to_le_bytes/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/to_le_bytes/src/main.nr
@@ -1,14 +1,13 @@
 use dep::std;
 
-fn main(x : Field) -> pub [u8; 4] {
+fn main(x : Field) -> pub [u8; 31] {
     // The result of this byte array will be little-endian
     let byte_array = x.to_le_bytes(31);
-    let mut first_four_bytes = [0; 4];
-    for i in 0..4 {
-        first_four_bytes[i] = byte_array[i];
+    assert(byte_array.len() == 31);
+    
+    let mut bytes = [0; 31];
+    for i in 0..31 {
+        bytes[i] = byte_array[i];
     }
-    // Issue #617 fix
-    // We were incorrectly mapping our output array from bit decomposition functions during acir generation
-    first_four_bytes[3] = byte_array[31];
-    first_four_bytes
+    bytes
 }

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -859,10 +859,6 @@ impl BrilligContext {
         big_endian: bool,
     ) {
         self.mov_instruction(target_vector.size, limb_count);
-        // The full array that is returned is going to be the limb count + 1
-        if !big_endian {
-            self.usize_op_in_place(target_vector.size, BinaryIntOp::Add, 1usize);
-        }
         self.allocate_array_instruction(target_vector.pointer, target_vector.size);
 
         let shifted_register = self.allocate_register();

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -858,7 +858,11 @@ impl BrilligContext {
         limb_count: RegisterIndex,
         big_endian: bool,
     ) {
+        let loop_iter_count = self.allocate_register();
+        self.mov_instruction(loop_iter_count, limb_count);
         self.mov_instruction(target_vector.size, limb_count);
+        // The full array that is returned is going to be the limb count + 1
+        self.usize_op_in_place(target_vector.size, BinaryIntOp::Add, 1usize);
         self.allocate_array_instruction(target_vector.pointer, target_vector.size);
 
         let shifted_register = self.allocate_register();
@@ -866,7 +870,7 @@ impl BrilligContext {
 
         let modulus_register: RegisterIndex = self.allocate_register();
 
-        self.loop_instruction(target_vector.size, |ctx, iterator_register| {
+        self.loop_instruction(loop_iter_count, |ctx, iterator_register| {
             // Compute the modulus
             ctx.modulo_instruction(
                 modulus_register,

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -858,11 +858,11 @@ impl BrilligContext {
         limb_count: RegisterIndex,
         big_endian: bool,
     ) {
-        let loop_iter_count = self.allocate_register();
-        self.mov_instruction(loop_iter_count, limb_count);
         self.mov_instruction(target_vector.size, limb_count);
         // The full array that is returned is going to be the limb count + 1
-        self.usize_op_in_place(target_vector.size, BinaryIntOp::Add, 1usize);
+        if !big_endian {
+            self.usize_op_in_place(target_vector.size, BinaryIntOp::Add, 1usize);
+        }
         self.allocate_array_instruction(target_vector.pointer, target_vector.size);
 
         let shifted_register = self.allocate_register();
@@ -870,7 +870,7 @@ impl BrilligContext {
 
         let modulus_register: RegisterIndex = self.allocate_register();
 
-        self.loop_instruction(loop_iter_count, |ctx, iterator_register| {
+        self.loop_instruction(target_vector.size, |ctx, iterator_register| {
             // Compute the modulus
             ctx.modulo_instruction(
                 modulus_register,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -780,16 +780,6 @@ impl AcirContext {
             limb_vars.reverse();
         }
 
-        // For legacy reasons (see #617) the to_radix interface supports 256 bits even though
-        // FieldElement::max_num_bits() is only 254 bits. Any limbs beyond the specified count
-        // become zero padding.
-        let max_decomposable_bits: u32 = 256;
-        let limb_count_with_padding = max_decomposable_bits / bit_size;
-        let zero = self.add_constant(FieldElement::zero());
-        while limb_vars.len() < limb_count_with_padding as usize {
-            limb_vars.push(AcirValue::Var(zero, result_element_type.clone()));
-        }
-
         Ok(vec![AcirValue::Array(limb_vars.into())])
     }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

References this comment and the preceding discussion: https://github.com/noir-lang/noir/pull/2348#issuecomment-1681214310

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
