### PR TITLE
chore: remove `toml2json` dependency

### DIFF
--- a/.github/workflows/publish-noir-js.yml
+++ b/.github/workflows/publish-noir-js.yml
@@ -23,11 +23,6 @@ jobs:
           source $HOME/.cargo/env
           cargo install -f wasm-bindgen-cli --version 0.2.86
 
-      - name: Install toml2json
-        run: |
-          source $HOME/.cargo/env
-          cargo install toml2json
-
       - name: Install wasm-opt
         run: |
           npm i wasm-opt -g

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -202,11 +202,6 @@ jobs:
         with:
           tool: wasm-bindgen-cli@0.2.86
 
-      - name: Install toml2json
-        uses: taiki-e/install-action@v2
-        with:
-          tool: toml2json@1.3.1
-
       - name: Install wasm-opt
         run: |
           npm i wasm-opt -g

--- a/.github/workflows/test-noir-js.yml
+++ b/.github/workflows/test-noir-js.yml
@@ -38,11 +38,6 @@ jobs:
         with:
           tool: wasm-bindgen-cli@0.2.86
 
-      - name: Install toml2json
-        uses: taiki-e/install-action@v2
-        with:
-          tool: toml2json@1.3.1
-
       - name: Install wasm-opt
         run: |
           npm i wasm-opt -g

--- a/acvm-repo/acvm_js/build.sh
+++ b/acvm-repo/acvm_js/build.sh
@@ -22,14 +22,13 @@ function run_or_fail {
   fi
 }
 
-require_command toml2json
 require_command jq
 require_command cargo
 require_command wasm-bindgen
 check_installed wasm-opt
 
 self_path=$(dirname "$(readlink -f "$0")")
-export pname=$(toml2json < $self_path/Cargo.toml | jq -r .package.name)
+export pname=$(cargo read-manifest | jq -r '.name')
 export CARGO_TARGET_DIR=$self_path/target
 
 rm -rf $self_path/outputs >/dev/null 2>&1

--- a/compiler/wasm/build.sh
+++ b/compiler/wasm/build.sh
@@ -22,14 +22,13 @@ function run_or_fail {
   fi
 }
 
-require_command toml2json
 require_command jq
 require_command cargo
 require_command wasm-bindgen
 check_installed wasm-opt
 
 self_path=$(dirname "$(readlink -f "$0")")
-export pname=$(toml2json < $self_path/Cargo.toml | jq -r .package.name)
+export pname=$(cargo read-manifest | jq -r '.name')
 export CARGO_TARGET_DIR=$self_path/target
 
 rm -rf $self_path/outputs >/dev/null 2>&1

--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,6 @@
           rustToolchain
           wasm-bindgen-cli
           binaryen
-          toml2json
         ];
 
         buildInputs = [ ] ++ extraBuildInputs;

--- a/tooling/noirc_abi_wasm/build.sh
+++ b/tooling/noirc_abi_wasm/build.sh
@@ -22,14 +22,13 @@ function run_or_fail {
   fi
 }
 
-require_command toml2json
 require_command jq
 require_command cargo
 require_command wasm-bindgen
 check_installed wasm-opt
 
 self_path=$(dirname "$(readlink -f "$0")")
-export pname=$(toml2json < $self_path/Cargo.toml | jq -r .package.name)
+export pname=$(cargo read-manifest | jq -r '.name')
 export CARGO_TARGET_DIR=$self_path/target
 
 rm -rf $self_path/outputs >/dev/null 2>&1


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently using `toml2json` only to extract the package name from `Cargo.toml` however we spend 3+ minutes in CI building this dependency.

This PR replaces usage of `toml2json` with `cargo read-manifest`

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
