### PR TITLE
feat: remove redundant predicate from brillig quotients

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -39,40 +39,31 @@ pub(crate) fn directive_invert() -> GeneratedBrillig {
 }
 
 /// Generates brillig bytecode which computes `a / b` and returns the quotient and remainder.
-/// It returns `(0,0)` if the predicate is null.
-///
 ///
 /// This is equivalent to the Noir (psuedo)code
 ///
 /// ```ignore
-/// fn quotient<T>(a: T, b: T, predicate: bool) -> (T,T) {
-///    if predicate != 0 {
-///      (a/b, a-a/b*b)
-///    } else {
-///      (0,0)
-///    }
+/// fn quotient<T>(a: T, b: T) -> (T,T) {
+///    (a/b, a-a/b*b)
 /// }
 /// ```
 pub(crate) fn directive_quotient(bit_size: u32) -> GeneratedBrillig {
     // `a` is (0) (i.e register index 0)
     // `b` is (1)
-    // `predicate` is (2)
     GeneratedBrillig {
         byte_code: vec![
-            // If the predicate is zero, we jump to the exit segment
-            BrilligOpcode::JumpIfNot { condition: RegisterIndex::from(2), location: 6 },
-            //q = a/b is set into register (3)
+            //q = a/b is set into register (2)
             BrilligOpcode::BinaryIntOp {
                 op: BinaryIntOp::UnsignedDiv,
                 lhs: RegisterIndex::from(0),
                 rhs: RegisterIndex::from(1),
-                destination: RegisterIndex::from(3),
+                destination: RegisterIndex::from(2),
                 bit_size,
             },
             //(1)= q*b
             BrilligOpcode::BinaryIntOp {
                 op: BinaryIntOp::Mul,
-                lhs: RegisterIndex::from(3),
+                lhs: RegisterIndex::from(2),
                 rhs: RegisterIndex::from(1),
                 destination: RegisterIndex::from(1),
                 bit_size,
@@ -88,17 +79,7 @@ pub(crate) fn directive_quotient(bit_size: u32) -> GeneratedBrillig {
             //(0) = q
             BrilligOpcode::Mov {
                 destination: RegisterIndex::from(0),
-                source: RegisterIndex::from(3),
-            },
-            BrilligOpcode::Stop,
-            // Exit segment: we return 0,0
-            BrilligOpcode::Const {
-                destination: RegisterIndex::from(0),
-                value: Value::from(0_usize),
-            },
-            BrilligOpcode::Const {
-                destination: RegisterIndex::from(1),
-                value: Value::from(0_usize),
+                source: RegisterIndex::from(2),
             },
             BrilligOpcode::Stop,
         ],

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -544,11 +544,7 @@ impl GeneratedAcir {
         let r_witness = self.next_witness_index();
 
         let quotient_code = brillig_directive::directive_quotient(max_bit_size);
-        let inputs = vec![
-            BrilligInputs::Single(lhs),
-            BrilligInputs::Single(rhs),
-            BrilligInputs::Single(predicate.clone()),
-        ];
+        let inputs = vec![BrilligInputs::Single(lhs), BrilligInputs::Single(rhs)];
         let outputs = vec![BrilligOutputs::Simple(q_witness), BrilligOutputs::Simple(r_witness)];
         self.brillig(Some(predicate), quotient_code, inputs, outputs);
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Currently we're inserting a predicate into the `directive_quotient` brillig bytecode as well as into the actual Brillig ACIR opcode. This means that we've got an entire codepath which is never used (as it corresponds to a situation in which the brillig bytecode is never executed.)

We should then remove this predicate from `directive_quotient` and rely on the predicate on the Brillig ACIR opcode instead.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
