### PR TITLE
chore: wrap backend info response in a struct instead of boxed closure

### DIFF
--- a/tooling/acvm_backend_barretenberg/src/lib.rs
+++ b/tooling/acvm_backend_barretenberg/src/lib.rs
@@ -1,13 +1,14 @@
 #![warn(unused_crate_dependencies, unused_extern_crates)]
 #![warn(unreachable_pub)]
 
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 mod cli;
 mod download;
 mod proof_system;
 mod smart_contract;
 
+use acvm::acir::circuit::Opcode;
 pub use download::download_backend;
 
 const BACKENDS_DIR: &str = ".nargo/backends";
@@ -93,6 +94,26 @@ impl Backend {
 
     fn crs_directory(&self) -> PathBuf {
         self.backend_directory().join("crs")
+    }
+}
+
+pub struct BackendOpcodeSupport {
+    opcodes: HashSet<String>,
+    black_box_functions: HashSet<String>,
+}
+
+impl BackendOpcodeSupport {
+    pub fn is_opcode_supported(&self, opcode: &Opcode) -> bool {
+        match opcode {
+            Opcode::Arithmetic(_) => self.opcodes.contains("arithmetic"),
+            Opcode::Directive(_) => self.opcodes.contains("directive"),
+            Opcode::Brillig(_) => self.opcodes.contains("brillig"),
+            Opcode::MemoryInit { .. } => self.opcodes.contains("memory_init"),
+            Opcode::MemoryOp { .. } => self.opcodes.contains("memory_op"),
+            Opcode::BlackBoxFuncCall(func) => {
+                self.black_box_functions.contains(func.get_black_box_func().name())
+            }
+        }
     }
 }
 

--- a/tooling/acvm_backend_barretenberg/src/proof_system.rs
+++ b/tooling/acvm_backend_barretenberg/src/proof_system.rs
@@ -2,14 +2,13 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use acvm::acir::circuit::Opcode;
 use acvm::acir::{circuit::Circuit, native_types::WitnessMap};
 use acvm::FieldElement;
 use acvm::Language;
 use tempfile::tempdir;
 
 use crate::cli::{GatesCommand, InfoCommand, ProveCommand, VerifyCommand, WriteVkCommand};
