### PR TITLE
feat: add `nargo backend ls` and `nargo backend use` command to switch between backends

### DIFF
--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -17,7 +17,7 @@ pub fn backends_directory() -> PathBuf {
 
 #[cfg(test)]
 fn get_bb() -> Backend {
-    let bb = Backend::new();
+    let bb = Backend::default();
     crate::assert_binary_exists(&bb);
     bb
 }
@@ -31,18 +31,24 @@ fn assert_binary_exists(backend: &Backend) -> PathBuf {
     binary_path
 }
 
-#[derive(Debug, Default)]
-pub struct Backend {}
+#[derive(Debug)]
+pub struct Backend {
+    name: String,
+}
+
+impl Default for Backend {
+    fn default() -> Self {
+        Self { name: "acvm-backend-barretenberg".to_string() }
+    }
+}
 
 impl Backend {
-    pub fn new() -> Backend {
-        Backend::default()
+    pub fn new(name: String) -> Backend {
+        Backend { name }
     }
 
     fn backend_directory(&self) -> PathBuf {
-        const BACKEND_NAME: &str = "acvm-backend-barretenberg";
-
-        backends_directory().join(BACKEND_NAME)
+        backends_directory().join(&self.name)
     }
 
     fn binary_path(&self) -> PathBuf {

--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -8,6 +8,13 @@ mod cli;
 mod proof_system;
 mod smart_contract;
 
+const BACKENDS_DIR: &str = ".nargo/backends";
+
+pub fn backends_directory() -> PathBuf {
+    let home_directory = dirs::home_dir().unwrap();
+    home_directory.join(BACKENDS_DIR)
+}
+
 #[cfg(test)]
 fn get_bb() -> Backend {
     let bb = Backend::new();
@@ -33,12 +40,9 @@ impl Backend {
     }
 
     fn backend_directory(&self) -> PathBuf {
-        const BACKENDS_DIR: &str = ".nargo/backends";
         const BACKEND_NAME: &str = "acvm-backend-barretenberg";
 
-        let home_directory = dirs::home_dir().unwrap();
-
-        home_directory.join(BACKENDS_DIR).join(BACKEND_NAME)
+        backends_directory().join(BACKEND_NAME)
     }
 
     fn binary_path(&self) -> PathBuf {

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -1,1 +1,22 @@
+use acvm_backend_barretenberg::backends_directory;
 pub(crate) use acvm_backend_barretenberg::Backend;
+
+pub(crate) fn set_active_backend(backend_name: &str) {
+    let backends_directory = backends_directory();
+    let active_backend_file = backends_directory.join("./.selected_backend");
+
+    std::fs::write(active_backend_file, backend_name.as_bytes()).unwrap();
+}
+
+pub(crate) fn get_active_backend() -> String {
+    let backends_directory = backends_directory();
+    let active_backend_file = backends_directory.join("./.selected_backend");
+
+    if !active_backend_file.is_file() {
+        let barretenberg = "acvm-backend-barretenberg";
+        set_active_backend(barretenberg);
+        return barretenberg.to_string();
+    }
+
+    std::fs::read_to_string(active_backend_file).unwrap()
+}

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -8,6 +8,10 @@ fn active_backend_file_path() -> PathBuf {
 }
 
 pub(crate) fn set_active_backend(backend_name: &str) {
+    std::fs::create_dir_all(
+        active_backend_file_path().parent().expect("active backend file should have parent"),
+    )
+    .unwrap();
     std::fs::write(active_backend_file_path(), backend_name.as_bytes()).unwrap();
 }
 

--- a/crates/nargo_cli/src/backends.rs
+++ b/crates/nargo_cli/src/backends.rs
@@ -1,16 +1,18 @@
+use std::path::PathBuf;
+
 use acvm_backend_barretenberg::backends_directory;
 pub(crate) use acvm_backend_barretenberg::Backend;
 
-pub(crate) fn set_active_backend(backend_name: &str) {
-    let backends_directory = backends_directory();
-    let active_backend_file = backends_directory.join("./.selected_backend");
+fn active_backend_file_path() -> PathBuf {
+    backends_directory().join(".selected_backend")
+}
 
-    std::fs::write(active_backend_file, backend_name.as_bytes()).unwrap();
+pub(crate) fn set_active_backend(backend_name: &str) {
+    std::fs::write(active_backend_file_path(), backend_name.as_bytes()).unwrap();
 }
 
 pub(crate) fn get_active_backend() -> String {
-    let backends_directory = backends_directory();
-    let active_backend_file = backends_directory.join("./.selected_backend");
+    let active_backend_file = active_backend_file_path();
 
     if !active_backend_file.is_file() {
         let barretenberg = "acvm-backend-barretenberg";

--- a/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
@@ -8,23 +8,25 @@ use crate::errors::CliError;
 pub(crate) struct LsCommand;
 
 pub(crate) fn run(_args: LsCommand) -> Result<(), CliError> {
+    for backend in get_available_backends() {
+        println!("{}", backend);
+    }
+
+    Ok(())
+}
+
+pub(super) fn get_available_backends() -> Vec<String> {
     let backend_directory_contents = std::fs::read_dir(backends_directory()).unwrap();
 
-    let backend_directories: Vec<std::path::PathBuf> = backend_directory_contents
+    backend_directory_contents
         .into_iter()
         .filter_map(|entry| {
             let path = entry.ok()?.path();
             if path.is_dir() {
-                Some(path)
+                path.file_name().map(|name| name.to_string_lossy().to_string())
             } else {
                 None
             }
         })
-        .collect();
-
-    for backend in backend_directories {
-        println!("{}", backend.file_name().unwrap().to_str().unwrap());
-    }
-
-    Ok(())
+        .collect()
 }

--- a/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
@@ -3,7 +3,7 @@ use clap::Args;
 
 use crate::errors::CliError;
 
-/// Checks the constraint system for errors
+/// Prints the list of available backends
 #[derive(Debug, Clone, Args)]
 pub(crate) struct LsCommand;
 

--- a/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
@@ -1,0 +1,30 @@
+use acvm_backend_barretenberg::backends_directory;
+use clap::Args;
+
+use crate::errors::CliError;
+
+/// Checks the constraint system for errors
+#[derive(Debug, Clone, Args)]
+pub(crate) struct LsCommand;
+
+pub(crate) fn run(_args: LsCommand) -> Result<(), CliError> {
+    let backend_directory_contents = std::fs::read_dir(backends_directory()).unwrap();
+
+    let backend_directories: Vec<std::path::PathBuf> = backend_directory_contents
+        .into_iter()
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.is_dir() {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for backend in backend_directories {
+        println!("{}", backend.file_name().unwrap().to_str().unwrap());
+    }
+
+    Ok(())
+}

--- a/crates/nargo_cli/src/cli/backend_cmd/mod.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/mod.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 use crate::errors::CliError;
 
 mod ls_cmd;
+mod use_cmd;
 
 #[non_exhaustive]
 #[derive(Args, Clone, Debug)]
@@ -15,6 +16,7 @@ pub(crate) struct BackendCommand {
 #[derive(Subcommand, Clone, Debug)]
 pub(crate) enum BackendCommands {
     Ls(ls_cmd::LsCommand),
+    Use(use_cmd::UseCommand),
 }
 
 pub(crate) fn run(cmd: BackendCommand) -> Result<(), CliError> {
@@ -22,6 +24,7 @@ pub(crate) fn run(cmd: BackendCommand) -> Result<(), CliError> {
 
     match command {
         BackendCommands::Ls(args) => ls_cmd::run(args),
+        BackendCommands::Use(args) => use_cmd::run(args),
     }?;
 
     Ok(())

--- a/crates/nargo_cli/src/cli/backend_cmd/mod.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/mod.rs
@@ -1,0 +1,28 @@
+use clap::{Args, Subcommand};
+
+use crate::errors::CliError;
+
+mod ls_cmd;
+
+#[non_exhaustive]
+#[derive(Args, Clone, Debug)]
+pub(crate) struct BackendCommand {
+    #[command(subcommand)]
+    command: BackendCommands,
+}
+
+#[non_exhaustive]
+#[derive(Subcommand, Clone, Debug)]
+pub(crate) enum BackendCommands {
+    Ls(ls_cmd::LsCommand),
+}
+
+pub(crate) fn run(cmd: BackendCommand) -> Result<(), CliError> {
+    let BackendCommand { command } = cmd;
+
+    match command {
+        BackendCommands::Ls(args) => ls_cmd::run(args),
+    }?;
+
+    Ok(())
+}

--- a/crates/nargo_cli/src/cli/backend_cmd/use_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/use_cmd.rs
@@ -1,0 +1,21 @@
+use clap::Args;
+
+use crate::{backends::set_active_backend, errors::CliError};
+
+use super::ls_cmd::get_available_backends;
+
+/// Checks the constraint system for errors
+#[derive(Debug, Clone, Args)]
+pub(crate) struct UseCommand {
+    backend: String,
+}
+
+pub(crate) fn run(args: UseCommand) -> Result<(), CliError> {
+    let backends = get_available_backends();
+
+    assert!(backends.contains(&args.backend), "backend doesn't exist");
+
+    set_active_backend(&args.backend);
+
+    Ok(())
+}

--- a/crates/nargo_cli/src/cli/backend_cmd/use_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/use_cmd.rs
@@ -4,7 +4,7 @@ use crate::{backends::set_active_backend, errors::CliError};
 
 use super::ls_cmd::get_available_backends;
 
-/// Checks the constraint system for errors
+/// Select the currently active backend
 #[derive(Debug, Clone, Args)]
 pub(crate) struct UseCommand {
     backend: String,

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 
 use color_eyre::eyre;
 
+use crate::backends::get_active_backend;
+
 mod fs;
 
 mod backend_cmd;
@@ -83,7 +85,8 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         config.program_dir = find_package_root(&config.program_dir)?;
     }
 
-    let backend = crate::backends::Backend::default();
+    let active_backend = get_active_backend();
+    let backend = crate::backends::Backend::new(active_backend);
 
     match command {
         NargoCommand::New(args) => new_cmd::run(&backend, args, config),

--- a/crates/nargo_cli/src/cli/mod.rs
+++ b/crates/nargo_cli/src/cli/mod.rs
@@ -7,6 +7,7 @@ use color_eyre::eyre;
 
 mod fs;
 
+mod backend_cmd;
 mod check_cmd;
 mod codegen_verifier_cmd;
 mod compile_cmd;
@@ -47,6 +48,8 @@ pub(crate) struct NargoConfig {
 #[non_exhaustive]
 #[derive(Subcommand, Clone, Debug)]
 enum NargoCommand {
+    #[command(hide = true)] // Hidden while dynamic backends feature is being built out.
+    Backend(backend_cmd::BackendCommand),
     Check(check_cmd::CheckCommand),
     CodegenVerifier(codegen_verifier_cmd::CodegenVerifierCommand),
     #[command(alias = "build")]
@@ -70,7 +73,13 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
     }
 
     // Search through parent directories to find package root if necessary.
-    if !matches!(command, NargoCommand::New(_) | NargoCommand::Init(_) | NargoCommand::Lsp(_)) {
+    if !matches!(
+        command,
+        NargoCommand::New(_)
+            | NargoCommand::Init(_)
+            | NargoCommand::Lsp(_)
+            | NargoCommand::Backend(_)
+    ) {
         config.program_dir = find_package_root(&config.program_dir)?;
     }
 
@@ -87,6 +96,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         NargoCommand::Test(args) => test_cmd::run(&backend, args, config),
         NargoCommand::Info(args) => info_cmd::run(&backend, args, config),
         NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(&backend, args, config),
+        NargoCommand::Backend(args) => backend_cmd::run(args),
         NargoCommand::Lsp(args) => lsp_cmd::run(&backend, args, config),
     }?;
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2527 

## Summary\*

This PR adds the `nargo backend` subcommand. All the commands related to dynamic backends are going to be stored under this.

This PR in particular creates the `nargo backend ls` command which lists all of the directories in `~/.nargo/backends`. The user can then pass one of these names to `nargo backend use` to switch to that backend.

I've hidden the `nargo backend` command for the meantime as we build out dynamic backends.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
