### PR TITLE
feat: Update to `acvm` 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,44 +4,16 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9915f2895792d8d9e4f25d9e026bac35774513a97c564fa7604e80462ac19e04"
-dependencies = [
- "acir_field 0.21.0",
- "bincode",
- "brillig 0.21.0",
- "flate2",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "acir"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86577747c44f23e2e8e6d972287d01341c0eea42a78ce15c5efd212a39d0fc27"
 dependencies = [
- "acir_field 0.22.0",
+ "acir_field",
  "bincode",
- "brillig 0.22.0",
+ "brillig",
  "flate2",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "acir_field"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a43a2e9419db7a1b046e763154fa67e66039e8fe08b88c13f18f81f9220ebdf"
-dependencies = [
- "ark-bn254",
- "ark-ff",
- "cfg-if",
- "hex",
- "num-bigint",
- "serde",
 ]
 
 [[package]]
@@ -60,32 +32,15 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38362933e2f7fcf6faf6c7c969f4c1ad2370953c35613801686259cdb8b5d194"
-dependencies = [
- "acir 0.21.0",
- "acvm_blackbox_solver 0.21.0",
- "acvm_stdlib 0.21.0",
- "async-trait",
- "brillig_vm 0.21.0",
- "indexmap 1.9.3",
- "num-bigint",
- "num-traits",
- "thiserror",
-]
-
-[[package]]
-name = "acvm"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74351bab6e0fd2ec1bd631abc73260f374cc28d2baf85c0e11300c0c989d5e53"
 dependencies = [
- "acir 0.22.0",
- "acvm_blackbox_solver 0.22.0",
- "acvm_stdlib 0.22.0",
+ "acir",
+ "acvm_blackbox_solver",
+ "acvm_stdlib",
  "async-trait",
- "brillig_vm 0.22.0",
+ "brillig_vm",
  "indexmap 1.9.3",
  "num-bigint",
  "num-traits",
@@ -94,11 +49,11 @@ dependencies = [
 
 [[package]]
 name = "acvm-backend-barretenberg"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48216028c1e503f26e52f85b3888010ee2cedc72d67de629a1318ceaf09dc67c"
+checksum = "438eb3837cfc37e0798e18f4a0ebae595e4cbe32a3f4cecfb47ccc1354180dc8"
 dependencies = [
- "acvm 0.21.0",
+ "acvm",
  "barretenberg-sys",
  "bincode",
  "bytesize",
@@ -114,41 +69,17 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2d887ed2c7203f08efb6661d8f30ecfd69b453fe2965393d7e99664afc7558"
-dependencies = [
- "acir 0.21.0",
- "blake2",
- "k256",
- "p256",
- "sha2",
- "sha3",
- "thiserror",
-]
-
-[[package]]
-name = "acvm_blackbox_solver"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a362499180c6498acc0ebf77bd919be8ccd9adabc84a695d4af44ca180ba0709"
 dependencies = [
- "acir 0.22.0",
+ "acir",
  "blake2",
  "k256",
  "p256",
  "sha2",
  "sha3",
  "thiserror",
-]
-
-[[package]]
-name = "acvm_stdlib"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7958693ac099e257b1791dc71f0296b0cc5e97764e55d67efc06f25191ecbaf"
-dependencies = [
- "acir 0.21.0",
 ]
 
 [[package]]
@@ -157,7 +88,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e485b3bc3331eaa10bc92fb092ca14275936c8935c3ae7ec89fb0bd48246ab42"
 dependencies = [
- "acir 0.22.0",
+ "acir",
 ]
 
 [[package]]
@@ -485,7 +416,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.31.1",
+ "object",
  "rustc-demangle",
 ]
 
@@ -605,34 +536,12 @@ dependencies = [
 
 [[package]]
 name = "brillig"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d24f35009f581a810c74628ab6bf03eb717b0e55d2c27994694b11ae98ff950"
-dependencies = [
- "acir_field 0.21.0",
- "serde",
-]
-
-[[package]]
-name = "brillig"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64df3df7d2d96fc2519e4dd64bc6bc23eee2949ee86725d9041ef7703c283ab"
 dependencies = [
- "acir_field 0.22.0",
+ "acir_field",
  "serde",
-]
-
-[[package]]
-name = "brillig_vm"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1534e2b03604d08a586ef735fa704f692c468c7e0e6663210fd414bac5382040"
-dependencies = [
- "acir 0.21.0",
- "acvm_blackbox_solver 0.21.0",
- "num-bigint",
- "num-traits",
 ]
 
 [[package]]
@@ -641,8 +550,8 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b306b3d79b6da192fd2ed68b94ab07712496f39bb5d50fedce44dac3f4953065"
 dependencies = [
- "acir 0.22.0",
- "acvm_blackbox_solver 0.22.0",
+ "acir",
+ "acvm_blackbox_solver",
  "num-bigint",
  "num-traits",
 ]
@@ -702,6 +611,12 @@ name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -986,62 +901,86 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+checksum = "2a2ab4512dfd3a6f4be184403a195f76e81a8a9f9e6c898e19d2dc3ce20e0115"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+checksum = "98b022ed2a5913a38839dfbafe6cf135342661293b08049843362df4301261dc"
 dependencies = [
+ "arrayvec",
+ "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
+ "cranelift-egraph",
  "cranelift-entity",
+ "cranelift-isle",
  "gimli 0.26.2",
  "log",
- "regalloc",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+checksum = "639307b45434ad112a98f8300c0f0ab085cbefcd767efcdef9ef19d4c0756e74"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+checksum = "278e52e29c53fcf32431ef08406c295699a70306d05a0715c5b1bf50e33a9ab7"
+
+[[package]]
+name = "cranelift-egraph"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624b54323b06e675293939311943ba82d323bb340468ce1889be5da7932c8d73"
+dependencies = [
+ "cranelift-entity",
+ "fxhash",
+ "hashbrown 0.12.3",
+ "indexmap 1.9.3",
+ "log",
+ "smallvec",
+]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+checksum = "9a59bcbca89c3f1b70b93ab3cbba5e5e0cbf3e63dadb23c7525cb142e21a9d4c"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+checksum = "0d70abacb8cfef3dc8ff7e8836e9c1d70f7967dfdac824a4cd5e30223415aca6"
 dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "393bc73c451830ff8dbb3a07f61843d6cb41a084f9996319917c0b291ed785bb"
 
 [[package]]
 name = "crc32fast"
@@ -1207,6 +1146,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.26",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1614,6 +1566,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2156,27 +2117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
-name = "loupe"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
-dependencies = [
- "indexmap 1.9.3",
- "loupe-derive",
- "rustversion",
-]
-
-[[package]]
-name = "loupe-derive"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "lsp-types"
 version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -2286,7 +2226,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "base64",
  "fm",
  "iter-extended",
@@ -2305,7 +2245,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
@@ -2373,7 +2313,7 @@ dependencies = [
 name = "noir_lsp"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "async-lsp",
  "codespan-lsp",
  "codespan-reporting",
@@ -2394,7 +2334,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "build-data",
  "console_error_panic_hook",
  "fm",
@@ -2412,7 +2352,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "iter-extended",
  "serde",
  "serde_json",
@@ -2426,7 +2366,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "base64",
  "clap",
  "fm",
@@ -2441,7 +2381,7 @@ dependencies = [
 name = "noirc_errors"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "chumsky",
  "codespan",
  "codespan-reporting",
@@ -2454,7 +2394,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "im",
  "iter-extended",
  "noirc_abi",
@@ -2468,7 +2408,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.10.3"
 dependencies = [
- "acvm 0.22.0",
+ "acvm",
  "arena",
  "chumsky",
  "fm",
@@ -2550,18 +2490,6 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "crc32fast",
- "hashbrown 0.11.2",
- "indexmap 1.9.3",
- "memchr",
 ]
 
 [[package]]
@@ -2996,13 +2924,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.34"
+name = "regalloc2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
+checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
 dependencies = [
+ "fxhash",
  "log",
- "rustc-hash",
+ "slice-group-by",
  "smallvec",
 ]
 
@@ -3148,6 +3077,7 @@ dependencies = [
  "bitvec",
  "bytecheck",
  "hashbrown 0.12.3",
+ "indexmap 1.9.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -3417,12 +3347,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.12"
+name = "serde-wasm-bindgen"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
 dependencies = [
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3587,6 +3519,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "small-ord-set"
@@ -4231,6 +4169,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-downcast"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dac026d43bcca6e7ce1c0956ba68f59edf6403e8e930a5d891be72c31a44340"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "wasm-bindgen-downcast-macros",
+]
+
+[[package]]
+name = "wasm-bindgen-downcast-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5020cfa87c7cecefef118055d44e3c1fc122c7ec25701d528ee458a0b45f38f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4293,25 +4254,26 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+checksum = "78caedecd8cb71ed47ccca03b68d69414a3d278bb031e6f93f15759344efdd52"
 dependencies = [
+ "bytes",
  "cfg-if",
+ "derivative",
  "indexmap 1.9.3",
  "js-sys",
- "loupe",
  "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde-wasm-bindgen",
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
- "wasmer-artifact",
+ "wasm-bindgen-downcast",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
- "wasmer-engine",
- "wasmer-engine-dylib",
- "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
  "wat",
@@ -4319,47 +4281,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
-dependencies = [
- "enumset",
- "loupe",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-compiler"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
+checksum = "726a8450541af4a57c34af7b6973fdbfc79f896cc7e733429577dfd1d1687180"
 dependencies = [
+ "backtrace",
+ "cfg-if",
+ "enum-iterator",
  "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
+ "lazy_static",
+ "leb128",
+ "memmap2",
+ "more-asserts",
+ "region",
  "smallvec",
- "target-lexicon",
  "thiserror",
  "wasmer-types",
+ "wasmer-vm",
  "wasmparser",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
+checksum = "a1e5633f90f372563ebbdf3f9799c7b29ba11c90e56cf9b54017112d2e656c95"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "gimli 0.26.2",
- "loupe",
  "more-asserts",
  "rayon",
  "smallvec",
@@ -4371,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+checksum = "97901fdbaae383dbb90ea162cc3a76a9fa58ac39aec7948b4c0b9bbef9307738"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -4382,151 +4335,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-engine"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
-dependencies = [
- "cfg-if",
- "enum-iterator",
- "enumset",
- "leb128",
- "libloading",
- "loupe",
- "object 0.28.4",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
-]
-
-[[package]]
-name = "wasmer-engine-universal"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
-dependencies = [
- "cfg-if",
- "enumset",
- "leb128",
- "loupe",
- "region",
- "rkyv",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-engine-universal-artifact",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-engine-universal-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
-dependencies = [
- "enum-iterator",
- "enumset",
- "loupe",
- "rkyv",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
-dependencies = [
- "object 0.28.4",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-types"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
+checksum = "67f1f2839f4f61509550e4ddcd0e658e19f3af862b51c79fda15549d735d659b"
 dependencies = [
- "backtrace",
+ "bytecheck",
  "enum-iterator",
+ "enumset",
  "indexmap 1.9.3",
- "loupe",
  "more-asserts",
  "rkyv",
- "serde",
+ "target-lexicon",
  "thiserror",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "2.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
+checksum = "043118ec4f16d1714fed3aab758b502b864bd865e1d5188626c9ad290100563f"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
  "corosensei",
+ "dashmap",
+ "derivative",
  "enum-iterator",
+ "fnv",
  "indexmap 1.9.3",
  "lazy_static",
  "libc",
- "loupe",
  "mach",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "more-asserts",
  "region",
- "rkyv",
  "scopeguard",
- "serde",
  "thiserror",
- "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
+dependencies = [
+ "indexmap 1.9.3",
+ "url",
+]
 
 [[package]]
 name = "wast"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9915f2895792d8d9e4f25d9e026bac35774513a97c564fa7604e80462ac19e04"
+source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
 dependencies = [
  "acir_field",
  "bincode",
@@ -19,8 +18,7 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a43a2e9419db7a1b046e763154fa67e66039e8fe08b88c13f18f81f9220ebdf"
+source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -33,8 +31,7 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38362933e2f7fcf6faf6c7c969f4c1ad2370953c35613801686259cdb8b5d194"
+source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -70,8 +67,7 @@ dependencies = [
 [[package]]
 name = "acvm_blackbox_solver"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2d887ed2c7203f08efb6661d8f30ecfd69b453fe2965393d7e99664afc7558"
+source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
 dependencies = [
  "acir",
  "blake2",
@@ -85,8 +81,7 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7958693ac099e257b1791dc71f0296b0cc5e97764e55d67efc06f25191ecbaf"
+source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
 dependencies = [
  "acir",
 ]
@@ -537,8 +532,7 @@ dependencies = [
 [[package]]
 name = "brillig"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d24f35009f581a810c74628ab6bf03eb717b0e55d2c27994694b11ae98ff950"
+source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
 dependencies = [
  "acir_field",
  "serde",
@@ -547,8 +541,7 @@ dependencies = [
 [[package]]
 name = "brillig_vm"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1534e2b03604d08a586ef735fa704f692c468c7e0e6663210fd414bac5382040"
+source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -661,7 +654,8 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "time",
+ "serde",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1102,6 +1096,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.26",
 ]
 
@@ -1133,6 +1128,15 @@ checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1875,6 +1879,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -2338,11 +2343,13 @@ dependencies = [
 name = "noirc_errors"
 version = "0.10.3"
 dependencies = [
+ "acvm",
  "chumsky",
  "codespan",
  "codespan-reporting",
  "fm",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -3375,6 +3382,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.25",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3712,6 +3748,34 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+dependencies = [
+ "deranged",
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,11 +5,26 @@ version = 3
 [[package]]
 name = "acir"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9915f2895792d8d9e4f25d9e026bac35774513a97c564fa7604e80462ac19e04"
 dependencies = [
- "acir_field",
+ "acir_field 0.21.0",
  "bincode",
- "brillig",
+ "brillig 0.21.0",
+ "flate2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "acir"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86577747c44f23e2e8e6d972287d01341c0eea42a78ce15c5efd212a39d0fc27"
+dependencies = [
+ "acir_field 0.22.0",
+ "bincode",
+ "brillig 0.22.0",
  "flate2",
  "serde",
  "thiserror",
@@ -18,7 +33,22 @@ dependencies = [
 [[package]]
 name = "acir_field"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a43a2e9419db7a1b046e763154fa67e66039e8fe08b88c13f18f81f9220ebdf"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "cfg-if",
+ "hex",
+ "num-bigint",
+ "serde",
+]
+
+[[package]]
+name = "acir_field"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4239156a8eddd55b2ae8bd25aa169d012bae70e0fd7c635f08f68ada54a8cb6c"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -31,13 +61,31 @@ dependencies = [
 [[package]]
 name = "acvm"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38362933e2f7fcf6faf6c7c969f4c1ad2370953c35613801686259cdb8b5d194"
 dependencies = [
- "acir",
- "acvm_blackbox_solver",
- "acvm_stdlib",
+ "acir 0.21.0",
+ "acvm_blackbox_solver 0.21.0",
+ "acvm_stdlib 0.21.0",
  "async-trait",
- "brillig_vm",
+ "brillig_vm 0.21.0",
+ "indexmap 1.9.3",
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "acvm"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74351bab6e0fd2ec1bd631abc73260f374cc28d2baf85c0e11300c0c989d5e53"
+dependencies = [
+ "acir 0.22.0",
+ "acvm_blackbox_solver 0.22.0",
+ "acvm_stdlib 0.22.0",
+ "async-trait",
+ "brillig_vm 0.22.0",
  "indexmap 1.9.3",
  "num-bigint",
  "num-traits",
@@ -50,7 +98,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48216028c1e503f26e52f85b3888010ee2cedc72d67de629a1318ceaf09dc67c"
 dependencies = [
- "acvm",
+ "acvm 0.21.0",
  "barretenberg-sys",
  "bincode",
  "bytesize",
@@ -67,9 +115,25 @@ dependencies = [
 [[package]]
 name = "acvm_blackbox_solver"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2d887ed2c7203f08efb6661d8f30ecfd69b453fe2965393d7e99664afc7558"
 dependencies = [
- "acir",
+ "acir 0.21.0",
+ "blake2",
+ "k256",
+ "p256",
+ "sha2",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "acvm_blackbox_solver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a362499180c6498acc0ebf77bd919be8ccd9adabc84a695d4af44ca180ba0709"
+dependencies = [
+ "acir 0.22.0",
  "blake2",
  "k256",
  "p256",
@@ -81,9 +145,19 @@ dependencies = [
 [[package]]
 name = "acvm_stdlib"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7958693ac099e257b1791dc71f0296b0cc5e97764e55d67efc06f25191ecbaf"
 dependencies = [
- "acir",
+ "acir 0.21.0",
+]
+
+[[package]]
+name = "acvm_stdlib"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e485b3bc3331eaa10bc92fb092ca14275936c8935c3ae7ec89fb0bd48246ab42"
+dependencies = [
+ "acir 0.22.0",
 ]
 
 [[package]]
@@ -532,19 +606,43 @@ dependencies = [
 [[package]]
 name = "brillig"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d24f35009f581a810c74628ab6bf03eb717b0e55d2c27994694b11ae98ff950"
 dependencies = [
- "acir_field",
+ "acir_field 0.21.0",
+ "serde",
+]
+
+[[package]]
+name = "brillig"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64df3df7d2d96fc2519e4dd64bc6bc23eee2949ee86725d9041ef7703c283ab"
+dependencies = [
+ "acir_field 0.22.0",
  "serde",
 ]
 
 [[package]]
 name = "brillig_vm"
 version = "0.21.0"
-source = "git+https://github.com/noir-lang/acvm#27a5a935849f8904e10056b08089f532a06962b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1534e2b03604d08a586ef735fa704f692c468c7e0e6663210fd414bac5382040"
 dependencies = [
- "acir",
- "acvm_blackbox_solver",
+ "acir 0.21.0",
+ "acvm_blackbox_solver 0.21.0",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "brillig_vm"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b306b3d79b6da192fd2ed68b94ab07712496f39bb5d50fedce44dac3f4953065"
+dependencies = [
+ "acir 0.22.0",
+ "acvm_blackbox_solver 0.22.0",
  "num-bigint",
  "num-traits",
 ]
@@ -2188,7 +2286,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 name = "nargo"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "base64",
  "fm",
  "iter-extended",
@@ -2207,7 +2305,7 @@ dependencies = [
 name = "nargo_cli"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "acvm-backend-barretenberg",
  "assert_cmd",
  "assert_fs",
@@ -2275,7 +2373,7 @@ dependencies = [
 name = "noir_lsp"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "async-lsp",
  "codespan-lsp",
  "codespan-reporting",
@@ -2296,7 +2394,7 @@ dependencies = [
 name = "noir_wasm"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "build-data",
  "console_error_panic_hook",
  "fm",
@@ -2314,7 +2412,7 @@ dependencies = [
 name = "noirc_abi"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "iter-extended",
  "serde",
  "serde_json",
@@ -2328,7 +2426,7 @@ dependencies = [
 name = "noirc_driver"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "base64",
  "clap",
  "fm",
@@ -2343,7 +2441,7 @@ dependencies = [
 name = "noirc_errors"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "chumsky",
  "codespan",
  "codespan-reporting",
@@ -2356,7 +2454,7 @@ dependencies = [
 name = "noirc_evaluator"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "im",
  "iter-extended",
  "noirc_abi",
@@ -2370,7 +2468,7 @@ dependencies = [
 name = "noirc_frontend"
 version = "0.10.3"
 dependencies = [
- "acvm",
+ "acvm 0.22.0",
  "arena",
  "chumsky",
  "fm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ url = "2.2.0"
 wasm-bindgen = { version = "=0.2.86", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
+
+[patch.crates-io]
+acvm = { git = "https://github.com/noir-lang/acvm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2021"
 rust-version = "1.66"
 
 [workspace.dependencies]
-acvm = "0.21.0"
+acvm = "0.22.0"
 arena = { path = "crates/arena" }
 fm = { path = "crates/fm" }
 iter-extended = { path = "crates/iter-extended" }
@@ -57,6 +57,3 @@ url = "2.2.0"
 wasm-bindgen = { version = "=0.2.86", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3.33"
 base64 = "0.21.2"
-
-[patch.crates-io]
-acvm = { git = "https://github.com/noir-lang/acvm" }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1.0", features = ["io-std"] }
 tokio-util = { version = "0.7.8", features = ["compat"] }
 
 # Backends
-acvm-backend-barretenberg = { version = "0.10.0", default-features = false }
+acvm-backend-barretenberg = { version = "0.11.0", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/noirc_errors/Cargo.toml
+++ b/crates/noirc_errors/Cargo.toml
@@ -7,8 +7,10 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+acvm.workspace = true
 codespan-reporting.workspace = true
 codespan.workspace = true
 fm.workspace = true
 chumsky.workspace = true
 serde.workspace = true
+serde_with = "3.2.0"

--- a/crates/noirc_errors/src/debug_info.rs
+++ b/crates/noirc_errors/src/debug_info.rs
@@ -23,10 +23,11 @@ impl DebugInfo {
         DebugInfo { locations }
     }
 
-    /// Updates the locations map when the circuit is modified.
-    /// The OpcodeLocations are generated with the ACIR, but passing the ACIR through a transformation step
-    /// renders the old OpcodeLocations invalid. The AcirTransformationMap is able to map the old OpcodeLocation to the new ones.
-    /// Note: One old OpcodeLocation might have transformed into more than one new OpcodeLocation.
+    /// Updates the locations map when the [`Circuit`][acvm::acir::circuit::Circuit] is modified.
+    ///
+    /// The [`OpcodeLocation`]s are generated with the ACIR, but passing the ACIR through a transformation step
+    /// renders the old `OpcodeLocation`s invalid. The AcirTransformationMap is able to map the old `OpcodeLocation` to the new ones.
+    /// Note: One old `OpcodeLocation` might have transformed into more than one new `OpcodeLocation`.
     pub fn update_acir(&mut self, update_map: AcirTransformationMap) {
         let mut new_locations_map = BTreeMap::new();
 

--- a/crates/noirc_errors/src/debug_info.rs
+++ b/crates/noirc_errors/src/debug_info.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct DebugInfo {
     /// Map opcode index of an ACIR circuit into the source code location
+    /// Serde does not support mapping keys being enums for json, so we indicate
+    /// that they should be serialized to/from strings.
     #[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
     pub locations: BTreeMap<OpcodeLocation, Vec<Location>>,
 }
@@ -21,7 +23,10 @@ impl DebugInfo {
         DebugInfo { locations }
     }
 
-    /// Updates the locations map when the circuit is modified
+    /// Updates the locations map when the circuit is modified.
+    /// The OpcodeLocations are generated with the ACIR, but passing the ACIR through a transformation step
+    /// renders the old OpcodeLocations invalid. The AcirTransformationMap is able to map the old OpcodeLocation to the new ones.
+    /// Note: One old OpcodeLocation might have transformed into more than one new OpcodeLocation.
     pub fn update_acir(&mut self, update_map: AcirTransformationMap) {
         let mut new_locations_map = BTreeMap::new();
 

--- a/crates/noirc_errors/src/debug_info.rs
+++ b/crates/noirc_errors/src/debug_info.rs
@@ -1,39 +1,41 @@
+use acvm::acir::circuit::OpcodeLocation;
+use acvm::compiler::AcirTransformationMap;
+
+use serde_with::serde_as;
+use serde_with::DisplayFromStr;
 use std::collections::BTreeMap;
 
 use crate::Location;
 use serde::{Deserialize, Serialize};
 
+#[serde_as]
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct DebugInfo {
     /// Map opcode index of an ACIR circuit into the source code location
-    pub locations: BTreeMap<usize, Vec<Location>>,
+    #[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
+    pub locations: BTreeMap<OpcodeLocation, Vec<Location>>,
 }
 
 impl DebugInfo {
-    pub fn new(locations: BTreeMap<usize, Vec<Location>>) -> Self {
+    pub fn new(locations: BTreeMap<OpcodeLocation, Vec<Location>>) -> Self {
         DebugInfo { locations }
     }
 
     /// Updates the locations map when the circuit is modified
-    ///
-    /// When the circuit is generated, the indices are 0,1,..,n
-    /// When the circuit is modified, the opcodes are eventually
-    /// mixed, removed, or with new ones. For instance 5,2,6,n+1,0,12,..
-    /// Since new opcodes (n+1 in the ex) don't have a location
-    /// we use the index of the old opcode that they replace.
-    /// This is the case during fallback or width 'optimization'
-    /// opcode_indices is this list of mixed indices
-    pub fn update_acir(&mut self, opcode_indices: Vec<usize>) {
-        let mut new_locations = BTreeMap::new();
-        for (i, idx) in opcode_indices.iter().enumerate() {
-            if self.locations.contains_key(idx) {
-                new_locations.insert(i, self.locations[idx].clone());
+    pub fn update_acir(&mut self, update_map: AcirTransformationMap) {
+        let mut new_locations_map = BTreeMap::new();
+
+        for (old_opcode_location, source_locations) in &self.locations {
+            let new_opcode_locations = update_map.new_locations(*old_opcode_location);
+            for new_opcode_location in new_opcode_locations {
+                new_locations_map.insert(new_opcode_location, source_locations.clone());
             }
         }
-        self.locations = new_locations;
+
+        self.locations = new_locations_map;
     }
 
-    pub fn opcode_location(&self, idx: usize) -> Option<Vec<Location>> {
-        self.locations.get(&idx).cloned()
+    pub fn opcode_location(&self, loc: &OpcodeLocation) -> Option<Vec<Location>> {
+        self.locations.get(loc).cloned()
     }
 }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -14,6 +14,7 @@ use acvm::acir::{
         brillig::{Brillig as AcvmBrillig, BrilligInputs, BrilligOutputs},
         directives::LogInfo,
         opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode},
+        OpcodeLocation,
     },
     native_types::Witness,
     BlackBoxFunc,
@@ -46,7 +47,7 @@ pub(crate) struct GeneratedAcir {
     pub(crate) input_witnesses: Vec<Witness>,
 
     /// Correspondance between an opcode index (in opcodes) and the source code call stack which generated it
-    pub(crate) locations: BTreeMap<usize, CallStack>,
+    pub(crate) locations: BTreeMap<OpcodeLocation, CallStack>,
 
     /// Source code location of the current instruction being processed
     /// None if we do not know the location
@@ -63,7 +64,8 @@ impl GeneratedAcir {
     fn push_opcode(&mut self, opcode: AcirOpcode) {
         self.opcodes.push(opcode);
         if !self.call_stack.is_empty() {
-            self.locations.insert(self.opcodes.len() - 1, self.call_stack.clone());
+            self.locations
+                .insert(OpcodeLocation::Acir(self.opcodes.len() - 1), self.call_stack.clone());
         }
     }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Starts using acvm 0.22 and backend 0.11. It also substitutes direct acir indexes with the new OpcodeLocation enum.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
