### PR TITLE
feat: add syntax for specifying function type environments

### DIFF
--- a/crates/nargo_cli/tests/execution_success/closure_explicit_types/Nargo.toml
+++ b/crates/nargo_cli/tests/execution_success/closure_explicit_types/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "closure_explicit_types"
+type = "bin"
+authors = [""]
+compiler_version = "0.10.3"
+
+[dependencies]

--- a/crates/nargo_cli/tests/execution_success/closure_explicit_types/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/closure_explicit_types/src/main.nr
@@ -1,0 +1,60 @@
+
+fn ret_normal_lambda1() -> fn() -> Field {
+    || 10
+}
+
+// explicitly specified empty capture group
+fn ret_normal_lambda2() -> fn[]() -> Field {
+    || 20
+}
+
+// return lamda that captures a thing
+fn ret_closure1() -> fn[Field]() -> Field {
+    let x = 20;
+    || x + 10
+}
+
+// return lamda that captures two things
+fn ret_closure2() -> fn[Field,Field]() -> Field {
+    let x = 20;
+    let y = 10;
+    || x + y + 10
+}
+
+// return lamda that captures two things with different types
+fn ret_closure3() -> fn[u32,u64]() -> u64 {
+    let x: u32 = 20;
+    let y: u64 = 10;
+    || x as u64 + y + 10
+}
+
+// accepts closure that has 1 thing in its env, calls it and returns the result
+fn accepts_closure1(f: fn[Field]() -> Field) -> Field {
+    f()
+}
+
+// accepts closure that has 1 thing in its env and returns it
+fn accepts_closure2(f: fn[Field]() -> Field) -> fn[Field]() -> Field {
+    f
+}
+
+// accepts closure with different types in the capture group
+fn accepts_closure3(f: fn[u32, u64]() -> u64) -> u64 {
+    f()
+}
+
+fn main() {
+    assert(ret_normal_lambda1()() == 10);
+    assert(ret_normal_lambda2()() == 20);
+    assert(ret_closure1()() == 30);
+    assert(ret_closure2()() == 40);
+    assert(ret_closure3()() == 40);
+
+    let x = 50;
+    assert(accepts_closure1(|| x) == 50);
+    assert(accepts_closure2(|| x + 10)() == 60);
+
+    let y: u32 = 30;
+    let z: u64 = 40;
+    assert(accepts_closure3(|| y as u64 + z) == 70);
+}

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -361,10 +361,10 @@ impl<'a> Resolver<'a> {
             UnresolvedType::Tuple(fields) => {
                 Type::Tuple(vecmap(fields, |field| self.resolve_type_inner(field, new_variables)))
             }
-            UnresolvedType::Function(args, ret) => {
+            UnresolvedType::Function(args, ret, env) => {
                 let args = vecmap(args, |arg| self.resolve_type_inner(arg, new_variables));
                 let ret = Box::new(self.resolve_type_inner(*ret, new_variables));
-                let env = Box::new(Type::Unit);
+                let env = Box::new(self.resolve_type_inner(*env, new_variables));
                 Type::Function(args, ret, env)
             }
             UnresolvedType::MutableReference(element) => {

--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -837,13 +837,11 @@ impl<'interner> TypeChecker<'interner> {
         }
 
         for (param, (arg, _, arg_span)) in fn_params.iter().zip(callsite_args) {
-            if arg.try_unify_allow_incompat_lambdas(param).is_err() {
-                self.errors.push(TypeCheckError::TypeMismatch {
-                    expected_typ: param.to_string(),
-                    expr_typ: arg.to_string(),
-                    expr_span: *arg_span,
-                });
-            }
+            self.unify(arg, param, || TypeCheckError::TypeMismatch {
+                expected_typ: param.to_string(),
+                expr_typ: arg.to_string(),
+                expr_span: *arg_span,
+            });
         }
 
         fn_ret.clone()

--- a/crates/noirc_frontend/src/hir_def/types.rs
+++ b/crates/noirc_frontend/src/hir_def/types.rs
@@ -947,35 +947,6 @@ impl Type {
         }
     }
 
-    /// Similar to try_unify() but allows non-matching capture groups for function types
-    pub fn try_unify_allow_incompat_lambdas(&self, other: &Type) -> Result<(), UnificationError> {
-        use Type::*;
-        use TypeVariableKind::*;
-
-        match (self, other) {
-            (TypeVariable(binding, Normal), other) | (other, TypeVariable(binding, Normal)) => {
-                if let TypeBinding::Bound(link) = &*binding.borrow() {
-                    return link.try_unify_allow_incompat_lambdas(other);
-                }
-
-                other.try_bind_to(binding)
-            }
-            (Function(params_a, ret_a, _), Function(params_b, ret_b, _)) => {
-                if params_a.len() == params_b.len() {
-                    for (a, b) in params_a.iter().zip(params_b.iter()) {
-                        a.try_unify_allow_incompat_lambdas(b)?;
-                    }
-
-                    // no check for environments here!
-                    ret_b.try_unify_allow_incompat_lambdas(ret_a)
-                } else {
-                    Err(UnificationError)
-                }
-            }
-            _ => self.try_unify(other),
-        }
-    }
-
     /// Similar to `unify` but if the check fails this will attempt to coerce the
     /// argument to the target type. When this happens, the given expression is wrapped in
     /// a new expression to convert its type. E.g. `array` -> `array.as_slice()`


### PR DESCRIPTION
# Description


## Problem\*

Work towards https://github.com/noir-lang/noir/issues/2334


## Summary\*

In https://github.com/noir-lang/noir/pull/2335  we allowed higher order with closure arguments to pass type-checking -- this PR implements the monomorphizer changes needed to make those calls work.

### overridden_types

A new property `overridden_types` is added in the Monomorphizer. It allows us to change the type of an expression, for the currently monomorphized function instance only. It's used for adding capture environments to function types.

### propagate.rs

A function `propagate_overridden_types_expr` is added in a new file - propagate.rs. After we override the type of a parameter to add a capture group, we need to walk the body of the function and also update the types of all expressions where it is used.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


