### PR TITLE
chore: Formatter can now handle cast expressions

### DIFF
--- a/tooling/nargo_fmt/src/visitor/expr.rs
+++ b/tooling/nargo_fmt/src/visitor/expr.rs
@@ -25,7 +25,9 @@ impl FmtVisitor<'_> {
             ExpressionKind::Prefix(prefix) => {
                 format!("{}{}", prefix.operator, self.format_expr(prefix.rhs))
             }
-            // TODO:
+            ExpressionKind::Cast(cast) => {
+                format!("{} as {}", self.format_expr(cast.lhs), cast.r#type)
+            }
             _expr => slice!(self, span.start(), span.end()).to_string(),
         }
     }

--- a/tooling/nargo_fmt/tests/expected/cast.nr
+++ b/tooling/nargo_fmt/tests/expected/cast.nr
@@ -1,0 +1,3 @@
+fn main() {
+    x as u8
+}

--- a/tooling/nargo_fmt/tests/input/cast.nr
+++ b/tooling/nargo_fmt/tests/input/cast.nr
@@ -1,0 +1,3 @@
+fn main() {
+x  as  u8
+}


### PR DESCRIPTION
# Description

Related to #2933 

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
