### PR TITLE
chore: upload acir artifacts as a github artifact

### DIFF
--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -2,15 +2,39 @@ name: Rebuild ACIR artifacts
 
 on:
   push:
+    pull_request:
     branches:
       - master
 
 jobs:
+  check-artifacts-requested:
+    runs-on: ubuntu-22.04
+    outputs:
+      publish: ${{ steps.check.outputs.publish }}
+    
+    steps:
+      - name: Check if artifacts should be published
+        id: check
+        run: |
+          if [ ${{ github.ref_name }} == "master" ]; then
+            # Always publish on master
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            # Only publish on PRs if label is set
+            HAS_ARTIFACT_LABEL=$(gh pr view $PR --json labels | jq '.labels | any(.name == "publish-acir")')
+            echo "publish=$HAS_ARTIFACT_LABEL" >> "$GITHUB_OUTPUT"
+          fi
+        with:
+          PR: ${{ github.event.pull_request.number }}
+
+          
   build-nargo:
     runs-on: ubuntu-22.04
+    needs: [check-artifacts-requested]
+    if:  ${{ needs.check-artifacts-requested.outputs.publish }}
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-gnu]
+        target: [x86_64-unknown-linux-gnu]  
         
     steps:
       - name: Checkout Noir repo

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           if [ ${{ github.ref_name }} == "master" ]; then
             git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
-          else
+          fi
           
       - name: Create or Update PR
         if: steps.check_changes.outputs.changes == 'true'

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -25,6 +25,7 @@ jobs:
             echo "publish=$HAS_ARTIFACT_LABEL" >> "$GITHUB_OUTPUT"
           fi
         env:
+          GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
 
           

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   check-artifacts-requested:
+    name: Check if artifacts should be published
     runs-on: ubuntu-22.04
     outputs:
       publish: ${{ steps.check.outputs.publish }}
@@ -29,8 +30,8 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPO_URL: ${{ github.repositoryUrl }}
 
-          
   build-nargo:
+    name: Build nargo binary
     runs-on: ubuntu-22.04
     needs: [check-artifacts-requested]
     if:  ${{ needs.check-artifacts-requested.outputs.publish }}
@@ -68,6 +69,7 @@ jobs:
           retention-days: 3
 
   auto-pr-rebuild-script:
+    name: Rebuild ACIR artifacts
     needs: [build-nargo]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -105,7 +105,9 @@ jobs:
       - name: Check for changes in acir_artifacts directory
         id: check_changes
         run: |
-          git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
+          if [ ${{ github.ref_name }} == "master" ]; then
+            git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
+          else
           
       - name: Create or Update PR
         if: steps.check_changes.outputs.changes == 'true'

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -24,7 +24,7 @@ jobs:
             HAS_ARTIFACT_LABEL=$(gh pr view $PR --json labels | jq '.labels | any(.name == "publish-acir")')
             echo "publish=$HAS_ARTIFACT_LABEL" >> "$GITHUB_OUTPUT"
           fi
-        with:
+        env:
           PR: ${{ github.event.pull_request.number }}
 
           

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -1,8 +1,8 @@
 name: Rebuild ACIR artifacts
 
 on:
+  pull_request:
   push:
-    pull_request:
     branches:
       - master
 
@@ -34,7 +34,7 @@ jobs:
     if:  ${{ needs.check-artifacts-requested.outputs.publish }}
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-gnu]  
+        target: [x86_64-unknown-linux-gnu]
         
     steps:
       - name: Checkout Noir repo

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -108,10 +108,10 @@ jobs:
 
       - name: Check for changes in acir_artifacts directory
         id: check_changes
+        if: ${{ github.ref_name }} == "master"
         run: |
-          if [ ${{ github.ref_name }} == "master" ]; then
-            git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
-          fi
+          git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
+
           
       - name: Create or Update PR
         if: steps.check_changes.outputs.changes == 'true'

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build nargo binary
     runs-on: ubuntu-22.04
     needs: [check-artifacts-requested]
-    if:  ${{ needs.check-artifacts-requested.outputs.publish }}
+    if:  ${{ needs.check-artifacts-requested.outputs.publish == true }}
     strategy:
       matrix:
         target: [x86_64-unknown-linux-gnu]

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -71,6 +71,13 @@ jobs:
           chmod +x ./rebuild.sh
           ./rebuild.sh
 
+      - name: Upload ACIR artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: acir-artifacts
+          path: ./tooling/nargo_cli/tests/acir_artifacts
+          retention-days: 10
+
       - name: Check for changes in acir_artifacts directory
         id: check_changes
         run: |

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -21,12 +21,13 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           else
             # Only publish on PRs if label is set
-            HAS_ARTIFACT_LABEL=$(gh pr view $PR --json labels | jq '.labels | any(.name == "publish-acir")')
+            HAS_ARTIFACT_LABEL=$(gh pr view $PR --repo $REPO_URL --json labels | jq '.labels | any(.name == "publish-acir")')
             echo "publish=$HAS_ARTIFACT_LABEL" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
+          REPO_URL: ${{ github.repositoryUrl }}
 
           
   build-nargo:

--- a/tooling/nargo_cli/tests/rebuild.sh
+++ b/tooling/nargo_cli/tests/rebuild.sh
@@ -42,13 +42,14 @@ for dir in $base_path/*; do
       # Delete the JSON file after extracting bytecode field
       rm ./target/${dir_name}.json
 
-      # Delete the target directory in acir_artifacts if it exists
+      # Clear the target directory in acir_artifacts
       if [ -d "$current_dir/acir_artifacts/$dir_name/target" ]; then
         rm -r "$current_dir/acir_artifacts/$dir_name/target"
       fi
+      mkdir $current_dir/acir_artifacts/$dir_name/target
       
-      # Move the target directory to the corresponding directory in acir_artifacts
-      mv ./target/ $current_dir/acir_artifacts/$dir_name/
+      # Move the artifacts from the target directory to the corresponding directory in acir_artifacts
+      mv ./target/*.gz $current_dir/acir_artifacts/$dir_name/target/
 
       cd $base_path
   fi


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Keeping the `acir_artifacts` directory in sync causes us (well..  me at least) a bunch of trouble due to merge conflicts.

## Summary\*

This PR acts as a first step on moving us away from having committed ACIR artifacts in this repository. We now publish an artifact containing the acir + witnesses.

`aztec-packages` can then pull these artifacts from workflow runs attached to master. At this point we'll no longer need to commit artifacts to this repository.

## Documentation

- [ ] This PR requires documentation updates when merged.

  <!-- If checked, check one of the following: -->

  - [ ] I will submit a noir-lang/docs PR.

  <!-- Submit a PR on https://github.com/noir-lang/docs. Thank you! -->

  - [ ] I will request for and support Dev Rel's help in documenting this PR.

  <!-- List / highlight what should be documented. -->
  <!-- Dev Rel will reach out for clarifications when needed. Thank you! -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
