### PR TITLE
chore: add `CompilationResult` helper type

### DIFF
--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -411,7 +411,7 @@ fn on_did_save_text_document(
         let (mut context, crate_id) = prepare_package(package);
 
         let file_diagnostics = match check_crate(&mut context, crate_id, false) {
-            Ok(warnings) => warnings,
+            Ok(((), warnings)) => warnings,
             Err(errors_and_warnings) => errors_and_warnings,
         };
 

--- a/crates/nargo_cli/src/cli/check_cmd.rs
+++ b/crates/nargo_cli/src/cli/check_cmd.rs
@@ -171,6 +171,6 @@ pub(crate) fn check_crate_and_report_errors(
     crate_id: CrateId,
     deny_warnings: bool,
 ) -> Result<(), CompileError> {
-    let result = check_crate(context, crate_id, deny_warnings).map(|warnings| ((), warnings));
+    let result = check_crate(context, crate_id, deny_warnings);
     super::compile_cmd::report_errors(result, &context.file_manager, deny_warnings)
 }

--- a/crates/nargo_cli/src/cli/compile_cmd.rs
+++ b/crates/nargo_cli/src/cli/compile_cmd.rs
@@ -12,7 +12,7 @@ use nargo::package::Package;
 use nargo::prepare_package;
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{
-    compile_main, CompileOptions, CompiledContract, CompiledProgram, ErrorsAndWarnings, Warnings,
+    compile_main, CompilationResult, CompileOptions, CompiledContract, CompiledProgram,
 };
 use noirc_errors::debug_info::DebugInfo;
 use noirc_frontend::graph::CrateName;
@@ -203,10 +203,10 @@ fn save_contracts(
     }
 }
 
-/// Helper function for reporting any errors in a Result<(T, Warnings), ErrorsAndWarnings>
+/// Helper function for reporting any errors in a `CompilationResult<T>`
 /// structure that is commonly used as a return result in this file.
 pub(crate) fn report_errors<T>(
-    result: Result<(T, Warnings), ErrorsAndWarnings>,
+    result: CompilationResult<T>,
     file_manager: &FileManager,
     deny_warnings: bool,
 ) -> Result<T, CompileError> {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR codifies the `Result<(T, Warnings), ErrorsAndWarnings>` return type which we use in `noirc_driver` into a type alias. This is useful for some work related to #2613 where we need to pass around and map this result more.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
