### PR TITLE
fix(ssa): codegen missing check for unary minus

### DIFF
--- a/crates/nargo_cli/tests/execution_success/unary_operators/Nargo.toml
+++ b/crates/nargo_cli/tests/execution_success/unary_operators/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "unary_operators"
+type = "bin"
+authors = [""]
+compiler_version = "0.10.3"
+
+[dependencies]

--- a/crates/nargo_cli/tests/execution_success/unary_operators/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/unary_operators/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {
+    let x = -1;
+    assert(x == 1 - 2);
+
+    let y: i32 = -1;
+    assert(x == 1 - 2);
+}

--- a/crates/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -207,7 +207,7 @@ impl<'a> FunctionContext<'a> {
                 let rhs = rhs.into_leaf().eval(self);
                 let typ = self.builder.type_of_value(rhs);
                 let zero = self.builder.numeric_constant(0u128, typ);
-                self.builder.insert_binary(zero, BinaryOp::Sub, rhs).into()
+                self.insert_binary(zero, noirc_frontend::BinaryOpKind::Subtract, rhs, None).into()
             }
             noirc_frontend::UnaryOp::MutableReference => {
                 self.codegen_reference(&unary.rhs).map(|rhs| {
@@ -252,7 +252,7 @@ impl<'a> FunctionContext<'a> {
     fn codegen_binary(&mut self, binary: &ast::Binary) -> Values {
         let lhs = self.codegen_non_tuple_expression(&binary.lhs);
         let rhs = self.codegen_non_tuple_expression(&binary.rhs);
-        self.insert_binary(lhs, binary.operator, rhs, binary.location)
+        self.insert_binary(lhs, binary.operator, rhs, Some(binary.location))
     }
 
     fn codegen_index(&mut self, index: &ast::Index) -> Values {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue --> https://github.com/noir-lang/noir/issues/2412

## Summary\*

For normal binary expression we call `FunctionContext::insert_binary` which inserts a binary instruction and checks if truncation is needed.

However, for unary minus we directly call into the `FunctionBuilder` which skips this check -- this PR replaces that function call with a call to `FunctionContext::insert_binary`.

The `location` argument in `FunctionContext::insert_binary` is also made optional since `ast::Unary` doesn't have a location and it would be a bit of a pain to add it, because in mono we sometimes generate unary expressions on the fly. 

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
