### PR TITLE
chore: Patch 0.5.0 to 0.5.1 [DO NOT MERGE]

### DIFF
--- a/crates/acvm_backend_barretenberg/src/bb.rs
+++ b/crates/acvm_backend_barretenberg/src/bb.rs
@@ -4,7 +4,7 @@ use const_format::formatcp;
 
 const USERNAME: &str = "AztecProtocol";
 const REPO: &str = "barretenberg";
-const VERSION: &str = "0.5.0";
+const VERSION: &str = "0.5.1";
 const TAG: &str = formatcp!("barretenberg-v{}", VERSION);
 
 const API_URL: &str =

--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -15,8 +15,7 @@ pub fn backends_directory() -> PathBuf {
     home_directory.join(BACKENDS_DIR)
 }
 
-#[cfg(test)]
-fn get_bb() -> Backend {
+pub fn get_bb() -> Backend {
     let bb = Backend::new("acvm-backend-barretenberg".to_string());
     crate::assert_binary_exists(&bb);
     bb

--- a/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
@@ -23,7 +23,7 @@ pub(super) fn get_available_backends() -> Vec<String> {
         .filter_map(|entry| {
             let path = entry.ok()?.path();
             if path.is_dir() {
-                path.file_name().map(|name| name.to_string_lossy().to_string())
+                Some(path.to_str().unwrap().to_string())
             } else {
                 None
             }

--- a/crates/nargo_cli/src/cli/backend_cmd/mod.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/mod.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 use crate::errors::CliError;
 
 mod ls_cmd;
+mod rm_all_cmd;
 mod use_cmd;
 
 #[non_exhaustive]
@@ -17,6 +18,7 @@ pub(crate) struct BackendCommand {
 pub(crate) enum BackendCommands {
     Ls(ls_cmd::LsCommand),
     Use(use_cmd::UseCommand),
+    RmAll(rm_all_cmd::RmAllCommand),
 }
 
 pub(crate) fn run(cmd: BackendCommand) -> Result<(), CliError> {
@@ -25,6 +27,7 @@ pub(crate) fn run(cmd: BackendCommand) -> Result<(), CliError> {
     match command {
         BackendCommands::Ls(args) => ls_cmd::run(args),
         BackendCommands::Use(args) => use_cmd::run(args),
+        BackendCommands::RmAll(args) => rm_all_cmd::run(args),
     }?;
 
     Ok(())

--- a/crates/nargo_cli/src/cli/backend_cmd/rm_all_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/rm_all_cmd.rs
@@ -1,0 +1,25 @@
+use acvm_backend_barretenberg::backends_directory;
+use clap::Args;
+
+use crate::errors::CliError;
+
+/// Deletes all backends
+#[derive(Debug, Clone, Args)]
+pub(crate) struct RmAllCommand;
+
+pub(crate) fn run(_args: RmAllCommand) -> Result<(), CliError> {
+    remove_all_backends().map_err(|io_error| CliError::Generic(io_error.to_string()))
+}
+
+pub(super) fn remove_all_backends() -> std::io::Result<()> {
+    let backend_directory_contents = std::fs::read_dir(backends_directory()).unwrap();
+    for entry in backend_directory_contents {
+        if let Ok(entry) = entry {
+            let path = entry.path();
+            if path.is_dir() {
+                std::fs::remove_dir_all(path)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/nargo_cli/src/cli/backend_cmd/use_cmd.rs
+++ b/crates/nargo_cli/src/cli/backend_cmd/use_cmd.rs
@@ -13,7 +13,14 @@ pub(crate) struct UseCommand {
 pub(crate) fn run(args: UseCommand) -> Result<(), CliError> {
     let backends = get_available_backends();
 
-    assert!(backends.contains(&args.backend), "backend doesn't exist");
+    if !backends.contains(&args.backend) {
+        // If its bb we re-download it
+        if args.backend == "acvm-backend-barretenberg" {
+            acvm_backend_barretenberg::get_bb();
+        } else {
+            return Err(CliError::Generic(format!("backend {} doesn't exist", args.backend)));
+        }
+    }
 
     set_active_backend(&args.backend);
 


### PR DESCRIPTION
# Description

This creates a patch from 0.5.0 to 0.5.1

**Usage**

Compile nargo from this branch using noirup or cargo install.

```
nargo backend ls // This should show the ccvm-backend-barretenberg
nargo backend rm-all // to remove all backends
nargo backend use acvm-backend-barretenberg // This will re-download barretenberg
```

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
