### PR TITLE
feat: Allow a trait to be implemented multiple times for the same struct

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -126,7 +126,7 @@ pub struct DefCollector {
 pub enum CompilationError {
     ParseError(ParserError),
     DefinitionError(DefCollectorErrorKind),
-    ResolveError(ResolverError),
+    ResolverError(ResolverError),
     TypeError(TypeCheckError),
 }
 
@@ -135,7 +135,7 @@ impl From<CompilationError> for CustomDiagnostic {
         match value {
             CompilationError::ParseError(error) => error.into(),
             CompilationError::DefinitionError(error) => error.into(),
-            CompilationError::ResolveError(error) => error.into(),
+            CompilationError::ResolverError(error) => error.into(),
             CompilationError::TypeError(error) => error.into(),
         }
     }
@@ -155,7 +155,7 @@ impl From<DefCollectorErrorKind> for CompilationError {
 
 impl From<ResolverError> for CompilationError {
     fn from(value: ResolverError) -> Self {
-        CompilationError::ResolveError(value)
+        CompilationError::ResolverError(value)
     }
 }
 impl From<TypeCheckError> for CompilationError {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -529,7 +529,7 @@ fn collect_trait_impl(
         let path_resolver = StandardPathResolver::new(module);
         let file = def_maps[&crate_id].file_id(trait_impl.module_id);
         let mut resolver = Resolver::new(interner, &path_resolver, def_maps, file);
-        let typ = resolver.resolve_type(unresolved_type.clone());
+        let typ = resolver.resolve_type(unresolved_type);
         errors.extend(take_errors(trait_impl.file_id, resolver));
 
         if let Some(struct_type) = get_struct_type(&typ) {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -7,7 +7,7 @@ use noirc_errors::Location;
 use crate::{
     graph::CrateId,
     hir::def_collector::dc_crate::{UnresolvedStruct, UnresolvedTrait},
-    node_interner::{TraitId, TypeAliasId},
+    node_interner::{FunctionModifiers, TraitId, TypeAliasId},
     parser::{SortedModule, SortedSubModule},
     FunctionDefinition, Ident, LetStatement, NoirFunction, NoirStruct, NoirTrait, NoirTraitImpl,
     NoirTypeAlias, TraitImplItem, TraitItem, TypeImpl,
@@ -378,11 +378,22 @@ impl<'a> ModCollector<'a> {
                         body,
                     } => {
                         let func_id = context.def_interner.push_empty_fn();
+                        let modifiers = FunctionModifiers {
+                            name: name.to_string(),
+                            visibility: crate::FunctionVisibility::Public,
+                            // TODO(Maddiaa): Investigate trait implementations with attributes see: https://github.com/noir-lang/noir/issues/2629
+                            attributes: crate::token::Attributes::empty(),
+                            is_unconstrained: false,
+                            contract_function_type: None,
+                            is_internal: None,
+                        };
+
+                        context.def_interner.push_function_definition(func_id, modifiers, id.0);
+
                         match self.def_collector.def_map.modules[id.0.local_id.0]
                             .declare_function(name.clone(), func_id)
                         {
                             Ok(()) => {
-                                // TODO(Maddiaa): Investigate trait implementations with attributes see: https://github.com/noir-lang/noir/issues/2629
                                 if let Some(body) = body {
                                     let impl_method =
                                         NoirFunction::normal(FunctionDefinition::normal(

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -618,9 +618,10 @@ impl NodeInterner {
     #[cfg(test)]
     pub fn push_test_function_definition(&mut self, name: String) -> FuncId {
         let id = self.push_fn(HirFunction::empty());
-        let modifiers = FunctionModifiers::new();
+        let mut modifiers = FunctionModifiers::new();
+        modifiers.name = name;
         let module = ModuleId::dummy_id();
-        self.push_function_definition(name, id, modifiers, module);
+        self.push_function_definition(id, modifiers, module);
         id
     }
 
@@ -631,7 +632,6 @@ impl NodeInterner {
         module: ModuleId,
     ) -> DefinitionId {
         use ContractFunctionType::*;
-        let name = function.name.0.contents.clone();
 
         // We're filling in contract_function_type and is_internal now, but these will be verified
         // later during name resolution.
@@ -643,16 +643,16 @@ impl NodeInterner {
             contract_function_type: Some(if function.is_open { Open } else { Secret }),
             is_internal: Some(function.is_internal),
         };
-        self.push_function_definition(name, id, modifiers, module)
+        self.push_function_definition(id, modifiers, module)
     }
 
     pub fn push_function_definition(
         &mut self,
-        name: String,
         func: FuncId,
         modifiers: FunctionModifiers,
         module: ModuleId,
     ) -> DefinitionId {
+        let name = modifiers.name.clone();
         self.function_modifiers.insert(func, modifiers);
         self.function_modules.insert(func, module);
         self.push_definition(name, false, DefinitionKind::Function(func))

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -461,7 +461,7 @@ mod test {
 
         for (err, _file_id) in errors {
             match &err {
-                CompilationError::ResolveError(ResolverError::PathResolutionError(
+                CompilationError::ResolverError(ResolverError::PathResolutionError(
                     PathResolutionError::Unresolved(ident),
                 )) => {
                     assert_eq!(ident, "NotAType");
@@ -533,18 +533,23 @@ mod test {
             }
         }
 
-        fn main() {
-        }
+        fn main() {}
         ";
         let errors = get_program_errors(src);
         assert!(!has_parser_error(&errors));
-        assert!(errors.len() == 1, "Expected 1 error, got: {:?}", errors);
+        assert!(errors.len() == 2, "Expected 2 errors, got: {:?}", errors);
         for (err, _file_id) in errors {
             match &err {
                 CompilationError::DefinitionError(
                     DefCollectorErrorKind::TraitImplNotAllowedFor { trait_path, span: _ },
                 ) => {
                     assert_eq!(trait_path.as_string(), "Default");
+                }
+                CompilationError::ResolverError(ResolverError::Expected {
+                    expected, got, ..
+                }) => {
+                    assert_eq!(expected, "type");
+                    assert_eq!(got, "function");
                 }
                 _ => {
                     panic!("No other errors are expected! Found = {:?}", err);
@@ -810,7 +815,7 @@ mod test {
         assert!(errors.len() == 1, "Expected 1 error, got: {:?}", errors);
         // It should be regarding the unused variable
         match &errors[0].0 {
-            CompilationError::ResolveError(ResolverError::UnusedVariable { ident }) => {
+            CompilationError::ResolverError(ResolverError::UnusedVariable { ident }) => {
                 assert_eq!(&ident.0.contents, "y");
             }
             _ => unreachable!("we should only have an unused var error"),
@@ -829,7 +834,7 @@ mod test {
         assert!(errors.len() == 1, "Expected 1 error, got: {:?}", errors);
         // It should be regarding the unresolved var `z` (Maybe change to undeclared and special case)
         match &errors[0].0 {
-            CompilationError::ResolveError(ResolverError::VariableNotDeclared {
+            CompilationError::ResolverError(ResolverError::VariableNotDeclared {
                 name,
                 span: _,
             }) => assert_eq!(name, "z"),
@@ -848,7 +853,7 @@ mod test {
         assert!(errors.len() == 1, "Expected 1 error, got: {:?}", errors);
         for (compilation_error, _file_id) in errors {
             match compilation_error {
-                CompilationError::ResolveError(err) => {
+                CompilationError::ResolverError(err) => {
                     match err {
                         ResolverError::PathResolutionError(PathResolutionError::Unresolved(
                             name,
@@ -892,7 +897,7 @@ mod test {
         // `foo::bar` does not exist
         for (compilation_error, _file_id) in errors {
             match compilation_error {
-                CompilationError::ResolveError(err) => {
+                CompilationError::ResolverError(err) => {
                     match err {
                         ResolverError::UnusedVariable { ident } => {
                             assert_eq!(&ident.0.contents, "z");
@@ -1069,12 +1074,13 @@ mod test {
 
         for (err, _file_id) in errors {
             match &err {
-                CompilationError::ResolveError(ResolverError::VariableNotDeclared {
-                    name, ..
+                CompilationError::ResolverError(ResolverError::VariableNotDeclared {
+                    name,
+                    ..
                 }) => {
                     assert_eq!(name, "i");
                 }
-                CompilationError::ResolveError(ResolverError::NumericConstantInFormatString {
+                CompilationError::ResolverError(ResolverError::NumericConstantInFormatString {
                     name,
                     ..
                 }) => {

--- a/tooling/nargo_cli/tests/compile_success_empty/trait_generics/Nargo.toml
+++ b/tooling/nargo_cli/tests/compile_success_empty/trait_generics/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "trait_generics"
+type = "bin"
+authors = [""]
+compiler_version = "0.10.5"
+
+[dependencies]

--- a/tooling/nargo_cli/tests/compile_success_empty/trait_generics/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/trait_generics/src/main.nr
@@ -1,0 +1,27 @@
+
+struct Empty<T> {}
+
+trait Foo {
+    fn foo(self) -> u32;
+}
+
+impl Foo for Empty<u32> {
+    fn foo(_self: Self) -> u32 { 32 }
+}
+
+impl Foo for Empty<u64> {
+    fn foo(_self: Self) -> u32 { 64 }
+}
+
+fn main() {
+    let x: Empty<u32> = Empty {};
+    let y: Empty<u64> = Empty {};
+    let z = Empty {};
+
+    assert(x.foo() == 32);
+    assert(y.foo() == 64);
+
+    // Types matching multiple impls will currently choose 
+    // the first matching one instead of erroring
+    assert(z.foo() == 32);
+}


### PR DESCRIPTION
# Description

<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

## Problem\*

Trait impl methods are all placed within a struct's namespace which doesn't allow for the same trait to be implemented on different instances of a generic type, such as `Foo<u32>` and `Foo<u64>`.

## Summary\*

This PR allows implementing a trait multiple times for the same struct, although still does not allow fully generic impls such as `impl<T> Bar for Foo<T>`. This was a bit awkward to fit in with the existing way trait impls are put in modules. In the future when we have fully generic traits this will need to be reworked entirely so that only the abstract trait definition is visible and an impl is chosen later during type checking.

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Documentation

No documentation yet - I'm waiting until traits are fully finished and no longer marked experimental.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
