### PR TITLE
feat: Remove unnecessary truncation of boolean multiplication

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -774,7 +774,15 @@ fn operator_result_max_bit_size_to_truncate(
     match op {
         Add => Some(std::cmp::max(lhs_bit_size, rhs_bit_size) + 1),
         Subtract => Some(std::cmp::max(lhs_bit_size, rhs_bit_size) + 1),
-        Multiply => Some(lhs_bit_size + rhs_bit_size),
+        Multiply => {
+            if lhs_bit_size == 1 || rhs_bit_size == 1 {
+                // Truncation is unnecessary as multiplication by a boolean value cannot cause an overflow.
+                None
+            } else {
+                Some(lhs_bit_size + rhs_bit_size)
+            }
+        }
+
         ShiftLeft => {
             if let Some(rhs_constant) = dfg.get_numeric_constant(rhs) {
                 // Happy case is that we know precisely by how many bits the the integer will


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

It's unnecessary to truncate after `x * <u1 value>` as the result is bounded by `x`. We can then omit this instruction when multiplying integers of width 1 together.

I'm not sure if signed integers of width 1 need special casing on this.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
