### PR TITLE
chore(ci): create cache entries in merge queue

### DIFF
--- a/.github/workflows/abi_wasm.yml
+++ b/.github/workflows/abi_wasm.yml
@@ -46,13 +46,12 @@ jobs:
           nix build -L .#noirc_abi_wasm
 
       - name: Export cache from nix store
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
           nix copy --to "file://${{ env.CACHED_PATH }}?compression=zstd&parallel-compression=true" .#noirc-abi-wasm-cargo-artifacts
 
       - uses: actions/cache/save@v3
-        # Don't create cache entries for the merge queue.
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.CACHED_PATH }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,7 @@ jobs:
           cargo build --package nargo_cli --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
 
       - uses: actions/cache/save@v3
-        # Don't create cache entries for the merge queue.
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -145,8 +144,7 @@ jobs:
           cross build --package nargo_cli --release --target=${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
 
       - uses: actions/cache/save@v3
-        # Don't create cache entries for the merge queue.
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/cache/save@v3
         # Write a cache entry even if the tests fail but don't create any for the merge queue.
-        if: ${{ always() && steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ always() && steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -36,8 +36,7 @@ jobs:
         run: cargo build --package nargo_cli --release
 
       - uses: actions/cache/save@v3
-        # Don't create cache entries for the merge queue.
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -92,13 +91,12 @@ jobs:
           nix build -L .#wasm
 
       - name: Export cache from nix store
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
           nix copy --to "file://${{ env.CACHED_PATH }}?compression=zstd&parallel-compression=true" .#noir-wasm-cargo-artifacts
 
       - uses: actions/cache/save@v3
-        # Don't create cache entries for the merge queue.
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.CACHED_PATH }}
           key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is an experiment as the CI results associated with the merge queue are being applied to the `master` branch. We then check to see if cache entries are then applied to `master` branch as well.

If this doesn't work then we can revert this PR and explicitly run CI on `master` to generate cache entries.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
