### PR TITLE
fix: Parse parenthesized lvalues

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -409,7 +409,7 @@ impl<'interner> TypeChecker<'interner> {
         });
 
         let lhs_type = self.check_expression(&index_expr.collection);
-        match lhs_type {
+        match lhs_type.follow_bindings() {
             // XXX: We can check the array bounds here also, but it may be better to constant fold first
             // and have ConstId instead of ExprId for constants
             Type::Array(_, base_type) => *base_type,

--- a/compiler/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/stmt.rs
@@ -227,16 +227,16 @@ impl<'interner> TypeChecker<'interner> {
                     },
                 );
 
-                let (result, array) = self.check_lvalue(*array, assign_span);
+                let (array_type, array) = self.check_lvalue(*array, assign_span);
                 let array = Box::new(array);
 
-                let typ = match result {
+                let typ = match array_type.follow_bindings() {
                     Type::Array(_, elem_type) => *elem_type,
                     Type::Error => Type::Error,
                     other => {
                         // TODO: Need a better span here
                         self.errors.push(TypeCheckError::TypeMismatch {
-                            expected_typ: "an array".to_string(),
+                            expected_typ: "array".to_string(),
                             expr_typ: other.to_string(),
                             expr_span: assign_span,
                         });
@@ -252,6 +252,7 @@ impl<'interner> TypeChecker<'interner> {
 
                 let element_type = Type::type_variable(self.interner.next_type_variable_id());
                 let expected_type = Type::MutableReference(Box::new(element_type.clone()));
+
                 self.unify(&reference_type, &expected_type, || TypeCheckError::TypeMismatch {
                     expected_typ: expected_type.to_string(),
                     expr_typ: reference_type.to_string(),

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -948,29 +948,34 @@ enum LValueRhs {
     Index(Expression),
 }
 
-fn lvalue<'a, P>(expr_parser: P) -> impl NoirParser<LValue>
+fn lvalue<'a, P>(expr_parser: P) -> impl NoirParser<LValue> + 'a
 where
     P: ExprParser + 'a,
 {
-    let l_ident = ident().map(LValue::Ident);
+    recursive(|lvalue| {
+        let l_ident = ident().map(LValue::Ident);
 
-    let l_member_rhs = just(Token::Dot).ignore_then(field_name()).map(LValueRhs::MemberAccess);
+        let dereferences = just(Token::Star)
+            .ignore_then(lvalue.clone())
+            .map(|lvalue| LValue::Dereference(Box::new(lvalue)));
 
-    let l_index = expr_parser
-        .delimited_by(just(Token::LeftBracket), just(Token::RightBracket))
-        .map(LValueRhs::Index);
+        let parenthesized = lvalue.delimited_by(just(Token::LeftParen), just(Token::RightParen));
 
-    let dereferences = just(Token::Star).repeated();
+        let term = choice((parenthesized, dereferences, l_ident));
 
-    let lvalues =
-        l_ident.then(l_member_rhs.or(l_index).repeated()).foldl(|lvalue, rhs| match rhs {
+        let l_member_rhs = just(Token::Dot).ignore_then(field_name()).map(LValueRhs::MemberAccess);
+
+        let l_index = expr_parser
+            .delimited_by(just(Token::LeftBracket), just(Token::RightBracket))
+            .map(LValueRhs::Index);
+
+        term.then(l_member_rhs.or(l_index).repeated()).foldl(|lvalue, rhs| match rhs {
             LValueRhs::MemberAccess(field_name) => {
                 LValue::MemberAccess { object: Box::new(lvalue), field_name }
             }
             LValueRhs::Index(index) => LValue::Index { array: Box::new(lvalue), index },
-        });
-
-    dereferences.then(lvalues).foldr(|_, lvalue| LValue::Dereference(Box::new(lvalue)))
+        })
+    })
 }
 
 fn parse_type<'a>() -> impl NoirParser<UnresolvedType> + 'a {

--- a/tooling/nargo_cli/tests/execution_success/assign_ex/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/assign_ex/src/main.nr
@@ -3,4 +3,13 @@ fn main(x: Field, y: Field) {
     assert(z == 3);
     z = x * y;
     assert(z == 2);
+
+    regression_3057();
+}
+
+// Ensure parsing parenthesized lvalues works
+fn regression_3057() {
+    let mut array = [[0, 1], [2, 3]];
+    (array[0])[1] = 2;
+    assert(array[0][1] == 2);
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #3057

## Summary\*

The left hand side of an assignment previously did not allow any parenthesis. This made parsing something like `(*a)[0]` impossible since doing `*a[0]` would dereference the result of the index rather than the other way around. This PR also fixes 2 quick, related type errors to the issue.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
