### PR TITLE
chore: Avoid source-resolver in a WASI environment

### DIFF
--- a/compiler/fm/Cargo.toml
+++ b/compiler/fm/Cargo.toml
@@ -13,7 +13,7 @@ cfg-if.workspace = true
 rust-embed = "6.6.0"
 serde.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 wasm-bindgen.workspace = true
 
 [dev-dependencies]

--- a/compiler/fm/src/file_reader.rs
+++ b/compiler/fm/src/file_reader.rs
@@ -22,7 +22,7 @@ pub(super) fn is_stdlib_asset(path: &Path) -> bool {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(target_arch = "wasm32")] {
+    if #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))] {
         use wasm_bindgen::{prelude::*, JsValue};
 
         #[wasm_bindgen(module = "@noir-lang/source-resolver")]


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This change avoids the `source-resolver` in a WASI environment, which works with normal rust filesystem calls. This is needed to remove wasm-bindgen from the LSP with the WASI target.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
