### PR TITLE
fix: Conditionally run the "Create or Update PR" step in acir artifacts rebuild workflow

### DIFF
--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -75,8 +75,6 @@ jobs:
         id: check_changes
         run: |
           git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
-        outputs:
-          changes: ${{ steps.check_changes.outputs.changes }}
           
       - name: Create or Update PR
         if: steps.check_changes.outputs.changes == 'true'

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -70,11 +70,16 @@ jobs:
         run: |
           chmod +x ./rebuild.sh
           ./rebuild.sh
-      
-      - name: Discard changes in nargo directory
-        run: git restore --source=HEAD --staged --worktree -- nargo/
-    
+
+      - name: Check for changes in acir_artifacts directory
+        id: check_changes
+        run: |
+          git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
+        outputs:
+          changes: ${{ steps.check_changes.outputs.changes }}
+          
       - name: Create or Update PR
+        if: steps.check_changes.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.NOIR_REPO_TOKEN }}


### PR DESCRIPTION
# Description

The last github action was failing when there was nothing to commit, so we conditionally run this step if there is something to commit

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
