### PR TITLE
chore: use `circuit.get_assert_message` instead of closure/helper function

### DIFF
--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -85,12 +85,12 @@ pub async fn execute_circuit_with_black_box_solver(
                         opcode_location: ErrorLocation::Resolved(opcode_location),
                         ..
                     } => {
-                        (circuit.get_assert_message(opcode_location), Some(vec![*opcode_location]))
+                        (circuit.get_assert_message(*opcode_location), Some(vec![*opcode_location]))
                     }
                     OpcodeResolutionError::BrilligFunctionFailed { call_stack, .. } => {
                         let failing_opcode =
                             call_stack.last().expect("Brillig error call stacks cannot be empty");
-                        (circuit.get_assert_message(failing_opcode), Some(call_stack.clone()))
+                        (circuit.get_assert_message(*failing_opcode), Some(call_stack.clone()))
                     }
                     _ => (None, None),
                 };

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -84,17 +84,13 @@ pub async fn execute_circuit_with_black_box_solver(
                     | OpcodeResolutionError::IndexOutOfBounds {
                         opcode_location: ErrorLocation::Resolved(opcode_location),
                         ..
-                    } => (
-                        get_assert_message(&circuit.assert_messages, opcode_location),
-                        Some(vec![*opcode_location]),
-                    ),
+                    } => {
+                        (circuit.get_assert_message(opcode_location), Some(vec![*opcode_location]))
+                    }
                     OpcodeResolutionError::BrilligFunctionFailed { call_stack, .. } => {
                         let failing_opcode =
                             call_stack.last().expect("Brillig error call stacks cannot be empty");
-                        (
-                            get_assert_message(&circuit.assert_messages, failing_opcode),
-                            Some(call_stack.clone()),
-                        )
+                        (circuit.get_assert_message(failing_opcode), Some(call_stack.clone()))
                     }
                     _ => (None, None),
                 };
@@ -116,16 +112,4 @@ pub async fn execute_circuit_with_black_box_solver(
 
     let witness_map = acvm.finalize();
     Ok(witness_map.into())
-}
-
-// Searches the slice for `opcode_location`.
-// This is functionality equivalent to .get on a map.
-fn get_assert_message(
-    assert_messages: &[(OpcodeLocation, String)],
-    opcode_location: &OpcodeLocation,
-) -> Option<String> {
-    assert_messages
-        .iter()
-        .find(|(loc, _)| loc == opcode_location)
-        .map(|(_, message)| message.clone())
 }

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -1,5 +1,5 @@
 use acvm::{
-    acir::circuit::{Circuit, OpcodeLocation},
+    acir::circuit::Circuit,
     pwg::{ACVMStatus, ErrorLocation, OpcodeResolutionError, ACVM},
 };
 #[allow(deprecated)]

--- a/tooling/nargo/src/ops/execute.rs
+++ b/tooling/nargo/src/ops/execute.rs
@@ -15,15 +15,6 @@ pub fn execute_circuit<B: BlackBoxFunctionSolver>(
 ) -> Result<WitnessMap, NargoError> {
     let mut acvm = ACVM::new(blackbox_solver, &circuit.opcodes, initial_witness);
 
-    // Assert messages are not a map due to https://github.com/noir-lang/acvm/issues/522
-    let get_assert_message = |opcode_location| {
-        circuit
-            .assert_messages
-            .iter()
-            .find(|(loc, _)| loc == opcode_location)
-            .map(|(_, message)| message.clone())
-    };
-
     let mut foreign_call_executor = ForeignCallExecutor::default();
 
     loop {
@@ -47,10 +38,10 @@ pub fn execute_circuit<B: BlackBoxFunctionSolver>(
 
                 return Err(NargoError::ExecutionError(match call_stack {
                     Some(call_stack) => {
-                        if let Some(assert_message) = get_assert_message(
-                            call_stack.last().expect("Call stacks should not be empty"),
+                        if let Some(assert_message) = circuit.get_assert_message(
+                            *call_stack.last().expect("Call stacks should not be empty"),
                         ) {
-                            ExecutionError::AssertionFailed(assert_message, call_stack)
+                            ExecutionError::AssertionFailed(assert_message.to_owned(), call_stack)
                         } else {
                             ExecutionError::SolvingError(error)
                         }


### PR DESCRIPTION

# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently don't use `circuit.get_assert_message` as previously it caused issues related to ownership over the circuit's opcodes. Now we pass the opcodes to the ACVM by reference, we can just use the `circuit.get_assert_message` directly.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
