### PR TITLE
chore(ci): ensure that the artifact rebuilding PR will run CI

### DIFF
--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Set up Git user (Github Action)
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name kevaundray
+          git config --local user.email kevtheappdev@gmail.com
 
       - name: Run rebuild script
         working-directory: tooling/nargo_cli/tests
@@ -74,7 +74,7 @@ jobs:
       - name: Create or Update PR
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NOIR_REPO_TOKEN }}
           commit-message: "chore: update acir artifacts"
           title: "chore: Update ACIR artifacts"
           body: "Automatic PR to update acir artifacts"


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Currently the PR to automatically update the build artifacts is being committed by the `github-actions` bot but this [doesn't allow for workflows to run on the created PR](https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092). A workaround for this is for us to make the PR as @kevaundray which will then run CI as usual.

The alternative for this is that we have to always close and reopen the PR before CI will run.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
