### PR TITLE
feat(lsp): add "info" codelens

### DIFF
--- a/tooling/lsp/src/codelens/mod.rs
+++ b/tooling/lsp/src/codelens/mod.rs
@@ -24,6 +24,8 @@ const TEST_COMMAND: &str = "nargo.test";
 const TEST_CODELENS_TITLE: &str = "Run Test";
 const COMPILE_COMMAND: &str = "nargo.compile";
 const COMPILE_CODELENS_TITLE: &str = "Compile";
+const INFO_COMMAND: &str = "nargo.info";
+const INFO_CODELENS_TITLE: &str = "Info";
 const EXECUTE_COMMAND: &str = "nargo.execute";
 const EXECUTE_CODELENS_TITLE: &str = "Execute";
 
@@ -148,6 +150,16 @@ fn on_code_lens_request_inner(
 
                 lenses.push(compile_lens);
 
+                let info_command = Command {
+                    title: INFO_CODELENS_TITLE.to_string(),
+                    command: INFO_COMMAND.into(),
+                    arguments: Some(package_selection_args(&workspace, package)),
+                };
+
+                let info_lens = CodeLens { range, command: Some(info_command), data: None };
+
+                lenses.push(info_lens);
+
                 let execute_command = Command {
                     title: EXECUTE_CODELENS_TITLE.to_string(),
                     command: EXECUTE_COMMAND.into(),
@@ -186,6 +198,16 @@ fn on_code_lens_request_inner(
                 let compile_lens = CodeLens { range, command: Some(compile_command), data: None };
 
                 lenses.push(compile_lens);
+
+                let info_command = Command {
+                    title: INFO_CODELENS_TITLE.to_string(),
+                    command: INFO_COMMAND.into(),
+                    arguments: Some(package_selection_args(&workspace, package)),
+                };
+
+                let info_lens = CodeLens { range, command: Some(info_command), data: None };
+
+                lenses.push(info_lens);
             }
         }
     }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2942

![image](https://github.com/noir-lang/noir/assets/15848336/cee72243-b503-4aa4-af5c-30f033348111)


This PR adds a codelens to run `nargo info` on programs/contracts.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
