### PR TITLE
fix: Modulo with divisor of zero should fail constraints

### DIFF
--- a/crates/nargo_cli/tests/compile_failure/div_by_zero_modulo/Nargo.toml
+++ b/crates/nargo_cli/tests/compile_failure/div_by_zero_modulo/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "div_by_zero_modulo"
+type = "bin"
+authors = [""]
+compiler_version = "0.10.5"
+
+[dependencies]

--- a/crates/nargo_cli/tests/compile_failure/div_by_zero_modulo/src/main.nr
+++ b/crates/nargo_cli/tests/compile_failure/div_by_zero_modulo/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {
+    let a: u32 = 6;
+	let b = 3;
+	let c = 0;
+	let res = (a*b) % c;
+	assert(res != 5);
+}

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -634,7 +634,8 @@ impl Binary {
             // If the rhs of a division is zero, attempting to evaluate the divison will cause a compiler panic.
             // Thus, we do not evaluate this divison as we want to avoid triggering a panic,
             // and division by zero should be handled by laying down constraints during ACIR generation.
-            if matches!(self.operator, BinaryOp::Div) && rhs == FieldElement::zero() {
+            if matches!(self.operator, BinaryOp::Div | BinaryOp::Mod) && rhs == FieldElement::zero()
+            {
                 return SimplifyResult::None;
             }
             return match self.eval_constants(dfg, lhs, rhs, operand_type) {


### PR DESCRIPTION
# Description

## Problem\*

Resolves #2572 

## Summary\*

In PR #2475 we make sure that we have a constraint failure if we attempt to divide by zero. This required preventing simplifications even if both the lhs and rhs of a binary op are known so that we can fail when processing the ACIR opcodes.

This PR simply adds the modulus case for simplification.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
