### PR TITLE
feat(debugger): Allow debugger to inspect variable state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ dependencies = [
  "acvm",
  "easy-repl",
  "nargo",
+ "noirc_frontend",
  "noirc_printable_type",
  "thiserror",
 ]

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -111,8 +111,17 @@ impl<'b, B: BlackBoxFunctionSolver> BrilligSolver<'b, B> {
         Ok(Self { vm, acir_index })
     }
 
+    pub(super) fn program_counter(&self) -> usize {
+        self.vm.program_counter()
+    }
+
     pub(super) fn solve(&mut self) -> Result<BrilligSolverStatus, OpcodeResolutionError> {
         let status = self.vm.process_opcodes();
+        self.handle_vm_status(status)
+    }
+
+    pub(super) fn step(&mut self) -> Result<BrilligSolverStatus, OpcodeResolutionError> {
+        let status = self.vm.process_opcode();
         self.handle_vm_status(status)
     }
 

--- a/compiler/noirc_errors/src/debug_info.rs
+++ b/compiler/noirc_errors/src/debug_info.rs
@@ -3,10 +3,11 @@ use acvm::compiler::AcirTransformationMap;
 
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap,HashMap};
 use std::mem;
 
 use crate::Location;
+use fm::FileId;
 use serde::{Deserialize, Serialize};
 
 #[serde_as]
