### PR TITLE
fix: allow usage of decimal string encoding for fields larger than a `i128`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,8 @@ dependencies = [
  "acvm",
  "iter-extended",
  "noirc_frontend",
+ "num-bigint",
+ "num-traits",
  "serde",
  "serde_json",
  "strum",

--- a/crates/noirc_abi/Cargo.toml
+++ b/crates/noirc_abi/Cargo.toml
@@ -14,6 +14,8 @@ toml.workspace = true
 serde_json = "1.0"
 serde.workspace = true
 thiserror.workspace = true
+num-bigint = "0.4"
+num-traits = "0.2"
 
 [dev-dependencies]
 strum = "0.24"

--- a/crates/noirc_abi/src/input_parser/mod.rs
+++ b/crates/noirc_abi/src/input_parser/mod.rs
@@ -1,6 +1,5 @@
-mod json;
-mod toml;
-
+use num_bigint::BigUint;
+use num_traits::Num;
 use std::collections::BTreeMap;
 
 use acvm::FieldElement;
@@ -8,6 +7,10 @@ use serde::Serialize;
 
 use crate::errors::InputParserError;
 use crate::{Abi, AbiType};
+
+mod json;
+mod toml;
+
 /// This is what all formats eventually transform into
 /// For example, a toml file will parse into TomlTypes
 /// and those TomlTypes will be mapped to Value
@@ -183,20 +186,52 @@ fn parse_str_to_field(value: &str) -> Result<FieldElement, InputParserError> {
     if value.starts_with("0x") {
         FieldElement::from_hex(value).ok_or_else(|| InputParserError::ParseHexStr(value.to_owned()))
     } else {
-        value
-            .parse::<i128>()
+        BigUint::from_str_radix(value, 10)
             .map_err(|err_msg| InputParserError::ParseStr(err_msg.to_string()))
-            .map(FieldElement::from)
+            // Note that we're reducing here. Should we reject inputs that don't fit in the field?
+            .map(field_from_big_uint)
     }
+}
+
+fn field_from_big_uint(bigint: BigUint) -> FieldElement {
+    FieldElement::from_be_bytes_reduce(&bigint.to_bytes_be())
 }
 
 #[cfg(test)]
 mod test {
+    use acvm::FieldElement;
+    use num_bigint::BigUint;
+
     use super::parse_str_to_field;
+
+    fn big_uint_from_field(field: FieldElement) -> BigUint {
+        BigUint::from_bytes_be(&field.to_be_bytes())
+    }
 
     #[test]
     fn parse_empty_str_fails() {
         // Check that this fails appropriately rather than being treated as 0, etc.
         assert!(parse_str_to_field("").is_err());
+    }
+
+    #[test]
+    fn parse_fields_from_strings() {
+        let fields = vec![
+            FieldElement::zero(),
+            FieldElement::one(),
+            FieldElement::from(u128::MAX) + FieldElement::one(),
+            // Equivalent to `FieldElement::modulus() - 1`
+            -FieldElement::one(),
+        ];
+
+        for field in fields {
+            let hex_field = format!("0x{}", field.to_hex());
+            let field_from_hex = parse_str_to_field(&hex_field).unwrap();
+            assert_eq!(field_from_hex, field);
+
+            let dec_field = big_uint_from_field(field).to_string();
+            let field_from_dec = parse_str_to_field(&dec_field).unwrap();
+            assert_eq!(field_from_dec, field);
+        }
     }
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2545
Resolves partly #2456 

## Summary\*

When parsing fields from strings, we're currently converting the string into an `i128` temporarily if it's a decimal representation. This limits the size of values which can be passed in as a decimal string compared to hex strings.

We now instead parse using a `BigUint` to ensure that we can handle all inputs.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

Note that `FieldElement` has a `try_from_str` implementation but as it returns an `Option<FieldElement>` rather than a `Result<FieldElement, Err>`, it's then not suitable for dealing with user input.

https://github.com/noir-lang/acvm/blob/5ad18bf8b365b57ba4c6f84004b5178e54562e7e/acir_field/src/generic_ark.rs#L204-L211

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
