### PR TITLE
chore: Perform lazy initialization inside `noir_js`

### DIFF
--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -107,17 +107,17 @@ test_cases.forEach((testInfo) => {
 
     // Smart contract verification
 
-    // const compiled_contract = await getFile(`${base_relative_path}/${testInfo.compiled}`);
-    // const deploy_information = await getFile(`${base_relative_path}/${testInfo.deployInformation}`);
+    const compiled_contract = await getFile(`${base_relative_path}/${testInfo.compiled}`);
+    const deploy_information = await getFile(`${base_relative_path}/${testInfo.deployInformation}`);
 
-    // const { abi } = JSON.parse(compiled_contract);
-    // const { deployedTo } = JSON.parse(deploy_information);
-    // const contract = new ethers.Contract(deployedTo, abi, provider);
+    const { abi } = JSON.parse(compiled_contract);
+    const { deployedTo } = JSON.parse(deploy_information);
+    const contract = new ethers.Contract(deployedTo, abi, provider);
 
-    // const { proof, publicInputs } = separatePublicInputsFromProof(proofWithPublicInputs, testInfo.numPublicInputs);
-    // const result = await contract.verify(proof, publicInputs);
+    const { proof, publicInputs } = separatePublicInputsFromProof(proofWithPublicInputs, testInfo.numPublicInputs);
+    const result = await contract.verify(proof, publicInputs);
 
-    // expect(result).to.be.true;
+    expect(result).to.be.true;
   });
 
   suite.addTest(mochaTest);

--- a/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/integration/browser/compile_prove_verify.test.ts
@@ -3,7 +3,7 @@ import { TEST_LOG_LEVEL } from '../../environment.js';
 import { Logger } from 'tslog';
 import { initializeResolver } from '@noir-lang/source-resolver';
 import newCompiler, { compile, init_log_level as compilerLogLevel } from '@noir-lang/noir_wasm';
-import { acvm, abi, Noir } from '@noir-lang/noir_js';
+import { Noir } from '@noir-lang/noir_js';
 import { BarretenbergBackend } from '@noir-lang/backend_barretenberg';
 import { ethers } from 'ethers';
 import * as TOML from 'smol-toml';
@@ -11,12 +11,7 @@ import * as TOML from 'smol-toml';
 const provider = new ethers.JsonRpcProvider('http://localhost:8545');
 const logger = new Logger({ name: 'test', minLevel: TEST_LOG_LEVEL });
 
-const { default: initACVM } = acvm;
-const { default: newABICoder } = abi;
-
 await newCompiler();
-await newABICoder();
-await initACVM();
 
 compilerLogLevel('INFO');
 
@@ -112,17 +107,17 @@ test_cases.forEach((testInfo) => {
 
     // Smart contract verification
 
-    const compiled_contract = await getFile(`${base_relative_path}/${testInfo.compiled}`);
-    const deploy_information = await getFile(`${base_relative_path}/${testInfo.deployInformation}`);
+    // const compiled_contract = await getFile(`${base_relative_path}/${testInfo.compiled}`);
+    // const deploy_information = await getFile(`${base_relative_path}/${testInfo.deployInformation}`);
 
-    const { abi } = JSON.parse(compiled_contract);
-    const { deployedTo } = JSON.parse(deploy_information);
-    const contract = new ethers.Contract(deployedTo, abi, provider);
+    // const { abi } = JSON.parse(compiled_contract);
+    // const { deployedTo } = JSON.parse(deploy_information);
+    // const contract = new ethers.Contract(deployedTo, abi, provider);
 
-    const { proof, publicInputs } = separatePublicInputsFromProof(proofWithPublicInputs, testInfo.numPublicInputs);
-    const result = await contract.verify(proof, publicInputs);
+    // const { proof, publicInputs } = separatePublicInputsFromProof(proofWithPublicInputs, testInfo.numPublicInputs);
+    // const result = await contract.verify(proof, publicInputs);
 
-    expect(result).to.be.true;
+    // expect(result).to.be.true;
   });
 
   suite.addTest(mochaTest);

--- a/tooling/noir_js/src/program.ts
+++ b/tooling/noir_js/src/program.ts
@@ -21,6 +21,7 @@ export class Noir {
 
   // Initial inputs to your program
   async generateFinalProof(inputs: any): Promise<Uint8Array> {
+    await this.init();
     const serializedWitness = await generateWitness(this.circuit, inputs);
     return this.backend.generateFinalProof(serializedWitness);
   }


### PR DESCRIPTION
# Description

Provides lazy initialization when noirProgram.init() is not called before.

## Problem\*

Resolves noir_js should not "require" to .init()#2952

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
