### PR TITLE
fix(wasm): Remove stacker from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,6 @@ version = "0.8.0"
 source = "git+https://github.com/jfecher/chumsky?rev=ad9d312#ad9d312d9ffbc66c14514fa2b5752f4127b44f1e"
 dependencies = [
  "hashbrown 0.11.2",
- "stacker",
 ]
 
 [[package]]
@@ -2707,15 +2706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,19 +3527,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ clap = { version = "4.3.19", features = ["derive"] }
 codespan = { version = "0.11.1", features = ["serialization"] }
 codespan-lsp = "0.11.1"
 codespan-reporting = "0.11.1"
-chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312" }
+chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312", default-features = false, features = ["ahash", "std"] }
 dirs = "4"
 lsp-types = "0.94"
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

Up until this change, we've been unable to build `noir_wasm` on Mac. When trying to compile, we'd get this message:
```
    Compiling libc v0.2.147
    Compiling psm v0.1.21
 error: failed to build archive: section too large

 The following warnings were emitted during compilation:

 warning: warning: /bin/ranlib: archive library: /private/tmp/nix-build-noir_wasm-deps-0.11.1.drv-0/source/target/wasm32-unknown-unknown/release/build/psm-015060b7823c61b7/out/libpsm_s.a the table of contents is empty (no object file members in the library define global symbols)

 error: could not compile `psm` due to previous error
```

While the error was "Section too large", I felt like it might be a red herring since the `libpsm_s.a` was mentioned in the warning. In the [psm docs](https://crates.io/crates/psm), it claims:
> This library is not applicable to the target. WASM hasn’t a specified C ABI, the callstack is not even in an address space and does not appear to be manipulatable.

I did some digging and found we were only getting the dependency due to default features of chumsky (the `spill-stack` feature), so I turned off the feature and tried for compiling to wasm—and it worked!

I'm not exactly sure why `noir_wasm` compiles on Linux but not Mac with this dependency, but seems that it wouldn't be doing anything in the wasm context, so I'm also guessing we don't rely on it.

@jfecher Do you know if Noir actively depend upon this `spill-stack` feature through the `stacker` dependency of chumsky?

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
