### PR TITLE
chore: fix body expr span

### DIFF
--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -168,12 +168,12 @@ fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunction> {
         .then(parenthesized(function_parameters(allow_self)))
         .then(function_return_type())
         .then(where_clause())
-        .then(block(expression()))
-        .validate(|(((args, ret), where_clause), body), span, emit| {
+        .then(spanned(block(expression())))
+        .validate(|(((args, ret), where_clause), (body, body_span)), span, emit| {
             let ((((attribute, modifiers), name), generics), parameters) = args;
             validate_where_clause(&generics, &where_clause, span, emit);
             FunctionDefinition {
-                span: name.0.span(),
+                span: body_span,
                 name,
                 attribute, // XXX: Currently we only have one attribute defined. If more attributes are needed per function, we can make this a vector and make attribute definition more expressive
                 is_unconstrained: modifiers.0,


### PR DESCRIPTION
# Description
before:

```
error: expected type Field, found type ()
  ┌─ /home/work/subject/oliver/noir/sss/src/main.nr:1:4
  │
1 │ fn main() -> Field {
  │    ----      ----- expected Field because of return type
  │    │          
  │    () returned here
  │
```

after:
```
error: expected type Field, found type ()
  ┌─ /home/work/subject/oliver/noir/sss/src/main.nr:1:14
  │  
1 │   fn main() -> Field {
  │                ----- expected Field because of return type
  │ ╭────────────────────'
2 │ │     let n = 3;
3 │ │     let n2 = 5;
4 │ │ 
5 │ │     
6 │ │ }
  │ ╰─' () returned here
  │  

```

## Problem

https://github.com/noir-lang/noir/pull/2302#discussion_r1294856077

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
