### PR TITLE
chore(ci): Rename Noir.js test job

### DIFF
--- a/.github/workflows/test-noir-js.yml
+++ b/.github/workflows/test-noir-js.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-noir-js:
-    name: test
+    name: Test Noir JS
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/test-noir-js.yml
+++ b/.github/workflows/test-noir-js.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test-noir-js:
+    name: test
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/test-noir-js.yml
+++ b/.github/workflows/test-noir-js.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  test:
+  test-noir-js:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
# Description

See [here](https://github.com/noir-lang/noir/issues/2930#issuecomment-1742870802)

Not sure why github only shows the job name and not workflow-name/job-name
## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
