### PR TITLE
feat: pass brillig bytecode to VM by reference

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -79,7 +79,7 @@ impl BrilligSolver {
         let mut vm = VM::new(
             input_registers,
             input_memory,
-            brillig.bytecode.clone(),
+            &brillig.bytecode,
             brillig.foreign_call_results.clone(),
             bb_solver,
         );

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -60,7 +60,7 @@ pub enum VMStatus {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// VM encapsulates the state of the Brillig VM during execution.
-pub struct VM<'bb_solver, B: BlackBoxFunctionSolver> {
+pub struct VM<'a, B: BlackBoxFunctionSolver> {
     /// Register storage
     registers: Registers,
     /// Instruction pointer
@@ -72,7 +72,7 @@ pub struct VM<'bb_solver, B: BlackBoxFunctionSolver> {
     /// List is appended onto by the caller upon reaching a [VMStatus::ForeignCallWait]
     foreign_call_results: Vec<ForeignCallResult>,
     /// Executable opcodes
-    bytecode: Vec<Opcode>,
+    bytecode: &'a [Opcode],
     /// Status of the VM
     status: VMStatus,
     /// Memory of the VM
@@ -80,17 +80,17 @@ pub struct VM<'bb_solver, B: BlackBoxFunctionSolver> {
     /// Call stack
     call_stack: Vec<Value>,
     /// The solver for blackbox functions
-    black_box_solver: &'bb_solver B,
+    black_box_solver: &'a B,
 }
 
-impl<'bb_solver, B: BlackBoxFunctionSolver> VM<'bb_solver, B> {
+impl<'a, B: BlackBoxFunctionSolver> VM<'a, B> {
     /// Constructs a new VM instance
     pub fn new(
         inputs: Registers,
         memory: Vec<Value>,
-        bytecode: Vec<Opcode>,
+        bytecode: &'a [Opcode],
         foreign_call_results: Vec<ForeignCallResult>,
-        black_box_solver: &'bb_solver B,
+        black_box_solver: &'a B,
     ) -> Self {
         Self {
             registers: inputs,
@@ -443,7 +443,8 @@ mod tests {
         };
 
         // Start VM
-        let mut vm = VM::new(input_registers, vec![], vec![opcode], vec![], &DummyBlackBoxSolver);
+        let opcodes = [opcode];
+        let mut vm = VM::new(input_registers, vec![], &opcodes, vec![], &DummyBlackBoxSolver);
 
         // Process a single VM opcode
         //
@@ -487,7 +488,7 @@ mod tests {
         opcodes.push(Opcode::JumpIf { condition: RegisterIndex::from(2), location: 3 });
 
         let mut vm =
-            VM::new(Registers::load(registers), vec![], opcodes, vec![], &DummyBlackBoxSolver);
+            VM::new(Registers::load(registers), vec![], &opcodes, vec![], &DummyBlackBoxSolver);
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
@@ -528,13 +529,9 @@ mod tests {
             destination: RegisterIndex::from(2),
         };
 
-        let mut vm = VM::new(
-            input_registers,
-            vec![],
-            vec![jump_opcode, trap_opcode, not_equal_cmp_opcode, jump_if_not_opcode, add_opcode],
-            vec![],
-            &DummyBlackBoxSolver,
-        );
+        let opcodes =
+            [jump_opcode, trap_opcode, not_equal_cmp_opcode, jump_if_not_opcode, add_opcode];
+        let mut vm = VM::new(input_registers, vec![], &opcodes, vec![], &DummyBlackBoxSolver);
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
@@ -571,8 +568,8 @@ mod tests {
         let mov_opcode =
             Opcode::Mov { destination: RegisterIndex::from(2), source: RegisterIndex::from(0) };
 
-        let mut vm =
-            VM::new(input_registers, vec![], vec![mov_opcode], vec![], &DummyBlackBoxSolver);
+        let opcodes = &[mov_opcode];
+        let mut vm = VM::new(input_registers, vec![], opcodes, vec![], &DummyBlackBoxSolver);
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::Finished);
@@ -629,13 +626,8 @@ mod tests {
             destination: RegisterIndex::from(2),
         };
 
-        let mut vm = VM::new(
-            input_registers,
-            vec![],
-            vec![equal_opcode, not_equal_opcode, less_than_opcode, less_than_equal_opcode],
-            vec![],
-            &DummyBlackBoxSolver,
-        );
+        let opcodes = [equal_opcode, not_equal_opcode, less_than_opcode, less_than_equal_opcode];
+        let mut vm = VM::new(input_registers, vec![], &opcodes, vec![], &DummyBlackBoxSolver);
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
@@ -705,7 +697,9 @@ mod tests {
                 // if tmp != 0 goto loop_body
                 Opcode::JumpIf { condition: r_tmp, location: start.len() },
             ];
-            let vm = brillig_execute_and_get_vm(memory, [&start[..], &loop_body[..]].concat());
+
+            let opcodes = [&start[..], &loop_body[..]].concat();
+            let vm = brillig_execute_and_get_vm(memory, &opcodes);
             vm.get_memory().clone()
         }
 
@@ -780,7 +774,9 @@ mod tests {
                 // if tmp != 0 goto loop_body
                 Opcode::JumpIf { condition: r_tmp, location: start.len() },
             ];
-            let vm = brillig_execute_and_get_vm(memory, [&start[..], &loop_body[..]].concat());
+
+            let opcodes = [&start[..], &loop_body[..]].concat();
+            let vm = brillig_execute_and_get_vm(memory, &opcodes);
             vm.registers.get(r_sum)
         }
 
@@ -858,7 +854,8 @@ mod tests {
                 Opcode::Return {},
             ];
 
-            let vm = brillig_execute_and_get_vm(memory, [&start[..], &recursive_fn[..]].concat());
+            let opcodes = [&start[..], &recursive_fn[..]].concat();
+            let vm = brillig_execute_and_get_vm(memory, &opcodes);
             vm.get_memory().clone()
         }
 
@@ -883,8 +880,8 @@ mod tests {
     /// Helper to execute brillig code
     fn brillig_execute_and_get_vm(
         memory: Vec<Value>,
-        opcodes: Vec<Opcode>,
-    ) -> VM<'static, DummyBlackBoxSolver> {
+        opcodes: &[Opcode],
+    ) -> VM<'_, DummyBlackBoxSolver> {
         let mut vm = VM::new(empty_registers(), memory, opcodes, vec![], &DummyBlackBoxSolver);
         brillig_execute(&mut vm);
         assert_eq!(vm.call_stack, vec![]);
@@ -917,7 +914,7 @@ mod tests {
             },
         ];
 
-        let mut vm = brillig_execute_and_get_vm(vec![], double_program);
+        let mut vm = brillig_execute_and_get_vm(vec![], &double_program);
 
         // Check that VM is waiting
         assert_eq!(
@@ -978,7 +975,7 @@ mod tests {
             },
         ];
 
-        let mut vm = brillig_execute_and_get_vm(initial_matrix.clone(), invert_program);
+        let mut vm = brillig_execute_and_get_vm(initial_matrix.clone(), &invert_program);
 
         // Check that VM is waiting
         assert_eq!(
@@ -1051,7 +1048,7 @@ mod tests {
             },
         ];
 
-        let mut vm = brillig_execute_and_get_vm(input_string.clone(), string_double_program);
+        let mut vm = brillig_execute_and_get_vm(input_string.clone(), &string_double_program);
 
         // Check that VM is waiting
         assert_eq!(
@@ -1113,7 +1110,7 @@ mod tests {
             },
         ];
 
-        let mut vm = brillig_execute_and_get_vm(initial_matrix.clone(), invert_program);
+        let mut vm = brillig_execute_and_get_vm(initial_matrix.clone(), &invert_program);
 
         // Check that VM is waiting
         assert_eq!(
@@ -1198,7 +1195,7 @@ mod tests {
         ];
         let mut initial_memory = matrix_a.clone();
         initial_memory.extend(matrix_b.clone());
-        let mut vm = brillig_execute_and_get_vm(initial_memory, matrix_mul_program);
+        let mut vm = brillig_execute_and_get_vm(initial_memory, &matrix_mul_program);
 
         // Check that VM is waiting
         assert_eq!(


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR is the equivalent to #2872 but for the Brillig VM.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
