### PR TITLE
feat(wasm)!: update wasm artifacts to match cli artifacts

### DIFF
--- a/compiler/integration-tests/test/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/browser/compile_prove_verify.test.ts
@@ -49,17 +49,16 @@ test_cases.forEach((testInfo) => {
 
     const noir_source = await getFile(`${base_relative_path}/${test_case}/src/main.nr`);
 
-    let compile_output;
+    let noir_program;
     try {
-      compile_output = await getCircuit(noir_source);
+      noir_program = await getCircuit(noir_source);
 
-      expect(await compile_output, 'Compile output ').to.be.an('object');
+      expect(await noir_program, 'Compile output ').to.be.an('object');
     } catch (e) {
       expect(e, 'Compilation Step').to.not.be.an('error');
       throw e;
     }
 
-    const noir_program = { bytecode: compile_output.circuit, abi: compile_output.abi };
     const backend = new BarretenbergBackend(noir_program);
     const program = new Noir(noir_program, backend);
 

--- a/compiler/integration-tests/test/browser/recursion.test.ts
+++ b/compiler/integration-tests/test/browser/recursion.test.ts
@@ -48,10 +48,9 @@ describe('It compiles noir program code, receiving circuit bytes and abi object.
   });
 
   it('Should generate valid inner proof for correct input, then verify proof within a proof', async () => {
-    const { circuit: main_circuit, abi: main_abi } = await getCircuit(circuit_main_source);
+    const main_program = await getCircuit(circuit_main_source);
     const main_inputs = TOML.parse(circuit_main_toml);
 
-    const main_program = { bytecode: main_circuit, abi: main_abi };
     const main_backend = new BarretenbergBackend(main_program);
 
     const main_witnessUint8Array = await generateWitness(main_program, main_inputs);
@@ -79,8 +78,7 @@ describe('It compiles noir program code, receiving circuit bytes and abi object.
 
     logger.debug('recursion_inputs', recursion_inputs);
 
-    const { circuit: recursion_circuit, abi: recursion_abi } = await getCircuit(circuit_recursion_source);
-    const recursion_program = { bytecode: recursion_circuit, abi: recursion_abi };
+    const recursion_program = await getCircuit(circuit_recursion_source);
 
     const recursion_backend = new BarretenbergBackend(recursion_program);
 

--- a/compiler/integration-tests/test/node/smart_contract_verifier.test.ts
+++ b/compiler/integration-tests/test/node/smart_contract_verifier.test.ts
@@ -38,17 +38,16 @@ test_cases.forEach((testInfo) => {
 
     const noir_source_path = resolve(`${base_relative_path}/${test_case}/src/main.nr`);
 
-    let compile_output;
+    let noir_program;
     try {
-      compile_output = await getCircuit(noir_source_path);
+      noir_program = await getCircuit(noir_source_path);
 
-      expect(await compile_output, 'Compile output ').to.be.an('object');
+      expect(await noir_program, 'Compile output ').to.be.an('object');
     } catch (e) {
       expect(e, 'Compilation Step').to.not.be.an('error');
       throw e;
     }
 
-    const noir_program = { bytecode: compile_output.circuit, abi: compile_output.abi };
     const backend = new BarretenbergBackend(noir_program);
     const program = new Noir(noir_program, backend);
 

--- a/compiler/wasm/test/browser/index.test.ts
+++ b/compiler/wasm/test/browser/index.test.ts
@@ -16,19 +16,23 @@ async function getSource(): Promise<string> {
   return getFileContent(noirSourcePath);
 }
 
-async function getPrecompiledSource(): Promise<string> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getPrecompiledSource(): Promise<any> {
   const compiledData = await getFileContent(nargoArtifactPath);
-  return JSON.parse(compiledData).bytecode;
+  return JSON.parse(compiledData);
 }
 
 describe('noir wasm compilation', () => {
   it('matches nargos compilation', async () => {
     const source = await getSource();
 
-    const wasmCircuitBase64 = await compileNoirSource(source);
+    const wasmCircuit = await compileNoirSource(source);
 
-    const cliCircuitBase64 = await getPrecompiledSource();
+    const cliCircuit = await getPrecompiledSource();
 
-    expect(wasmCircuitBase64).to.equal(cliCircuitBase64);
+    // We don't expect the hashes to match due to how `noir_wasm` handles dependencies
+    expect(wasmCircuit.bytecode).to.eq(cliCircuit.bytecode);
+    expect(wasmCircuit.abi).to.deep.eq(cliCircuit.abi);
+    expect(wasmCircuit.backend).to.eq(cliCircuit.backend);
   }).timeout(20e3); // 20 seconds
 });

--- a/compiler/wasm/test/node/index.test.ts
+++ b/compiler/wasm/test/node/index.test.ts
@@ -11,25 +11,23 @@ async function getSource(): Promise<string> {
   return getFileContent(noirSourcePath);
 }
 
-async function getPrecompiledSource(): Promise<string> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getPrecompiledSource(): Promise<any> {
   const compiledData = await getFileContent(nargoArtifactPath);
-  return JSON.parse(compiledData).bytecode;
+  return JSON.parse(compiledData);
 }
 
 describe('noir wasm compilation', () => {
   it('matches nargos compilation', async () => {
     const source = await getSource();
 
-    const wasmCircuitBase64 = await compileNoirSource(source);
+    const wasmCircuit = await compileNoirSource(source);
 
-    const cliCircuitBase64 = await getPrecompiledSource();
+    const cliCircuit = await getPrecompiledSource();
 
-    console.log('wasm', wasmCircuitBase64);
-
-    console.log('cli', cliCircuitBase64);
-
-    console.log('Compilation is a match? ', wasmCircuitBase64 === cliCircuitBase64);
-
-    expect(wasmCircuitBase64).to.equal(cliCircuitBase64);
+    // We don't expect the hashes to match due to how `noir_wasm` handles dependencies
+    expect(wasmCircuit.bytecode).to.eq(cliCircuit.bytecode);
+    expect(wasmCircuit.abi).to.deep.eq(cliCircuit.abi);
+    expect(wasmCircuit.backend).to.eq(cliCircuit.backend);
   }).timeout(10e3);
 });

--- a/compiler/wasm/test/shared.ts
+++ b/compiler/wasm/test/shared.ts
@@ -4,7 +4,8 @@ import { compile } from '@noir-lang/noir_wasm';
 export const noirSourcePath = '../../noir-script/src/main.nr';
 export const nargoArtifactPath = '../../noir-script/target/noir_wasm_testing.json';
 
-export async function compileNoirSource(noir_source: string): Promise<unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function compileNoirSource(noir_source: string): Promise<any> {
   console.log('Compiling Noir source...');
 
   initializeResolver((id: string) => {
@@ -24,7 +25,7 @@ export async function compileNoirSource(noir_source: string): Promise<unknown> {
 
     console.log('Noir source compilation done.');
 
-    return compiled_noir.circuit;
+    return compiled_noir;
   } catch (e) {
     console.log('Error while compiling:', e);
   }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2972 

## Summary\*

This PR changes `noir_wasm` to output the same artifacts as Nargo does.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
