### PR TITLE
feat: Implement string escape sequences

### DIFF
--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -21,6 +21,12 @@ pub enum LexerErrorKind {
     LogicalAnd { span: Span },
     #[error("Unterminated block comment")]
     UnterminatedBlockComment { span: Span },
+    #[error("Unterminated string literal")]
+    UnterminatedStringLiteral { span: Span },
+    #[error(
+        "'\\{escaped}' is not a valid escape sequence. Use '\\' for a literal backslash character."
+    )]
+    InvalidEscape { escaped: char, span: Span },
 }
 
 impl LexerErrorKind {
@@ -33,6 +39,8 @@ impl LexerErrorKind {
             LexerErrorKind::TooManyBits { span, .. } => *span,
             LexerErrorKind::LogicalAnd { span } => *span,
             LexerErrorKind::UnterminatedBlockComment { span } => *span,
+            LexerErrorKind::UnterminatedStringLiteral { span } => *span,
+            LexerErrorKind::InvalidEscape { span, .. } => *span,
         }
     }
 
@@ -46,30 +54,30 @@ impl LexerErrorKind {
                 let found: String = found.map(Into::into).unwrap_or_else(|| "<eof>".into());
 
                 (
-                    "an unexpected character was found".to_string(),
-                    format!(" expected {expected} , but got {found}"),
+                    "An unexpected character was found".to_string(),
+                    format!("Expected {expected}, but found {found}"),
                     *span,
                 )
             },
             LexerErrorKind::NotADoubleChar { span, found } => (
-                format!("tried to parse {found} as double char"),
+                format!("Tried to parse {found} as double char"),
                 format!(
                     " {found:?} is not a double char, this is an internal error"
                 ),
                 *span,
             ),
             LexerErrorKind::InvalidIntegerLiteral { span, found } => (
-                "invalid integer literal".to_string(),
+                "Invalid integer literal".to_string(),
                 format!(" {found} is not an integer"),
                 *span,
             ),
             LexerErrorKind::MalformedFuncAttribute { span, found } => (
-                "malformed function attribute".to_string(),
+                "Malformed function attribute".to_string(),
                 format!(" {found} is not a valid attribute"),
                 *span,
             ),
             LexerErrorKind::TooManyBits { span, max, got } => (
-                "integer literal too large".to_string(),
+                "Integer literal too large".to_string(),
                 format!(
                     "The maximum number of bits needed to represent a field is {max}, This integer type needs {got} bits"
                 ),
@@ -80,7 +88,11 @@ impl LexerErrorKind {
                 "Try `&` instead, or use `if` only if you require short-circuiting".to_string(),
                 *span,
             ),
-            LexerErrorKind::UnterminatedBlockComment { span } => ("unterminated block comment".to_string(), "Unterminated block comment".to_string(), *span),
+            LexerErrorKind::UnterminatedBlockComment { span } => ("Unterminated block comment".to_string(), "Unterminated block comment".to_string(), *span),
+            LexerErrorKind::UnterminatedStringLiteral { span } =>
+                ("Unterminated string literal".to_string(), "Unterminated string literal".to_string(), *span),
+            LexerErrorKind::InvalidEscape { escaped, span } =>
+                (format!("'\\{escaped}' is not a valid escape sequence. Use '\\' for a literal backslash character."), "Invalid escape sequence".to_string(), *span),
         }
     }
 }

--- a/tooling/nargo_cli/tests/execution_success/strings/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/strings/src/main.nr
@@ -19,7 +19,7 @@ fn main(message : pub str<11>, y : Field, hex_as_string : str<4>, hex_as_field :
     assert(y == 5); // Change to y != 5 to see how the later print statements are not called
     std::println(array);
 
-    bad_message = "helld world";
+    bad_message = "hell\0\"world";
     std::println(bad_message);
     assert(message != bad_message);
 


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/issues/2657

## Summary\*

Implements escape sequences for string literals

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [x] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [x] I will request for and support Dev Rel's help in documenting this PR.
    - String literals can now use "\t" to insert a tab character, "\n" for a newline, "\r" for a carriage return, "\0" for a null character, "\"" for a quote, and "\\" to insert a backslash. As an example, the string `"Hi\tHello\"There"` will be printed out as `Hi	Hello"There`

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
