### PR TITLE
chore: simple lint api

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -97,8 +97,6 @@ pub enum TypeCheckError {
     },
     #[error("Cannot infer type of expression, type annotations needed before this point")]
     TypeAnnotationsNeeded { span: Span },
-    #[error("use of deprecated function {name}")]
-    CallDeprecated { name: String, note: Option<String>, span: Span },
     #[error("{0}")]
     ResolverError(ResolverError),
     #[error("Unused expression result of type {expr_type}")]
@@ -242,12 +240,6 @@ impl From<TypeCheckError> for Diagnostic {
                 };
 
                 Diagnostic::simple_error(message, String::new(), span)
-            }
-            TypeCheckError::CallDeprecated { span, ref note, .. } => {
-                let primary_message = error.to_string();
-                let secondary_message = note.clone().unwrap_or_default();
-
-                Diagnostic::simple_warning(primary_message, secondary_message, span)
             }
             TypeCheckError::UnusedResultError { expr_type, expr_span } => {
                 Diagnostic::simple_warning(

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -10,31 +10,13 @@ use crate::{
         },
         types::Type,
     },
-    node_interner::{DefinitionKind, ExprId, FuncId, TraitMethodId},
+    node_interner::{ExprId, FuncId, TraitMethodId},
     BinaryOpKind, Signedness, TypeBinding, TypeVariableKind, UnaryOp,
 };
 
 use super::{errors::TypeCheckError, TypeChecker};
 
 impl<'interner> TypeChecker<'interner> {
-    fn check_if_deprecated(&mut self, expr: &ExprId) {
-        if let HirExpression::Ident(expr::HirIdent { location, id }) =
-            self.interner.expression(expr)
-        {
-            if let Some(DefinitionKind::Function(func_id)) =
-                self.interner.try_definition(id).map(|def| &def.kind)
-            {
-                let attributes = self.interner.function_attributes(func_id);
-                if let Some(note) = attributes.get_deprecated_note() {
-                    self.errors.push(TypeCheckError::CallDeprecated {
-                        name: self.interner.definition_name(id).to_string(),
-                        note,
-                        span: location.span,
-                    });
-                }
-            }
-        }
-    }
     /// Infers a type for a given expression, and return this type.
     /// As a side-effect, this function will also remember this type in the NodeInterner
     /// for the given expr_id key.
@@ -130,8 +112,6 @@ impl<'interner> TypeChecker<'interner> {
             }
             HirExpression::Index(index_expr) => self.check_index_expression(index_expr),
             HirExpression::Call(call_expr) => {
-                self.check_if_deprecated(&call_expr.func);
-
                 let function = self.check_expression(&call_expr.func);
                 let args = vecmap(&call_expr.arguments, |arg| {
                     let typ = self.check_expression(arg);

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -19,6 +19,7 @@ pub mod parser;
 
 pub mod hir;
 pub mod hir_def;
+mod lint;
 
 // Lexer API
 pub use lexer::token;

--- a/compiler/noirc_frontend/src/lint/deprecated.rs
+++ b/compiler/noirc_frontend/src/lint/deprecated.rs
@@ -1,0 +1,31 @@
+use super::{Lint, LintDiagnostic};
+use crate::hir_def::expr::{HirExpression, HirIdent};
+use crate::node_interner::{DefinitionKind, NodeInterner};
+
+pub(crate) struct Deprecated<'me> {
+    pub(crate) interner: &'me NodeInterner,
+    pub(crate) diagnostics: Vec<LintDiagnostic>,
+}
+
+impl Lint for Deprecated<'_> {
+    fn check_expr(&mut self, expr: &HirExpression) {
+        if let HirExpression::Ident(HirIdent { location, id }) = expr {
+            if let Some(DefinitionKind::Function(func_id)) =
+                self.interner.try_definition(*id).map(|def| &def.kind)
+            {
+                let attributes = self.interner.function_attributes(func_id);
+                if let Some(note) = attributes.get_deprecated_note() {
+                    self.diagnostics.push(LintDiagnostic::Deprecated {
+                        name: self.interner.definition_name(*id).to_string(),
+                        note,
+                        span: location.span,
+                    });
+                }
+            }
+        }
+    }
+
+    fn finish(&mut self) -> Vec<LintDiagnostic> {
+        std::mem::take(&mut self.diagnostics)
+    }
+}

--- a/compiler/noirc_frontend/src/lint/mod.rs
+++ b/compiler/noirc_frontend/src/lint/mod.rs
@@ -1,0 +1,160 @@
+mod deprecated;
+
+use fm::FileId;
+use noirc_errors::{CustomDiagnostic, Span};
+
+use crate::{
+    hir::def_collector::dc_crate::CompilationError,
+    hir_def::{expr::HirExpression, function::HirFunction, stmt::HirStatement},
+    node_interner::{ExprId, FuncId, NodeInterner, StmtId},
+};
+
+#[derive(Debug, Clone)]
+pub enum LintDiagnostic {
+    Deprecated { name: String, note: Option<String>, span: Span },
+}
+
+impl From<LintDiagnostic> for noirc_errors::CustomDiagnostic {
+    fn from(value: LintDiagnostic) -> Self {
+        match value {
+            LintDiagnostic::Deprecated { name, note, span } => {
+                let primary_message = format!("use of deprecated function {name}");
+                let secondary_message = note.unwrap_or_default();
+
+                CustomDiagnostic::simple_warning(primary_message, secondary_message, span)
+            }
+        }
+    }
+}
+
+pub(crate) fn functions(
+    interner: &NodeInterner,
+    func_ids: &[(FileId, FuncId)],
+) -> Vec<(CompilationError, fm::FileId)> {
+    func_ids
+        .iter()
+        .flat_map(|(file_id, func_id)| {
+            function(interner, *func_id).into_iter().map(|diagnostic| (diagnostic.into(), *file_id))
+        })
+        .collect()
+}
+
+fn function(interner: &NodeInterner, func_id: FuncId) -> Vec<LintDiagnostic> {
+    let mut out = Vec::new();
+    let lints: [&mut dyn Lint; 1] =
+        [&mut deprecated::Deprecated { interner, diagnostics: Vec::new() }];
+
+    for lint in lints {
+        let mut visitor = Visitor { interner, lint };
+        visitor.visit_func(func_id);
+
+        out.extend(visitor.lint.finish());
+    }
+
+    out
+}
+
+struct Visitor<'me> {
+    interner: &'me NodeInterner,
+    lint: &'me mut dyn Lint,
+}
+
+impl<'me> Visitor<'me> {
+    fn visit_func(&mut self, func_id: FuncId) {
+        let func = self.interner.function(&func_id);
+        let body = *func.as_expr();
+
+        self.lint.check_func(func_id);
+        self.lint.check_func_body(func);
+
+        self.visit_expr(body);
+    }
+
+    fn visit_expr(&mut self, expr_id: ExprId) {
+        let expr = self.interner.expression(&expr_id);
+        self.lint.check_expr(&expr);
+
+        match expr {
+            HirExpression::Ident(_) | HirExpression::Literal(_) => {}
+            HirExpression::Block(block) => {
+                for stmt_id in block.0 {
+                    self.visit_stmt(stmt_id);
+                }
+            }
+            HirExpression::Prefix(prefix) => {
+                self.visit_expr(prefix.rhs);
+            }
+            HirExpression::Infix(infix) => {
+                self.visit_expr(infix.lhs);
+                self.visit_expr(infix.rhs);
+            }
+            HirExpression::Index(index) => {
+                self.visit_expr(index.collection);
+                self.visit_expr(index.index);
+            }
+            HirExpression::Constructor(constructor) => {
+                for (_field_name, field) in constructor.fields {
+                    self.visit_expr(field);
+                }
+            }
+            HirExpression::MemberAccess(member_access) => {
+                self.visit_expr(member_access.lhs);
+            }
+            HirExpression::Call(call) => {
+                self.visit_expr(call.func);
+
+                for arg in call.arguments {
+                    self.visit_expr(arg);
+                }
+            }
+            HirExpression::MethodCall(_) => todo!(),
+            HirExpression::Cast(cast) => {
+                self.visit_expr(cast.lhs);
+            }
+            HirExpression::If(if_expr) => {
+                self.visit_expr(if_expr.condition);
+                self.visit_expr(if_expr.consequence);
+
+                if let Some(alternative) = if_expr.alternative {
+                    self.visit_expr(alternative);
+                }
+            }
+            HirExpression::Tuple(tuple) => {
+                for expr in tuple {
+                    self.visit_expr(expr);
+                }
+            }
+            HirExpression::Lambda(_) => todo!(),
+            HirExpression::TraitMethodReference(_, _) => todo!(),
+            HirExpression::Error => todo!(),
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt_id: StmtId) {
+        match self.interner.statement(&stmt_id) {
+            HirStatement::Let(let_stmt) => {
+                self.visit_expr(let_stmt.expression);
+            }
+            HirStatement::Constrain(constrain) => {
+                self.visit_expr(constrain.0);
+            }
+            HirStatement::Assign(assign) => {
+                self.visit_expr(assign.expression);
+            }
+            HirStatement::For(for_stmt) => {
+                self.visit_expr(for_stmt.start_range);
+                self.visit_expr(for_stmt.end_range);
+                self.visit_expr(for_stmt.block);
+            }
+            HirStatement::Expression(expr) | HirStatement::Semi(expr) => self.visit_expr(expr),
+            HirStatement::Error => {}
+        }
+    }
+}
+
+trait Lint {
+    fn check_func(&mut self, _func: FuncId) {}
+    fn check_func_body(&mut self, _func: HirFunction) {}
+    fn check_expr(&mut self, _expr: &HirExpression) {}
+    fn finish(&mut self) -> Vec<LintDiagnostic>;
+}


### PR DESCRIPTION
# Description

TODO

## Problem

Resolves TODO

## Summary

* Simple API linter.
* Moved the deprecated checking logic from the type checker to the linter.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
