### PR TITLE
chore(ci): reenable CI for `noir_wasm`

### DIFF
--- a/.github/workflows/abi_wasm.yml
+++ b/.github/workflows/abi_wasm.yml
@@ -110,6 +110,7 @@ jobs:
           path: ./result
 
       - name: Query playwright version
+        working-directory: ./crates/noirc_abi_wasm
         run: echo "PLAYWRIGHT_VERSION=$(yarn info @web/test-runner-playwright --json | jq .children.Version)" >> $GITHUB_ENV
 
       - name: Cache playwright binaries

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -146,9 +146,21 @@ jobs:
           chmod +x $nargo_binary
           $nargo_binary compile
 
-      - name: Install dependencies
-        working-directory: ./crates/wasm
-        run: yarn install
+      - name: Set up test environment
+        uses: ./.github/actions/setup
+        with:
+          working-directory: ./crates/wasm
+
+      - name: Query playwright version
+        run: echo "PLAYWRIGHT_VERSION=$(yarn info @web/test-runner-playwright --json | jq .children.Version)" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install playwright deps
         working-directory: ./crates/wasm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -119,45 +119,45 @@ jobs:
           path: ${{ env.UPLOAD_PATH }}
           retention-days: 3
 
-  # test:
-  #   needs: [build-wasm, build-nargo]
-  #   name: Test noir_wasm
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout noir-lang/noir
-  #       uses: actions/checkout@v4
+  test:
+    needs: [build-wasm, build-nargo]
+    name: Test noir_wasm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout noir-lang/noir
+        uses: actions/checkout@v4
 
-  #     - name: Download wasm package artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: noir_wasm
-  #         path: ./crates/wasm/result
+      - name: Download wasm package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: noir_wasm
+          path: ./crates/wasm/result
 
-  #     - name: Download nargo binary
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: nargo
-  #         path: ./nargo
+      - name: Download nargo binary
+        uses: actions/download-artifact@v3
+        with:
+          name: nargo
+          path: ./nargo
 
-  #     - name: Compile test program with Nargo CLI
-  #       working-directory: ./crates/wasm/noir-script
-  #       run: |
-  #         nargo_binary=${{ github.workspace }}/nargo/nargo
-  #         chmod +x $nargo_binary
-  #         $nargo_binary compile
+      - name: Compile test program with Nargo CLI
+        working-directory: ./crates/wasm/noir-script
+        run: |
+          nargo_binary=${{ github.workspace }}/nargo/nargo
+          chmod +x $nargo_binary
+          $nargo_binary compile
 
-  #     - name: Install dependencies
-  #       working-directory: ./crates/wasm
-  #       run: yarn install
+      - name: Install dependencies
+        working-directory: ./crates/wasm
+        run: yarn install
 
-  #     - name: Install playwright deps
-  #       working-directory: ./crates/wasm
-  #       run: |
-  #         npx playwright install
-  #         npx playwright install-deps
+      - name: Install playwright deps
+        working-directory: ./crates/wasm
+        run: |
+          npx playwright install
+          npx playwright install-deps
 
-  #     - name: Run tests
-  #       working-directory: ./crates/wasm
-  #       run: |
-  #         yarn test:browser
-  #         yarn test:node
+      - name: Run tests
+        working-directory: ./crates/wasm
+        run: |
+          yarn test:browser
+          yarn test:node

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -152,6 +152,7 @@ jobs:
           working-directory: ./crates/wasm
 
       - name: Query playwright version
+        working-directory: ./crates/wasm
         run: echo "PLAYWRIGHT_VERSION=$(yarn info @web/test-runner-playwright --json | jq .children.Version)" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
@@ -163,6 +164,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install playwright deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ./crates/wasm
         run: |
           npx playwright install

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -151,20 +151,11 @@ jobs:
         with:
           working-directory: ./crates/wasm
 
-      - name: Query playwright version
+      - name: Install dependencies
         working-directory: ./crates/wasm
-        run: echo "PLAYWRIGHT_VERSION=$(yarn info @web/test-runner-playwright --json | jq .children.Version)" >> $GITHUB_ENV
-
-      - name: Cache playwright binaries
-        uses: actions/cache@v3
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        run: yarn install
 
       - name: Install playwright deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ./crates/wasm
         run: |
           npx playwright install

--- a/crates/wasm/web-test-runner.config.mjs
+++ b/crates/wasm/web-test-runner.config.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import { esbuildPlugin } from "@web/dev-server-esbuild";
 import { playwrightLauncher } from "@web/test-runner-playwright";
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #2565 

## Summary\*

This PR fixes out `noir_wasm` testing in CI.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
