### PR TITLE
chore: remove `private: true` on package.json in acvm_js

### DIFF
--- a/acvm-repo/acvm_js/package.json
+++ b/acvm-repo/acvm_js/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@noir-lang/acvm_js",
   "version": "0.27.4",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/noir-lang/acvm.git"


### PR DESCRIPTION
# Description

This field indicates that we don't want to publish the package to npm registry

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
