### PR TITLE
fix: include .nr and .sol files in builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
           # Custom filter with various file extensions that we rely upon to build packages
           # Currently: `.nr`, `.sol`, `.sh`, `.json`, `.md`
           filter = path: type:
-            (builtins.match ".*\.(sh|json|md)$" path != null) || (craneLib.filterCargoSources path type);
+            (builtins.match ".*\.(nr|sol|sh|json|md)$" path != null) || (craneLib.filterCargoSources path type);
         };
 
         # TODO(#1198): It'd be nice to include these flags when running `cargo clippy` in a devShell.


### PR DESCRIPTION
# Description

This PR restores an older Nix filter to include `.nr` and `.sol` files in builds.

## Problem\*

WASM builds of the compiler would fail compiling because they couldn't add `noir_stdlib` to the build.

## Summary\*

The stdlib wasn't being embedded into the wasm file. The output wasm file was lighter (~1.2MB lighter compared to previous builds) but it couldn't compile contracts.

## Documentation

N/A

## Additional Context

N/A

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

Thanks @sirasistant for the help debugging this!
