### PR TITLE
chore: Change .unwrap to an error variant when reading program from file

### DIFF
--- a/tooling/nargo_cli/src/cli/fs/program.rs
+++ b/tooling/nargo_cli/src/cli/fs/program.rs
@@ -55,8 +55,8 @@ pub(crate) fn read_program_from_file<P: AsRef<Path>>(
 
     let input_string =
         std::fs::read(&file_path).map_err(|_| FilesystemError::PathNotValid(file_path))?;
-
-    let program = serde_json::from_slice(&input_string).expect("could not deserialize program");
+    let program = serde_json::from_slice(&input_string)
+        .map_err(|err| FilesystemError::ProgramSerializationError(err.to_string()))?;
 
     Ok(program)
 }

--- a/tooling/nargo_cli/src/errors.rs
+++ b/tooling/nargo_cli/src/errors.rs
@@ -26,6 +26,9 @@ pub(crate) enum FilesystemError {
     /// WitnessMap serialization error
     #[error(transparent)]
     WitnessMapSerialization(#[from] WitnessMapError),
+
+    #[error("Error: could not deserialize build program: {0}")]
+    ProgramSerializationError(String),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
# Description

This changes the unwrap to a FileSystemError incase there is a malformed serialized program. 

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
