### PR TITLE
fix: prevent duplicated assert message transformation

### DIFF
--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -11,6 +11,7 @@ mod optimizers;
 mod transformers;
 
 pub use optimizers::optimize;
+use optimizers::optimize_internal;
 pub use transformers::transform;
 use transformers::transform_internal;
 
@@ -73,7 +74,12 @@ pub fn compile(
     np_language: Language,
     is_opcode_supported: impl Fn(&Opcode) -> bool,
 ) -> Result<(Circuit, AcirTransformationMap), CompileError> {
-    let (acir, AcirTransformationMap { acir_opcode_positions }) = optimize(acir);
+    let (acir, AcirTransformationMap { acir_opcode_positions }) = optimize_internal(acir);
 
-    transform_internal(acir, np_language, is_opcode_supported, acir_opcode_positions)
+    let (mut acir, transformation_map) =
+        transform_internal(acir, np_language, is_opcode_supported, acir_opcode_positions)?;
+
+    acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
+
+    Ok((acir, transformation_map))
 }

--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -14,12 +14,11 @@ use super::{transform_assert_messages, AcirTransformationMap};
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
 pub fn optimize(acir: Circuit) -> (Circuit, AcirTransformationMap) {
     let (mut acir, transformation_map) = optimize_internal(acir);
-    
+
     acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
 
     (acir, transformation_map)
 }
-
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
 pub(super) fn optimize_internal(acir: Circuit) -> (Circuit, AcirTransformationMap) {


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

`acvm::compiler::compile` builds up a transformation map over the optimization and transformation steps and transforms the assert messsages using this once at the end. https://github.com/noir-lang/noir/pull/3010 broke assert message transformations as it applied the map after the optimization transformation resulting in the final transformation map being incorrect.

## Summary\*

This PR fixes #3010 by adding an internal optimize function which avoids this extra transformation.


## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
