### PR TITLE
chore: allow parenthesizing in two type locations 

### DIFF
--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -942,10 +942,11 @@ fn type_expression() -> impl NoirParser<UnresolvedTypeExpression> {
         expression_with_precedence(
             Precedence::lowest_type_precedence(),
             nothing(),
-            expr,
+            expr.clone(),
             true,
             false,
         )
+        .or(parenthesized(expr))
     })
     .labelled(ParsingRuleLabel::TypeExpression)
     .try_map(UnresolvedTypeExpression::from_expr)
@@ -1056,13 +1057,13 @@ where
     P2: ExprParser + 'a,
 {
     if precedence == Precedence::Highest {
-        if is_type_expression {
-            type_expression_term(expr_parser).boxed().labelled(ParsingRuleLabel::Term)
+        let expr_parser = if is_type_expression {
+            type_expression_term(expr_parser).boxed()
         } else {
-            term(expr_parser, expr_no_constructors, allow_constructors)
-                .boxed()
-                .labelled(ParsingRuleLabel::Term)
-        }
+            term(expr_parser, expr_no_constructors, allow_constructors).boxed()
+        };
+
+        expr_parser.clone().or(parenthesized(expr_parser)).boxed().labelled(ParsingRuleLabel::Term)
     } else {
         let next_precedence =
             if is_type_expression { precedence.next_type_precedence() } else { precedence.next() };
@@ -1643,6 +1644,11 @@ mod test {
             array_expr(expression()),
             vec!["0,1,2,3,4]", "[[0,1,2,3,4]", "[0,1,2,,]", "[0,1,2,3,4"],
         );
+    }
+
+    #[test]
+    fn parse_type_expression() {
+        parse_all(type_expression(), vec!["(123)", "123", "((1 + 1))", "(1 + (1))"]);
     }
 
     #[test]


### PR DESCRIPTION
# Description

allow parenthesizing in two type locations:

```
fn foo2<Bar>(bar: [Bar; (123)]) {}

fn foo<Foo>(bar: str<(Foo)>) {}
```

## Problem

Resolves #2375 

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
