### PR TITLE
(chore) printing integers as integers instead of fields

### DIFF
--- a/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -6,8 +6,8 @@ use crate::{
     hir::def_collector::dc_crate::{UnresolvedStruct, UnresolvedTrait},
     node_interner::TraitId,
     parser::SubModule,
-    FunctionDefinition, Ident, LetStatement, NoirFunction, NoirStruct,
-    NoirTrait, NoirTypeAlias, ParsedModule, TraitImpl, TraitImplItem, TraitItem, TypeImpl,
+    FunctionDefinition, Ident, LetStatement, NoirFunction, NoirStruct, NoirTrait, NoirTypeAlias,
+    ParsedModule, TraitImpl, TraitImplItem, TraitItem, TypeImpl,
 };
 
 use super::{

--- a/crates/noirc_printable_type/src/lib.rs
+++ b/crates/noirc_printable_type/src/lib.rs
@@ -161,11 +161,10 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
             output.push_str(&format_field_string(*f));
         }
         (
-            PrintableValue::Field(_f),
+            PrintableValue::Field(f),
             PrintableType::SignedInteger { .. } | PrintableType::UnsignedInteger { .. },
         ) => {
-            output
-                .push_str(&format!("{}", PrintableValueDisplay::Plain(value.clone(), typ.clone())));
+            output.push_str(&format!("{}", f.to_u128()));
         }
         (PrintableValue::Field(f), PrintableType::Boolean) => {
             if f.is_one() {

--- a/crates/noirc_printable_type/src/lib.rs
+++ b/crates/noirc_printable_type/src/lib.rs
@@ -162,9 +162,12 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
         }
         (
             PrintableValue::Field(f),
-            PrintableType::SignedInteger { .. } | PrintableType::UnsignedInteger { .. },
+            PrintableType::UnsignedInteger { .. },
         ) => {
             output.push_str(&format!("{}", f.to_u128()));
+        }
+        (PrintableValue::Field(_f), PrintableType::SignedInteger { .. }) => {
+            // TODO: I am not sure how to convert an element to a signed integer in this case 
         }
         (PrintableValue::Field(f), PrintableType::Boolean) => {
             if f.is_one() {

--- a/crates/noirc_printable_type/src/lib.rs
+++ b/crates/noirc_printable_type/src/lib.rs
@@ -157,14 +157,15 @@ fn fetch_printable_type(
 fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
     let mut output = String::new();
     match (value, typ) {
-        (
-            PrintableValue::Field(f),
-            PrintableType::Field
-            // TODO(#2401): We should print the sign for these and probably print normal integers instead of field strings
-            | PrintableType::SignedInteger { .. }
-            | PrintableType::UnsignedInteger { .. },
-        ) => {
+        (PrintableValue::Field(f), PrintableType::Field) => {
             output.push_str(&format_field_string(*f));
+        }
+        (
+            PrintableValue::Field(_f),
+            PrintableType::SignedInteger { .. } | PrintableType::UnsignedInteger { .. },
+        ) => {
+            output
+                .push_str(&format!("{}", PrintableValueDisplay::Plain(value.clone(), typ.clone())));
         }
         (PrintableValue::Field(f), PrintableType::Boolean) => {
             if f.is_one() {
@@ -176,8 +177,11 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
         (PrintableValue::Vec(vector), PrintableType::Array { typ, .. }) => {
             output.push('[');
             let mut values = vector.iter().peekable();
-            while let Some(value) = values.next()  {
-                output.push_str(&format!("{}", PrintableValueDisplay::Plain(value.clone(), *typ.clone())));
+            while let Some(value) = values.next() {
+                output.push_str(&format!(
+                    "{}",
+                    PrintableValueDisplay::Plain(value.clone(), *typ.clone())
+                ));
                 if values.peek().is_some() {
                     output.push_str(", ");
                 }
@@ -193,9 +197,12 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
             output.push_str(&format!("{name} {{ "));
 
             let mut fields = fields.iter().peekable();
-            while let Some((key, field_type)) = fields.next()  {
+            while let Some((key, field_type)) = fields.next() {
                 let value = &map[key];
-                output.push_str(&format!("{key}: {}", PrintableValueDisplay::Plain(value.clone(), field_type.clone())));
+                output.push_str(&format!(
+                    "{key}: {}",
+                    PrintableValueDisplay::Plain(value.clone(), field_type.clone())
+                ));
                 if fields.peek().is_some() {
                     output.push_str(", ");
                 }
@@ -204,7 +211,7 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
             output.push_str(" }");
         }
 
-        _ => return None
+        _ => return None,
     };
 
     Some(output)

--- a/crates/noirc_printable_type/src/lib.rs
+++ b/crates/noirc_printable_type/src/lib.rs
@@ -160,14 +160,11 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
         (PrintableValue::Field(f), PrintableType::Field) => {
             output.push_str(&format_field_string(*f));
         }
-        (
-            PrintableValue::Field(f),
-            PrintableType::UnsignedInteger { .. },
-        ) => {
+        (PrintableValue::Field(f), PrintableType::UnsignedInteger { .. }) => {
             output.push_str(&format!("{}", f.to_u128()));
         }
         (PrintableValue::Field(_f), PrintableType::SignedInteger { .. }) => {
-            // TODO: I am not sure how to convert an element to a signed integer in this case 
+            // TODO: I am not sure how to convert an element to a signed integer in this case
         }
         (PrintableValue::Field(f), PrintableType::Boolean) => {
             if f.is_one() {


### PR DESCRIPTION
# Description

I am working on a solution to #2401 and I have ran into a blocker on this. 
Here is where I am blocked for reference:
https://github.com/jtfirek/noir/blob/6ec4d4aed7127738ac73b01d0ea411859a970bf4/crates/noirc_printable_type/src/lib.rs#L163-L168
## Problem\*

The implementation for this field element struct doesn't seem to currently have a way to cover field elements into a signed value. should I add an implementation for this?

https://github.com/noir-lang/acvm/blob/0d6656b0784e76047484c17a98d08d6913270cd0/acir_field/src/generic_ark.rs#L223-L238


