### PR TITLE
chore(ci): always build all workspace dependencies of integration test package

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -220,9 +220,8 @@ jobs:
 
       - name: Setup `integration-tests`
         run: |
-          yarn workspace @noir-lang/source-resolver build
-          yarn workspace @noir-lang/acvm_js build
-          yarn workspace @noir-lang/noir_js build
+          # Build all workspace dependencies of `integration-tests`.
+          yarn workspaces foreach -pR --topological-dev --from 'integration-tests' run build
 
       - name: Run `integration-tests`
         run: |


### PR DESCRIPTION

# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the integration test workflow to recursively build all of its workspace dependencies instead of requiring us to enumerate them manually.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
