### PR TITLE
fix: Closure lvalue capture bugfix

### DIFF
--- a/crates/nargo_cli/tests/execution_success/closures_mut_ref/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/closures_mut_ref/src/main.nr
@@ -15,4 +15,17 @@ fn main(mut x: Field) {
     add2(&mut x);
     assert(x == 3);
 
+    issue_2120();
+}
+
+// https://github.com/noir-lang/noir/issues/2120
+fn issue_2120() {
+    let x1 = &mut 42;
+    let set_x1 = |y| { *x1 = y; };
+
+    assert(*x1 == 42);
+    set_x1(44);
+    assert(*x1 == 44);
+    set_x1(*x1);
+    assert(*x1 == 44);
 }

--- a/crates/noirc_frontend/src/monomorphization/mod.rs
+++ b/crates/noirc_frontend/src/monomorphization/mod.rs
@@ -1126,7 +1126,7 @@ impl<'interner> Monomorphizer<'interner> {
         });
 
         let location = None; // TODO: This should match the location of the lambda expression
-        let mutable = false;
+        let mutable = true;
         let definition = Definition::Local(env_local_id);
 
         let env_ident = ast::Ident {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue --> https://github.com/noir-lang/noir/issues/2120

## Summary\*

We used to not capture lvalues in closures properly, which was fixed in https://github.com/noir-lang/noir/pull/2257, however a few codegen issue popped up (https://github.com/noir-lang/noir/issues/2255, https://github.com/noir-lang/noir/issues/2316) which still prevented the following example from verifying:

```rust
fn issue_2120() {
    let x1 = &mut 42;
    let set_x1 = |y| { *x1 = y; };

    assert(*x1 == 42);
    set_x1(44);
    assert(*x1 == 44);
    set_x1(*x1);
    assert(*x1 == 44);
}
```

Those are now both fixed, but the code above still doesn't verify, because in the previous PR I've forgotten to mark the closure environment's ast::Ident as mutable, which causes us to take a wrong branch later on in ssa_gen.

This PR fixes that and adds the example above as a test case.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
