### PR TITLE
fix(ssa): Use correct result type for left bit shift truncate

### DIFF
--- a/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
@@ -21,3 +21,18 @@ fn regression_2250() {
 	let b: u32 = 1 >> 32;
 	assert(b == 0);
 }
+
+fn regression_2399() {
+    let result_0 = bitshift_variable(0);
+    assert(result_0 == 1);
+
+    let result_4 = bitshift_variable(4);
+    assert(result_4 == 16);
+}
+
+fn bitshift_variable(idx: u64) -> u64 {
+    let mut bits: u64 = 0;
+    bits |= 1 << idx;
+
+    bits
+}

--- a/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/bit_shifts_comptime/src/main.nr
@@ -12,6 +12,7 @@ fn main(x: u64) {
 	assert(x >> 2 == 16);
 
 	regression_2250();
+	regression_2399();
 }
 
 fn regression_2250() {

--- a/crates/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -317,7 +317,7 @@ impl<'a> FunctionContext<'a> {
             rhs,
             &self.builder.current_function.dfg,
         ) {
-            let result_type = self.builder.current_function.dfg.type_of_value(result);
+            let result_type = self.builder.current_function.dfg.type_of_value(lhs);
             let bit_size = match result_type {
                 Type::Numeric(NumericType::Signed { bit_size })
                 | Type::Numeric(NumericType::Unsigned { bit_size }) => bit_size,

--- a/crates/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/crates/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -244,14 +244,20 @@ impl<'a> FunctionContext<'a> {
     fn insert_shift_left(&mut self, lhs: ValueId, rhs: ValueId) -> ValueId {
         let base = self.builder.field_constant(FieldElement::from(2_u128));
         let pow = self.pow(base, rhs);
-        self.builder.insert_binary(lhs, BinaryOp::Mul, pow)
+        let result = self.builder.insert_binary(lhs, BinaryOp::Mul, pow);
+        // `pow` returns a Field so we must cast the result to make sure it has the correct type
+        let result_type = self.builder.current_function.dfg.type_of_value(lhs);
+        self.builder.insert_cast(result, result_type)
     }
 
     /// Insert ssa instructions which computes lhs >> rhs by doing lhs/2^rhs
     fn insert_shift_right(&mut self, lhs: ValueId, rhs: ValueId) -> ValueId {
         let base = self.builder.field_constant(FieldElement::from(2_u128));
         let pow = self.pow(base, rhs);
-        self.builder.insert_binary(lhs, BinaryOp::Div, pow)
+        let result = self.builder.insert_binary(lhs, BinaryOp::Div, pow);
+        // `pow` returns a Field so we must cast the result to make sure it has the correct type
+        let result_type = self.builder.current_function.dfg.type_of_value(lhs);
+        self.builder.insert_cast(result, result_type)
     }
 
     /// Computes lhs^rhs via square&multiply, using the bits decomposition of rhs
@@ -317,7 +323,7 @@ impl<'a> FunctionContext<'a> {
             rhs,
             &self.builder.current_function.dfg,
         ) {
-            let result_type = self.builder.current_function.dfg.type_of_value(lhs);
+            let result_type = self.builder.current_function.dfg.type_of_value(result);
             let bit_size = match result_type {
                 Type::Numeric(NumericType::Signed { bit_size })
                 | Type::Numeric(NumericType::Unsigned { bit_size }) => bit_size,


### PR DESCRIPTION
# Description

## Problem\*

Resolves #2399 

## Summary\*

The issue states that the bug occurs with bit shifts at runtime but it is in fact an error with how we were specifying the result type for comptime left shift operation. The type of the result value from `insert_shift_left` was being used to determine the bit size for truncation. However, the internals of `insert_shift_left` call the `pow` method which will ultimately turn lhs << rhs into lhs*2^rhs, where the resulting binary op multiplication is a field element. We should instead use the lhs for fetching the result type of the binary operation and the bit size for truncation. This also follows our simplification code for binary ops where we set the operand type based off of the type of the lhs value.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
