### PR TITLE
fix(ssa): Slice mergers with multiple ifs

### DIFF
--- a/crates/nargo_cli/tests/execution_success/slice_dynamic_index/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/slice_dynamic_index/src/main.nr
@@ -183,7 +183,7 @@ fn dynamic_slice_merge_two_ifs(mut slice: [Field], x: Field) {
     } else {
         slice = slice.push_back(15);
     }
-    // Breaks if the push back happens without the else case
+    // TODO(#2599): Breaks if the push back happens without the else case
     // slice = slice.push_back(15);
 
     assert(slice.len() == 7);

--- a/crates/nargo_cli/tests/execution_success/slice_dynamic_index/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/slice_dynamic_index/src/main.nr
@@ -10,7 +10,6 @@ fn regression_dynamic_slice_index(x: Field, y: Field) {
     }
     assert(slice.len() == 5);
     
-
     dynamic_slice_index_set_if(slice, x, y);
     dynamic_slice_index_set_else(slice, x, y);
     dynamic_slice_index_set_nested_if_else_else(slice, x, y);
@@ -22,7 +21,6 @@ fn regression_dynamic_slice_index(x: Field, y: Field) {
     dynamic_slice_merge_if(slice, x);
     dynamic_slice_merge_else(slice, x);
     dynamic_slice_merge_two_ifs(slice, x);
-
 }
 
 fn dynamic_slice_index_set_if(mut slice: [Field], x: Field, y: Field) {

--- a/crates/nargo_cli/tests/execution_success/slice_dynamic_index/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/slice_dynamic_index/src/main.nr
@@ -10,6 +10,7 @@ fn regression_dynamic_slice_index(x: Field, y: Field) {
     }
     assert(slice.len() == 5);
     
+
     dynamic_slice_index_set_if(slice, x, y);
     dynamic_slice_index_set_else(slice, x, y);
     dynamic_slice_index_set_nested_if_else_else(slice, x, y);
@@ -20,6 +21,8 @@ fn regression_dynamic_slice_index(x: Field, y: Field) {
 
     dynamic_slice_merge_if(slice, x);
     dynamic_slice_merge_else(slice, x);
+    dynamic_slice_merge_two_ifs(slice, x);
+
 }
 
 fn dynamic_slice_index_set_if(mut slice: [Field], x: Field, y: Field) {
@@ -161,6 +164,35 @@ fn dynamic_slice_merge_else(mut slice: [Field], x: Field) {
 
     slice = slice.push_back(20);
     assert(slice.len() == 7);
+    assert(slice[slice.len() - 1] == 20);
+}
+
+fn dynamic_slice_merge_two_ifs(mut slice: [Field], x: Field) {
+    if x as u32 > 10 {
+        assert(slice[x] == 0);
+        slice[x] = 2;
+    } else {
+        assert(slice[x] == 4);
+        slice[x] = slice[x] - 2;
+        slice = slice.push_back(10);
+    }
+
+    assert(slice.len() == 6);
+    assert(slice[slice.len() - 1] == 10);
+
+    if x == 20 {
+        slice = slice.push_back(20);
+    } else {
+        slice = slice.push_back(15);
+    }
+    // Breaks if the push back happens without the else case
+    // slice = slice.push_back(15);
+
+    assert(slice.len() == 7);
+    assert(slice[slice.len() - 1] == 15);
+
+    slice = slice.push_back(20);
+    assert(slice.len() == 8);
     assert(slice[slice.len() - 1] == 20);
 }
 

--- a/crates/nargo_cli/tests/execution_success/slices/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/slices/src/main.nr
@@ -2,51 +2,51 @@ use dep::std::slice;
 use dep::std;
 
 fn main(x : Field, y : pub Field) {
-    let mut slice = [0; 2];
-    assert(slice[0] == 0);
-    assert(slice[0] != 1);
-    slice[0] = x;
-    assert(slice[0] == x);
+    // let mut slice = [0; 2];
+    // assert(slice[0] == 0);
+    // assert(slice[0] != 1);
+    // slice[0] = x;
+    // assert(slice[0] == x);
 
-    let slice_plus_10 = slice.push_back(y);
-    assert(slice_plus_10[2] == 10);
-    assert(slice_plus_10[2] != 8);
-    assert(slice_plus_10.len() == 3);
+    // let slice_plus_10 = slice.push_back(y);
+    // assert(slice_plus_10[2] == 10);
+    // assert(slice_plus_10[2] != 8);
+    // assert(slice_plus_10.len() == 3);
 
-    let mut new_slice = [];
-    for i in 0..5 {
-        new_slice = new_slice.push_back(i);
-    }
-    assert(new_slice.len() == 5);
+    // let mut new_slice = [];
+    // for i in 0..5 {
+    //     new_slice = new_slice.push_back(i);
+    // }
+    // assert(new_slice.len() == 5);
 
-    new_slice = new_slice.push_front(20);
-    assert(new_slice[0] == 20);
-    assert(new_slice.len() == 6);
+    // new_slice = new_slice.push_front(20);
+    // assert(new_slice[0] == 20);
+    // assert(new_slice.len() == 6);
 
-    let (popped_slice, last_elem) = new_slice.pop_back();
-    assert(last_elem == 4);
-    assert(popped_slice.len() == 5);
+    // let (popped_slice, last_elem) = new_slice.pop_back();
+    // assert(last_elem == 4);
+    // assert(popped_slice.len() == 5);
 
-    let (first_elem, rest_of_slice) = popped_slice.pop_front();
-    assert(first_elem == 20);
-    assert(rest_of_slice.len() == 4);
+    // let (first_elem, rest_of_slice) = popped_slice.pop_front();
+    // assert(first_elem == 20);
+    // assert(rest_of_slice.len() == 4);
 
-    new_slice = rest_of_slice.insert(2, 100);
-    assert(new_slice[2] == 100);
-    assert(new_slice[4] == 3);
-    assert(new_slice.len() == 5);
+    // new_slice = rest_of_slice.insert(2, 100);
+    // assert(new_slice[2] == 100);
+    // assert(new_slice[4] == 3);
+    // assert(new_slice.len() == 5);
 
-    let (remove_slice, removed_elem) = new_slice.remove(3);
-    assert(removed_elem == 2);
-    assert(remove_slice[3] == 3);
-    assert(remove_slice.len() == 4);
+    // let (remove_slice, removed_elem) = new_slice.remove(3);
+    // assert(removed_elem == 2);
+    // assert(remove_slice[3] == 3);
+    // assert(remove_slice.len() == 4);
 
-    let append = [1, 2].append([3, 4, 5]);
-    assert(append.len() == 5);
-    assert(append[0] == 1);
-    assert(append[4] == 5);
+    // let append = [1, 2].append([3, 4, 5]);
+    // assert(append.len() == 5);
+    // assert(append[0] == 1);
+    // assert(append[4] == 5);
 
-    regression_2083();
+    // regression_2083();
     // The parameters to this function must come from witness values (inputs to main)
     regression_merge_slices(x, y);
 }
@@ -86,8 +86,14 @@ fn regression_2083() {
 
 // The parameters to this function must come from witness values (inputs to main)
 fn regression_merge_slices(x: Field, y: Field) {
-    merge_slices_if(x, y);
-    merge_slices_else(x);
+    // merge_slices_if(x, y);
+    // merge_slices_else(x);
+    
+    let slice = merge_slices_mutate_two_ifs(x, y);
+    assert(slice.len() == 6);
+    assert(slice[3] == 5);
+    assert(slice[4] == 15);
+    assert(slice[5] == 30);
 }
 
 fn merge_slices_if(x: Field, y: Field) {
@@ -155,5 +161,26 @@ fn merge_slices_mutate_in_loop(x: Field, y: Field) -> [Field] {
     } else {
         slice = slice.push_back(x);
     }
+    slice
+}
+
+fn merge_slices_mutate_two_ifs(x: Field, y: Field) -> [Field] {
+    let mut slice = [0; 2];
+    if x != y {
+        slice = slice.push_back(y);
+        slice = slice.push_back(x);
+    } else {
+        slice = slice.push_back(x);
+    }
+    if x == 20 {
+        slice = slice.push_back(20);
+    } 
+    else {
+        slice = slice.push_back(15);
+    }
+    // Breaks if the push back happens without the else case
+    // slice = slice.push_back(15);
+    slice = slice.push_back(30);
+    
     slice
 }

--- a/crates/nargo_cli/tests/execution_success/slices/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/slices/src/main.nr
@@ -2,51 +2,51 @@ use dep::std::slice;
 use dep::std;
 
 fn main(x : Field, y : pub Field) {
-    // let mut slice = [0; 2];
-    // assert(slice[0] == 0);
-    // assert(slice[0] != 1);
-    // slice[0] = x;
-    // assert(slice[0] == x);
+    let mut slice = [0; 2];
+    assert(slice[0] == 0);
+    assert(slice[0] != 1);
+    slice[0] = x;
+    assert(slice[0] == x);
 
-    // let slice_plus_10 = slice.push_back(y);
-    // assert(slice_plus_10[2] == 10);
-    // assert(slice_plus_10[2] != 8);
-    // assert(slice_plus_10.len() == 3);
+    let slice_plus_10 = slice.push_back(y);
+    assert(slice_plus_10[2] == 10);
+    assert(slice_plus_10[2] != 8);
+    assert(slice_plus_10.len() == 3);
 
-    // let mut new_slice = [];
-    // for i in 0..5 {
-    //     new_slice = new_slice.push_back(i);
-    // }
-    // assert(new_slice.len() == 5);
+    let mut new_slice = [];
+    for i in 0..5 {
+        new_slice = new_slice.push_back(i);
+    }
+    assert(new_slice.len() == 5);
 
-    // new_slice = new_slice.push_front(20);
-    // assert(new_slice[0] == 20);
-    // assert(new_slice.len() == 6);
+    new_slice = new_slice.push_front(20);
+    assert(new_slice[0] == 20);
+    assert(new_slice.len() == 6);
 
-    // let (popped_slice, last_elem) = new_slice.pop_back();
-    // assert(last_elem == 4);
-    // assert(popped_slice.len() == 5);
+    let (popped_slice, last_elem) = new_slice.pop_back();
+    assert(last_elem == 4);
+    assert(popped_slice.len() == 5);
 
-    // let (first_elem, rest_of_slice) = popped_slice.pop_front();
-    // assert(first_elem == 20);
-    // assert(rest_of_slice.len() == 4);
+    let (first_elem, rest_of_slice) = popped_slice.pop_front();
+    assert(first_elem == 20);
+    assert(rest_of_slice.len() == 4);
 
-    // new_slice = rest_of_slice.insert(2, 100);
-    // assert(new_slice[2] == 100);
-    // assert(new_slice[4] == 3);
-    // assert(new_slice.len() == 5);
+    new_slice = rest_of_slice.insert(2, 100);
+    assert(new_slice[2] == 100);
+    assert(new_slice[4] == 3);
+    assert(new_slice.len() == 5);
 
-    // let (remove_slice, removed_elem) = new_slice.remove(3);
-    // assert(removed_elem == 2);
-    // assert(remove_slice[3] == 3);
-    // assert(remove_slice.len() == 4);
+    let (remove_slice, removed_elem) = new_slice.remove(3);
+    assert(removed_elem == 2);
+    assert(remove_slice[3] == 3);
+    assert(remove_slice.len() == 4);
 
-    // let append = [1, 2].append([3, 4, 5]);
-    // assert(append.len() == 5);
-    // assert(append[0] == 1);
-    // assert(append[4] == 5);
+    let append = [1, 2].append([3, 4, 5]);
+    assert(append.len() == 5);
+    assert(append[0] == 1);
+    assert(append[4] == 5);
 
-    // regression_2083();
+    regression_2083();
     // The parameters to this function must come from witness values (inputs to main)
     regression_merge_slices(x, y);
 }
@@ -86,14 +86,8 @@ fn regression_2083() {
 
 // The parameters to this function must come from witness values (inputs to main)
 fn regression_merge_slices(x: Field, y: Field) {
-    // merge_slices_if(x, y);
-    // merge_slices_else(x);
-    
-    let slice = merge_slices_mutate_two_ifs(x, y);
-    assert(slice.len() == 6);
-    assert(slice[3] == 5);
-    assert(slice[4] == 15);
-    assert(slice[5] == 30);
+    merge_slices_if(x, y);
+    merge_slices_else(x);
 }
 
 fn merge_slices_if(x: Field, y: Field) {
@@ -108,6 +102,18 @@ fn merge_slices_if(x: Field, y: Field) {
     let slice = merge_slices_mutate_in_loop(x, y);
     assert(slice[6] == 4);
     assert(slice.len() == 7);
+
+    let slice = merge_slices_mutate_two_ifs(x, y);
+    assert(slice.len() == 6);
+    assert(slice[3] == 5);
+    assert(slice[4] == 15);
+    assert(slice[5] == 30);
+
+    let slice = merge_slices_mutate_between_ifs(x, y);
+    assert(slice.len() == 6);
+    assert(slice[3] == 5);
+    assert(slice[4] == 30);
+    assert(slice[5] == 15);
 }
 
 fn merge_slices_else(x: Field) {
@@ -174,13 +180,34 @@ fn merge_slices_mutate_two_ifs(x: Field, y: Field) -> [Field] {
     }
     if x == 20 {
         slice = slice.push_back(20);
-    } 
-    else {
+    } else {
         slice = slice.push_back(15);
     }
     // Breaks if the push back happens without the else case
     // slice = slice.push_back(15);
     slice = slice.push_back(30);
     
+    slice
+}
+
+fn merge_slices_mutate_between_ifs(x: Field, y: Field) -> [Field] {
+    let mut slice = [0; 2];
+    if x != y {
+        slice = slice.push_back(y);
+        slice = slice.push_back(x);
+    } else {
+        slice = slice.push_back(x);
+    }
+
+    slice = slice.push_back(30);
+
+    if x == 20 {
+        slice = slice.push_back(20);
+    } else {
+        slice = slice.push_back(15);
+    }
+    // Breaks if the push back happens without the else case
+    // slice = slice.push_back(15);
+
     slice
 }

--- a/crates/nargo_cli/tests/execution_success/slices/src/main.nr
+++ b/crates/nargo_cli/tests/execution_success/slices/src/main.nr
@@ -183,7 +183,7 @@ fn merge_slices_mutate_two_ifs(x: Field, y: Field) -> [Field] {
     } else {
         slice = slice.push_back(15);
     }
-    // Breaks if the push back happens without the else case
+    // TODO(#2599): Breaks if the push back happens without the else case
     // slice = slice.push_back(15);
     slice = slice.push_back(30);
     
@@ -206,7 +206,7 @@ fn merge_slices_mutate_between_ifs(x: Field, y: Field) -> [Field] {
     } else {
         slice = slice.push_back(15);
     }
-    // Breaks if the push back happens without the else case
+    // TODO(#2599): Breaks if the push back happens without the else case
     // slice = slice.push_back(15);
 
     slice

--- a/crates/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -171,7 +171,7 @@ pub(crate) enum Instruction {
     /// Creates a new array with the new value at the given index. All other elements are identical
     /// to those in the given array. This will not modify the original array.
     ///
-    /// An optional length can be provided to enabling handling of dynamic slice indices
+    /// An optional length can be provided to enable handling of dynamic slice indices.
     ArraySet { array: ValueId, index: ValueId, value: ValueId, length: Option<ValueId> },
 }
 

--- a/crates/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/crates/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -5,18 +5,19 @@ use iter_extended::vecmap;
 use num_bigint::BigUint;
 
 use crate::ssa::ir::{
+    basic_block::BasicBlockId,
     dfg::DataFlowGraph,
     instruction::Intrinsic,
     map::Id,
     types::Type,
-    value::{Value, ValueId}, basic_block::BasicBlockId,
+    value::{Value, ValueId},
 };
 
 use super::{Binary, BinaryOp, Endian, Instruction, SimplifyResult};
 
 /// Try to simplify this call instruction. If the instruction can be simplified to a known value,
 /// that value is returned. Otherwise None is returned.
-/// 
+///
 /// The `block` parameter indicates the block any new instructions that are part of a call's
 /// simplification will be inserted into. For example, all slice intrinsics require updates
 /// to the slice length, which requires inserting a binary instruction. This update instruction
@@ -232,7 +233,12 @@ pub(super) fn simplify_call(
 /// The binary operation performed on the slice length is always an addition or subtraction of `1`.
 /// This is because the slice length holds the user length (length as displayed by a `.len()` call),
 /// and not a flattened length used internally to represent arrays of tuples.
-fn update_slice_length(slice_len: ValueId, dfg: &mut DataFlowGraph, operator: BinaryOp, block: BasicBlockId) -> ValueId {
+fn update_slice_length(
+    slice_len: ValueId,
+    dfg: &mut DataFlowGraph,
+    operator: BinaryOp,
+    block: BasicBlockId,
+) -> ValueId {
     let one = dfg.make_constant(FieldElement::one(), Type::field());
     let instruction = Instruction::Binary(Binary { lhs: slice_len, operator, rhs: one });
     let call_stack = dfg.get_value_call_stack(slice_len);

--- a/crates/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/crates/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -492,17 +492,14 @@ impl<'f> Context<'f> {
             Value::Instruction { instruction: instruction_id, .. } => {
                 let instruction = &self.inserter.function.dfg[*instruction_id];
                 match instruction {
-                    Instruction::ArraySet { array, .. } => {
-                        self.get_slice_length(*array)
-                    }
+                    Instruction::ArraySet { array, .. } => self.get_slice_length(*array),
                     Instruction::Load { address } => {
                         let context_store = if let Some(store) = self.store_values.get(address) {
                             store
                         } else {
-                            self
-                            .outer_block_stores
-                            .get(address)
-                            .expect("ICE: load in merger should have store from outer block")
+                            self.outer_block_stores
+                                .get(address)
+                                .expect("ICE: load in merger should have store from outer block")
                         };
 
                         self.get_slice_length(context_store.new_value)
@@ -514,10 +511,14 @@ impl<'f> Context<'f> {
                             Value::Intrinsic(intrinsic) => match intrinsic {
                                 Intrinsic::SlicePushBack
                                 | Intrinsic::SlicePushFront
-                                | Intrinsic::SliceInsert => self.get_slice_length(slice_contents) + 1,
+                                | Intrinsic::SliceInsert => {
+                                    self.get_slice_length(slice_contents) + 1
+                                }
                                 Intrinsic::SlicePopBack
                                 | Intrinsic::SlicePopFront
-                                | Intrinsic::SliceRemove => self.get_slice_length(slice_contents) - 1,
+                                | Intrinsic::SliceRemove => {
+                                    self.get_slice_length(slice_contents) - 1
+                                }
                                 _ => {
                                     unreachable!("ICE: Intrinsic not supported, got {intrinsic:?}")
                                 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

No issue as this was found and quickly patched as part of #374 

## Summary\*

The handling of `get_slice_length` was incorrect in that for some instruction cases it used the slice capacity (the total number of slice elements in an array value) and in some cases it used the slice length prefix. During slice merger we should _only_ ever use the capacity. The length is to be used only for checking against user out of bounds accesses. This was not a problem in the existing tests, but when trying to do a push back outside of an if statement where there was a slice merger we get mismatched slice values as the length is not correct. 

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
