### PR TITLE
chore: first pass at adding proper errors to dynamic backends

### DIFF
--- a/crates/acvm_backend_barretenberg/src/cli/contract.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/contract.rs
@@ -27,18 +27,18 @@ impl ContractCommand {
             .arg("-o")
             .arg("-");
 
-        let output = command.output().expect("Failed to execute command");
+        let output = command.output()?;
 
         if output.status.success() {
             Ok(String::from_utf8(output.stdout).unwrap())
         } else {
-            Err(BackendError(String::from_utf8(output.stderr).unwrap()))
+            Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()))
         }
     }
 }
 
 #[test]
-fn contract_command() {
+fn contract_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
     let backend = crate::get_mock_backend();
@@ -58,11 +58,12 @@ fn contract_command() {
         is_recursive: false,
         crs_path: crs_path.clone(),
     };
-
-    assert!(write_vk_command.run(&backend.binary_path()).is_ok());
+    write_vk_command.run(&backend.binary_path())?;
 
     let contract_command = ContractCommand { vk_path, crs_path };
+    contract_command.run(&backend.binary_path())?;
 
-    assert!(contract_command.run(&backend.binary_path()).is_ok());
     drop(temp_directory);
+
+    Ok(())
 }

--- a/crates/acvm_backend_barretenberg/src/cli/contract.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/contract.rs
@@ -30,9 +30,10 @@ impl ContractCommand {
         let output = command.output()?;
 
         if output.status.success() {
-            Ok(String::from_utf8(output.stdout).unwrap())
+            String::from_utf8(output.stdout)
+                .map_err(|error| BackendError::MalformedResponse(error.into_bytes()))
         } else {
-            Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()))
+            Err(BackendError::CommandFailed(output.stderr))
         }
     }
 }

