### PR TITLE
fix(aztec_noir): support bools as input types

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_map/aztec_library.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/aztec_library.rs
@@ -327,7 +327,9 @@ fn create_context(ty: &str, params: &[(Pattern, UnresolvedType, Visibility)]) ->
                     UnresolvedTypeData::FieldElement => add_field_to_hasher(identifier),
                     // Add the integer to the hasher, casted to a field
                     // `hasher.add({ident} as Field)`
-                    UnresolvedTypeData::Integer(..) => add_int_to_hasher(identifier),
+                    UnresolvedTypeData::Integer(..) | UnresolvedTypeData::Bool => {
+                        add_cast_to_hasher(identifier)
+                    }
                     _ => unreachable!("[Aztec Noir] Provided parameter type is not supported"),
                 };
                 injected_expressions.push(expression);
@@ -613,7 +615,7 @@ fn add_field_to_hasher(identifier: &Ident) -> Statement {
     ))
 }
 
-fn add_int_to_hasher(identifier: &Ident) -> Statement {
+fn add_cast_to_hasher(identifier: &Ident) -> Statement {
     // `hasher.add({ident} as Field)`
     // `{ident} as Field`
     let cast_operation = cast(


### PR DESCRIPTION
# Description

Quick fix to unblock @LHerskind, fast follow will be comprehensive tests for this lib

fixes:
- https://github.com/AztecProtocol/aztec-packages/issues/2175

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
