### PR TITLE
chore: Cleanup mem2reg pass

### DIFF
--- a/crates/acvm_backend_barretenberg/src/proof_system.rs
+++ b/crates/acvm_backend_barretenberg/src/proof_system.rs
@@ -76,9 +76,8 @@ impl ProofSystemCompiler for Barretenberg {
         let temp_dir_path_str = temp_directory.to_str().unwrap();
 
         // Create a temporary file for the witness
-        let serialized_witnesses: Vec<u8> = witness_values
-            .try_into()
-            .expect("could not serialize witness map");
+        let serialized_witnesses: Vec<u8> =
+            witness_values.try_into().expect("could not serialize witness map");
         let witness_path = temp_directory.join("witness").with_extension("tr");
         write_to_file(&serialized_witnesses, &witness_path);
 
@@ -232,9 +231,8 @@ fn prepend_public_inputs(proof: Vec<u8>, public_inputs: Vec<FieldElement>) -> Ve
         return proof;
     }
 
-    let public_inputs_bytes = public_inputs
-        .into_iter()
-        .flat_map(|assignment| assignment.to_be_bytes());
+    let public_inputs_bytes =
+        public_inputs.into_iter().flat_map(|assignment| assignment.to_be_bytes());
 
     public_inputs_bytes.chain(proof.into_iter()).collect()
 }

