### PR TITLE
chore: only install `tokio-util` dependency on windows

### DIFF
--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -46,10 +46,12 @@ hex = "0.4.2"
 termcolor = "1.1.2"
 color-eyre = "0.6.2"
 tokio = { version = "1.0", features = ["io-std"] }
-tokio-util = { version = "0.7.8", features = ["compat"] }
 
 # Backends
 acvm-backend-barretenberg = { version = "0.11.0", default-features = false }
+
+[target.'cfg(not(unix))'.dependencies]
+tokio-util = { version = "0.7.8", features = ["compat"] }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/nargo_cli/src/main.rs
+++ b/crates/nargo_cli/src/main.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-#![warn(unused_extern_crates)]
+#![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
 #![warn(clippy::semicolon_if_nothing_returned)]
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We only use to `tokio-util` dependency on `not(unix)` targets so there's no need to install it on unix.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
