### PR TITLE
chore: remove duplicate span from FunctionReturnType

### DIFF
--- a/crates/noirc_frontend/src/ast/expression.rs
+++ b/crates/noirc_frontend/src/ast/expression.rs
@@ -377,7 +377,7 @@ pub enum FunctionReturnType {
     /// Returns type is not specified.
     Default(Span),
     /// Everything else.
-    Ty(UnresolvedType, Span),
+    Ty(UnresolvedType),
 }
 
 /// Describes the types of smart contract functions that are allowed.
@@ -692,7 +692,7 @@ impl FunctionReturnType {
     pub fn get_type(&self) -> &UnresolvedTypeData {
         match self {
             FunctionReturnType::Default(_span) => &UnresolvedTypeData::Unit,
-            FunctionReturnType::Ty(typ, _span) => &typ.typ,
+            FunctionReturnType::Ty(typ) => &typ.typ,
         }
     }
 }
@@ -701,7 +701,7 @@ impl Display for FunctionReturnType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FunctionReturnType::Default(_) => f.write_str(""),
-            FunctionReturnType::Ty(ty, _) => write!(f, "{ty}"),
+            FunctionReturnType::Ty(ty) => write!(f, "{ty}"),
         }
     }
 }

--- a/crates/noirc_frontend/src/ast/function.rs
+++ b/crates/noirc_frontend/src/ast/function.rs
@@ -47,7 +47,7 @@ impl NoirFunction {
             FunctionReturnType::Default(_) => {
                 UnresolvedType::without_span(UnresolvedTypeData::Unit)
             }
-            FunctionReturnType::Ty(ty, _) => ty.clone(),
+            FunctionReturnType::Ty(ty) => ty.clone(),
         }
     }
     pub fn name(&self) -> &str {

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -440,7 +440,7 @@ fn resolve_trait_methods(
             let arguments = vecmap(parameters, |param| resolver.resolve_type(param.1.clone()));
             let resolved_return_type = match return_type {
                 FunctionReturnType::Default(_) => None,
-                FunctionReturnType::Ty(unresolved_type, _span) => {
+                FunctionReturnType::Ty(unresolved_type) => {
                     Some(resolver.resolve_type(unresolved_type.clone()))
                 }
             };

--- a/crates/noirc_frontend/src/hir/type_check/errors.rs
+++ b/crates/noirc_frontend/src/hir/type_check/errors.rs
@@ -205,8 +205,9 @@ impl From<TypeCheckError> for Diagnostic {
                     Source::Comparison => format!("Unsupported types for comparison: {expected} and {actual}"),
                     Source::BinOp => format!("Unsupported types for binary operation: {expected} and {actual}"),
                     Source::Return(ret_ty, expr_span) => {
-                        let ret_ty_span = match ret_ty {
-                            FunctionReturnType::Default(span) | FunctionReturnType::Ty(_, span) => span
+                        let ret_ty_span = match ret_ty.clone() {
+                            FunctionReturnType::Default(span) => span,
+                            FunctionReturnType::Ty(ty) => ty.span.unwrap(),
                         };
 
                         let mut diagnostic = Diagnostic::simple_error(format!("expected type {expected}, found type {actual}"), format!("expected {expected} because of return type"), ret_ty_span);

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -268,7 +268,7 @@ fn function_return_type() -> impl NoirParser<((Distinctness, Visibility), Functi
         .then(spanned(parse_type()))
         .or_not()
         .map_with_span(|ret, span| match ret {
-            Some((head, (ty, span))) => (head, FunctionReturnType::Ty(ty, span)),
+            Some((head, (ty, _))) => (head, FunctionReturnType::Ty(ty)),
             None => (
                 (Distinctness::DuplicationAllowed, Visibility::Private),
                 FunctionReturnType::Default(span),


### PR DESCRIPTION
# Description



<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

We have a struct called `FunctionReturnType`, that has a UnresolvedType and a Span. Recently we added a Span to `UnresolvedType` itself, so the Span is no longer needed



## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
