### PR TITLE
fix: return error rather than panicking on unreadable circuits

### DIFF
--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -137,8 +137,8 @@ impl Circuit {
         let mut gz_decoder = flate2::read::GzDecoder::new(reader);
         let mut buf_d = Vec::new();
         gz_decoder.read_to_end(&mut buf_d).unwrap();
-        let circuit = bincode::deserialize(&buf_d).unwrap();
-        Ok(circuit)
+        bincode::deserialize(&buf_d)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))
     }
 }
 

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -128,15 +128,15 @@ impl Circuit {
     pub fn write<W: std::io::Write>(&self, writer: W) -> std::io::Result<()> {
         let buf = bincode::serialize(self).unwrap();
         let mut encoder = flate2::write::GzEncoder::new(writer, Compression::default());
-        encoder.write_all(&buf).unwrap();
-        encoder.finish().unwrap();
+        encoder.write_all(&buf)?;
+        encoder.finish()?;
         Ok(())
     }
 
     pub fn read<R: std::io::Read>(reader: R) -> std::io::Result<Self> {
         let mut gz_decoder = flate2::read::GzDecoder::new(reader);
         let mut buf_d = Vec::new();
-        gz_decoder.read_to_end(&mut buf_d).unwrap();
+        gz_decoder.read_to_end(&mut buf_d)?;
         bincode::deserialize(&buf_d)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))
     }

--- a/compiler/noirc_driver/src/program.rs
+++ b/compiler/noirc_driver/src/program.rs
@@ -5,6 +5,7 @@ use fm::FileId;
 
 use base64::Engine;
 use noirc_errors::debug_info::DebugInfo;
+use serde::{de::Error as DeserializationError, ser::Error as SerializationError};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::debug::DebugFile;
@@ -29,7 +30,7 @@ where
     S: Serializer,
 {
     let mut circuit_bytes: Vec<u8> = Vec::new();
-    circuit.write(&mut circuit_bytes).unwrap();
+    circuit.write(&mut circuit_bytes).map_err(S::Error::custom)?;
 
     let encoded_b64 = base64::engine::general_purpose::STANDARD.encode(circuit_bytes);
     s.serialize_str(&encoded_b64)
@@ -40,7 +41,8 @@ where
     D: Deserializer<'de>,
 {
     let bytecode_b64: String = serde::Deserialize::deserialize(deserializer)?;
-    let circuit_bytes = base64::engine::general_purpose::STANDARD.decode(bytecode_b64).unwrap();
-    let circuit = Circuit::read(&*circuit_bytes).unwrap();
+    let circuit_bytes =
+        base64::engine::general_purpose::STANDARD.decode(bytecode_b64).map_err(D::Error::custom)?;
+    let circuit = Circuit::read(&*circuit_bytes).map_err(D::Error::custom)?;
     Ok(circuit)
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR pulls out the changes related to not panicking on an invalid circuit from https://github.com/noir-lang/noir/pull/3156.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