--- a/crates/acvm_backend_barretenberg/src/cli/contract.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/contract.rs
@@ -41,7 +41,7 @@ impl ContractCommand {
 fn contract_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
-    let backend = crate::get_mock_backend();
+    let backend = crate::get_mock_backend()?;
 
     let temp_directory = tempdir().expect("could not create a temporary directory");
     let temp_directory_path = temp_directory.path();

--- a/crates/acvm_backend_barretenberg/src/cli/gates.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/gates.rs
@@ -55,7 +55,7 @@ impl GatesCommand {
 fn gate_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
-    let backend = crate::get_mock_backend();
+    let backend = crate::get_mock_backend()?;
 
     let temp_directory = tempdir().expect("could not create a temporary directory");
     let temp_directory_path = temp_directory.path();

--- a/crates/acvm_backend_barretenberg/src/cli/gates.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/gates.rs
@@ -21,15 +21,13 @@ impl GatesCommand {
             .output()?;
 
         if !output.status.success() {
-            return Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()));
+            return Err(BackendError::CommandFailed(output.stderr));
         }
         // Note: barretenberg includes the newline, so that subsequent prints to stdout
         // are not on the same line as the gates output.
 
-        let output_len = output.stdout.len();
-        let gates_bytes: [u8; 8] = output.stdout.try_into().map_err(|_| {
-            BackendError::BinaryError(format!("Unexpected 8 bytes, received {}", output_len))
-        })?;
+        let gates_bytes: [u8; 8] =
+            output.stdout.try_into().map_err(BackendError::MalformedResponse)?;
 
         // Convert bytes to u64 in little-endian format
         let value = u64::from_le_bytes(gates_bytes);

--- a/crates/acvm_backend_barretenberg/src/cli/gates.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/gates.rs
@@ -22,14 +22,14 @@ impl GatesCommand {
             .expect("Failed to execute command");
 
         if !output.status.success() {
-            return Err(BackendError(String::from_utf8(output.stderr).unwrap()));
+            return Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()));
         }
         // Note: barretenberg includes the newline, so that subsequent prints to stdout
         // are not on the same line as the gates output.
 
         // Ensure we got the expected number of bytes
         if output.stdout.len() != 8 {
-            return Err(BackendError(format!(
+            return Err(BackendError::BinaryError(format!(
                 "Unexpected 8 bytes, received {}",
                 output.stdout.len()
             )));
@@ -52,7 +52,7 @@ impl GatesCommand {
 }
 
 #[test]
-fn gate_command() {
+fn gate_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
     let backend = crate::get_mock_backend();
@@ -66,7 +66,9 @@ fn gate_command() {
 
     let gate_command = GatesCommand { crs_path, bytecode_path };
 
-    let output = gate_command.run(&backend.binary_path()).unwrap();
+    let output = gate_command.run(&backend.binary_path())?;
     // Mock backend always returns zero gates.
     assert_eq!(output, 0);
+
+    Ok(())
 }

--- a/crates/acvm_backend_barretenberg/src/cli/info.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/info.rs
@@ -35,7 +35,7 @@ impl InfoCommand {
         let output = command.output()?;
 
         if !output.status.success() {
-            return Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()));
+            return Err(BackendError::CommandFailed(output.stderr));
         }
 
         let backend_info: InfoResponse =

--- a/crates/acvm_backend_barretenberg/src/cli/info.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/info.rs
@@ -32,10 +32,10 @@ impl InfoCommand {
 
         command.arg("info").arg("-c").arg(self.crs_path).arg("-o").arg("-");
 
-        let output = command.output().expect("Failed to execute command");
+        let output = command.output()?;
 
         if !output.status.success() {
-            return Err(BackendError(String::from_utf8(output.stderr).unwrap()));
+            return Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()));
         }
 
         let backend_info: InfoResponse =
@@ -71,7 +71,7 @@ impl InfoCommand {
 }
 
 #[test]
-fn info_command() {
+fn info_command() -> Result<(), BackendError> {
     use acvm::acir::circuit::black_box_functions::BlackBoxFunc;
     use acvm::acir::circuit::opcodes::{BlackBoxFuncCall, Opcode};
 
@@ -80,8 +80,7 @@ fn info_command() {
     let backend = crate::get_mock_backend();
     let crs_path = backend.backend_directory();
 
-    let (language, is_opcode_supported) =
-        InfoCommand { crs_path }.run(&backend.binary_path()).unwrap();
+    let (language, is_opcode_supported) = InfoCommand { crs_path }.run(&backend.binary_path())?;
 
     assert!(matches!(language, Language::PLONKCSat { width: 3 }));
     assert!(is_opcode_supported(&Opcode::Arithmetic(Expression::default())));
@@ -90,4 +89,6 @@ fn info_command() {
         #[allow(deprecated)]
         BlackBoxFuncCall::dummy(BlackBoxFunc::Keccak256)
     )));
+
+    Ok(())
 }

--- a/crates/acvm_backend_barretenberg/src/cli/info.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/info.rs
@@ -77,7 +77,7 @@ fn info_command() -> Result<(), BackendError> {
 
     use acvm::acir::native_types::Expression;
 
-    let backend = crate::get_mock_backend();
+    let backend = crate::get_mock_backend()?;
     let crs_path = backend.backend_directory();
 
     let (language, is_opcode_supported) = InfoCommand { crs_path }.run(&backend.binary_path())?;

--- a/crates/acvm_backend_barretenberg/src/cli/mod.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/mod.rs
@@ -15,10 +15,10 @@ pub(crate) use verify::VerifyCommand;
 pub(crate) use write_vk::WriteVkCommand;
 
 #[test]
-fn no_command_provided_works() {
+fn no_command_provided_works() -> Result<(), crate::BackendError> {
     // This is a simple test to check that the binaries work
 
-    let backend = crate::get_mock_backend();
+    let backend = crate::get_mock_backend()?;
 
     let output = std::process::Command::new(backend.binary_path())
         .output()
@@ -27,4 +27,6 @@ fn no_command_provided_works() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     // Assert help message is printed due to no command being provided.
     assert!(stderr.contains("Usage: mock_backend <COMMAND>"));
+
+    Ok(())
 }

--- a/crates/acvm_backend_barretenberg/src/cli/mod.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/mod.rs
@@ -20,9 +20,7 @@ fn no_command_provided_works() -> Result<(), crate::BackendError> {
 
     let backend = crate::get_mock_backend()?;
 
-    let output = std::process::Command::new(backend.binary_path())
-        .output()
-        .expect("Failed to execute command");
+    let output = std::process::Command::new(backend.binary_path()).output()?;
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     // Assert help message is printed due to no command being provided.

--- a/crates/acvm_backend_barretenberg/src/cli/prove.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/prove.rs
@@ -39,7 +39,7 @@ impl ProveCommand {
         if output.status.success() {
             Ok(output.stdout)
         } else {
-            Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()))
+            Err(BackendError::CommandFailed(output.stderr))
         }
     }
 }

--- a/crates/acvm_backend_barretenberg/src/cli/prove.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/prove.rs
@@ -35,17 +35,17 @@ impl ProveCommand {
             command.arg("-r");
         }
 
-        let output = command.output().expect("Failed to execute command");
+        let output = command.output()?;
         if output.status.success() {
             Ok(output.stdout)
         } else {
-            Err(BackendError(String::from_utf8(output.stderr).unwrap()))
+            Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()))
         }
     }
 }
 
 #[test]
