### PR TITLE
feat(lsp): Add nargo capabilities for test metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,6 +2270,7 @@ dependencies = [
  "noirc_driver",
  "noirc_errors",
  "noirc_frontend",
+ "serde",
  "serde_json",
  "tokio",
  "toml",

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -18,6 +18,7 @@ nargo_toml.workspace = true
 noirc_driver.workspace = true
 noirc_errors.workspace = true
 noirc_frontend.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 tower.workspace = true

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -207,12 +207,12 @@ fn on_test_run_request(
                 return future::ready(Ok(result));
             };
 
-            let test_funcs = context.get_all_test_functions_in_crate_matching(
+            let test_functions = context.get_all_test_functions_in_crate_matching(
                 &crate_id,
                 FunctionNameMatch::Exact(function_name),
             );
 
-            match test_funcs.into_iter().next() {
+            match test_functions.into_iter().next() {
                 Some((_, test_function)) => {
                     #[allow(deprecated)]
                     let blackbox_solver = acvm::blackbox_solver::BarretenbergSolver::new();

--- a/tooling/lsp/src/types.rs
+++ b/tooling/lsp/src/types.rs
@@ -117,15 +117,18 @@ pub(crate) struct InitializeResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
-pub(crate) struct NargoTestId(CrateName, String);
+pub(crate) struct NargoTestId {
+    package: CrateName,
+    fully_qualified_path: String,
+}
 
 impl TryFrom<String> for NargoTestId {
     type Error = String;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        if let Some((crate_name, func_name)) = value.split_once('/') {
+        if let Some((crate_name, function_name)) = value.split_once('/') {
             let crate_name = crate_name.parse()?;
-            Ok(Self(crate_name, func_name.to_string()))
+            Ok(Self { package: crate_name, fully_qualified_path: function_name.to_string() })
         } else {
             Err("NargoTestId should be serialized as package_name/fully_qualified_path".to_string())
         }
@@ -134,21 +137,21 @@ impl TryFrom<String> for NargoTestId {
 
 impl From<NargoTestId> for String {
     fn from(value: NargoTestId) -> Self {
-        format!("{}/{}", value.0, value.1)
+        format!("{}/{}", value.package, value.fully_qualified_path)
     }
 }
 
 impl NargoTestId {
-    pub(crate) fn new(crate_name: CrateName, func_name: String) -> Self {
-        Self(crate_name, func_name)
+    pub(crate) fn new(crate_name: CrateName, function_name: String) -> Self {
+        Self { package: crate_name, fully_qualified_path: function_name }
     }
 
     pub(crate) fn crate_name(&self) -> &CrateName {
-        &self.0
+        &self.package
     }
 
     pub(crate) fn function_name(&self) -> &String {
-        &self.1
+        &self.fully_qualified_path
     }
 }
 

--- a/tooling/lsp/src/types.rs
+++ b/tooling/lsp/src/types.rs
@@ -1,0 +1,187 @@
+use noirc_frontend::graph::CrateName;
+use serde::{Deserialize, Serialize};
+
+// Re-providing lsp_types that we don't need to override
+pub(crate) use lsp_types::{
+    CodeLens, CodeLensOptions, CodeLensParams, Command, Diagnostic, DiagnosticSeverity,
+    DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, InitializeParams, InitializedParams,
+    LogMessageParams, MessageType, Position, PublishDiagnosticsParams, Range, ServerInfo,
+    TextDocumentSyncCapability, TextDocumentSyncOptions, Url,
+};
+
+pub(crate) mod request {
+    use lsp_types::{request::Request, InitializeParams};
+
+    use super::{
+        InitializeResult, NargoTestRunParams, NargoTestRunResult, NargoTestsParams,
+        NargoTestsResult,
+    };
+
+    // Re-providing lsp_types that we don't need to override
+    pub(crate) use lsp_types::request::{CodeLensRequest as CodeLens, Shutdown};
+
+    #[derive(Debug)]
+    pub(crate) struct Initialize;
+    impl Request for Initialize {
+        type Params = InitializeParams;
+        type Result = InitializeResult;
+        const METHOD: &'static str = "initialize";
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct NargoTestRun;
+    impl Request for NargoTestRun {
+        type Params = NargoTestRunParams;
+        type Result = NargoTestRunResult;
+        const METHOD: &'static str = "nargo/tests/run";
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct NargoTests;
+    impl Request for NargoTests {
+        type Params = NargoTestsParams;
+        type Result = NargoTestsResult;
+        const METHOD: &'static str = "nargo/tests";
+    }
+}
+
+pub(crate) mod notification {
+    use lsp_types::notification::Notification;
+
+    use super::NargoPackageTests;
+
+    // Re-providing lsp_types that we don't need to override
+    pub(crate) use lsp_types::notification::{
+        DidChangeConfiguration, DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument,
+        DidSaveTextDocument, Exit, Initialized,
+    };
+
+    pub(crate) struct NargoUpdateTests;
+    impl Notification for NargoUpdateTests {
+        type Params = NargoPackageTests;
+        const METHOD: &'static str = "nargo/tests/update";
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NargoTestsOptions {
+    /// Tests can be requested from the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fetch: Option<bool>,
+
+    /// Tests runs can be requested from the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) run: Option<bool>,
+
+    /// The server will send notifications to update tests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) update: Option<bool>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NargoCapability {
+    /// The server will provide various features related to testing within Nargo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tests: Option<NargoTestsOptions>,
+}
+
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ServerCapabilities {
+    /// Defines how text documents are synced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) text_document_sync: Option<TextDocumentSyncCapability>,
+
+    /// The server provides code lens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) code_lens_provider: Option<CodeLensOptions>,
+
+    /// The server handles and provides custom nargo messages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) nargo: Option<NargoCapability>,
+}
+
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InitializeResult {
+    /// The capabilities the language server provides.
+    pub(crate) capabilities: ServerCapabilities,
+
+    /// Information about the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) server_info: Option<ServerInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub(crate) struct NargoTestId(CrateName, String);
+
+impl TryFrom<String> for NargoTestId {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if let Some((crate_name, func_name)) = value.split_once('/') {
+            let crate_name = crate_name.parse()?;
+            Ok(Self(crate_name, func_name.to_string()))
+        } else {
+            Err("NargoTestId should be serialized as package_name/fully_qualified_path".to_string())
+        }
+    }
+}
+
+impl From<NargoTestId> for String {
+    fn from(value: NargoTestId) -> Self {
+        format!("{}/{}", value.0, value.1)
+    }
+}
+
+impl NargoTestId {
+    pub(crate) fn new(crate_name: CrateName, func_name: String) -> Self {
+        Self(crate_name, func_name)
+    }
+
+    pub(crate) fn crate_name(&self) -> &CrateName {
+        &self.0
+    }
+
+    pub(crate) fn function_name(&self) -> &String {
+        &self.1
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct NargoTest {
+    pub(crate) id: NargoTestId,
+    /// Fully-qualified path to the test within the crate
+    pub(crate) label: String,
+    pub(crate) range: Range,
+    pub(crate) uri: Url,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct NargoPackageTests {
+    pub(crate) package: String,
+    pub(crate) tests: Vec<NargoTest>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct NargoTestsParams {}
+
+pub(crate) type NargoTestsResult = Option<Vec<NargoPackageTests>>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct NargoTestRunParams {
+    pub(crate) id: NargoTestId,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct NargoTestRunResult {
+    pub(crate) id: NargoTestId,
+    pub(crate) result: String,
+    pub(crate) message: Option<String>,
+}
+
+pub(crate) type CodeLensResult = Option<Vec<CodeLens>>;


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2442 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This reworks types for the LSP to allow us to send back custom capabilities, such as
```json
{
    "capabilities": {
        "codeLensProvider": {
            "resolveProvider": false
        },
        "nargo": {
            "tests": {
                "fetch": true,
                "run": true,
                "update": true
            }
        },
        "textDocumentSync": {
            "save": true
        }
    }
}
```

This also adds support for requesting metadata about tests, asking the LSP to run a test, and notifications for updating tests upon file save. These custom capabilities are in service of the Test Panel in vscode, but other LSP clients can decide not to implement them if they don't have testing APIs like vscode.

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

It's probably worth documenting the new UI elements that will be added to the vscode extension. I'll be including screenshots in the related PR that will be linked to this.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
