### PR TITLE
fix: add error message for a contract package with no contracts

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -186,6 +186,12 @@ pub fn compile_contract(
         let err = CustomDiagnostic::from_message("Packages are limited to a single contract")
             .in_file(FileId::default());
         return Err(vec![err]);
+    } else if contracts.is_empty() {
+        let err = CustomDiagnostic::from_message(
+            "cannot compile crate into a contract as it does not contain any contracts",
+        )
+        .in_file(FileId::default());
+        return Err(vec![err]);
     };
 
     for contract in contracts {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR has a quick fix for the panic that Lisa was experiencing where Nargo cannot find any contracts within a contract package.

Rather than panicking when we assert that we have a single contract, we return an error message similar to that for when a binary crate has no `main` function.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
