### PR TITLE
feat: Implement automatic dereferencing for index expressions

### DIFF
--- a/tooling/nargo_cli/tests/compile_success_empty/auto_deref/Nargo.toml
+++ b/tooling/nargo_cli/tests/compile_success_empty/auto_deref/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "auto_deref"
+type = "bin"
+authors = [""]
+compiler_version = "0.16.0"
+
+[dependencies]

--- a/tooling/nargo_cli/tests/compile_success_empty/auto_deref/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/auto_deref/src/main.nr
@@ -1,0 +1,5 @@
+
+fn main() {
+    let a = &mut [1, 2, 3];
+    assert(a[0] == 1);
+}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves part of #3042

## Summary\*

Implements automatic dereferencing when indexing references pointing to arrays. Notably, this PR does not include automatic dereferencing for lvalues on the lhs of an assignment so `a[0] = 1;` will not work if `a : &mut [Field]`, yet `a[0]` in an expression context will. I'm going to split the handling of lvalues into another PR.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
