### PR TITLE
feat(brillig): Added locations for brillig artifacts

### DIFF
--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -1,6 +1,7 @@
 use crate::brillig::brillig_ir::{
     BrilligBinaryOp, BrilligContext, BRILLIG_INTEGER_ARITHMETIC_BIT_SIZE,
 };
+use crate::ssa::ir::dfg::CallStack;
 use crate::ssa::ir::{
     basic_block::{BasicBlock, BasicBlockId},
     dfg::DataFlowGraph,
@@ -202,6 +203,7 @@ impl<'block> BrilligBlock<'block> {
     /// Converts an SSA instruction into a sequence of Brillig opcodes.
     fn convert_ssa_instruction(&mut self, instruction_id: InstructionId, dfg: &DataFlowGraph) {
         let instruction = &dfg[instruction_id];
+        self.brillig_context.set_call_stack(dfg.get_call_stack(instruction_id));
 
         match instruction {
             Instruction::Binary(binary) => {
@@ -479,6 +481,8 @@ impl<'block> BrilligBlock<'block> {
             }
             _ => todo!("ICE: Instruction not supported {instruction:?}"),
         };
+
+        self.brillig_context.set_call_stack(CallStack::new());
     }
 
     fn convert_ssa_function_call(

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -33,6 +33,7 @@ pub(crate) fn directive_invert() -> GeneratedBrillig {
             },
             BrilligOpcode::Stop,
         ],
+        locations: Default::default(),
     }
 }
 
@@ -100,5 +101,6 @@ pub(crate) fn directive_quotient(bit_size: u32) -> GeneratedBrillig {
             },
             BrilligOpcode::Stop,
         ],
+        locations: Default::default(),
     }
 }

--- a/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -2,8 +2,10 @@ use acvm::acir::brillig::{
     BinaryFieldOp, BinaryIntOp, Opcode as BrilligOpcode, RegisterIndex, Value,
 };
 
+use crate::brillig::brillig_ir::artifact::GeneratedBrillig;
+
 /// Generates brillig bytecode which computes the inverse of its input if not null, and zero else.
