### PR TITLE
chore: add standard linting setup to all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,7 +2331,6 @@ version = "0.15.0"
 dependencies = [
  "acvm",
  "async-lsp",
- "barretenberg_blackbox_solver",
  "codespan-lsp",
  "codespan-reporting",
  "fm",
@@ -2344,7 +2343,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
  "tower",
 ]
 

--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -112,7 +112,7 @@ mod tests {
             assert_eq!(
                 resolved_func, bb_func,
                 "BlackBoxFunc::lookup returns unexpected BlackBoxFunc"
-            )
+            );
         }
     }
 }

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -167,7 +167,7 @@ impl std::fmt::Display for Circuit {
         write_public_inputs(f, &self.return_values)?;
 
         for opcode in &self.opcodes {
-            writeln!(f, "{opcode}")?
+            writeln!(f, "{opcode}")?;
         }
         Ok(())
     }
@@ -236,7 +236,7 @@ mod tests {
         }
 
         let (circ, got_circ) = read_write(circuit);
-        assert_eq!(circ, got_circ)
+        assert_eq!(circ, got_circ);
     }
 
     #[test]

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -327,7 +327,7 @@ fn get_inputs_string(inputs: &[FunctionInput]) -> String {
             result += &format!("(_{}, num_bits: {})", inp.witness.witness_index(), inp.num_bits);
             // Add a comma, unless it is the last entry
             if index != inputs.len() - 1 {
-                result += ", "
+                result += ", ";
             }
         }
         result
@@ -358,7 +358,7 @@ fn get_outputs_string(outputs: &[Witness]) -> String {
             result += &format!("_{}", output.witness_index());
             // Add a comma, unless it is the last entry
             if index != outputs.len() - 1 {
-                result += ", "
+                result += ", ";
             }
         }
         result

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -1,5 +1,7 @@
-#![warn(unused_crate_dependencies)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 // Arbitrary Circuit Intermediate Representation
 

--- a/acvm-repo/acir/src/native_types/expression/mod.rs
+++ b/acvm-repo/acir/src/native_types/expression/mod.rs
@@ -72,7 +72,7 @@ impl Expression {
 
     /// Adds a new linear term to the `Expression`.
     pub fn push_addition_term(&mut self, coefficient: FieldElement, variable: Witness) {
-        self.linear_combinations.push((coefficient, variable))
+        self.linear_combinations.push((coefficient, variable));
     }
 
     /// Adds a new quadratic term to the `Expression`.
@@ -82,7 +82,7 @@ impl Expression {
         lhs: Witness,
         rhs: Witness,
     ) {
-        self.mul_terms.push((coefficient, lhs, rhs))
+        self.mul_terms.push((coefficient, lhs, rhs));
     }
 
     /// Returns `true` if the expression represents a constant polynomial.
@@ -394,5 +394,5 @@ fn add_mul_smoketest() {
             linear_combinations: vec![(FieldElement::from(40u128), Witness(4))],
             q_c: FieldElement::from(10u128)
         }
-    )
+    );
 }

--- a/acvm-repo/acir_field/src/generic_ark.rs
+++ b/acvm-repo/acir_field/src/generic_ark.rs
@@ -81,7 +81,7 @@ impl<F: PrimeField> std::fmt::Debug for FieldElement<F> {
 
 impl<F: PrimeField> std::hash::Hash for FieldElement<F> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.to_be_bytes())
+        state.write(&self.to_be_bytes());
     }
 }
 
@@ -295,7 +295,7 @@ impl<F: PrimeField> FieldElement<F> {
     fn byte_to_bit(byte: u8) -> Vec<bool> {
         let mut bits = Vec::with_capacity(8);
         for index in (0..=7).rev() {
-            bits.push((byte & (1 << index)) >> index == 1)
+            bits.push((byte & (1 << index)) >> index == 1);
         }
         bits
     }
@@ -433,13 +433,13 @@ mod tests {
         for (i, string) in hex_strings.into_iter().enumerate() {
             let minus_i_field_element =
                 -crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
-            assert_eq!(minus_i_field_element.to_hex(), string)
+            assert_eq!(minus_i_field_element.to_hex(), string);
         }
     }
     #[test]
     fn max_num_bits_smoke() {
         let max_num_bits_bn254 = crate::generic_ark::FieldElement::<ark_bn254::Fr>::max_num_bits();
-        assert_eq!(max_num_bits_bn254, 254)
+        assert_eq!(max_num_bits_bn254, 254);
     }
 }
 

