### PR TITLE
chore: make backend instantiate available

### DIFF
--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -22,7 +22,7 @@ export class BarretenbergBackend implements Backend {
     this.acirUncompressedBytecode = acirToUint8Array(acirBytecodeBase64);
   }
 
-  private async instantiate(): Promise<void> {
+  async instantiate(): Promise<void> {
     if (!this.api) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore


### PR DESCRIPTION
# Description

Makes `BarretenbergBackend.instantiate()` available for user to call.

This makes api consistent with `noir_js` approach to lazilly instatiate when user does not choose to do so upfront, while enabling user to initialize before any execution steps.

This is to wrap: Cleanup Noir.js#2910

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