-pub(crate) fn directive_invert() -> Vec<BrilligOpcode> {
+pub(crate) fn directive_invert() -> GeneratedBrillig {
     //  We generate the following code:
     // fn invert(x : Field) -> Field {
     //    1/ x
@@ -16,20 +18,22 @@ pub(crate) fn directive_invert() -> Vec<BrilligOpcode> {
     // Location of the stop opcode
     let stop_location = 3;
 
-    vec![
-        // If the input is zero, then we jump to the stop opcode
-        BrilligOpcode::JumpIfNot { condition: input, location: stop_location },
-        // Put value one in register (1)
-        BrilligOpcode::Const { destination: one_const, value: Value::from(1_usize) },
-        // Divide 1 by the input, and set the result of the division into register (0)
-        BrilligOpcode::BinaryFieldOp {
-            op: BinaryFieldOp::Div,
-            lhs: one_const,
-            rhs: input,
-            destination: input,
-        },
-        BrilligOpcode::Stop,
-    ]
+    GeneratedBrillig {
+        byte_code: vec![
+            // If the input is zero, then we jump to the stop opcode
+            BrilligOpcode::JumpIfNot { condition: input, location: stop_location },
+            // Put value one in register (1)
+            BrilligOpcode::Const { destination: one_const, value: Value::from(1_usize) },
+            // Divide 1 by the input, and set the result of the division into register (0)
+            BrilligOpcode::BinaryFieldOp {
+                op: BinaryFieldOp::Div,
+                lhs: one_const,
+                rhs: input,
+                destination: input,
+            },
+            BrilligOpcode::Stop,
+        ],
+    }
 }
 
 /// Generates brillig bytecode which computes `a / b` and returns the quotient and remainder.
@@ -47,43 +51,54 @@ pub(crate) fn directive_invert() -> Vec<BrilligOpcode> {
 ///    }
 /// }
 /// ```
-pub(crate) fn directive_quotient(bit_size: u32) -> Vec<BrilligOpcode> {
+pub(crate) fn directive_quotient(bit_size: u32) -> GeneratedBrillig {
     // `a` is (0) (i.e register index 0)
     // `b` is (1)
     // `predicate` is (2)
-    vec![
-        // If the predicate is zero, we jump to the exit segment
-        BrilligOpcode::JumpIfNot { condition: RegisterIndex::from(2), location: 6 },
-        //q = a/b is set into register (3)
-        BrilligOpcode::BinaryIntOp {
-            op: BinaryIntOp::UnsignedDiv,
-            lhs: RegisterIndex::from(0),
-            rhs: RegisterIndex::from(1),
-            destination: RegisterIndex::from(3),
-            bit_size,
-        },
-        //(1)= q*b
-        BrilligOpcode::BinaryIntOp {
-            op: BinaryIntOp::Mul,
-            lhs: RegisterIndex::from(3),
-            rhs: RegisterIndex::from(1),
-            destination: RegisterIndex::from(1),
-            bit_size,
-        },
-        //(1) = a-q*b
-        BrilligOpcode::BinaryIntOp {
-            op: BinaryIntOp::Sub,
-            lhs: RegisterIndex::from(0),
-            rhs: RegisterIndex::from(1),
-            destination: RegisterIndex::from(1),
-            bit_size,
-        },
-        //(0) = q
-        BrilligOpcode::Mov { destination: RegisterIndex::from(0), source: RegisterIndex::from(3) },
-        BrilligOpcode::Stop,
-        // Exit segment: we return 0,0
-        BrilligOpcode::Const { destination: RegisterIndex::from(0), value: Value::from(0_usize) },
-        BrilligOpcode::Const { destination: RegisterIndex::from(1), value: Value::from(0_usize) },
-        BrilligOpcode::Stop,
-    ]
+    GeneratedBrillig {
+        byte_code: vec![
+            // If the predicate is zero, we jump to the exit segment
+            BrilligOpcode::JumpIfNot { condition: RegisterIndex::from(2), location: 6 },
+            //q = a/b is set into register (3)
+            BrilligOpcode::BinaryIntOp {
+                op: BinaryIntOp::UnsignedDiv,
+                lhs: RegisterIndex::from(0),
+                rhs: RegisterIndex::from(1),
+                destination: RegisterIndex::from(3),
+                bit_size,
+            },
+            //(1)= q*b
+            BrilligOpcode::BinaryIntOp {
+                op: BinaryIntOp::Mul,
+                lhs: RegisterIndex::from(3),
+                rhs: RegisterIndex::from(1),
+                destination: RegisterIndex::from(1),
+                bit_size,
+            },
+            //(1) = a-q*b
+            BrilligOpcode::BinaryIntOp {
+                op: BinaryIntOp::Sub,
+                lhs: RegisterIndex::from(0),
+                rhs: RegisterIndex::from(1),
+                destination: RegisterIndex::from(1),
+                bit_size,
+            },
+            //(0) = q
+            BrilligOpcode::Mov {
+                destination: RegisterIndex::from(0),
+                source: RegisterIndex::from(3),
+            },
+            BrilligOpcode::Stop,
+            // Exit segment: we return 0,0
+            BrilligOpcode::Const {
+                destination: RegisterIndex::from(0),
+                value: Value::from(0_usize),
+            },
+            BrilligOpcode::Const {
+                destination: RegisterIndex::from(1),
+                value: Value::from(0_usize),
+            },
+            BrilligOpcode::Stop,
+        ],
+    }
 }

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -970,7 +970,7 @@ pub(crate) mod tests {
 
     use crate::brillig::brillig_ir::BrilligContext;
 
-    use super::artifact::BrilligParameter;
+    use super::artifact::{BrilligParameter, GeneratedBrillig};
     use super::{BrilligOpcode, ReservedRegisters};
 
     pub(crate) struct DummyBlackBoxSolver;
@@ -1010,7 +1010,7 @@ pub(crate) mod tests {
         context: BrilligContext,
         arguments: Vec<BrilligParameter>,
         returns: Vec<BrilligParameter>,
-    ) -> Vec<BrilligOpcode> {
+    ) -> GeneratedBrillig {
         let artifact = context.artifact();
         let mut entry_point_artifact =
             BrilligContext::new_entry_point_artifact(arguments, returns, "test".to_string());
@@ -1028,7 +1028,7 @@ pub(crate) mod tests {
         let mut vm = VM::new(
             Registers { inner: param_registers },
             memory,
-            create_entry_point_bytecode(context, arguments, returns),
+            create_entry_point_bytecode(context, arguments, returns).byte_code,
             vec![],
             &DummyBlackBoxSolver,
         );

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -948,6 +948,7 @@ impl BrilligContext {
         }
     }
 
+    /// Sets a current call stack that the next pushed opcodes will be associated with.
     pub(crate) fn set_call_stack(&mut self, call_stack: CallStack) {
         self.obj.set_call_stack(call_stack);
     }

--- a/crates/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -10,6 +10,8 @@ pub(crate) mod registers;
 
 mod entry_point;
 
+use crate::ssa::ir::dfg::CallStack;
+
 use self::{
     artifact::{BrilligArtifact, UnresolvedJumpLocation},
     registers::BrilligRegistersContext,
@@ -104,7 +106,7 @@ impl BrilligContext {
 
     /// Adds a brillig instruction to the brillig byte code
     pub(crate) fn push_opcode(&mut self, opcode: BrilligOpcode) {
-        self.obj.byte_code.push(opcode);
+        self.obj.push_opcode(opcode);
     }
 
     /// Returns the artifact
@@ -945,6 +947,10 @@ impl BrilligContext {
             _ => unreachable!("ICE: Expected vector, got {variable:?}"),
         }
     }
+
+    pub(crate) fn set_call_stack(&mut self, call_stack: CallStack) {
+        self.obj.set_call_stack(call_stack);
+    }
 }
 
 /// Type to encapsulate the binary operation types in Brillig
@@ -1079,7 +1085,7 @@ pub(crate) mod tests {
 
         context.stop_instruction();
 
-        let bytecode = context.artifact().byte_code;
+        let bytecode = context.artifact().finish().byte_code;
         let number_sequence: Vec<Value> = (0_usize..12_usize).map(Value::from).collect();
         let mut vm = VM::new(
             Registers { inner: vec![] },

--- a/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -13,7 +13,7 @@ pub(crate) enum BrilligParameter {
 
 /// The result of compiling and linking brillig artifacts.
 /// This is ready to run bytecode with attached metadata.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct GeneratedBrillig {
     pub(crate) byte_code: Vec<BrilligOpcode>,
     pub(crate) locations: BTreeMap<OpcodeLocation, CallStack>,

--- a/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -1,6 +1,11 @@
 use acvm::acir::brillig::Opcode as BrilligOpcode;
 use std::collections::HashMap;
 
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedBrillig {
+    pub(crate) byte_code: Vec<BrilligOpcode>,
+}
+
 /// Represents a parameter or a return value of a function.
 #[derive(Debug, Clone)]
 pub(crate) enum BrilligParameter {
@@ -52,9 +57,9 @@ pub(crate) type UnresolvedJumpLocation = Label;
 
 impl BrilligArtifact {
     /// Resolves all jumps and generates the final bytecode
-    pub(crate) fn finish(mut self) -> Vec<BrilligOpcode> {
+    pub(crate) fn finish(mut self) -> GeneratedBrillig {
         self.resolve_jumps();
-        self.byte_code
+        GeneratedBrillig { byte_code: self.byte_code }
     }
 
     /// Gets the first unresolved function call of this artifact.

--- a/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -239,7 +239,6 @@ impl BrilligArtifact {
         }
     }
 
-    /// Sets a current call stack that the next pushed opcodes will be associated with.
     pub(crate) fn set_call_stack(&mut self, call_stack: CallStack) {
         self.call_stack = call_stack;
     }

--- a/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/crates/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -3,18 +3,20 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::ssa::ir::dfg::CallStack;
 
-#[derive(Debug, Clone)]
-pub(crate) struct GeneratedBrillig {
-    pub(crate) byte_code: Vec<BrilligOpcode>,
-    pub(crate) locations: BTreeMap<OpcodeLocation, CallStack>,
-}
-
 /// Represents a parameter or a return value of a function.
 #[derive(Debug, Clone)]
 pub(crate) enum BrilligParameter {
     Simple,
     Array(Vec<BrilligParameter>, usize),
     Slice(Vec<BrilligParameter>),
+}
+
+/// The result of compiling and linking brillig artifacts.
+/// This is ready to run bytecode with attached metadata.
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedBrillig {
+    pub(crate) byte_code: Vec<BrilligOpcode>,
+    pub(crate) locations: BTreeMap<OpcodeLocation, CallStack>,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -34,9 +36,9 @@ pub(crate) struct BrilligArtifact {
     /// TODO: perhaps we should combine this with the `unresolved_jumps` field
     /// TODO: and have an enum which indicates whether the jump is internal or external
     unresolved_external_call_labels: Vec<(JumpInstructionPosition, UnresolvedJumpLocation)>,
-
+    /// Maps the opcodes that are associated with a callstack to it.
     locations: BTreeMap<OpcodeLocation, CallStack>,
-
+    /// The current call stack. All opcodes that are pushed will be associated with this call stack.
     call_stack: CallStack,
 }
 
@@ -237,6 +239,7 @@ impl BrilligArtifact {
         }
     }
 
+    /// Sets a current call stack that the next pushed opcodes will be associated with.
     pub(crate) fn set_call_stack(&mut self, call_stack: CallStack) {
         self.call_stack = call_stack;
     }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -1,5 +1,6 @@
 use super::generated_acir::GeneratedAcir;
 use crate::brillig::brillig_gen::brillig_directive;
+use crate::brillig::brillig_ir::artifact::GeneratedBrillig;
 use crate::errors::{InternalError, RuntimeError};
 use crate::ssa::acir_gen::{AcirDynamicArray, AcirValue};
 use crate::ssa::ir::dfg::CallStack;
@@ -910,7 +911,7 @@ impl AcirContext {
     pub(crate) fn brillig(
         &mut self,
         predicate: AcirVar,
-        code: Vec<BrilligOpcode>,
+        code: GeneratedBrillig,
         inputs: Vec<AcirValue>,
         outputs: Vec<AcirType>,
     ) -> Result<Vec<AcirValue>, InternalError> {
@@ -932,7 +933,9 @@ impl AcirContext {
 
         // Optimistically try executing the brillig now, if we can complete execution they just return the results.
         // This is a temporary measure pending SSA optimizations being applied to Brillig which would remove constant-input opcodes (See #2066)
-        if let Some(brillig_outputs) = self.execute_brillig(code.clone(), &b_inputs, &outputs) {
+        if let Some(brillig_outputs) =
+            self.execute_brillig(code.byte_code.clone(), &b_inputs, &outputs)
+        {
             return Ok(brillig_outputs);
         }
 

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -911,7 +911,7 @@ impl AcirContext {
     pub(crate) fn brillig(
         &mut self,
         predicate: AcirVar,
-        code: GeneratedBrillig,
+        generated_brillig: GeneratedBrillig,
         inputs: Vec<AcirValue>,
         outputs: Vec<AcirType>,
     ) -> Result<Vec<AcirValue>, InternalError> {
@@ -934,7 +934,7 @@ impl AcirContext {
         // Optimistically try executing the brillig now, if we can complete execution they just return the results.
         // This is a temporary measure pending SSA optimizations being applied to Brillig which would remove constant-input opcodes (See #2066)
         if let Some(brillig_outputs) =
-            self.execute_brillig(code.byte_code.clone(), &b_inputs, &outputs)
+            self.execute_brillig(generated_brillig.byte_code.clone(), &b_inputs, &outputs)
         {
             return Ok(brillig_outputs);
         }
@@ -956,7 +956,7 @@ impl AcirContext {
             }
         });
         let predicate = self.var_to_expression(predicate)?;
-        self.acir_ir.brillig(Some(predicate), code, b_inputs, b_outputs);
+        self.acir_ir.brillig(Some(predicate), generated_brillig, b_inputs, b_outputs);
 
         Ok(outputs_var)
     }

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -3,13 +3,12 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    brillig::brillig_gen::brillig_directive,
+    brillig::{brillig_gen::brillig_directive, brillig_ir::artifact::GeneratedBrillig},
     errors::{InternalError, RuntimeError},
     ssa::ir::dfg::CallStack,
 };
 
 use acvm::acir::{
-    brillig::Opcode as BrilligOpcode,
     circuit::{
         brillig::{Brillig as AcvmBrillig, BrilligInputs, BrilligOutputs},
         opcodes::{BlackBoxFuncCall, FunctionInput, Opcode as AcirOpcode},
@@ -788,7 +787,7 @@ impl GeneratedAcir {
     pub(crate) fn brillig(
         &mut self,
         predicate: Option<Expression>,
-        code: Vec<BrilligOpcode>,
+        code: GeneratedBrillig,
         inputs: Vec<BrilligInputs>,
         outputs: Vec<BrilligOutputs>,
     ) {
@@ -796,7 +795,7 @@ impl GeneratedAcir {
             inputs,
             outputs,
             foreign_call_results: Vec::new(),
-            bytecode: code,
+            bytecode: code.byte_code,
             predicate,
         });
         self.push_opcode(opcode);

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -799,6 +799,12 @@ impl GeneratedAcir {
             predicate,
         });
         self.push_opcode(opcode);
+        for (brillig_index, call_stack) in code.locations {
+            self.locations.insert(
+                OpcodeLocation::Brillig { acir_index: self.opcodes.len() - 1, brillig_index },
+                call_stack,
+            );
+        }
     }
 
     /// Generate gates and control bits witnesses which ensure that out_expr is a permutation of in_expr

--- a/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -787,7 +787,7 @@ impl GeneratedAcir {
     pub(crate) fn brillig(
         &mut self,
         predicate: Option<Expression>,
-        code: GeneratedBrillig,
+        generated_brillig: GeneratedBrillig,
         inputs: Vec<BrilligInputs>,
         outputs: Vec<BrilligOutputs>,
     ) {
@@ -795,11 +795,11 @@ impl GeneratedAcir {
             inputs,
             outputs,
             foreign_call_results: Vec::new(),
-            bytecode: code.byte_code,
+            bytecode: generated_brillig.byte_code,
             predicate,
         });
         self.push_opcode(opcode);
-        for (brillig_index, call_stack) in code.locations {
+        for (brillig_index, call_stack) in generated_brillig.locations {
             self.locations.insert(
                 OpcodeLocation::Brillig { acir_index: self.opcodes.len() - 1, brillig_index },
                 call_stack,

--- a/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -20,12 +20,13 @@ use super::{
     },
     ssa_gen::Ssa,
 };
+use crate::brillig::brillig_ir::artifact::GeneratedBrillig;
 use crate::brillig::brillig_ir::BrilligContext;
 use crate::brillig::{brillig_gen::brillig_fn::FunctionContext as BrilligFunctionContext, Brillig};
 use crate::errors::{InternalError, RuntimeError};
 pub(crate) use acir_ir::generated_acir::GeneratedAcir;
 use acvm::{
-    acir::{brillig::Opcode, circuit::opcodes::BlockId, native_types::Expression},
+    acir::{circuit::opcodes::BlockId, native_types::Expression},
     FieldElement,
 };
 use iter_extended::{try_vecmap, vecmap};
@@ -435,7 +436,7 @@ impl Context {
         &self,
         func: &Function,
         brillig: &Brillig,
-    ) -> Result<Vec<Opcode>, InternalError> {
+    ) -> Result<GeneratedBrillig, InternalError> {
         // Create the entry point artifact
         let mut entry_point = BrilligContext::new_entry_point_artifact(
             BrilligFunctionContext::parameters(func),


### PR DESCRIPTION
# Description
Introduces the same system of opcode locations that ACIR has for Brillig.
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

We were only generating location metadata for acir opcodes. 

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->
This PR basically replicates the exact same approach that we're applying for ACIR to brillig. 

In the future we can improve the errors in the Brillig VM to produce a proper runtime callstack, because right now we'd only get the last inlined calls of the call stack (since the brillig VM only provides the opcode location that failed but not the opcode locations of the previous CALL instructions)
## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