--- a/acvm-repo/acir_field/src/lib.rs
+++ b/acvm-repo/acir_field/src/lib.rs
@@ -1,5 +1,7 @@
-#![warn(unused_crate_dependencies)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "bn254")] {

--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -94,7 +94,7 @@ pub fn compile(
     for opcode in acir.opcodes {
         match opcode {
             Opcode::Arithmetic(arith_expr) => {
-                opcodes.push(Opcode::Arithmetic(GeneralOptimizer::optimize(arith_expr)))
+                opcodes.push(Opcode::Arithmetic(GeneralOptimizer::optimize(arith_expr)));
             }
             other_opcode => opcodes.push(other_opcode),
         };
@@ -168,7 +168,7 @@ pub fn compile(
                 match func {
                     acir::circuit::opcodes::BlackBoxFuncCall::AND { output, .. }
                     | acir::circuit::opcodes::BlackBoxFuncCall::XOR { output, .. } => {
-                        transformer.mark_solvable(*output)
+                        transformer.mark_solvable(*output);
                     }
                     acir::circuit::opcodes::BlackBoxFuncCall::RANGE { .. } => (),
                     acir::circuit::opcodes::BlackBoxFuncCall::SHA256 { outputs, .. }
@@ -192,7 +192,7 @@ pub fn compile(
                     }
                     | acir::circuit::opcodes::BlackBoxFuncCall::Pedersen { outputs, .. } => {
                         transformer.mark_solvable(outputs.0);
-                        transformer.mark_solvable(outputs.1)
+                        transformer.mark_solvable(outputs.1);
                     }
                     acir::circuit::opcodes::BlackBoxFuncCall::HashToField128Security {
                         output,
@@ -201,7 +201,7 @@ pub fn compile(
                     | acir::circuit::opcodes::BlackBoxFuncCall::EcdsaSecp256k1 { output, .. }
                     | acir::circuit::opcodes::BlackBoxFuncCall::EcdsaSecp256r1 { output, .. }
                     | acir::circuit::opcodes::BlackBoxFuncCall::SchnorrVerify { output, .. } => {
-                        transformer.mark_solvable(*output)
+                        transformer.mark_solvable(*output);
                     }
                 }
 

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -233,6 +233,6 @@ mod tests {
         let acir_opcode_positions = circuit.opcodes.iter().enumerate().map(|(i, _)| i).collect();
         let optimizer = RangeOptimizer::new(circuit);
         let (optimized_circuit, _) = optimizer.replace_redundant_ranges(acir_opcode_positions);
-        assert_eq!(optimized_circuit.opcodes.len(), 5)
+        assert_eq!(optimized_circuit.opcodes.len(), 5);
     }
 }

--- a/acvm-repo/acvm/src/lib.rs
+++ b/acvm-repo/acvm/src/lib.rs
@@ -1,5 +1,7 @@
-#![warn(unused_crate_dependencies)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 pub mod compiler;
 pub mod pwg;

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -137,11 +137,11 @@ impl BrilligSolver {
         for output in &brillig.outputs {
             match output {
                 BrilligOutputs::Simple(witness) => {
-                    insert_value(witness, FieldElement::zero(), initial_witness)?
+                    insert_value(witness, FieldElement::zero(), initial_witness)?;
                 }
                 BrilligOutputs::Array(witness_arr) => {
                     for witness in witness_arr {
-                        insert_value(witness, FieldElement::zero(), initial_witness)?
+                        insert_value(witness, FieldElement::zero(), initial_witness)?;
                     }
                 }
             }

--- a/acvm-repo/acvm/src/pwg/directives/mod.rs
+++ b/acvm-repo/acvm/src/pwg/directives/mod.rs
@@ -80,7 +80,7 @@ pub(super) fn solve_directives(
                     None => FieldElement::zero(),
                 };
 
-                insert_value(witness, value, initial_witness)?
+                insert_value(witness, value, initial_witness)?;
             }
 
             Ok(())

--- a/acvm-repo/acvm/src/pwg/directives/sorting.rs
+++ b/acvm-repo/acvm/src/pwg/directives/sorting.rs
@@ -292,7 +292,7 @@ mod tests {
             result.push(*out1.last().unwrap());
             result.push(*out2.last().unwrap());
         } else {
-            result.push(*out2.last().unwrap())
+            result.push(*out2.last().unwrap());
         }
         result
     }

--- a/acvm-repo/acvm_js/src/lib.rs
+++ b/acvm-repo/acvm_js/src/lib.rs
@@ -1,5 +1,7 @@
-// #![warn(unused_crate_dependencies, unused_extern_crates)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 // TODO: Absence of per package targets
 // https://doc.rust-lang.org/cargo/reference/unstable.html#per-package-target

--- a/acvm-repo/barretenberg_blackbox_solver/src/lib.rs
+++ b/acvm-repo/barretenberg_blackbox_solver/src/lib.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]

--- a/acvm-repo/barretenberg_blackbox_solver/src/lib.rs
+++ b/acvm-repo/barretenberg_blackbox_solver/src/lib.rs
@@ -1,3 +1,8 @@
+#![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
+
 use acir::{BlackBoxFunc, FieldElement};
 use acvm_blackbox_solver::{BlackBoxFunctionSolver, BlackBoxResolutionError};
 

--- a/acvm-repo/barretenberg_blackbox_solver/src/wasm/mod.rs
+++ b/acvm-repo/barretenberg_blackbox_solver/src/wasm/mod.rs
@@ -195,7 +195,7 @@ impl Barretenberg {
         let store = self.store.borrow();
         let memory_view = memory.view(&store);
 
-        memory_view.write(offset as u64, data).unwrap()
+        memory_view.write(offset as u64, data).unwrap();
     }
 
     // TODO: Consider making this Result-returning
@@ -231,7 +231,7 @@ impl Barretenberg {
 
         let mut args: Vec<Value> = vec![];
         for param in params.into_iter().cloned() {
-            args.push(param.try_into()?)
+            args.push(param.try_into()?);
         }
         let func = self
             .instance

--- a/acvm-repo/blackbox_solver/src/lib.rs
+++ b/acvm-repo/blackbox_solver/src/lib.rs
@@ -271,7 +271,7 @@ mod secp256k1_tests {
         let valid =
             verify_secp256k1_ecdsa_signature(&HASHED_MESSAGE, &PUB_KEY_X, &PUB_KEY_Y, &SIGNATURE);
 
-        assert!(valid)
+        assert!(valid);
     }
 
     #[test]
@@ -300,7 +300,7 @@ mod secp256k1_tests {
             &SIGNATURE,
         );
 
-        assert!(!valid)
+        assert!(!valid);
     }
 
     #[test]
@@ -316,7 +316,7 @@ mod secp256k1_tests {
             &SIGNATURE,
         );
 
-        assert!(valid)
+        assert!(valid);
     }
 }
 
@@ -352,7 +352,7 @@ mod secp256r1_tests {
         let valid =
             verify_secp256r1_ecdsa_signature(&HASHED_MESSAGE, &PUB_KEY_X, &PUB_KEY_Y, &SIGNATURE);
 
-        assert!(valid)
+        assert!(valid);
     }
 
     #[test]
@@ -381,7 +381,7 @@ mod secp256r1_tests {
             &SIGNATURE,
         );
 
-        assert!(!valid)
+        assert!(!valid);
     }
 
     #[test]
