### PR TITLE
fix: remove duplicate file extension in stack trace

### DIFF
--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -199,7 +199,7 @@ fn stack_trace<'files>(
         let source = files.source(call_item.file).expect("should get file source");
 
         let (line, column) = location(source.as_ref(), call_item.span.start());
-        result += &format!("{}. {}.nr:{}:{}\n", i + 1, path, line, column);
+        result += &format!("{}. {}:{}:{}\n", i + 1, path, line, column);
     }
 
     result


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves #2654 

## Summary\*

`path` already contains the extension so we're just adding a duplicate here.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
