### PR TITLE
chore: make paths in `wasm` tests absolute

### DIFF
--- a/compiler/wasm/test/node/index.test.ts
+++ b/compiler/wasm/test/node/index.test.ts
@@ -4,19 +4,18 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile } from '@noir-lang/noir_wasm';
 
-async function getFileContent(path: string): Promise<string> {
-  return readFileSync(join(__dirname, path)).toString();
-}
+const absoluteNoirSourcePath = join(__dirname, noirSourcePath);
+const absoluteNargoArtifactPath = join(__dirname, nargoArtifactPath);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getPrecompiledSource(): Promise<any> {
-  const compiledData = await getFileContent(nargoArtifactPath);
+  const compiledData = readFileSync(absoluteNargoArtifactPath).toString();
   return JSON.parse(compiledData);
 }
 
 describe('noir wasm compilation', () => {
   it('matches nargos compilation', async () => {
-    const wasmCircuit = await compile(noirSourcePath);
+    const wasmCircuit = await compile(absoluteNoirSourcePath);
     const cliCircuit = await getPrecompiledSource();
 
     // We don't expect the hashes to match due to how `noir_wasm` handles dependencies


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR fixes the CI failure in #3039 by making the paths provided to `noir_wasm` absolute.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
