### PR TITLE
fix(ssa): Do not optimize for allocates in constant folding

### DIFF
--- a/crates/noirc_evaluator/src/ssa.rs
+++ b/crates/noirc_evaluator/src/ssa.rs
@@ -63,6 +63,8 @@ pub(crate) fn optimize_into_acir(
             // and this pass is missed, slice merging will fail inside of flattening.
             .mem2reg()
             .print(print_ssa_passes, "After Mem2Reg:")
+            .fold_constants()
+            .print(print_ssa_passes, "After Constant Folding:")
             .flatten_cfg()
             .print(print_ssa_passes, "After Flattening:")
             // Run mem2reg once more with the flattened CFG to catch any remaining loads/stores

--- a/crates/noirc_evaluator/src/ssa.rs
+++ b/crates/noirc_evaluator/src/ssa.rs
@@ -63,8 +63,6 @@ pub(crate) fn optimize_into_acir(
             // and this pass is missed, slice merging will fail inside of flattening.
             .mem2reg()
             .print(print_ssa_passes, "After Mem2Reg:")
-            .fold_constants()
-            .print(print_ssa_passes, "After Constant Folding:")
             .flatten_cfg()
             .print(print_ssa_passes, "After Flattening:")
             // Run mem2reg once more with the flattened CFG to catch any remaining loads/stores

--- a/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -102,7 +102,9 @@ impl Context {
 
         // If the instruction doesn't have side-effects, cache the results so we can reuse them if
         // the same instruction appears again later in the block.
-        if !instruction.has_side_effects(&function.dfg) {
+        if !instruction.has_side_effects(&function.dfg)
+            && !matches!(instruction, Instruction::Allocate)
+        {
             instruction_result_cache.insert(instruction, new_results.clone());
         }
         for (old_result, new_result) in old_results.iter().zip(new_results) {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -371,7 +371,8 @@ impl<'a> Resolver<'a> {
                 // expect() here is valid, because the only places we don't have a span are omitted types
                 // e.g. a function without return type implicitly has a spanless UnresolvedType::Unit return type
                 // To get an invalid env type, the user must explicitly specify the type, which will have a span
-                let env_span = env.span.expect("Unexpected missing span for closure environment type");
+                let env_span =
+                    env.span.expect("Unexpected missing span for closure environment type");
 
                 let env = Box::new(self.resolve_type_inner(*env, new_variables));
 


### PR DESCRIPTION
# Description

## Problem\*

Quick fix found when working on (https://github.com/noir-lang/noir/pull/2446) so no issue

## Summary\*

In order to get dynamic slices working I included a constant folding pass before flattening. In this PR (https://github.com/noir-lang/noir/pull/2460) we reuse duplicate instructions with no side effects. However, Allocate instructions are not explicitly marked as having side effects so that they can be removed in DIE. 

For example in `execution_success/slices` executing just this method:
```rust
fn merge_slices_mutate(x: Field, y: Field) -> [Field] {
    let mut slice = [0; 2];
    if x != y {
        slice = slice.push_back(y);
        slice = slice.push_back(x);
    } else {
        slice = slice.push_back(x);
    };
    slice
}
```
Will lead to this SSA (with constant folding before flattening):
```

After Mem2Reg:
acir fn main f4 {
  b0(v0: Field, v1: Field):
    v5 = allocate
    store Field 2 at v5
    v7 = allocate
    store [Field 0, Field 0] at v7
    v10 = eq v0, v1
    v11 = not v10
    jmpif v11 then: b1, else: b2
  b1():
    v21, v22 = call slice_push_back(Field 2, [Field 0, Field 0], v1)
    v25, v26 = call slice_push_back(v21, v22, v0)
    store v25 at v5
    store v26 at v7
    jmp b3()
  b3():
    v17 = load v5
    v18 = load v7
    v27 = cast v17 as u64
    v29 = lt Field 3, v27
    constrain v29
    v30 = array_get v18, index Field 3
    v32 = eq v30, Field 5
    constrain v32
    v34 = eq v17, Field 4
    constrain v34
    return 
  b2():
    v15, v16 = call slice_push_back(Field 2, [Field 0, Field 0], v0)
    store v15 at v5
    store v16 at v7
    jmp b3()
}

After Constant Folding:
acir fn main f4 {
  b0(v0: Field, v1: Field):
    v36 = allocate
    store Field 2 at v36
    store [Field 0, Field 0] at v36
    v37 = eq v0, v1
    v38 = not v37
    jmpif v38 then: b1, else: b2
  b1():
    store Field 4 at v36
    store [Field 0, Field 0, v1, v0] at v36
    jmp b3()
  b3():
    v41 = load v36
    v42 = load v36
    v43 = cast v41 as u64
    v44 = lt Field 3, v43
    constrain v44
    v45 = array_get v42, index Field 3
    v46 = eq v45, Field 5
    constrain v46
    v47 = eq v41, Field 4
    constrain v47
    return 
  b2():
    store Field 3 at v36
    store [Field 0, Field 0, v0] at v36
    jmp b3()
}
```

If you look in b0 the allocate instruction are being malformed. We are fetching our results from this map HashMap<Instruction, Vec<ValueId>> which can lead to duplicate instructions. I included a check that we do not cache allocate instructions.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
