### PR TITLE
feat: Contract events in artifacts

### DIFF
--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 use acvm::acir::circuit::Circuit;
 use fm::FileId;
-use noirc_abi::Abi;
+use noirc_abi::{Abi, ContractEvent};
 use noirc_errors::debug_info::DebugInfo;
 
 use super::debug::DebugFile;
@@ -33,6 +33,9 @@ pub struct CompiledContract {
     /// Each of the contract's functions are compiled into a separate `CompiledProgram`
     /// stored in this `Vector`.
     pub functions: Vec<ContractFunction>,
+
+    /// All the events defined inside the contract scope.
+    pub events: Vec<ContractEvent>,
 
     pub file_map: BTreeMap<FileId, DebugFile>,
 }

--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -35,6 +35,8 @@ pub struct CompiledContract {
     pub functions: Vec<ContractFunction>,
 
     /// All the events defined inside the contract scope.
+    /// An event is a struct value that can be emitted via oracles
+    /// by any contract function during execution.
     pub events: Vec<ContractEvent>,
 
     pub file_map: BTreeMap<FileId, DebugFile>,

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -6,7 +6,7 @@
 use clap::Args;
 use debug::filter_relevant_files;
 use fm::FileId;
-use noirc_abi::{AbiParameter, AbiType};
+use noirc_abi::{AbiParameter, AbiType, ContractEvent};
 use noirc_errors::{CustomDiagnostic, FileDiagnostic};
 use noirc_evaluator::{create_circuit, into_abi_params};
 use noirc_frontend::graph::{CrateId, CrateName};
@@ -285,7 +285,20 @@ fn compile_contract_inner(
         let debug_infos: Vec<_> = functions.iter().map(|function| function.debug.clone()).collect();
         let file_map = filter_relevant_files(&debug_infos, &context.file_manager);
 
-        Ok(CompiledContract { name: contract.name, functions, file_map })
+        Ok(CompiledContract {
+            name: contract.name,
+            events: contract
+                .events
+                .iter()
+                .map(|event_id| {
+                    let typ = context.def_interner.get_struct(*event_id);
+                    let typ = typ.borrow();
+                    ContractEvent::from_struct_type(context, &typ)
+                })
+                .collect(),
+            functions,
+            file_map,
+        })
     } else {
         Err(errors)
     }

--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -27,4 +27,5 @@ strum = "0.24"
 strum_macros = "0.24"
 
 [features]
+default=["aztec"]
 aztec = []

--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -27,5 +27,4 @@ strum = "0.24"
 strum_macros = "0.24"
 
 [features]
-default=["aztec"]
 aztec = []

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -248,7 +248,7 @@ pub struct ContractFunctionMeta {
     pub is_entry_point: bool,
 }
 
-/// A 'contract' in Noir source code with the given name and functions.
+/// A 'contract' in Noir source code with a given name, functions and events.
 /// This is not an AST node, it is just a convenient form to return for CrateDefMap::get_all_contracts.
 pub struct Contract {
     /// To keep `name` semi-unique, it is prefixed with the names of parent modules via CrateDefMap::get_module_path

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -97,6 +97,10 @@ impl ModuleData {
         self.scope.find_name(name)
     }
 
+    pub fn type_definitions(&self) -> impl Iterator<Item = ModuleDefId> + '_ {
+        self.definitions.types().values().map(|(id, _)| *id)
+    }
+
     /// Return an iterator over all definitions defined within this module,
     /// excluding any type definitions.
     pub fn value_definitions(&self) -> impl Iterator<Item = ModuleDefId> + '_ {

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -467,6 +467,7 @@ impl Attribute {
             ["contract_library_method"] => {
                 Attribute::Secondary(SecondaryAttribute::ContractLibraryMethod)
             }
+            ["event"] => Attribute::Secondary(SecondaryAttribute::Event),
             ["deprecated", name] => {
                 if !name.starts_with('"') && !name.ends_with('"') {
                     return Err(LexerErrorKind::MalformedFuncAttribute {
@@ -544,6 +545,7 @@ pub enum SecondaryAttribute {
     // is a helper method for a contract and should not be seen as
     // the entry point.
     ContractLibraryMethod,
+    Event,
     Custom(String),
 }
 
@@ -556,6 +558,7 @@ impl fmt::Display for SecondaryAttribute {
             }
             SecondaryAttribute::Custom(ref k) => write!(f, "#[{k}]"),
             SecondaryAttribute::ContractLibraryMethod => write!(f, "#[contract_library_method]"),
+            SecondaryAttribute::Event => write!(f, "#[event]"),
         }
     }
 }
@@ -578,6 +581,7 @@ impl AsRef<str> for SecondaryAttribute {
             SecondaryAttribute::Deprecated(None) => "",
             SecondaryAttribute::Custom(string) => string,
             SecondaryAttribute::ContractLibraryMethod => "",
+            SecondaryAttribute::Event => "",
         }
     }
 }

--- a/tooling/nargo/src/artifacts/contract.rs
+++ b/tooling/nargo/src/artifacts/contract.rs
@@ -1,5 +1,5 @@
 use acvm::acir::circuit::Circuit;
-use noirc_abi::Abi;
+use noirc_abi::{Abi, ContractEvent};
 use noirc_driver::ContractFunctionType;
 use serde::{Deserialize, Serialize};
 
@@ -16,6 +16,8 @@ pub struct PreprocessedContract {
     pub backend: String,
     /// Each of the contract's functions are compiled into a separate program stored in this `Vec`.
     pub functions: Vec<PreprocessedContractFunction>,
+    /// All the events defined inside the contract scope.
+    pub events: Vec<ContractEvent>,
 }
 
 /// Each function in the contract will be compiled as a separate noir program.

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -267,6 +267,7 @@ fn save_contract(
         name: contract.name,
         backend: String::from(BACKEND_IDENTIFIER),
         functions: preprocessed_functions,
+        events: contract.events,
     };
 
     save_contract_to_file(

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -502,7 +502,7 @@ impl ContractEvent {
         // For the ABI, we always want to resolve the struct paths from the root crate
         let path = context.fully_qualified_struct_path(context.root_crate_id(), struct_type.id);
 
-        Self { name: struct_type.name.0.contents.clone(), path: path, fields: fields }
+        Self { name: struct_type.name.0.contents.clone(), path, fields }
     }
 }
 


### PR DESCRIPTION
# Description
Exposes in the contract artifacts all events of a given contract. An event is identified by using the `event` attribute in a contract scope:
```
contract Example {

    #[event]
    struct MyEvent {
        a: Field,
    }
...
```
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Working towards https://github.com/AztecProtocol/aztec-packages/issues/2323

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
