### PR TITLE
feat(traits): Improve support for traits static method resolution

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -117,8 +117,11 @@ impl<'a> ModCollector<'a> {
         let module_id = ModuleId { krate, local_id: self.module_id };
 
         for r#impl in impls {
-            let mut unresolved_functions =
-                UnresolvedFunctions { file_id: self.file_id, functions: Vec::new() };
+            let mut unresolved_functions = UnresolvedFunctions {
+                file_id: self.file_id,
+                functions: Vec::new(),
+                trait_id: None,
+            };
 
             for method in r#impl.methods {
                 let func_id = context.def_interner.push_empty_fn();
@@ -171,7 +174,7 @@ impl<'a> ModCollector<'a> {
         krate: CrateId,
     ) -> UnresolvedFunctions {
         let mut unresolved_functions =
-            UnresolvedFunctions { file_id: self.file_id, functions: Vec::new() };
+            UnresolvedFunctions { file_id: self.file_id, functions: Vec::new(), trait_id: None };
 
         let module = ModuleId { krate, local_id: self.module_id };
 
@@ -193,7 +196,7 @@ impl<'a> ModCollector<'a> {
         krate: CrateId,
     ) -> Vec<(CompilationError, FileId)> {
         let mut unresolved_functions =
-            UnresolvedFunctions { file_id: self.file_id, functions: Vec::new() };
+            UnresolvedFunctions { file_id: self.file_id, functions: Vec::new(), trait_id: None };
         let mut errors = vec![];
 
         let module = ModuleId { krate, local_id: self.module_id };
@@ -351,8 +354,11 @@ impl<'a> ModCollector<'a> {
             }
 
             // Add all functions that have a default implementation in the trait
-            let mut unresolved_functions =
-                UnresolvedFunctions { file_id: self.file_id, functions: Vec::new() };
+            let mut unresolved_functions = UnresolvedFunctions {
+                file_id: self.file_id,
+                functions: Vec::new(),
+                trait_id: None,
+            };
             for trait_item in &trait_definition.items {
                 // TODO(Maddiaa): Investigate trait implementations with attributes see: https://github.com/noir-lang/noir/issues/2629
                 if let TraitItem::Function {

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1491,8 +1491,10 @@ impl<'a> Resolver<'a> {
         for UnresolvedTraitConstraint { typ, trait_bound } in self.trait_bounds.clone() {
             if let UnresolvedTypeData::Named(constraint_path, _) = &typ.typ {
                 // if `path` is `T::method_name`, we're looking for constraint of the form `T: SomeTrait`
-                if constraint_path.segments.len() == 1 && path.segments[0] != constraint_path.last_segment() {
-                    continue
+                if constraint_path.segments.len() == 1
+                    && path.segments[0] != constraint_path.last_segment()
+                {
+                    continue;
                 }
 
                 if let Ok(ModuleDefId::TraitId(trait_id)) =

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1514,7 +1514,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_trait_generic_path(&mut self, path: &Path) -> Option<HirExpression> {
-        self.resolve_trait_static_method_by_self(&path)
+        self.resolve_trait_static_method_by_self(path)
             .or_else(|| self.resolve_trait_method_by_named_generic(path))
     }
 

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1453,8 +1453,8 @@ impl<'a> Resolver<'a> {
         self.lookup(path).ok().map(|id| self.interner.get_type_alias(id))
     }
 
-    fn resolve_generic_path(&self, path: &Path) -> Option<HirExpression> {
-        for UnresolvedTraitConstraint { typ, trait_bound } in &self.trait_bounds {
+    fn resolve_generic_path(&mut self, path: &Path) -> Option<HirExpression> {
+        for UnresolvedTraitConstraint { typ, trait_bound } in self.trait_bounds.clone() {
             if let UnresolvedTypeData::Named(constraint_path, _) = &typ.typ {
                 // if we're attempting to resolve `T::U::V::some_method` and constraint is `T::U::V: SomeTrait`
                 // we iterate through the Trait's elements.
@@ -1476,7 +1476,8 @@ impl<'a> Resolver<'a> {
                             if let Some(method) =
                                 the_trait.find_method(path.segments.last().unwrap().clone())
                             {
-                                return Some(HirExpression::TraitMethodReference(method));
+                                let self_type = self.resolve_type(typ.clone());
+                                return Some(HirExpression::TraitMethodReference(self_type, method));
                             }
                         }
                     }

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -173,8 +173,11 @@ impl<'interner> TypeChecker<'interner> {
                             }
                         }
 
-                        let (function_id, function_call) =
-                            method_call.into_function_call(method_ref.clone(), location, self.interner);
+                        let (function_id, function_call) = method_call.into_function_call(
+                            method_ref.clone(),
+                            location,
+                            self.interner,
+                        );
 
                         let span = self.interner.expr_span(expr_id);
                         let ret = self.check_method_call(&function_id, method_ref, args, span);
@@ -872,7 +875,10 @@ impl<'interner> TypeChecker<'interner> {
                             if method.name.0.contents == method_name {
                                 let trait_method =
                                     TraitMethodId { trait_id: constraint.trait_id, method_index };
-                                return Some(HirMethodReference::TraitMethodId(object_type.clone(), trait_method));
+                                return Some(HirMethodReference::TraitMethodId(
+                                    object_type.clone(),
+                                    trait_method,
+                                ));
                             }
                         }
                     }

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -174,7 +174,7 @@ impl<'interner> TypeChecker<'interner> {
                         }
 
                         let (function_id, function_call) =
-                            method_call.into_function_call(method_ref, location, self.interner);
+                            method_call.into_function_call(method_ref.clone(), location, self.interner);
 
                         let span = self.interner.expr_span(expr_id);
                         let ret = self.check_method_call(&function_id, method_ref, args, span);
@@ -288,7 +288,7 @@ impl<'interner> TypeChecker<'interner> {
 
                 Type::Function(params, Box::new(lambda.return_type), Box::new(env_type))
             }
-            HirExpression::TraitMethodReference(method) => {
+            HirExpression::TraitMethodReference(_, method) => {
                 let the_trait = self.interner.get_trait(method.trait_id);
                 let method = &the_trait.methods[method.method_index];
 
@@ -507,7 +507,7 @@ impl<'interner> TypeChecker<'interner> {
 
                 (func_meta.typ, param_len)
             }
-            HirMethodReference::TraitMethodId(method) => {
+            HirMethodReference::TraitMethodId(_, method) => {
                 let the_trait = self.interner.get_trait(method.trait_id);
                 let method = &the_trait.methods[method.method_index];
 
@@ -872,7 +872,7 @@ impl<'interner> TypeChecker<'interner> {
                             if method.name.0.contents == method_name {
                                 let trait_method =
                                     TraitMethodId { trait_id: constraint.trait_id, method_index };
-                                return Some(HirMethodReference::TraitMethodId(trait_method));
+                                return Some(HirMethodReference::TraitMethodId(object_type.clone(), trait_method));
                             }
                         }
                     }

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -30,7 +30,7 @@ pub enum HirExpression {
     If(HirIfExpression),
     Tuple(Vec<ExprId>),
     Lambda(HirLambda),
-    TraitMethodReference(TraitMethodId),
+    TraitMethodReference(Type, TraitMethodId),
     Error,
 }
 
@@ -151,7 +151,7 @@ pub struct HirMethodCallExpression {
     pub location: Location,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum HirMethodReference {
     /// A method can be defined in a regular `impl` block, in which case
     /// it's syntax sugar for a normal function call, and can be
@@ -161,7 +161,7 @@ pub enum HirMethodReference {
     /// Or a method can come from a Trait impl block, in which case
     /// the actual function called will depend on the instantiated type,
     /// which can be only known during monomorphizaiton.
-    TraitMethodId(TraitMethodId),
+    TraitMethodId(Type, TraitMethodId),
 }
 
 impl HirMethodCallExpression {
@@ -179,8 +179,8 @@ impl HirMethodCallExpression {
                 let id = interner.function_definition_id(func_id);
                 HirExpression::Ident(HirIdent { location, id })
             }
-            HirMethodReference::TraitMethodId(method_id) => {
-                HirExpression::TraitMethodReference(method_id)
+            HirMethodReference::TraitMethodId(typ, method_id) => {
+                HirExpression::TraitMethodReference(typ, method_id)
             }
         };
         let func = interner.push_expr(expr);

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     graph::CrateId,
-    node_interner::{FuncId, TraitId},
+    node_interner::{FuncId, TraitId, TraitMethodId},
     Generics, Ident, NoirFunction, Type, TypeVariable, TypeVariableId,
 };
 use noirc_errors::Span;
@@ -110,6 +110,15 @@ impl Trait {
 
     pub fn set_methods(&mut self, methods: Vec<TraitFunction>) {
         self.methods = methods;
+    }
+
+    pub fn find_method(&self, name: Ident) -> Option<TraitMethodId> {
+        for (idx, method) in self.methods.iter().enumerate() {
+            if method.name == name {
+                return Some(TraitMethodId { trait_id: self.id, method_index: idx });
+            }
+        }
+        None
     }
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -803,11 +803,6 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> ast::Expression {
         let function_type = self.interner.id_type(expr_id);
 
-        // the substitute() here is to replace all internal occurences of the 'Self' typevar
-        // with whatever 'Self' is currently bound to, so we don't lose type information
-        // if we need to rebind the trait.
-        println!("self_type: {self_type} // {self_type:?}");
-
         let trait_impl = self
             .interner
             .get_trait_implementation(&TraitImplKey {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -378,10 +378,9 @@ impl<'interner> Monomorphizer<'interner> {
 
             HirExpression::Lambda(lambda) => self.lambda(lambda, expr),
 
-            HirExpression::TraitMethodReference(method) => {
-                if let Type::Function(args, _, _) = self.interner.id_type(expr) {
-                    let self_type = args[0].clone();
-                    self.resolve_trait_method_reference(self_type, expr, method)
+            HirExpression::TraitMethodReference(typ, method) => {
+                if let Type::Function(_, _, _) = self.interner.id_type(expr) {
+                    self.resolve_trait_method_reference(typ, expr, method)
                 } else {
                     unreachable!(
                         "Calling a non-function, this should've been caught in typechecking"

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -203,6 +203,11 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     fn function(&mut self, f: node_interner::FuncId, id: FuncId) {
+        if let Some((self_type, trait_id)) = self.interner.get_function_trait(&f) {
+            let the_trait = self.interner.get_trait(trait_id);
+            *the_trait.self_type_typevar.borrow_mut() = TypeBinding::Bound(self_type);
+        }
+
         let meta = self.interner.function_meta(&f);
         let modifiers = self.interner.function_modifiers(&f);
         let name = self.interner.function_name(&f).to_owned();
@@ -801,6 +806,8 @@ impl<'interner> Monomorphizer<'interner> {
         // the substitute() here is to replace all internal occurences of the 'Self' typevar
         // with whatever 'Self' is currently bound to, so we don't lose type information
         // if we need to rebind the trait.
+        println!("self_type: {self_type} // {self_type:?}");
+
         let trait_impl = self
             .interner
             .get_trait_implementation(&TraitImplKey {

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -115,6 +115,9 @@ pub struct NodeInterner {
 
     /// Methods on primitive types defined in the stdlib.
     primitive_methods: HashMap<(TypeMethodKey, String), FuncId>,
+
+    // For trait implementation functions, this is their self type and trait they belong to
+    func_id_to_trait: HashMap<FuncId, (Type, TraitId)>,
 }
 
 /// All the information from a function that is filled out during definition collection rather than
@@ -364,6 +367,7 @@ impl Default for NodeInterner {
             function_definition_ids: HashMap::new(),
             function_modifiers: HashMap::new(),
             function_modules: HashMap::new(),
+            func_id_to_trait: HashMap::new(),
             id_to_location: HashMap::new(),
             definitions: vec![],
             id_to_type: HashMap::new(),
@@ -626,6 +630,14 @@ impl NodeInterner {
         self.function_modifiers.insert(func, modifiers);
         self.function_modules.insert(func, module);
         self.push_definition(name, false, DefinitionKind::Function(func))
+    }
+
+    pub fn set_function_trait(&mut self, func: FuncId, self_type: Type, trait_id: TraitId) {
+        self.func_id_to_trait.insert(func, (self_type, trait_id));
+    }
+
+    pub fn get_function_trait(&self, func: &FuncId) -> Option<(Type, TraitId)> {
+        self.func_id_to_trait.get(func).cloned()
     }
 
     /// Returns the visibility of the given function.

--- a/tooling/nargo_cli/tests/execution_success/trait_self/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/trait_self/src/main.nr
@@ -1,5 +1,13 @@
 trait ATrait {
     fn asd() -> Self;
+
+    fn static_method() -> Field {
+        Self::static_method_2()
+    };
+
+    fn static_method_2() -> Field {
+        100
+    };
 }
 
 struct Foo {
@@ -21,7 +29,13 @@ impl ATrait for Bar {
     fn asd() -> Bar {
         Bar{x: 100}
     }
+
+    fn static_method_2() -> Field {
+        200
+    }
 }
 
 fn main() {
+    assert(Foo::static_method() == 100);
+    assert(Bar::static_method() == 200);
 }

--- a/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/main.nr
@@ -8,6 +8,7 @@
 // import the trait from another module to ensure the where clauses are ok with that
 mod the_trait;
 use crate::the_trait::Asd;
+use crate::the_trait::StaticTrait;
 
 struct Add10  { x: Field, }
 struct Add20  { x: Field, }
@@ -24,8 +25,22 @@ impl Asd for AddXY {
     }
 }
 
+struct Foo {}
+impl StaticTrait for Foo {
+    fn static_function(slf: Self) -> Field { 100 }
+}
+
+struct Bar {}
+impl StaticTrait for Bar {
+    fn static_function(slf: Self) -> Field { 200 }
+}
+
 fn assert_asd_eq_100<T>(t: T) where T: crate::the_trait::Asd {
     assert(t.asd() == 100);
+}
+
+fn test_static_functions_resolve<T>(t: T) -> Field where T: StaticTrait {
+    T::static_function(t) + 1
 }
 
 fn main() {
@@ -38,4 +53,7 @@ fn main() {
     assert_asd_eq_100(z);
     assert_asd_eq_100(a);
     assert_asd_eq_100(xy);
+
+    assert(test_static_functions_resolve(Foo{}) == 101);
+    assert(test_static_functions_resolve(Bar{}) == 201);
 }

--- a/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/main.nr
@@ -5,7 +5,7 @@
 //      - trait impl blocks (impl<T,U> Foo for Bar where T...)
 //      - structs (struct Foo<T> where T: ...)
 
-// import the trait from another module to ensure the where clauses are ok with that
+// import the traits from another module to ensure the where clauses are ok with that
 mod the_trait;
 use crate::the_trait::Asd;
 use crate::the_trait::StaticTrait;
@@ -25,13 +25,13 @@ impl Asd for AddXY {
     }
 }
 
-struct Foo {}
-impl StaticTrait for Foo {
-    fn static_function(slf: Self) -> Field { 100 }
+struct Static100 {}
+impl StaticTrait for Static100 {
+    // use default implementatino for static_function, which returns 100
 }
 
-struct Bar {}
-impl StaticTrait for Bar {
+struct Static200 {}
+impl StaticTrait for Static200 {
     fn static_function(slf: Self) -> Field { 200 }
 }
 
@@ -39,7 +39,7 @@ fn assert_asd_eq_100<T>(t: T) where T: crate::the_trait::Asd {
     assert(t.asd() == 100);
 }
 
-fn test_static_functions_resolve<T>(t: T) -> Field where T: StaticTrait {
+fn add_one_to_static_function<T>(t: T) -> Field where T: StaticTrait {
     T::static_function(t) + 1
 }
 
@@ -54,6 +54,6 @@ fn main() {
     assert_asd_eq_100(a);
     assert_asd_eq_100(xy);
 
-    assert(test_static_functions_resolve(Foo{}) == 101);
-    assert(test_static_functions_resolve(Bar{}) == 201);
+    assert(add_one_to_static_function(Static100{}) == 101);
+    assert(add_one_to_static_function(Static200{}) == 201);
 }

--- a/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/the_trait.nr
+++ b/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/the_trait.nr
@@ -1,3 +1,7 @@
 trait Asd {
     fn asd(self) -> Field;
 }
+
+trait StaticTrait {
+    fn static_function(slf: Self) -> Field;
+}

--- a/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/the_trait.nr
+++ b/tooling/nargo_cli/tests/execution_success/trait_where_clause/src/the_trait.nr
@@ -3,5 +3,7 @@ trait Asd {
 }
 
 trait StaticTrait {
-    fn static_function(slf: Self) -> Field;
+    fn static_function(slf: Self) -> Field {
+        100
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*
Progress towards https://github.com/noir-lang/noir/issues/2568

This adds support for two trait method resolution cases that previously didn't work:

1. Trait methods calling static trait methods in the default implementation via Self. Now the call is properly resolved as `HirExpression::HirMethodReference`
```rust
trait ATrait {
    fn static_method() -> Field {
        Self::static_method_2() // This used to fail, ok now
    };
    fn static_method_2() -> Field;
}
```

2. The second is something I missed when implementing where clauses - static methods need to be resolvable with a colon syntax via the NamedGeneric
```rust
fn whatever<T>(t: T) -> Field where T: ATrait {
    T::static_method() // this used to fail, ok now
}
```

Even though the `Self::whatever` and `T::whatever` are Paths, I've handled the resolution in `Resolver` rather than `PathResolver`, since there are no modules involved and we to make use of the `NodeInterner`.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
