### PR TITLE
feat: Implement copy on write optimization for arrays in brillig

### DIFF
--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -24,6 +24,7 @@ impl From<usize> for RegisterIndex {
 pub struct HeapArray {
     pub pointer: RegisterIndex,
     pub size: usize,
+    pub reference_count: RegisterIndex,
 }
 
 /// A register-sized vector passed starting from a Brillig register memory location and with a register-held size
@@ -31,6 +32,7 @@ pub struct HeapArray {
 pub struct HeapVector {
     pub pointer: RegisterIndex,
     pub size: RegisterIndex,
+    pub reference_count: RegisterIndex,
 }
 
 /// Lays out various ways an external foreign call's input and output data may be interpreted inside Brillig.

--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -24,7 +24,6 @@ impl From<usize> for RegisterIndex {
 pub struct HeapArray {
     pub pointer: RegisterIndex,
     pub size: usize,
-    pub reference_count: RegisterIndex,
 }
 
 /// A register-sized vector passed starting from a Brillig register memory location and with a register-held size
@@ -32,7 +31,6 @@ pub struct HeapArray {
 pub struct HeapVector {
     pub pointer: RegisterIndex,
     pub size: RegisterIndex,
-    pub reference_count: RegisterIndex,
 }
 
 /// Lays out various ways an external foreign call's input and output data may be interpreted inside Brillig.

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -221,7 +221,7 @@ impl<'a, B: BlackBoxFunctionSolver> VM<'a, B> {
                                 "Function result size does not match brillig bytecode (expected 1 result)"
                             ),
                         },
-                        RegisterOrMemory::HeapArray(HeapArray { pointer: pointer_index, size }) => {
+                        RegisterOrMemory::HeapArray(HeapArray { pointer, size, reference_count }) => {
                             match output {
                                 ForeignCallParam::Array(values) => {
                                     if values.len() != *size {
@@ -229,22 +229,24 @@ impl<'a, B: BlackBoxFunctionSolver> VM<'a, B> {
                                         break;
                                     }
                                     // Convert the destination pointer to a usize
-                                    let destination = self.registers.get(*pointer_index).to_usize();
+                                    let destination = self.registers.get(*pointer).to_usize();
                                     // Write to our destination memory
                                     self.memory.write_slice(destination, values);
+                                    self.registers.set(*reference_count, Value::from(1usize));
                                 }
                                 _ => {
                                     unreachable!("Function result size does not match brillig bytecode size")
                                 }
                             }
                         }
-                        RegisterOrMemory::HeapVector(HeapVector { pointer: pointer_index, size: size_index }) => {
+                        RegisterOrMemory::HeapVector(HeapVector { pointer, size, reference_count }) => {
                             match output {
                                 ForeignCallParam::Array(values) => {
                                     // Set our size in the size register
-                                    self.registers.set(*size_index, Value::from(values.len()));
+                                    self.registers.set(*size, Value::from(values.len()));
+                                    self.registers.set(*reference_count, Value::from(1_usize));
                                     // Convert the destination pointer to a usize
-                                    let destination = self.registers.get(*pointer_index).to_usize();
+                                    let destination = self.registers.get(*pointer).to_usize();
                                     // Write to our destination memory
                                     self.memory.write_slice(destination, values);
                                 }
@@ -337,16 +339,13 @@ impl<'a, B: BlackBoxFunctionSolver> VM<'a, B> {
     fn get_register_value_or_memory_values(&self, input: RegisterOrMemory) -> ForeignCallParam {
         match input {
             RegisterOrMemory::RegisterIndex(value_index) => self.registers.get(value_index).into(),
-            RegisterOrMemory::HeapArray(HeapArray { pointer: pointer_index, size }) => {
-                let start = self.registers.get(pointer_index);
+            RegisterOrMemory::HeapArray(HeapArray { pointer, size, reference_count: _ }) => {
+                let start = self.registers.get(pointer);
                 self.memory.read_slice(start.to_usize(), size).to_vec().into()
             }
-            RegisterOrMemory::HeapVector(HeapVector {
-                pointer: pointer_index,
-                size: size_index,
-            }) => {
-                let start = self.registers.get(pointer_index);
-                let size = self.registers.get(size_index);
+            RegisterOrMemory::HeapVector(HeapVector { pointer, size, reference_count: _ }) => {
+                let start = self.registers.get(pointer);
+                let size = self.registers.get(size);
                 self.memory.read_slice(start.to_usize(), size.to_usize()).to_vec().into()
             }
         }
@@ -943,10 +942,13 @@ mod tests {
         // Ensure the foreign call counter has been incremented
         assert_eq!(vm.foreign_call_counter, 1);
     }
+
     #[test]
     fn foreign_call_opcode_memory_result() {
         let r_input = RegisterIndex::from(0);
         let r_output = RegisterIndex::from(1);
+
+        let reference_count = RegisterIndex::from(2);
 
         // Define a simple 2x2 matrix in memory
         let initial_matrix =
@@ -967,10 +969,12 @@ mod tests {
                 destinations: vec![RegisterOrMemory::HeapArray(HeapArray {
                     pointer: r_output,
                     size: initial_matrix.len(),
+                    reference_count,
                 })],
                 inputs: vec![RegisterOrMemory::HeapArray(HeapArray {
                     pointer: r_input,
                     size: initial_matrix.len(),
+                    reference_count,
                 })],
             },
         ];
@@ -1008,9 +1012,11 @@ mod tests {
     fn foreign_call_opcode_vector_input_and_output() {
         let r_input_pointer = RegisterIndex::from(0);
         let r_input_size = RegisterIndex::from(1);
+        let r_input_rc = RegisterIndex::from(2);
         // We need to pass a location of appropriate size
-        let r_output_pointer = RegisterIndex::from(2);
-        let r_output_size = RegisterIndex::from(3);
+        let r_output_pointer = RegisterIndex::from(3);
+        let r_output_size = RegisterIndex::from(4);
+        let r_output_rc = RegisterIndex::from(5);
 
         // Our first string to use the identity function with
         let input_string =
@@ -1040,10 +1046,12 @@ mod tests {
                 destinations: vec![RegisterOrMemory::HeapVector(HeapVector {
                     pointer: r_output_pointer,
                     size: r_output_size,
+                    reference_count: r_output_rc,
                 })],
                 inputs: vec![RegisterOrMemory::HeapVector(HeapVector {
                     pointer: r_input_pointer,
                     size: r_input_size,
+                    reference_count: r_input_rc,
                 })],
             },
         ];
@@ -1083,6 +1091,9 @@ mod tests {
         let r_input = RegisterIndex::from(0);
         let r_output = RegisterIndex::from(1);
 
+        let r_input_rc = RegisterIndex::from(2);
+        let r_output_rc = RegisterIndex::from(3);
+
         // Define a simple 2x2 matrix in memory
         let initial_matrix =
             vec![Value::from(1u128), Value::from(2u128), Value::from(3u128), Value::from(4u128)];
@@ -1102,10 +1113,12 @@ mod tests {
                 destinations: vec![RegisterOrMemory::HeapArray(HeapArray {
                     pointer: r_output,
                     size: initial_matrix.len(),
+                    reference_count: r_output_rc,
                 })],
                 inputs: vec![RegisterOrMemory::HeapArray(HeapArray {
                     pointer: r_input,
                     size: initial_matrix.len(),
+                    reference_count: r_input_rc,
                 })],
             },
         ];
@@ -1148,6 +1161,9 @@ mod tests {
         let r_input_b = RegisterIndex::from(1);
         let r_output = RegisterIndex::from(2);
 
+        let r_input_rc = RegisterIndex::from(3);
+        let r_output_rc = RegisterIndex::from(4);
+
         // Define a simple 2x2 matrix in memory
         let matrix_a =
             vec![Value::from(1u128), Value::from(2u128), Value::from(3u128), Value::from(4u128)];
@@ -1180,15 +1196,18 @@ mod tests {
                 destinations: vec![RegisterOrMemory::HeapArray(HeapArray {
                     pointer: r_output,
                     size: matrix_a.len(),
+                    reference_count: r_output_rc,
                 })],
                 inputs: vec![
                     RegisterOrMemory::HeapArray(HeapArray {
                         pointer: r_input_a,
                         size: matrix_a.len(),
+                        reference_count: r_input_rc,
                     }),
                     RegisterOrMemory::HeapArray(HeapArray {
                         pointer: r_input_b,
                         size: matrix_b.len(),
+                        reference_count: r_input_rc,
                     }),
                 ],
             },

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -563,7 +563,7 @@ impl<'block> BrilligBlock<'block> {
                 };
 
                 let operator = BrilligBinaryOp::Field { op: BinaryFieldOp::Add };
-                let one = self.brillig_context.make_constant(0_usize.into());
+                let one = self.brillig_context.make_constant(1_usize.into());
 
                 // TODO: Does this work for += 1?
                 self.brillig_context.binary_instruction(rc_register, one, rc_register, operator);
@@ -694,7 +694,7 @@ impl<'block> BrilligBlock<'block> {
             _ => unreachable!("ICE: array set on non-array"),
         };
 
-        let one = self.brillig_context.make_constant(0_usize.into());
+        let one = self.brillig_context.make_constant(1_usize.into());
         let condition = self.brillig_context.allocate_register();
         self.brillig_context.binary_instruction(
             reference_count,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -1121,7 +1121,7 @@ impl<'block> BrilligBlock<'block> {
                     new_variable
                 }
             }
-            _ => {
+            Value::Function(_) | Value::Intrinsic(_) | Value::ForeignFunction(_) => {
                 todo!("ICE: Cannot convert value {value:?}")
             }
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -213,7 +213,7 @@ impl<'block> BrilligBlock<'block> {
                 // In the case of arrays, the values should already be in memory and the register should
                 // Be a valid pointer to the array.
                 // For slices, two registers are passed, the pointer to the data and a register holding the size of the slice.
-                Type::Numeric(_) | Type::Array(..) | Type::Slice(..) | Type::Reference => {
+                Type::Numeric(_) | Type::Array(..) | Type::Slice(..) | Type::Reference(_) => {
                     self.variables.get_block_param(
                         self.function_context,
                         self.block_id,
@@ -1220,7 +1220,7 @@ pub(crate) fn type_of_binary_operation(lhs_type: &Type, rhs_type: &Type) -> Type
         (_, Type::Function) | (Type::Function, _) => {
             unreachable!("Functions are invalid in binary operations")
         }
-        (_, Type::Reference) | (Type::Reference, _) => {
+        (_, Type::Reference(_)) | (Type::Reference(_), _) => {
             unreachable!("References are invalid in binary operations")
         }
         (_, Type::Array(..)) | (Type::Array(..), _) => {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -554,7 +554,10 @@ impl<'block> BrilligBlock<'block> {
                     value_variable,
                 );
             }
-            _ => todo!("ICE: Instruction not supported {instruction:?}"),
+            Instruction::IncrementRc { .. } => todo!("Implement inc_rc in brillig"),
+            Instruction::EnableSideEffects { .. } => {
+                todo!("ICE: Instruction not supported {instruction:?}")
+            }
         };
 
         let dead_variables = self

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -559,7 +559,7 @@ impl<'block> BrilligBlock<'block> {
                 };
 
                 // TODO: Does this work for += 1?
-                self.increment(rc_register, rc_register);
+                self.brillig_context.increment(rc_register, rc_register);
             }
             Instruction::EnableSideEffects { .. } => {
                 todo!("ICE: Instruction not supported {instruction:?}")
@@ -1147,7 +1147,7 @@ impl<'block> BrilligBlock<'block> {
 
                             // Add one to the vector's size to account for the extra reference count field
                             let size = self.brillig_context.allocate_register();
-                            self.increment(heap_vector.size, size);
+                            self.brillig_context.increment(heap_vector.size, size);
 
                             self.brillig_context
                                 .allocate_array_instruction(heap_vector.pointer, heap_vector.size);

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
@@ -170,7 +170,7 @@ pub(crate) fn allocate_value(
     let typ = dfg.type_of_value(value_id);
 
     match typ {
-        Type::Numeric(_) | Type::Reference => {
+        Type::Numeric(_) | Type::Reference(_) => {
             let register = brillig_context.allocate_register();
             RegisterOrMemory::RegisterIndex(register)
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
@@ -175,17 +175,16 @@ pub(crate) fn allocate_value(
             RegisterOrMemory::RegisterIndex(register)
         }
         Type::Array(item_typ, elem_count) => {
-            let pointer_register = brillig_context.allocate_register();
+            let pointer = brillig_context.allocate_register();
+            let reference_count = brillig_context.allocate_register();
             let size = compute_array_length(&item_typ, elem_count);
-            RegisterOrMemory::HeapArray(HeapArray { pointer: pointer_register, size })
+            RegisterOrMemory::HeapArray(HeapArray { pointer, size, reference_count })
         }
         Type::Slice(_) => {
-            let pointer_register = brillig_context.allocate_register();
-            let size_register = brillig_context.allocate_register();
-            RegisterOrMemory::HeapVector(HeapVector {
-                pointer: pointer_register,
-                size: size_register,
-            })
+            let pointer = brillig_context.allocate_register();
+            let size = brillig_context.allocate_register();
+            let reference_count = brillig_context.allocate_register();
+            RegisterOrMemory::HeapVector(HeapVector { pointer, size, reference_count })
         }
         Type::Function => {
             unreachable!("ICE: Function values should have been removed from the SSA")

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
@@ -176,15 +176,13 @@ pub(crate) fn allocate_value(
         }
         Type::Array(item_typ, elem_count) => {
             let pointer = brillig_context.allocate_register();
-            let reference_count = brillig_context.allocate_register();
             let size = compute_array_length(&item_typ, elem_count);
-            RegisterOrMemory::HeapArray(HeapArray { pointer, size, reference_count })
+            RegisterOrMemory::HeapArray(HeapArray { pointer, size })
         }
         Type::Slice(_) => {
             let pointer = brillig_context.allocate_register();
             let size = brillig_context.allocate_register();
-            let reference_count = brillig_context.allocate_register();
-            RegisterOrMemory::HeapVector(HeapVector { pointer, size, reference_count })
+            RegisterOrMemory::HeapVector(HeapVector { pointer, size })
         }
         Type::Function => {
             unreachable!("ICE: Function values should have been removed from the SSA")

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -72,7 +72,7 @@ impl FunctionContext {
 
     fn ssa_type_to_parameter(typ: &Type) -> BrilligParameter {
         match typ {
-            Type::Numeric(_) | Type::Reference => BrilligParameter::Simple,
+            Type::Numeric(_) | Type::Reference(_) => BrilligParameter::Simple,
             Type::Array(item_type, size) => BrilligParameter::Array(
                 vecmap(item_type.iter(), |item_typ| {
                     FunctionContext::ssa_type_to_parameter(item_typ)

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -332,7 +332,7 @@ mod test {
         let v0 = builder.add_parameter(Type::field());
         let v1 = builder.add_parameter(Type::field());
 
-        let v3 = builder.insert_allocate();
+        let v3 = builder.insert_allocate(Type::field());
 
         let zero = builder.numeric_constant(0u128, Type::field());
         builder.insert_store(v3, zero);
@@ -439,7 +439,7 @@ mod test {
         let v0 = builder.add_parameter(Type::field());
         let v1 = builder.add_parameter(Type::field());
 
-        let v3 = builder.insert_allocate();
+        let v3 = builder.insert_allocate(Type::field());
 
         let zero = builder.numeric_constant(0u128, Type::field());
         builder.insert_store(v3, zero);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -350,11 +350,7 @@ impl BrilligContext {
 
     /// Internal function used to compute the section labels
     fn compute_section_label(&self, section: usize) -> String {
-        let ret = format!("{}-{}", self.context_label, section);
-        if ret.contains("b42-1") {
-            panic!("Found {}", ret);
-        }
-        ret
+        format!("{}-{}", self.context_label, section)
     }
 
     /// Returns the current section label

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -321,7 +321,7 @@ impl BrilligContext {
     }
 
     /// Add one to the given register value and store it in the given register
-    fn increment(&mut self, value: RegisterIndex, result: RegisterIndex) {
+    pub(crate) fn increment(&mut self, value: RegisterIndex, result: RegisterIndex) {
         let one = self.make_constant(1_usize.into());
         let add = BrilligBinaryOp::Field { op: BinaryFieldOp::Add };
         self.binary_instruction(value, one, result, add);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -20,6 +20,7 @@ impl BrilligContext {
             registers: BrilligRegistersContext::new(),
             context_label: String::default(),
             section_label: 0,
+            next_section: 1,
             debug_show: DebugShow::new(false),
         };
 

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -1413,7 +1413,7 @@ impl Context {
             (_, Type::Function) | (Type::Function, _) => {
                 unreachable!("all functions should be inlined")
             }
-            (_, Type::Reference) | (Type::Reference, _) => {
+            (_, Type::Reference(_)) | (Type::Reference(_), _) => {
                 unreachable!("References are invalid in binary operations")
             }
             (_, Type::Array(..)) | (Type::Array(..), _) => {

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -529,6 +529,9 @@ impl Context {
             Instruction::Load { .. } => {
                 unreachable!("Expected all load instructions to be removed before acir_gen")
             }
+            Instruction::IncrementRc { .. } => {
+                // Do nothing. Only Brillig needs to worry about reference counted arrays
+            }
         }
         self.acir_context.set_call_stack(CallStack::new());
         Ok(())

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -364,12 +364,15 @@ impl FunctionBuilder {
                     self.increment_array_reference_count(value);
                 }
             }
-            Type::Array(element_types, _length) => {
+            Type::Array(element_types, length) => {
                 self.insert_instruction(Instruction::IncrementRc { value }, None);
 
-                for element_type in element_types.iter() {
-                    if element_type.contains_an_array() {
-                        todo!("inc_rc for nested arrays")
+                if element_types.iter().any(|element| element.contains_an_array()) {
+                    for i in 0 .. length {
+                        let index = self.field_constant(i as u128);
+                        let element_type = element_types[i % element_types.len()].clone();
+                        let element = self.insert_array_get(value, index, element_type);
+                        self.increment_array_reference_count(element);
                     }
                 }
             }

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -169,8 +169,8 @@ impl FunctionBuilder {
     /// Insert an allocate instruction at the end of the current block, allocating the
     /// given amount of field elements. Returns the result of the allocate instruction,
     /// which is always a Reference to the allocated data.
-    pub(crate) fn insert_allocate(&mut self) -> ValueId {
-        self.insert_instruction(Instruction::Allocate, None).first()
+    pub(crate) fn insert_allocate(&mut self, element_type: Type) -> ValueId {
+        self.insert_instruction(Instruction::Allocate, Some(vec![element_type])).first()
     }
 
     pub(crate) fn set_location(&mut self, location: Location) -> &mut FunctionBuilder {

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -318,7 +318,7 @@ impl DataFlowGraph {
     /// True if the type of this value is Type::Reference.
     /// Using this method over type_of_value avoids cloning the value's type.
     pub(crate) fn value_is_reference(&self, value: ValueId) -> bool {
-        matches!(self.values[value].get_type(), Type::Reference)
+        matches!(self.values[value].get_type(), Type::Reference(_))
     }
 
     /// Appends a result type to the instruction.

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -192,7 +192,6 @@ impl Instruction {
         match self {
             Instruction::Binary(binary) => binary.result_type(),
             Instruction::Cast(_, typ) => InstructionResultType::Known(typ.clone()),
-            Instruction::Allocate { .. } => InstructionResultType::Known(Type::Reference),
             Instruction::Not(value) | Instruction::Truncate { value, .. } => {
                 InstructionResultType::Operand(*value)
             }
@@ -200,9 +199,10 @@ impl Instruction {
             Instruction::Constrain(..)
             | Instruction::Store { .. }
             | Instruction::EnableSideEffects { .. } => InstructionResultType::None,
-            Instruction::Load { .. } | Instruction::ArrayGet { .. } | Instruction::Call { .. } => {
-                InstructionResultType::Unknown
-            }
+            Instruction::Allocate { .. }
+            | Instruction::Load { .. }
+            | Instruction::ArrayGet { .. }
+            | Instruction::Call { .. } => InstructionResultType::Unknown,
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -172,5 +172,8 @@ pub(crate) fn display_instruction(
                 show(*value)
             )
         }
+        Instruction::IncrementRc { value } => {
+            writeln!(f, "inc_rc {}", show(*value))
+        }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -24,7 +24,7 @@ pub(crate) enum Type {
     Numeric(NumericType),
 
     /// A reference to some value, such as an array
-    Reference,
+    Reference(Rc<Type>),
 
     /// An immutable array value with the given element type and length
     Array(Rc<CompositeType>, usize),
@@ -103,7 +103,7 @@ impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Type::Numeric(numeric) => numeric.fmt(f),
-            Type::Reference => write!(f, "reference"),
+            Type::Reference(element) => write!(f, "&mut {element}"),
             Type::Array(element, length) => {
                 let elements = vecmap(element.iter(), |element| element.to_string());
                 write!(f, "[{}; {length}]", elements.join(", "))

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -92,6 +92,15 @@ impl Type {
         }
         size
     }
+
+    /// True if this type is an array (or slice) or internally contains an array (or slice)
+    pub(crate) fn contains_an_array(&self) -> bool {
+        match self {
+            Type::Numeric(_) | Type::Function => false,
+            Type::Array(_, _) | Type::Slice(_) => true,
+            Type::Reference(element) => element.contains_an_array(),
+        }
+    }
 }
 
 /// Composite Types are essentially flattened struct or tuple types.

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -176,10 +176,10 @@ mod test {
         builder.switch_to_block(b1);
         let _v3 = builder.add_block_parameter(b1, Type::field());
 
-        let v4 = builder.insert_allocate();
+        let v4 = builder.insert_allocate(Type::field());
         let _v5 = builder.insert_load(v4, Type::field());
 
-        let v6 = builder.insert_allocate();
+        let v6 = builder.insert_allocate(Type::field());
         builder.insert_store(v6, one);
         let v7 = builder.insert_load(v6, Type::field());
         let v8 = builder.insert_binary(v7, BinaryOp::Add, one);

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -801,7 +801,7 @@ mod test {
     #[test]
     fn merge_stores() {
         // fn main f0 {
-        //   b0(v0: u1, v1: ref):
+        //   b0(v0: u1, v1: &mut Field):
         //     jmpif v0, then: b1, else: b2
         //   b1():
         //     store v1, Field 5
@@ -816,7 +816,7 @@ mod test {
         let b2 = builder.insert_block();
 
         let v0 = builder.add_parameter(Type::bool());
-        let v1 = builder.add_parameter(Type::Reference);
+        let v1 = builder.add_parameter(Type::Reference(Rc::new(Type::field())));
 
         builder.terminate_with_jmpif(v0, b1, b2);
 
@@ -878,7 +878,7 @@ mod test {
         let b3 = builder.insert_block();
 
         let v0 = builder.add_parameter(Type::bool());
-        let v1 = builder.add_parameter(Type::Reference);
+        let v1 = builder.add_parameter(Type::Reference(Rc::new(Type::field())));
 
         builder.terminate_with_jmpif(v0, b1, b2);
 
@@ -977,7 +977,7 @@ mod test {
         let c1 = builder.add_parameter(Type::bool());
         let c4 = builder.add_parameter(Type::bool());
 
-        let r1 = builder.insert_allocate();
+        let r1 = builder.insert_allocate(Type::field());
 
         let store_value = |builder: &mut FunctionBuilder, value: u128| {
             let value = builder.field_constant(value);
@@ -1128,7 +1128,7 @@ mod test {
         builder.terminate_with_jmpif(v0, b1, b2);
 
         builder.switch_to_block(b1);
-        let v2 = builder.insert_allocate();
+        let v2 = builder.insert_allocate(Type::field());
         let zero = builder.field_constant(0u128);
         builder.insert_store(v2, zero);
         let _v4 = builder.insert_load(v2, Type::field());
@@ -1297,7 +1297,7 @@ mod test {
         let v8 = builder.insert_binary(v6, BinaryOp::Mod, i_two);
         let v9 = builder.insert_cast(v8, Type::bool());
 
-        let v10 = builder.insert_allocate();
+        let v10 = builder.insert_allocate(Type::field());
         builder.insert_store(v10, zero);
 
         builder.terminate_with_jmpif(v9, b1, b2);
@@ -1396,9 +1396,9 @@ mod test {
         let ten = builder.field_constant(10u128);
         let one_hundred = builder.field_constant(100u128);
 
-        let v0 = builder.insert_allocate();
+        let v0 = builder.insert_allocate(Type::field());
         builder.insert_store(v0, zero);
-        let v2 = builder.insert_allocate();
+        let v2 = builder.insert_allocate(Type::field());
         builder.insert_store(v2, two);
         let v4 = builder.insert_load(v2, Type::field());
         let v5 = builder.insert_binary(v4, BinaryOp::Lt, two);

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -60,7 +60,7 @@ impl<'a> ValueMerger<'a> {
             typ @ Type::Slice(_) => {
                 self.merge_slice_values(typ, then_condition, else_condition, then_value, else_value)
             }
-            Type::Reference => panic!("Cannot return references from an if expression"),
+            Type::Reference(_) => panic!("Cannot return references from an if expression"),
             Type::Function => panic!("Cannot return functions from an if expression"),
         }
     }
@@ -325,7 +325,7 @@ impl<'a> ValueMerger<'a> {
             Type::Slice(_) => {
                 unreachable!("ICE: Slices of slice is unsupported")
             }
-            Type::Reference => {
+            Type::Reference(_) => {
                 unreachable!("ICE: Merging references is unsupported")
             }
             Type::Function => {

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -427,7 +427,7 @@ mod tests {
 
         let func_id = Id::test_new(0);
         let mut builder = FunctionBuilder::new("func".into(), func_id, RuntimeType::Acir);
-        let v0 = builder.insert_allocate();
+        let v0 = builder.insert_allocate(Type::Array(Rc::new(vec![Type::field()]), 2));
         let one = builder.field_constant(FieldElement::one());
         let two = builder.field_constant(FieldElement::one());
 
@@ -468,7 +468,7 @@ mod tests {
 
         let func_id = Id::test_new(0);
         let mut builder = FunctionBuilder::new("func".into(), func_id, RuntimeType::Acir);
-        let v0 = builder.insert_allocate();
+        let v0 = builder.insert_allocate(Type::field());
         let one = builder.field_constant(FieldElement::one());
         builder.insert_store(v0, one);
         let v1 = builder.insert_load(v0, Type::field());
@@ -502,7 +502,7 @@ mod tests {
 
         let func_id = Id::test_new(0);
         let mut builder = FunctionBuilder::new("func".into(), func_id, RuntimeType::Acir);
-        let v0 = builder.insert_allocate();
+        let v0 = builder.insert_allocate(Type::field());
         let const_one = builder.field_constant(FieldElement::one());
         builder.insert_store(v0, const_one);
         builder.terminate_with_return(vec![v0]);
@@ -562,7 +562,7 @@ mod tests {
         let main_id = Id::test_new(0);
         let mut builder = FunctionBuilder::new("main".into(), main_id, RuntimeType::Acir);
 
-        let v0 = builder.insert_allocate();
+        let v0 = builder.insert_allocate(Type::field());
 
         let five = builder.field_constant(5u128);
         builder.insert_store(v0, five);
@@ -642,12 +642,12 @@ mod tests {
         let main_id = Id::test_new(0);
         let mut builder = FunctionBuilder::new("main".into(), main_id, RuntimeType::Acir);
 
-        let v0 = builder.insert_allocate();
+        let v0 = builder.insert_allocate(Type::field());
 
         let zero = builder.field_constant(0u128);
         builder.insert_store(v0, zero);
 
-        let v2 = builder.insert_allocate();
+        let v2 = builder.insert_allocate(Type::Reference(Rc::new(Type::field())));
         builder.insert_store(v2, v0);
 
         let v3 = builder.insert_load(v2, Type::field());

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -326,7 +326,7 @@ impl<'f> PerFunctionContext<'f> {
         match typ {
             Type::Numeric(_) => false,
             Type::Function => false,
-            Type::Reference => true,
+            Type::Reference(_) => true,
             Type::Array(elements, _) | Type::Slice(elements) => {
                 elements.iter().any(Self::contains_references)
             }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -242,11 +242,12 @@ impl<'a> FunctionContext<'a> {
                 self.codegen_reference(&unary.rhs).map(|rhs| {
                     match rhs {
                         value::Value::Normal(value) => {
-                            let alloc = self.builder.insert_allocate();
+                            let rhs_type = self.builder.current_function.dfg.type_of_value(value);
+                            let alloc = self.builder.insert_allocate(rhs_type);
                             self.builder.insert_store(alloc, value);
                             Tree::Leaf(value::Value::Normal(alloc))
                         }
-                        // NOTE: The `.into()` here converts the Value::Mutable into
+                        // The `.into()` here converts the Value::Mutable into
                         // a Value::Normal so it is no longer automatically dereferenced.
                         value::Value::Mutable(reference, _) => reference.into(),
                     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -571,6 +571,7 @@ impl<'a> FunctionContext<'a> {
 
         values = values.map(|value| {
             let value = value.eval(self);
+
             // Make sure to increment array reference counts on each let binding
             self.builder.increment_array_reference_count(value);
 

--- a/tooling/nargo_cli/tests/compile_success_empty/option/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/option/src/main.nr
@@ -10,6 +10,8 @@ fn main() {
     assert(some.is_some());
 
     assert(some.unwrap() == 3);
+    assert(some.expect("error never shown") == 3);
+    assert(none.expect("error shown") == 3);
 
     assert(none.unwrap_or(2) == 2);
     assert(some.unwrap_or(2) == 3);


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Use of `array_set` in a loop can greatly slow down brillig code since under the hood on master, brillig will currently copy the entire array in order to return a new array with one element changed.

Resolves (couldn't find an existing issue for this, do we have one?)

## Summary\*

This PR adds the copy on write optimization to brillig in order to optimize this usecase. To implement this, arrays in brillig are now reference counted and there is a new `Instruction::IncrementRc` instruction in SSA to increment reference count (1). During an `array_set` in brillig, the reference count is checked. If it is 1, brillig will mutate the existing array instead of copying to a new one. If not, brillig will fall back to creating a new array, although crucially this new array will always have reference count 1, allowing each subsequent set to be a mutated one. This leads to exponential speedup in loops using array_set.

The reference count is increased when creating a new variable via `let` and when passing values to functions. The reference count is also (currently) never decreased - so the analysis is rather pessimistic. We could look into changing this in the future, but for now it is sufficient since the first `array_set` performs a copy and the rest will still be optimized.

The following example:

```rs
fn main() {
    let array = [0; 5000];
    assert(foo(array) != 100);
    assert(array[5] == 0);
}

unconstrained fn foo<N>(mut array: [Field; N]) -> Field {
    let copy = array;
    let mut sum = 0;

    for i in 0 .. array.len() {
        array[i] = i;
        sum += i;
    }

    assert(copy[5] == 0);
    sum
}
```

Runs in 58s on master (release) on my machine, and 0.8s with the optimization on this branch. Results may vary of course, and will be slower when compiling nargo on the debug profile.

Note that this test also includes array aliases so we can see the mutations are safe to perform without affecting other values.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

Regarding (1), a possible alternate design is to encode & expose reference counts directly in SSA rather than keeping them only in brillig. For example, arrays could instead be represented as a tuple of `(reference_count, array)` where `reference_count: &mut Field`. From here, we could have each `array_set` either translate to an if under the hood:

```
  v1 = load reference_count
  v2 = eq v1, Field 1
  jmp_if v2, then: b2, else: b3
b2:
  // array has 1 rc
  array_set_mut array, index, value
  jmp b4(array)
b3:
  // array has > 1 rc
  v3 = array_set array, index, value
  jmp b4(v3)
b4(v4: [Field]):
  ... continue with v4 for the result of the array set ...
```

This would greatly bloat the ssa however, so I decided against it. An alternative would be modifying the array_set instruction to accept the reference count as an argument:

```
v1 = load reference_count
v2 = array_set array, index, value, v1
```

Then internally (in brillig, as it is ignored in ssa) we would check the reference count for each array set operation similarly to how is currently done in this PR.

---------

Additionally, this is still a draft because I've left some TODO's / messy bits in the code to clean up. The core approach should be ready for review though or we can discuss whether the alternative approach above would be better.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
