### PR TITLE
chore: build yarn packages in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "release-tests"
     ],
     "scripts": {
-        "build": "yarn workspaces foreach run build",
+        "build": "yarn workspaces foreach --parallel --topological-dev --verbose run build",
         "test": "yarn workspaces foreach run test",
         "test:integration": "yarn workspace integration-tests test",
         "clean:workspaces": "yarn workspaces foreach run clean",


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Currently running `yarn build` from the monorepo root just attempts to build the yarn workspaces in an order which doesn't take into account the workspace dependencies. This results in `@noir-lang/noir_js` failing to compile as it's looking for `@noir-lang/noirc_abi` despite it not being built yet.

This PR adds the `--topological-dev` flag to the build command so that we don't try to build a workspace package until all of its workspace dependencies have been built.

I've thrown in the `--parallel` (shaves about a minute off from the build time) and `--verbose` (prints the package name at the beginning of each line in the console output which makes it much easier to see what's going on in my experience.)

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
