### PR TITLE
chore(debugger): avoid taking ownership of Circuit when building debug context 

### DIFF
--- a/tooling/debugger/src/lib.rs
+++ b/tooling/debugger/src/lib.rs
@@ -21,7 +21,7 @@ struct DebugContext<'backend, B: BlackBoxFunctionSolver> {
     acvm: Option<ACVM<'backend, B>>,
     debug_artifact: DebugArtifact,
     foreign_call_executor: ForeignCallExecutor,
-    circuit: Circuit,
+    circuit: &'backend Circuit,
     show_output: bool,
 }
 
@@ -115,7 +115,7 @@ fn map_command_status(result: SolveResult) -> CommandStatus {
 
 pub fn debug_circuit<B: BlackBoxFunctionSolver>(
     blackbox_solver: &B,
-    circuit: Circuit,
+    circuit: &Circuit,
     debug_artifact: DebugArtifact,
     initial_witness: WitnessMap,
     show_output: bool,

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -120,7 +120,7 @@ pub(crate) fn debug_program(
 
     noir_debugger::debug_circuit(
         &blackbox_solver,
-        &compiled_program.circuit.clone(),
+        &compiled_program.circuit,
         debug_artifact,
         initial_witness,
         true,

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -120,7 +120,7 @@ pub(crate) fn debug_program(
 
     noir_debugger::debug_circuit(
         &blackbox_solver,
-        compiled_program.circuit.clone(),
+        &compiled_program.circuit.clone(),
         debug_artifact,
         initial_witness,
         true,


### PR DESCRIPTION
# Description

## Problem

This is a follow up PR to https://github.com/noir-lang/noir/pull/2995, addressing this comment: https://github.com/noir-lang/noir/pull/2995#discussion_r1358237222.

## Summary

Passes circuit to debugger by reference instead of moving it.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
