### PR TITLE
feat(stdlib): optimize constraint counts in sha256/sha512

### DIFF
--- a/noir_stdlib/src/sha256.nr
+++ b/noir_stdlib/src/sha256.nr
@@ -5,7 +5,9 @@
 // Auxiliary mappings; names as in FIPS PUB 180-4
 fn rotr32(a: u32, b: u32) -> u32 // 32-bit right rotation
 {
-    (a >> b) | (a << (32 as u32 - b))
+    // None of the bits overlap between `(a >> b)` and `(a << (32 - b))`
+    // Addition is then equivalent to OR, with fewer constraints.
+    (a >> b) + (a << (32 as u32 - b))
 }
 
 fn ch(x: u32, y: u32, z: u32) -> u32

--- a/noir_stdlib/src/sha256.nr
+++ b/noir_stdlib/src/sha256.nr
@@ -7,7 +7,7 @@ fn rotr32(a: u32, b: u32) -> u32 // 32-bit right rotation
 {
     // None of the bits overlap between `(a >> b)` and `(a << (32 - b))`
     // Addition is then equivalent to OR, with fewer constraints.
-    (a >> b) + (a << (32 as u32 - b))
+    (a >> b) + (a << (32 - b))
 }
 
 fn ch(x: u32, y: u32, z: u32) -> u32

--- a/noir_stdlib/src/sha512.nr
+++ b/noir_stdlib/src/sha512.nr
@@ -5,7 +5,9 @@
 // Auxiliary mappings; names as in FIPS PUB 180-4
 fn rotr64(a: u64, b: u64) -> u64 // 64-bit right rotation
 {
-    (a >> b) | (a << (64 - b))
+    // None of the bits overlap between `(a >> b)` and `(a << (64 - b))`
+    // Addition is then equivalent to OR, with fewer constraints.
+    (a >> b) + (a << (64 - b))
 }
 
 fn sha_ch(x: u64, y: u64, z: u64) -> u64


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR optimizes the sha256 and sha512 implementations to use a simple addition instead of an OR black box function. We can do this as none of the bits in the two operands overlap so the operations are equivalent.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
