### PR TITLE
chore: make `acvm` a non-optional field on `DebugContext`

### DIFF
--- a/tooling/debugger/src/lib.rs
+++ b/tooling/debugger/src/lib.rs
@@ -119,10 +119,8 @@ pub fn debug_circuit<B: BlackBoxFunctionSolver>(
     initial_witness: WitnessMap,
     show_output: bool,
 ) -> Result<Option<WitnessMap>, NargoError> {
-    let opcodes = circuit.opcodes.clone();
-
     let context = RefCell::new(DebugContext {
-        acvm: ACVM::new(blackbox_solver, &opcodes, initial_witness),
+        acvm: ACVM::new(blackbox_solver, &circuit.opcodes, initial_witness),
         foreign_call_executor: ForeignCallExecutor::default(),
         circuit,
         debug_artifact,

--- a/tooling/debugger/src/lib.rs
+++ b/tooling/debugger/src/lib.rs
@@ -18,7 +18,7 @@ enum SolveResult {
 }
 
 struct DebugContext<'backend, B: BlackBoxFunctionSolver> {
-    acvm: Option<ACVM<'backend, B>>,
+    acvm: ACVM<'backend, B>,
     debug_artifact: DebugArtifact,
     foreign_call_executor: ForeignCallExecutor,
     circuit: Circuit,
@@ -27,7 +27,7 @@ struct DebugContext<'backend, B: BlackBoxFunctionSolver> {
 
 impl<'backend, B: BlackBoxFunctionSolver> DebugContext<'backend, B> {
     fn step_opcode(&mut self) -> Result<SolveResult, NargoError> {
-        let solver_status = self.acvm.as_mut().unwrap().solve_opcode();
+        let solver_status = self.acvm.solve_opcode();
 
         match solver_status {
             ACVMStatus::Solved => Ok(SolveResult::Done),
@@ -59,16 +59,15 @@ impl<'backend, B: BlackBoxFunctionSolver> DebugContext<'backend, B> {
             ACVMStatus::RequiresForeignCall(foreign_call) => {
                 let foreign_call_result =
                     self.foreign_call_executor.execute(&foreign_call, self.show_output)?;
-                self.acvm.as_mut().unwrap().resolve_pending_foreign_call(foreign_call_result);
+                self.acvm.resolve_pending_foreign_call(foreign_call_result);
                 Ok(SolveResult::Ok)
             }
         }
     }
 
     fn show_current_vm_status(&self) {
-        let acvm = self.acvm.as_ref().unwrap();
-        let ip = acvm.instruction_pointer();
-        let opcodes = acvm.opcodes();
+        let ip = self.acvm.instruction_pointer();
+        let opcodes = self.acvm.opcodes();
         if ip >= opcodes.len() {
             println!("Finished execution");
         } else {
@@ -101,8 +100,8 @@ impl<'backend, B: BlackBoxFunctionSolver> DebugContext<'backend, B> {
         Ok(SolveResult::Done)
     }
 
-    fn finalize(&mut self) -> WitnessMap {
-        self.acvm.take().unwrap().finalize()
+    fn finalize(self) -> WitnessMap {
+        self.acvm.finalize()
     }
 }
 
@@ -123,7 +122,7 @@ pub fn debug_circuit<B: BlackBoxFunctionSolver>(
     let opcodes = circuit.opcodes.clone();
 
     let context = RefCell::new(DebugContext {
-        acvm: Some(ACVM::new(blackbox_solver, &opcodes, initial_witness)),
+        acvm: ACVM::new(blackbox_solver, &opcodes, initial_witness),
         foreign_call_executor: ForeignCallExecutor::default(),
         circuit,
         debug_artifact,
@@ -169,8 +168,12 @@ pub fn debug_circuit<B: BlackBoxFunctionSolver>(
 
     repl.run().expect("Debugger error");
 
+    // REPL execution has finished.
+    // Drop it so that we can move fields out from `context` again.
+    drop(repl);
+
     if solved.get() {
-        let solved_witness = context.borrow_mut().finalize();
+        let solved_witness = context.into_inner().finalize();
         Ok(Some(solved_witness))
     } else {
         Ok(None)


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/noir/pull/2995#discussion_r1358235413

## Summary\*

This PR addresses a workaround for the borrow checker in #2995.

`repl` holds two references to `Context` so we can't move the witness map out of the contained `ACVM` instance while `repl` (and so the references) exists.

As we don't need `repl` once we've finished execution, this PR explicitly drops `repl` to remove those references, We can then unwrap the `RefCell` and get at the contained `Context` to pull out the witness map.

cc @mverzilli @ggiraldez as you may be interested in this solution.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
