### PR TITLE
fix(ssa): Handle right shift with constants

### DIFF
--- a/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
@@ -10,4 +10,13 @@ fn main(x: u64) {
 	// shifts on runtime values
 	assert(x << 1 == 128);
 	assert(x >> 2 == 16);
+
+	regression_2250();
+}
+
+fn regression_2250() {
+	let a: u1 = 1 >> 1;
+	assert(a == 0);
+    let b: u32 = 1 >> 32;
+	assert(b == 0);
 }

--- a/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
@@ -17,6 +17,7 @@ fn main(x: u64) {
 fn regression_2250() {
 	let a: u1 = 1 >> 1;
 	assert(a == 0);
-    let b: u32 = 1 >> 32;
+	
+	let b: u32 = 1 >> 32;
 	assert(b == 0);
 }

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -764,10 +764,10 @@ impl Binary {
                 // and the operation should be handled by ACIR generation.
                 if matches!(self.operator, BinaryOp::Div) && rhs == 0 {
                     return None;
-                } else {
-                    let result = function(lhs, rhs);
-                    truncate(result, *bit_size).into()
                 }
+
+                let result = function(lhs, rhs);
+                truncate(result, *bit_size).into()
             }
             _ => return None,
         };

--- a/crates/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -247,7 +247,7 @@ impl<'a> FunctionContext<'a> {
         self.builder.insert_binary(lhs, BinaryOp::Mul, pow)
     }
 
-    /// Insert ssa instructions which computes lhs << rhs by doing lhs/2^rhs
+    /// Insert ssa instructions which computes lhs >> rhs by doing lhs/2^rhs
     fn insert_shift_right(&mut self, lhs: ValueId, rhs: ValueId) -> ValueId {
         let base = self.builder.field_constant(FieldElement::from(2_u128));
         let pow = self.pow(base, rhs);


### PR DESCRIPTION
# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2250 

## Summary\*

The poster of the issue this PR aims to solve was correct in their assessment as to what was causing the panic. We were truncating the divisor into the operand type (which comes from the dividend). This caused the rhs to be `0`. When we have `0` in the divisor we should not simplify and instead leave the computation to runtime so we can handle it correctly. In this case, both bit shifts should result in `0`. This is similar to one of the fixes that had to be done in PR https://github.com/noir-lang/noir/pull/2475

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
