### PR TITLE
chore: disable yarn immutable

### DIFF
--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -87,7 +87,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Install Yarn dependencies
-        run: yarn install
+        run: YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
       - name: Build ES Packages
         run: yarn prepare:publish

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,6 +1020,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@noir-lang/types@workspace:tooling/noir_js_types"
   dependencies:
+    "@noir-lang/noirc_abi": "workspace:*"
     "@types/prettier": ^3
     eslint: ^8.50.0
     eslint-plugin-prettier: ^5.0.0


### PR DESCRIPTION
# Description

When `yarn install` is run with `env.CI=true` it operates with `YARN_ENABLE_IMMUTABLE_INSTALLS=true`. 
Disabling this in workflow will prevent failure.

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
