### PR TITLE
chore: Add MPL-2.0 to allow list for deny action

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -56,6 +56,8 @@ allow = [
     "LicenseRef-webpki",
     # https://github.com/rustls/webpki/blob/main/LICENSE ISC Style
     "LicenseRef-rustls-webpki",
+    # bitmaps 2.1.0, generational-arena 0.2.9,im 15.1.0
+    "MPL-2.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
@@ -95,6 +97,4 @@ unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = [
-    "https://github.com/jfecher/chumsky"
-]
+allow-git = ["https://github.com/jfecher/chumsky"]


### PR DESCRIPTION
# Description

The deny action is failing on master due to some of our dependencies using MPL-2.0 and also an issue with respects to duplicate entries in Cargo.toml.

For the first, I added MPL-2.0 to deny.toml and the for the second I regenerated the .lock file, but this got rolled back for now. This PR only adds the MPL license

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
