### PR TITLE
chore: remove unnecessary `AcirValue`s

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -299,13 +299,12 @@ impl AcirContext {
 
         // Compute the inverse with brillig code
         let inverse_code = brillig_directive::directive_invert();
-        let field_type = AcirType::NumericType(NumericType::NativeField);
 
         let results = self.brillig(
             predicate,
             inverse_code,
-            vec![AcirValue::Var(var, field_type.clone())],
-            vec![field_type],
+            vec![AcirValue::Var(var, AcirType::field())],
+            vec![AcirType::field()],
         )?;
         let inverted_var = Self::expect_one_var(results);
 
@@ -1007,17 +1006,10 @@ impl AcirContext {
             AcirValue::DynamicArray(AcirDynamicArray { block_id, len }) => {
                 for i in 0..len {
                     // We generate witnesses corresponding to the array values
-                    let index = AcirValue::Var(
-                        self.add_constant(FieldElement::from(i as u128)),
-                        AcirType::NumericType(NumericType::NativeField),
-                    );
-                    let index_var = index.into_var()?;
+                    let index_var = self.add_constant(FieldElement::from(i as u128));
 
                     let value_read_var = self.read_from_memory(block_id, &index_var)?;
-                    let value_read = AcirValue::Var(
-                        value_read_var,
-                        AcirType::NumericType(NumericType::NativeField),
-                    );
+                    let value_read = AcirValue::Var(value_read_var, AcirType::field());
 
                     self.brillig_array_input(var_expressions, value_read)?;
                 }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -400,11 +400,8 @@ impl Context {
 
                 let mut read_dynamic_array_index =
                     |block_id: BlockId, array_index: usize| -> Result<AcirVar, InternalError> {
-                        let index = AcirValue::Var(
-                            self.acir_context.add_constant(FieldElement::from(array_index as u128)),
-                            AcirType::NumericType(NumericType::NativeField),
-                        );
-                        let index_var = index.into_var()?;
+                        let index_var =
+                            self.acir_context.add_constant(FieldElement::from(array_index as u128));
 
                         self.acir_context.read_from_memory(block_id, &index_var)
                     };
@@ -896,16 +893,10 @@ impl Context {
             // Initialize the new array with the values from the old array
             result_block_id = self.block_id(result_id);
             let init_values = try_vecmap(0..array_len, |i| {
-                let index = AcirValue::Var(
-                    self.acir_context.add_constant(FieldElement::from(i as u128)),
-                    AcirType::NumericType(NumericType::NativeField),
-                );
-                let var = index.into_var()?;
-                let read = self.acir_context.read_from_memory(block_id, &var)?;
-                Ok::<AcirValue, RuntimeError>(AcirValue::Var(
-                    read,
-                    AcirType::NumericType(NumericType::NativeField),
-                ))
+                let index_var = self.acir_context.add_constant(FieldElement::from(i as u128));
+
+                let read = self.acir_context.read_from_memory(block_id, &index_var)?;
+                Ok::<AcirValue, RuntimeError>(AcirValue::Var(read, AcirType::field()))
             })?;
             self.initialize_array(
                 result_block_id,
@@ -1609,18 +1600,11 @@ impl Context {
             AcirValue::DynamicArray(AcirDynamicArray { block_id, len }) => {
                 for i in 0..len {
                     // We generate witnesses corresponding to the array values
-                    let index = AcirValue::Var(
-                        self.acir_context.add_constant(FieldElement::from(i as u128)),
-                        AcirType::NumericType(NumericType::NativeField),
-                    );
+                    let index_var = self.acir_context.add_constant(FieldElement::from(i as u128));
 
-                    let index_var = index.into_var()?;
                     let value_read_var =
                         self.acir_context.read_from_memory(block_id, &index_var)?;
-                    let value_read = AcirValue::Var(
-                        value_read_var,
-                        AcirType::NumericType(NumericType::NativeField),
-                    );
+                    let value_read = AcirValue::Var(value_read_var, AcirType::field());
 
                     old_slice.push_back(value_read);
                 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR uses `AcirType::field()` to reduce some verbosity and removes some unnecessary `AcirValues` which just get unwrapped again immediately.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
