### PR TITLE
fix: Initialize structs during def collection, not name resolution

### DIFF
--- a/crates/acvm_backend_barretenberg/src/proof_system.rs
+++ b/crates/acvm_backend_barretenberg/src/proof_system.rs
@@ -76,9 +76,8 @@ impl ProofSystemCompiler for Barretenberg {
         let temp_dir_path_str = temp_directory.to_str().unwrap();
 
         // Create a temporary file for the witness
-        let serialized_witnesses: Vec<u8> = witness_values
-            .try_into()
-            .expect("could not serialize witness map");
+        let serialized_witnesses: Vec<u8> =
+            witness_values.try_into().expect("could not serialize witness map");
         let witness_path = temp_directory.join("witness").with_extension("tr");
         write_to_file(&serialized_witnesses, &witness_path);
 
@@ -232,9 +231,8 @@ fn prepend_public_inputs(proof: Vec<u8>, public_inputs: Vec<FieldElement>) -> Ve
         return proof;
     }
 
-    let public_inputs_bytes = public_inputs
-        .into_iter()
-        .flat_map(|assignment| assignment.to_be_bytes());
+    let public_inputs_bytes =
+        public_inputs.into_iter().flat_map(|assignment| assignment.to_be_bytes());
 
     public_inputs_bytes.chain(proof.into_iter()).collect()
 }

--- a/crates/nargo_cli/tests/execution_success/type_aliases/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/type_aliases/src/main.nr
@@ -26,4 +26,11 @@ fn main(x : [Field; 2]) {
         foo: 10
     };
     assert(s.foo == 10);
+
+    let _regression2502: Regression2502Alias = Regression2502 {};
 }
+
+// An ICE was occurring if a type alias referred to a struct before it was initialized
+// during name resolution. The fix was to initialize structs during def collection instead.
+type Regression2502Alias = Regression2502;
+struct Regression2502 {}

--- a/crates/noirc_frontend/src/hir/mod.rs
+++ b/crates/noirc_frontend/src/hir/mod.rs
@@ -98,7 +98,7 @@ impl Context {
     /// For example, if you project contains a `main.nr` and `foo.nr` and you provide the `main_crate_id` and the
     /// `bar_struct_id` where the `Bar` struct is inside `foo.nr`, this function would return `foo::Bar` as a [String].
     pub fn fully_qualified_struct_path(&self, crate_id: &CrateId, id: StructId) -> String {
-        let module_id = id.0;
+        let module_id = id.module_id();
         let child_id = module_id.local_id.0;
         let def_map =
             self.def_map(&module_id.krate).expect("The local crate should be analyzed already");

--- a/crates/noirc_frontend/src/hir/resolution/import.rs
+++ b/crates/noirc_frontend/src/hir/resolution/import.rs
@@ -151,7 +151,7 @@ fn resolve_name_in_module(
             ModuleDefId::ModuleId(id) => id,
             ModuleDefId::FunctionId(_) => panic!("functions cannot be in the type namespace"),
             // TODO: If impls are ever implemented, types can be used in a path
-            ModuleDefId::TypeId(id) => id.0,
+            ModuleDefId::TypeId(id) => id.module_id(),
             ModuleDefId::TypeAliasId(_) => panic!("type aliases cannot be used in type namespace"),
             ModuleDefId::TraitId(id) => id.0,
             ModuleDefId::GlobalId(_) => panic!("globals cannot be in the type namespace"),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2502

## Summary\*

We now push structs to the node interner a bit earlier so that when aliases refer to them, they will already be initialized. Generally, initializing a global item should be done in the def collector and name resolution should only have to peek into the definition of the item to resolve those. For structs this means the struct name is resolved in def collection and the struct fields should be resolved during name resolution (because they may refer to other structs).

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
