### PR TITLE
chore: remove unused argument from `write_vk` command

### DIFF
--- a/tooling/backend_interface/src/cli/contract.rs
+++ b/tooling/backend_interface/src/cli/contract.rs
@@ -58,7 +58,6 @@ fn contract_command() -> Result<(), BackendError> {
     let write_vk_command = super::WriteVkCommand {
         bytecode_path,
         vk_path_output: vk_path.clone(),
-        is_recursive: false,
         crs_path: crs_path.clone(),
     };
     write_vk_command.run(backend.binary_path())?;

--- a/tooling/backend_interface/src/cli/verify.rs
+++ b/tooling/backend_interface/src/cli/verify.rs
@@ -59,7 +59,6 @@ fn verify_command() -> Result<(), BackendError> {
     let write_vk_command = WriteVkCommand {
         bytecode_path: bytecode_path.clone(),
         crs_path: crs_path.clone(),
-        is_recursive: false,
         vk_path_output: vk_path_output.clone(),
     };
 

--- a/tooling/backend_interface/src/cli/write_vk.rs
+++ b/tooling/backend_interface/src/cli/write_vk.rs
@@ -7,7 +7,6 @@ use crate::BackendError;
 /// to write a verification key to a file
 pub(crate) struct WriteVkCommand {
     pub(crate) crs_path: PathBuf,
-    pub(crate) is_recursive: bool,
     pub(crate) bytecode_path: PathBuf,
     pub(crate) vk_path_output: PathBuf,
 }
@@ -24,10 +23,6 @@ impl WriteVkCommand {
             .arg(self.bytecode_path)
             .arg("-o")
             .arg(self.vk_path_output);
-
-        if self.is_recursive {
-            command.arg("-r");
-        }
 
         let output = command.output()?;
         if output.status.success() {
@@ -54,7 +49,7 @@ fn write_vk_command() -> Result<(), BackendError> {
     std::fs::File::create(&bytecode_path).expect("file should be created");
 
     let write_vk_command =
-        WriteVkCommand { bytecode_path, crs_path, is_recursive: false, vk_path_output };
+        WriteVkCommand { bytecode_path, crs_path, vk_path_output };
 
     write_vk_command.run(backend.binary_path())?;
     drop(temp_directory);

--- a/tooling/backend_interface/src/cli/write_vk.rs
+++ b/tooling/backend_interface/src/cli/write_vk.rs
@@ -48,8 +48,7 @@ fn write_vk_command() -> Result<(), BackendError> {
 
     std::fs::File::create(&bytecode_path).expect("file should be created");
 
-    let write_vk_command =
-        WriteVkCommand { bytecode_path, crs_path, vk_path_output };
+    let write_vk_command = WriteVkCommand { bytecode_path, crs_path, vk_path_output };
 
     write_vk_command.run(backend.binary_path())?;
     drop(temp_directory);

--- a/tooling/backend_interface/src/proof_system.rs
+++ b/tooling/backend_interface/src/proof_system.rs
@@ -110,7 +110,6 @@ impl Backend {
 
         WriteVkCommand {
             crs_path: self.crs_directory(),
-            is_recursive,
             bytecode_path,
             vk_path_output: vk_path.clone(),
         }

--- a/tooling/backend_interface/src/smart_contract.rs
+++ b/tooling/backend_interface/src/smart_contract.rs
@@ -24,7 +24,6 @@ impl Backend {
 
         WriteVkCommand {
             crs_path: self.crs_directory(),
-            is_recursive: false,
             bytecode_path,
             vk_path_output: vk_path.clone(),
         }

--- a/tooling/backend_interface/test-binaries/mock_backend/src/write_vk_cmd.rs
+++ b/tooling/backend_interface/test-binaries/mock_backend/src/write_vk_cmd.rs
@@ -9,9 +9,6 @@ pub(crate) struct WriteVkCommand {
     #[clap(short = 'b')]
     pub(crate) bytecode_path: PathBuf,
 
-    #[clap(short = 'r')]
-    pub(crate) is_recursive: bool,
-
     #[clap(short = 'o')]
     pub(crate) vk_path: PathBuf,
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This argument is unused by `bb` ([see here](https://github.com/AztecProtocol/aztec-packages/blob/434228050ffc65277191aa5b8df6207a3323f466/barretenberg/cpp/src/barretenberg/bb/main.cpp#L375)). I've then removed it.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
