### PR TITLE
chore(github): Update PR template per new documentation workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,16 @@ Resolves <!-- Link to GitHub Issue -->
 
 
 
-## Documentation
-
-
-
 ## Additional Context
 
 
+
+## Documentation\*
+
+Check one:
+- [ ] No documentation needed.
+- [ ] Documentation included in this PR.
+- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.
 
 # PR Checklist\*
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,37 +1,20 @@
 # Description
 
-<!-- Thanks for taking the time to improve Noir! -->
-<!-- Please fill out all fields marked with an asterisk (*). -->
-
 ## Problem\*
-
-<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->
 
 Resolves <!-- Link to GitHub Issue -->
 
 ## Summary\*
 
-<!-- Describe the changes in this PR. -->
-<!-- Supplement code examples and highlight breaking changes, if applicable. -->
+
 
 ## Documentation
 
-- [ ] This PR requires documentation updates when merged.
 
-  <!-- If checked, check one of the following: -->
-
-  - [ ] I will submit a noir-lang/docs PR.
-
-  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->
-
-  - [ ] I will request for and support Dev Rel's help in documenting this PR.
-
-  <!-- List / highlight what should be documented. -->
-  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->
 
 ## Additional Context
 
-<!-- Supplement further information if applicable. -->
+
 
 # PR Checklist\*
 


### PR DESCRIPTION
# Description

## Context

To better promote secure and best development practices through documentation, Noir's contribution workflow now requires code authors to include documentation updates per their code changes (if applicable) in the same PRs.

The workflow would be very helpful for capturing design philosophies, contexts, details and caveats from the original authors in the Noir documentation that otherwise could easily go missing in translation.

## Summary\*

This PR updates the GitHub PR template to reflect the new workflow.

Additionally the PR also trims the verbose comments in the template.

## Additional Context

Related effort: https://github.com/noir-lang/noir/pull/3162

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
