### PR TITLE
chore: Remove `set_value_from_id` and `resolve` in the `DataFlowGraph`

### DIFF
--- a/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/crates/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -584,8 +584,7 @@ impl Context {
             }
             AcirValue::DynamicArray(_) => (),
         }
-        let resolved_array = dfg.resolve(array);
-        let map_array = last_array_uses.get(&resolved_array) == Some(&instruction);
+        let map_array = last_array_uses.get(&array) == Some(&instruction);
         if let Some(store) = store_value {
             self.array_set(instruction, array, index, store, dfg, map_array)?;
         } else {
@@ -603,7 +602,6 @@ impl Context {
         index: ValueId,
         dfg: &DataFlowGraph,
     ) -> Result<(), RuntimeError> {
-        let array = dfg.resolve(array);
         let block_id = self.block_id(&array);
         if !self.initialized_arrays.contains(&block_id) {
             match &dfg[array] {
@@ -651,9 +649,6 @@ impl Context {
         dfg: &DataFlowGraph,
         map_array: bool,
     ) -> Result<(), InternalError> {
-        // Fetch the internal SSA ID for the array
-        let array = dfg.resolve(array);
-
         // Use the SSA ID to get or create its block ID
         let block_id = self.block_id(&array);
 
@@ -790,7 +785,6 @@ impl Context {
     /// involving such values are evaluated via a separate path and stored in
     /// `ssa_value_to_array_address` instead.
     fn convert_value(&mut self, value_id: ValueId, dfg: &DataFlowGraph) -> AcirValue {
-        let value_id = dfg.resolve(value_id);
         let value = &dfg[value_id];
         if let Some(acir_value) = self.ssa_values.get(&value_id) {
             return acir_value.clone();

--- a/crates/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -409,6 +409,12 @@ impl DataFlowGraph {
     pub(crate) fn is_constant(&self, argument: ValueId) -> bool {
         !matches!(&self[argument], Value::Instruction { .. } | Value::Param { .. })
     }
+
+    pub(crate) fn iter_instructions_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (InstructionId, &mut Instruction)> {
+        self.instructions.iter_mut()
+    }
 }
 
 impl std::ops::Index<InstructionId> for DataFlowGraph {

--- a/crates/noirc_evaluator/src/ssa/ir/function_inserter.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/function_inserter.rs
@@ -27,8 +27,7 @@ impl<'f> FunctionInserter<'f> {
     /// Resolves a ValueId to its new, updated value.
     /// If there is no updated value for this id, this returns the same
     /// ValueId that was passed in.
-    pub(crate) fn resolve(&mut self, mut value: ValueId) -> ValueId {
-        value = self.function.dfg.resolve(value);
+    pub(crate) fn resolve(&mut self, value: ValueId) -> ValueId {
         match self.values.get(&value) {
             Some(value) => self.resolve(*value),
             None => match &self.function.dfg[value] {
@@ -102,8 +101,7 @@ impl<'f> FunctionInserter<'f> {
         block: BasicBlockId,
         call_stack: CallStack,
     ) -> InsertInstructionResult {
-        let results = self.function.dfg.instruction_results(id);
-        let results = vecmap(results, |id| self.function.dfg.resolve(*id));
+        let results = self.function.dfg.instruction_results(id).to_vec();
 
         let ctrl_typevars = instruction
             .requires_ctrl_typevars()

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -355,7 +355,7 @@ impl Instruction {
             Instruction::Binary(binary) => binary.simplify(dfg),
             Instruction::Cast(value, typ) => simplify_cast(*value, typ, dfg),
             Instruction::Not(value) => {
-                match &dfg[dfg.resolve(*value)] {
+                match &dfg[*value] {
                     // Limit optimizing ! on constants to only booleans. If we tried it on fields,
                     // there is no Not on FieldElement, so we'd need to convert between u128. This
                     // would be incorrect however since the extra bits on the field would not be flipped.
@@ -375,7 +375,7 @@ impl Instruction {
                 }
             }
             Instruction::Constrain(lhs, rhs) => {
-                if dfg.resolve(*lhs) == dfg.resolve(*rhs) {
+                if *lhs == *rhs {
                     // Remove trivial case `assert_eq(x, x)`
                     SimplifyResult::Remove
                 } else {
@@ -685,7 +685,7 @@ impl Binary {
                 }
             }
             BinaryOp::Eq => {
-                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
+                if self.lhs == self.rhs {
                     let one = dfg.make_constant(FieldElement::one(), Type::bool());
                     return SimplifyResult::SimplifiedTo(one);
                 }
@@ -707,7 +707,7 @@ impl Binary {
                 }
             }
             BinaryOp::Lt => {
-                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
+                if self.lhs == self.rhs {
                     let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                     return SimplifyResult::SimplifiedTo(zero);
                 }
@@ -722,7 +722,7 @@ impl Binary {
                     let zero = dfg.make_constant(FieldElement::zero(), operand_type);
                     return SimplifyResult::SimplifiedTo(zero);
                 }
-                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
+                if self.lhs == self.rhs {
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }
                 if operand_type == Type::bool() {
@@ -738,7 +738,7 @@ impl Binary {
                 if rhs_is_zero {
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }
-                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
+                if self.lhs == self.rhs {
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }
             }
@@ -749,7 +749,7 @@ impl Binary {
                 if rhs_is_zero {
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }
-                if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
+                if self.lhs == self.rhs {
                     let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                     return SimplifyResult::SimplifiedTo(zero);
                 }

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -300,6 +300,51 @@ impl Instruction {
         }
     }
 
+    /// Mutates each ValueId inside this instruction to a new ValueId using the given mapping function.
+    pub(crate) fn map_values_mut(&mut self, mut f: impl FnMut(ValueId) -> ValueId) {
+        match self {
+            Instruction::Binary(binary) => {
+                binary.lhs = f(binary.lhs);
+                binary.rhs = f(binary.rhs);
+            }
+            Instruction::Cast(value, _) => *value = f(*value),
+            Instruction::Not(value) => *value = f(*value),
+            Instruction::Truncate { value, .. } => {
+                *value = f(*value);
+            }
+            Instruction::Constrain(lhs, rhs) => {
+                *lhs = f(*lhs);
+                *rhs = f(*rhs);
+            }
+            Instruction::Call { func, arguments } => {
+                *func = f(*func);
+                for argument in arguments {
+                    *argument = f(*argument);
+                }
+            }
+            Instruction::Allocate => (),
+            Instruction::Load { address } => {
+                *address = f(*address);
+            }
+            Instruction::Store { address, value } => {
+                *address = f(*address);
+                *value = f(*value);
+            }
+            Instruction::EnableSideEffects { condition } => {
+                *condition = f(*condition);
+            }
+            Instruction::ArrayGet { array, index } => {
+                *array = f(*array);
+                *index = f(*index);
+            }
+            Instruction::ArraySet { array, index, value } => {
+                *array = f(*array);
+                *index = f(*index);
+                *value = f(*value);
+            }
+        }
+    }
+
     /// Applies a function to each input value this instruction holds.
     pub(crate) fn for_each_value<T>(&self, mut f: impl FnMut(ValueId) -> T) {
         match self {

--- a/crates/noirc_evaluator/src/ssa/ir/map.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/map.rs
@@ -149,6 +149,14 @@ impl<T> DenseMap<T> {
         let ids_iter = (0..self.storage.len()).map(|idx| Id::new(idx));
         ids_iter.zip(self.storage.iter())
     }
+
+    /// Gets an iterator to a mutable reference to each element in the dense map paired with its id.
+    ///
+    /// The id-element pairs are ordered by the numeric values of the ids.
+    pub(crate) fn iter_mut(&mut self) -> impl ExactSizeIterator<Item = (Id<T>, &mut T)> {
+        let ids_iter = (0..self.storage.len()).map(|idx| Id::new(idx));
+        ids_iter.zip(self.storage.iter_mut())
+    }
 }
 
 impl<T> Default for DenseMap<T> {

--- a/crates/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/printer.rs
@@ -61,7 +61,6 @@ pub(crate) fn display_block(
 /// constant or a function we print those directly.
 fn value(function: &Function, id: ValueId) -> String {
     use super::value::Value;
-    let id = function.dfg.resolve(id);
     match &function.dfg[id] {
         Value::NumericConstant { constant, typ } => {
             format!("{typ} {constant}")

--- a/crates/noirc_evaluator/src/ssa/opt/array_use.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/array_use.rs
@@ -38,14 +38,12 @@ fn last_use(
     for instruction_id in block.instructions() {
         match &dfg[*instruction_id] {
             Instruction::ArrayGet { array, .. } | Instruction::ArraySet { array, .. } => {
-                let array = dfg.resolve(*array);
-                array_def.insert(array, *instruction_id);
+                array_def.insert(*array, *instruction_id);
             }
             Instruction::Call { arguments, .. } => {
                 for argument in arguments {
-                    let resolved_arg = dfg.resolve(*argument);
-                    if matches!(dfg[resolved_arg], Value::Array { .. }) {
-                        array_def.insert(resolved_arg, *instruction_id);
+                    if matches!(dfg[*argument], Value::Array { .. }) {
+                        array_def.insert(*argument, *instruction_id);
                     }
                 }
             }

--- a/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -1,11 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use iter_extended::vecmap;
-
 use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
-        dfg::InsertInstructionResult,
         function::Function,
         function_inserter::FunctionInserter,
         instruction::{Instruction, InstructionId},
@@ -69,6 +66,8 @@ impl<'f> Context<'f> {
         for instruction_id in instructions {
             self.push_instruction(block, instruction_id, &mut cached_instruction_results);
         }
+
+        self.inserter.map_terminator_in_place(block);
         self.block_queue.extend(self.inserter.function.dfg[block].successors());
     }
 

--- a/crates/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -132,9 +132,11 @@ impl DefunctionalizationContext {
                     // If the value is a static function, transform it to the function id
                     Value::Function(id) => {
                         if !call_target_values.contains(&value_id) {
-                            let new_value =
+                            let _new_value =
                                 func.dfg.make_constant(function_id_to_field(*id), Type::field());
-                            func.dfg.set_value_from_id(value_id, new_value);
+
+                            // func.dfg.set_value_from_id(value_id, new_value);
+                            todo!("defunctionalization now needs to manually go through each instruction")
                         }
                     }
                     // If the value is a function used as value, just change the type of it

--- a/crates/noirc_evaluator/src/ssa/opt/die.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/die.rs
@@ -109,7 +109,6 @@ impl Context {
     /// Inspects a value recursively (as it could be an array) and marks all comprised instruction
     /// results as used.
     fn mark_used_instruction_results(&mut self, dfg: &DataFlowGraph, value_id: ValueId) {
-        let value_id = dfg.resolve(value_id);
         match &dfg[value_id] {
             Value::Instruction { .. } => {
                 self.used_values.insert(value_id);

--- a/crates/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -405,11 +405,10 @@ impl<'function> PerFunctionContext<'function> {
         call_stack.append(self.source_function.dfg.get_call_stack(id));
 
         let results = self.source_function.dfg.instruction_results(id);
-        let results = vecmap(results, |id| self.source_function.dfg.resolve(*id));
 
         let ctrl_typevars = instruction
             .requires_ctrl_typevars()
-            .then(|| vecmap(&results, |result| self.source_function.dfg.type_of_value(*result)));
+            .then(|| vecmap(results, |result| self.source_function.dfg.type_of_value(*result)));
 
         self.context.builder.set_call_stack(call_stack);
 

--- a/crates/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -413,7 +413,7 @@ impl<'function> PerFunctionContext<'function> {
         self.context.builder.set_call_stack(call_stack);
 
         let new_results = self.context.builder.insert_instruction(instruction, ctrl_typevars);
-        Self::insert_new_instruction_results(&mut self.values, &results, new_results);
+        Self::insert_new_instruction_results(&mut self.values, results, new_results);
     }
 
     /// Modify the values HashMap to remember the mapping between an instruction result's previous

--- a/crates/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -124,7 +124,7 @@ fn remove_block_parameters(
         let mut inserter = FunctionInserter::new(function);
 
         for (param, arg) in block_params.into_iter().zip(jump_args) {
-            inserter.map_value(param, arg)
+            inserter.map_value(param, arg);
         }
 
         inserter


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves (none)

## Summary\*

This is another experimental change in the SSA IR. This one is aimed at reducing the surface for bugs by removing `DataFlowGraph::set_value_from_id` and subsequently the need to call `DataFlowGraph::resolve` for each value as well. This has historically been a source of bugs when one forgets to call resolve. Now that the mem2reg no longer relies on `set_value_from_id`, the only passes that still use it are cfg simplification which just needed a small change, and defunctionalization which still needs a larger change.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
