### PR TITLE
fix: Transform hir before type checks 

### DIFF
--- a/compiler/noirc_frontend/src/hir/aztec_library.rs
+++ b/compiler/noirc_frontend/src/hir/aztec_library.rs
@@ -10,14 +10,13 @@ use crate::node_interner::{NodeInterner, StructId};
 use crate::token::SecondaryAttribute;
 use crate::{
     hir::Context, BlockExpression, CallExpression, CastExpression, Distinctness, Expression,
-    ExpressionKind, ForExpression, FunctionReturnType, Ident, ImportStatement, IndexExpression,
-    LetStatement, Literal, MemberAccessExpression, MethodCallExpression, NoirFunction,
-    ParsedModule, Path, PathKind, Pattern, Statement, UnresolvedType, UnresolvedTypeData,
-    Visibility,
+    ExpressionKind, FunctionReturnType, Ident, ImportStatement, IndexExpression, LetStatement,
+    Literal, MemberAccessExpression, MethodCallExpression, NoirFunction, ParsedModule, Path,
+    PathKind, Pattern, Statement, UnresolvedType, UnresolvedTypeData, Visibility,
 };
 use crate::{
-    FunctionDefinition, NoirStruct, PrefixExpression, Signedness, StructType, Type, TypeImpl,
-    UnaryOp,
+    ForLoopStatement, FunctionDefinition, NoirStruct, PrefixExpression, Signedness, StructType,
+    Type, TypeImpl, UnaryOp,
 };
 use fm::FileId;
 
@@ -819,14 +818,14 @@ fn create_loop_over(var: Expression, loop_body: Vec<Statement>) -> Statement {
     let for_loop_block = expression(ExpressionKind::Block(BlockExpression(loop_body)));
 
     // `for i in 0..{ident}.len()`
-    Statement::Expression(expression(ExpressionKind::For(Box::new(ForExpression {
+    Statement::For(ForLoopStatement {
         identifier: ident("i"),
         start_range: expression(ExpressionKind::Literal(Literal::Integer(FieldElement::from(
             i128::from(0),
         )))),
         end_range: end_range_expression,
         block: for_loop_block,
-    }))))
+    })
 }
 
 fn add_array_to_hasher(identifier: &Ident) -> Statement {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -336,6 +336,11 @@ impl DefCollector {
         );
 
         errors.extend(resolved_globals.errors);
+
+        // We run hir transformations before type checks
+        #[cfg(feature = "aztec")]
+        crate::hir::aztec_library::transform_hir(&crate_id, context);
+
         errors.extend(type_check_globals(&mut context.def_interner, resolved_globals.globals));
 
         // Type check all of the functions in the crate

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -17,9 +17,6 @@ pub use module_data::*;
 mod namespace;
 pub use namespace::*;
 
-#[cfg(feature = "aztec")]
-mod aztec_library;
-
 /// The name that is used for a non-contract program's entry-point function.
 pub const MAIN_FUNCTION: &str = "main";
 
@@ -88,7 +85,7 @@ impl CrateDefMap {
         let (ast, parsing_errors) = parse_file(&context.file_manager, root_file_id);
 
         #[cfg(feature = "aztec")]
-        let ast = match aztec_library::transform(ast, &crate_id, context) {
+        let ast = match super::aztec_library::transform(ast, &crate_id, context) {
             Ok(ast) => ast,
             Err((error, file_id)) => {
                 errors.push((error.into(), file_id));
@@ -110,8 +107,6 @@ impl CrateDefMap {
 
         // Now we want to populate the CrateDefMap using the DefCollector
         errors.extend(DefCollector::collect(def_map, context, ast, root_file_id));
-        #[cfg(feature = "aztec")]
-        aztec_library::transform_hir(&crate_id, context);
 
         errors.extend(
             parsing_errors.iter().map(|e| (e.clone().into(), root_file_id)).collect::<Vec<_>>(),

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -4,6 +4,9 @@ pub mod resolution;
 pub mod scope;
 pub mod type_check;
 
+#[cfg(feature = "aztec")]
+pub(crate) mod aztec_library;
+
 use crate::graph::{CrateGraph, CrateId, Dependency};
 use crate::hir_def::function::FuncMeta;
 use crate::node_interner::{FuncId, NodeInterner, StructId};


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*
Transforming after type unification made the code to transform the hir very brittle. Updated that transformation to happen before type unification. Also fixed for statements in aztec_library and updated the compute selector path.
<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
