### PR TITLE
feat: documentSymbolsProvider for lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,6 +2556,7 @@ dependencies = [
  "acvm",
  "async-lsp",
  "cfg-if",
+ "codespan",
  "codespan-lsp",
  "codespan-reporting",
  "lsp-types 0.94.0",

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 tower.workspace = true
 cfg-if.workspace = true
 async-lsp = { version = "0.0.5", default-features = false, features = ["omni-trait"] }
+codespan.workspace = true
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 wasm-bindgen.workspace = true

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
 use std::{
+    collections::HashMap,
     future::Future,
     ops::{self, ControlFlow},
     path::{Path, PathBuf},
@@ -26,7 +27,8 @@ use notifications::{
     on_did_open_text_document, on_did_save_text_document, on_exit, on_initialized,
 };
 use requests::{
-    on_code_lens_request, on_initialize, on_shutdown, on_test_run_request, on_tests_request,
+    on_code_lens_request, on_document_symbols, on_initialize, on_shutdown, on_test_run_request,
+    on_tests_request,
 };
 use serde_json::Value as JsonValue;
 use tower::Service;
@@ -44,11 +46,17 @@ pub struct LspState {
     root_path: Option<PathBuf>,
     client: ClientSocket,
     solver: WrapperSolver,
+    open_files: HashMap<Url, String>,
 }
 
 impl LspState {
     fn new(client: &ClientSocket, solver: impl BlackBoxFunctionSolver + 'static) -> Self {
-        Self { client: client.clone(), root_path: None, solver: WrapperSolver(Box::new(solver)) }
+        Self {
+            client: client.clone(),
+            root_path: None,
+            solver: WrapperSolver(Box::new(solver)),
+            open_files: Default::default(),
+        }
     }
 }
 
@@ -66,6 +74,7 @@ impl NargoLspService {
             .request::<request::CodeLens, _>(on_code_lens_request)
             .request::<request::NargoTests, _>(on_tests_request)
             .request::<request::NargoTestRun, _>(on_test_run_request)
+            .request::<request::DocumentSymbolRequest, _>(on_document_symbols)
             .notification::<notification::Initialized>(on_initialized)
             .notification::<notification::DidChangeConfiguration>(on_did_change_configuration)
             .notification::<notification::DidOpenTextDocument>(on_did_open_text_document)

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -30,23 +30,33 @@ pub(super) fn on_did_change_configuration(
 }
 
 pub(super) fn on_did_open_text_document(
-    _state: &mut LspState,
-    _params: DidOpenTextDocumentParams,
+    state: &mut LspState,
+    params: DidOpenTextDocumentParams,
 ) -> ControlFlow<Result<(), async_lsp::Error>> {
+    if params.text_document.language_id != "noir" {
+        return ControlFlow::Continue(());
+    }
+    state.open_files.insert(params.text_document.uri.clone(), params.text_document.text);
     ControlFlow::Continue(())
 }
 
 pub(super) fn on_did_change_text_document(
-    _state: &mut LspState,
-    _params: DidChangeTextDocumentParams,
+    state: &mut LspState,
+    params: DidChangeTextDocumentParams,
 ) -> ControlFlow<Result<(), async_lsp::Error>> {
+    params.content_changes.into_iter().for_each(|change| {
+        state.open_files.insert(params.text_document.uri.clone(), change.text);
+    });
     ControlFlow::Continue(())
 }
 
 pub(super) fn on_did_close_text_document(
-    _state: &mut LspState,
-    _params: DidCloseTextDocumentParams,
+    state: &mut LspState,
+    params: DidCloseTextDocumentParams,
 ) -> ControlFlow<Result<(), async_lsp::Error>> {
+    if state.open_files.contains_key(&params.text_document.uri) {
+        state.open_files.remove(&params.text_document.uri);
+    }
     ControlFlow::Continue(())
 }
 

--- a/tooling/lsp/src/requests/document_symbol_request.rs
+++ b/tooling/lsp/src/requests/document_symbol_request.rs
@@ -1,0 +1,242 @@
+use std::future::{self, Future};
+
+use async_lsp::{ErrorCode, ResponseError};
+use lsp_types::{DocumentSymbol, SymbolKind};
+use noirc_frontend::{
+    parse_program, parser::ItemKind, NoirFunction, Pattern, TraitImplItem, TraitItem,
+};
+
+use crate::{
+    types::{DocumentSymbolParams, DocumentSymbolResponse},
+    LspState,
+};
+
+pub(crate) fn on_document_symbols(
+    state: &mut LspState,
+    params: DocumentSymbolParams,
+) -> impl Future<Output = Result<Option<DocumentSymbolResponse>, ResponseError>> {
+    future::ready(on_document_symbols_inner(state, params))
+}
+
+fn on_document_symbols_inner(
+    state: &mut LspState,
+    params: DocumentSymbolParams,
+) -> Result<Option<DocumentSymbolResponse>, ResponseError> {
+    let text = if state.open_files.contains_key(&params.text_document.uri) {
+        state.open_files.get(&params.text_document.uri).unwrap().clone()
+    } else {
+        std::fs::read_to_string(params.text_document.uri.path()).map_err(|err| {
+            ResponseError::new(ErrorCode::REQUEST_FAILED, format!("Could not read file: {err}"))
+        })?
+    };
+
+    let (parsed_module, _) = parse_program(text.as_str());
+    let symbols: Vec<DocumentSymbol> =
+        parsed_module.items.iter().map(|item| to_document_symbol(&text, item)).flatten().collect();
+    Ok(Some(DocumentSymbolResponse::Nested(symbols)))
+}
+
+fn to_document_symbol(text: &str, item: &noirc_frontend::parser::Item) -> Option<DocumentSymbol> {
+    match &item.kind {
+        ItemKind::Function(function) => Some(noir_function_to_document_symbol(text, function)),
+        ItemKind::Struct(struct_) => Some(DocumentSymbol {
+            name: struct_.name.to_string(),
+            detail: None,
+            kind: SymbolKind::STRUCT,
+            tags: None,
+            deprecated: None,
+            range: Default::default(),
+            selection_range: Default::default(),
+            children: Some(
+                struct_
+                    .fields
+                    .iter()
+                    .map(|(ident, type_)| DocumentSymbol {
+                        name: ident.to_string(),
+                        detail: Some(type_.to_string()),
+                        kind: SymbolKind::FIELD,
+                        tags: None,
+                        deprecated: None,
+                        range: Default::default(),
+                        selection_range: Default::default(),
+                        children: None,
+                    })
+                    .collect(),
+            ),
+        }),
+        ItemKind::Trait(trait_) => Some(DocumentSymbol {
+            name: trait_.name.to_string(),
+            detail: None,
+            kind: SymbolKind::INTERFACE,
+            tags: None,
+            deprecated: None,
+            range: Default::default(),
+            selection_range: Default::default(),
+            children: Some(
+                trait_
+                    .items
+                    .iter()
+                    .map(|trait_item| match trait_item {
+                        TraitItem::Constant { name, typ, default_value } => {
+                            (DocumentSymbol {
+                                name: name.to_string(),
+                                detail: Some(typ.to_string()),
+                                kind: SymbolKind::CONSTANT,
+                                tags: None,
+                                deprecated: None,
+                                range: Default::default(),
+                                selection_range: Default::default(),
+                                children: None,
+                            })
+                        }
+                        TraitItem::Function { name, .. } => {
+                            (DocumentSymbol {
+                                name: name.to_string(),
+                                detail: None,
+                                kind: SymbolKind::FUNCTION,
+                                tags: None,
+                                deprecated: None,
+                                range: Default::default(),
+                                selection_range: Default::default(),
+                                children: None,
+                            })
+                        }
+                        TraitItem::Type { name } => DocumentSymbol {
+                            name: name.to_string(),
+                            detail: None,
+                            kind: SymbolKind::TYPE_PARAMETER,
+                            tags: None,
+                            deprecated: None,
+                            range: Default::default(),
+                            selection_range: Default::default(),
+                            children: None,
+                        },
+                    })
+                    .collect(),
+            ),
+        }),
+        ItemKind::TraitImpl(impl_) => Some(DocumentSymbol {
+            name: impl_.trait_name.to_string(),
+            detail: None,
+            kind: SymbolKind::OBJECT, // rust-analyzer uses object for impls
+            tags: None,
+            deprecated: None,
+            range: Default::default(),
+            selection_range: Default::default(),
+            children: Some(
+                impl_
+                    .items
+                    .iter()
+                    .map(|item| match item {
+                        TraitImplItem::Constant(ident, type_, _) => DocumentSymbol {
+                            name: ident.to_string(),
+                            detail: Some(type_.to_string()),
+                            kind: SymbolKind::CONSTANT,
+                            tags: None,
+                            deprecated: None,
+                            range: Default::default(),
+                            selection_range: Default::default(),
+                            children: None,
+                        },
+                        TraitImplItem::Function(function) => {
+                            noir_function_to_document_symbol(text, function)
+                        }
+                        TraitImplItem::Type { name, .. } => DocumentSymbol {
+                            name: name.to_string(),
+                            detail: None,
+                            kind: SymbolKind::TYPE_PARAMETER,
+                            tags: None,
+                            deprecated: None,
+                            range: Default::default(),
+                            selection_range: Default::default(),
+                            children: None,
+                        },
+                    })
+                    .collect(),
+            ),
+        }),
+        ItemKind::Impl(impl_) => {
+            let objname = impl_.object_type.to_string();
+            let generics = impl_
+                .generics
+                .iter()
+                .map(|gen| gen.to_string())
+                .collect::<Vec<String>>()
+                .join(", ");
+            let name = format!("impl{}<{}> {{}}", objname, generics);
+            Some(DocumentSymbol {
+                name: name,
+                detail: None,
+                kind: SymbolKind::OBJECT,
+                tags: None,
+                deprecated: None,
+                range: Default::default(),
+                selection_range: Default::default(),
+                children: Some(
+                    impl_
+                        .methods
+                        .iter()
+                        .map(|item| noir_function_to_document_symbol(text, item))
+                        .collect(),
+                ),
+            })
+        }
+        ItemKind::Global(global) => {
+            if let Pattern::Identifier(ident) = &global.pattern {
+                Some(DocumentSymbol {
+                    name: ident.to_string(),
+                    detail: None,
+                    kind: SymbolKind::VARIABLE,
+                    tags: None,
+                    deprecated: None,
+                    range: Default::default(),
+                    selection_range: Default::default(),
+                    children: None,
+                })
+            } else {
+                None
+            }
+        }
+        ItemKind::ModuleDecl(module) => Some(DocumentSymbol {
+            name: module.to_string(),
+            detail: None,
+            kind: SymbolKind::MODULE,
+            tags: None,
+            deprecated: None,
+            range: Default::default(),
+            selection_range: Default::default(),
+            children: None,
+        }),
+        ItemKind::Submodules(submodule) => Some(DocumentSymbol {
+            name: submodule.name.to_string(),
+            detail: None,
+            kind: SymbolKind::MODULE,
+            tags: None,
+            deprecated: None,
+            range: Default::default(),
+            selection_range: Default::default(),
+            children: Some(
+                submodule
+                    .contents
+                    .items
+                    .iter()
+                    .filter_map(|item| to_document_symbol(text, item))
+                    .collect(),
+            ),
+        }),
+        ItemKind::TypeAlias(_) | ItemKind::Import(_) => None,
+    }
+}
+
+fn noir_function_to_document_symbol(text: &str, function: &NoirFunction) -> DocumentSymbol {
+    DocumentSymbol {
+        name: function.name().to_string(),
+        detail: None,
+        kind: SymbolKind::FUNCTION,
+        tags: None,
+        deprecated: None,
+        range: Default::default(),
+        selection_range: Default::default(),
+        children: None,
+    }
+}

--- a/tooling/lsp/src/types.rs
+++ b/tooling/lsp/src/types.rs
@@ -1,3 +1,4 @@
+use lsp_types::DocumentSymbolClientCapabilities;
 use noirc_frontend::graph::CrateName;
 use serde::{Deserialize, Serialize};
 
@@ -5,8 +6,9 @@ use serde::{Deserialize, Serialize};
 pub(crate) use lsp_types::{
     CodeLens, CodeLensOptions, CodeLensParams, Command, Diagnostic, DiagnosticSeverity,
     DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, InitializeParams, InitializedParams,
-    LogMessageParams, MessageType, Position, PublishDiagnosticsParams, Range, ServerInfo,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentSymbolOptions,
+    DocumentSymbolParams, DocumentSymbolResponse, InitializeParams, InitializedParams,
+    LogMessageParams, MessageType, OneOf, Position, PublishDiagnosticsParams, Range, ServerInfo,
     TextDocumentSyncCapability, TextDocumentSyncOptions, Url,
 };
 
@@ -19,7 +21,9 @@ pub(crate) mod request {
     };
 
     // Re-providing lsp_types that we don't need to override
-    pub(crate) use lsp_types::request::{CodeLensRequest as CodeLens, Shutdown};
+    pub(crate) use lsp_types::request::{
+        CodeLensRequest as CodeLens, DocumentSymbolRequest, Shutdown,
+    };
 
     #[derive(Debug)]
     pub(crate) struct Initialize;
@@ -98,6 +102,9 @@ pub(crate) struct ServerCapabilities {
     /// The server provides code lens.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) code_lens_provider: Option<CodeLensOptions>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) document_symbol_provider: Option<OneOf<bool, DocumentSymbolOptions>>,
 
     /// The server handles and provides custom nargo messages.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
# Description

This implements the `textDocument/documentSymbol` request for the LSP protocol.
- [ ] Span to range conversion is pending.

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