-fn prove_command() {
+fn prove_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
     let backend = crate::get_mock_backend();
@@ -61,7 +61,9 @@ fn prove_command() {
     let crs_path = backend.backend_directory();
     let prove_command = ProveCommand { crs_path, bytecode_path, witness_path, is_recursive: false };
 
-    let proof = prove_command.run(&backend.binary_path()).unwrap();
+    let proof = prove_command.run(&backend.binary_path())?;
     assert_eq!(proof, "proof".as_bytes());
     drop(temp_directory);
+
+    Ok(())
 }

--- a/crates/acvm_backend_barretenberg/src/cli/prove.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/prove.rs
@@ -48,7 +48,7 @@ impl ProveCommand {
 fn prove_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
-    let backend = crate::get_mock_backend();
+    let backend = crate::get_mock_backend()?;
 
     let temp_directory = tempdir().expect("could not create a temporary directory");
     let temp_directory_path = temp_directory.path();

--- a/crates/acvm_backend_barretenberg/src/cli/verify.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/verify.rs
@@ -42,7 +42,7 @@ fn verify_command() -> Result<(), BackendError> {
     use super::{ProveCommand, WriteVkCommand};
     use crate::proof_system::write_to_file;
 
-    let backend = crate::get_mock_backend();
+    let backend = crate::get_mock_backend()?;
 
     let temp_directory = tempdir().expect("could not create a temporary directory");
     let temp_directory_path = temp_directory.path();

--- a/crates/acvm_backend_barretenberg/src/cli/verify.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/verify.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::BackendError;
+
 /// VerifyCommand will call the barretenberg binary
 /// to verify a proof
 pub(crate) struct VerifyCommand {
@@ -10,7 +12,7 @@ pub(crate) struct VerifyCommand {
 }
 
 impl VerifyCommand {
-    pub(crate) fn run(self, binary_path: &Path) -> bool {
+    pub(crate) fn run(self, binary_path: &Path) -> Result<bool, BackendError> {
         let mut command = std::process::Command::new(binary_path);
 
         command
@@ -26,15 +28,15 @@ impl VerifyCommand {
             command.arg("-r");
         }
 
-        let output = command.output().expect("Failed to execute command");
+        let output = command.output()?;
 
         // We currently do not distinguish between an invalid proof and an error inside the backend.
-        output.status.success()
+        Ok(output.status.success())
     }
 }
 
 #[test]
-fn verify_command() {
+fn verify_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
     use super::{ProveCommand, WriteVkCommand};
@@ -61,8 +63,7 @@ fn verify_command() {
         vk_path_output: vk_path_output.clone(),
     };
 
-    let vk_written = write_vk_command.run(&backend.binary_path());
-    assert!(vk_written.is_ok());
+    write_vk_command.run(&backend.binary_path())?;
 
     let prove_command = ProveCommand {
         crs_path: crs_path.clone(),
@@ -70,14 +71,16 @@ fn verify_command() {
         bytecode_path,
         witness_path,
     };
-    let proof = prove_command.run(&backend.binary_path()).unwrap();
+    let proof = prove_command.run(&backend.binary_path())?;
 
     write_to_file(&proof, &proof_path);
 
     let verify_command =
         VerifyCommand { crs_path, is_recursive: false, proof_path, vk_path: vk_path_output };
 
-    let verified = verify_command.run(&backend.binary_path());
+    let verified = verify_command.run(&backend.binary_path())?;
     assert!(verified);
+
     drop(temp_directory);
+    Ok(())
 }

--- a/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
@@ -28,17 +28,17 @@ impl WriteVkCommand {
             command.arg("-r");
         }
 
-        let output = command.output().expect("Failed to execute command");
+        let output = command.output()?;
         if output.status.success() {
             Ok(())
         } else {
-            Err(BackendError(String::from_utf8(output.stderr).unwrap()))
+            Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()))
         }
     }
 }
 
 #[test]
-fn write_vk_command() {
+fn write_vk_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
     let backend = crate::get_mock_backend();
@@ -55,7 +55,8 @@ fn write_vk_command() {
     let write_vk_command =
         WriteVkCommand { bytecode_path, crs_path, is_recursive: false, vk_path_output };
 
-    let vk_written = write_vk_command.run(&backend.binary_path());
-    assert!(vk_written.is_ok());
+    write_vk_command.run(&backend.binary_path())?;
     drop(temp_directory);
+
+    Ok(())
 }

--- a/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
@@ -41,7 +41,7 @@ impl WriteVkCommand {
 fn write_vk_command() -> Result<(), BackendError> {
     use tempfile::tempdir;
 
-    let backend = crate::get_mock_backend();
+    let backend = crate::get_mock_backend()?;
 
     let temp_directory = tempdir().expect("could not create a temporary directory");
     let temp_directory_path = temp_directory.path();

--- a/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
+++ b/crates/acvm_backend_barretenberg/src/cli/write_vk.rs
@@ -32,7 +32,7 @@ impl WriteVkCommand {
         if output.status.success() {
             Ok(())
         } else {
-            Err(BackendError::BinaryError(String::from_utf8(output.stderr).unwrap()))
+            Err(BackendError::CommandFailed(output.stderr))
         }
     }
 }

--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -22,24 +22,23 @@ pub fn backends_directory() -> PathBuf {
 test_binary::build_test_binary_once!(mock_backend, "test-binaries");
 
 #[cfg(test)]
-fn get_mock_backend() -> Backend {
+fn get_mock_backend() -> Result<Backend, BackendError> {
     std::env::set_var("NARGO_BACKEND_PATH", path_to_mock_backend());
 
     let mock_backend = Backend::new("mock_backend".to_string());
-    if !mock_backend.binary_path().is_file() {
-        panic!("Mock backend binary does not exist at expected path");
-    }
-    mock_backend
+    mock_backend.assert_binary_exists().map(|_| mock_backend)
 }
 
-fn assert_binary_exists(backend: &Backend) -> PathBuf {
-    let binary_path = backend.binary_path();
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 
-    if !binary_path.is_file() {
-        let bb_url = std::env::var("BB_BINARY_URL").unwrap_or(env!("BB_BINARY_URL").to_string());
-        download_backend(&bb_url, &binary_path)
-    }
-    binary_path
+    #[error("Backend binary does not exist")]
+    MissingBinary,
+
+    #[error("{0}")]
+    BinaryError(String),
 }
 
 #[derive(Debug)]
@@ -52,16 +51,27 @@ impl Backend {
         Backend { name }
     }
 
-    fn backend_directory(&self) -> PathBuf {
-        // If an explicit path to a backend binary has been provided then place CRS, etc. in same directory.
-        if let Some(binary_path) = std::env::var_os("NARGO_BACKEND_PATH") {
-            PathBuf::from(binary_path)
-                .parent()
-                .expect("backend binary should have a parent directory")
-                .to_path_buf()
+    fn assert_binary_exists(&self) -> Result<PathBuf, BackendError> {
+        let binary_path = self.binary_path();
+        if binary_path.is_file() {
+            Ok(binary_path)
         } else {
-            backends_directory().join(&self.name)
+            if self.name == ACVM_BACKEND_BARRETENBERG {
+                // If we're trying to use barretenberg, automatically go and install it.
+                let bb_url =
+                    std::env::var("BB_BINARY_URL").unwrap_or(env!("BB_BINARY_URL").to_string());
+                download_backend(&bb_url, &binary_path);
+                return Ok(binary_path);
+            }
+            Err(BackendError::MissingBinary)
         }
+    }
+
+    fn backend_directory(&self) -> PathBuf {
+        self.binary_path()
+            .parent()
+            .expect("backend binary should have a parent directory")
+            .to_path_buf()
     }
 
     fn crs_directory(&self) -> PathBuf {
@@ -79,11 +89,16 @@ impl Backend {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum BackendError {
-    #[error(transparent)]
-    IoError(#[from] std::io::Error),
+#[cfg(test)]
+mod backend {
+    use crate::{Backend, BackendError};
 
-    #[error("{0}")]
-    BinaryError(String),
+    #[test]
+    fn raises_error_on_missing_binary() {
+        let bad_backend = Backend::new("i_dont_exist".to_string());
+
+        let binary_path = bad_backend.assert_binary_exists();
+
+        assert!(matches!(binary_path, Err(BackendError::MissingBinary)));
+    }
 }

--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -37,8 +37,11 @@ pub enum BackendError {
     #[error("Backend binary does not exist")]
     MissingBinary,
 
-    #[error("{0}")]
-    BinaryError(String),
+    #[error("The backend responded with malformed data: {0:?}")]
+    MalformedResponse(Vec<u8>),
+
+    #[error("The backend encountered an error")]
+    CommandFailed(Vec<u8>),
 }
 
 #[derive(Debug)]

--- a/crates/acvm_backend_barretenberg/src/lib.rs
+++ b/crates/acvm_backend_barretenberg/src/lib.rs
@@ -80,10 +80,10 @@ impl Backend {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub struct BackendError(String);
+pub enum BackendError {
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 
-impl std::fmt::Display for BackendError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
+    #[error("{0}")]
+    BinaryError(String),
 }

--- a/crates/acvm_backend_barretenberg/src/proof_system.rs
+++ b/crates/acvm_backend_barretenberg/src/proof_system.rs
@@ -120,11 +120,8 @@ impl Backend {
         .run(&binary_path)?;
 
         // Verify the proof
-        let valid_proof =
-            VerifyCommand { crs_path: self.crs_directory(), is_recursive, proof_path, vk_path }
-                .run(&binary_path);
-
-        Ok(valid_proof)
+        VerifyCommand { crs_path: self.crs_directory(), is_recursive, proof_path, vk_path }
+            .run(&binary_path)
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR turns `BackendError` into an enum of the main error variants. 

This PR also fixes a bug where attempting to use a backend with a missing binary will install barretenberg in its place.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
