### PR TITLE
fix: Silence unused variable warnings in stdlib

### DIFF
--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -40,10 +40,10 @@ pub fn assert_constant<T>(_x: T) {}
 // `as` should be the default for users to cast between primitive types, and in the future
 // traits can be used to work with generic types.
 #[builtin(from_field)]
-fn from_field<T>(x : Field) -> T {}
+fn from_field<T>(_x : Field) -> T {}
 
 #[builtin(as_field)]
-fn as_field<T>(x : T) -> Field {}
+fn as_field<T>(_x : T) -> Field {}
 
 
 pub fn wrapping_add<T>(x : T, y: T) -> T {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
