### PR TITLE
fix: Fix lexer error formatting

### DIFF
--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -11,15 +11,15 @@ use thiserror::Error;
 pub enum LexerErrorKind {
     #[error("An unexpected character {:?} was found.", found)]
     UnexpectedCharacter { span: Span, expected: String, found: Option<char> },
-    #[error("NotADoubleChar : {:?} is not a double char token", found)]
+    #[error("Internal error: Tried to lex {:?} as a double char token", found)]
     NotADoubleChar { span: Span, found: Token },
-    #[error("InvalidIntegerLiteral : {:?} is not a integer", found)]
+    #[error("Invalid integer literal, {:?} is not a integer", found)]
     InvalidIntegerLiteral { span: Span, found: String },
-    #[error("MalformedFuncAttribute : {:?} is not a valid attribute", found)]
+    #[error("{:?} is not a valid attribute", found)]
     MalformedFuncAttribute { span: Span, found: String },
-    #[error("TooManyBits")]
+    #[error("Integer type is larger than the maximum supported size of u127")]
     TooManyBits { span: Span, max: u32, got: u32 },
-    #[error("LogicalAnd used instead of bitwise and")]
+    #[error("Logical and used instead of bitwise and")]
     LogicalAnd { span: Span },
     #[error("Unterminated block comment")]
     UnterminatedBlockComment { span: Span },

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -128,7 +128,7 @@ impl std::fmt::Display for ParserError {
 
 impl From<ParserError> for Diagnostic {
     fn from(error: ParserError) -> Diagnostic {
-        match &error.reason {
+        match error.reason {
             Some(reason) => {
                 match reason {
                     ParserErrorReason::ConstrainDeprecated => Diagnostic::simple_error(
@@ -146,11 +146,11 @@ impl From<ParserError> for Diagnostic {
                         "".into(),
                         error.span,
                     ),
-                    reason @ ParserErrorReason::ExpectedPatternButFoundType(ty) => {
-                        Diagnostic::simple_error(reason.to_string(), format!("{ty} is a type and cannot be used as a variable name"), error.span)
+                    ParserErrorReason::ExpectedPatternButFoundType(ty) => {
+                        Diagnostic::simple_error("Expected a ; separating these two statements".into(), format!("{ty} is a type and cannot be used as a variable name"), error.span)
                     }
+                    ParserErrorReason::Lexer(error) => error.into(),
                     other => {
-
                         Diagnostic::simple_error(format!("{other}"), String::new(), error.span)
                     }
                 }


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

This is something I noticed while working on #3236. Lexer errors would display a short printout like `error: TooManyBits` instead of the full formatting.

## Summary\*

This was a result of the parser using the error/debug trait to display lexer errors instead of the conversion to a custom diagnostic. 

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
