### PR TITLE
fix: display correct range for `u128` in `OverflowingAssignment` error

### DIFF
--- a/crates/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/crates/noirc_frontend/src/hir/type_check/stmt.rs
@@ -283,12 +283,14 @@ impl<'interner> TypeChecker<'interner> {
             HirExpression::Literal(HirLiteral::Integer(value)) => {
                 let v = value.to_u128();
                 if let Type::Integer(_, bit_count) = annotated_type {
-                    let max = 1 << bit_count;
+                    // Avoid overflow in bitshift
+                    let max: u128 =
+                        if *bit_count == 128 { u128::MAX } else { (1 << bit_count) - 1 };
                     if v >= max {
                         self.errors.push(TypeCheckError::OverflowingAssignment {
                             expr: value,
                             ty: annotated_type.clone(),
-                            range: format!("0..={}", max - 1),
+                            range: format!("0..={}", max),
                             span,
                         });
                     };


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #2623 

## Summary\*

This PR addresses an overflow which was occurring when calculating the maximum value of a u128. We now special case  `u128` and only calculate the maximum for smaller types.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
