### PR TITLE
chore: move `wasm-bindgen` dependency to `noir_lsp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,6 @@ dependencies = [
  "rust-embed",
  "serde",
  "tempfile",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2344,6 +2343,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/compiler/fm/Cargo.toml
+++ b/compiler/fm/Cargo.toml
@@ -12,9 +12,6 @@ codespan-reporting.workspace = true
 rust-embed = "6.6.0"
 serde.workspace = true
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
-wasm-bindgen.workspace = true
-
 [dev-dependencies]
 tempfile = "3.2.0"
 iter-extended.workspace = true

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -25,5 +25,8 @@ tower.workspace = true
 cfg-if.workspace = true
 async-lsp = { version = "0.0.5", default-features = false, features = ["omni-trait"] }
 
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+wasm-bindgen.workspace = true
+
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This should have been done as part of #2649 

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
