### PR TITLE
fix(docs): update `editUrl` path for docusaurus

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,12 +45,12 @@ const config = {
               label: 'dev',
               path: 'dev',
             },
-            "0.7.1": {
-              label: '0.7.1 / 0.8.0'
+            '0.7.1': {
+              label: '0.7.1 / 0.8.0',
             },
           },
           editUrl: ({ versionDocsDirPath, docPath }) =>
-            `https://github.com/noir-lang/docs/edit/master/${versionDocsDirPath}/${docPath}`,
+            `https://github.com/noir-lang/noir/edit/master/docs/${versionDocsDirPath}/${docPath}`,
         },
         blog: false,
         theme: {
@@ -107,8 +107,8 @@ const config = {
               },
               {
                 label: 'Discord',
-                href: 'https://discord.gg/JtqzkdeQ6G'
-              }
+                href: 'https://discord.gg/JtqzkdeQ6G',
+              },
             ],
           },
           {


### PR DESCRIPTION
# Description

update the editUrl that links to github to "edit this page".

![image](https://github.com/noir-lang/noir/assets/18372439/eb72c966-aec3-47cd-8cd0-c16aa7cffd7a)


## Problem\*

links to old docs repo

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
