### PR TITLE
chore: use Noir number in release PR

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "bump-patch-for-minor-pre-major": true,
   "prerelease": true,
   "pull-request-title-pattern": "chore(noir): Release ${scope}",
-  "group-pull-request-title-pattern": "chore(noir): Release ${scope}",
+  "group-pull-request-title-pattern": "chore: Release Noir(${version})",
   "packages": {
     ".": {
       "release-type": "simple",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "prerelease": true,
-  "pull-request-title-pattern": "chore(noir): Release ${scope}",
+  "pull-request-title-pattern": "chore: Release Noir(${version})",
   "group-pull-request-title-pattern": "chore: Release Noir(${version})",
   "packages": {
     ".": {


### PR DESCRIPTION
# Description

This will now have the release PR say `chore: Release Noir(0.13.0)`

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
