### PR TITLE
chore: remove usage of `serial_test` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serial_test",
  "tar",
  "tempfile",
  "test-binary",
@@ -1483,7 +1482,6 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1505,17 +1503,6 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -3410,31 +3397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.26",
-]
-
-[[package]]
-name = "serial_test"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.26",

--- a/crates/acvm_backend_barretenberg/Cargo.toml
+++ b/crates/acvm_backend_barretenberg/Cargo.toml
@@ -28,7 +28,6 @@ reqwest = { version = "0.11.16", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-serial_test = "2.0.0"
 test-binary = "3.0.1"
 
 [build-dependencies]

--- a/crates/acvm_backend_barretenberg/src/cli/contract.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/contract.rs
@@ -38,7 +38,6 @@ impl ContractCommand {
 }
 
 #[test]
-#[serial_test::serial]
 fn contract_command() {
     use tempfile::tempdir;
 

--- a/crates/acvm_backend_barretenberg/src/cli/gates.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/gates.rs
@@ -52,7 +52,6 @@ impl GatesCommand {
 }
 
 #[test]
-#[serial_test::serial]
 fn gate_command() {
     let backend = crate::get_mock_backend();
     let bytecode_path = PathBuf::from("./src/1_mul.bytecode");

--- a/crates/acvm_backend_barretenberg/src/cli/info.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/info.rs
@@ -71,7 +71,6 @@ impl InfoCommand {
 }
 
 #[test]
-#[serial_test::serial]
 fn info_command() {
     use acvm::acir::circuit::black_box_functions::BlackBoxFunc;
     use acvm::acir::circuit::opcodes::{BlackBoxFuncCall, Opcode};

--- a/crates/acvm_backend_barretenberg/src/cli/mod.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/mod.rs
@@ -15,7 +15,6 @@ pub(crate) use verify::VerifyCommand;
 pub(crate) use write_vk::WriteVkCommand;
 
 #[test]
-#[serial_test::serial]
 fn no_command_provided_works() {
     // This is a simple test to check that the binaries work
 

--- a/crates/acvm_backend_barretenberg/src/cli/prove.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/prove.rs
@@ -46,7 +46,6 @@ impl ProveCommand {
 }
 
 #[test]
-#[serial_test::serial]
 fn prove_command() {
     use tempfile::tempdir;
 

--- a/crates/acvm_backend_barretenberg/src/cli/verify.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/verify.rs
@@ -34,7 +34,6 @@ impl VerifyCommand {
 }
 
 #[test]
-#[serial_test::serial]
 fn verify_command() {
     use tempfile::tempdir;
 

--- a/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
@@ -38,7 +38,6 @@ impl WriteVkCommand {
 }
 
 #[test]
-#[serial_test::serial]
 fn write_vk_command() {
     use tempfile::tempdir;
 

--- a/crates/acvm_backend_barretenberg/src/smart_contract.rs
+++ b/crates/acvm_backend_barretenberg/src/smart_contract.rs
@@ -61,7 +61,6 @@ mod tests {
     use crate::get_mock_backend;
 
     #[test]
-    #[serial_test::serial]
     fn test_smart_contract() {
         let expression = &(Witness(1) + Witness(2)) - &Expression::from(Witness(3));
         let constraint = Opcode::Arithmetic(expression);


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We used to require this as we were installing the mocked backend in each test (which resulted in many backends being simultaneously written to the same location. We now allow using backends at arbitrary paths so no longer need to do this.

We then run these tests in parallel.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
