### PR TITLE
chore: query opcode support from backend once per workspace

### DIFF
--- a/crates/nargo/src/errors.rs
+++ b/crates/nargo/src/errors.rs
@@ -17,6 +17,12 @@ pub enum NargoError {
     ForeignCallError(#[from] ForeignCallError),
 }
 
+impl From<acvm::compiler::CompileError> for NargoError {
+    fn from(_: acvm::compiler::CompileError) -> Self {
+        NargoError::CompilationError
+    }
+}
+
 impl NargoError {
     /// Extracts the user defined failure message from the ExecutionError
     /// If one exists.

--- a/crates/nargo/src/ops/mod.rs
+++ b/crates/nargo/src/ops/mod.rs
@@ -1,6 +1,8 @@
 pub use self::execute::execute_circuit;
+pub use self::optimize::{optimize_circuit, optimize_contract};
 pub use self::test::{run_test, TestStatus};
 
 mod execute;
 mod foreign_calls;
+mod optimize;
 mod test;

--- a/crates/nargo/src/ops/mod.rs
+++ b/crates/nargo/src/ops/mod.rs
@@ -1,5 +1,5 @@
 pub use self::execute::execute_circuit;
-pub use self::optimize::{optimize_circuit, optimize_contract};
+pub use self::optimize::{optimize_contract, optimize_program};
 pub use self::test::{run_test, TestStatus};
 
 mod execute;

--- a/crates/nargo/src/ops/optimize.rs
+++ b/crates/nargo/src/ops/optimize.rs
@@ -1,0 +1,33 @@
+use acvm::{
+    acir::circuit::{Circuit, Opcode},
+    compiler::AcirTransformationMap,
+    Language,
+};
+use iter_extended::try_vecmap;
+use noirc_driver::CompiledContract;
+
+use crate::NargoError;
+
+pub fn optimize_circuit(
+    circuit: Circuit,
+    np_language: Language,
+    is_opcode_supported: &impl Fn(&Opcode) -> bool,
+) -> Result<(Circuit, AcirTransformationMap), NargoError> {
+    acvm::compiler::compile(circuit, np_language, &is_opcode_supported).map_err(NargoError::from)
+}
+
+pub fn optimize_contract(
+    contract: CompiledContract,
+    np_language: Language,
+    is_opcode_supported: &impl Fn(&Opcode) -> bool,
+) -> Result<CompiledContract, NargoError> {
+    let functions = try_vecmap(contract.functions, |mut func| {
+        let (optimized_bytecode, location_map) =
+            acvm::compiler::compile(func.bytecode, np_language, &is_opcode_supported)?;
+        func.bytecode = optimized_bytecode;
+        func.debug.update_acir(location_map);
+        Ok::<_, NargoError>(func)
+    })?;
+
+    Ok(CompiledContract { functions, ..contract })
+}

--- a/crates/nargo/src/ops/optimize.rs
+++ b/crates/nargo/src/ops/optimize.rs
@@ -1,19 +1,20 @@
-use acvm::{
-    acir::circuit::{Circuit, Opcode},
-    compiler::AcirTransformationMap,
-    Language,
-};
+use acvm::{acir::circuit::Opcode, Language};
 use iter_extended::try_vecmap;
-use noirc_driver::CompiledContract;
+use noirc_driver::{CompiledContract, CompiledProgram};
 
 use crate::NargoError;
 
-pub fn optimize_circuit(
-    circuit: Circuit,
+pub fn optimize_program(
+    mut program: CompiledProgram,
     np_language: Language,
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
-) -> Result<(Circuit, AcirTransformationMap), NargoError> {
-    acvm::compiler::compile(circuit, np_language, &is_opcode_supported).map_err(NargoError::from)
+) -> Result<CompiledProgram, NargoError> {
+    let (optimized_circuit, location_map) =
+        acvm::compiler::compile(program.circuit, np_language, &is_opcode_supported)?;
+
+    program.circuit = optimized_circuit;
+    program.debug.update_acir(location_map);
+    Ok(program)
 }
 
 pub fn optimize_contract(

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use acvm::acir::circuit::Opcode;
+use acvm::Language;
 use fm::FileManager;
 use iter_extended::{try_vecmap, vecmap};
 use nargo::artifacts::contract::PreprocessedContract;
@@ -63,14 +65,20 @@ pub(crate) fn run(
     let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
     let circuit_dir = workspace.target_directory_path();
 
+    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
     for package in &workspace {
         // If `contract` package type, we're compiling every function in a 'contract' rather than just 'main'.
         if package.is_contract() {
-            let (file_manager, contracts) =
-                compile_contracts(backend, package, &args.compile_options)?;
+            let (file_manager, contracts) = compile_contracts(
+                package,
+                &args.compile_options,
+                np_language,
+                &is_opcode_supported,
+            )?;
             save_contracts(&file_manager, contracts, package, &circuit_dir, args.output_debug);
         } else {
-            let (file_manager, program) = compile_package(backend, package, &args.compile_options)?;
+            let (file_manager, program) =
+                compile_package(package, &args.compile_options, np_language, &is_opcode_supported)?;
             save_program(&file_manager, program, package, &circuit_dir, args.output_debug);
         }
     }
@@ -79,9 +87,10 @@ pub(crate) fn run(
 }
 
 pub(crate) fn compile_package(
-    backend: &Backend,
     package: &Package,
     compile_options: &CompileOptions,
+    np_language: Language,
+    is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> Result<(FileManager, CompiledProgram), CliError> {
     if package.is_library() {
         return Err(CompileError::LibraryCrate(package.name.clone()).into());
@@ -92,7 +101,6 @@ pub(crate) fn compile_package(
     let program = report_errors(result, &context.file_manager, compile_options.deny_warnings)?;
 
     // Apply backend specific optimizations.
-    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
     let optimized_program =
         nargo::ops::optimize_program(program, np_language, &is_opcode_supported)
             .expect("Backend does not support an opcode that is in the IR");
@@ -101,15 +109,15 @@ pub(crate) fn compile_package(
 }
 
 pub(crate) fn compile_contracts(
-    backend: &Backend,
     package: &Package,
     compile_options: &CompileOptions,
+    np_language: Language,
+    is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> Result<(FileManager, Vec<CompiledContract>), CliError> {
     let (mut context, crate_id) = prepare_package(package);
     let result = noirc_driver::compile_contracts(&mut context, crate_id, compile_options);
     let contracts = report_errors(result, &context.file_manager, compile_options.deny_warnings)?;
 
-    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
     let optimized_contracts = try_vecmap(contracts, |contract| {
         nargo::ops::optimize_contract(contract, np_language, &is_opcode_supported)
     })?;


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR centralises the querying of opcode support from the backend to once per workspace. We then pass around a reference to this data for each package to avoid needing to call out to `bb` many times (and so needing to allocate memory for a massive circuit each time)

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
