### PR TITLE
fix: remove duplication of code to load stdlib files

### DIFF
--- a/compiler/fm/src/file_reader.rs
+++ b/compiler/fm/src/file_reader.rs
@@ -21,6 +21,28 @@ pub(super) fn is_stdlib_asset(path: &Path) -> bool {
     path.starts_with("std/")
 }
 
+fn get_stdlib_asset(path: &Path) -> std::io::Result<String> {
+    if !is_stdlib_asset(path) {
+        return Err(Error::new(ErrorKind::InvalidInput, "requested a non-stdlib asset"));
+    }
+
+    match StdLibAssets::get(path.to_str().unwrap()) {
+        Some(std_lib_asset) => {
+            Ok(std::str::from_utf8(std_lib_asset.data.as_ref()).unwrap().to_string())
+        }
+
+        None => Err(Error::new(ErrorKind::NotFound, "invalid stdlib path")),
+    }
+}
+
+pub(crate) fn read_file_to_string(path_to_file: &Path) -> std::io::Result<String> {
+    if is_stdlib_asset(path_to_file) {
+        get_stdlib_asset(path_to_file)
+    } else {
+        get_non_stdlib_asset(path_to_file)
+    }
+}
+
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))] {
         use wasm_bindgen::{prelude::*, JsValue};
@@ -33,42 +55,16 @@ cfg_if::cfg_if! {
 
         }
 
-        pub(crate) fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
-            let path_str = path_to_file.to_str().unwrap();
-            match StdLibAssets::get(path_str) {
-
-                Some(std_lib_asset) => {
-                    Ok(std::str::from_utf8(std_lib_asset.data.as_ref()).unwrap().to_string())
-                },
-
-                None if is_stdlib_asset(path_to_file) => {
-                    Err(Error::new(ErrorKind::NotFound, "invalid stdlib path"))
-                }
-
-                None => match read_file(path_str) {
-                    Ok(buffer) => Ok(buffer),
-                    Err(_) => Err(Error::new(ErrorKind::Other, "could not read file using wasm")),
-                }
-
+        fn get_non_stdlib_asset(path_to_file: &Path) -> std::io::Result<String> {
+            match read_file(path_str) {
+                Ok(buffer) => Ok(buffer),
+                Err(_) => Err(Error::new(ErrorKind::Other, "could not read file using wasm")),
             }
         }
     } else {
 
-        pub(crate) fn read_file_to_string(path_to_file: &Path) -> Result<String, Error> {
-
-            match StdLibAssets::get(path_to_file.to_str().unwrap()) {
-
-                Some(std_lib_asset) => {
-                    Ok(std::str::from_utf8(std_lib_asset.data.as_ref()).unwrap().to_string())
-                },
-
-                None if is_stdlib_asset(path_to_file) => {
-                    Err(Error::new(ErrorKind::NotFound, "invalid stdlib path"))
-                }
-
-                None => std::fs::read_to_string(path_to_file)
-
-            }
+        fn get_non_stdlib_asset(path_to_file: &Path) -> std::io::Result<String> {
+            std::fs::read_to_string(path_to_file)
         }
     }
 }

--- a/compiler/fm/src/file_reader.rs
+++ b/compiler/fm/src/file_reader.rs
@@ -56,6 +56,7 @@ cfg_if::cfg_if! {
         }
 
         fn get_non_stdlib_asset(path_to_file: &Path) -> std::io::Result<String> {
+            let path_str = path_to_file.to_str().unwrap();
             match read_file(path_str) {
                 Ok(buffer) => Ok(buffer),
                 Err(_) => Err(Error::new(ErrorKind::Other, "could not read file using wasm")),


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Breaking out a necessary change from #2649 to keep PRs small.

This PR moves the code relevant to loading stdlib files out from the two architecture specific functions into a single entrypoint function.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
