### PR TITLE
chore: Add more information to backend errors

### DIFF
--- a/tooling/backend_interface/src/cli/contract.rs
+++ b/tooling/backend_interface/src/cli/contract.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use crate::BackendError;
 
+use super::string_from_stderr;
+
 /// VerifyCommand will call the barretenberg binary
 /// to return a solidity library with the verification key
 /// that can be used to verify proofs on-chain.
@@ -31,9 +33,9 @@ impl ContractCommand {
 
         if output.status.success() {
             String::from_utf8(output.stdout)
-                .map_err(|error| BackendError::MalformedResponse(error.into_bytes()))
+                .map_err(|error| BackendError::InvalidUTF8Vector(error.into_bytes()))
         } else {
-            Err(BackendError::CommandFailed(output.stderr))
+            Err(BackendError::CommandFailed(string_from_stderr(&output.stderr)))
         }
     }
 }

--- a/tooling/backend_interface/src/cli/info.rs
+++ b/tooling/backend_interface/src/cli/info.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 
 use crate::{BackendError, BackendOpcodeSupport};
 
+use super::string_from_stderr;
+
 pub(crate) struct InfoCommand {
     pub(crate) crs_path: PathBuf,
 }
@@ -43,7 +45,7 @@ impl InfoCommand {
         let output = command.output()?;
 
         if !output.status.success() {
-            return Err(BackendError::CommandFailed(output.stderr));
+            return Err(BackendError::CommandFailed(string_from_stderr(&output.stderr)));
         }
 
         let backend_info: InfoResponse =

--- a/tooling/backend_interface/src/cli/mod.rs
+++ b/tooling/backend_interface/src/cli/mod.rs
@@ -22,9 +22,14 @@ fn no_command_provided_works() -> Result<(), crate::BackendError> {
 
     let output = std::process::Command::new(backend.binary_path()).output()?;
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = string_from_stderr(&output.stderr);
     // Assert help message is printed due to no command being provided.
     assert!(stderr.contains("Usage: mock_backend <COMMAND>"));
 
     Ok(())
+}
+
+// Converts a stderr byte array to a string (including invalid characters)
+fn string_from_stderr(stderr: &[u8]) -> String {
+    String::from_utf8_lossy(stderr).to_string()
 }

--- a/tooling/backend_interface/src/cli/prove.rs
+++ b/tooling/backend_interface/src/cli/prove.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use crate::BackendError;
 
+use super::string_from_stderr;
+
 /// ProveCommand will call the barretenberg binary
 /// to create a proof, given the witness and the bytecode.
 ///
@@ -39,7 +41,7 @@ impl ProveCommand {
         if output.status.success() {
             Ok(output.stdout)
         } else {
-            Err(BackendError::CommandFailed(output.stderr))
+            Err(BackendError::CommandFailed(string_from_stderr(&output.stderr)))
         }
     }
 }

--- a/tooling/backend_interface/src/cli/write_vk.rs
+++ b/tooling/backend_interface/src/cli/write_vk.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use super::string_from_stderr;
 use crate::BackendError;
 
 /// WriteCommand will call the barretenberg binary
@@ -32,7 +33,7 @@ impl WriteVkCommand {
         if output.status.success() {
             Ok(())
         } else {
-            Err(BackendError::CommandFailed(output.stderr))
+            Err(BackendError::CommandFailed(string_from_stderr(&output.stderr)))
         }
     }
 }

--- a/tooling/backend_interface/src/lib.rs
+++ b/tooling/backend_interface/src/lib.rs
@@ -40,11 +40,16 @@ pub enum BackendError {
     #[error("Backend binary does not exist")]
     MissingBinary,
 
-    #[error("The backend responded with malformed data: {0:?}")]
-    MalformedResponse(Vec<u8>),
+    #[error("The backend responded with a malformed UTF8 byte vector: {0:?}")]
+    InvalidUTF8Vector(Vec<u8>),
 
-    #[error("The backend encountered an error")]
-    CommandFailed(Vec<u8>),
+    #[error(
+        "The backend responded with a unexpected number of bytes. Expected: {0:} but got {1:?}"
+    )]
+    UnexpectedNumberOfBytes(usize, Vec<u8>),
+
+    #[error("The backend encountered an error: {0:?}")]
+    CommandFailed(String),
 }
 
 #[derive(Debug)]

--- a/tooling/backend_interface/src/lib.rs
+++ b/tooling/backend_interface/src/lib.rs
@@ -44,7 +44,7 @@ pub enum BackendError {
     InvalidUTF8Vector(Vec<u8>),
 
     #[error(
-        "The backend responded with a unexpected number of bytes. Expected: {0:} but got {1:?}"
+        "The backend responded with a unexpected number of bytes. Expected: {0} but got {.1.len()} ({1:?})",
     )]
     UnexpectedNumberOfBytes(usize, Vec<u8>),
 

--- a/tooling/backend_interface/src/lib.rs
+++ b/tooling/backend_interface/src/lib.rs
@@ -44,7 +44,7 @@ pub enum BackendError {
     InvalidUTF8Vector(Vec<u8>),
 
     #[error(
-        "The backend responded with a unexpected number of bytes. Expected: {0} but got {.1.len()} ({1:?})",
+        "The backend responded with a unexpected number of bytes. Expected: {0} but got {} ({1:?})", .1.len()
     )]
     UnexpectedNumberOfBytes(usize, Vec<u8>),
 


### PR DESCRIPTION
# Description

When we get a backend error, this makes it so that we can see what error the backend displayed as a utf8 encoded string.

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
