### PR TITLE
chore: Rework `CrateGraph` to only have one root crate

### DIFF
--- a/crates/nargo/src/lib.rs
+++ b/crates/nargo/src/lib.rs
@@ -17,7 +17,7 @@ pub mod workspace;
 use std::collections::BTreeMap;
 
 use fm::FileManager;
-use noirc_driver::{add_dep, prepare_crate};
+use noirc_driver::{add_dep, prepare_crate, prepare_dependency};
 use noirc_frontend::{
     graph::{CrateGraph, CrateId, CrateName},
     hir::Context,
@@ -34,7 +34,7 @@ pub fn prepare_dependencies(
     for (dep_name, dep) in dependencies.iter() {
         match dep {
             Dependency::Remote { package } | Dependency::Local { package } => {
-                let crate_id = prepare_crate(context, &package.entry_path);
+                let crate_id = prepare_dependency(context, &package.entry_path);
                 add_dep(context, parent_crate, crate_id, dep_name.clone());
                 prepare_dependencies(context, crate_id, &package.dependencies);
             }

--- a/crates/noirc_driver/src/lib.rs
+++ b/crates/noirc_driver/src/lib.rs
@@ -56,11 +56,18 @@ pub fn compile_file(
     compile_main(context, crate_id, &CompileOptions::default())
 }
 
-/// Adds the file from the file system at `Path` to the crate graph
+/// Adds the file from the file system at `Path` to the crate graph as a root file
 pub fn prepare_crate(context: &mut Context, file_name: &Path) -> CrateId {
     let root_file_id = context.file_manager.add_file(file_name).unwrap();
 
     context.crate_graph.add_crate_root(root_file_id)
+}
+
+// Adds the file from the file system at `Path` to the crate graph
+pub fn prepare_dependency(context: &mut Context, file_name: &Path) -> CrateId {
+    let root_file_id = context.file_manager.add_file(file_name).unwrap();
+
+    context.crate_graph.add_crate(root_file_id)
 }
 
 /// Adds a edge in the crate graph for two crates

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -149,11 +149,18 @@ impl CrateGraph {
     }
 
     pub fn add_crate(&mut self, file_id: FileId) -> CrateId {
-        // Should this also be asserted that it only has exactly one match?
-        let mut roots_with_file_id =
-            self.arena.iter().filter(|(_, crate_data)| crate_data.root_file_id == file_id);
+        let mut crates_with_file_id = self
+            .arena
+            .iter()
+            .filter(|(_, crate_data)| crate_data.root_file_id == file_id)
+            .peekable();
 
-        match roots_with_file_id.next() {
+        let matching_id = crates_with_file_id.next();
+        if crates_with_file_id.peek().is_some() {
+            panic!("ICE: Found multiple crates with the same FileId");
+        }
+
+        match matching_id {
             Some((crate_id @ CrateId::Crate(_), _)) => *crate_id,
             Some((CrateId::Root(_), _)) => {
                 panic!("ICE: Tried to re-add the root crate as a regular crate")

--- a/crates/noirc_frontend/src/graph/mod.rs
+++ b/crates/noirc_frontend/src/graph/mod.rs
@@ -127,7 +127,7 @@ impl CrateGraph {
         self.arena
             .keys()
             .find(|crate_id| crate_id.is_root())
-            .expect("ICE: A root crate should exist in the CrateCraph")
+            .expect("ICE: A root crate should exist in the CrateGraph")
     }
 
     pub fn add_crate_root(&mut self, file_id: FileId) -> CrateId {

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -59,6 +59,10 @@ impl Context {
         self.crate_graph.iter_keys()
     }
 
+    pub fn root_crate_id(&self) -> &CrateId {
+        self.crate_graph.root_crate_id()
+    }
+
     // TODO: Decide if we actually need `function_name` and `fully_qualified_function_name`
     pub fn function_name(&self, id: &FuncId) -> &str {
         self.def_interner.function_name(id)

--- a/crates/wasm/src/compile.rs
+++ b/crates/wasm/src/compile.rs
@@ -3,8 +3,8 @@ use fm::FileManager;
 use gloo_utils::format::JsValueSerdeExt;
 use log::debug;
 use noirc_driver::{
-    check_crate, compile_contracts, compile_no_check, prepare_crate, propagate_dep, CompileOptions,
-    CompiledContract,
+    check_crate, compile_contracts, compile_no_check, prepare_crate, prepare_dependency,
+    propagate_dep, CompileOptions, CompiledContract,
 };
 use noirc_frontend::{graph::CrateGraph, hir::Context};
 use serde::{Deserialize, Serialize};
@@ -60,7 +60,7 @@ impl Default for WASMCompileOptions {
 
 fn add_noir_lib(context: &mut Context, crate_name: &str) {
     let path_to_lib = Path::new(&crate_name).join("lib.nr");
-    let library_crate = prepare_crate(context, &path_to_lib);
+    let library_crate = prepare_dependency(context, &path_to_lib);
 
     propagate_dep(context, library_crate, &crate_name.parse().unwrap());
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Towards #2238  <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This reworks the `CrateGraph` to only have one root crate. This allows us to lookup the root crate when building an ABI for it. I also cleaned up the Dummy case so we aren't storing a `std::usize::MAX` for each dummy id.

This significantly cleans up my prototype solution in #2374

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
