### PR TITLE
feat(stdlib): grumpkin scalar multiplication API

### DIFF
--- a/noir_stdlib/src/grumpkin_scalar.nr
+++ b/noir_stdlib/src/grumpkin_scalar.nr
@@ -5,7 +5,7 @@ struct GrumpkinScalar {
 
 impl GrumpkinScalar {
     fn new(low: Field, high: Field) -> Self {
-        // TODO: max value check
+        // TODO: check that the low and high value fit within the grumpkin modulus
         GrumpkinScalar { low, high }
     }
 }

--- a/noir_stdlib/src/grumpkin_scalar.nr
+++ b/noir_stdlib/src/grumpkin_scalar.nr
@@ -1,21 +1,21 @@
 struct GrumpkinScalar {
-    high: Field,
     low: Field,
+    high: Field,
 }
 
 impl GrumpkinScalar {
-    fn new(high: Field, low: Field) -> Self {
+    fn new(low: Field, high: Field) -> Self {
         // TODO: max value check
-        GrumpkinScalar { high, low }
+        GrumpkinScalar { low, high }
     }
 }
 
 global GRUMPKIN_SCALAR_SERIALISED_LEN: Field = 2;
 
 fn deserialise_grumpkin_scalar(fields: [Field; GRUMPKIN_SCALAR_SERIALISED_LEN]) -> GrumpkinScalar {
-    GrumpkinScalar { high: fields[0], low: fields[1] }
+    GrumpkinScalar { low: fields[0], high: fields[1] }
 }
 
 fn serialise_grumpkin_scalar(scalar: GrumpkinScalar) -> [Field; GRUMPKIN_SCALAR_SERIALISED_LEN] {
-    [scalar.high, scalar.low]
+    [scalar.low, scalar.high]
 }

--- a/noir_stdlib/src/grumpkin_scalar.nr
+++ b/noir_stdlib/src/grumpkin_scalar.nr
@@ -1,0 +1,21 @@
+struct GrumpkinScalar {
+    high: Field,
+    low: Field,
+}
+
+impl GrumpkinScalar {
+    fn new(high: Field, low: Field) -> Self {
+        // TODO: max value check
+        GrumpkinScalar { high, low }
+    }
+}
+
+global GRUMPKIN_SCALAR_SERIALISED_LEN: Field = 2;
+
+fn deserialise_grumpkin_scalar(fields: [Field; GRUMPKIN_SCALAR_SERIALISED_LEN]) -> GrumpkinScalar {
+    GrumpkinScalar { high: fields[0], low: fields[1] }
+}
+
+fn serialise_grumpkin_scalar(scalar: GrumpkinScalar) -> [Field; GRUMPKIN_SCALAR_SERIALISED_LEN] {
+    [scalar.high, scalar.low]
+}

--- a/noir_stdlib/src/grumpkin_scalar_mul.nr
+++ b/noir_stdlib/src/grumpkin_scalar_mul.nr
@@ -2,5 +2,6 @@ use crate::grumpkin_scalar::GrumpkinScalar;
 use crate::scalar_mul::fixed_base_embedded_curve;
 
 fn grumpkin_fixed_base(scalar: GrumpkinScalar) -> [Field; 2] {
+    // TODO: this should use both the low and high limbs to do the scalar multiplication
     fixed_base_embedded_curve(scalar.low)
 }

--- a/noir_stdlib/src/grumpkin_scalar_mul.nr
+++ b/noir_stdlib/src/grumpkin_scalar_mul.nr
@@ -1,0 +1,6 @@
+use crate::grumpkin_scalar::GrumpkinScalar;
+use crate::scalar_mul::fixed_base_embedded_curve;
+
+fn grumpkin_fixed_base(scalar: GrumpkinScalar) -> [Field; 2] {
+    fixed_base_embedded_curve(scalar.low)
+}

--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -6,6 +6,8 @@ mod schnorr;
 mod ecdsa_secp256k1;
 mod ecdsa_secp256r1;
 mod eddsa;
+mod grumpkin_scalar;
+mod grumpkin_scalar_mul;
 mod scalar_mul;
 mod sha256;
 mod sha512;


### PR DESCRIPTION
# Description

Grumpkin scalar does not fit into the default `Field` type and for this reason we can't use the `fixed_base_embedded_curve` method which is already present in the stdlib. Kev advised me to first make a function which takes the full `GrumpkinScalar` and calls `fixed_base_embedded_curve` just with the high "half" of the grumpkin scalar because so that we have the API ready.
