### PR TITLE
chore(ci): Run CI on master to populate cache

### DIFF
--- a/.github/workflows/abi_wasm.yml
+++ b/.github/workflows/abi_wasm.yml
@@ -3,6 +3,9 @@ name: ABI Wasm test
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - master
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:

--- a/.github/workflows/abi_wasm.yml
+++ b/.github/workflows/abi_wasm.yml
@@ -49,12 +49,13 @@ jobs:
           nix build -L .#noirc_abi_wasm
 
       - name: Export cache from nix store
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         run: |
           nix copy --to "file://${{ env.CACHED_PATH }}?compression=zstd&parallel-compression=true" .#noirc-abi-wasm-cargo-artifacts
 
       - uses: actions/cache/save@v3
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        # Don't create cache entries for the merge queue.
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         with:
           path: ${{ env.CACHED_PATH }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,8 @@ jobs:
           cargo build --package nargo_cli --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
 
       - uses: actions/cache/save@v3
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        # Don't create cache entries for the merge queue.
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -144,7 +145,8 @@ jobs:
           cross build --package nargo_cli --release --target=${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
 
       - uses: actions/cache/save@v3
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        # Don't create cache entries for the merge queue.
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - master
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
@@ -39,7 +42,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.CACHED_PATHS }}
-          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.66.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.CACHED_PATHS }}
-          key: ${{ runner.os }}-flake-${{ hashFiles('*.lock') }}
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.66.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/cache/save@v3
         # Write a cache entry even if the tests fail but don't create any for the merge queue.
-        if: ${{ always() && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ always() && steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -3,6 +3,9 @@ name: Wasm
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
@@ -18,7 +21,10 @@ jobs:
         ~/.cargo/registry/cache/
         ~/.cargo/git/db/
         target/
-
+    strategy:
+      matrix:
+        target: [x86_64-unknown-linux-gnu]
+        
     steps:
       - name: Checkout Noir repo
         uses: actions/checkout@v4
@@ -27,7 +33,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.CACHED_PATHS }}
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.66.0

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -42,7 +42,8 @@ jobs:
         run: cargo build --package nargo_cli --release
 
       - uses: actions/cache/save@v3
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        # Don't create cache entries for the merge queue.
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -97,12 +98,13 @@ jobs:
           nix build -L .#wasm
 
       - name: Export cache from nix store
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         run: |
           nix copy --to "file://${{ env.CACHED_PATH }}?compression=zstd&parallel-compression=true" .#noir-wasm-cargo-artifacts
 
       - uses: actions/cache/save@v3
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        # Don't create cache entries for the merge queue.
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name != 'merge_group' }}
         with:
           path: ${{ env.CACHED_PATH }}
           key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Reverts #2618 

## Summary\*

This PR reverts #2618 and adds new triggers to CI to run on pushes to master. This will ensure that master has cache entries for all workflows.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
