### PR TITLE
fix: Remove duplicte `T` in `expected T, found T` error on tuple assignment

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/expr.rs
+++ b/crates/noirc_frontend/src/hir/type_check/expr.rs
@@ -686,8 +686,8 @@ impl<'interner> TypeChecker<'interner> {
                     Ok(Bool)
                 } else {
                     Err(TypeCheckError::TypeMismatchWithSource {
-                        lhs: lhs_type.clone(),
-                        rhs: rhs_type.clone(),
+                        expected: lhs_type.clone(),
+                        actual: rhs_type.clone(),
                         span,
                         source: Source::Binary,
                     })
@@ -732,15 +732,15 @@ impl<'interner> TypeChecker<'interner> {
                 if matches!(op.kind, Equal | NotEqual) =>
             {
                 self.unify(x_type, y_type, || TypeCheckError::TypeMismatchWithSource {
-                    lhs: lhs_type.clone(),
-                    rhs: rhs_type.clone(),
+                    expected: lhs_type.clone(),
+                    actual: rhs_type.clone(),
                     source: Source::ArrayElements,
                     span: op.location.span,
                 });
 
                 self.unify(x_size, y_size, || TypeCheckError::TypeMismatchWithSource {
-                    lhs: lhs_type.clone(),
-                    rhs: rhs_type.clone(),
+                    expected: lhs_type.clone(),
+                    actual: rhs_type.clone(),
                     source: Source::ArrayLen,
                     span: op.location.span,
                 });
@@ -752,16 +752,16 @@ impl<'interner> TypeChecker<'interner> {
                     return Ok(Bool);
                 }
                 Err(TypeCheckError::TypeMismatchWithSource {
-                    lhs: lhs.clone(),
-                    rhs: rhs.clone(),
+                    expected: lhs.clone(),
+                    actual: rhs.clone(),
                     source: Source::Comparison,
                     span,
                 })
             }
             (String(x_size), String(y_size)) => {
                 self.unify(x_size, y_size, || TypeCheckError::TypeMismatchWithSource {
-                    rhs: *x_size.clone(),
-                    lhs: *y_size.clone(),
+                    expected: *x_size.clone(),
+                    actual: *y_size.clone(),
                     span: op.location.span,
                     source: Source::StringLen,
                 });
@@ -769,8 +769,8 @@ impl<'interner> TypeChecker<'interner> {
                 Ok(Bool)
             }
             (lhs, rhs) => Err(TypeCheckError::TypeMismatchWithSource {
-                lhs: lhs.clone(),
-                rhs: rhs.clone(),
+                expected: lhs.clone(),
+                actual: rhs.clone(),
                 source: Source::Comparison,
                 span,
             }),
@@ -936,8 +936,8 @@ impl<'interner> TypeChecker<'interner> {
                     Ok(other.clone())
                 } else {
                     Err(TypeCheckError::TypeMismatchWithSource {
-                        rhs: lhs_type.clone(),
-                        lhs: rhs_type.clone(),
+                        expected: lhs_type.clone(),
+                        actual: rhs_type.clone(),
                         source: Source::Binary,
                         span,
                     })
@@ -996,8 +996,8 @@ impl<'interner> TypeChecker<'interner> {
             (Bool, Bool) => Ok(Bool),
 
             (lhs, rhs) => Err(TypeCheckError::TypeMismatchWithSource {
-                rhs: lhs.clone(),
-                lhs: rhs.clone(),
+                expected: lhs.clone(),
+                actual: rhs.clone(),
                 source: Source::BinOp,
                 span,
             }),

--- a/crates/noirc_frontend/src/hir/type_check/mod.rs
+++ b/crates/noirc_frontend/src/hir/type_check/mod.rs
@@ -74,8 +74,8 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
                 &mut errors,
                 || {
                     let mut error = TypeCheckError::TypeMismatchWithSource {
-                        lhs: declared_return_type.clone(),
-                        rhs: function_last_type.clone(),
+                        expected: declared_return_type.clone(),
+                        actual: function_last_type.clone(),
                         span: func_span,
                         source: Source::Return(meta.return_type, expr_span),
                     };


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2351

## Summary\*

The same `other` variable was used for both types in the error message, leading to a confusing error.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
