### PR TITLE
chore: defer reporting of errors until after compilation and optimization is finished

### DIFF
--- a/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use super::NargoConfig;
 use super::{
-    compile_cmd::compile_package,
+    compile_cmd::compile_bin_package,
     fs::{create_named_dir, program::read_program_from_file, write_to_file},
 };
 use crate::backends::Backend;
@@ -82,7 +82,7 @@ fn smart_contract_for_package(
         read_program_from_file(circuit_build_path)?
     } else {
         let (program, _) =
-            compile_package(package, compile_options, np_language, &is_opcode_supported)?;
+            compile_bin_package(package, compile_options, np_language, &is_opcode_supported)?;
 
         PreprocessedProgram {
             backend: String::from(BACKEND_IDENTIFIER),

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -15,7 +15,7 @@ use noirc_driver::{CompileOptions, CompiledProgram};
 use noirc_errors::CustomDiagnostic;
 use noirc_frontend::graph::CrateName;
 
-use super::compile_cmd::compile_package;
+use super::compile_cmd::compile_bin_package;
 use super::fs::{inputs::read_inputs_from_file, witness::save_witness_to_dir};
 use super::NargoConfig;
 use crate::backends::Backend;
@@ -88,7 +88,7 @@ fn execute_package(
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> Result<(Option<InputValue>, WitnessMap), CliError> {
     let (compiled_program, debug_artifact) =
-        compile_package(package, compile_options, np_language, &is_opcode_supported)?;
+        compile_bin_package(package, compile_options, np_language, &is_opcode_supported)?;
     let CompiledProgram { abi, circuit, .. } = compiled_program;
 
     // Parse the initial witness values from Prover.toml

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -11,9 +11,12 @@ use prettytable::{row, table, Row};
 use serde::Serialize;
 
 use crate::backends::Backend;
-use crate::{cli::compile_cmd::compile_package, errors::CliError};
+use crate::errors::CliError;
 
-use super::{compile_cmd::compile_contracts, NargoConfig};
+use super::{
+    compile_cmd::{compile_bin_package, compile_contract_package},
+    NargoConfig,
+};
 
 /// Provides detailed information on a circuit
 ///
@@ -172,7 +175,7 @@ fn count_opcodes_and_gates_in_program(
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> Result<ProgramInfo, CliError> {
     let (compiled_program, _) =
-        compile_package(package, compile_options, np_language, &is_opcode_supported)?;
+        compile_bin_package(package, compile_options, np_language, &is_opcode_supported)?;
     let (language, _) = backend.get_backend_info()?;
 
     Ok(ProgramInfo {
@@ -190,7 +193,8 @@ fn count_opcodes_and_gates_in_contracts(
     np_language: Language,
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> Result<Vec<ContractInfo>, CliError> {
-    let contracts = compile_contracts(package, compile_options, np_language, &is_opcode_supported)?;
+    let contracts =
+        compile_contract_package(package, compile_options, np_language, &is_opcode_supported)?;
     let (language, _) = backend.get_backend_info()?;
 
     try_vecmap(contracts, |(contract, _)| {

--- a/tooling/nargo_cli/src/cli/prove_cmd.rs
+++ b/tooling/nargo_cli/src/cli/prove_cmd.rs
@@ -11,7 +11,7 @@ use noirc_abi::input_parser::Format;
 use noirc_driver::CompileOptions;
 use noirc_frontend::graph::CrateName;
 
-use super::compile_cmd::compile_package;
+use super::compile_cmd::compile_bin_package;
 use super::fs::{
     inputs::{read_inputs_from_file, write_inputs_to_file},
     program::read_program_from_file,
@@ -102,7 +102,7 @@ pub(crate) fn prove_package(
         (program, None)
     } else {
         let (program, debug_artifact) =
-            compile_package(package, compile_options, np_language, &is_opcode_supported)?;
+            compile_bin_package(package, compile_options, np_language, &is_opcode_supported)?;
         let preprocessed_program = PreprocessedProgram {
             backend: String::from(BACKEND_IDENTIFIER),
             abi: program.abi,

--- a/tooling/nargo_cli/src/cli/verify_cmd.rs
+++ b/tooling/nargo_cli/src/cli/verify_cmd.rs
@@ -1,6 +1,6 @@
 use super::NargoConfig;
 use super::{
-    compile_cmd::compile_package,
+    compile_cmd::compile_bin_package,
     fs::{inputs::read_inputs_from_file, load_hex_data, program::read_program_from_file},
 };
 use crate::{backends::Backend, errors::CliError};
@@ -86,7 +86,7 @@ fn verify_package(
         read_program_from_file(circuit_build_path)?
     } else {
         let (program, _) =
-            compile_package(package, compile_options, np_language, &is_opcode_supported)?;
+            compile_bin_package(package, compile_options, np_language, &is_opcode_supported)?;
 
         PreprocessedProgram {
             backend: String::from(BACKEND_IDENTIFIER),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*


Progress towards #2613 

## Summary\*

This PR reworks `compile_contracts` and `compile_package` so that they return a `CompilationResult<T>`. This means that they no longer report their errors/warnings as soon as they can, but delegate this to `compile_cmd::run`. This is useful for #2613 as we can now construct two vectors of `CompilationResult<T>` (one for programs, one for contracts) in parallel and then simply iterate through them to print out the warnings/errors safely.

~The file manager is leaking again as we need to get `report_all_errors` to pick up the debug artifacts.~ This would require us to have a debug artifact for a failed compilation which seems uglier in my mind. We should probably maintain the usage of `FileManager` for compilation errors and just use `DebugArtifact` for execution errors.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
