### PR TITLE
chore: adding docs conventional commit, adapt conditional labeling

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,8 +21,14 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          const PR_TITLE_PREFIX = 'docs:';
+          const LABEL_NAME = 'documentation';
+          const DOC_PATH_PREFIX = 'docs/';
+
+          const prTitle = context.payload.pull_request.title;
           const labels = context.payload.pull_request.labels.map(label => label.name);
-          if (labels.includes('documentation')) {
+
+          if (labels.includes(LABEL_NAME) || prTitle.startsWith(PR_TITLE_PREFIX)) {
             return true;
           }
 

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -27,3 +27,4 @@ jobs:
             fix
             feat
             chore
+            docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Generally, we want to only use the three primary types defined by the specificat
 - `feat:` - This should be the most used type, as most work we are doing in the project are new features. Commits using this type will always show up in the Changelog.
 - `fix:` - When fixing a bug, we should use this type. Commits using this type will always show up in the Changelog.
 - `chore:` - The least used type, these are __not__ included in the Changelog unless they are breaking changes. But remain useful for an understandable commit history.
+- `docs` - If your changes are only on the docs, use this type
 
 ### Conventional Commits: Breaking Changes
 


### PR DESCRIPTION
# Description

Adds the `docs` conventional commit, and uses it to trigger conditional labelling

## Problem\*

Not exactly a problem, just another way to trigger the `documentation` label and provide a preview

## Summary\*

- Adds a `docs` type on the CONTRIBUTING guide.
- Refactors the build-docs workflow to check for PR title and apply label if it matches the type
