### PR TITLE
fix: Complete debug metadata

### DIFF
--- a/compiler/noirc_driver/src/debug.rs
+++ b/compiler/noirc_driver/src/debug.rs
@@ -24,7 +24,7 @@ pub(crate) fn filter_relevant_files(
             function_symbols
                 .locations
                 .values()
-                .filter_map(|call_stack| call_stack.last().map(|location| location.file))
+                .flat_map(|call_stack| call_stack.iter().map(|location| location.file))
         })
         .collect();
 

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -27,7 +27,7 @@ impl DebugArtifact {
                 function_symbols
                     .locations
                     .values()
-                    .filter_map(|call_stack| call_stack.last().map(|location| location.file))
+                    .flat_map(|call_stack| call_stack.iter().map(|location| location.file))
             })
             .collect();
 


### PR DESCRIPTION
# Description
Debug metadata only included files that had the last item of any callstack. Since we resolve complete callstacks, we need all files present on those.
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
