### PR TITLE
fix: Fix panic in some cases when calling a private function

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -252,6 +252,7 @@ impl<'a> ModCollector<'a> {
                             let method_name = name.0.contents.clone();
                             let func_id = context.def_interner.push_empty_fn();
                             let modifiers = FunctionModifiers {
+                                name: name.0.contents.clone(),
                                 // trait functions are always public
                                 visibility: crate::Visibility::Public,
                                 attributes: Attributes::empty(),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Found while testing https://github.com/noir-lang/noir/issues/2658.

In short: we were using `interner.function_name` while reporting errors for private functions. Since a function's name requires the FuncMeta which is only filled out during name resolution itself, it may not be initialized at the time of reporting. This crate happened to be one case where it was not. To fix this, I've moved the function's name to the FunctionModifiers struct which is filled out before name resolution.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