--- a/crates/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -61,10 +61,10 @@
 //! SSA optimization pipeline, although it will be more successful the simpler the program's CFG is.
 //! This pass is currently performed several times to enable other passes - most notably being
 //! performed before loop unrolling to try to allow for mutable variables used for loop indices.
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
-};
+mod alias_set;
+mod block;
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::ssa::{
     ir::{
@@ -80,6 +80,9 @@ use crate::ssa::{
     },
     ssa_gen::Ssa,
 };
+
+use self::alias_set::AliasSet;
+use self::block::{Block, Expression};
 
 impl Ssa {
     /// Attempts to remove any load instructions that recover values that are already available in
@@ -108,56 +111,6 @@ struct PerFunctionContext<'f> {
     /// We avoid removing individual instructions as we go since removing elements
     /// from the middle of Vecs many times will be slower than a single call to `retain`.
     instructions_to_remove: BTreeSet<InstructionId>,
-}
-
-#[derive(Debug, Default, Clone)]
-struct Block {
-    /// Maps a ValueId to the Expression it represents.
-    /// Multiple ValueIds can map to the same Expression, e.g.
-    /// dereferences to the same allocation.
-    expressions: BTreeMap<ValueId, Expression>,
-
-    /// Each expression is tracked as to how many aliases it
-    /// may have. If there is only 1, we can attempt to optimize
-    /// out any known loads to that alias. Note that "alias" here
-    /// includes the original reference as well.
-    aliases: BTreeMap<Expression, AliasSet>,
-
-    /// Each allocate instruction result (and some reference block parameters)
-    /// will map to a Reference value which tracks whether the last value stored
-    /// to the reference is known.
-    references: BTreeMap<ValueId, ReferenceValue>,
-
-    /// The last instance of a `Store` instruction to each address in this block
-    last_stores: BTreeMap<ValueId, InstructionId>,
-}
-
-/// An `Expression` here is used to represent a canonical key
-/// into the aliases map since otherwise two dereferences of the
-/// same address will be given different ValueIds.
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
-enum Expression {
-    Dereference(Box<Expression>),
-    ArrayElement(Box<Expression>),
-    Other(ValueId),
-}
-
-/// Every reference's value is either Known and can be optimized away, or Unknown.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum ReferenceValue {
-    Unknown,
-    Known(ValueId),
-}
-
-/// A set of possible aliases. Each ValueId in this set represents one possible value the reference
-/// holding this AliasSet may be aliased to. This struct wrapper is provided so that when we take
-/// the union of multiple alias sets, the result should be empty if any individual set is empty.
-///
-/// Note that we distinguish between "definitely has no aliases" - `Some(BTreeSet::new())`, and
-/// "unknown which aliases this may refer to" - `None`.
-#[derive(Debug, Default, Clone)]
-struct AliasSet {
-    aliases: Option<BTreeSet<ValueId>>,
 }
 
 impl<'f> PerFunctionContext<'f> {
@@ -441,249 +394,6 @@ impl<'f> PerFunctionContext<'f> {
                 // than setting them all to ReferenceValue::Unknown since no other block should
                 // have a block with a Return terminator as a predecessor anyway.
                 self.mark_all_unknown(return_values, references);
-            }
-        }
-    }
-}
-
-impl Block {
-    /// If the given reference id points to a known value, return the value
-    fn get_known_value(&self, address: ValueId) -> Option<ValueId> {
-        if let Some(expression) = self.expressions.get(&address) {
-            if let Some(aliases) = self.aliases.get(expression) {
-                // We could allow multiple aliases if we check that the reference
-                // value in each is equal.
-                if let Some(alias) = aliases.single_alias() {
-                    if let Some(ReferenceValue::Known(value)) = self.references.get(&alias) {
-                        return Some(*value);
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    /// If the given address is known, set its value to `ReferenceValue::Known(value)`.
-    fn set_known_value(&mut self, address: ValueId, value: ValueId) {
-        self.set_value(address, ReferenceValue::Known(value));
-    }
-
-    fn set_unknown(&mut self, address: ValueId) {
-        self.set_value(address, ReferenceValue::Unknown);
-    }
-
-    fn set_value(&mut self, address: ValueId, value: ReferenceValue) {
-        let expression = self.expressions.entry(address).or_insert(Expression::Other(address));
-        let aliases = self.aliases.entry(expression.clone()).or_default();
-
-        if aliases.is_unknown() {
-            // uh-oh, we don't know at all what this reference refers to, could be anything.
-            // Now we have to invalidate every reference we know of
-            self.invalidate_all_references();
-        } else if let Some(alias) = aliases.single_alias() {
-            self.references.insert(alias, value);
-        } else {
-            // More than one alias. We're not sure which it refers to so we have to
-            // conservatively invalidate all references it may refer to.
-            aliases.for_each(|alias| {
-                if let Some(reference_value) = self.references.get_mut(&alias) {
-                    *reference_value = ReferenceValue::Unknown;
-                }
-            });
-        }
-    }
-
-    fn invalidate_all_references(&mut self) {
-        for reference_value in self.references.values_mut() {
-            *reference_value = ReferenceValue::Unknown;
-        }
-
-        self.last_stores.clear();
-    }
-
-    fn unify(mut self, other: &Self) -> Self {
-        for (value_id, expression) in &other.expressions {
-            if let Some(existing) = self.expressions.get(value_id) {
-                assert_eq!(existing, expression, "Expected expressions for {value_id} to be equal");
-            } else {
-                self.expressions.insert(*value_id, expression.clone());
-            }
-        }
-
-        for (expression, new_aliases) in &other.aliases {
-            let expression = expression.clone();
-
-            self.aliases
-                .entry(expression)
-                .and_modify(|aliases| aliases.unify(new_aliases))
-                .or_insert_with(|| new_aliases.clone());
-        }
-
-        // Keep only the references present in both maps.
-        let mut intersection = BTreeMap::new();
-        for (value_id, reference) in &other.references {
-            if let Some(existing) = self.references.get(value_id) {
-                intersection.insert(*value_id, existing.unify(*reference));
-            }
-        }
-        self.references = intersection;
-
-        self
-    }
-
-    /// Remember that `result` is the result of dereferencing `address`. This is important to
-    /// track aliasing when references are stored within other references.
-    fn remember_dereference(&mut self, function: &Function, address: ValueId, result: ValueId) {
-        if function.dfg.value_is_reference(result) {
-            if let Some(known_address) = self.get_known_value(address) {
-                self.expressions.insert(result, Expression::Other(known_address));
-            } else {
-                let expression = Expression::Dereference(Box::new(Expression::Other(address)));
-                self.expressions.insert(result, expression);
-                // No known aliases to insert for this expression... can we find an alias
-                // even if we don't have a known address? If not we'll have to invalidate all
-                // known references if this reference is ever stored to.
-            }
-        }
-    }
-
-    /// Iterate through each known alias of the given address and apply the function `f` to each.
-    fn for_each_alias_of<T>(
-        &mut self,
-        address: ValueId,
-        mut f: impl FnMut(&mut Self, ValueId) -> T,
-    ) {
-        if let Some(expr) = self.expressions.get(&address) {
-            if let Some(aliases) = self.aliases.get(expr).cloned() {
-                aliases.for_each(|alias| {
-                    f(self, alias);
-                });
-            }
-        }
-    }
-
-    fn keep_last_stores_for(&mut self, address: ValueId, function: &Function) {
-        let address = function.dfg.resolve(address);
-        self.keep_last_store(address, function);
-        self.for_each_alias_of(address, |t, alias| t.keep_last_store(alias, function));
-    }
-
-    fn keep_last_store(&mut self, address: ValueId, function: &Function) {
-        let address = function.dfg.resolve(address);
-
-        if let Some(instruction) = self.last_stores.remove(&address) {
-            // Whenever we decide we want to keep a store instruction, we also need
-            // to go through its stored value and mark that used as well.
-            match &function.dfg[instruction] {
-                Instruction::Store { value, .. } => {
-                    self.mark_value_used(*value, function);
-                }
-                other => {
-                    unreachable!("last_store held an id of a non-store instruction: {other:?}")
-                }
-            }
-        }
-    }
-
-    fn mark_value_used(&mut self, value: ValueId, function: &Function) {
-        self.keep_last_stores_for(value, function);
-
-        // We must do a recursive check for arrays since they're the only Values which may contain
-        // other ValueIds.
-        if let Some((array, _)) = function.dfg.get_array_constant(value) {
-            for value in array {
-                self.mark_value_used(value, function);
-            }
-        }
-    }
-
-    /// Collect all aliases used by the given value list
-    fn collect_all_aliases(&self, values: impl IntoIterator<Item = ValueId>) -> AliasSet {
-        let mut aliases = AliasSet::known_empty();
-        for value in values {
-            aliases.unify(&self.get_aliases_for_value(value));
-        }
-        aliases
-    }
-
-    fn get_aliases_for_value(&self, value: ValueId) -> Cow<AliasSet> {
-        if let Some(expression) = self.expressions.get(&value) {
-            if let Some(aliases) = self.aliases.get(expression) {
-                return Cow::Borrowed(aliases);
-            }
-        }
-
-        Cow::Owned(AliasSet::unknown())
-    }
-}
-
-impl ReferenceValue {
-    fn unify(self, other: Self) -> Self {
-        if self == other {
-            self
-        } else {
-            ReferenceValue::Unknown
-        }
-    }
-}
-
-impl AliasSet {
-    fn unknown() -> AliasSet {
-        Self { aliases: None }
-    }
-
-    fn known(value: ValueId) -> AliasSet {
-        let mut aliases = BTreeSet::new();
-        aliases.insert(value);
-        Self { aliases: Some(aliases) }
-    }
-
-    /// In rare cases, such as when creating an empty array of references, the set of aliases for a
-    /// particular value will be known to be zero, which is distinct from being unknown and
-    /// possibly referring to any alias.
-    fn known_empty() -> AliasSet {
-        Self { aliases: Some(BTreeSet::new()) }
-    }
-
-    fn is_unknown(&self) -> bool {
-        self.aliases.is_none()
-    }
-
-    /// Return the single known alias if there is exactly one.
-    /// Otherwise, return None.
-    fn single_alias(&self) -> Option<ValueId> {
-        self.aliases
-            .as_ref()
-            .and_then(|aliases| (aliases.len() == 1).then(|| *aliases.first().unwrap()))
-    }
-
-    /// Unify this alias set with another. The result of this set is empty if either set is empty.
-    /// Otherwise, it is the union of both alias sets.
-    fn unify(&mut self, other: &Self) {
-        if let (Some(self_aliases), Some(other_aliases)) = (&mut self.aliases, &other.aliases) {
-            self_aliases.extend(other_aliases);
-        } else {
-            self.aliases = None;
-        }
-    }
-
-    /// Inserts a new alias into this set if it is not unknown
-    fn insert(&mut self, new_alias: ValueId) {
-        if let Some(aliases) = &mut self.aliases {
-            aliases.insert(new_alias);
-        }
-    }
-
-    /// Returns `Some(true)` if `f` returns true for any known alias in this set.
-    /// If this alias set is unknown, None is returned.
-    fn any(&self, f: impl FnMut(ValueId) -> bool) -> Option<bool> {
-        self.aliases.as_ref().map(|aliases| aliases.iter().copied().any(f))
-    }
-
-    fn for_each(&self, mut f: impl FnMut(ValueId)) {
-        if let Some(aliases) = &self.aliases {
-            for alias in aliases {
-                f(*alias);
             }
         }
     }

--- a/crates/noirc_evaluator/src/ssa/opt/mem2reg/alias_set.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/mem2reg/alias_set.rs
@@ -1,0 +1,76 @@
+use std::collections::BTreeSet;
+
+use crate::ssa::ir::value::ValueId;
+
+/// A set of possible aliases. Each ValueId in this set represents one possible value the reference
+/// holding this AliasSet may be aliased to. This struct wrapper is provided so that when we take
+/// the union of multiple alias sets, the result should be empty if any individual set is empty.
+///
+/// Note that we distinguish between "definitely has no aliases" - `Some(BTreeSet::new())`, and
+/// "unknown which aliases this may refer to" - `None`.
+#[derive(Debug, Default, Clone)]
+pub(super) struct AliasSet {
+    aliases: Option<BTreeSet<ValueId>>,
+}
+
+impl AliasSet {
+    pub(super) fn unknown() -> AliasSet {
+        Self { aliases: None }
+    }
+
+    pub(super) fn known(value: ValueId) -> AliasSet {
+        let mut aliases = BTreeSet::new();
+        aliases.insert(value);
+        Self { aliases: Some(aliases) }
+    }
+
+    /// In rare cases, such as when creating an empty array of references, the set of aliases for a
+    /// particular value will be known to be zero, which is distinct from being unknown and
+    /// possibly referring to any alias.
+    pub(super) fn known_empty() -> AliasSet {
+        Self { aliases: Some(BTreeSet::new()) }
+    }
+
+    pub(super) fn is_unknown(&self) -> bool {
+        self.aliases.is_none()
+    }
+
+    /// Return the single known alias if there is exactly one.
+    /// Otherwise, return None.
+    pub(super) fn single_alias(&self) -> Option<ValueId> {
+        self.aliases
+            .as_ref()
+            .and_then(|aliases| (aliases.len() == 1).then(|| *aliases.first().unwrap()))
+    }
+
+    /// Unify this alias set with another. The result of this set is empty if either set is empty.
+    /// Otherwise, it is the union of both alias sets.
+    pub(super) fn unify(&mut self, other: &Self) {
+        if let (Some(self_aliases), Some(other_aliases)) = (&mut self.aliases, &other.aliases) {
+            self_aliases.extend(other_aliases);
+        } else {
+            self.aliases = None;
+        }
+    }
+
+    /// Inserts a new alias into this set if it is not unknown
+    pub(super) fn insert(&mut self, new_alias: ValueId) {
+        if let Some(aliases) = &mut self.aliases {
+            aliases.insert(new_alias);
+        }
+    }
+
+    /// Returns `Some(true)` if `f` returns true for any known alias in this set.
+    /// If this alias set is unknown, None is returned.
+    pub(super) fn any(&self, f: impl FnMut(ValueId) -> bool) -> Option<bool> {
+        self.aliases.as_ref().map(|aliases| aliases.iter().copied().any(f))
+    }
+
+    pub(super) fn for_each(&self, mut f: impl FnMut(ValueId)) {
+        if let Some(aliases) = &self.aliases {
+            for alias in aliases {
+                f(*alias);
+            }
+        }
+    }
+}

--- a/crates/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -1,0 +1,243 @@
+use std::{borrow::Cow, collections::BTreeMap};
+
+use crate::ssa::ir::{
+    function::Function,
+    instruction::{Instruction, InstructionId},
+    value::ValueId,
+};
+
+use super::alias_set::AliasSet;
+
+/// A `Block` acts as a per-block context for the mem2reg pass.
+/// Most notably, it contains the current alias set thought to track each
+/// reference value if known, and it contains the expected ReferenceValue
+/// for each ValueId. When a block is finished, the final values of these
+/// are expected to match the values held by each ValueId at the very end
+/// of a block.
+#[derive(Debug, Default, Clone)]
+pub(super) struct Block {
+    /// Maps a ValueId to the Expression it represents.
+    /// Multiple ValueIds can map to the same Expression, e.g.
+    /// dereferences to the same allocation.
+    pub(super) expressions: BTreeMap<ValueId, Expression>,
+
+    /// Each expression is tracked as to how many aliases it
+    /// may have. If there is only 1, we can attempt to optimize
+    /// out any known loads to that alias. Note that "alias" here
+    /// includes the original reference as well.
+    pub(super) aliases: BTreeMap<Expression, AliasSet>,
+
+    /// Each allocate instruction result (and some reference block parameters)
+    /// will map to a Reference value which tracks whether the last value stored
+    /// to the reference is known.
+    pub(super) references: BTreeMap<ValueId, ReferenceValue>,
+
+    /// The last instance of a `Store` instruction to each address in this block
+    pub(super) last_stores: BTreeMap<ValueId, InstructionId>,
+}
+
+/// An `Expression` here is used to represent a canonical key
+/// into the aliases map since otherwise two dereferences of the
+/// same address will be given different ValueIds.
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub(super) enum Expression {
+    Dereference(Box<Expression>),
+    ArrayElement(Box<Expression>),
+    Other(ValueId),
+}
+
+/// Every reference's value is either Known and can be optimized away, or Unknown.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum ReferenceValue {
+    Unknown,
+    Known(ValueId),
+}
+
+impl ReferenceValue {
+    fn unify(self, other: Self) -> Self {
+        if self == other {
+            self
+        } else {
+            ReferenceValue::Unknown
+        }
+    }
+}
+
+impl Block {
+    /// If the given reference id points to a known value, return the value
+    pub(super) fn get_known_value(&self, address: ValueId) -> Option<ValueId> {
+        if let Some(expression) = self.expressions.get(&address) {
+            if let Some(aliases) = self.aliases.get(expression) {
+                // We could allow multiple aliases if we check that the reference
+                // value in each is equal.
+                if let Some(alias) = aliases.single_alias() {
+                    if let Some(ReferenceValue::Known(value)) = self.references.get(&alias) {
+                        return Some(*value);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// If the given address is known, set its value to `ReferenceValue::Known(value)`.
+    pub(super) fn set_known_value(&mut self, address: ValueId, value: ValueId) {
+        self.set_value(address, ReferenceValue::Known(value));
+    }
+
+    pub(super) fn set_unknown(&mut self, address: ValueId) {
+        self.set_value(address, ReferenceValue::Unknown);
+    }
+
+    fn set_value(&mut self, address: ValueId, value: ReferenceValue) {
+        let expression = self.expressions.entry(address).or_insert(Expression::Other(address));
+        let aliases = self.aliases.entry(expression.clone()).or_default();
+
+        if aliases.is_unknown() {
+            // uh-oh, we don't know at all what this reference refers to, could be anything.
+            // Now we have to invalidate every reference we know of
+            self.invalidate_all_references();
+        } else if let Some(alias) = aliases.single_alias() {
+            self.references.insert(alias, value);
+        } else {
+            // More than one alias. We're not sure which it refers to so we have to
+            // conservatively invalidate all references it may refer to.
+            aliases.for_each(|alias| {
+                if let Some(reference_value) = self.references.get_mut(&alias) {
+                    *reference_value = ReferenceValue::Unknown;
+                }
+            });
+        }
+    }
+
+    fn invalidate_all_references(&mut self) {
+        for reference_value in self.references.values_mut() {
+            *reference_value = ReferenceValue::Unknown;
+        }
+
+        self.last_stores.clear();
+    }
+
+    pub(super) fn unify(mut self, other: &Self) -> Self {
+        for (value_id, expression) in &other.expressions {
+            if let Some(existing) = self.expressions.get(value_id) {
+                assert_eq!(existing, expression, "Expected expressions for {value_id} to be equal");
+            } else {
+                self.expressions.insert(*value_id, expression.clone());
+            }
+        }
+
+        for (expression, new_aliases) in &other.aliases {
+            let expression = expression.clone();
+
+            self.aliases
+                .entry(expression)
+                .and_modify(|aliases| aliases.unify(new_aliases))
+                .or_insert_with(|| new_aliases.clone());
+        }
+
+        // Keep only the references present in both maps.
+        let mut intersection = BTreeMap::new();
+        for (value_id, reference) in &other.references {
+            if let Some(existing) = self.references.get(value_id) {
+                intersection.insert(*value_id, existing.unify(*reference));
+            }
+        }
+        self.references = intersection;
+
+        self
+    }
+
+    /// Remember that `result` is the result of dereferencing `address`. This is important to
+    /// track aliasing when references are stored within other references.
+    pub(super) fn remember_dereference(
+        &mut self,
+        function: &Function,
+        address: ValueId,
+        result: ValueId,
+    ) {
+        if function.dfg.value_is_reference(result) {
+            if let Some(known_address) = self.get_known_value(address) {
+                self.expressions.insert(result, Expression::Other(known_address));
+            } else {
+                let expression = Expression::Dereference(Box::new(Expression::Other(address)));
+                self.expressions.insert(result, expression);
+                // No known aliases to insert for this expression... can we find an alias
+                // even if we don't have a known address? If not we'll have to invalidate all
+                // known references if this reference is ever stored to.
+            }
+        }
+    }
+
+    /// Iterate through each known alias of the given address and apply the function `f` to each.
+    fn for_each_alias_of<T>(
+        &mut self,
+        address: ValueId,
+        mut f: impl FnMut(&mut Self, ValueId) -> T,
+    ) {
+        if let Some(expr) = self.expressions.get(&address) {
+            if let Some(aliases) = self.aliases.get(expr).cloned() {
+                aliases.for_each(|alias| {
+                    f(self, alias);
+                });
+            }
+        }
+    }
+
+    fn keep_last_stores_for(&mut self, address: ValueId, function: &Function) {
+        let address = function.dfg.resolve(address);
+        self.keep_last_store(address, function);
+        self.for_each_alias_of(address, |t, alias| t.keep_last_store(alias, function));
+    }
+
+    fn keep_last_store(&mut self, address: ValueId, function: &Function) {
+        let address = function.dfg.resolve(address);
+
+        if let Some(instruction) = self.last_stores.remove(&address) {
+            // Whenever we decide we want to keep a store instruction, we also need
+            // to go through its stored value and mark that used as well.
+            match &function.dfg[instruction] {
+                Instruction::Store { value, .. } => {
+                    self.mark_value_used(*value, function);
+                }
+                other => {
+                    unreachable!("last_store held an id of a non-store instruction: {other:?}")
+                }
+            }
+        }
+    }
+
+    pub(super) fn mark_value_used(&mut self, value: ValueId, function: &Function) {
+        self.keep_last_stores_for(value, function);
+
+        // We must do a recursive check for arrays since they're the only Values which may contain
+        // other ValueIds.
+        if let Some((array, _)) = function.dfg.get_array_constant(value) {
+            for value in array {
+                self.mark_value_used(value, function);
+            }
+        }
+    }
+
+    /// Collect all aliases used by the given value list
+    pub(super) fn collect_all_aliases(
+        &self,
+        values: impl IntoIterator<Item = ValueId>,
+    ) -> AliasSet {
+        let mut aliases = AliasSet::known_empty();
+        for value in values {
+            aliases.unify(&self.get_aliases_for_value(value));
+        }
+        aliases
+    }
+
+    pub(super) fn get_aliases_for_value(&self, value: ValueId) -> Cow<AliasSet> {
+        if let Some(expression) = self.expressions.get(&value) {
+            if let Some(aliases) = self.aliases.get(expression) {
+                return Cow::Borrowed(aliases);
+            }
+        }
+
+        Cow::Owned(AliasSet::unknown())
+    }
+}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Cleans up the mem2reg pass a bit by adding a wrapper type for `AliasSet`s and putting types in different modules.

Compared to the old `BTreeMap<ValueId, ReferenceValue>`, the new `AliasSet` makes it harder to accidentally handle unifying zero values as a set union (`A U {} = A`) instead of the correct `A U {} = {}`. In addition, it turns out an original assumption that a value will never be known to have exactly 0 aliases was incorrect. This can happen if we have an empty array of references. The array is empty, so although it has reference-typed elements, we know it does not actually alias anything at all. This means alias sets can no longer use an empty btree to represent the unknown case. It is now represented as an `Option<BTreeMap<...>>` internally instead.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

I was working on some other PRs including #2494 and an addition to handle SlicePushBack and friends, and found it useful to break out this change into another PR.

I'm also unable to run `cargo t` currently (see slack) as I'm getting base64 errors, so I've no idea if this PR is passing or not.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
