### PR TITLE
chore: fix building through `nix build`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,12 +99,18 @@
       GIT_COMMIT = if (self ? rev) then self.rev else "unknown";
       GIT_DIRTY = if (self ? rev) then "false" else "true";
 
+      # We use `include_str!` macro to embed the solidity verifier template so we need to create a special
+      # source filter to include .sol files in addition to usual rust/cargo source files.
+      solidityFilter = path: _type: builtins.match ".*sol$" path != null;
+      # We use `.bytecode` and `.tr` files to test interactions with `bb` so we add a source filter to include these.
+      bytecodeFilter = path: _type: builtins.match ".*bytecode$" path != null;
+      witnessFilter = path: _type: builtins.match ".*tr$" path != null;
       # We use `.nr` and `.toml` files in tests so we need to create a special source
       # filter to include those files in addition to usual rust/cargo source files
       noirFilter = path: _type: builtins.match ".*nr$" path != null;
       tomlFilter = path: _type: builtins.match ".*toml$" path != null;
       sourceFilter = path: type:
-        (noirFilter path type) || (tomlFilter path type) || (craneLib.filterCargoSources path type);
+        (solidityFilter path type) || (bytecodeFilter path type)|| (witnessFilter path type) || (noirFilter path type) || (tomlFilter path type) || (craneLib.filterCargoSources path type);
 
       # As per https://discourse.nixos.org/t/gcc11stdenv-and-clang/17734/7 since it seems that aarch64-linux uses
       # gcc9 instead of gcc11 for the C++ stdlib, while all other targets we support provide the correct libstdc++


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently fail to build through nix due to being unable to find `contract.sol` in `acvm-backend-barretenberg`. This fixes the build by adding new source filters so that we include the files we need.

The bytecode/witness filters are going to pick up the committed ACIR artifacts as well so we probably want to refine these before merging.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
