### PR TITLE
chore: move noir program templates into separate files

### DIFF
--- a/tooling/nargo_cli/src/cli/init_cmd.rs
+++ b/tooling/nargo_cli/src/cli/init_cmd.rs
@@ -29,38 +29,9 @@ pub(crate) struct InitCommand {
     pub(crate) contract: bool,
 }
 
-const BIN_EXAMPLE: &str = r#"fn main(x : Field, y : pub Field) {
-    assert(x != y);
-}
-
-#[test]
-fn test_main() {
-    main(1, 2);
-
-    // Uncomment to make test fail
-    // main(1, 1);
-}
-"#;
-
-const CONTRACT_EXAMPLE: &str = r#"contract Main {
-    internal fn double(x: Field) -> pub Field { x * 2 }
-    fn triple(x: Field) -> pub Field { x * 3 }
-    fn quadruple(x: Field) -> pub Field { double(double(x)) }
-}
-"#;
-
-const LIB_EXAMPLE: &str = r#"fn my_util(x : Field, y : Field) -> bool {
-    x != y
-}
-
-#[test]
-fn test_my_util() {
-    assert(my_util(1, 2));
-
-    // Uncomment to make test fail
-    // assert(my_util(1, 1));
-}
-"#;
+const BIN_EXAMPLE: &str = include_str!("./noir_template_files/binary.nr");
+const CONTRACT_EXAMPLE: &str = include_str!("./noir_template_files/contract.nr");
+const LIB_EXAMPLE: &str = include_str!("./noir_template_files/library.nr");
 
 pub(crate) fn run(
     // Backend is currently unused, but we might want to use it to inform the "new" template in the future

--- a/tooling/nargo_cli/src/cli/noir_template_files/binary.nr
+++ b/tooling/nargo_cli/src/cli/noir_template_files/binary.nr
@@ -1,0 +1,11 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[test]
+fn test_main() {
+    main(1, 2);
+
+    // Uncomment to make test fail
+    // main(1, 1);
+}

--- a/tooling/nargo_cli/src/cli/noir_template_files/contract.nr
+++ b/tooling/nargo_cli/src/cli/noir_template_files/contract.nr
@@ -1,0 +1,5 @@
+contract Main {
+    internal fn double(x: Field) -> pub Field { x * 2 }
+    fn triple(x: Field) -> pub Field { x * 3 }
+    fn quadruple(x: Field) -> pub Field { double(double(x)) }
+}

--- a/tooling/nargo_cli/src/cli/noir_template_files/library.nr
+++ b/tooling/nargo_cli/src/cli/noir_template_files/library.nr
@@ -1,0 +1,11 @@
+fn not_equal(x: Field, y: Field) -> bool {
+    x != y
+}
+
+#[test]
+fn test_not_equal() {
+    assert(not_equal(1, 2));
+
+    // Uncomment to make test fail
+    // assert(not_equal(1, 1));
+}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR moves the template noir programs into their own files to remove some noise from the rust source files.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
