### PR TITLE
chore!: use american spelling of "serialize" in stdlib

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_map/aztec_library.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/aztec_library.rs
@@ -321,7 +321,7 @@ fn create_context(ty: &str, params: &[(Pattern, UnresolvedType, Visibility)]) ->
                 let expression = match unresolved_type {
                     // `hasher.add_multiple({ident}.serialize())`
                     UnresolvedTypeData::Named(..) => add_struct_to_hasher(identifier),
-                    // TODO: if this is an array of structs, we should call serialise on each of them (no methods currently do this yet)
+                    // TODO: if this is an array of structs, we should call serialize on each of them (no methods currently do this yet)
                     UnresolvedTypeData::Array(..) => add_array_to_hasher(identifier),
                     // `hasher.add({ident})`
                     UnresolvedTypeData::FieldElement => add_field_to_hasher(identifier),
@@ -443,12 +443,12 @@ fn make_return_push_array(push_value: Expression) -> Statement {
 /// ```noir
 /// `context.return_values.push_array({push_value}.serialize())`
 fn make_struct_return_type(expression: Expression) -> Statement {
-    let serialised_call = method_call(
+    let serialized_call = method_call(
         expression.clone(), // variable
         "serialize",        // method name
         vec![],             // args
     );
-    make_return_push_array(serialised_call)
+    make_return_push_array(serialized_call)
 }
 
 /// Make array return type
@@ -545,7 +545,7 @@ pub(crate) fn create_context_finish() -> Statement {
 
 fn add_struct_to_hasher(identifier: &Ident) -> Statement {
     // If this is a struct, we call serialize and add the array to the hasher
-    let serialised_call = method_call(
+    let serialized_call = method_call(
         variable_path(path(identifier.clone())), // variable
         "serialize",                             // method name
         vec![],                                  // args
@@ -554,7 +554,7 @@ fn add_struct_to_hasher(identifier: &Ident) -> Statement {
     Statement::Semi(method_call(
         variable("hasher"),    // variable
         "add_multiple",        // method name
-        vec![serialised_call], // args
+        vec![serialized_call], // args
     ))
 }
 

--- a/noir_stdlib/src/grumpkin_scalar.nr
+++ b/noir_stdlib/src/grumpkin_scalar.nr
@@ -10,12 +10,12 @@ impl GrumpkinScalar {
     }
 }
 
-global GRUMPKIN_SCALAR_SERIALISED_LEN: Field = 2;
+global GRUMPKIN_SCALAR_SERIALIZED_LEN: Field = 2;
 
-fn deserialise_grumpkin_scalar(fields: [Field; GRUMPKIN_SCALAR_SERIALISED_LEN]) -> GrumpkinScalar {
+fn deserialize_grumpkin_scalar(fields: [Field; GRUMPKIN_SCALAR_SERIALIZED_LEN]) -> GrumpkinScalar {
     GrumpkinScalar { low: fields[0], high: fields[1] }
 }
 
-fn serialise_grumpkin_scalar(scalar: GrumpkinScalar) -> [Field; GRUMPKIN_SCALAR_SERIALISED_LEN] {
+fn serialize_grumpkin_scalar(scalar: GrumpkinScalar) -> [Field; GRUMPKIN_SCALAR_SERIALIZED_LEN] {
     [scalar.low, scalar.high]
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR standardizes on the american spelling of "serialize". Annoyingly this was used in the stdlib so this is a breaking change.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