@@ -17,11 +18,15 @@ pub struct DebugInfo {
     /// that they should be serialized to/from strings.
     #[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
     pub locations: BTreeMap<OpcodeLocation, Vec<Location>>,
+    pub variables: HashMap<String, u32>,
 }
 
 impl DebugInfo {
-    pub fn new(locations: BTreeMap<OpcodeLocation, Vec<Location>>) -> Self {
-        DebugInfo { locations }
+    pub fn new(
+        locations: BTreeMap<OpcodeLocation, Vec<Location>>,
+        variables: HashMap<String, u32>,
+    ) -> Self {
+        Self { locations, variables }
     }
 
     /// Updates the locations map when the [`Circuit`][acvm::acir::circuit::Circuit] is modified.

--- a/compiler/noirc_errors/src/debug_info.rs
+++ b/compiler/noirc_errors/src/debug_info.rs
@@ -1,5 +1,6 @@
 use acvm::acir::circuit::OpcodeLocation;
 use acvm::compiler::AcirTransformationMap;
+use fm::FileId;
 
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
@@ -7,7 +8,6 @@ use std::collections::{BTreeMap,HashMap};
 use std::mem;
 
 use crate::Location;
-use fm::FileId;
 use serde::{Deserialize, Serialize};
 
 #[serde_as]
@@ -46,5 +46,15 @@ impl DebugInfo {
 
     pub fn opcode_location(&self, loc: &OpcodeLocation) -> Option<Vec<Location>> {
         self.locations.get(loc).cloned()
+    }
+
+    pub fn get_file_ids(&self) -> Vec<FileId> {
+        self
+            .locations
+            .values()
+            .filter_map(|call_stack| {
+                call_stack.last().map(|location| location.file)
+            })
+            .collect()
     }
 }

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -107,13 +107,16 @@ pub fn create_circuit(
         assert_messages: assert_messages.into_iter().collect(),
     };
 
+    let file_id = locations.first_key_value().unwrap().1[0].file;
+
     // This converts each im::Vector in the BTreeMap to a Vec
     let locations = locations
         .into_iter()
         .map(|(index, locations)| (index, locations.into_iter().collect()))
         .collect();
 
-    let mut debug_info = DebugInfo::new(locations);
+    let variables = context.debug_states.get(&file_id).unwrap().var_name_to_id.clone();
+    let mut debug_info = DebugInfo::new(locations, variables);
 
     // Perform any ACIR-level optimizations
     let (optimized_circuit, transformation_map) = acvm::compiler::optimize(circuit);

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -107,15 +107,13 @@ pub fn create_circuit(
         assert_messages: assert_messages.into_iter().collect(),
     };
 
-    let file_id = locations.first_key_value().unwrap().1[0].file;
-
     // This converts each im::Vector in the BTreeMap to a Vec
     let locations = locations
         .into_iter()
         .map(|(index, locations)| (index, locations.into_iter().collect()))
         .collect();
 
-    let variables = context.debug_states.get(&file_id).unwrap().var_name_to_id.clone();
+    let variables = context.debug_state.get_variables();
     let mut debug_info = DebugInfo::new(locations, variables);
 
     // Perform any ACIR-level optimizations

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use crate::parser::ParsedModule;
+use crate::{ast, parser::{Item,ItemKind}, ast::{Path,PathKind,UseTreeKind}};
+use noirc_errors::{Span, Spanned};
+
+// debug struct
+// assert values
+// variable values
+// function arguments
+// program gets linearized so maybe show arguments as if that wasn't the case
+
+// annotate things like division which do not have direct mappings to opcodes
+
+// set empty locations to make the instructions skippable
+
+pub struct DebugState {
+    var_id_to_name: HashMap<u32,String>,
+    var_name_to_id: HashMap<String,u32>,
+    var_id_to_value: HashMap<u32,String>, // TODO: something more sophisticated for lexical levels
+    // TODO: ^ use Value type?
+    next_var_id: u32,
+    pub enabled: bool,
+}
+
+impl Default for DebugState {
+    fn default() -> Self {
+        Self {
+            var_id_to_name: HashMap::new(),
+            var_name_to_id: HashMap::new(),
+            var_id_to_value: HashMap::new(),
+            next_var_id: 0,
+            enabled: true, // TODO
+        }
+    }
+
+}
+
+impl DebugState {
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item=(&'a str,&'a str)> {
+        self.var_id_to_value.iter().filter_map(|(var_id,value)| {
+            self.var_id_to_name.get(var_id).map(|name| {
+                (name.as_str(),value.as_str())
+            })
+        })
+    }
+
+    fn insert_var(&mut self, var_name: &str) -> u32 {
+        let var_id = self.next_var_id;
+        self.next_var_id += 1;
+        self.var_id_to_name.insert(var_id, var_name.to_string());
+        self.var_name_to_id.insert(var_name.to_string(), var_id);
+        var_id
+    }
+
+    pub fn set_var_by_id(&mut self, var_id: u32, value: String) {
+        self.var_id_to_value.insert(var_id, value);
+    }
+
+    pub fn insert_symbols(&mut self, module: &mut ParsedModule) {
+        if !self.enabled { return }
+        let empty = Span::single_char(0);
+        let prefix = Path {
+            segments: vec![ ast::Ident(Spanned::from(empty.clone(), "std".to_string())) ],
+            kind: PathKind::Dep,
+        };
+        let kind = UseTreeKind::Path(
+            ast::Ident(Spanned::from(empty.clone(), "__debug_state_set".to_string())),
+            Some(ast::Ident(Spanned::from(empty.clone(), "__debug_state_set".to_string()))),
+        );
+        module.items.push(Item {
+            kind: ItemKind::Import(ast::UseTree { prefix, kind }),
+            span: empty.clone(),
+        });
+
+        module.items.iter_mut().for_each(|item| {
+            match item {
+                Item { kind: ItemKind::Function(f), .. } => {
+                    // todo: f.def.parameters
+                    f.def.body.0.iter_mut().for_each(|stmt| self.walk_statement(stmt));
+                },
+                _ => {},
+            }
+        });
+    }
+
+    fn walk_expr(&mut self, _expr: &mut ast::Expression) {
+    }
+
+    fn debug_expr(&mut self, var_name: &str, expr: ast::Expression) -> ast::Expression {
+        let var_id = self.insert_var(var_name);
+        let func = Box::new(ast::Expression {
+            kind: ast::ExpressionKind::Call(Box::new(ast::CallExpression {
+                func: Box::new(ast::Expression {
+                    kind: ast::ExpressionKind::Variable(ast::Path {
+                        segments: vec![ast::Ident(
+                            Spanned::from(Span::single_char(0), "__debug_state_set".to_string())
+                        )],
+                        kind: PathKind::Plain
+                    }),
+                    span: Span::single_char(0),
+                }),
+                arguments: vec![
+                    ast::Expression {
+                        kind: ast::ExpressionKind::Literal(ast::Literal::Integer(
+                            (var_id as u128).into()
+                        )),
+                        span: Span::single_char(0),
+                    },
+                    ast::Expression {
+                        kind: ast::ExpressionKind::Literal(ast::Literal::FmtStr(format!["{}={{{}}}", var_name, var_name])),
+                        span: Span::single_char(0),
+                    }
+                ],
+            })),
+            span: Span::single_char(0),
+        });
+        let kind = ast::ExpressionKind::Call(Box::new(ast::CallExpression {
+            func,
+            arguments: vec![expr],
+        }));
+        ast::Expression { kind, span: Span::single_char(0) }
+    }
+
+    fn walk_statement(&mut self, stmt: &mut ast::Statement) {
+        match &mut stmt.kind {
+            ast::StatementKind::Let(ref mut let_stmt) => {
+                match &let_stmt.pattern {
+                    ast::Pattern::Identifier(id) => {
+                        let expr = let_stmt.expression.clone();
+                        let_stmt.expression = self.debug_expr(&id.0.contents, expr);
+                    },
+                    ast::Pattern::Mutable(_, _) => {
+                    },
+                    ast::Pattern::Tuple(_, _) => {
+                    },
+                    ast::Pattern::Struct(_, _, _) => {
+                    },
+                }
+                self.walk_expr(&mut let_stmt.expression);
+            },
+            _ => {},
+        }
+    }
+}

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -14,9 +14,9 @@ use noirc_errors::{Span, Spanned};
 // set empty locations to make the instructions skippable
 
 pub struct DebugState {
-    var_id_to_name: HashMap<u32,String>,
-    var_name_to_id: HashMap<String,u32>,
-    var_id_to_value: HashMap<u32,String>, // TODO: something more sophisticated for lexical levels
+    pub var_id_to_name: HashMap<u32,String>,
+    pub var_name_to_id: HashMap<String,u32>,
+    pub var_id_to_value: HashMap<u32,String>, // TODO: something more sophisticated for lexical levels
     // TODO: ^ use Value type?
     next_var_id: u32,
     pub enabled: bool,
@@ -32,20 +32,29 @@ impl Default for DebugState {
             enabled: true, // TODO
         }
     }
-
 }
 
 impl DebugState {
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item=(&'a str,&'a str)> {
+    pub fn new(vars: HashMap<String,u32>) -> Self {
+        let mut debug_state = Self::default();
+        for (var_name, var_id) in vars.iter() {
+            debug_state.var_id_to_name.insert(*var_id, var_name.clone());
+            debug_state.var_name_to_id.insert(var_name.clone(), *var_id);
+            debug_state.next_var_id = debug_state.next_var_id.max(var_id+1);
+        }
+        debug_state
+    }
+
+    pub fn get_values(&self) -> HashMap<String,String> {
         println!["ITER"];
         println!["  var_id_to_value={:?}", &self.var_id_to_value];
         println!["  var_id_to_name={:?}", &self.var_id_to_name];
         println!["  var_name_to_id={:?}", &self.var_name_to_id];
         self.var_id_to_value.iter().filter_map(|(var_id,value)| {
             self.var_id_to_name.get(var_id).map(|name| {
-                (name.as_str(),value.as_str())
+                (name.clone(),value.clone())
             })
-        })
+        }).collect()
     }
 
     fn insert_var(&mut self, var_name: &str) -> u32 {

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -13,6 +13,7 @@ use noirc_errors::{Span, Spanned};
 
 // set empty locations to make the instructions skippable
 
+#[derive(Debug,Clone)]
 pub struct DebugState {
     pub var_id_to_name: HashMap<u32,String>,
     pub var_name_to_id: HashMap<String,u32>,

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use crate::parser::ParsedModule;
 use crate::{ast, parser::{Item,ItemKind}, ast::{Path,PathKind,UseTreeKind}};
 use noirc_errors::{Span, Spanned};
+use std::collections::VecDeque;
 
 #[derive(Debug,Clone)]
 pub struct DebugState {
@@ -76,14 +77,12 @@ impl DebugState {
     fn walk_expr(&mut self, _expr: &mut ast::Expression) {
     }
 
-    fn debug_expr(&mut self, var_name: &str, expr: ast::Expression) -> ast::Expression {
+    fn wrap_var_expr(&mut self, var_name: &str, expr: ast::Expression) -> ast::Expression {
         let var_id = self.insert_var(var_name);
         let kind = ast::ExpressionKind::Call(Box::new(ast::CallExpression {
             func: Box::new(ast::Expression {
                 kind: ast::ExpressionKind::Variable(ast::Path {
-                    segments: vec![ast::Ident(
-                        Spanned::from(Span::single_char(0), "__debug_state_set".to_string())
-                    )],
+                    segments: vec![ident("__debug_state_set")],
                     kind: PathKind::Plain
                 }),
                 span: Span::single_char(0),
@@ -101,24 +100,105 @@ impl DebugState {
         ast::Expression { kind, span: Span::single_char(0) }
     }
 
+    fn wrap_let_statement(&mut self, let_stmt: &ast::LetStatement) -> ast::Statement {
+        // rewrites let statements written like this:
+        //   let (((a,b,c),D { d }),e,f) = x;
+        //
+        // into statements like this:
+        //
+        //   let (a,b,c,d,e,f,g) = {
+        //     let (((a,b,c),D { d }),e,f) = x;
+        //     wrap(a);
+        //     wrap(b);
+        //     ...
+        //     wrap(f);
+        //     (a,b,c,d,e,f,g)
+        //   };
+
+        let vars = pattern_vars(&let_stmt.pattern);
+        let vars_pattern: Vec<ast::Pattern> = vars.iter().map(|id| {
+            ast::Pattern::Identifier(id.clone())
+        }).collect();
+        let vars_exprs: Vec<ast::Expression> = vars.iter().map(|id| id_expr(id)).collect();
+
+        let mut block_stmts = vec![
+            ast::Statement {
+                kind: ast::StatementKind::Let(let_stmt.clone()),
+                span: Span::single_char(0),
+            },
+        ];
+        block_stmts.extend(vars.iter().map(|id| {
+            let var_name = &id.0.contents;
+            ast::Statement {
+                kind: ast::StatementKind::Semi(self.wrap_var_expr(var_name, id_expr(id))),
+                span: Span::single_char(0),
+            }
+        }));
+        block_stmts.push(ast::Statement {
+            kind: ast::StatementKind::Expression(ast::Expression {
+                kind: ast::ExpressionKind::Tuple(vars_exprs),
+                span: Span::single_char(0),
+            }),
+            span: Span::single_char(0),
+        });
+
+        ast::Statement {
+            kind: ast::StatementKind::Let(ast::LetStatement {
+                pattern: ast::Pattern::Tuple(vars_pattern, Span::single_char(0)),
+                r#type: ast::UnresolvedType::unspecified(),
+                expression: ast::Expression {
+                    kind: ast::ExpressionKind::Block(ast::BlockExpression(block_stmts)),
+                    span: Span::single_char(0),
+                },
+            }),
+            span: Span::single_char(0),
+        }
+    }
+
     fn walk_statement(&mut self, stmt: &mut ast::Statement) {
         match &mut stmt.kind {
-            ast::StatementKind::Let(ref mut let_stmt) => {
-                match &let_stmt.pattern {
-                    ast::Pattern::Identifier(id) => {
-                        let expr = let_stmt.expression.clone();
-                        let_stmt.expression = self.debug_expr(&id.0.contents, expr);
-                    },
-                    ast::Pattern::Mutable(_, _) => {
-                    },
-                    ast::Pattern::Tuple(_, _) => {
-                    },
-                    ast::Pattern::Struct(_, _, _) => {
-                    },
-                }
-                self.walk_expr(&mut let_stmt.expression);
+            ast::StatementKind::Let(let_stmt) => {
+                *stmt = self.wrap_let_statement(&let_stmt);
             },
             _ => {},
         }
+    }
+}
+
+fn pattern_vars(pattern: &ast::Pattern) -> Vec<ast::Ident> {
+    let mut vars = vec![];
+    let mut stack = VecDeque::from([ pattern ]);
+    while stack.front().is_some() {
+        let pattern = stack.pop_front().unwrap();
+        match pattern {
+            ast::Pattern::Identifier(id) => {
+                vars.push(id.clone());
+            },
+            ast::Pattern::Mutable(pattern, _) => {
+                stack.push_back(pattern);
+            },
+            ast::Pattern::Tuple(patterns, _) => {
+                stack.extend(patterns.iter());
+            },
+            ast::Pattern::Struct(_, pids, _) => {
+                stack.extend(pids.iter().map(|(_, pattern)| pattern));
+                vars.extend(pids.iter().map(|(id, _)| id.clone()));
+            },
+        }
+    }
+    vars
+}
+
+fn ident(s: &str) -> ast::Ident {
+    ast::Ident(Spanned::from(Span::single_char(0), s.to_string()))
+}
+
+fn id_expr(id: &ast::Ident) -> ast::Expression {
+    ast::Expression {
+        kind: ast::ExpressionKind::Variable(Path {
+            segments: vec![id.clone()],
+            kind: PathKind::Plain,
+        }),
+        span: Span::single_char(0),
     }
 }

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -20,7 +20,7 @@ use super::{
     },
     errors::{DefCollectorErrorKind, DuplicateType},
 };
-use crate::hir::def_map::{parse_file, LocalModuleId, ModuleData, ModuleId};
+use crate::hir::def_map::{LocalModuleId, ModuleData, ModuleId};
 use crate::hir::resolution::import::ImportDirective;
 use crate::hir::Context;
 
@@ -525,8 +525,7 @@ impl<'a> ModCollector<'a> {
         context.visited_files.insert(child_file_id, location);
 
         // Parse the AST for the module we just found and then recursively look for it's defs
-        let (ast, parsing_errors) = parse_file(&context.file_manager, child_file_id);
-        let ast = ast.into_sorted();
+        let (ast, parsing_errors) = context.parse_file(child_file_id, crate_id);
 
         errors.extend(
             parsing_errors.iter().map(|e| (e.clone().into(), child_file_id)).collect::<Vec<_>>(),

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -81,9 +81,8 @@ impl CrateDefMap {
         }
 
         // First parse the root file.
-        let root_file_id = context.crate_graph[crate_id].root_file_id;
-        let (ast, parsing_errors) = parse_file(&context.file_manager, root_file_id);
-        let ast = ast.into_sorted();
+        let root_file_id = context.get_root_id(crate_id);
+        let (ast, parsing_errors) = context.parse_file(root_file_id, crate_id);
 
         #[cfg(feature = "aztec")]
         let ast = match super::aztec_library::transform(ast, &crate_id, context) {
@@ -257,7 +256,7 @@ pub struct Contract {
     pub events: Vec<StructId>,
 }
 
-/// Given a FileId, fetch the File, from the FileManager and parse it's content
+/// Given a FileId, fetch the File, from the FileManager and parse it's content.
 pub fn parse_file(fm: &FileManager, file_id: FileId) -> (ParsedModule, Vec<ParserError>) {
     let file = fm.fetch_file(file_id);
     parse_program(file.source())

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -28,7 +28,7 @@ pub struct Context {
     pub(crate) def_maps: BTreeMap<CrateId, CrateDefMap>,
     pub file_manager: FileManager,
     pub root_crate_id: CrateId,
-    pub debug_states: BTreeMap<FileId, DebugState>,
+    pub debug_state: DebugState,
 
     /// A map of each file that already has been visited from a prior `mod foo;` declaration.
     /// This is used to issue an error if a second `mod foo;` is declared to the same file.
@@ -58,7 +58,7 @@ impl Context {
             file_manager,
             storage_slots: BTreeMap::new(),
             root_crate_id: CrateId::Dummy,
-            debug_states: BTreeMap::new(),
+            debug_state: DebugState::default(),
         }
     }
 
@@ -206,12 +206,9 @@ impl Context {
     /// applying sorting and debug transforms if debug mode is enabled.
     pub fn parse_file(&mut self, file_id: FileId, crate_id: CrateId) -> (SortedModule, Vec<ParserError>) {
         let (mut ast, parsing_errors) = parse_file(&self.file_manager, file_id);
+
         if crate_id == self.root_crate_id {
-            if !self.debug_states.contains_key(&file_id) {
-                let ds = DebugState::default();
-                self.debug_states.insert(file_id, ds);
-            }
-            self.debug_states.get_mut(&file_id).unwrap().insert_symbols(&mut ast);
+            self.debug_state.insert_symbols(&mut ast);
         }
         (ast.into_sorted(), parsing_errors)
     }

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -35,11 +35,13 @@ pub struct ResolvedImport {
 impl From<PathResolutionError> for CustomDiagnostic {
     fn from(error: PathResolutionError) -> Self {
         match error {
-            PathResolutionError::Unresolved(ident) => CustomDiagnostic::simple_error(
-                format!("Could not resolve '{ident}' in path"),
-                String::new(),
-                ident.span(),
-            ),
+            PathResolutionError::Unresolved(ident) => {
+                CustomDiagnostic::simple_error(
+                    format!("Could not resolve '{ident}' in path"),
+                    String::new(),
+                    ident.span(),
+                )
+            }
             PathResolutionError::ExternalContractUsed(ident) => CustomDiagnostic::simple_error(
                 format!("Contract variable '{ident}' referenced from outside the contract"),
                 "Contracts may only be referenced from within a contract".to_string(),

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -11,6 +11,7 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 
 pub mod ast;
+pub mod debug;
 pub mod graph;
 pub mod lexer;
 pub mod monomorphization;

--- a/tooling/debugger/Cargo.toml
+++ b/tooling/debugger/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 acvm.workspace = true
 nargo.workspace = true
+noirc_frontend.workspace = true
 noirc_printable_type.workspace = true
 thiserror.workspace = true
 easy-repl = "0.2.1"

--- a/tooling/debugger/Cargo.toml
+++ b/tooling/debugger/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [dependencies]
 acvm.workspace = true
+fm.workspace = true
 nargo.workspace = true
 noirc_frontend.workspace = true
 noirc_printable_type.workspace = true

--- a/tooling/debugger/src/lib.rs
+++ b/tooling/debugger/src/lib.rs
@@ -27,7 +27,7 @@ struct DebugContext<'backend, B: BlackBoxFunctionSolver> {
 
 impl<'backend, B: BlackBoxFunctionSolver> DebugContext<'backend, B> {
     fn step_opcode(&mut self) -> Result<SolveResult, NargoError> {
-        let solver_status = self.acvm.as_mut().unwrap().step_opcode();
+        let solver_status = self.acvm.as_mut().unwrap().step_opcode(true);
 
         self.handle_acvm_status(solver_status)
     }

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -278,7 +278,10 @@ fn on_did_save_text_document(
 
     for package in &workspace {
         let (mut context, crate_id) =
-            prepare_package(package, Box::new(|path| std::fs::read_to_string(path)));
+            prepare_package(package, Box::new(|path| {
+                println!["prepare_package {:?}", &path];
+                std::fs::read_to_string(path)
+            }));
 
         let file_diagnostics = match check_crate(&mut context, crate_id, false) {
             Ok(((), warnings)) => warnings,

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -1,9 +1,10 @@
 use codespan_reporting::files::{Error, Files, SimpleFile};
 use noirc_driver::DebugFile;
 use noirc_errors::debug_info::DebugInfo;
+use noirc_frontend::debug::DebugState;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     ops::Range,
 };
 
@@ -44,6 +45,15 @@ impl DebugArtifact {
         }
 
         Self { debug_symbols, file_map }
+    }
+
+    pub fn to_debug_states(&self) -> HashMap<FileId,DebugState> {
+        let file_id = *self.file_map.first_key_value().unwrap().0;
+        self.debug_symbols.iter()
+            .map(|info| {
+                (file_id, DebugState::new(info.variables.clone()))
+            })
+            .collect()
     }
 }
 

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -1,14 +1,14 @@
 use codespan_reporting::files::{Error, Files, SimpleFile};
-use noirc_driver::DebugFile;
+use noirc_driver::{DebugFile,CompiledProgram};
 use noirc_errors::debug_info::DebugInfo;
-use noirc_frontend::debug::DebugState;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::BTreeMap,
     ops::Range,
 };
 
 use fm::{FileId, FileManager, PathString};
+pub use super::debug_vars::DebugVars;
 
 /// A Debug Artifact stores, for a given program, the debug info for every function
 /// along with a map of file Id to the source code so locations in debug info can be mapped to source code they point to.
@@ -22,24 +22,19 @@ impl DebugArtifact {
     pub fn new(debug_symbols: Vec<DebugInfo>, file_manager: &FileManager) -> Self {
         let mut file_map = BTreeMap::new();
 
-        let files_with_debug_symbols: BTreeSet<FileId> = debug_symbols
+        let file_ids: Vec<FileId> = debug_symbols
             .iter()
-            .flat_map(|function_symbols| {
-                function_symbols
-                    .locations
-                    .values()
-                    .filter_map(|call_stack| call_stack.last().map(|location| location.file))
-            })
+            .flat_map(|debug_info| debug_info.get_file_ids())
             .collect();
 
-        for file_id in files_with_debug_symbols {
-            let file_source = file_manager.fetch_file(file_id).source();
+        for file_id in file_ids.iter() {
+            let file_source = file_manager.fetch_file(*file_id).source();
 
             file_map.insert(
-                file_id,
+                *file_id,
                 DebugFile {
                     source: file_source.to_string(),
-                    path: file_manager.path(file_id).to_path_buf(),
+                    path: file_manager.path(*file_id).to_path_buf(),
                 },
             );
         }
@@ -47,13 +42,11 @@ impl DebugArtifact {
         Self { debug_symbols, file_map }
     }
 
-    pub fn to_debug_states(&self) -> HashMap<FileId,DebugState> {
-        let file_id = *self.file_map.first_key_value().unwrap().0;
-        self.debug_symbols.iter()
-            .map(|info| {
-                (file_id, DebugState::new(info.variables.clone()))
-            })
-            .collect()
+    pub fn from_program(program: &CompiledProgram) -> Self {
+        Self {
+            debug_symbols: vec![program.debug.clone()],
+            file_map: program.file_map.clone(),
+        }
     }
 }
 

--- a/tooling/nargo/src/artifacts/debug_vars.rs
+++ b/tooling/nargo/src/artifacts/debug_vars.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use acvm::acir::brillig::Value;
+
+#[derive(Debug, Default, Clone)]
+pub struct DebugVars {
+    id_to_name: HashMap<u32,String>,
+    name_to_id: HashMap<String,u32>,
+    id_to_value: HashMap<u32, Value>, // TODO: something more sophisticated for lexical levels
+}
+
+impl DebugVars {
+    pub fn new(vars: &HashMap<String,u32>) -> Self {
+        let mut debug_vars = Self::default();
+        debug_vars.id_to_name = vars.iter().map(|(name,id)| (*id, name.clone())).collect();
+        debug_vars.name_to_id = vars.clone();
+        debug_vars
+    }
+
+    pub fn get_values<'a>(&'a self) -> HashMap<String,&'a Value> {
+        self.id_to_value.iter().filter_map(|(var_id,value)| {
+            self.id_to_name.get(var_id).map(|name| {
+                (name.clone(),value)
+            })
+        }).collect()
+    }
+
+    pub fn insert_variables(&mut self, vars: &HashMap<String,u32>) {
+        vars.iter().for_each(|(var_name,var_id)| {
+            self.id_to_name.insert(*var_id, var_name.clone());
+            self.name_to_id.insert(var_name.clone(), *var_id);
+        });
+    }
+
+    pub fn set_by_id(&mut self, var_id: u32, value: Value) {
+        self.id_to_value.insert(var_id, value);
+    }
+
+    pub fn get_by_id<'a>(&'a mut self, var_id: u32) -> Option<&'a Value> {
+        self.id_to_value.get(&var_id)
+    }
+
+    pub fn get_by_name<'a>(&'a mut self, var_name: &str) -> Option<&'a Value> {
+        self.name_to_id.get(var_name).and_then(|var_id| self.id_to_value.get(var_id))
+    }
+}

--- a/tooling/nargo/src/artifacts/mod.rs
+++ b/tooling/nargo/src/artifacts/mod.rs
@@ -10,6 +10,7 @@ use serde::{Deserializer, Serializer};
 pub mod contract;
 pub mod debug;
 pub mod program;
+mod debug_vars;
 
 // TODO: move these down into ACVM.
 fn serialize_circuit<S>(circuit: &Circuit, s: S) -> Result<S::Ok, S::Error>

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -49,6 +49,7 @@ pub fn prepare_package(package: &Package, file_reader: Box<FileReader>) -> (Cont
     let mut context = Context::new(fm, graph);
 
     let crate_id = prepare_crate(&mut context, &package.entry_path);
+    context.root_crate_id = crate_id.clone();
 
     prepare_dependencies(&mut context, crate_id, &package.dependencies);
 

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -273,15 +273,14 @@ fn save_program(
     let preprocessed_program = PreprocessedProgram {
         hash: program.hash,
         backend: String::from(BACKEND_IDENTIFIER),
-        abi: program.abi,
-        bytecode: program.circuit,
+        abi: program.abi.clone(),
+        bytecode: program.circuit.clone(),
     };
 
     save_program_to_file(&preprocessed_program, &package.name, circuit_dir);
 
     if output_debug {
-        let debug_artifact =
-            DebugArtifact { debug_symbols: vec![program.debug], file_map: program.file_map };
+        let debug_artifact = DebugArtifact::from_program(&program);
         let circuit_name: String = (&package.name).into();
         save_debug_artifact_to_file(&debug_artifact, &circuit_name, circuit_dir);
     }

--- a/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
@@ -1,3 +1,11 @@
+#[oracle(__debug_state_set)]
+unconstrained fn __debug_state_set_oracle<T>(_var_id: u32, _input: T) {}
+
+unconstrained pub fn __debug_state_set<T>(var_id: u32, value: T) -> T {
+    __debug_state_set_oracle(var_id, value);
+    value
+}
+
 // Tests a very simple program.
 // 
 // The features being tested are:

--- a/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
@@ -8,7 +8,7 @@ fn main(x : Field, y : Field, z : Field) -> pub Field {
     assert(y as u1 == 0);
 
     let a = x + x; // 3 + 3 = 6
-    let b = a - y; // 6 - 4 = 2
+    let b = a - y; // 7 - 4 = 2
     let c = b * z; // 2 * 5 = 10
     let d = c / a; // 10 / 6 (This uses field inversion, so we test it by multiplying by `a`)
     d * a

--- a/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
@@ -1,11 +1,3 @@
-#[oracle(__debug_state_set)]
-unconstrained fn __debug_state_set_oracle<T>(_var_id: u32, _input: T) {}
-
-unconstrained pub fn __debug_state_set<T>(var_id: u32, value: T) -> T {
-    __debug_state_set_oracle(var_id, value);
-    value
-}
-
 // Tests a very simple program.
 // 
 // The features being tested are:

--- a/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/arithmetic_binary_operations/src/main.nr
@@ -11,9 +11,18 @@ unconstrained pub fn __debug_state_set<T>(var_id: u32, value: T) -> T {
 // The features being tested are:
 // Binary addition, multiplication, division, constant modulo
 // x = 3, y = 4, z = 5
+
+struct V { q: u32, r: u32 }
+struct U { v: V, w: (u32,u32) }
+
 fn main(x : Field, y : Field, z : Field) -> pub Field {
+    let uu = U { v: V { q: 100, r: 200 }, w: (300,400) };
+    //let U { v: V { q, ..}, w: (w1,w1) } = uu;
+    let U { v, w } = uu;
+    //let (q,r,(s,t)) = (3,4,(5,6));
+
     //cast
-    assert(y as u1 == 0);
+    //assert(y as u1 == 0);
 
     let a = x + x; // 3 + 3 = 6
     let b = a - y; // 7 - 4 = 2


### PR DESCRIPTION
# Description

## Problem

Part of #3015. This is an experimental implementation of a mechanism to instrument variable state inspection for consumption from the debugger.

## Summary

We want to use this draft PR as an RFC on an approach to inspect variable state at debugging time. Read Additional Context for a detailed overview.

## Additional Context

So far, maybe the trickiest piece of the debugger puzzle that we have been trying to figure out is how to map variables defined in a Noir program to their runtime values, so you can inspect them upon debugging.

The first naïve idea was to attempt extending the current DebugArtifact, and somehow relating opcode offsets to variable names. We found some weeks ago that this approach wasn't very promising. As far as we can tell from tinkering with the compiler internals, there's just too much information lost throughout the different compiler phases, mainly because of optimization passes. There's also some challenges arising from the fact that some info is stored in contexts and discarded at different phases of the compiler. 

We then pivoted to another direction, which is the one we want to propose. I'll try to explain and provide some references to specific snippets of code in this PR. The code is super raw as we're still dealing with "plumbing" issues, but we believe the approach is sound and would add a level of instrumentation to the runtime (only when built in debug mode) that would set us up to do pretty powerful stuff, like not only inspecting but also modifying variable values at runtime, or instrumenting particularly important statements such as comparisons in a specific way.

The gist of the idea is to [add a new foreign call](https://github.com/noir-lang/noir/blob/6168ef6e091b30a98c222e61aa5e7b9a3e7ea259/tooling/nargo/src/ops/foreign_calls.rs#L35) `__debug_state_set` that [logs debug data](https://github.com/manastech/noir/blob/6168ef6e091b30a98c222e61aa5e7b9a3e7ea259/tooling/nargo/src/ops/foreign_calls.rs#L135) to a new [DebugState](https://github.com/manastech/noir/blob/6168ef6e091b30a98c222e61aa5e7b9a3e7ea259/compiler/noirc_frontend/src/debug/mod.rs#L17) data structure. [We then introduce a new debug phase](https://github.com/manastech/noir/blob/6168ef6e091b30a98c222e61aa5e7b9a3e7ea259/compiler/noirc_frontend/src/hir/mod.rs#L214) (or maybe more aptly called "aspect"?) that walks the AST and injects calls to that function. Example here of [how it looks when capturing variable values right after a let expression](https://github.com/manastech/noir/blob/6168ef6e091b30a98c222e61aa5e7b9a3e7ea259/compiler/noirc_frontend/src/debug/mod.rs#L136), which is the initial use case we're using as an excuse to lay out the plumbing of the solution. 

Note that this same kind of AST manipulation could be used to route variable access from the program itself to these DebugState data structures, thus eventually enabling us to let users override variable values from the debugger REPL, for example. It's also worth noting too that this machinery would only be applied when compiling with debug symbols and using the debugger.

The debugger then can simply consume this DebugState data structure, [as shown here in a very crude way](https://github.com/manastech/noir/blob/6168ef6e091b30a98c222e61aa5e7b9a3e7ea259/tooling/debugger/src/lib.rs#L212), which ends up printing things like the code below for the arithmetic_binary_operations test example:

```
> vars
ITER
  var_id_to_value={1: "Single(Value { inner: 2 })", 0: "Single(Value { inner: 6 })"}
  var_id_to_name={2: "c", 0: "a", 1: "b", 3: "d"}
  var_name_to_id={"b": 1, "c": 2, "a": 0, "d": 3}
{"a": "Single(Value { inner: 6 })", "b": "Single(Value { inner: 2 })"}
```

The main caveat of this approach, is that it could be considered a bit invasive, kind of proportionally to the power of the features that it enables. Please do share your comments :slightly_smiling_face:


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
