### PR TITLE
chore: add initial version of `Backend` interface for `noir_js`

### DIFF
--- a/tooling/noir_js/test/backend/backend_interface.ts
+++ b/tooling/noir_js/test/backend/backend_interface.ts
@@ -1,0 +1,13 @@
+export interface Backend {
+  // Generate an outer proof. This is the proof for the circuit which will verify
+  // inner proofs and or can be seen as the proof created for regular circuits.
+  generateOuterProof(decompressedWitness: Uint8Array): Promise<Uint8Array>;
+
+  // Generates an inner proof. This is the proof that will be verified
+  // in another circuit.
+  generateInnerProof(decompressedWitness: Uint8Array): Promise<Uint8Array>;
+
+  verifyOuterProof(proof: Uint8Array): Promise<boolean>;
+
+  verifyInnerProof(proof: Uint8Array): Promise<boolean>;
+}

--- a/tooling/noir_js/test/backend/barretenberg.ts
+++ b/tooling/noir_js/test/backend/barretenberg.ts
@@ -3,8 +3,9 @@ import { Barretenberg, Crs, RawBuffer } from '@aztec/bb.js';
 // TODO: This should be re-exported from @aztec/bb-js
 import { Ptr } from '@aztec/bb.js/dest/browser/types';
 import { acirToUint8Array } from '../../src/index.js';
+import { Backend } from './backend_interface.js';
 
-export class Backend {
+export class BarretenbergBackend implements Backend {
   // These type assertions are used so that we don't
   // have to initialize `api` and `acirComposer` in the constructor.
   // These are initialized asynchronously in the `init` function,
@@ -16,7 +17,8 @@ export class Backend {
   constructor(acirBytecodeBase64: string) {
     this.acirUncompressedBytecode = acirToUint8Array(acirBytecodeBase64);
   }
-  async init() {
+
+  async init(): Promise<void> {
     const numThreads = 4;
 
     const { api, composer } = await this.initBarretenberg(numThreads, this.acirUncompressedBytecode);
@@ -25,7 +27,7 @@ export class Backend {
     this.acirComposer = composer;
   }
 
-  async initBarretenberg(numThreads: number, acirUncompressedBytecode: Uint8Array) {
+  private async initBarretenberg(numThreads: number, acirUncompressedBytecode: Uint8Array) {
     const api = await Barretenberg.new(numThreads);
 
     const [_exact, _total, subgroupSize] = await api.acirGetCircuitSizes(acirUncompressedBytecode);
@@ -42,7 +44,7 @@ export class Backend {
   //
   // The settings for this proof are the same as the settings for a "normal" proof
   // ie one that is not in the recursive setting.
-  async generateOuterProof(decompressedWitness: Uint8Array) {
+  async generateOuterProof(decompressedWitness: Uint8Array): Promise<Uint8Array> {
     const makeEasyToVerifyInCircuit = false;
     return this.generateProof(decompressedWitness, makeEasyToVerifyInCircuit);
   }
@@ -58,12 +60,12 @@ export class Backend {
   // We set `makeEasyToVerifyInCircuit` to true, which will tell the backend to
   // generate the proof using components that will make the proof
   // easier to verify in a circuit.
-  async generateInnerProof(witness: Uint8Array) {
+  async generateInnerProof(witness: Uint8Array): Promise<Uint8Array> {
     const makeEasyToVerifyInCircuit = true;
     return this.generateProof(witness, makeEasyToVerifyInCircuit);
   }
 
-  async generateProof(decompressedWitness: Uint8Array, makeEasyToVerifyInCircuit: boolean) {
+  async generateProof(decompressedWitness: Uint8Array, makeEasyToVerifyInCircuit: boolean): Promise<Uint8Array> {
     const proof = await this.api.acirCreateProof(
       this.acirComposer,
       this.acirUncompressedBytecode,
@@ -83,7 +85,14 @@ export class Backend {
   // method.
   //
   // The number of public inputs denotes how many public inputs are in the inner proof.
-  async generateInnerProofArtifacts(proof: Uint8Array, numOfPublicInputs = 0) {
+  async generateInnerProofArtifacts(
+    proof: Uint8Array,
+    numOfPublicInputs = 0,
+  ): Promise<{
+    proofAsFields: string[];
+    vkAsFields: string[];
+    vkHash: string;
+  }> {
     const proofAsFields = await this.api.acirSerializeProofIntoFields(this.acirComposer, proof, numOfPublicInputs);
 
     // TODO: perhaps we should put this in the init function. Need to benchmark
@@ -100,23 +109,23 @@ export class Backend {
     };
   }
 
-  async verifyOuterProof(proof: Uint8Array) {
+  async verifyOuterProof(proof: Uint8Array): Promise<boolean> {
     const makeEasyToVerifyInCircuit = false;
     const verified = await this.verifyProof(proof, makeEasyToVerifyInCircuit);
     return verified;
   }
 
-  async verifyInnerProof(proof: Uint8Array) {
+  async verifyInnerProof(proof: Uint8Array): Promise<boolean> {
     const makeEasyToVerifyInCircuit = true;
     return this.verifyProof(proof, makeEasyToVerifyInCircuit);
   }
 
-  async verifyProof(proof: Uint8Array, makeEasyToVerifyInCircuit: boolean) {
+  async verifyProof(proof: Uint8Array, makeEasyToVerifyInCircuit: boolean): Promise<boolean> {
     await this.api.acirInitVerificationKey(this.acirComposer);
     return await this.api.acirVerifyProof(this.acirComposer, proof, makeEasyToVerifyInCircuit);
   }
 
-  async destroy() {
+  async destroy(): Promise<void> {
     await this.api.destroy();
   }
 }

--- a/tooling/noir_js/test/node/e2e.test.ts
+++ b/tooling/noir_js/test/node/e2e.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import assert_lt_json from '../noir_compiled_examples/assert_lt/target/assert_lt.json' assert { type: 'json' };
 import { generateWitness } from '../../src/index.js';
-import { Backend } from '../backend/barretenberg.js';
+import { BarretenbergBackend as Backend } from '../backend/barretenberg.js';
 
 it('end-to-end proof creation and verification (outer)', async () => {
   // Noir.Js part


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR defined a `Backend` interface which defines how a JS backend will expose proving and verifying. This can be refined later.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