@@ -397,6 +397,6 @@ mod secp256r1_tests {
             &SIGNATURE,
         );
 
-        assert!(valid)
+        assert!(valid);
     }
 }

--- a/acvm-repo/blackbox_solver/src/lib.rs
+++ b/acvm-repo/blackbox_solver/src/lib.rs
@@ -1,5 +1,7 @@
-#![warn(unused_crate_dependencies)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 //! This crate provides the implementation of BlackBox functions of ACIR and Brillig.
 //! For functions that are backend-dependent, it provides a Trait [BlackBoxFunctionSolver] that must be implemented by the backend.

--- a/acvm-repo/brillig/src/lib.rs
+++ b/acvm-repo/brillig/src/lib.rs
@@ -1,5 +1,7 @@
-#![warn(unused_crate_dependencies)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 //! The Brillig bytecode is distinct from regular [ACIR][acir] in that it does not generate constraints.
 //! This is a generalization over the fixed directives that exists within in the ACVM.

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -1,5 +1,7 @@
-#![warn(unused_crate_dependencies)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 //! The Brillig VM is a specialized VM which allows the [ACVM][acvm] to perform custom non-determinism.
 //!

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -211,7 +211,7 @@ impl<'bb_solver, B: BlackBoxFunctionSolver> VM<'bb_solver, B> {
                     match destination {
                         RegisterOrMemory::RegisterIndex(value_index) => match output {
                             ForeignCallOutput::Single(value) => {
-                                self.registers.set(*value_index, *value)
+                                self.registers.set(*value_index, *value);
                             }
                             _ => unreachable!(
                                 "Function result size does not match brillig bytecode (expected 1 result)"
@@ -365,7 +365,7 @@ impl<'bb_solver, B: BlackBoxFunctionSolver> VM<'bb_solver, B> {
         let result_value =
             evaluate_binary_field_op(&op, lhs_value.to_field(), rhs_value.to_field());
 
-        self.registers.set(result, result_value.into())
+        self.registers.set(result, result_value.into());
     }
 
     /// Process a binary operation.
@@ -455,7 +455,7 @@ mod tests {
         let VM { registers, .. } = vm;
         let output_value = registers.get(RegisterIndex::from(2));
 
-        assert_eq!(output_value, Value::from(3u128))
+        assert_eq!(output_value, Value::from(3u128));
     }
 
     #[test]
@@ -895,7 +895,7 @@ mod tests {
             if matches!(status, VMStatus::Finished | VMStatus::ForeignCallWait { .. }) {
                 break;
             }
-            assert_eq!(status, VMStatus::InProgress)
+            assert_eq!(status, VMStatus::InProgress);
         }
     }
 

--- a/acvm-repo/stdlib/src/blackbox_fallbacks/blake2s.rs
+++ b/acvm-repo/stdlib/src/blackbox_fallbacks/blake2s.rs
@@ -203,7 +203,7 @@ fn blake2s_compress(
             UInt32::from_witnesses(&mi_bytes, num_witness);
         new_opcodes.extend(extra_opcodes);
         m.push(mi[0]);
-        num_witness = updated_witness_counter
+        num_witness = updated_witness_counter;
     }
 
     for i in 0..8 {

--- a/acvm-repo/stdlib/src/blackbox_fallbacks/utils.rs
+++ b/acvm-repo/stdlib/src/blackbox_fallbacks/utils.rs
@@ -92,7 +92,7 @@ pub(crate) fn bit_decomposition(
     // First create a witness for each bit
     let mut bit_vector = Vec::with_capacity(bit_size as usize);
     for _ in 0..bit_size {
-        bit_vector.push(variables.new_variable())
+        bit_vector.push(variables.new_variable());
     }
 
     // Next create a directive which computes those bits.
@@ -139,7 +139,7 @@ pub(crate) fn byte_decomposition(
     // First create a witness for each byte
     let mut vector = Vec::with_capacity(num_bytes as usize);
     for _ in 0..num_bytes {
-        vector.push(variables.new_variable())
+        vector.push(variables.new_variable());
     }
 
     // Next create a directive which computes those byte.

--- a/acvm-repo/stdlib/src/lib.rs
+++ b/acvm-repo/stdlib/src/lib.rs
@@ -1,5 +1,7 @@
-#![warn(unused_crate_dependencies)]
+#![forbid(unsafe_code)]
 #![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 pub mod blackbox_fallbacks;
 pub mod helpers;

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 
 [dependencies]
 acvm.workspace = true
-barretenberg_blackbox_solver.workspace = true
 codespan-lsp.workspace = true
 codespan-reporting.workspace = true
 fm.workspace = true
@@ -22,7 +21,6 @@ noirc_errors.workspace = true
 noirc_frontend.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-toml.workspace = true
 tower.workspace = true
 async-lsp = { version = "0.0.5", default-features = false, features = ["omni-trait"] }
 

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -659,7 +659,7 @@ fn on_did_save_text_document(
                 for sec in diagnostic.secondaries {
                     // Not using `unwrap_or_default` here because we don't want to overwrite a valid range with a default range
                     if let Some(r) = byte_span_to_range(files, file_id, sec.span.into()) {
-                        range = r
+                        range = r;
                     }
                 }
                 let severity = match diagnostic.kind {
@@ -671,7 +671,7 @@ fn on_did_save_text_document(
                     severity,
                     message: diagnostic.message,
                     ..Default::default()
-                })
+                });
             }
         }
     }
@@ -717,7 +717,7 @@ fn get_package_tests_in_crate(
             uri: Url::from_file_path(file_path)
                 .expect("Expected a valid file path that can be converted into a URI"),
             range,
-        })
+        });
     }
 
     if package_tests.is_empty() {

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -1,3 +1,8 @@
+#![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
+
 use std::{
     future::{self, Future},
     ops::{self, ControlFlow},

--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -1,3 +1,8 @@
+#![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
+
 use std::{
     collections::BTreeMap,
     path::{Component, Path, PathBuf},


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

A number of crates didn't have our standard linting setup so I've added it and fixed all the warnings. As a result of this I've removed a number of unnecessary dependencies.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
