### PR TITLE
chore: refactor integration test codegen

### DIFF
--- a/crates/nargo_cli/build.rs
+++ b/crates/nargo_cli/build.rs
@@ -41,10 +41,11 @@ fn main() {
     };
     let test_dir = manifest_dir.join("tests");
 
-    let generate_execution_success_code: Box<TestCodeGenerator> = Box::new(|test_file, test_dir, test_name| {
-        write!(
-            test_file,
-            r#"
+    let generate_execution_success_code: Box<TestCodeGenerator> =
+        Box::new(|test_file, test_dir, test_name| {
+            write!(
+                test_file,
+                r#"
 #[test]
 fn execution_success_{test_name}() {{
     let test_program_dir = PathBuf::from("{test_dir}");
@@ -56,15 +57,16 @@ fn execution_success_{test_name}() {{
     cmd.assert().success();
 }}
             "#,
-            test_dir = test_dir.display(),
-        )
-        .expect("Could not write templated test file.");
-    });
+                test_dir = test_dir.display(),
+            )
+            .expect("Could not write templated test file.");
+        });
 
-    let generate_compile_success_empty_code: Box<TestCodeGenerator> = Box::new(|test_file, test_dir, test_name| {
-        write!(
-            test_file,
-            r#"
+    let generate_compile_success_empty_code: Box<TestCodeGenerator> =
+        Box::new(|test_file, test_dir, test_name| {
+            write!(
+                test_file,
+                r#"
 #[test]
 fn compile_success_empty_{test_name}() {{
     let test_program_dir = PathBuf::from("{test_dir}");
@@ -82,15 +84,16 @@ fn compile_success_empty_{test_name}() {{
         .and(predicate::str::contains("| 0            |")));
 }}
             "#,
-            test_dir = test_dir.display(),
-        )
-        .expect("Could not write templated test file.");
-    });
+                test_dir = test_dir.display(),
+            )
+            .expect("Could not write templated test file.");
+        });
 
-    let generate_compile_success_contract_code: Box<TestCodeGenerator> = Box::new(|test_file, test_dir, test_name| {
-        write!(
-            test_file,
-            r#"
+    let generate_compile_success_contract_code: Box<TestCodeGenerator> =
+        Box::new(|test_file, test_dir, test_name| {
+            write!(
+                test_file,
+                r#"
 #[test]
 fn compile_success_contract_{test_name}() {{
     let test_program_dir = PathBuf::from("{test_dir}");
@@ -102,13 +105,14 @@ fn compile_success_contract_{test_name}() {{
     cmd.assert().success();
 }}
             "#,
-            test_dir = test_dir.display(),
-        )
-        .expect("Could not write templated test file.");
-    });
+                test_dir = test_dir.display(),
+            )
+            .expect("Could not write templated test file.");
+        });
 
-    let generate_compile_failure_code: Box<TestCodeGenerator> = Box::new(|test_file, test_dir, test_name| {
-        write!(
+    let generate_compile_failure_code: Box<TestCodeGenerator> = Box::new(
+        |test_file, test_dir, test_name| {
+            write!(
             test_file,
             r#"
 #[test]
@@ -125,15 +129,36 @@ fn compile_failure_{test_name}() {{
             test_dir = test_dir.display(),
         )
         .expect("Could not write templated test file.");
-    });
+        },
+    );
 
-    generate_tests(&mut test_file, &test_dir, "execution_success", &*generate_execution_success_code);
-    generate_tests(&mut test_file, &test_dir, "compile_success_empty", &*generate_compile_success_empty_code);
-    generate_tests(&mut test_file, &test_dir, "compile_success_contract", &*generate_compile_success_contract_code);
+    generate_tests(
+        &mut test_file,
+        &test_dir,
+        "execution_success",
+        &*generate_execution_success_code,
+    );
+    generate_tests(
+        &mut test_file,
+        &test_dir,
+        "compile_success_empty",
+        &*generate_compile_success_empty_code,
+    );
+    generate_tests(
+        &mut test_file,
+        &test_dir,
+        "compile_success_contract",
+        &*generate_compile_success_contract_code,
+    );
     generate_tests(&mut test_file, &test_dir, "compile_failure", &*generate_compile_failure_code);
 }
 
-fn generate_tests(test_file: &mut File, test_data_dir: &Path, test_sub_dir: &str, generate_code: &TestCodeGenerator) {
+fn generate_tests(
+    test_file: &mut File,
+    test_data_dir: &Path,
+    test_sub_dir: &str,
+    generate_code: &TestCodeGenerator,
+) {
     let test_data_dir = test_data_dir.join(test_sub_dir);
 
     let test_case_dirs =


### PR DESCRIPTION
# Description

Refactors the integration test codegen

## Problem

This file had duplicate code

Resolves #2337

## Summary

I pass the template in as a closure into a single function that handles all of the cases

## Documentation

no documentation needed 

# PR Checklist

- [✅ ] I have tested the changes locally.
- [✅] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings. 

I am testing using `cd crates/nargo_cli && cargo tests`

I have set up my dev environment using `allow direnv`, but it looks like I am failing a good bit of the tests. Do you think their might be something wrong with my development environment or are my changes causing these failures? 
<img width="631" alt="Screenshot 2023-09-04 at 3 04 42 PM" src="https://github.com/noir-lang/noir/assets/106350168/4fc185fb-3f70-49ef-af62-a4b368cba4e7">

It seems like they are failing because because of this error:
<img width="970" alt="Screenshot 2023-09-04 at 3 06 26 PM" src="https://github.com/noir-lang/noir/assets/106350168/eac26834-d570-4521-ac1e-f48224f691fa">


 
