### PR TITLE
feat(traits): Implement trait bounds typechecker + monomorphizer passes

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -672,7 +672,7 @@ impl<'a> Resolver<'a> {
     ) -> Vec<TraitConstraint> {
         vecmap(where_clause, |constraint| TraitConstraint {
             typ: self.resolve_type(constraint.typ.clone()),
-            trait_id: constraint.trait_bound.trait_id.unwrap_or(TraitId::dummy_id()),
+            trait_id: constraint.trait_bound.trait_id.unwrap_or_else(TraitId::dummy_id),
         })
     }
 

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -672,7 +672,7 @@ impl<'a> Resolver<'a> {
     ) -> Vec<TraitConstraint> {
         vecmap(where_clause, |constraint| TraitConstraint {
             typ: self.resolve_type(constraint.typ.clone()),
-            trait_id: constraint.trait_bound.trait_id,
+            trait_id: constraint.trait_bound.trait_id.unwrap_or(TraitId::dummy_id()),
         })
     }
 

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -858,19 +858,18 @@ impl<'interner> TypeChecker<'interner> {
                 );
 
                 for constraint in func_meta.trait_constraints {
-                    if let Some(trait_id) = constraint.trait_id {
-                        // TODO(#2568): == on types is sketchy, since Field != TypeVar::Bound(Field)
-                        // unify() is sketchier here though, since it may accidentally commit typebindings.
-                        // this works for now, but likely needs to be revisited when we implement generic traits
-                        if *object_type == constraint.typ {
-                            let the_trait = self.interner.get_trait(trait_id);
-                            let the_trait = the_trait.borrow();
+                    // TODO(#2568): == on types is sketchy, since Field != TypeVar::Bound(Field)
+                    // unify() is sketchier here though, since it may accidentally commit typebindings.
+                    // this works for now, but likely needs to be revisited when we implement generic traits
+                    if *object_type == constraint.typ {
+                        let the_trait = self.interner.get_trait(constraint.trait_id);
+                        let the_trait = the_trait.borrow();
 
-                            for (method_index, method) in the_trait.methods.iter().enumerate() {
-                                if method.name.0.contents == method_name {
-                                    let trait_method = TraitMethodId { trait_id, method_index };
-                                    return Some(HirMethodReference::TraitMethodId(trait_method));
-                                }
+                        for (method_index, method) in the_trait.methods.iter().enumerate() {
+                            if method.name.0.contents == method_name {
+                                let trait_method =
+                                    TraitMethodId { trait_id: constraint.trait_id, method_index };
+                                return Some(HirMethodReference::TraitMethodId(trait_method));
                             }
                         }
                     }

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -858,9 +858,6 @@ impl<'interner> TypeChecker<'interner> {
                 );
 
                 for constraint in func_meta.trait_constraints {
-                    // TODO(#2568): == on types is sketchy, since Field != TypeVar::Bound(Field)
-                    // unify() is sketchier here though, since it may accidentally commit typebindings.
-                    // this works for now, but likely needs to be revisited when we implement generic traits
                     if *object_type == constraint.typ {
                         let the_trait = self.interner.get_trait(constraint.trait_id);
                         let the_trait = the_trait.borrow();

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -8,7 +8,6 @@ use crate::{
             self, HirArrayLiteral, HirBinaryOp, HirExpression, HirLiteral, HirMethodCallExpression,
             HirMethodReference, HirPrefixExpression,
         },
-        traits::TraitFunction,
         types::Type,
     },
     node_interner::{DefinitionKind, ExprId, FuncId, TraitMethodId},

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -172,7 +172,7 @@ impl<'interner> TypeChecker<'interner> {
                                     &mut args,
                                 );
                             }
-                        };
+                        }
 
                         let (function_id, function_call) = method_call.into_function_call(
                             method_ref.clone(),

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -502,7 +502,7 @@ impl<'interner> TypeChecker<'interner> {
             HirMethodReference::TraitMethodId(method) => {
                 let the_trait = self.interner.get_trait(method.trait_id);
                 let the_trait = the_trait.borrow();
-                let method: &TraitFunction = &the_trait.methods[method.method_index];
+                let method = &the_trait.methods[method.method_index];
 
                 (method.get_type(), method.arguments.len())
             }

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -27,6 +27,7 @@ pub struct TypeChecker<'interner> {
     delayed_type_checks: Vec<TypeCheckFn>,
     interner: &'interner mut NodeInterner,
     errors: Vec<TypeCheckError>,
+    current_function: Option<FuncId>,
 }
 
 /// Type checks a function and assigns the
@@ -40,6 +41,7 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     let function_body_id = function_body.as_expr();
 
     let mut type_checker = TypeChecker::new(interner);
+    type_checker.current_function = Some(func_id);
 
     // Bind each parameter to its annotated type.
     // This is locally obvious, but it must be bound here so that the
@@ -111,7 +113,7 @@ fn function_info(interner: &NodeInterner, function_body_id: &ExprId) -> (noirc_e
 
 impl<'interner> TypeChecker<'interner> {
     fn new(interner: &'interner mut NodeInterner) -> Self {
-        Self { delayed_type_checks: Vec::new(), interner, errors: vec![] }
+        Self { delayed_type_checks: Vec::new(), interner, errors: vec![], current_function: None }
     }
 
     pub fn push_delayed_type_check(&mut self, f: TypeCheckFn) {
@@ -127,7 +129,12 @@ impl<'interner> TypeChecker<'interner> {
     }
 
     pub fn check_global(id: &StmtId, interner: &'interner mut NodeInterner) -> Vec<TypeCheckError> {
-        let mut this = Self { delayed_type_checks: Vec::new(), interner, errors: vec![] };
+        let mut this = Self {
+            delayed_type_checks: Vec::new(),
+            interner,
+            errors: vec![],
+            current_function: None,
+        };
         this.check_statement(id);
         this.errors
     }

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -151,7 +151,7 @@ pub struct HirMethodCallExpression {
     pub location: Location,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum HirMethodReference {
     /// A method can be defined in a regular `impl` block, in which case
     /// it's syntax sugar for a normal function call, and can be

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -2,7 +2,7 @@ use acvm::FieldElement;
 use fm::FileId;
 use noirc_errors::Location;
 
-use crate::node_interner::{DefinitionId, ExprId, FuncId, NodeInterner, StmtId};
+use crate::node_interner::{DefinitionId, ExprId, FuncId, NodeInterner, StmtId, TraitMethodId};
 use crate::{BinaryOp, BinaryOpKind, Ident, Shared, UnaryOp};
 
 use super::stmt::HirPattern;
@@ -30,6 +30,7 @@ pub enum HirExpression {
     If(HirIfExpression),
     Tuple(Vec<ExprId>),
     Lambda(HirLambda),
+    TraitMethodReference(TraitMethodId),
     Error,
 }
 
@@ -150,20 +151,39 @@ pub struct HirMethodCallExpression {
     pub location: Location,
 }
 
+#[derive(Debug, Clone)]
+pub enum HirMethodReference {
+    /// A method can be defined in a regular `impl` block, in which case
+    /// it's syntax sugar for a normal function call, and can be
+    /// translated to one during type checking
+    FuncId(FuncId),
+
+    /// Or a method can come from a Trait impl block, in which case
+    /// the actual function called will depend on the instantiated type,
+    /// which can be only known during monomorphizaiton.
+    TraitMethodId(TraitMethodId),
+}
+
 impl HirMethodCallExpression {
     pub fn into_function_call(
         mut self,
-        func: FuncId,
+        method: HirMethodReference,
         location: Location,
         interner: &mut NodeInterner,
     ) -> (ExprId, HirExpression) {
         let mut arguments = vec![self.object];
         arguments.append(&mut self.arguments);
 
-        let id = interner.function_definition_id(func);
-        let ident = HirExpression::Ident(HirIdent { location, id });
-        let func = interner.push_expr(ident);
-
+        let expr = match method {
+            HirMethodReference::FuncId(func_id) => {
+                let id = interner.function_definition_id(func_id);
+                HirExpression::Ident(HirIdent { location, id })
+            }
+            HirMethodReference::TraitMethodId(method_id) => {
+                HirExpression::TraitMethodReference(method_id)
+            }
+        };
+        let func = interner.push_expr(expr);
         (func, HirExpression::Call(HirCallExpression { func, arguments, location }))
     }
 }

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -62,7 +62,7 @@ pub struct TraitImpl {
 #[derive(Debug, Clone)]
 pub struct TraitConstraint {
     pub typ: Type,
-    pub trait_id: Option<TraitId>,
+    pub trait_id: TraitId,
     // pub trait_generics: Generics, TODO
 }
 

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1017,6 +1017,10 @@ impl Type {
     /// given bindings if found. If a type variable is not found within
     /// the given TypeBindings, it is unchanged.
     pub fn substitute(&self, type_bindings: &TypeBindings) -> Type {
+        if type_bindings.is_empty() {
+            return self.clone();
+        }
+
         let substitute_binding = |binding: &TypeVariable| match &*binding.borrow() {
             TypeBinding::Bound(binding) => binding.substitute(type_bindings),
             TypeBinding::Unbound(id) => match type_bindings.get(id) {

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1017,10 +1017,6 @@ impl Type {
     /// given bindings if found. If a type variable is not found within
     /// the given TypeBindings, it is unchanged.
     pub fn substitute(&self, type_bindings: &TypeBindings) -> Type {
-        if type_bindings.is_empty() {
-            return self.clone();
-        }
-
         let substitute_binding = |binding: &TypeVariable| match &*binding.borrow() {
             TypeBinding::Bound(binding) => binding.substitute(type_bindings),
             TypeBinding::Unbound(id) => match type_bindings.get(id) {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -11,7 +11,10 @@
 use acvm::FieldElement;
 use iter_extended::{btree_map, vecmap};
 use noirc_printable_type::PrintableType;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    unreachable,
+};
 
 use crate::{
     hir_def::{
@@ -20,7 +23,7 @@ use crate::{
         stmt::{HirAssignStatement, HirLValue, HirLetStatement, HirPattern, HirStatement},
         types,
     },
-    node_interner::{self, DefinitionKind, NodeInterner, StmtId},
+    node_interner::{self, DefinitionKind, NodeInterner, StmtId, TraitImplKey, TraitMethodId},
     token::FunctionAttribute,
     ContractFunctionType, FunctionKind, Type, TypeBinding, TypeBindings, TypeVariableKind,
     Visibility,
@@ -374,6 +377,17 @@ impl<'interner> Monomorphizer<'interner> {
             HirExpression::Constructor(constructor) => self.constructor(constructor, expr),
 
             HirExpression::Lambda(lambda) => self.lambda(lambda, expr),
+
+            HirExpression::TraitMethodReference(method) => {
+                if let Type::Function(args, _, _) = self.interner.id_type(expr) {
+                    let self_type = args[0].clone();
+                    self.resolve_trait_method_reference(self_type, expr, method)
+                } else {
+                    unreachable!(
+                        "Calling a non-function, this should've been caught in typechecking"
+                    );
+                }
+            }
 
             HirExpression::MethodCall(_) => {
                 unreachable!("Encountered HirExpression::MethodCall during monomorphization")
@@ -775,6 +789,45 @@ impl<'interner> Monomorphizer<'interner> {
         } else {
             false
         }
+    }
+
+    fn resolve_trait_method_reference(
+        &mut self,
+        self_type: HirType,
+        expr_id: node_interner::ExprId,
+        method: TraitMethodId,
+    ) -> ast::Expression {
+        let function_type = self.interner.id_type(expr_id);
+
+        // the substitute() here is to replace all internal occurences of the 'Self' typevar
+        // with whatever 'Self' is currently bound to, so we don't lose type information
+        // if we need to rebind the trait.
+        let trait_impl = self
+            .interner
+            .get_trait_implementation(&TraitImplKey {
+                typ: self_type.substitute(&HashMap::new()),
+                trait_id: method.trait_id,
+            })
+            .expect("ICE: missing trait impl - should be caught during type checking");
+
+        let hir_func_id = trait_impl.borrow().methods[method.method_index];
+
+        let func_def = self.lookup_function(hir_func_id, expr_id, &function_type);
+        let func_id = match func_def {
+            Definition::Function(func_id) => func_id,
+            _ => unreachable!(),
+        };
+
+        let the_trait = self.interner.get_trait(method.trait_id);
+        let the_trait = the_trait.borrow();
+
+        ast::Expression::Ident(ast::Ident {
+            definition: Definition::Function(func_id),
+            mutable: false,
+            location: None,
+            name: the_trait.methods[method.method_index].name.0.contents.clone(),
+            typ: Self::convert_type(&function_type),
+        })
     }
 
     fn function_call(

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -805,7 +805,7 @@ impl<'interner> Monomorphizer<'interner> {
         let trait_impl = self
             .interner
             .get_trait_implementation(&TraitImplKey {
-                typ: self_type.substitute(&HashMap::new()),
+                typ: self_type.follow_bindings(),
                 trait_id: method.trait_id,
             })
             .expect("ICE: missing trait impl - should be caught during type checking");
@@ -826,7 +826,7 @@ impl<'interner> Monomorphizer<'interner> {
             mutable: false,
             location: None,
             name: the_trait.methods[method.method_index].name.0.contents.clone(),
-            typ: Self::convert_type(&function_type),
+            typ: self.convert_type(&function_type),
         })
     }
 

--- a/tooling/nargo_cli/tests/execution_success/trait_where_clause/Nargo.toml
+++ b/tooling/nargo_cli/tests/execution_success/trait_where_clause/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "trait_where_clause"
+type = "bin"
+authors = [""]
+compiler_version = "0.11.1"
+
+[dependencies]

--- a/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/main.nr
@@ -1,0 +1,41 @@
+// TODO(#2568): Currently we only support trait constraints on free functions.
+// There's a bunch of other places where they can pop up:
+//      - trait methods (trait Foo<T> where T: ... { )
+//      - free impl blocks (impl<T> Foo<T> where T...)
+//      - trait impl blocks (impl<T,U> Foo for Bar where T...)
+//      - structs (struct Foo<T> where T: ...)
+
+trait Asd {
+    fn asd(self) -> Field;
+}
+
+struct Add10  { x: Field, }
+struct Add20  { x: Field, }
+struct Add30  { x: Field, }
+struct AddXY  { x: Field, y: Field, }
+
+impl Asd for Add10 { fn asd(self) -> Field { self.x + 10 } }
+impl Asd for Add20 { fn asd(self) -> Field { self.x + 20 } }
+impl Asd for Add30 { fn asd(self) -> Field { self.x + 30 } }
+
+impl Asd for AddXY {
+    fn asd(self) -> Field {
+        self.x + self.y
+    }
+}
+
+fn assert_asd_eq_100<T>(t: T) where T: Asd {
+    assert(t.asd() == 100);
+}
+
+fn main() {
+    let x  = Add10{ x: 90 };
+    let z  = Add20{ x: 80 };
+    let a  = Add30{ x: 70 };
+    let xy = AddXY{ x: 30, y: 70 };
+
+    assert_asd_eq_100(x);
+    assert_asd_eq_100(z);
+    assert_asd_eq_100(a);
+    assert_asd_eq_100(xy);
+}


### PR DESCRIPTION
This needs to be merged after https://github.com/noir-lang/noir/pull/2652 and https://github.com/noir-lang/noir/pull/2716 - this PR also unfortunately includes the changes from that and the diff is currently quite ugly

# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Progress on https://github.com/noir-lang/noir/issues/2568

## Summary\*

This implements the type checker & monomorphizer passes for trait bounds. Changes include:

1. Added `HirMethodReference` which can reference either a concrete func id, or a trait method, which will be resolved to a concrete FuncId during monomorphization:
```rust
pub struct TraitMethodId {
    pub trait_id: TraitId,
    pub method_index: usize, // index in Trait::methods
}

pub enum HirMethodReference {
    FuncId(FuncId),
    TraitMethodId(TraitMethodId),
}
```
2. `lookup_method` now returns a `HirMethodReference`. if it sees a `NamedGeneric` it walks over the function's trait bounds and looking for a matching method.
3. There's a new `HirExpression` node for method references that need to be resolved during mono
4. This also includes the monomorphization logic to pick the correct func_id when instantiating generics

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