-use crate::{Backend, BackendError};
+use crate::{Backend, BackendError, BackendOpcodeSupport};
 
 impl Backend {
     pub fn get_exact_circuit_size(&self, circuit: &Circuit) -> Result<u32, BackendError> {
@@ -27,9 +26,7 @@ impl Backend {
             .run(binary_path)
     }
 
-    pub fn get_backend_info(
-        &self,
-    ) -> Result<(Language, Box<impl Fn(&Opcode) -> bool>), BackendError> {
+    pub fn get_backend_info(&self) -> Result<(Language, BackendOpcodeSupport), BackendError> {
         let binary_path = self.assert_binary_exists()?;
         InfoCommand { crs_path: self.crs_directory() }.run(binary_path)
     }

--- a/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -46,7 +46,7 @@ pub(crate) fn run(
     let selection = args.package.map_or(default_selection, PackageSelection::Selected);
     let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
 
-    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
+    let (np_language, opcode_support) = backend.get_backend_info()?;
     for package in &workspace {
         let circuit_build_path = workspace.package_build_path(package);
 
@@ -56,7 +56,7 @@ pub(crate) fn run(
             circuit_build_path,
             &args.compile_options,
             np_language,
-            &is_opcode_supported,
+            &|opcode| opcode_support.is_opcode_supported(opcode),
         )?;
 
         let contract_dir = workspace.contracts_directory_path(package);

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use acvm::acir::circuit::Opcode;
 use acvm::Language;
+use acvm_backend_barretenberg::BackendOpcodeSupport;
 use fm::FileManager;
 use iter_extended::vecmap;
 use nargo::artifacts::contract::PreprocessedContract;
@@ -69,8 +70,14 @@ pub(crate) fn run(
         .cloned()
         .partition(|package| package.is_binary());
 
-    let (compiled_programs, compiled_contracts) =
-        compile_workspace(backend, &binary_packages, &contract_packages, &args.compile_options)?;
+    let (np_language, opcode_support) = backend.get_backend_info()?;
+    let (compiled_programs, compiled_contracts) = compile_workspace(
+        &binary_packages,
+        &contract_packages,
+        np_language,
+        &opcode_support,
+        &args.compile_options,
+    )?;
 
     // Save build artifacts to disk.
     for (package, program) in binary_packages.into_iter().zip(compiled_programs) {
@@ -84,12 +91,13 @@ pub(crate) fn run(
 }
 
 pub(super) fn compile_workspace(
-    backend: &Backend,
     binary_packages: &[Package],
     contract_packages: &[Package],
+    np_language: Language,
+    opcode_support: &BackendOpcodeSupport,
     compile_options: &CompileOptions,
 ) -> Result<(Vec<CompiledProgram>, Vec<CompiledContract>), CliError> {
-    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
+    let is_opcode_supported = |opcode: &_| opcode_support.is_opcode_supported(opcode);
 
     // Compile all of the packages in parallel.
     let program_results: Vec<(FileManager, CompilationResult<CompiledProgram>)> = binary_packages

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -54,10 +54,12 @@ pub(crate) fn run(
     let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
     let target_dir = &workspace.target_directory_path();
 
-    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
+    let (np_language, opcode_support) = backend.get_backend_info()?;
     for package in &workspace {
         let compiled_program =
-            compile_bin_package(package, &args.compile_options, np_language, &is_opcode_supported)?;
+            compile_bin_package(package, &args.compile_options, np_language, &|opcode| {
+                opcode_support.is_opcode_supported(opcode)
+            })?;
 
         let (return_value, solved_witness) =
             execute_program_and_decode(compiled_program, package, &args.prover_name)?;

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -55,10 +55,15 @@ pub(crate) fn run(
         .cloned()
         .partition(|package| package.is_binary());
 
-    let (compiled_programs, compiled_contracts) =
-        compile_workspace(backend, &binary_packages, &contract_packages, &args.compile_options)?;
+    let (np_language, opcode_support) = backend.get_backend_info()?;
+    let (compiled_programs, compiled_contracts) = compile_workspace(
+        &binary_packages,
+        &contract_packages,
+        np_language,
+        &opcode_support,
+        &args.compile_options,
+    )?;
 
-    let (np_language, _) = backend.get_backend_info()?;
     let program_info = binary_packages
         .into_par_iter()
         .zip(compiled_programs)

--- a/tooling/nargo_cli/src/cli/prove_cmd.rs
+++ b/tooling/nargo_cli/src/cli/prove_cmd.rs
@@ -63,7 +63,7 @@ pub(crate) fn run(
     let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
     let proof_dir = workspace.proofs_directory_path();
 
-    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
+    let (np_language, opcode_support) = backend.get_backend_info()?;
     for package in &workspace {
         let circuit_build_path = workspace.package_build_path(package);
 
@@ -77,7 +77,7 @@ pub(crate) fn run(
             args.verify,
             &args.compile_options,
             np_language,
-            &is_opcode_supported,
+            &|opcode| opcode_support.is_opcode_supported(opcode),
         )?;
     }
 

--- a/tooling/nargo_cli/src/cli/verify_cmd.rs
+++ b/tooling/nargo_cli/src/cli/verify_cmd.rs
@@ -50,7 +50,7 @@ pub(crate) fn run(
     let workspace = resolve_workspace_from_toml(&toml_path, selection)?;
     let proofs_dir = workspace.proofs_directory_path();
 
-    let (np_language, is_opcode_supported) = backend.get_backend_info()?;
+    let (np_language, opcode_support) = backend.get_backend_info()?;
     for package in &workspace {
         let circuit_build_path = workspace.package_build_path(package);
 
@@ -64,7 +64,7 @@ pub(crate) fn run(
             &args.verifier_name,
             &args.compile_options,
             np_language,
-            &is_opcode_supported,
+            &|opcode| opcode_support.is_opcode_supported(opcode),
         )?;
     }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*


Returning a boxed closure from `Backend,get_backend_info` makes it harder for us to pass the opcode support between functions while making use of `rayon`.

## Summary\*

This PR defines a struct to contain information on the opcodes which the backend supports and a method to query this. We can then pass this around as we like. 

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
