### PR TITLE
chore: force compilation if debug flags are set

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -300,10 +300,14 @@ pub fn compile_no_check(
 ) -> Result<CompiledProgram, FileDiagnostic> {
     let program = monomorphize(main_function, &context.def_interner);
 
-    let hash = fxhash::hash64(&program);
-    if let Some(cached_program) = cached_program {
-        if hash == cached_program.hash {
-            return Ok(cached_program);
+    // If user has specified that they want to see intermediate steps printed then we should
+    // force compilation even if the program hasn't changed.
+    if !(options.print_acir || options.show_brillig || options.show_ssa) {
+        let hash = fxhash::hash64(&program);
+        if let Some(cached_program) = cached_program {
+            if hash == cached_program.hash {
+                return Ok(cached_program);
+            }
         }
     }
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -300,10 +300,11 @@ pub fn compile_no_check(
 ) -> Result<CompiledProgram, FileDiagnostic> {
     let program = monomorphize(main_function, &context.def_interner);
 
+    let hash = fxhash::hash64(&program);
+
     // If user has specified that they want to see intermediate steps printed then we should
     // force compilation even if the program hasn't changed.
     if !(options.print_acir || options.show_brillig || options.show_ssa) {
-        let hash = fxhash::hash64(&program);
         if let Some(cached_program) = cached_program {
             if hash == cached_program.hash {
                 return Ok(cached_program);


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR skips the program caching logic if the user has specified that they want to see brillig, SSA or ACIR printed to the console.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
