### PR TITLE
chore: move CRS files into their own directory

### DIFF
--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -42,9 +42,12 @@ impl Backend {
     }
 
     fn backend_directory(&self) -> PathBuf {
-        // If an explicit path to a backend binary has been provided then
+        // If an explicit path to a backend binary has been provided then place CRS, etc. in same directory.
         if let Some(binary_path) = std::env::var_os("NARGO_BACKEND_PATH") {
-            PathBuf::from(binary_path).parent().unwrap().to_path_buf()
+            PathBuf::from(binary_path)
+                .parent()
+                .expect("backend binary should have a parent directory")
+                .to_path_buf()
         } else {
             backends_directory().join(&self.name)
         }

--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -42,7 +42,16 @@ impl Backend {
     }
 
     fn backend_directory(&self) -> PathBuf {
-        backends_directory().join(&self.name)
+        // If an explicit path to a backend binary has been provided then
+        if let Some(binary_path) = std::env::var_os("NARGO_BACKEND_PATH") {
+            PathBuf::from(binary_path).parent().unwrap().to_path_buf()
+        } else {
+            backends_directory().join(&self.name)
+        }
+    }
+
+    fn crs_directory(&self) -> PathBuf {
+        self.backend_directory().join("crs")
     }
 
     fn binary_path(&self) -> PathBuf {

--- a/crates/acvm_backend_barretenberg/src/proof_system.rs
+++ b/crates/acvm_backend_barretenberg/src/proof_system.rs
@@ -26,7 +26,7 @@ impl Backend {
         write_to_file(serialized_circuit.as_bytes(), &circuit_path);
 
         let binary_path = assert_binary_exists(self);
-        GatesCommand { crs_path: self.backend_directory(), bytecode_path: circuit_path }
+        GatesCommand { crs_path: self.crs_directory(), bytecode_path: circuit_path }
             .run(&binary_path)
     }
 
@@ -82,7 +82,7 @@ impl Backend {
         // Create proof and store it in the specified path
         ProveCommand {
             verbose: true,
-            crs_path: self.backend_directory(),
+            crs_path: self.crs_directory(),
             is_recursive,
             bytecode_path,
             witness_path,
@@ -141,7 +141,7 @@ impl Backend {
         let binary_path = assert_binary_exists(self);
         WriteVkCommand {
             verbose: false,
-            crs_path: self.backend_directory(),
+            crs_path: self.crs_directory(),
             is_recursive,
             bytecode_path,
             vk_path_output: vk_path.clone(),
@@ -151,7 +151,7 @@ impl Backend {
         // Verify the proof
         let valid_proof = VerifyCommand {
             verbose: false,
-            crs_path: self.backend_directory(),
+            crs_path: self.crs_directory(),
             is_recursive,
             proof_path,
             vk_path,

--- a/crates/acvm_backend_barretenberg/src/smart_contract.rs
+++ b/crates/acvm_backend_barretenberg/src/smart_contract.rs
@@ -27,7 +27,7 @@ impl Backend {
         let binary_path = assert_binary_exists(self);
         WriteVkCommand {
             verbose: false,
-            crs_path: self.backend_directory(),
+            crs_path: self.crs_directory(),
             is_recursive: false,
             bytecode_path,
             vk_path_output: vk_path.clone(),
@@ -37,7 +37,7 @@ impl Backend {
         let contract_path = temp_directory_path.join("contract");
         ContractCommand {
             verbose: false,
-            crs_path: self.backend_directory(),
+            crs_path: self.crs_directory(),
             vk_path,
             contract_path: contract_path.clone(),
         }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*


## Summary\*

This PR moves the CRS for backends into a `crs` directory within the backend's directory. This makes it easier for us to clear this in future without knowing the CRS format.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
