### PR TITLE
fix: do not perform dead instruction elimination on mod,div unless rhs is constant

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -239,10 +239,19 @@ impl Instruction {
 
     pub(crate) fn has_side_effects(&self, dfg: &DataFlowGraph) -> bool {
         use Instruction::*;
-
         match self {
-            Binary(_)
-            | Cast(_, _)
+            Binary(binary) => {
+                if matches!(binary.operator, BinaryOp::Div | BinaryOp::Mod) {
+                    if let Some(rhs) = dfg.get_numeric_constant(binary.rhs) {
+                        rhs == FieldElement::zero()
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+            }
+            Cast(_, _)
             | Not(_)
             | Truncate { .. }
             | Allocate


### PR DESCRIPTION
# Description

Do not simplify div/mod when denominator is not known, because if it is null, it will have side-effects.

## Problem\*

Resolves #2584
Closes #2741
Closes #3053

## Summary\*

We do not simplify div or mod in dead instruction elimination, except if the denominator is constant and not null, in which case there will not be any side effect and we can simplify it.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

I do not add a test case because I requires  'execution failure', as  div/mod side effects occur during execution.
This PR supersede PR #2741 and #3053, which can be closed.
Allowing simplification for constant denominator solves the issue with the sha256 test cases on these PRs.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
