### PR TITLE
fix: force recompilation when `output_debug` flag is set.

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -58,7 +58,7 @@ pub type CompilationResult<T> = Result<(T, Warnings), ErrorsAndWarnings>;
 // with the restricted version which only uses one file
 pub fn compile_file(context: &mut Context, root_file: &Path) -> CompilationResult<CompiledProgram> {
     let crate_id = prepare_crate(context, root_file);
-    compile_main(context, crate_id, &CompileOptions::default(), None)
+    compile_main(context, crate_id, &CompileOptions::default(), None, true)
 }
 
 /// Adds the file from the file system at `Path` to the crate graph as a root file
@@ -148,6 +148,7 @@ pub fn compile_main(
     crate_id: CrateId,
     options: &CompileOptions,
     cached_program: Option<CompiledProgram>,
+    force_compile: bool,
 ) -> CompilationResult<CompiledProgram> {
     let (_, warnings) = check_crate(context, crate_id, options.deny_warnings)?;
 
@@ -163,7 +164,7 @@ pub fn compile_main(
         }
     };
 
-    let compiled_program = compile_no_check(context, options, main, cached_program)?;
+    let compiled_program = compile_no_check(context, options, main, cached_program, force_compile)?;
 
     if options.print_acir {
         println!("Compiled ACIR for main (unoptimized):");
@@ -257,7 +258,7 @@ fn compile_contract_inner(
             continue;
         }
 
-        let function = match compile_no_check(context, options, function_id, None) {
+        let function = match compile_no_check(context, options, function_id, None, true) {
             Ok(function) => function,
             Err(new_error) => {
                 errors.push(new_error);
@@ -314,6 +315,7 @@ pub fn compile_no_check(
     options: &CompileOptions,
     main_function: FuncId,
     cached_program: Option<CompiledProgram>,
+    force_compile: bool,
 ) -> Result<CompiledProgram, FileDiagnostic> {
     let program = monomorphize(main_function, &context.def_interner);
 
@@ -321,7 +323,7 @@ pub fn compile_no_check(
 
     // If user has specified that they want to see intermediate steps printed then we should
     // force compilation even if the program hasn't changed.
-    if !(options.print_acir || options.show_brillig || options.show_ssa) {
+    if !(force_compile || options.print_acir || options.show_brillig || options.show_ssa) {
         if let Some(cached_program) = cached_program {
             if hash == cached_program.hash {
                 return Ok(cached_program);

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -125,9 +125,10 @@ pub fn compile(args: JsValue) -> JsValue {
 
         <JsValue as JsValueSerdeExt>::from_serde(&optimized_contract).unwrap()
     } else {
-        let compiled_program = compile_main(&mut context, crate_id, &options.compile_options, None)
-            .expect("Compilation failed")
-            .0;
+        let compiled_program =
+            compile_main(&mut context, crate_id, &options.compile_options, None, true)
+                .expect("Compilation failed")
+                .0;
 
         let optimized_program =
             nargo::ops::optimize_program(compiled_program, np_language, &is_opcode_supported)

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -20,7 +20,7 @@ pub fn run_test<B: BlackBoxFunctionSolver>(
     show_output: bool,
     config: &CompileOptions,
 ) -> TestStatus {
-    let program = compile_no_check(context, config, test_function.get_id(), None);
+    let program = compile_no_check(context, config, test_function.get_id(), None, false);
     match program {
         Ok(program) => {
             // Run the backend to ensure the PWG evaluates functions like std::hash::pedersen,

--- a/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -76,6 +76,7 @@ fn smart_contract_for_package(
         workspace,
         package,
         compile_options,
+        false,
         np_language,
         &is_opcode_supported,
     )?;

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -194,13 +194,21 @@ fn compile_program(
         None
     };
 
-    let (program, warnings) =
-        match noirc_driver::compile_main(&mut context, crate_id, compile_options, cached_program) {
-            Ok(program_and_warnings) => program_and_warnings,
-            Err(errors) => {
-                return (context.file_manager, Err(errors));
-            }
-        };
+    // If we want to output the debug information then we need to perform a full recompilation of the ACIR.
+    let force_recompile = output_debug;
+
+    let (program, warnings) = match noirc_driver::compile_main(
+        &mut context,
+        crate_id,
+        compile_options,
+        cached_program,
+        force_compile,
+    ) {
+        Ok(program_and_warnings) => program_and_warnings,
+        Err(errors) => {
+            return (context.file_manager, Err(errors));
+        }
+    };
 
     // Apply backend specific optimizations.
     let optimized_program =

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -202,7 +202,7 @@ fn compile_program(
         crate_id,
         compile_options,
         cached_program,
-        force_compile,
+        force_recompile,
     ) {
         Ok(program_and_warnings) => program_and_warnings,
         Err(errors) => {

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -82,6 +82,7 @@ pub(crate) fn run(
         np_language,
         &opcode_support,
         &args.compile_options,
+        args.output_debug,
     )?;
 
     // Save build artifacts to disk.
@@ -99,6 +100,7 @@ pub(super) fn compile_workspace(
     np_language: Language,
     opcode_support: &BackendOpcodeSupport,
     compile_options: &CompileOptions,
+    output_debug: bool,
 ) -> Result<(Vec<CompiledProgram>, Vec<CompiledContract>), CliError> {
     let is_opcode_supported = |opcode: &_| opcode_support.is_opcode_supported(opcode);
 
@@ -106,7 +108,14 @@ pub(super) fn compile_workspace(
     let program_results: Vec<(FileManager, CompilationResult<CompiledProgram>)> = binary_packages
         .par_iter()
         .map(|package| {
-            compile_program(workspace, package, compile_options, np_language, &is_opcode_supported)
+            compile_program(
+                workspace,
+                package,
+                compile_options,
+                output_debug,
+                np_language,
+                &is_opcode_supported,
+            )
         })
         .collect();
     let contract_results: Vec<(FileManager, CompilationResult<CompiledContract>)> =
@@ -138,6 +147,7 @@ pub(crate) fn compile_bin_package(
     workspace: &Workspace,
     package: &Package,
     compile_options: &CompileOptions,
+    output_debug: bool,
     np_language: Language,
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> Result<CompiledProgram, CliError> {
@@ -145,8 +155,14 @@ pub(crate) fn compile_bin_package(
         return Err(CompileError::LibraryCrate(package.name.clone()).into());
     }
 
-    let (file_manager, compilation_result) =
-        compile_program(workspace, package, compile_options, np_language, &is_opcode_supported);
+    let (file_manager, compilation_result) = compile_program(
+        workspace,
+        package,
+        compile_options,
+        output_debug,
+        np_language,
+        &is_opcode_supported,
+    );
 
     let program = report_errors(compilation_result, &file_manager, compile_options.deny_warnings)?;
 
@@ -157,6 +173,7 @@ fn compile_program(
     workspace: &Workspace,
     package: &Package,
     compile_options: &CompileOptions,
+    output_debug: bool,
     np_language: Language,
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> (FileManager, CompilationResult<CompiledProgram>) {
@@ -190,7 +207,12 @@ fn compile_program(
         nargo::ops::optimize_program(program, np_language, &is_opcode_supported)
             .expect("Backend does not support an opcode that is in the IR");
 
-    save_program(optimized_program.clone(), package, &workspace.target_directory_path(), false);
+    save_program(
+        optimized_program.clone(),
+        package,
+        &workspace.target_directory_path(),
+        output_debug,
+    );
 
     (context.file_manager, Ok((optimized_program, warnings)))
 }

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -60,6 +60,7 @@ pub(crate) fn run(
             &workspace,
             package,
             &args.compile_options,
+            false,
             np_language,
             &|opcode| opcode_support.is_opcode_supported(opcode),
         )?;

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -63,6 +63,7 @@ pub(crate) fn run(
         np_language,
         &opcode_support,
         &args.compile_options,
+        false,
     )?;
 
     let program_info = binary_packages

--- a/tooling/nargo_cli/src/cli/prove_cmd.rs
+++ b/tooling/nargo_cli/src/cli/prove_cmd.rs
@@ -59,6 +59,7 @@ pub(crate) fn run(
             &workspace,
             package,
             &args.compile_options,
+            false,
             np_language,
             &|opcode| opcode_support.is_opcode_supported(opcode),
         )?;

--- a/tooling/nargo_cli/src/cli/verify_cmd.rs
+++ b/tooling/nargo_cli/src/cli/verify_cmd.rs
@@ -50,6 +50,7 @@ pub(crate) fn run(
             &workspace,
             package,
             &args.compile_options,
+            false,
             np_language,
             &|opcode| opcode_support.is_opcode_supported(opcode),
         )?;


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes the hardcoding of `output_debug` and forces a recompilation if it is set.


## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
