### PR TITLE
chore: remove unnecessary clone when executing brillig

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -878,7 +878,7 @@ impl AcirContext {
         // Optimistically try executing the brillig now, if we can complete execution they just return the results.
         // This is a temporary measure pending SSA optimizations being applied to Brillig which would remove constant-input opcodes (See #2066)
         if let Some(brillig_outputs) =
-            self.execute_brillig(generated_brillig.byte_code.clone(), &b_inputs, &outputs)
+            self.execute_brillig(&generated_brillig.byte_code, &b_inputs, &outputs)
         {
             return Ok(brillig_outputs);
         }
@@ -965,7 +965,7 @@ impl AcirContext {
 
     fn execute_brillig(
         &mut self,
-        code: Vec<BrilligOpcode>,
+        code: &[BrilligOpcode],
         inputs: &[BrilligInputs],
         outputs_types: &[AcirType],
     ) -> Option<Vec<AcirValue>> {
@@ -1238,7 +1238,7 @@ pub(crate) struct AcirVar(usize);
 ///
 /// Returns `None` if complete execution of the Brillig bytecode is not possible.
 fn execute_brillig(
-    code: Vec<BrilligOpcode>,
+    code: &[BrilligOpcode],
     inputs: &[BrilligInputs],
 ) -> Option<(Registers, Vec<Value>)> {
     struct NullBbSolver;
@@ -1294,7 +1294,7 @@ fn execute_brillig(
 
     // Instantiate a Brillig VM given the solved input registers and memory, along with the Brillig bytecode.
     let input_registers = Registers::load(input_register_values);
-    let mut vm = VM::new(input_registers, input_memory, &code, Vec::new(), &NullBbSolver);
+    let mut vm = VM::new(input_registers, input_memory, code, Vec::new(), &NullBbSolver);
 
     // Run the Brillig VM on these inputs, bytecode, etc!
     let vm_status = vm.process_opcodes();


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
