### PR TITLE
chore(ci): cache binaries for playwright

### DIFF
--- a/.github/workflows/abi_wasm.yml
+++ b/.github/workflows/abi_wasm.yml
@@ -118,7 +118,6 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          # TODO: Inspect yarn.lock and pull installed version automatically
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Set up test environment

--- a/.github/workflows/abi_wasm.yml
+++ b/.github/workflows/abi_wasm.yml
@@ -109,12 +109,22 @@ jobs:
           name: noirc_abi_wasm
           path: ./result
 
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          # TODO: Inspect yarn.lock and pull installed version automatically
+          key: ${{ runner.os }}-playwright-0.10.1
+
       - name: Set up test environment
         uses: ./.github/actions/setup
         with:
           working-directory: ./crates/noirc_abi_wasm
 
       - name: Install playwright deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ./crates/noirc_abi_wasm
         run: |
           npx playwright install

--- a/.github/workflows/abi_wasm.yml
+++ b/.github/workflows/abi_wasm.yml
@@ -109,6 +109,9 @@ jobs:
           name: noirc_abi_wasm
           path: ./result
 
+      - name: Query playwright version
+        run: echo "PLAYWRIGHT_VERSION=$(yarn info @web/test-runner-playwright --json | jq .children.Version)" >> $GITHUB_ENV
+
       - name: Cache playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
@@ -116,7 +119,7 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           # TODO: Inspect yarn.lock and pull installed version automatically
-          key: ${{ runner.os }}-playwright-0.10.1
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Set up test environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a cache for the playwright binaries to reduce CI times by a whopping 40 seconds

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
