### PR TITLE
chore(docs): Recommend `yarn` instead of for cutting doc versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ In the docs folder, you'll find the current, unreleased version, which we call `
 While the versioning is intended to be managed by the core maintainers, we feel it's important for external contributors to understand why and how is it maintained. To bump to a new version, run the following command, replacing with the intended version:
 
 ```bash
-npm run docusaurus docs:version <new_version_tag>
+yarn docusaurus docs:version <new_version_tag>
 ```
 
 This should create a new version by copying the docs folder and the sidebars.js file to the relevant folders, as well as adding this version to versions.json.


### PR DESCRIPTION
# Description

## Problem\*

Cutting a new doc version with:

```bash
npm run docusaurus docs:version <new_version_tag>
```

did not work on my machine, gave the error of:

```bash
npm ERR! Lifecycle script `docusaurus` failed with error: 
npm ERR! Error: Missing script: "docusaurus"

To see a list of scripts, run:
  npm run 
npm ERR!   in workspace: docs@0.0.0 
npm ERR!   at location: /Users/s/Dev/noir-lang/noir/docs 
npm ERR! Missing script: docusaurus

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/s/.npm/_logs/2023-10-25T14_01_36_763Z-debug-0.log
```

## Summary\*

Using:

```bash
yarn docusaurus docs:version <new_version_tag>
```

instead worked.

## Additional Context

Both approaches are recommended on [Docusaurus's docs](https://docusaurus.io/docs/versioning#tagging-a-new-version).

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.