### PR TITLE
chore: return `FileManager` instead of `Context` from compilation functions

### DIFF
--- a/crates/nargo/src/artifacts/debug.rs
+++ b/crates/nargo/src/artifacts/debug.rs
@@ -5,8 +5,7 @@ use std::{
     path::PathBuf,
 };
 
-use fm::FileId;
-use noirc_frontend::hir::Context;
+use fm::{FileId, FileManager};
 
 /// For a given file, we store the source code and the path to the file
 /// so consumers of the debug artifact can reconstruct the original source code structure.
@@ -25,7 +24,7 @@ pub struct DebugArtifact {
 }
 
 impl DebugArtifact {
-    pub fn new(debug_symbols: Vec<DebugInfo>, compilation_context: &Context) -> Self {
+    pub fn new(debug_symbols: Vec<DebugInfo>, file_manager: &FileManager) -> Self {
         let mut file_map = BTreeMap::new();
 
         let files_with_debug_symbols: BTreeSet<FileId> = debug_symbols
@@ -39,13 +38,13 @@ impl DebugArtifact {
             .collect();
 
         for file_id in files_with_debug_symbols {
-            let file_source = compilation_context.file_manager.fetch_file(file_id).source();
+            let file_source = file_manager.fetch_file(file_id).source();
 
             file_map.insert(
                 file_id,
                 DebugFile {
                     source: file_source.to_string(),
-                    path: compilation_context.file_manager.path(file_id).to_path_buf(),
+                    path: file_manager.path(file_id).to_path_buf(),
                 },
             );
         }

--- a/crates/nargo_cli/Cargo.toml
+++ b/crates/nargo_cli/Cargo.toml
@@ -19,6 +19,7 @@ toml.workspace = true
 
 [dependencies]
 clap.workspace = true
+fm.workspace = true
 iter-extended.workspace = true
 nargo.workspace = true
 nargo_toml.workspace = true

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -172,5 +172,5 @@ pub(crate) fn check_crate_and_report_errors(
     deny_warnings: bool,
 ) -> Result<(), CompileError> {
     let result = check_crate(context, crate_id, deny_warnings).map(|warnings| ((), warnings));
-    super::compile_cmd::report_errors(result, context, deny_warnings)
+    super::compile_cmd::report_errors(result, &context.file_manager, deny_warnings)
 }

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use acvm::{acir::circuit::Circuit, compiler::AcirTransformationMap};
+use fm::FileManager;
 use iter_extended::{try_vecmap, vecmap};
 use nargo::artifacts::contract::PreprocessedContractFunction;
 use nargo::artifacts::debug::DebugArtifact;
@@ -14,7 +15,6 @@ use noirc_driver::{
 };
 use noirc_errors::debug_info::DebugInfo;
 use noirc_frontend::graph::CrateName;
-use noirc_frontend::hir::Context;
 
 use clap::Args;
 
@@ -67,11 +67,12 @@ pub(crate) fn run(
     for package in &workspace {
         // If `contract` package type, we're compiling every function in a 'contract' rather than just 'main'.
         if package.is_contract() {
-            let (context, contracts) = compile_contracts(backend, package, &args.compile_options)?;
-            save_contracts(&context, contracts, package, &circuit_dir, args.output_debug);
+            let (file_manager, contracts) =
+                compile_contracts(backend, package, &args.compile_options)?;
+            save_contracts(&file_manager, contracts, package, &circuit_dir, args.output_debug);
         } else {
-            let (context, program) = compile_package(backend, package, &args.compile_options)?;
-            save_program(&context, program, package, &circuit_dir, args.output_debug);
+            let (file_manager, program) = compile_package(backend, package, &args.compile_options)?;
+            save_program(&file_manager, program, package, &circuit_dir, args.output_debug);
         }
     }
 
@@ -82,14 +83,14 @@ pub(crate) fn compile_package(
     backend: &Backend,
     package: &Package,
     compile_options: &CompileOptions,
-) -> Result<(Context, CompiledProgram), CompileError> {
+) -> Result<(FileManager, CompiledProgram), CompileError> {
     if package.is_library() {
         return Err(CompileError::LibraryCrate(package.name.clone()));
     }
 
     let (mut context, crate_id) = prepare_package(package);
     let result = compile_main(&mut context, crate_id, compile_options);
-    let mut program = report_errors(result, &context, compile_options.deny_warnings)?;
+    let mut program = report_errors(result, &context.file_manager, compile_options.deny_warnings)?;
     // Apply backend specific optimizations.
     let (optimized_circuit, location_map) = optimize_circuit(backend, program.circuit)
         .expect("Backend does not support an opcode that is in the IR");
@@ -98,21 +99,21 @@ pub(crate) fn compile_package(
     program.circuit = optimized_circuit;
     program.debug.update_acir(location_map);
 
-    Ok((context, program))
+    Ok((context.file_manager, program))
 }
 
 pub(crate) fn compile_contracts(
     backend: &Backend,
     package: &Package,
     compile_options: &CompileOptions,
-) -> Result<(Context, Vec<CompiledContract>), CliError> {
+) -> Result<(FileManager, Vec<CompiledContract>), CliError> {
     let (mut context, crate_id) = prepare_package(package);
     let result = noirc_driver::compile_contracts(&mut context, crate_id, compile_options);
-    let contracts = report_errors(result, &context, compile_options.deny_warnings)?;
+    let contracts = report_errors(result, &context.file_manager, compile_options.deny_warnings)?;
 
     let optimized_contracts =
         try_vecmap(contracts, |contract| optimize_contract(backend, contract))?;
-    Ok((context, optimized_contracts))
+    Ok((context.file_manager, optimized_contracts))
 }
 
 pub(super) fn optimize_circuit(
@@ -142,7 +143,7 @@ pub(super) fn optimize_contract(
 }
 
 fn save_program(
-    context: &Context,
+    file_manager: &FileManager,
     program: CompiledProgram,
     package: &Package,
     circuit_dir: &Path,
@@ -157,14 +158,14 @@ fn save_program(
     save_program_to_file(&preprocessed_program, &package.name, circuit_dir);
 
     if output_debug {
-        let debug_artifact = DebugArtifact::new(vec![program.debug], context);
+        let debug_artifact = DebugArtifact::new(vec![program.debug], file_manager);
         let circuit_name: String = (&package.name).into();
         save_debug_artifact_to_file(&debug_artifact, &circuit_name, circuit_dir);
     }
 }
 
 fn save_contracts(
-    context: &Context,
+    file_manager: &FileManager,
     contracts: Vec<CompiledContract>,
     package: &Package,
     circuit_dir: &Path,
@@ -210,7 +211,7 @@ fn save_contracts(
         );
 
         if output_debug {
-            let debug_artifact = DebugArtifact::new(debug_infos, context);
+            let debug_artifact = DebugArtifact::new(debug_infos, file_manager);
             save_debug_artifact_to_file(
                 &debug_artifact,
                 &format!("{}-{}", package.name, contract.name),
@@ -224,13 +225,13 @@ fn save_contracts(
 /// structure that is commonly used as a return result in this file.
 pub(crate) fn report_errors<T>(
     result: Result<(T, Warnings), ErrorsAndWarnings>,
-    context: &Context,
+    file_manager: &FileManager,
     deny_warnings: bool,
 ) -> Result<T, CompileError> {
     let (t, warnings) = result.map_err(|errors| {
-        noirc_errors::reporter::report_all(&context.file_manager, &errors, deny_warnings)
+        noirc_errors::reporter::report_all(file_manager, &errors, deny_warnings)
     })?;
 
-    noirc_errors::reporter::report_all(&context.file_manager, &warnings, deny_warnings);
+    noirc_errors::reporter::report_all(file_manager, &warnings, deny_warnings);
     Ok(t)
 }

--- a/crates/nargo_cli/src/cli/execute_cmd.rs
+++ b/crates/nargo_cli/src/cli/execute_cmd.rs
@@ -2,6 +2,7 @@ use acvm::acir::circuit::OpcodeLocation;
 use acvm::acir::{circuit::Circuit, native_types::WitnessMap};
 use acvm::pwg::{ErrorLocation, OpcodeResolutionError};
 use clap::Args;
+use fm::FileManager;
 use nargo::constants::PROVER_INPUT_FILE;
 use nargo::errors::{ExecutionError, NargoError};
 use nargo::package::Package;
@@ -11,7 +12,6 @@ use noirc_abi::{Abi, InputMap};
 use noirc_driver::{CompileOptions, CompiledProgram};
 use noirc_errors::{debug_info::DebugInfo, CustomDiagnostic};
 use noirc_frontend::graph::CrateName;
-use noirc_frontend::hir::Context;
 
 use super::compile_cmd::compile_package;
 use super::fs::{inputs::read_inputs_from_file, witness::save_witness_to_dir};
@@ -133,7 +133,7 @@ fn extract_opcode_error_from_nargo_error(
 fn report_error_with_opcode_locations(
     opcode_err_info: Option<(Vec<OpcodeLocation>, &ExecutionError)>,
     debug: &DebugInfo,
-    context: &Context,
+    file_manager: &FileManager,
 ) {
     if let Some((opcode_locations, opcode_err)) = opcode_err_info {
         let source_locations: Vec<_> = opcode_locations
@@ -173,7 +173,7 @@ fn report_error_with_opcode_locations(
             CustomDiagnostic::simple_error(message, String::new(), location.span)
                 .in_file(location.file)
                 .with_call_stack(source_locations)
-                .report(&context.file_manager, false);
+                .report(file_manager, false);
         }
     }
 }
@@ -183,7 +183,7 @@ pub(crate) fn execute_program(
     circuit: Circuit,
     abi: &Abi,
     inputs_map: &InputMap,
-    debug_data: Option<(DebugInfo, Context)>,
+    debug_data: Option<(DebugInfo, FileManager)>,
 ) -> Result<WitnessMap, CliError> {
     #[allow(deprecated)]
     let blackbox_solver = acvm::blackbox_solver::BarretenbergSolver::new();
@@ -195,9 +195,9 @@ pub(crate) fn execute_program(
     match solved_witness_err {
         Ok(solved_witness) => Ok(solved_witness),
         Err(err) => {
-            if let Some((debug, context)) = debug_data {
+            if let Some((debug, file_manager)) = debug_data {
                 let opcode_err_info = extract_opcode_error_from_nargo_error(&err);
-                report_error_with_opcode_locations(opcode_err_info, &debug, &context);
+                report_error_with_opcode_locations(opcode_err_info, &debug, &file_manager);
             }
 
             Err(crate::errors::CliError::NargoError(err))


### PR DESCRIPTION

# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR passes back just the `FileManager` from the compilation functions to restrict how much of the compilation context leaks into the rest of Nargo.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
