### PR TITLE
feat: Make generic impls callable

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -160,6 +160,7 @@ impl<'a> ModCollector<'a> {
                 trait_path: trait_name,
                 methods: unresolved_functions,
                 object_type: trait_impl.object_type,
+                generics: trait_impl.impl_generics,
                 trait_id: None, // will be filled later
             };
 

--- a/tooling/nargo_cli/tests/compile_success_empty/trait_generics/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/trait_generics/src/main.nr
@@ -24,4 +24,22 @@ fn main() {
     // Types matching multiple impls will currently choose 
     // the first matching one instead of erroring
     assert(z.foo() == 32);
+
+    // Ensure we can call a generic impl
+    let x: u8 = 7;
+    let y: i8 = 8;
+    let s2_u8 = S2 { x };
+    let s2_i8 = S2 { x: y };
+    assert(s2_u8.t2().x == 7);
+    assert(s2_i8.t2().x == 8);
+}
+
+trait T2 {
+    fn t2(self) -> Self;
+}
+
+struct S2<T> { x: T }
+
+impl<T> T2 for S2<T> {
+    fn t2(self) -> Self { self }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR makes generic trait impls like `impl<T> Foo for Bar<T>` callable. Note that this PR does the bare minimum - there is no overlap checking for these impls currently so you can define two identical generic impls without error. The error will come in a later PR.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
