### PR TITLE
chore: remove dead code from SSA optimization passes

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -88,9 +88,6 @@ struct PerFunctionContext<'function> {
     /// block.
     blocks: HashMap<BasicBlockId, BasicBlockId>,
 
-    /// Maps InstructionIds from the function being inlined to the function being inlined into.
-    instructions: HashMap<InstructionId, InstructionId>,
-
     /// True if we're currently working on the entry point function.
     inlining_entry: bool,
 }
@@ -191,7 +188,6 @@ impl<'function> PerFunctionContext<'function> {
             context,
             source_function,
             blocks: HashMap::default(),
-            instructions: HashMap::default(),
             values: HashMap::default(),
             inlining_entry: false,
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -70,7 +70,6 @@ use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
         cfg::ControlFlowGraph,
-        dom::DominatorTree,
         function::Function,
         function_inserter::FunctionInserter,
         instruction::{Instruction, InstructionId, TerminatorInstruction},
@@ -100,7 +99,6 @@ impl Ssa {
 struct PerFunctionContext<'f> {
     cfg: ControlFlowGraph,
     post_order: PostOrder,
-    dom_tree: DominatorTree,
 
     blocks: BTreeMap<BasicBlockId, Block>,
 
@@ -117,12 +115,10 @@ impl<'f> PerFunctionContext<'f> {
     fn new(function: &'f mut Function) -> Self {
         let cfg = ControlFlowGraph::with_function(function);
         let post_order = PostOrder::with_function(function);
-        let dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
 
         PerFunctionContext {
             cfg,
             post_order,
-            dom_tree,
             inserter: FunctionInserter::new(function),
             blocks: BTreeMap::new(),
             instructions_to_remove: BTreeSet::new(),

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -75,7 +75,6 @@ struct Loops {
     yet_to_unroll: Vec<Loop>,
     modified_blocks: HashSet<BasicBlockId>,
     cfg: ControlFlowGraph,
-    dom_tree: DominatorTree,
 }
 
 /// Find a loop in the program by finding a node that dominates any predecessor node.
@@ -109,7 +108,6 @@ fn find_all_loops(function: &Function) -> Loops {
         yet_to_unroll: loops,
         modified_blocks: HashSet::new(),
         cfg,
-        dom_tree,
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently have all dead code lints disabled in `noirc_evaluator`, ideally we'd remove this in future but we'll have to deal with all these violations first.

This PR removes dead code from the SSA optimization passes.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
