### PR TITLE
chore: use `secrets.NOIR_RELEASES_TOKEN` for ACVM

### DIFF
--- a/.github/workflows/acvm-release.yml
+++ b/.github/workflows/acvm-release.yml
@@ -17,7 +17,7 @@ jobs:
         id: release
         uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.ACVM_RELEASE_TOKEN }}
+          token: ${{ secrets.NOIR_RELEASES_TOKEN }}
           command: manifest
 
   publish:


### PR DESCRIPTION
# Description

Changes ACVM_RELEASE_TOKEN to NOIR_RELEASE_TOKEN

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
