### PR TITLE
fix: modify `assert(x)` span to cover entire statement

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -814,9 +814,13 @@ where
     ignore_then_commit(keyword(Keyword::Assert), parenthesized(argument_parser))
         .labelled(ParsingRuleLabel::Statement)
         .validate(|expressions, span, emit| {
-            let condition = expressions.get(0).unwrap_or(&Expression::error(span)).clone();
-            let mut message_str = None;
+            let mut condition =
+                expressions.get(0).cloned().unwrap_or_else(|| Expression::error(span));
+            // This is a bit of a hack but we want the span to cover the `assert` keyword as well.
+            // Perhaps `ConstrainStatement` should have it's own span rather than overloading the condition?
+            condition.span = span;
 
+            let mut message_str = None;
             if let Some(message) = expressions.get(1) {
                 if let ExpressionKind::Literal(Literal::Str(message)) = &message.kind {
                     message_str = Some(message.clone());


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #3175 

## Summary\*

This PR fixes #3175 but I'm not sure if it's exactly the route we want to go down in general. I'm now setting the span of the constraint's `condition` to cover the entire statement rather than purely the condition alone. This is consistent with how we handle `assert_eq` but feels like I'm misusing this.

Perhaps we should assign explicit spans to statements rather than relying on using the spans of their fields.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
