### PR TITLE
fix(wasm): Avoid requesting stdlib paths from the source-resolver

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,10 +1,13 @@
 name: test-integration
 
 on:
+  push:
+    branches:
+      - phated/wasm-stdlib-debug
   workflow_dispatch:
   schedule:
     - cron: "0 2 * * *" # Run nightly at 2 AM UTC
-    
+
 jobs:
   wasm-packages-build-test:
     runs-on: ubuntu-latest
@@ -100,8 +103,8 @@ jobs:
         working-directory: ./compiler/integration-tests
         run: |
           yarn test:browser
-          
-      - name: Alert on nightly test failure  
+
+      - name: Alert on nightly test failure
         uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() && github.event_name == 'schedule' }}
         env:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,9 +1,6 @@
 name: test-integration
 
 on:
-  push:
-    branches:
-      - phated/wasm-stdlib-debug
   workflow_dispatch:
   schedule:
     - cron: "0 2 * * *" # Run nightly at 2 AM UTC

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
 		"mkhl.direnv",
 		"jnoortheen.nix-ide",
 		"rust-lang.rust-analyzer",
-		"redhat.vscode-yaml"
+		"redhat.vscode-yaml",
+		"esbenp.prettier-vscode"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,4 +16,7 @@
     "yaml.schemas": {
         "https://json.schemastore.org/github-workflow.json": "${workspaceRoot}/.github/workflows/*.yml"
     },
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
 }

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -27,18 +27,6 @@ pub struct FileManager {
     path_to_id: HashMap<VirtualPath, FileId>,
 }
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
-
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-extern "C" {
-    // Use `js_namespace` here to bind `console.log(..)` instead of just
-    // `log(..)`
-    #[wasm_bindgen(js_namespace = console)]
-    fn log(s: &str);
-}
-
 impl FileManager {
     pub fn new(root: &Path) -> Self {
         Self {
@@ -54,12 +42,6 @@ impl FileManager {
     }
 
     pub fn add_file(&mut self, file_name: &Path) -> Option<FileId> {
-        #[cfg(target_arch = "wasm32")]
-        log(&format!("{}", file_name.display()));
-
-        #[cfg(not(target_arch = "wasm32"))]
-        println!("{}", file_name.display());
-
         // Handle both relative file paths and std/lib virtual paths.
         let resolved_path: PathBuf = if is_stdlib_asset(file_name) {
             // Special case for stdlib where we want to read specifically the `std/` relative path

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -57,6 +57,9 @@ impl FileManager {
         #[cfg(target_arch = "wasm32")]
         log(&format!("{}", file_name.display()));
 
+        #[cfg(not(target_arch = "wasm32"))]
+        println!("{}", file_name.display());
+
         // Handle both relative file paths and std/lib virtual paths.
         let resolved_path: PathBuf = if is_stdlib_asset(file_name) {
             // Special case for stdlib where we want to read specifically the `std/` relative path

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -27,6 +27,18 @@ pub struct FileManager {
     path_to_id: HashMap<VirtualPath, FileId>,
 }
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+extern "C" {
+    // Use `js_namespace` here to bind `console.log(..)` instead of just
+    // `log(..)`
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
 impl FileManager {
     pub fn new(root: &Path) -> Self {
         Self {
@@ -42,6 +54,9 @@ impl FileManager {
     }
 
     pub fn add_file(&mut self, file_name: &Path) -> Option<FileId> {
+        #[cfg(target_arch = "wasm32")]
+        log(&format!("{}", file_name.display()));
+
         // Handle both relative file paths and std/lib virtual paths.
         let resolved_path: PathBuf = if is_stdlib_asset(file_name) {
             // Special case for stdlib where we want to read specifically the `std/` relative path

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -68,10 +68,7 @@ test_cases.forEach((testInfo) => {
 
         initialiseResolver((id: String) => {
             console.log("Resoving:", id);
-            if (id === "/main.nr") {
-                console.log("Returning source:", noir_source);
-                return noir_source;
-            }
+            return noir_source;
         });
 
         const inputs = TOML.parse(prover_toml);

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -67,11 +67,10 @@ test_cases.forEach((testInfo) => {
         expect(noir_source).to.be.a.string;
 
         initialiseResolver((id: String) => {
+            console.log("Resoving:", id);
             if (id.endsWith("/main.nr")) {
-                console.log("Resoving:", id);
+                console.log("Returning source:", noir_source);
                 return noir_source;
-            } else {
-                throw new Error()
             }
         });
 

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -53,7 +53,7 @@ suite.timeout(60*10e3);//10mins
 
 test_cases.forEach((testInfo) => {
     const test_name = testInfo.case.split("/").pop();
-    const mochaTest = new Mocha.Test(`${test_name} (Compile, Execute, Proove, Verify)`, async () => {
+    const mochaTest = new Mocha.Test(`${test_name} (Compile, Execute, Prove, Verify)`, async () => {
 
         const base_relative_path = "../../../../..";
         const test_case = testInfo.case;
@@ -67,7 +67,7 @@ test_cases.forEach((testInfo) => {
         expect(noir_source).to.be.a.string;
 
         initialiseResolver((id: String) => {
-            console.log("Resoving:", id);
+            console.log("Resolving:", id);
             return noir_source;
         });
 

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -132,17 +132,17 @@ test_cases.forEach((testInfo) => {
 
             const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
 
-            const proof = await api.acirCreateProof(
-                acirComposer,
-                acirUint8Array,
-                witnessUint8Array,
-                isRecursive
-            );
+            // const proof = await api.acirCreateProof(
+            //     acirComposer,
+            //     acirUint8Array,
+            //     witnessUint8Array,
+            //     isRecursive
+            // );
 
 
-            const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
+            // const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
 
-            expect(verified).to.be.true;
+            // expect(verified).to.be.true;
 
         } catch (e) {
             expect(e, "Proving and Verifying").to.not.be.an('error');

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -89,65 +89,65 @@ test_cases.forEach((testInfo) => {
         }
 
 
-        // let witnessMap: WitnessMap;
-        // try {
+        let witnessMap: WitnessMap;
+        try {
 
-        //     witnessMap = abiEncode(compile_output.abi, inputs, null);
+            witnessMap = abiEncode(compile_output.abi, inputs, null);
 
-        // } catch (e) {
-        //     expect(e, "Abi Encoding Step").to.not.be.an('error');
-        //     throw e;
-        // }
+        } catch (e) {
+            expect(e, "Abi Encoding Step").to.not.be.an('error');
+            throw e;
+        }
 
-        // let solvedWitness: WitnessMap;
-        // let compressedByteCode;
-        // try {
-        //     compressedByteCode = Uint8Array.from(atob(compile_output.circuit), c => c.charCodeAt(0));
+        let solvedWitness: WitnessMap;
+        let compressedByteCode;
+        try {
+            compressedByteCode = Uint8Array.from(atob(compile_output.circuit), c => c.charCodeAt(0));
 
-        //     solvedWitness = await executeCircuit(
-        //         compressedByteCode,
-        //         witnessMap,
-        //         () => {
-        //             throw Error("unexpected oracle");
-        //         }
-        //     );
+            solvedWitness = await executeCircuit(
+                compressedByteCode,
+                witnessMap,
+                () => {
+                    throw Error("unexpected oracle");
+                }
+            );
 
-        // } catch (e) {
-        //     expect(e, "Abi Encoding Step").to.not.be.an('error');
-        //     throw e;
-        // }
+        } catch (e) {
+            expect(e, "Abi Encoding Step").to.not.be.an('error');
+            throw e;
+        }
 
-        // try {
-        //     const compressedWitness = compressWitness(solvedWitness);
-        //     const acirUint8Array = gunzip(compressedByteCode);
-        //     const witnessUint8Array = gunzip(compressedWitness);
+        try {
+            const compressedWitness = compressWitness(solvedWitness);
+            const acirUint8Array = gunzip(compressedByteCode);
+            const witnessUint8Array = gunzip(compressedWitness);
 
-        //     const isRecursive = true;
-        //     const api = await Barretenberg.new(numberOfThreads);
-        //     await api.commonInitSlabAllocator(CIRCUIT_SIZE);
+            const isRecursive = true;
+            const api = await Barretenberg.new(numberOfThreads);
+            await api.commonInitSlabAllocator(CIRCUIT_SIZE);
 
-        //     // Plus 1 needed!
-        //     const crs = await Crs.new(CIRCUIT_SIZE + 1);
-        //     await api.srsInitSrs(new RawBuffer(crs.getG1Data()), crs.numPoints, new RawBuffer(crs.getG2Data()));
+            // Plus 1 needed!
+            const crs = await Crs.new(CIRCUIT_SIZE + 1);
+            await api.srsInitSrs(new RawBuffer(crs.getG1Data()), crs.numPoints, new RawBuffer(crs.getG2Data()));
 
-        //     const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
+            const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
 
-        //     const proof = await api.acirCreateProof(
-        //         acirComposer,
-        //         acirUint8Array,
-        //         witnessUint8Array,
-        //         isRecursive
-        //     );
+            const proof = await api.acirCreateProof(
+                acirComposer,
+                acirUint8Array,
+                witnessUint8Array,
+                isRecursive
+            );
 
 
-        //     const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
+            const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
 
-        //     expect(verified).to.be.true;
+            expect(verified).to.be.true;
 
-        // } catch (e) {
-        //     expect(e, "Proving and Verifying").to.not.be.an('error');
-        //     throw e;
-        // }
+        } catch (e) {
+            expect(e, "Proving and Verifying").to.not.be.an('error');
+            throw e;
+        }
 
     });
 

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -92,65 +92,65 @@ test_cases.forEach((testInfo) => {
         }
 
 
-        let witnessMap: WitnessMap;
-        try {
+        // let witnessMap: WitnessMap;
+        // try {
 
-            witnessMap = abiEncode(compile_output.abi, inputs, null);
+        //     witnessMap = abiEncode(compile_output.abi, inputs, null);
 
-        } catch (e) {
-            expect(e, "Abi Encoding Step").to.not.be.an('error');
-            throw e;
-        }
+        // } catch (e) {
+        //     expect(e, "Abi Encoding Step").to.not.be.an('error');
+        //     throw e;
+        // }
 
-        let solvedWitness: WitnessMap;
-        let compressedByteCode;
-        try {
-            compressedByteCode = Uint8Array.from(atob(compile_output.circuit), c => c.charCodeAt(0));
+        // let solvedWitness: WitnessMap;
+        // let compressedByteCode;
+        // try {
+        //     compressedByteCode = Uint8Array.from(atob(compile_output.circuit), c => c.charCodeAt(0));
 
-            solvedWitness = await executeCircuit(
-                compressedByteCode,
-                witnessMap,
-                () => {
-                    throw Error("unexpected oracle");
-                }
-            );
+        //     solvedWitness = await executeCircuit(
+        //         compressedByteCode,
+        //         witnessMap,
+        //         () => {
+        //             throw Error("unexpected oracle");
+        //         }
+        //     );
 
-        } catch (e) {
-            expect(e, "Abi Encoding Step").to.not.be.an('error');
-            throw e;
-        }
+        // } catch (e) {
+        //     expect(e, "Abi Encoding Step").to.not.be.an('error');
+        //     throw e;
+        // }
 
-        try {
-            const compressedWitness = compressWitness(solvedWitness);
-            const acirUint8Array = gunzip(compressedByteCode);
-            const witnessUint8Array = gunzip(compressedWitness);
+        // try {
+        //     const compressedWitness = compressWitness(solvedWitness);
+        //     const acirUint8Array = gunzip(compressedByteCode);
+        //     const witnessUint8Array = gunzip(compressedWitness);
 
-            const isRecursive = true;
-            const api = await Barretenberg.new(numberOfThreads);
-            await api.commonInitSlabAllocator(CIRCUIT_SIZE);
+        //     const isRecursive = true;
+        //     const api = await Barretenberg.new(numberOfThreads);
+        //     await api.commonInitSlabAllocator(CIRCUIT_SIZE);
 
-            // Plus 1 needed!
-            const crs = await Crs.new(CIRCUIT_SIZE + 1);
-            await api.srsInitSrs(new RawBuffer(crs.getG1Data()), crs.numPoints, new RawBuffer(crs.getG2Data()));
+        //     // Plus 1 needed!
+        //     const crs = await Crs.new(CIRCUIT_SIZE + 1);
+        //     await api.srsInitSrs(new RawBuffer(crs.getG1Data()), crs.numPoints, new RawBuffer(crs.getG2Data()));
 
-            const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
+        //     const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
 
-            const proof = await api.acirCreateProof(
-                acirComposer,
-                acirUint8Array,
-                witnessUint8Array,
-                isRecursive
-            );
+        //     const proof = await api.acirCreateProof(
+        //         acirComposer,
+        //         acirUint8Array,
+        //         witnessUint8Array,
+        //         isRecursive
+        //     );
 
 
-            const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
+        //     const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
 
-            expect(verified).to.be.true;
+        //     expect(verified).to.be.true;
 
-        } catch (e) {
-            expect(e, "Proving and Verifying").to.not.be.an('error');
-            throw e;
-        }
+        // } catch (e) {
+        //     expect(e, "Proving and Verifying").to.not.be.an('error');
+        //     throw e;
+        // }
 
     });
 

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -132,7 +132,7 @@ test_cases.forEach((testInfo) => {
 
             const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
 
-            // This took 6.5 minutes!
+            // This took ~6.5 minutes!
             const proof = await api.acirCreateProof(
                 acirComposer,
                 acirUint8Array,
@@ -140,7 +140,7 @@ test_cases.forEach((testInfo) => {
                 isRecursive
             );
 
-
+            // And this took ~5 minutes!
             const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
 
             expect(verified).to.be.true;

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -132,12 +132,12 @@ test_cases.forEach((testInfo) => {
 
             const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
 
-            // const proof = await api.acirCreateProof(
-            //     acirComposer,
-            //     acirUint8Array,
-            //     witnessUint8Array,
-            //     isRecursive
-            // );
+            const proof = await api.acirCreateProof(
+                acirComposer,
+                acirUint8Array,
+                witnessUint8Array,
+                isRecursive
+            );
 
 
             // const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -12,7 +12,7 @@ import initACVM, {
     compressWitness,
 } from "@noir-lang/acvm_js";
 
-// @ts-ignore  
+// @ts-ignore
 import { Barretenberg, RawBuffer, Crs } from '@aztec/bb.js';
 
 import * as TOML from 'smol-toml'
@@ -67,8 +67,12 @@ test_cases.forEach((testInfo) => {
         expect(noir_source).to.be.a.string;
 
         initialiseResolver((id: String) => {
-            console.log("Resoving:", id);
-            return noir_source;
+            if (id.endsWith("/main.nr")) {
+                console.log("Resoving:", id);
+                return noir_source;
+            } else {
+                throw new Error()
+            }
         });
 
         const inputs = TOML.parse(prover_toml);

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -68,7 +68,7 @@ test_cases.forEach((testInfo) => {
 
         initialiseResolver((id: String) => {
             console.log("Resoving:", id);
-            if (id.endsWith("/main.nr")) {
+            if (id === "/main.nr") {
                 console.log("Returning source:", noir_source);
                 return noir_source;
             }

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -49,7 +49,7 @@ const numberOfThreads = navigator.hardwareConcurrency || 1;
 
 let suite = Mocha.Suite.create(mocha.suite, "Noir end to end test");
 
-suite.timeout(60*10e3);//10mins
+suite.timeout(60*20e3);//20mins
 
 test_cases.forEach((testInfo) => {
     const test_name = testInfo.case.split("/").pop();
@@ -132,6 +132,7 @@ test_cases.forEach((testInfo) => {
 
             const acirComposer = await api.acirNewAcirComposer(CIRCUIT_SIZE);
 
+            // This took 6.5 minutes!
             const proof = await api.acirCreateProof(
                 acirComposer,
                 acirUint8Array,
@@ -140,9 +141,9 @@ test_cases.forEach((testInfo) => {
             );
 
 
-            // const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
+            const verified = await api.acirVerifyProof(acirComposer, proof, isRecursive);
 
-            // expect(verified).to.be.true;
+            expect(verified).to.be.true;
 
         } catch (e) {
             expect(e, "Proving and Verifying").to.not.be.an('error');

--- a/compiler/integration-tests/web-test-runner.config.mjs
+++ b/compiler/integration-tests/web-test-runner.config.mjs
@@ -27,5 +27,5 @@ export default {
     },
   },
   rootDir: fileURLToPath(new URL("./../..", import.meta.url)),
-  testsFinishTimeout: 60 * 10e3, // 10 minutes
+  testsFinishTimeout: 60 * 20e3, // 20 minutes
 };

--- a/compiler/integration-tests/web-test-runner.config.mjs
+++ b/compiler/integration-tests/web-test-runner.config.mjs
@@ -1,20 +1,19 @@
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from "url";
 import { esbuildPlugin } from "@web/dev-server-esbuild";
-import { webdriverLauncher } from '@web/test-runner-webdriver';
+import { webdriverLauncher } from "@web/test-runner-webdriver";
 
 export default {
   browsers: [
     webdriverLauncher({
-      automationProtocol: 'webdriver',
+      automationProtocol: "webdriver",
       capabilities: {
-        browserName: 'firefox',
-        'moz:firefoxOptions': {
-          args: ['-headless'],
+        browserName: "firefox",
+        "moz:firefoxOptions": {
+          args: ["-headless"],
         },
       },
     }),
-  
-],
+  ],
   plugins: [
     esbuildPlugin({
       ts: true,
@@ -27,6 +26,6 @@ export default {
       ui: "bdd",
     },
   },
-  rootDir:  fileURLToPath(new URL('./../..', import.meta.url)),
-
+  rootDir: fileURLToPath(new URL("./../..", import.meta.url)),
+  testsFinishTimeout: 60 * 10e3, // 10 minutes
 };

--- a/compiler/noirc_errors/src/debug_info.rs
+++ b/compiler/noirc_errors/src/debug_info.rs
@@ -33,7 +33,7 @@ impl DebugInfo {
         let old_locations = mem::take(&mut self.locations);
 
         for (old_opcode_location, source_locations) in old_locations {
-            let _ = update_map.new_locations(old_opcode_location).map(|new_opcode_location| {
+            update_map.new_locations(old_opcode_location).for_each(|new_opcode_location| {
                 self.locations.insert(new_opcode_location, source_locations.clone());
             });
         }

--- a/compiler/wasm/test/browser/index.test.ts
+++ b/compiler/wasm/test/browser/index.test.ts
@@ -31,5 +31,5 @@ describe("noir wasm compilation", () => {
 
 
     expect(wasmCircuitBase64).to.equal(cliCircuitBase64);
-  }).timeout(10e3);
+  }).timeout(20e3); // 20 seconds
 });


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #1244 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This fixes the noir_wasm integration tests, such that they succeed. The fundamental problem was that the implementation of `source-resolver` isn't actually checking file paths to know what files to load. Instead, it was always returning the entry file as the source code, so this meant the stdlib was setup all wrong inside the compiler.

While this is a lazy way to implement the source-resolver, none of the stdlib file paths should be reaching it in the first place. So I've added an extra case in the `file_reader.rs` to never go to the filesystem for the stdlib, which we always embed.

Also note that some stuff in the integration test needed to change because proving takes 6.5 minutes and verifying takes 5 minutes.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
