### PR TITLE
chore: remove `default` empty features array

### DIFF
--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -28,5 +28,4 @@ strum = "0.24"
 strum_macros = "0.24"
 
 [features]
-default = []
 aztec = []


### PR DESCRIPTION
# Description

This PR fixes 'Publish Noir ES Packages' CI job by removing the empty 'default' features.

## Problem\*

```
error: while parsing a TOML string: [error] toml::insert_value: value ("default") already exists.
```

## Summary\*

## Documentation

N/A

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
