### PR TITLE
chore: Add Spell Checker to recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,9 @@
 		"jnoortheen.nix-ide",
 		"rust-lang.rust-analyzer",
 		"redhat.vscode-yaml",
-		"esbenp.prettier-vscode"
+		"esbenp.prettier-vscode",
+		// Spell checking
+    		"streetsidesoftware.code-spell-checker",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []


### PR DESCRIPTION
# Description

## Problem\*

The Noir repo does not currently enforce any spell checks, which could lead to:
- Misspelt APIs, commands, flags, etc. --> user confusions
- Mismatched interfaces due to e.g. American vs British spelling of the same function --> dev frictions and/or user confusions

## Summary\*

This PR doesn't enforce a spell check, but adds [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) as a recommended VS Code extension for users building in this repo.

Further spell alignments can then be made and enforced more easily through the shared config file [cspell.json](https://github.com/noir-lang/noir/blob/004f8dd733cb23da4ed57b160f6b86d53bc0b5f1/cspell.json) of this repo.

## Additional Context

Referenced https://github.com/AztecProtocol/aztec-packages/pull/2817.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.