### PR TITLE
chore: transforming lexical errors into parser errors

### DIFF
--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -1,3 +1,5 @@
+use crate::parser::ParserError;
+use crate::parser::ParserErrorReason;
 use crate::token::SpannedToken;
 
 use super::token::Token;
@@ -27,6 +29,24 @@ pub enum LexerErrorKind {
         "'\\{escaped}' is not a valid escape sequence. Use '\\' for a literal backslash character."
     )]
     InvalidEscape { escaped: char, span: Span },
+}
+
+impl From<LexerErrorKind> for ParserError {
+    fn from(value: LexerErrorKind) -> Self {
+        let span = match value {
+            LexerErrorKind::UnexpectedCharacter { span, .. }
+            | LexerErrorKind::NotADoubleChar { span, .. }
+            | LexerErrorKind::InvalidIntegerLiteral { span, .. }
+            | LexerErrorKind::MalformedFuncAttribute { span, .. }
+            | LexerErrorKind::TooManyBits { span, .. }
+            | LexerErrorKind::LogicalAnd { span }
+            | LexerErrorKind::UnterminatedBlockComment { span }
+            | LexerErrorKind::UnterminatedStringLiteral { span }
+            | LexerErrorKind::InvalidEscape { span, .. } => span,
+        };
+
+        ParserError::with_reason(ParserErrorReason::Lexer(value), span)
+    }
 }
 
 impl LexerErrorKind {

--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -33,18 +33,7 @@ pub enum LexerErrorKind {
 
 impl From<LexerErrorKind> for ParserError {
     fn from(value: LexerErrorKind) -> Self {
-        let span = match value {
-            LexerErrorKind::UnexpectedCharacter { span, .. }
-            | LexerErrorKind::NotADoubleChar { span, .. }
-            | LexerErrorKind::InvalidIntegerLiteral { span, .. }
-            | LexerErrorKind::MalformedFuncAttribute { span, .. }
-            | LexerErrorKind::TooManyBits { span, .. }
-            | LexerErrorKind::LogicalAnd { span }
-            | LexerErrorKind::UnterminatedBlockComment { span }
-            | LexerErrorKind::UnterminatedStringLiteral { span }
-            | LexerErrorKind::InvalidEscape { span, .. } => span,
-        };
-
+        let span = value.span();
         ParserError::with_reason(ParserErrorReason::Lexer(value), span)
     }
 }

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -1,3 +1,4 @@
+use crate::lexer::errors::LexerErrorKind;
 use crate::lexer::token::Token;
 use crate::Expression;
 use small_ord_set::SmallOrdSet;
@@ -39,6 +40,8 @@ pub enum ParserErrorReason {
     NoFunctionAttributesAllowedOnStruct,
     #[error("Assert statements can only accept string literals")]
     AssertMessageNotString,
+    #[error("{0}")]
+    Lexer(LexerErrorKind),
 }
 
 /// Represents a parsing error, or a parsing error in the making.

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -55,8 +55,11 @@ use noirc_errors::{Span, Spanned};
 /// Vec is non-empty, there may be Error nodes in the Ast to fill in the gaps that
 /// failed to parse. Otherwise the Ast is guaranteed to have 0 Error nodes.
 pub fn parse_program(source_program: &str) -> (ParsedModule, Vec<ParserError>) {
-    let (tokens, _lexing_errors) = Lexer::lex(source_program);
-    let (module, parsing_errors) = program().parse_recovery_verbose(tokens);
+    let (tokens, lexing_errors) = Lexer::lex(source_program);
+    let (module, mut parsing_errors) = program().parse_recovery_verbose(tokens);
+
+    parsing_errors.extend(lexing_errors.into_iter().map(Into::into));
+
     (module.unwrap(), parsing_errors)
 }
 


### PR DESCRIPTION
# Description

chore: transforming lexical errors into parser errors

## Problem

Resolves #3125 

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
