### PR TITLE
chore: remove usage of `Backend` trait

### DIFF
--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -21,20 +21,19 @@ mod smart_contract;
 const FIELD_BYTES: usize = 32;
 
 #[derive(Debug, Default)]
-pub struct Barretenberg;
+pub struct Backend {}
 
-impl Barretenberg {
-    pub fn new() -> Barretenberg {
-        Barretenberg
+impl Backend {
+    pub fn new() -> Backend {
+        Backend {}
     }
 }
 
-impl acvm::Backend for Barretenberg {}
-
 #[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub struct BackendError(#[from] Error);
+pub struct BackendError(String);
 
-#[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, thiserror::Error)]
-enum Error {}
+impl std::fmt::Display for BackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/crates/acvm_backend_barretenberg/src/proof_system.rs
+++ b/crates/acvm_backend_barretenberg/src/proof_system.rs
@@ -9,7 +9,7 @@ use acvm::Language;
 use tempfile::tempdir;
 
 use crate::bb::{GatesCommand, ProveCommand, VerifyCommand, WriteVkCommand};
-use crate::{BackendError, Barretenberg};
+use crate::{Backend, BackendError};
 
 impl Backend {
     pub fn np_language(&self) -> Language {

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -1,1 +1,1 @@
-pub(crate) use acvm_backend_barretenberg::Barretenberg as ConcreteBackend;
+pub(crate) use acvm_backend_barretenberg::Backend;

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -1,5 +1,6 @@
+use crate::backends::Backend;
 use crate::errors::{CliError, CompileError};
-use acvm::Backend;
+
 use clap::Args;
 use iter_extended::btree_map;
 use nargo::{package::Package, prepare_package};
@@ -29,11 +30,11 @@ pub(crate) struct CheckCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<B: Backend>(
-    _backend: &B,
+pub(crate) fn run(
+    _backend: &Backend,
     args: CheckCommand,
     config: NargoConfig,
-) -> Result<(), CliError<B>> {
+) -> Result<(), CliError> {
     let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -1,7 +1,6 @@
 use acvm::acir::circuit::OpcodeLocation;
 use acvm::acir::{circuit::Circuit, native_types::WitnessMap};
 use acvm::pwg::ErrorLocation;
-use acvm::Backend;
 use clap::Args;
 use nargo::constants::PROVER_INPUT_FILE;
 use nargo::package::Package;
@@ -17,6 +16,7 @@ use noirc_frontend::hir::Context;
 use super::compile_cmd::compile_package;
 use super::fs::{inputs::read_inputs_from_file, witness::save_witness_to_dir};
 use super::NargoConfig;
+use crate::backends::Backend;
 use crate::errors::CliError;
 
 /// Executes a circuit to calculate its return value
@@ -41,11 +41,11 @@ pub(crate) struct ExecuteCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<B: Backend>(
-    backend: &B,
+pub(crate) fn run(
+    backend: &Backend,
     args: ExecuteCommand,
     config: NargoConfig,
-) -> Result<(), CliError<B>> {
+) -> Result<(), CliError> {
     let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
@@ -70,12 +70,12 @@ pub(crate) fn run<B: Backend>(
     Ok(())
 }
 
-fn execute_package<B: Backend>(
-    backend: &B,
+fn execute_package(
+    backend: &Backend,
     package: &Package,
     prover_name: &str,
     compile_options: &CompileOptions,
-) -> Result<(Option<InputValue>, WitnessMap), CliError<B>> {
+) -> Result<(Option<InputValue>, WitnessMap), CliError> {
     let (context, compiled_program) = compile_package(backend, package, compile_options)?;
     let CompiledProgram { abi, circuit, debug } = compiled_program;
 
@@ -161,13 +161,13 @@ fn report_error_with_opcode_location(
     }
 }
 
-pub(crate) fn execute_program<B: Backend>(
-    _backend: &B,
+pub(crate) fn execute_program(
+    _backend: &Backend,
     circuit: Circuit,
     abi: &Abi,
     inputs_map: &InputMap,
     debug_data: Option<(DebugInfo, Context)>,
-) -> Result<WitnessMap, CliError<B>> {
+) -> Result<WitnessMap, CliError> {
     #[allow(deprecated)]
     let blackbox_solver = acvm::blackbox_solver::BarretenbergSolver::new();
 

--- a/crates/nargo_cli/src/cli/init_cmd.rs
+++ b/crates/nargo_cli/src/cli/init_cmd.rs
@@ -1,8 +1,8 @@
+use crate::backends::Backend;
 use crate::errors::CliError;
 
 use super::fs::{create_named_dir, write_to_file};
 use super::{NargoConfig, CARGO_PKG_VERSION};
-use acvm::Backend;
 use clap::Args;
 use nargo::constants::{PKG_FILE, SRC_DIR};
 use nargo::package::PackageType;
@@ -62,12 +62,12 @@ fn test_my_util() {
 }
 "#;
 
-pub(crate) fn run<B: Backend>(
+pub(crate) fn run(
     // Backend is currently unused, but we might want to use it to inform the "new" template in the future
-    _backend: &B,
+    _backend: &Backend,
     args: InitCommand,
     config: NargoConfig,
-) -> Result<(), CliError<B>> {
+) -> Result<(), CliError> {
     let package_name = match args.name {
         Some(name) => name,
         None => {

--- a/crates/nargo_cli/src/cli/lsp_cmd.rs
+++ b/crates/nargo_cli/src/cli/lsp_cmd.rs
@@ -1,4 +1,3 @@
-use acvm::Backend;
 use async_lsp::{
     client_monitor::ClientProcessMonitorLayer, concurrency::ConcurrencyLayer,
     panic::CatchUnwindLayer, server::LifecycleLayer, tracing::TracingLayer,
@@ -8,6 +7,7 @@ use noir_lsp::NargoLspService;
 use tower::ServiceBuilder;
 
 use super::NargoConfig;
+use crate::backends::Backend;
 use crate::errors::CliError;
 
 /// Starts the Noir LSP server
@@ -18,12 +18,12 @@ use crate::errors::CliError;
 #[derive(Debug, Clone, Args)]
 pub(crate) struct LspCommand;
 
-pub(crate) fn run<B: Backend>(
+pub(crate) fn run(
     // Backend is currently unused, but we might want to use it to inform the lsp in the future
-    _backend: &B,
+    _backend: &Backend,
     _args: LspCommand,
     _config: NargoConfig,
-) -> Result<(), CliError<B>> {
+) -> Result<(), CliError> {
     use tokio::runtime::Builder;
 
     let runtime = Builder::new_current_thread().enable_all().build().unwrap();

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -74,7 +74,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         config.program_dir = find_package_root(&config.program_dir)?;
     }
 
-    let backend = crate::backends::ConcreteBackend;
+    let backend = crate::backends::Backend::default();
 
     match command {
         NargoCommand::New(args) => new_cmd::run(&backend, args, config),

--- a/crates/nargo_cli/src/cli/new_cmd.rs
+++ b/crates/nargo_cli/src/cli/new_cmd.rs
@@ -1,7 +1,7 @@
+use crate::backends::Backend;
 use crate::errors::CliError;
 
 use super::{init_cmd::initialize_project, NargoConfig};
-use acvm::Backend;
 use clap::Args;
 use nargo::package::PackageType;
 use noirc_frontend::graph::CrateName;
@@ -30,12 +30,12 @@ pub(crate) struct NewCommand {
     pub(crate) contract: bool,
 }
 
-pub(crate) fn run<B: Backend>(
+pub(crate) fn run(
     // Backend is currently unused, but we might want to use it to inform the "new" template in the future
-    _backend: &B,
+    _backend: &Backend,
     args: NewCommand,
     config: NargoConfig,
-) -> Result<(), CliError<B>> {
+) -> Result<(), CliError> {
     let package_dir = config.program_dir.join(&args.path);
 
     if package_dir.exists() {

--- a/crates/nargo_cli/src/cli/test_cmd.rs
+++ b/crates/nargo_cli/src/cli/test_cmd.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use acvm::{Backend, BlackBoxFunctionSolver};
+use acvm::BlackBoxFunctionSolver;
 use clap::Args;
 use nargo::{
     ops::{run_test, TestStatus},
@@ -12,7 +12,7 @@ use noirc_driver::CompileOptions;
 use noirc_frontend::{graph::CrateName, hir::FunctionNameMatch};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use crate::{cli::check_cmd::check_crate_and_report_errors, errors::CliError};
+use crate::{backends::Backend, cli::check_cmd::check_crate_and_report_errors, errors::CliError};
 
 use super::NargoConfig;
 
@@ -42,11 +42,11 @@ pub(crate) struct TestCommand {
     compile_options: CompileOptions,
 }
 
-pub(crate) fn run<B: Backend>(
-    _backend: &B,
+pub(crate) fn run(
+    _backend: &Backend,
     args: TestCommand,
     config: NargoConfig,
-) -> Result<(), CliError<B>> {
+) -> Result<(), CliError> {
     let toml_path = get_package_manifest(&config.program_dir)?;
     let default_selection =
         if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
@@ -75,13 +75,13 @@ pub(crate) fn run<B: Backend>(
     Ok(())
 }
 
-fn run_tests<B: Backend, S: BlackBoxFunctionSolver>(
+fn run_tests<S: BlackBoxFunctionSolver>(
     blackbox_solver: &S,
     package: &Package,
     test_name: FunctionNameMatch,
     show_output: bool,
     compile_options: &CompileOptions,
-) -> Result<(), CliError<B>> {
+) -> Result<(), CliError> {
     let (mut context, crate_id) = prepare_package(package);
     check_crate_and_report_errors(&mut context, crate_id, compile_options.deny_warnings)?;
 

--- a/crates/nargo_cli/src/errors.rs
+++ b/crates/nargo_cli/src/errors.rs
@@ -1,4 +1,5 @@
-use acvm::{acir::native_types::WitnessMapError, Backend, ProofSystemCompiler, SmartContract};
+use acvm::acir::native_types::WitnessMapError;
+use acvm_backend_barretenberg::BackendError;
 use hex::FromHexError;
 use nargo::NargoError;
 use nargo_toml::ManifestError;
@@ -29,7 +30,7 @@ pub(crate) enum FilesystemError {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum CliError<B: Backend> {
+pub(crate) enum CliError {
     #[error("{0}")]
     Generic(String),
     #[error("Error: destination {} already exists", .0.display())]
@@ -64,13 +65,9 @@ pub(crate) enum CliError<B: Backend> {
     #[error(transparent)]
     CompileError(#[from] CompileError),
 
-    /// Backend error caused by a function on the SmartContract trait
+    /// Backend error
     #[error(transparent)]
-    SmartContractError(<B as SmartContract>::Error), // Unfortunately, Rust won't let us `impl From` over an Associated Type on a generic
-
-    /// Backend error caused by a function on the ProofSystemCompiler trait
-    #[error(transparent)]
-    ProofSystemCompilerError(<B as ProofSystemCompiler>::Error), // Unfortunately, Rust won't let us `impl From` over an Associated Type on a generic
+    SmartContractError(#[from] BackendError),
 }
 
 /// Errors covering situations where a package cannot be compiled.


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're planning on removing the `Backend` trait as the backend interface is now being defined through the command line (i.e. the contents of `acvm-backend-barretenberg::bb`). We should then stop conforming to this trait.

This PR replaces the `Barretenberg` struct which implements the `Backend` trait with a `Backend` struct which will be a generic wrapper around the CLI interface which backends will conform to. This can in future hold config information about which backend we're wanting to interact with as we add support for multiple backends.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
