### PR TITLE
fix: Fix panic when using repeated arrays which define variables

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -324,7 +324,6 @@ pub fn compile_no_check(
     force_compile: bool,
 ) -> Result<CompiledProgram, RuntimeError> {
     let program = monomorphize(main_function, &context.def_interner);
-    println!("{program}");
 
     let hash = fxhash::hash64(&program);
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -324,6 +324,7 @@ pub fn compile_no_check(
     force_compile: bool,
 ) -> Result<CompiledProgram, RuntimeError> {
     let program = monomorphize(main_function, &context.def_interner);
+    println!("{program}");
 
     let hash = fxhash::hash64(&program);
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -412,12 +412,11 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> ast::Expression {
         let typ = self.convert_type(&self.interner.id_type(array));
 
-        let contents = self.expr(repeated_element);
         let length = length
             .evaluate_to_u64()
             .expect("Length of array is unknown when evaluating numeric generic");
 
-        let contents = vec![contents; length as usize];
+        let contents = vecmap(0..length, |_| self.expr(repeated_element));
         ast::Expression::Literal(ast::Literal::Array(ast::ArrayLiteral { contents, typ }))
     }
 

--- a/tooling/nargo_cli/tests/compile_success_empty/let_stmt/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/let_stmt/src/main.nr
@@ -7,4 +7,5 @@ fn main() {
     let _ = 42;
 
     let Foo { a: _ } = Foo { a: 42 };
+    let _regression_2786 = [Foo { a: 1 }; 8];
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2786

## Summary\*

We were panicking previously whenever using the repeated array element syntax where the element defined a new variable internally. This is because we were simply cloning the expression which leads to redefining the same variable. Running `self.expr` each time instead will create a new variable.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
