### PR TITLE
chore: Constrain slices from field decomposition functions to be expected length

### DIFF
--- a/noir_stdlib/src/field.nr
+++ b/noir_stdlib/src/field.nr
@@ -1,9 +1,16 @@
 
 impl Field {
-    #[builtin(to_le_bits)]
-    fn to_le_bits(_x : Field, _bit_size: u32) -> [u1] {}
-    #[builtin(to_be_bits)]
-    fn to_be_bits(_x : Field, _bit_size: u32) -> [u1] {}
+    
+    fn to_le_bits(x : Field, bit_size: u32) -> [u1] {
+        let bit_array = x.__to_le_bits(bit_size);
+        assert(bit_array.len() == bit_size as Field);
+        bit_array
+    }
+    fn to_be_bits(x : Field, bit_size: u32) -> [u1] {
+        let bit_array = x.__to_be_bits(bit_size);
+        assert(bit_array.len() == bit_size as Field);
+        bit_array
+    }
 
     fn to_le_bytes(x : Field, byte_size: u32) -> [u8] {
         x.to_le_radix(256, byte_size)
@@ -12,12 +19,30 @@ impl Field {
         x.to_be_radix(256, byte_size)
     }
 
-    #[builtin(to_le_radix)]
+    fn to_le_radix(x : Field, radix: u32, result_len: u32) -> [u8] {
+        let radix_array = x.__to_le_radix(radix, result_len);
+        assert(radix_array.len() == result_len as Field);
+        radix_array
+    }
+    
+    fn to_be_radix(x : Field, radix: u32, result_len: u32) -> [u8] {
+        let radix_array = x.__to_be_radix(radix, result_len);
+        assert(radix_array.len() == result_len as Field);
+        radix_array
+    }
+
+    #[builtin(to_le_bits)]
+    fn __to_le_bits(_x : Field, _bit_size: u32) -> [u1] {}
+    #[builtin(to_be_bits)]
+    fn __to_be_bits(_x : Field, _bit_size: u32) -> [u1] {}
+
+
     //decompose _x into a _result_len vector over the _radix basis
     //_radix must be less than 256
-    fn to_le_radix(_x : Field, _radix: u32, _result_len: u32) -> [u8] {}
+    #[builtin(to_le_radix)]
+    fn __to_le_radix(_x : Field, _radix: u32, _result_len: u32) -> [u8] {}
     #[builtin(to_be_radix)]
-    fn to_be_radix(_x : Field, _radix: u32, _result_len: u32) -> [u8] {}
+    fn __to_be_radix(_x : Field, _radix: u32, _result_len: u32) -> [u8] {}
 
     // Returns self to the power of the given exponent value.
     // Caution: we assume the exponent fits into 32 bits


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Draft PR as I'm getting test failures from this where I don't expect them.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
