### PR TITLE
fix: add `pub` modifier to grumpkin functions

### DIFF
--- a/noir_stdlib/src/grumpkin_scalar.nr
+++ b/noir_stdlib/src/grumpkin_scalar.nr
@@ -4,7 +4,7 @@ struct GrumpkinScalar {
 }
 
 impl GrumpkinScalar {
-    fn new(low: Field, high: Field) -> Self {
+    pub fn new(low: Field, high: Field) -> Self {
         // TODO: check that the low and high value fit within the grumpkin modulus
         GrumpkinScalar { low, high }
     }
@@ -12,10 +12,10 @@ impl GrumpkinScalar {
 
 global GRUMPKIN_SCALAR_SERIALIZED_LEN: Field = 2;
 
-fn deserialize_grumpkin_scalar(fields: [Field; GRUMPKIN_SCALAR_SERIALIZED_LEN]) -> GrumpkinScalar {
+pub fn deserialize_grumpkin_scalar(fields: [Field; GRUMPKIN_SCALAR_SERIALIZED_LEN]) -> GrumpkinScalar {
     GrumpkinScalar { low: fields[0], high: fields[1] }
 }
 
-fn serialize_grumpkin_scalar(scalar: GrumpkinScalar) -> [Field; GRUMPKIN_SCALAR_SERIALIZED_LEN] {
+pub fn serialize_grumpkin_scalar(scalar: GrumpkinScalar) -> [Field; GRUMPKIN_SCALAR_SERIALIZED_LEN] {
     [scalar.low, scalar.high]
 }

--- a/noir_stdlib/src/grumpkin_scalar_mul.nr
+++ b/noir_stdlib/src/grumpkin_scalar_mul.nr
@@ -1,7 +1,7 @@
 use crate::grumpkin_scalar::GrumpkinScalar;
 use crate::scalar_mul::fixed_base_embedded_curve;
 
-fn grumpkin_fixed_base(scalar: GrumpkinScalar) -> [Field; 2] {
+pub fn grumpkin_fixed_base(scalar: GrumpkinScalar) -> [Field; 2] {
     // TODO: this should use both the low and high limbs to do the scalar multiplication
     fixed_base_embedded_curve(scalar.low, scalar.high)
 }


### PR DESCRIPTION
# Description

This PR fixes an issue with compiling Aztec.nr packages with noir v0.16.0

## Problem\*

v0.16.0 of the compiler would error saying some functions were not publicly accessible from the Noir standard library.

## Summary\*

Adds `pub` modifiers to Grumpkin functions used in Aztec.nr.

## Documentation

N/A

## Additional Context

Related to AztecProtocol/aztec-packages#2644

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
