### PR TITLE
fix: Fix subtract with underflow in flattening pass

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -461,7 +461,7 @@ impl<'f> Context<'f> {
                 let mut get_element = |array, typevars, len| {
                     // The smaller slice is filled with placeholder data. Codegen for slice accesses must
                     // include checks against the dynamic slice length so that this placeholder data is not incorrectly accessed.
-                    if (len - 1) < index_value.to_u128() as usize {
+                    if len <= index_value.to_u128() as usize {
                         let zero = FieldElement::zero();
                         self.inserter.function.dfg.make_constant(zero, Type::field())
                     } else {

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -286,35 +286,23 @@ impl<'f> Context<'f> {
                 let else_block = *else_destination;
                 let then_condition = self.inserter.resolve(old_condition);
 
-                let one = FieldElement::one();
-                let then_branch =
-                    self.inline_branch(block, then_block, old_condition, then_condition, one);
-
-                let else_condition =
-                    self.insert_instruction(Instruction::Not(then_condition), CallStack::new());
-                let zero = FieldElement::zero();
-
-                // Make sure the else branch sees the previous values of each store
-                // rather than any values created in the 'then' branch.
-                self.undo_stores_in_then_branch(&then_branch);
-
-                let else_branch =
-                    self.inline_branch(block, else_block, old_condition, else_condition, zero);
-
-                // We must remember to reset whether side effects are enabled when both branches
-                // end, in addition to resetting the value of old_condition since it is set to
-                // known to be true/false within the then/else branch respectively.
-                self.insert_current_side_effects_enabled();
-
-                // We must map back to `then_condition` here. Mapping `old_condition` to itself would
-                // lose any previous mappings.
-                self.inserter.map_value(old_condition, then_condition);
-
-                // While there is a condition on the stack we don't compile outside the condition
-                // until it is popped. This ensures we inline the full then and else branches
-                // before continuing from the end of the conditional here where they can be merged properly.
-                let end = self.branch_ends[&block];
-                self.inline_branch_end(end, then_branch, else_branch)
+                if let Some(condition) =
+                    self.inserter.function.dfg.get_numeric_constant(then_condition)
+                {
+                    if condition.is_zero() {
+                        self.handle_constant_jmpif(block, else_block, old_condition)
+                    } else {
+                        self.handle_constant_jmpif(block, then_block, old_condition)
+                    }
+                } else {
+                    self.handle_non_constant_jmpif(
+                        block,
+                        then_block,
+                        else_block,
+                        old_condition,
+                        then_condition,
+                    )
+                }
             }
             TerminatorInstruction::Jmp { destination, arguments, call_stack: _ } => {
                 if let Some((end_block, _)) = self.conditions.last() {
@@ -335,6 +323,78 @@ impl<'f> Context<'f> {
                 block
             }
         }
+    }
+
+    fn handle_constant_jmpif(
+        &mut self,
+        block: BasicBlockId,
+        branch_block: BasicBlockId,
+        old_condition: ValueId,
+    ) -> BasicBlockId {
+        // This value will be unused since the condition is constant
+        let one = FieldElement::one();
+        let new_condition = self.inserter.function.dfg.make_constant(one, Type::bool());
+
+        let branch = self.inline_branch(block, branch_block, old_condition, new_condition, one);
+
+        // We must remember to reset whether side effects are enabled when both branches
+        // end, in addition to resetting the value of old_condition since it is set to
+        // known to be true/false within the then/else branch respectively.
+        self.insert_current_side_effects_enabled();
+
+        // We must map back to `new_condition` here. Mapping `old_condition` to itself would
+        // lose any previous mappings.
+        self.inserter.map_value(old_condition, new_condition);
+
+        // While there is a condition on the stack we don't compile outside the condition
+        // until it is popped. This ensures we inline the full then and else branches
+        // before continuing from the end of the conditional here where they can be merged properly.
+        let end = self.branch_ends[&block];
+
+        let args = self.inserter.function.dfg[branch.last_block].terminator_arguments().to_vec();
+        let params = self.inserter.function.dfg.block_parameters(end);
+        assert_eq!(params.len(), args.len());
+
+        // insert merge instruction
+        self.inline_block(end, &args)
+    }
+
+    fn handle_non_constant_jmpif(
+        &mut self,
+        block: BasicBlockId,
+        then_block: BasicBlockId,
+        else_block: BasicBlockId,
+        old_condition: ValueId,
+        then_condition: ValueId,
+    ) -> BasicBlockId {
+        let one = FieldElement::one();
+        let then_branch = self.inline_branch(block, then_block, old_condition, then_condition, one);
+
+        let else_condition =
+            self.insert_instruction(Instruction::Not(then_condition), CallStack::new());
+        let zero = FieldElement::zero();
+
+        // Make sure the else branch sees the previous values of each store
+        // rather than any values created in the 'then' branch.
+        self.undo_stores_in_then_branch(&then_branch);
+
+        let else_branch =
+            self.inline_branch(block, else_block, old_condition, else_condition, zero);
+
+        // We must remember to reset whether side effects are enabled when both branches
+        // end, in addition to resetting the value of old_condition since it is set to
+        // known to be true/false within the then/else branch respectively.
+        self.insert_current_side_effects_enabled();
+
+        // We must map back to `then_condition` here. Mapping `old_condition` to itself would
+        // lose any previous mappings.
+        self.inserter.map_value(old_condition, then_condition);
+
+        // While there is a condition on the stack we don't compile outside the condition
+        // until it is popped. This ensures we inline the full then and else branches
+        // before continuing from the end of the conditional here where they can be merged properly.
+        let end = self.branch_ends[&block];
+        self.inline_branch_end(end, then_branch, else_branch)
     }
 
     /// Push a condition to the stack of conditions.


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2787

## Summary\*

The error message in the issue is outdated and already fixed, but attempting to run it still results in a panic with "attempting to subtract with overflow."

~~This PR adds a check in the flattening pass that resembles a check done in the simplify cfg pass. If a jmpif condition is constant, inline the block it jumps to and discard the other, unreachable block(s). Adding this check in the flattening pass makes the pass slightly larger bug means there is no need to always have the simplify cfg pass directly before flattening.~~

~~Note that this avoids the "attempting to subtract with overflow" issue rather than fixing the underlying cause. I'm still investigating this and will make a separate PR.~~

All of the above is invalid, I've added a commit to reverse the previous changes as I've fixed the underlying subtract with underflow instead.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
