### PR TITLE
chore: Make one input public in simple assertion program

### DIFF
--- a/tooling/nargo_cli/tests/execution_success/assert_statement/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/assert_statement/src/main.nr
@@ -1,7 +1,7 @@
 // Tests a very simple program.
 // 
 // The features being tested is assertion
-fn main(x : Field, y : Field)  {
+fn main(x : Field, y : pub Field)  {
     assert(x == y, "x and y are not equal");
     assert_eq(x, y, "x and y are not equal");
 }


### PR DESCRIPTION
# Description

## Problem\*

No issue as minor chore

I want to make a script to enable easy regeneration of the artifacts for `double_verify_proof` when the inner proof circuit has changed due to internal bb changes. I want to maintain in the test that the inner proof has public inputs, however, none of our simple assertion program use a public input.  

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
