### PR TITLE
fix(noirc_errors): Switch update_acir to use for-loop instead of iter

### DIFF
--- a/crates/noirc_errors/src/debug_info.rs
+++ b/crates/noirc_errors/src/debug_info.rs
@@ -33,9 +33,10 @@ impl DebugInfo {
         let old_locations = mem::take(&mut self.locations);
 
         for (old_opcode_location, source_locations) in old_locations {
-            let _ = update_map.new_locations(old_opcode_location).map(|new_opcode_location| {
+            let new_locations = update_map.new_locations(old_opcode_location);
+            for new_opcode_location in new_locations {
                 self.locations.insert(new_opcode_location, source_locations.clone());
-            });
+            }
         }
     }
 


### PR DESCRIPTION
# Description


## Problem\*

Some context here: https://github.com/noir-lang/noir/issues/2645#issuecomment-1714640028

Iterators are lazy in Rust. In `update_acir` we did not use the iterator for new_locations. This means we are calling `mem::take` on our location data, but never inserting back into it, thus removing all our runtime location data.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
