### PR TITLE
chore(lsp): Construct the LSP with a blackbox solver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     # Crates related to tooling built ontop of the Noir compiler
     "tooling/backend_interface",
     "tooling/bb_abstraction_leaks",
+    "tooling/lsp",
     "tooling/nargo",
     "tooling/nargo_cli",
     "tooling/nargo_toml",

--- a/tooling/nargo_cli/src/cli/lsp_cmd.rs
+++ b/tooling/nargo_cli/src/cli/lsp_cmd.rs
@@ -30,7 +30,9 @@ pub(crate) fn run(
 
     runtime.block_on(async {
         let (server, _) = async_lsp::MainLoop::new_server(|client| {
-            let router = NargoLspService::new(&client);
+            #[allow(deprecated)]
+            let blackbox_solver = barretenberg_blackbox_solver::BarretenbergSolver::new();
+            let router = NargoLspService::new(&client, blackbox_solver);
 
             ServiceBuilder::new()
                 .layer(TracingLayer::default())


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This removes the hardcoded `barretenberg_blackbox_solver` from the LSP and instead requires it to be passed when the LSP server is constructed. This removes the wasm-bindgen code added to the LSP when trying to compile to the WASI target.

It required a new struct to wrap the dynamic trait and proxies to the backend.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
