### PR TITLE
fix: Improve error message when multiplying unit values

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::hir::resolution::errors::ResolverError;
 use crate::hir_def::expr::HirBinaryOp;
 use crate::hir_def::types::Type;
+use crate::BinaryOpKind;
 use crate::FunctionReturnType;
 use crate::Signedness;
 
@@ -23,8 +24,8 @@ pub enum Source {
     StringLen,
     #[error("Comparison")]
     Comparison,
-    #[error("BinOp")]
-    BinOp,
+    #[error("{0}")]
+    BinOp(BinaryOpKind),
     #[error("Return")]
     Return(FunctionReturnType, Span),
 }
@@ -218,7 +219,7 @@ impl From<TypeCheckError> for Diagnostic {
                     Source::ArrayLen => format!("Can only compare arrays of the same length. Here LHS is of length {expected}, and RHS is {actual}"),
                     Source::StringLen => format!("Can only compare strings of the same length. Here LHS is of length {expected}, and RHS is {actual}"),
                     Source::Comparison => format!("Unsupported types for comparison: {expected} and {actual}"),
-                    Source::BinOp => format!("Unsupported types for binary operation: {expected} and {actual}"),
+                    Source::BinOp(kind) => format!("Unsupported types for operator `{kind}`: {expected} and {actual}"),
                     Source::Return(ret_ty, expr_span) => {
                         let ret_ty_span = match ret_ty.clone() {
                             FunctionReturnType::Default(span) => span,

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -1060,8 +1060,6 @@ impl<'interner> TypeChecker<'interner> {
                 Err(TypeCheckError::InvalidInfixOp { kind: "Tuples", span })
             }
 
-            (Unit, _) | (_, Unit) => Ok(Unit),
-
             // The result of two Fields is always a witness
             (FieldElement, FieldElement) => {
                 if op.is_bitwise() {
@@ -1075,7 +1073,7 @@ impl<'interner> TypeChecker<'interner> {
             (lhs, rhs) => Err(TypeCheckError::TypeMismatchWithSource {
                 expected: lhs.clone(),
                 actual: rhs.clone(),
-                source: Source::BinOp,
+                source: Source::BinOp(op.kind),
                 span,
             }),
         }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Working on #2911 I realized the error message issued was that the result of the multiplication didn't match the function type. When first two checks should have occured:

1. This should not have been a multiplication at all, but a sequnce of a for loop and dereference. This requires parser changes I'll address in another PR.
2. We should have checked that the operand types `()` and `&mut ...` aren't valid to multiply together. This was caused by a catch-all case to make all unit operations valid, for some unknown reason. I've removed this case and improved the error message to mention the specific binary operator that was used.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
