### PR TITLE
chore: Fix clippy warnings for rust version 1.67.0

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -87,7 +87,7 @@ impl<'block> BrilligBlock<'block> {
     ///
     /// This is so that during linking there are no duplicates or labels being overwritten.
     fn create_block_label(function_id: FunctionId, block_id: BasicBlockId) -> String {
-        format!("{}-{}", function_id, block_id)
+        format!("{function_id}-{block_id}")
     }
 
     /// Converts an SSA terminator instruction into the necessary opcodes.

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
@@ -99,7 +99,7 @@ impl DebugToString for BrilligBinaryOp {
                 if *bit_size >= BRILLIG_MEMORY_ADDRESSING_BIT_SIZE {
                     op.into()
                 } else {
-                    format!("{}:{}", op, bit_size)
+                    format!("{op}:{bit_size}")
                 }
             }
         }

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -46,7 +46,7 @@ pub enum RuntimeError {
 // assert(foo < bar) fails with "failed constraint: 0 = 1."
 fn format_failed_constraint(message: &Option<String>) -> String {
     match message {
-        Some(message) => format!("Failed constraint: '{}'", message),
+        Some(message) => format!("Failed constraint: '{message}'"),
         None => "Failed constraint".to_owned(),
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -994,11 +994,7 @@ impl Context {
             // If either side is a numeric type, then we expect their types to be
             // the same.
             (Type::Numeric(lhs_type), Type::Numeric(rhs_type)) => {
-                assert_eq!(
-                    lhs_type, rhs_type,
-                    "lhs and rhs types in {:?} are not the same",
-                    binary
-                );
+                assert_eq!(lhs_type, rhs_type, "lhs and rhs types in {binary:?} are not the same");
                 Type::Numeric(lhs_type)
             }
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -250,8 +250,7 @@ fn create_apply_functions(
     for (signature, variants) in variants_map.into_iter() {
         assert!(
             !variants.is_empty(),
-            "ICE: at least one variant should exist for a dynamic call {:?}",
-            signature
+            "ICE: at least one variant should exist for a dynamic call {signature:?}"
         );
         let dispatches_to_multiple_functions = variants.len() > 1;
 

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -247,7 +247,7 @@ impl Display for UseTree {
                 write!(f, "{name}")?;
 
                 while let Some(alias) = alias {
-                    write!(f, " as {}", alias)?;
+                    write!(f, " as {alias}")?;
                 }
 
                 Ok(())

--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -144,21 +144,20 @@ impl Display for TraitItem {
 
                 write!(
                     f,
-                    "fn {name}<{}>({}) -> {} where {}",
-                    generics, parameters, return_type, where_clause
+                    "fn {name}<{generics}>({parameters}) -> {return_type} where {where_clause}"
                 )?;
 
                 if let Some(body) = body {
-                    write!(f, "{}", body)
+                    write!(f, "{body}")
                 } else {
                     write!(f, ";")
                 }
             }
             TraitItem::Constant { name, typ, default_value } => {
-                write!(f, "let {}: {}", name, typ)?;
+                write!(f, "let {name}: {typ}")?;
 
                 if let Some(default_value) = default_value {
-                    write!(f, "{};", default_value)
+                    write!(f, "{default_value};")
                 } else {
                     write!(f, ";")
                 }
@@ -209,7 +208,7 @@ impl Display for TraitImplItem {
             TraitImplItem::Function(function) => function.fmt(f),
             TraitImplItem::Type { name, alias } => write!(f, "type {name} = {alias};"),
             TraitImplItem::Constant(name, typ, value) => {
-                write!(f, "let {}: {} = {};", name, typ, value)
+                write!(f, "let {name}: {typ} = {value};")
             }
         }
     }

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -118,7 +118,7 @@ impl From<DefCollectorErrorKind> for Diagnostic {
             ),
             DefCollectorErrorKind::NonStructTraitImpl { trait_ident, span } => {
                 Diagnostic::simple_error(
-                    format!("Only struct types may implement trait `{}`", trait_ident),
+                    format!("Only struct types may implement trait `{trait_ident}`"),
                     "Only struct types may implement traits".into(),
                     span,
                 )
@@ -129,7 +129,7 @@ impl From<DefCollectorErrorKind> for Diagnostic {
                 span,
             ),
             DefCollectorErrorKind::TraitNotFound { trait_ident } => Diagnostic::simple_error(
-                format!("Trait {} not found", trait_ident),
+                format!("Trait {trait_ident} not found"),
                 "".to_string(),
                 trait_ident.span(),
             ),

--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -47,7 +47,7 @@ impl LexerErrorKind {
 
                 (
                     "an unexpected character was found".to_string(),
-                    format!(" expected {expected} , but got {}", found),
+                    format!(" expected {expected} , but got {found}"),
                     *span,
                 )
             },

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -351,7 +351,7 @@ impl fmt::Display for TestScope {
         match self {
             TestScope::None => write!(f, ""),
             TestScope::ShouldFailWith { reason } => match reason {
-                Some(failure_reason) => write!(f, "(should_fail_with = ({}))", failure_reason),
+                Some(failure_reason) => write!(f, "(should_fail_with = ({failure_reason}))"),
                 None => write!(f, "should_fail"),
             },
         }

--- a/compiler/noirc_frontend/src/parser/labels.rs
+++ b/compiler/noirc_frontend/src/parser/labels.rs
@@ -36,7 +36,7 @@ impl fmt::Display for ParsingRuleLabel {
             ParsingRuleLabel::Statement => write!(f, "statement"),
             ParsingRuleLabel::Term => write!(f, "term"),
             ParsingRuleLabel::TypeExpression => write!(f, "type expression"),
-            ParsingRuleLabel::TokenKind(token_kind) => write!(f, "{:?}", token_kind),
+            ParsingRuleLabel::TokenKind(token_kind) => write!(f, "{token_kind:?}"),
         }
     }
 }

--- a/tooling/acvm_backend_barretenberg/build.rs
+++ b/tooling/acvm_backend_barretenberg/build.rs
@@ -21,12 +21,12 @@ fn main() -> Result<(), String> {
     let os = match build_target::target_os().unwrap() {
         os @ (Os::Linux | Os::MacOs) => os,
         Os::Windows => todo!("Windows is not currently supported"),
-        os_name => panic!("Unsupported OS {}", os_name),
+        os_name => panic!("Unsupported OS {os_name}"),
     };
 
     let arch = match build_target::target_arch().unwrap() {
         arch @ (Arch::X86_64 | Arch::AARCH64) => arch,
-        arch_name => panic!("Unsupported Architecture {}", arch_name),
+        arch_name => panic!("Unsupported Architecture {arch_name}"),
     };
 
     // Arm builds of linux are not supported

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -170,7 +170,7 @@ fn on_code_lens_request(
             // We can reconsider this when we can build a file without the need for a Nargo.toml file to resolve deps
             let _ = state.client.log_message(LogMessageParams {
                 typ: MessageType::WARNING,
-                message: format!("{}", err),
+                message: format!("{err}"),
             });
             return future::ready(Ok(None));
         }
@@ -181,7 +181,7 @@ fn on_code_lens_request(
             // If we found a manifest, but the workspace is invalid, we raise an error about it
             return future::ready(Err(ResponseError::new(
                 ErrorCode::REQUEST_FAILED,
-                format!("{}", err),
+                format!("{err}"),
             )));
         }
     };
@@ -388,7 +388,7 @@ fn on_did_save_text_document(
             // We can reconsider this when we can build a file without the need for a Nargo.toml file to resolve deps
             let _ = state.client.log_message(LogMessageParams {
                 typ: MessageType::WARNING,
-                message: format!("{}", err),
+                message: format!("{err}"),
             });
             return ControlFlow::Continue(());
         }
@@ -399,7 +399,7 @@ fn on_did_save_text_document(
             // If we found a manifest, but the workspace is invalid, we raise an error about it
             return ControlFlow::Break(Err(ResponseError::new(
                 ErrorCode::REQUEST_FAILED,
-                format!("{}", err),
+                format!("{err}"),
             )
             .into()));
         }

--- a/tooling/nargo/src/ops/foreign_calls.rs
+++ b/tooling/nargo/src/ops/foreign_calls.rs
@@ -73,7 +73,7 @@ impl ForeignCall {
                     ],
                 })
             }
-            None => panic!("unexpected foreign call {:?}", foreign_call_name),
+            None => panic!("unexpected foreign call {foreign_call_name:?}"),
         }
     }
 

--- a/tooling/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
+++ b/tooling/nargo_cli/src/cli/backend_cmd/ls_cmd.rs
@@ -9,7 +9,7 @@ pub(crate) struct LsCommand;
 
 pub(crate) fn run(_args: LsCommand) -> Result<(), CliError> {
     for backend in get_available_backends() {
-        println!("{}", backend);
+        println!("{backend}");
     }
 
     Ok(())

--- a/tooling/nargo_cli/src/cli/fs/program.rs
+++ b/tooling/nargo_cli/src/cli/fs/program.rs
@@ -31,7 +31,7 @@ pub(crate) fn save_debug_artifact_to_file<P: AsRef<Path>>(
     circuit_name: &str,
     circuit_dir: P,
 ) -> PathBuf {
-    let artifact_name = format!("debug_{}", circuit_name);
+    let artifact_name = format!("debug_{circuit_name}");
     save_build_artifact_to_file(debug_artifact, &artifact_name, circuit_dir)
 }
 


### PR DESCRIPTION
## Summary\*
Fix clippy warnings for rust version 1.67.0

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
