### PR TITLE
chore(ci): Distinguish between expected failures and compiler panics in `compile_failure` tests.

### DIFF
--- a/crates/nargo_cli/build.rs
+++ b/crates/nargo_cli/build.rs
@@ -190,7 +190,7 @@ fn compile_failure_{test_name}() {{
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("execute");
 
-    cmd.assert().failure();
+    cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
 }}
             "#,
             test_dir = test_dir.display(),


### PR DESCRIPTION
## Problem\*

Tests in the compiler_error subdirectory are treated as successful even if they cause the compiler to crash. This patch fixes that.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.