### PR TITLE
fix!: Issue an error when a module is declared twice & fix module search path

### DIFF
--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -104,7 +104,7 @@ impl FileManager {
 
 /// Returns true if a module's child module's are expected to be in the same directory.
 /// Returns false if they are expected to be in a subdirectory matching the name of the module.
-fn should_check_siblings_for_module(module_path: &PathBuf, parent_path: &Path) -> bool {
+fn should_check_siblings_for_module(module_path: &Path, parent_path: &Path) -> bool {
     if let Some(filename) = module_path.file_name() {
         // This check also means a `main.nr` or `lib.nr` file outside of the crate root would
         // check its same directory for child modules instead of a subdirectory. Should we prohibit

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -231,12 +231,13 @@ mod tests {
 
         let dep_file_name = Path::new("foo.nr");
         create_dummy_file(&dir, dep_file_name);
-        fm.find_module(file_id, "foo").unwrap();
+        fm.find_module(file_id, "foo").unwrap_err();
     }
+
     #[test]
     fn path_resolve_file_module_other_ext() {
         let dir = tempdir().unwrap();
-        let file_name = Path::new("foo.noir");
+        let file_name = Path::new("foo.nr");
         create_dummy_file(&dir, file_name);
 
         let mut fm = FileManager::new(dir.path());
@@ -245,6 +246,7 @@ mod tests {
 
         assert!(fm.path(file_id).ends_with("foo"));
     }
+
     #[test]
     fn path_resolve_sub_module() {
         let dir = tempdir().unwrap();

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -78,6 +78,7 @@ impl FileManager {
         // Unwrap as we ensure that all file_id's map to a corresponding file in the file map
         self.file_map.get_file(file_id).unwrap()
     }
+
     pub fn path(&self, file_id: FileId) -> &Path {
         // Unwrap as we ensure that all file_ids are created by the file manager
         // So all file_ids will points to a corresponding path
@@ -85,23 +86,38 @@ impl FileManager {
     }
 
     pub fn find_module(&mut self, anchor: FileId, mod_name: &str) -> Result<FileId, String> {
-        let mut candidate_files = Vec::new();
-
         let anchor_path = self.path(anchor).to_path_buf();
         let anchor_dir = anchor_path.parent().unwrap();
 
-        // First we attempt to look at `base/anchor/mod_name.nr` (child of the anchor)
-        candidate_files.push(anchor_path.join(format!("{mod_name}.{FILE_EXTENSION}")));
-        // If not found, we attempt to look at `base/mod_name.nr` (sibling of the anchor)
-        candidate_files.push(anchor_dir.join(format!("{mod_name}.{FILE_EXTENSION}")));
+        // if `anchor` is a `main.nr`, `lib.nr`, `mod.nr` or `{modname}.nr`, we check siblings of
+        // the anchor at `base/mod_name.nr`.
+        let candidate = if should_check_siblings_for_module(&anchor_path, anchor_dir) {
+            anchor_dir.join(format!("{mod_name}.{FILE_EXTENSION}"))
+        } else {
+            // Otherwise, we check for children of the anchor at `base/anchor/mod_name.nr`
+            anchor_path.join(format!("{mod_name}.{FILE_EXTENSION}"))
+        };
 
-        for candidate in candidate_files.iter() {
-            if let Some(file_id) = self.add_file(candidate) {
-                return Ok(file_id);
-            }
-        }
+        self.add_file(&candidate).ok_or_else(|| candidate.as_os_str().to_string_lossy().to_string())
+    }
+}
 
-        Err(candidate_files.remove(0).as_os_str().to_str().unwrap().to_owned())
+/// Returns true if a module's child module's are expected to be in the same directory.
+/// Returns false if they are expected to be in a subdirectory matching the name of the module.
+fn should_check_siblings_for_module(module_path: &PathBuf, parent_path: &Path) -> bool {
+    if let Some(filename) = module_path.file_name() {
+        // This check also means a `main.nr` or `lib.nr` file outside of the crate root would
+        // check its same directory for child modules instead of a subdirectory. Should we prohibit
+        // `main.nr` and `lib.nr` files outside of the crate root?
+        filename == "main"
+            || filename == "lib"
+            || filename == "mod"
+            || Some(filename) == parent_path.file_name()
+    } else {
+        // If there's no filename, we arbitrarily return true.
+        // Alternatively, we could panic, but this is left to a different step where we
+        // ideally have some source location to issue an error.
+        true
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -541,12 +541,12 @@ impl<'a> ModCollector<'a> {
 
         if let Some(old_location) = context.visited_files.get(&child_file_id) {
             let message = format!("Module '{mod_name}' is already part of the crate");
-            let secondary = format!("");
+            let secondary = String::new();
             let error = CustomDiagnostic::simple_error(message, secondary, location.span);
             errors.push(error.in_file(location.file));
 
             let message = format!("Note: {mod_name} was originally declared here");
-            let secondary = format!("");
+            let secondary = String::new();
             let error = CustomDiagnostic::simple_error(message, secondary, old_location.span);
             errors.push(error.in_file(old_location.file));
             return;

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -24,7 +24,7 @@ pub enum DefCollectorErrorKind {
     #[error("duplicate {typ} found in namespace")]
     Duplicate { typ: DuplicateType, first_def: Ident, second_def: Ident },
     #[error("unresolved import")]
-    UnresolvedModuleDecl { mod_name: Ident },
+    UnresolvedModuleDecl { mod_name: Ident, expected_path: String },
     #[error("path resolution error")]
     PathResolutionError(PathResolutionError),
     #[error("Non-struct type used in impl")]
@@ -76,7 +76,7 @@ impl From<DefCollectorErrorKind> for Diagnostic {
         match error {
             DefCollectorErrorKind::Duplicate { typ, first_def, second_def } => {
                 let primary_message = format!(
-                    "duplicate definitions of {} with name {} found",
+                    "Duplicate definitions of {} with name {} found",
                     &typ, &first_def.0.contents
                 );
                 {
@@ -84,19 +84,19 @@ impl From<DefCollectorErrorKind> for Diagnostic {
                     let second_span = second_def.0.span();
                     let mut diag = Diagnostic::simple_error(
                         primary_message,
-                        format!("first {} found here", &typ),
+                        format!("First {} found here", &typ),
                         first_span,
                     );
-                    diag.add_secondary(format!("second {} found here", &typ), second_span);
+                    diag.add_secondary(format!("Second {} found here", &typ), second_span);
                     diag
                 }
             }
-            DefCollectorErrorKind::UnresolvedModuleDecl { mod_name } => {
+            DefCollectorErrorKind::UnresolvedModuleDecl { mod_name, expected_path } => {
                 let span = mod_name.0.span();
                 let mod_name = &mod_name.0.contents;
 
                 Diagnostic::simple_error(
-                    format!("could not resolve module `{mod_name}` "),
+                    format!("No module `{mod_name}` at path `{expected_path}`"),
                     String::new(),
                     span,
                 )

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -9,6 +9,7 @@ use crate::hir_def::function::FuncMeta;
 use crate::node_interner::{FuncId, NodeInterner, StructId};
 use def_map::{Contract, CrateDefMap};
 use fm::FileManager;
+use noirc_errors::Location;
 use std::collections::BTreeMap;
 
 use self::def_map::TestFunction;
@@ -21,6 +22,10 @@ pub struct Context {
     pub crate_graph: CrateGraph,
     pub(crate) def_maps: BTreeMap<CrateId, CrateDefMap>,
     pub file_manager: FileManager,
+
+    /// A map of each file that already has been visited from a prior `mod foo;` declaration.
+    /// This is used to issue an error if a second `mod foo;` is declared to the same file.
+    pub visited_files: BTreeMap<fm::FileId, Location>,
 
     /// Maps a given (contract) module id to the next available storage slot
     /// for that contract.
@@ -41,6 +46,7 @@ impl Context {
         Context {
             def_interner: NodeInterner::default(),
             def_maps: BTreeMap::new(),
+            visited_files: BTreeMap::new(),
             crate_graph,
             file_manager,
             storage_slots: BTreeMap::new(),

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -844,8 +844,8 @@ impl Type {
             // No recursive try_unify call for struct fields. Don't want
             // to mutate shared type variables within struct definitions.
             // This isn't possible currently but will be once noir gets generic types
-            (Struct(fields_a, args_a), Struct(fields_b, args_b)) => {
-                if fields_a == fields_b {
+            (Struct(id_a, args_a), Struct(id_b, args_b)) => {
+                if id_a == id_b && args_a.len() == args_b.len() {
                     for (a, b) in args_a.iter().zip(args_b) {
                         a.try_unify(b)?;
                     }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/2658

## Summary\*

This is a rather comprehensive fix for the issue where a module can be declared twice. It is comprehensive because it includes two fixes (and some error message improvements), either individually would fix the issue but I've included all for completeness.

1. Keep track of which files were already used as modules and report an error if one is ever used twice. Although this error is more difficult (but still possible) to trigger now after the next change.
2. Change the path a `mod foo;` statement looks at to import `foo`. Previously we checked both `./foo.nr` and `./current_mod_name/foo.nr`. Now we only check the first if the current module is named `main.nr`, `lib.nr`, `mod.nr`, or `{foo}/{foo}.nr` where `foo` can be anything as long as it matches the name of its parent directory. This behavior matches rust's.
3. The error message we issue when a module's file is not found was improved from:

```
error: could not resolve module 'foo'
3| mod foo;
       ^^^
```
to
```
error: No module 'foo' at path '/a/b/c/foo.nr'
3| mod foo;
       ^^^
```

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

This is technically a breaking change as users will no longer be able to declare modules in the same directory as child modules of another in the same directory if the module is not `main.nr`, `lib.nr`, etc. This behavior wasn't intended previously but prohibiting it is still breaking any code that relied on it.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
