### PR TITLE
chore: Add noir-wasm publishing as a workflow

### DIFF
--- a/.github/workflows/release-noir-wasm.yml
+++ b/.github/workflows/release-noir-wasm.yml
@@ -1,4 +1,4 @@
-name: Update & Publish
+name: Release Noir Wasm
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-noir-wasm.yml
+++ b/.github/workflows/release-noir-wasm.yml
@@ -21,9 +21,9 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
         with:
-          nix_path: nixpkgs=channel:nixpkgs-22.05
+          nix_path: nixpkgs=channel:nixos-23.05
 
       - name: Build with Nix
         run: |

--- a/.github/workflows/release-noir-wasm.yml
+++ b/.github/workflows/release-noir-wasm.yml
@@ -2,10 +2,6 @@ name: Update & Publish
 
 on:
   workflow_dispatch:
-    inputs:
-      noir-ref:
-        description: The noir reference to checkout
-        required: false
 
 jobs:
   publish-noir-wasm:
@@ -41,7 +37,6 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Publish to npm
-        if: ${{ inputs.noir-ref }}
         run: |
           npm publish --access public
         env:

--- a/.github/workflows/release-noir-wasm.yml
+++ b/.github/workflows/release-noir-wasm.yml
@@ -8,24 +8,12 @@ on:
         required: false
 
 jobs:
-  update-and-publish:
+  publish-noir-wasm:
     runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - uses: actions/checkout@v3
-        with:
-          repository: "noir-lang/noir"
-          ref: ${{ inputs.noir-ref || 'master' }}
-          path: ".cache/noir"
-
-      - name: Collect Revision
-        id: collect-rev
-        working-directory: ".cache/noir"
-        run: |
-          echo "NOIR_REV_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         with:
@@ -45,37 +33,16 @@ jobs:
         run: |
           nix build -L github:noir-lang/noir/master#wasm
 
-      - name: Configure git
-        run: |
-          git config user.name kobyhallx
-          git config user.email koby@aztecprotocol.com
-
       - name: Copy output
         run: |
           cp -r $(readlink result)/* .
+    
+      - name: Authenticate with npm
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
-      - name: Update version with git hash
-        if: ${{ !inputs.noir-ref }}
-        # This will generate the prerelease with something like `.0` but that is okay because it is proper SemVer
-        run: |
-          npm version --no-git-tag-version --preid ${{ steps.collect-rev.outputs.NOIR_REV_SHORT }} prerelease
-
-      - name: Commit updates
-        run: |
-          git add .
-          git commit -m "tracking noir@${{ steps.collect-rev.outputs.NOIR_REV_SHORT }}"
-          git push --force
-
-      - name: Publish to npm (nightly tag)
-        if: ${{ !inputs.noir-ref }}
-        run: |
-          npm publish --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish to npm (latest tag)
+      - name: Publish to npm
         if: ${{ inputs.noir-ref }}
         run: |
-          npm publish --tag latest
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-noir-wasm.yml
+++ b/.github/workflows/release-noir-wasm.yml
@@ -1,0 +1,81 @@
+name: Update & Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      noir-ref:
+        description: The noir reference to checkout
+        required: false
+
+jobs:
+  update-and-publish:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/checkout@v3
+        with:
+          repository: "noir-lang/noir"
+          ref: ${{ inputs.noir-ref || 'master' }}
+          path: ".cache/noir"
+
+      - name: Collect Revision
+        id: collect-rev
+        working-directory: ".cache/noir"
+        run: |
+          echo "NOIR_REV_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-22.05
+
+      - name: Build with Nix
+        run: |
+          nix build -L github:noir-lang/noir/master#wasm
+
+      - name: Configure git
+        run: |
+          git config user.name kobyhallx
+          git config user.email koby@aztecprotocol.com
+
+      - name: Copy output
+        run: |
+          cp -r $(readlink result)/* .
+
+      - name: Update version with git hash
+        if: ${{ !inputs.noir-ref }}
+        # This will generate the prerelease with something like `.0` but that is okay because it is proper SemVer
+        run: |
+          npm version --no-git-tag-version --preid ${{ steps.collect-rev.outputs.NOIR_REV_SHORT }} prerelease
+
+      - name: Commit updates
+        run: |
+          git add .
+          git commit -m "tracking noir@${{ steps.collect-rev.outputs.NOIR_REV_SHORT }}"
+          git push --force
+
+      - name: Publish to npm (nightly tag)
+        if: ${{ !inputs.noir-ref }}
+        run: |
+          npm publish --tag nightly
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm (latest tag)
+        if: ${{ inputs.noir-ref }}
+        run: |
+          npm publish --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-noir-wasm.yml
+++ b/.github/workflows/release-noir-wasm.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build with Nix
         run: |
-          nix build -L github:noir-lang/noir/master#wasm
+          nix build -L .#wasm
 
       - name: Copy output
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,9 @@ jobs:
       - name: Dispatch to noir_wasm
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: update.yml
-          repo: noir-lang/noir_wasm
+          workflow: release-noir-wasm.yml
           ref: master
           token: ${{ secrets.NOIR_REPO_TOKEN }}
-          inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}" }'
 
   publish-noir-js:
     name: Publish noir_js package

--- a/compiler/wasm/build.sh
+++ b/compiler/wasm/build.sh
@@ -38,7 +38,7 @@ rm -rf $self_path/result >/dev/null 2>&1
 if [ -v out ]; then
   echo "Will install package to $out (defined outside installPhase.sh script)"
 else
-  out="$self_path/outputs/out"
+  export out="$self_path/outputs/out"
   echo "Will install package to $out"
 fi
 


### PR DESCRIPTION
# Description

noir wasm is currently being published from a separate repo. This brings publishing of it in here, so its like the other repos

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
