### PR TITLE
feat: adding destroy and options object

### DIFF
--- a/tooling/noir_js/src/program.ts
+++ b/tooling/noir_js/src/program.ts
@@ -5,7 +5,7 @@ import initAbi, { abiDecode, InputMap, InputValue } from '@noir-lang/noirc_abi';
 import initACVM from '@noir-lang/acvm_js';
 import { witnessMapToUint8Array } from './serialize.js';
 
-export class Noir implements Noir {
+export class Noir {
   constructor(
     private circuit: CompiledCircuit,
     private backend?: Backend,

--- a/tooling/noir_js/src/program.ts
+++ b/tooling/noir_js/src/program.ts
@@ -5,7 +5,7 @@ import initAbi, { abiDecode, InputMap, InputValue } from '@noir-lang/noirc_abi';
 import initACVM from '@noir-lang/acvm_js';
 import { witnessMapToUint8Array } from './serialize.js';
 
-export class Noir {
+export class Noir implements Noir {
   constructor(
     private circuit: CompiledCircuit,
     private backend?: Backend,
@@ -18,6 +18,10 @@ export class Noir {
     if (typeof initAbi === 'function') {
       await Promise.all([initAbi(), initACVM()]);
     }
+  }
+
+  async destroy(): Promise<void> {
+    await this.backend?.destroy();
   }
 
   private getBackend(): Backend {

--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -20,7 +20,6 @@ export class BarretenbergBackend implements Backend {
     private options: BackendOptions = { threads: 1 },
   ) {
     const acirBytecodeBase64 = acirCircuit.bytecode;
-    this.options = options;
     this.acirUncompressedBytecode = acirToUint8Array(acirBytecodeBase64);
   }
 

--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import { acirToUint8Array } from './serialize.js';
-import { Backend, CompiledCircuit, ProofData } from '@noir-lang/types';
+import { Backend, BackendOptions, CompiledCircuit, ProofData } from '@noir-lang/types';
 
 // This is the number of bytes in a UltraPlonk proof
 // minus the public inputs.
@@ -14,11 +14,13 @@ export class BarretenbergBackend implements Backend {
   private api: any;
   private acirComposer: any;
   private acirUncompressedBytecode: Uint8Array;
-  private numberOfThreads = 1;
 
-  constructor(acirCircuit: CompiledCircuit, numberOfThreads = 1) {
+  constructor(
+    acirCircuit: CompiledCircuit,
+    private options: BackendOptions = { threads: 1 },
+  ) {
     const acirBytecodeBase64 = acirCircuit.bytecode;
-    this.numberOfThreads = numberOfThreads;
+    this.options = options;
     this.acirUncompressedBytecode = acirToUint8Array(acirBytecodeBase64);
   }
 
@@ -27,7 +29,7 @@ export class BarretenbergBackend implements Backend {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
       const { Barretenberg, RawBuffer, Crs } = await import('@aztec/bb.js');
-      const api = await Barretenberg.new(this.numberOfThreads);
+      const api = await Barretenberg.new(this.options.threads);
 
       const [_exact, _total, subgroupSize] = await api.acirGetCircuitSizes(this.acirUncompressedBytecode);
       const crs = await Crs.new(subgroupSize + 1);

--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import { acirToUint8Array } from './serialize.js';
-import { Backend, BackendOptions, CompiledCircuit, ProofData } from '@noir-lang/types';
+import { Backend, CompiledCircuit, ProofData } from '@noir-lang/types';
+import { BackendOptions } from './types.js';
 
 // This is the number of bytes in a UltraPlonk proof
 // minus the public inputs.

--- a/tooling/noir_js_backend_barretenberg/src/types.ts
+++ b/tooling/noir_js_backend_barretenberg/src/types.ts
@@ -1,0 +1,3 @@
+export type BackendOptions = {
+  threads: number;
+};

--- a/tooling/noir_js_types/src/types.ts
+++ b/tooling/noir_js_types/src/types.ts
@@ -1,8 +1,14 @@
 import { Abi } from '@noir-lang/noirc_abi';
 
 export interface Backend {
+  // Generate an outer proof. This is the proof for the circuit which will verify
+  // inner proofs and or can be seen as the proof created for regular circuits.
   generateFinalProof(decompressedWitness: Uint8Array): Promise<ProofData>;
+
+  // Generates an inner proof. This is the proof that will be verified
+  // in another circuit.
   generateIntermediateProof(decompressedWitness: Uint8Array): Promise<ProofData>;
+
   verifyFinalProof(proofData: ProofData): Promise<boolean>;
   verifyIntermediateProof(proofData: ProofData): Promise<boolean>;
   destroy(): Promise<void>;

--- a/tooling/noir_js_types/src/types.ts
+++ b/tooling/noir_js_types/src/types.ts
@@ -1,18 +1,16 @@
 import { Abi } from '@noir-lang/noirc_abi';
 
 export interface Backend {
-  // Generate an outer proof. This is the proof for the circuit which will verify
-  // inner proofs and or can be seen as the proof created for regular circuits.
   generateFinalProof(decompressedWitness: Uint8Array): Promise<ProofData>;
-
-  // Generates an inner proof. This is the proof that will be verified
-  // in another circuit.
   generateIntermediateProof(decompressedWitness: Uint8Array): Promise<ProofData>;
-
   verifyFinalProof(proofData: ProofData): Promise<boolean>;
-
   verifyIntermediateProof(proofData: ProofData): Promise<boolean>;
+  destroy(): Promise<void>;
 }
+
+export type BackendOptions = {
+  threads: number;
+};
 
 export type ProofData = {
   publicInputs: Uint8Array[];

--- a/tooling/noir_js_types/src/types.ts
+++ b/tooling/noir_js_types/src/types.ts
@@ -14,10 +14,6 @@ export interface Backend {
   destroy(): Promise<void>;
 }
 
-export type BackendOptions = {
-  threads: number;
-};
-
 export type ProofData = {
   publicInputs: Uint8Array[];
   proof: Uint8Array;


### PR DESCRIPTION
# Description

Working on autogenerated docs at #3035 I came up with some improvements to UX and Devex for NoirJS.

## Problem\*

Not really a problem, just addressing some DevEx concerns and UX. Before this PR, standard usage was:

```js
const backend = new BarretenbergBackend(circuit, 4);
const noir = new Noir(circuit, backend);
```

This could be improved

## Summary\*

- It adds the destroy method to proxy to backend_barretenberg, saving user's resources.
- Adds an "options" object that is passed to the initialisation of barretenberg:
```js
// previously
new Backend(circuit, 4) // what's the 4?

// now
new Backend(circuit { numOfThreads : 4}) // oh it's the number of threads!
```

BEGIN_COMMIT_OVERRIDE
feat: Add `destroy` method to `Noir` (#3105)
feat: Add an options object to `BarretenbergBackend` constructor (#3105)
END_COMMIT_OVERRIDE
