### PR TITLE
chore(aztec_noir): import aztec library if not found yet

### DIFF
--- a/crates/noirc_frontend/src/hir/def_map/aztec_library.rs
+++ b/crates/noirc_frontend/src/hir/def_map/aztec_library.rs
@@ -113,9 +113,7 @@ pub(crate) fn transform(mut ast: ParsedModule) -> ParsedModule {
     // Usage -> mut ast -> aztec_library::transform(&mut ast)
 
     // Covers all functions in the ast
-    transform_module(&mut ast.functions);
-    include_relevant_imports(&mut ast);
-    for submodule in ast.submodules.iter_mut() {
+    for submodule in ast.submodules.iter_mut().filter(|submodule| submodule.is_contract) {
         include_relevant_imports(&mut submodule.contents);
         transform_module(&mut submodule.contents.functions);
     }


### PR DESCRIPTION
# Description

Makes the aztec macro code a bit more robust by performing required imports. It also turns anything that didnt need to be a macro into a function

Resolves: https://github.com/AztecProtocol/aztec-packages/issues/1888

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
