### PR TITLE
fix: Make `Vec::get` accept immutable `Vec`s

### DIFF
--- a/noir_stdlib/src/collections/vec.nr
+++ b/noir_stdlib/src/collections/vec.nr
@@ -18,7 +18,7 @@ impl<T> Vec<T> {
     /// Get an element from the vector at the given index.
     /// Panics if the given index
     /// points beyond the end of the vector.
-    pub fn get(&mut self, index: Field) -> T {
+    pub fn get(self, index: Field) -> T {
         self.slice[index]
      }
 
@@ -54,7 +54,7 @@ impl<T> Vec<T> {
     }
 
     /// Returns the number of elements in the vector
-    pub fn len(self: Self) -> Field {
+    pub fn len(self) -> Field {
         self.slice.len()
     }
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2775

## Summary\*

`Vec::get` used to require a mutable Vec since we did not automatically dereference `&mut T` -> `T` for objects of method calls before PR #2581. Now that this PR is merged, it can be immutable.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.
    - The type signature of `Vec::get` will need to be updated

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
