### PR TITLE
fix: fix method `program_counter`, change method signature

### DIFF
--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -313,7 +313,7 @@ impl<'bb_solver, B: BlackBoxFunctionSolver> VM<'bb_solver, B> {
     }
 
     /// Returns the current value of the program counter.
-    pub fn program_counter(self) -> usize {
+    pub fn program_counter(&self) -> usize {
         self.program_counter
     }
 


### PR DESCRIPTION
# Description

The structure `VM` of crate `brillig_vm` has method `program_counter` that should return copy of field. The signature of method is wrong because the getter consumes instance. 

## Problem\*

Resolves issues of VM work. 

## Summary\*

The PR change one line in method `program_counter`, it changes type of self from `self` to `&self`. 

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
