### PR TITLE
chore(ci): use mock backend for all tests

### DIFF
--- a/tooling/acvm_backend_barretenberg/src/cli/info.rs
+++ b/tooling/acvm_backend_barretenberg/src/cli/info.rs
@@ -72,8 +72,7 @@ impl InfoCommand {
 
 #[test]
 fn info_command() -> Result<(), BackendError> {
-    use acvm::acir::circuit::black_box_functions::BlackBoxFunc;
-    use acvm::acir::circuit::opcodes::{BlackBoxFuncCall, Opcode};
+    use acvm::acir::circuit::opcodes::Opcode;
 
     use acvm::acir::native_types::Expression;
 
@@ -84,11 +83,6 @@ fn info_command() -> Result<(), BackendError> {
 
     assert!(matches!(language, Language::PLONKCSat { width: 3 }));
     assert!(is_opcode_supported(&Opcode::Arithmetic(Expression::default())));
-
-    assert!(!is_opcode_supported(&Opcode::BlackBoxFuncCall(
-        #[allow(deprecated)]
-        BlackBoxFuncCall::dummy(BlackBoxFunc::Keccak256)
-    )));
 
     Ok(())
 }

--- a/tooling/acvm_backend_barretenberg/test-binaries/mock_backend/src/info_cmd.rs
+++ b/tooling/acvm_backend_barretenberg/test-binaries/mock_backend/src/info_cmd.rs
@@ -14,6 +14,7 @@ const INFO_RESPONSE: &str = r#"{
         "range",
         "sha256",
         "blake2s",
+        "keccak256",
         "schnorr_verify",
         "pedersen",
         "hash_to_field_128_security",

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -70,6 +70,7 @@ fn execution_success_{test_name}() {{
     let test_program_dir = PathBuf::from("{test_dir}");
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("execute");
 
@@ -158,6 +159,7 @@ fn compile_success_contract_{test_name}() {{
     let test_program_dir = PathBuf::from("{test_dir}");
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("compile");
 
@@ -195,6 +197,7 @@ fn compile_failure_{test_name}() {{
     let test_program_dir = PathBuf::from("{test_dir}");
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("execute");
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR uses the mock backend for all of the main integration test suite. This should speed up CI significantly as we don't have `bb` allocating a load of memory in order to return JSON.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
