### PR TITLE
chore!: Rename fixed_base scalar_mul to be more descriptive

### DIFF
--- a/noir_stdlib/src/scalar_mul.nr
+++ b/noir_stdlib/src/scalar_mul.nr
@@ -1,2 +1,2 @@
 #[foreign(fixed_base_scalar_mul)]
-fn fixed_base(_input : Field) -> [Field; 2] {}
+fn fixed_base_embedded_curve(_input : Field) -> [Field; 2] {}


### PR DESCRIPTION
# Description

This changes the method to denote the fact that it is doing scalar multiplication over the embedded curve. For bn254, this is grumpkin, but for other fields it will be different. 

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
