### PR TITLE
feat: Syntax for environment types now works with generics

### DIFF
--- a/crates/nargo_cli/tests/compile_success_empty/closure_explicit_types/src/main.nr
+++ b/crates/nargo_cli/tests/compile_success_empty/closure_explicit_types/src/main.nr
@@ -69,6 +69,7 @@ fn main() {
     let z: u64 = 40;
     assert(accepts_closure3(|| y as u64 + z) == 70);
 
+    let w = 50;
     assert(add_results(|| 100, || x ) == 150);
     assert(add_results(|| x + 100, || w + x ) == 250);
 

--- a/crates/nargo_cli/tests/compile_success_empty/closure_explicit_types/src/main.nr
+++ b/crates/nargo_cli/tests/compile_success_empty/closure_explicit_types/src/main.nr
@@ -3,49 +3,60 @@ fn ret_normal_lambda1() -> fn() -> Field {
     || 10
 }
 
-// explicitly specified empty capture group
-fn ret_normal_lambda2() -> fn[]() -> Field {
-    || 20
-}
-
 // return lamda that captures a thing
-fn ret_closure1() -> fn[Field]() -> Field {
+fn ret_closure1() -> fn[(Field,)]() -> Field {
     let x = 20;
     || x + 10
 }
 
 // return lamda that captures two things
-fn ret_closure2() -> fn[Field,Field]() -> Field {
+fn ret_closure2() -> fn[(Field,Field)]() -> Field {
     let x = 20;
     let y = 10;
     || x + y + 10
 }
 
 // return lamda that captures two things with different types
-fn ret_closure3() -> fn[u32,u64]() -> u64 {
+fn ret_closure3() -> fn[(u32,u64)]() -> u64 {
     let x: u32 = 20;
     let y: u64 = 10;
     || x as u64 + y + 10
 }
 
 // accepts closure that has 1 thing in its env, calls it and returns the result
-fn accepts_closure1(f: fn[Field]() -> Field) -> Field {
+fn accepts_closure1(f: fn[(Field,)]() -> Field) -> Field {
     f()
 }
 
 // accepts closure that has 1 thing in its env and returns it
-fn accepts_closure2(f: fn[Field]() -> Field) -> fn[Field]() -> Field {
+fn accepts_closure2(f: fn[(Field,)]() -> Field) -> fn[(Field,)]() -> Field {
     f
 }
 
 // accepts closure with different types in the capture group
-fn accepts_closure3(f: fn[u32, u64]() -> u64) -> u64 {
+fn accepts_closure3(f: fn[(u32, u64)]() -> u64) -> u64 {
     f()
+}
+
+// generic over closure environments
+fn add_results<Env1, Env2>(f1: fn[Env1]() -> Field, f2: fn[Env2]() -> Field) -> Field {
+    f1() + f2()
+}
+
+// a *really* generic function
+fn map<T, U, N, Env>(arr: [T; N], f: fn[Env](T) -> U) -> [U; N] {
+    let first_elem = f(arr[0]);
+    let mut ret = [first_elem; N];
+
+    for i in 1 .. N {
+        ret[i] = f(arr[i]);
+    }
+
+    ret
 }
 
 fn main() {
     assert(ret_normal_lambda1()() == 10);
-    assert(ret_normal_lambda2()() == 20);
     assert(ret_closure1()() == 30);
     assert(ret_closure2()() == 40);
     assert(ret_closure3()() == 40);
@@ -57,4 +68,12 @@ fn main() {
     let y: u32 = 30;
     let z: u64 = 40;
     assert(accepts_closure3(|| y as u64 + z) == 70);
+
+    assert(add_results(|| 100, || x ) == 150);
+    assert(add_results(|| x + 100, || w + x ) == 250);
+
+    let arr = [1,2,3,4];
+
+    assert(map(arr, |n| n + 1) == [2, 3, 4, 5]);
+    assert(map(arr, |n| n + x) == [51, 52, 53, 54]);
 }

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -4,7 +4,7 @@ use noirc_errors::Span;
 
 use crate::{token::Attribute, FunctionReturnType, Ident, Pattern, Visibility};
 
-use super::{FunctionDefinition, UnresolvedType};
+use super::{FunctionDefinition, UnresolvedType, UnresolvedTypeData};
 
 // A NoirFunction can be either a foreign low level function or a function definition
 // A closure / function definition will be stored under a name, so we do not differentiate between their variants
@@ -44,7 +44,9 @@ impl NoirFunction {
 
     pub fn return_type(&self) -> UnresolvedType {
         match &self.def.return_type {
-            FunctionReturnType::Default(_) => UnresolvedType::Unit,
+            FunctionReturnType::Default(_) => {
+                UnresolvedType::without_span(UnresolvedTypeData::Unit)
+            }
             FunctionReturnType::Ty(ty, _) => ty.clone(),
         }
     }

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use noirc_errors::Span;
+
 use crate::{token::Attribute, FunctionReturnType, Ident, Pattern, Visibility};
 
 use super::{FunctionDefinition, UnresolvedType};
@@ -66,6 +68,9 @@ impl NoirFunction {
     }
     pub fn number_of_statements(&self) -> usize {
         self.def.body.0.len()
+    }
+    pub fn span(&self) -> Span {
+        self.def.span
     }
 
     pub fn foreign(&self) -> Option<&FunctionDefinition> {

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -116,7 +116,7 @@ impl std::fmt::Display for UnresolvedType {
             Function(args, ret, env) => {
                 let args = vecmap(args, ToString::to_string);
 
-                match &**env {
+                match env.as_ref() {
                     UnresolvedType::Unit => {
                         write!(f, "fn({}) -> {ret}", args.join(", "))
                     }

--- a/crates/noirc_frontend/src/ast/mod.rs
+++ b/crates/noirc_frontend/src/ast/mod.rs
@@ -63,6 +63,10 @@ pub enum UnresolvedTypeData {
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct UnresolvedType {
     pub typ: UnresolvedTypeData,
+
+    // The span is None in the cases where the User omitted a type:
+    //  fn Foo() {}  --- return type is UnresolvedType::Unit without a span
+    //  let x = 100; --- type is UnresolvedType::Unspecified without a span
     pub span: Option<Span>,
 }
 

--- a/crates/noirc_frontend/src/hir/resolution/errors.rs
+++ b/crates/noirc_frontend/src/hir/resolution/errors.rs
@@ -74,6 +74,8 @@ pub enum ResolverError {
     ContractFunctionInternalInNormalFunction { span: Span },
     #[error("Numeric constants should be printed without formatting braces")]
     NumericConstantInFormatString { name: String, span: Span },
+    #[error("Closure environment must be a tuple or unit type")]
+    InvalidClosureEnvironment { typ: Type, span: Span },
 }
 
 impl ResolverError {
@@ -283,6 +285,9 @@ impl From<ResolverError> for Diagnostic {
                 "Numeric constants should be printed without formatting braces".to_string(),
                 span,
             ),
+            ResolverError::InvalidClosureEnvironment { span, typ } => Diagnostic::simple_error(
+                format!("{typ} is not a valid closure environment type"),
+                "Closure environment must be a tuple or unit type".to_string(), span),
         }
     }
 }

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -674,6 +674,7 @@ impl<'a> Resolver<'a> {
                 }
             });
 
+        self.current_expr_span = Some(func.span());
         let mut parameters = vec![];
         let mut parameter_types = vec![];
 
@@ -692,7 +693,6 @@ impl<'a> Resolver<'a> {
             parameter_types.push(typ);
         }
 
-        self.current_expr_span = Some(func.span());
         let return_type = Box::new(self.resolve_type(func.return_type()));
 
         self.declare_numeric_generics(&parameter_types, &return_type);

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -36,7 +36,8 @@ use crate::{
 use crate::{
     ArrayLiteral, ContractFunctionType, Distinctness, Generics, LValue, NoirStruct, NoirTypeAlias,
     Path, Pattern, Shared, StructType, Trait, Type, TypeAliasType, TypeBinding, TypeVariable,
-    UnaryOp, UnresolvedGenerics, UnresolvedType, UnresolvedTypeExpression, Visibility, ERROR_IDENT,
+    UnaryOp, UnresolvedGenerics, UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression,
+    Visibility, ERROR_IDENT,
 };
 use fm::FileId;
 use iter_extended::vecmap;
@@ -336,9 +337,11 @@ impl<'a> Resolver<'a> {
     /// Translates an UnresolvedType into a Type and appends any
     /// freshly created TypeVariables created to new_variables.
     fn resolve_type_inner(&mut self, typ: UnresolvedType, new_variables: &mut Generics) -> Type {
-        match typ {
-            UnresolvedType::FieldElement => Type::FieldElement,
-            UnresolvedType::Array(size, elem) => {
+        use UnresolvedTypeData::*;
+
+        match typ.typ {
+            FieldElement => Type::FieldElement,
+            Array(size, elem) => {
                 let elem = Box::new(self.resolve_type_inner(*elem, new_variables));
                 let size = if size.is_none() {
                     Type::NotConstant
@@ -347,26 +350,26 @@ impl<'a> Resolver<'a> {
                 };
                 Type::Array(Box::new(size), elem)
             }
-            UnresolvedType::Expression(expr) => self.convert_expression_type(expr),
-            UnresolvedType::Integer(sign, bits) => Type::Integer(sign, bits),
-            UnresolvedType::Bool => Type::Bool,
-            UnresolvedType::String(size) => {
+            Expression(expr) => self.convert_expression_type(expr),
+            Integer(sign, bits) => Type::Integer(sign, bits),
+            Bool => Type::Bool,
+            String(size) => {
                 let resolved_size = self.resolve_array_size(size, new_variables);
                 Type::String(Box::new(resolved_size))
             }
-            UnresolvedType::FormatString(size, fields) => {
+            FormatString(size, fields) => {
                 let resolved_size = self.convert_expression_type(size);
                 let fields = self.resolve_type_inner(*fields, new_variables);
                 Type::FmtString(Box::new(resolved_size), Box::new(fields))
             }
-            UnresolvedType::Unit => Type::Unit,
-            UnresolvedType::Unspecified => Type::Error,
-            UnresolvedType::Error => Type::Error,
-            UnresolvedType::Named(path, args) => self.resolve_named_type(path, args, new_variables),
-            UnresolvedType::Tuple(fields) => {
+            Unit => Type::Unit,
+            Unspecified => Type::Error,
+            Error => Type::Error,
+            Named(path, args) => self.resolve_named_type(path, args, new_variables),
+            Tuple(fields) => {
                 Type::Tuple(vecmap(fields, |field| self.resolve_type_inner(field, new_variables)))
             }
-            UnresolvedType::Function(args, ret, env) => {
+            Function(args, ret, env) => {
                 let args = vecmap(args, |arg| self.resolve_type_inner(arg, new_variables));
                 let ret = Box::new(self.resolve_type_inner(*ret, new_variables));
                 let env = Box::new(self.resolve_type_inner(*env, new_variables));
@@ -384,7 +387,7 @@ impl<'a> Resolver<'a> {
                     }
                 }
             }
-            UnresolvedType::MutableReference(element) => {
+            MutableReference(element) => {
                 Type::MutableReference(Box::new(self.resolve_type_inner(*element, new_variables)))
             }
         }
@@ -593,9 +596,9 @@ impl<'a> Resolver<'a> {
     /// Translates a (possibly Unspecified) UnresolvedType to a Type.
     /// Any UnresolvedType::Unspecified encountered are replaced with fresh type variables.
     fn resolve_inferred_type(&mut self, typ: UnresolvedType) -> Type {
-        match typ {
-            UnresolvedType::Unspecified => self.interner.next_type_variable(),
-            other => self.resolve_type_inner(other, &mut vec![]),
+        match &typ.typ {
+            UnresolvedTypeData::Unspecified => self.interner.next_type_variable(),
+            _ => self.resolve_type_inner(typ, &mut vec![]),
         }
     }
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -368,10 +368,10 @@ impl<'a> Resolver<'a> {
                 let args = vecmap(args, |arg| self.resolve_type_inner(arg, new_variables));
                 let ret = Box::new(self.resolve_type_inner(*ret, new_variables));
 
-                // unwrap() here is valid, because the only places we don't have a span are omitted types
+                // expect() here is valid, because the only places we don't have a span are omitted types
                 // e.g. a function without return type implicitly has a spanless UnresolvedType::Unit return type
                 // To get an invalid env type, the user must explicitly specify the type, which will have a span
-                let env_span = env.span.unwrap();
+                let env_span = env.span.expect("Invalid closure environment type");
 
                 let env = Box::new(self.resolve_type_inner(*env, new_variables));
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -371,7 +371,7 @@ impl<'a> Resolver<'a> {
                 // expect() here is valid, because the only places we don't have a span are omitted types
                 // e.g. a function without return type implicitly has a spanless UnresolvedType::Unit return type
                 // To get an invalid env type, the user must explicitly specify the type, which will have a span
-                let env_span = env.span.expect("Invalid closure environment type");
+                let env_span = env.span.expect("Unexpected missing span for closure environment type");
 
                 let env = Box::new(self.resolve_type_inner(*env, new_variables));
 

--- a/crates/noirc_frontend/src/parser/mod.rs
+++ b/crates/noirc_frontend/src/parser/mod.rs
@@ -403,7 +403,7 @@ impl ForRange {
                 // let fresh1 = array;
                 let let_array = Statement::Let(LetStatement {
                     pattern: Pattern::Identifier(array_ident.clone()),
-                    r#type: UnresolvedType::Unspecified,
+                    r#type: UnresolvedType::unspecified(),
                     expression: array,
                 });
 
@@ -436,7 +436,7 @@ impl ForRange {
                 // let elem = array[i];
                 let let_elem = Statement::Let(LetStatement {
                     pattern: Pattern::Identifier(identifier),
-                    r#type: UnresolvedType::Unspecified,
+                    r#type: UnresolvedType::unspecified(),
                     expression: Expression::new(loop_element, array_span),
                 });
 

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -353,7 +353,7 @@ fn self_parameter() -> impl NoirParser<(Pattern, UnresolvedType, Visibility)> {
             match pattern_keyword {
                 Some((Token::Ampersand, _)) => {
                     self_type =
-                        UnresolvedTypeData::MutableReference(Box::new(self_type)).with_span(span)
+                        UnresolvedTypeData::MutableReference(Box::new(self_type)).with_span(span);
                 }
                 Some((Token::Keyword(_), span)) => {
                     pattern = Pattern::Mutable(Box::new(pattern), span);

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -969,23 +969,13 @@ fn function_type<T>(type_parser: T) -> impl NoirParser<UnresolvedType>
 where
     T: NoirParser<UnresolvedType>,
 {
-    let types = type_parser.clone().separated_by(just(Token::Comma)).allow_trailing();
-    let args = parenthesized(types.clone());
+    let args = parenthesized(type_parser.clone().separated_by(just(Token::Comma)).allow_trailing());
 
     let env = just(Token::LeftBracket)
-        .ignore_then(types)
+        .ignore_then(type_parser.clone())
         .then_ignore(just(Token::RightBracket))
         .or_not()
-        .map(|args| match args {
-            Some(args) => {
-                if args.is_empty() {
-                    UnresolvedType::Unit
-                } else {
-                    UnresolvedType::Tuple(args)
-                }
-            }
-            None => UnresolvedType::Unit,
-        });
+        .map(|t| t.unwrap_or(UnresolvedType::Unit));
 
     keyword(Keyword::Fn)
         .ignore_then(env)

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -30,7 +30,9 @@ use super::{
     ForRange, NoirParser, ParsedModule, ParserError, ParserErrorReason, Precedence, SubModule,
     TopLevelStatement,
 };
-use crate::ast::{Expression, ExpressionKind, LetStatement, Statement, UnresolvedType};
+use crate::ast::{
+    Expression, ExpressionKind, LetStatement, Statement, UnresolvedType, UnresolvedTypeData,
+};
 use crate::lexer::Lexer;
 use crate::parser::{force, ignore_then_commit, statement_recovery};
 use crate::token::{Attribute, Keyword, Token, TokenKind};
@@ -256,7 +258,7 @@ fn lambda_return_type() -> impl NoirParser<UnresolvedType> {
     just(Token::Arrow)
         .ignore_then(parse_type())
         .or_not()
-        .map(|ret| ret.unwrap_or(UnresolvedType::Unspecified))
+        .map(|ret| ret.unwrap_or_else(UnresolvedType::unspecified))
 }
 
 fn function_return_type() -> impl NoirParser<((Distinctness, Visibility), FunctionReturnType)> {
@@ -295,7 +297,7 @@ fn lambda_parameters() -> impl NoirParser<Vec<(Pattern, UnresolvedType)>> {
 
     let parameter = pattern()
         .recover_via(parameter_name_recovery())
-        .then(typ.or_not().map(|typ| typ.unwrap_or(UnresolvedType::Unspecified)));
+        .then(typ.or_not().map(|typ| typ.unwrap_or_else(UnresolvedType::unspecified)));
 
     parameter
         .separated_by(just(Token::Comma))
@@ -345,12 +347,13 @@ fn self_parameter() -> impl NoirParser<(Pattern, UnresolvedType, Visibility)> {
         .map(|(pattern_keyword, span)| {
             let ident = Ident::new("self".to_string(), span);
             let path = Path::from_single("Self".to_owned(), span);
-            let mut self_type = UnresolvedType::Named(path, vec![]);
+            let mut self_type = UnresolvedTypeData::Named(path, vec![]).with_span(span);
             let mut pattern = Pattern::Identifier(ident);
 
             match pattern_keyword {
                 Some((Token::Ampersand, _)) => {
-                    self_type = UnresolvedType::MutableReference(Box::new(self_type));
+                    self_type =
+                        UnresolvedTypeData::MutableReference(Box::new(self_type)).with_span(span)
                 }
                 Some((Token::Keyword(_), span)) => {
                     pattern = Pattern::Mutable(Box::new(pattern), span);
@@ -582,7 +585,7 @@ fn check_statements_require_semicolon(
 fn optional_type_annotation<'a>() -> impl NoirParser<UnresolvedType> + 'a {
     ignore_then_commit(just(Token::Colon), parse_type())
         .or_not()
-        .map(|r#type| r#type.unwrap_or(UnresolvedType::Unspecified))
+        .map(|r#type| r#type.unwrap_or_else(UnresolvedType::unspecified))
 }
 
 fn module_declaration() -> impl NoirParser<TopLevelStatement> {
@@ -859,11 +862,15 @@ fn maybe_comp_time() -> impl NoirParser<()> {
 }
 
 fn field_type() -> impl NoirParser<UnresolvedType> {
-    maybe_comp_time().then_ignore(keyword(Keyword::Field)).map(|_| UnresolvedType::FieldElement)
+    maybe_comp_time()
+        .then_ignore(keyword(Keyword::Field))
+        .map_with_span(|_, span| UnresolvedTypeData::FieldElement.with_span(span))
 }
 
 fn bool_type() -> impl NoirParser<UnresolvedType> {
-    maybe_comp_time().then_ignore(keyword(Keyword::Bool)).map(|_| UnresolvedType::Bool)
+    maybe_comp_time()
+        .then_ignore(keyword(Keyword::Bool))
+        .map_with_span(|_, span| UnresolvedTypeData::Bool.with_span(span))
 }
 
 fn string_type() -> impl NoirParser<UnresolvedType> {
@@ -871,7 +878,7 @@ fn string_type() -> impl NoirParser<UnresolvedType> {
         .ignore_then(
             type_expression().delimited_by(just(Token::Less), just(Token::Greater)).or_not(),
         )
-        .map(UnresolvedType::String)
+        .map_with_span(|expr, span| UnresolvedTypeData::String(expr).with_span(span))
 }
 
 fn format_string_type(
@@ -884,7 +891,9 @@ fn format_string_type(
                 .then(type_parser)
                 .delimited_by(just(Token::Less), just(Token::Greater)),
         )
-        .map(|(size, fields)| UnresolvedType::FormatString(size, Box::new(fields)))
+        .map_with_span(|(size, fields), span| {
+            UnresolvedTypeData::FormatString(size, Box::new(fields)).with_span(span)
+        })
 }
 
 fn int_type() -> impl NoirParser<UnresolvedType> {
@@ -896,8 +905,8 @@ fn int_type() -> impl NoirParser<UnresolvedType> {
             }
         }))
         .validate(|(_, token), span, emit| {
-            let typ = UnresolvedType::from_int_token(token);
-            if let UnresolvedType::Integer(crate::Signedness::Signed, _) = &typ {
+            let typ = UnresolvedTypeData::from_int_token(token).with_span(span);
+            if let UnresolvedTypeData::Integer(crate::Signedness::Signed, _) = &typ.typ {
                 let reason = ParserErrorReason::ExperimentalFeature("Signed integer types");
                 emit(ParserError::with_reason(reason, span));
             }
@@ -908,7 +917,7 @@ fn int_type() -> impl NoirParser<UnresolvedType> {
 fn named_type(type_parser: impl NoirParser<UnresolvedType>) -> impl NoirParser<UnresolvedType> {
     path()
         .then(generic_type_args(type_parser))
-        .map(|(path, args)| UnresolvedType::Named(path, args))
+        .map_with_span(|(path, args), span| UnresolvedTypeData::Named(path, args).with_span(span))
 }
 
 fn generic_type_args(
@@ -920,7 +929,8 @@ fn generic_type_args(
         // separator afterward. Failing early here ensures we try the `type_expression`
         // parser afterward.
         .then_ignore(one_of([Token::Comma, Token::Greater]).rewind())
-        .or(type_expression().map(UnresolvedType::Expression))
+        .or(type_expression()
+            .map_with_span(|expr, span| UnresolvedTypeData::Expression(expr).with_span(span)))
         .separated_by(just(Token::Comma))
         .allow_trailing()
         .at_least(1)
@@ -934,7 +944,9 @@ fn array_type(type_parser: impl NoirParser<UnresolvedType>) -> impl NoirParser<U
         .ignore_then(type_parser)
         .then(just(Token::Semicolon).ignore_then(type_expression()).or_not())
         .then_ignore(just(Token::RightBracket))
-        .map(|(element_type, size)| UnresolvedType::Array(size, Box::new(element_type)))
+        .map_with_span(|(element_type, size), span| {
+            UnresolvedTypeData::Array(size, Box::new(element_type)).with_span(span)
+        })
 }
 
 fn type_expression() -> impl NoirParser<UnresolvedTypeExpression> {
@@ -956,11 +968,11 @@ where
     T: NoirParser<UnresolvedType>,
 {
     let fields = type_parser.separated_by(just(Token::Comma)).allow_trailing();
-    parenthesized(fields).map(|fields| {
+    parenthesized(fields).map_with_span(|fields, span| {
         if fields.is_empty() {
-            UnresolvedType::Unit
+            UnresolvedTypeData::Unit.with_span(span)
         } else {
-            UnresolvedType::Tuple(fields)
+            UnresolvedTypeData::Tuple(fields).with_span(span)
         }
     })
 }
@@ -975,14 +987,16 @@ where
         .ignore_then(type_parser.clone())
         .then_ignore(just(Token::RightBracket))
         .or_not()
-        .map(|t| t.unwrap_or(UnresolvedType::Unit));
+        .map_with_span(|t, span| t.unwrap_or_else(|| UnresolvedTypeData::Unit.with_span(span)));
 
     keyword(Keyword::Fn)
         .ignore_then(env)
         .then(args)
         .then_ignore(just(Token::Arrow))
         .then(type_parser)
-        .map(|((env, args), ret)| UnresolvedType::Function(args, Box::new(ret), Box::new(env)))
+        .map_with_span(|((env, args), ret), span| {
+            UnresolvedTypeData::Function(args, Box::new(ret), Box::new(env)).with_span(span)
+        })
 }
 
 fn mutable_reference_type<T>(type_parser: T) -> impl NoirParser<UnresolvedType>
@@ -992,7 +1006,9 @@ where
     just(Token::Ampersand)
         .ignore_then(keyword(Keyword::Mut))
         .ignore_then(type_parser)
-        .map(|element| UnresolvedType::MutableReference(Box::new(element)))
+        .map_with_span(|element, span| {
+            UnresolvedTypeData::MutableReference(Box::new(element)).with_span(span)
+        })
 }
 
 fn expression() -> impl ExprParser {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

The syntax for closure environment types that I added in https://github.com/noir-lang/noir/pull/2357 is sub-optimal as it does not play well with generics. 

Resolves: https://github.com/noir-lang/noir/issues/2334


## Summary\*
- As suggested in https://github.com/noir-lang/noir/pull/2357#discussion_r1298487380 this PR changes it changed from `fn[envarg1, envarg2](arg1, arg2, ...) -> ret` to `fn[env_type](arg1, arg2, ...) -> ret` so that a named generic can be used an environment. 

- Additional error checking is also added, since the new syntax allows passing any type as an environment, but the only valid ones are Unit/NamedGeneric/Tuple.

- Added tests for generic closure environments 



## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
