### PR TITLE
feat: documentation comments parsing

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -450,7 +450,6 @@ impl<'a> Lexer<'a> {
         }
 
         let end = start + (doc_comment.len() as u32);
-        dbg!(&doc_comment);
 
         if depth == 0 {
             Ok(SpannedToken::new(

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -19,6 +19,7 @@ pub enum Token {
     Keyword(Keyword),
     IntType(IntType),
     Attribute(Attribute),
+    DocComment(DocComments),
     /// <
     Less,
     /// <=
@@ -150,6 +151,7 @@ impl fmt::Display for Token {
             Token::Keyword(k) => write!(f, "{k}"),
             Token::Attribute(ref a) => write!(f, "{a}"),
             Token::IntType(ref i) => write!(f, "{i}"),
+            Token::DocComment(ref d) => write!(f, "{d}"),
             Token::Less => write!(f, "<"),
             Token::LessEqual => write!(f, "<="),
             Token::Greater => write!(f, ">"),
@@ -756,5 +758,20 @@ impl<'a> From<Tokens> for chumsky::Stream<'a, Token, Span, TokenMapIter> {
 
         let iter = tokens.0.into_iter().map(get_span as fn(_) -> _);
         chumsky::Stream::from_iter(end_of_input, iter)
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
+pub enum DocComments {
+    Single(String),
+    Block(String),
+}
+
+impl fmt::Display for DocComments {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DocComments::Single(comment) => write!(f, "{}", comment),
+            DocComments::Block(comment) => write!(f, "{}", comment),
+        }
     }
 }


### PR DESCRIPTION
# Description

Added doc comment token and functions for parsing it. 

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves the problem of supporting documentation comments is Noir.

## Summary\*

Now documentation comments are parsed by the lexer and not ignored. With this change it will be possible to create a tool for generating documentation.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
