### PR TITLE
fix: Allow two `TypeVariable::Constant(N)` to unify even if their constants are not equal

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -684,9 +684,16 @@ impl Type {
                             *binding.borrow_mut() = TypeBinding::Bound(clone);
                             Ok(())
                         }
-                        TypeVariableKind::Constant(_) | TypeVariableKind::IntegerOrField => {
-                            Err(UnificationError)
+                        // The lengths don't match, but neither are set in stone so we can
+                        // just set them both to NotConstant. See issue 2370
+                        TypeVariableKind::Constant(_) => {
+                            // *length != target_length
+                            drop(borrow);
+                            *var.borrow_mut() = TypeBinding::Bound(Type::NotConstant);
+                            *binding.borrow_mut() = TypeBinding::Bound(Type::NotConstant);
+                            Ok(())
                         }
+                        TypeVariableKind::IntegerOrField => Err(UnificationError),
                     },
                 }
             }

--- a/tooling/nargo_cli/tests/execution_success/slices/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/slices/src/main.nr
@@ -49,6 +49,7 @@ fn main(x : Field, y : pub Field) {
     regression_2083();
     // The parameters to this function must come from witness values (inputs to main)
     regression_merge_slices(x, y);
+    regression_2370();
 }
 
 // Ensure that slices of struct/tuple values work.
@@ -300,4 +301,11 @@ fn merge_slices_remove_between_ifs(x: Field, y: Field) -> [Field] {
     }
 
     slice
+}
+
+// Previously, we'd get a type error when trying to assign an array of a different size to
+// an existing array variable. Now, we infer the variable must be a slice.
+fn regression_2370() {
+    let mut slice = [];
+    slice = [1, 2, 3];
 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves #2370

## Summary\*

Previously if we had two unbound type variables, `TypeVariable::Constant(N)` and `TypeVariable::Constant(M)`, they would not unify unless `N == M`. Since both are unbound however, this PR allows us to instead bind both to `Type::NotConstant` if `N != M`. This effectively allows us to infer a mutable variable whose array changes in size to be a slice instead of an array (as in the linked issue).

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
