### PR TITLE
fix: Show types in error message in same order as in source code

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -686,8 +686,8 @@ impl<'interner> TypeChecker<'interner> {
                     Ok(Bool)
                 } else {
                     Err(TypeCheckError::TypeMismatchWithSource {
-                        rhs: lhs_type.clone(),
-                        lhs: rhs_type.clone(),
+                        lhs: lhs_type.clone(),
+                        rhs: rhs_type.clone(),
                         span,
                         source: Source::Binary,
                     })
@@ -732,15 +732,15 @@ impl<'interner> TypeChecker<'interner> {
                 if matches!(op.kind, Equal | NotEqual) =>
             {
                 self.unify(x_type, y_type, || TypeCheckError::TypeMismatchWithSource {
-                    rhs: lhs_type.clone(),
-                    lhs: rhs_type.clone(),
+                    lhs: lhs_type.clone(),
+                    rhs: rhs_type.clone(),
                     source: Source::ArrayElements,
                     span: op.location.span,
                 });
 
                 self.unify(x_size, y_size, || TypeCheckError::TypeMismatchWithSource {
-                    rhs: lhs_type.clone(),
-                    lhs: rhs_type.clone(),
+                    lhs: lhs_type.clone(),
+                    rhs: rhs_type.clone(),
                     source: Source::ArrayLen,
                     span: op.location.span,
                 });
@@ -752,8 +752,8 @@ impl<'interner> TypeChecker<'interner> {
                     return Ok(Bool);
                 }
                 Err(TypeCheckError::TypeMismatchWithSource {
-                    rhs: lhs.clone(),
-                    lhs: rhs.clone(),
+                    lhs: lhs.clone(),
+                    rhs: rhs.clone(),
                     source: Source::Comparison,
                     span,
                 })
@@ -769,8 +769,8 @@ impl<'interner> TypeChecker<'interner> {
                 Ok(Bool)
             }
             (lhs, rhs) => Err(TypeCheckError::TypeMismatchWithSource {
-                rhs: lhs.clone(),
-                lhs: rhs.clone(),
+                lhs: lhs.clone(),
+                rhs: rhs.clone(),
                 source: Source::Comparison,
                 span,
             }),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2352 

## Summary\*

Looks like we had our lefts and rights mixed up.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
