### PR TITLE
chore: test splitting and merging of public inputs

### DIFF
--- a/tooling/noir_js_backend_barretenberg/.mocharc.json
+++ b/tooling/noir_js_backend_barretenberg/.mocharc.json
@@ -1,0 +1,9 @@
+{
+  "require": "ts-node/register",
+  "extensions": [
+    "ts"
+  ],
+  "spec": [
+    "test/**/*.test.ts*"
+  ]
+}

--- a/tooling/noir_js_backend_barretenberg/package.json
+++ b/tooling/noir_js_backend_barretenberg/package.json
@@ -6,7 +6,6 @@
   "version": "0.7.10",
   "packageManager": "yarn@3.5.1",
   "license": "(MIT OR Apache-2.0)",
-  "type": "module",
   "source": "src/index.ts",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -25,6 +24,7 @@
     "generate:package": "bash ./fixup.sh",
     "build": "yarn clean && tsc && tsc -p ./tsconfig.cjs.json && yarn generate:package",
     "clean": "rm -rf ./lib",
+    "test": "mocha --timeout 25000 --exit --config ./.mocharc.json",
     "prettier": "prettier 'src/**/*.ts'",
     "prettier:fix": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
     "nightly:version": "jq --arg new_version \"-$(git rev-parse --short HEAD)$1\" '.version = .version + $new_version' package.json > package-tmp.json && mv package-tmp.json package.json",
@@ -37,11 +37,16 @@
     "fflate": "^0.8.0"
   },
   "devDependencies": {
+    "@types/chai": "^4",
+    "@types/mocha": "^10.0.1",
     "@types/node": "^20.6.2",
     "@types/prettier": "^3",
+    "chai": "^4.3.8",
     "eslint": "^8.50.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "mocha": "^10.2.0",
     "prettier": "3.0.3",
+    "ts-node": "^10.9.1",
     "typescript": "5.1.5"
   }
 }

--- a/tooling/noir_js_backend_barretenberg/src/proofs.ts
+++ b/tooling/noir_js_backend_barretenberg/src/proofs.ts
@@ -1,0 +1,57 @@
+import { ProofData } from '@noir-lang/types';
+
+// This is the number of bytes in a UltraPlonk proof
+// minus the public inputs.
+export const NUM_BYTES_IN_PROOF_WITHOUT_PUBLIC_INPUTS: number = 2144;
+
+export function splitPublicInputsFromProof(
+  proofWithPublicInputs: Uint8Array,
+  numBytesInProofWithoutPublicInputs: number,
+): ProofData {
+  const splitIndex = proofWithPublicInputs.length - numBytesInProofWithoutPublicInputs;
+
+  const publicInputSize = 32;
+  const publicInputsConcatenated = proofWithPublicInputs.slice(0, splitIndex);
+
+  const proof = proofWithPublicInputs.slice(splitIndex);
+  const publicInputs = chunkUint8Array(publicInputsConcatenated, publicInputSize);
+
+  return { proof, publicInputs };
+}
+
+export function reconstructProofWithPublicInputs(proofData: ProofData): Uint8Array {
+  // Flatten publicInputs
+  const publicInputsConcatenated = flattenUint8Arrays(proofData.publicInputs);
+
+  // Concatenate publicInputs and proof
+  const proofWithPublicInputs = Uint8Array.from([...publicInputsConcatenated, ...proofData.proof]);
+
+  return proofWithPublicInputs;
+}
+
+function chunkUint8Array(array: Uint8Array, chunkSize: number): Uint8Array[] {
+  if (array.length % chunkSize != 0) {
+    throw Error(`Uint8Array cannot be cleanly split into chunks of ${chunkSize} bytes`);
+  }
+
+  const chunkedArray: Uint8Array[] = [];
+  for (let i = 0; i < array.length; i += chunkSize) {
+    const chunk: Uint8Array = array.slice(i, i + chunkSize);
+    chunkedArray.push(chunk);
+  }
+
+  return chunkedArray;
+}
+
+function flattenUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((acc, val) => acc + val.length, 0);
+  const result = new Uint8Array(totalLength);
+
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+
+  return result;
+}

--- a/tooling/noir_js_backend_barretenberg/test/proof.test.ts
+++ b/tooling/noir_js_backend_barretenberg/test/proof.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { reconstructProofWithPublicInputs, splitPublicInputsFromProof } from '../src/proofs';
+
+it('splits off public inputs from a proof correctly', async () => {
+  const proofWithPublicInputs: Uint8Array = Uint8Array.from(Array.from({ length: 96 }), (_, i) => i);
+
+  const proofData = splitPublicInputsFromProof(proofWithPublicInputs, 32);
+
+  expect(proofData.publicInputs[0]).to.be.deep.eq(Uint8Array.from(Array.from({ length: 32 }), (_, i) => i));
+  expect(proofData.publicInputs[1]).to.be.deep.eq(Uint8Array.from(Array.from({ length: 32 }), (_, i) => i + 32));
+  expect(proofData.proof).to.be.deep.eq(Uint8Array.from(Array.from({ length: 32 }), (_, i) => i + 64));
+});
+
+it('restores the original array from separate proof and public inputs', async () => {
+  const proofWithPublicInputs: Uint8Array = Uint8Array.from(Array.from({ length: 96 }), (_, i) => i);
+
+  const proofData = splitPublicInputsFromProof(proofWithPublicInputs, 32);
+  const reconstructedProof = reconstructProofWithPublicInputs(proofData);
+
+  expect(reconstructedProof).to.be.deep.eq(proofWithPublicInputs);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,12 +3436,17 @@ __metadata:
   dependencies:
     "@aztec/bb.js": 0.8.10
     "@noir-lang/types": "workspace:*"
+    "@types/chai": ^4
+    "@types/mocha": ^10.0.1
     "@types/node": ^20.6.2
     "@types/prettier": ^3
+    chai: ^4.3.8
     eslint: ^8.50.0
     eslint-plugin-prettier: ^5.0.0
     fflate: ^0.8.0
+    mocha: ^10.2.0
     prettier: 3.0.3
+    ts-node: ^10.9.1
     typescript: 5.1.5
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR moves the code related to merging and splitting public inputs from a proof into a separate file.

It also adds a sanity check test that when we split and merge a proof with public inputs we restore the original array.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
