### PR TITLE
chore: bump bb version to 0.12.0

### DIFF
--- a/tooling/bb_abstraction_leaks/build.rs
+++ b/tooling/bb_abstraction_leaks/build.rs
@@ -10,7 +10,7 @@ use const_format::formatcp;
 
 const USERNAME: &str = "AztecProtocol";
 const REPO: &str = "aztec-packages";
-const VERSION: &str = "0.11.1";
+const VERSION: &str = "0.12.0";
 const TAG: &str = formatcp!("aztec-packages-v{}", VERSION);
 
 const API_URL: &str =

--- a/tooling/noir_js_backend_barretenberg/package.json
+++ b/tooling/noir_js_backend_barretenberg/package.json
@@ -32,7 +32,7 @@
     "lint": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ./.eslintignore  --max-warnings 0"
   },
   "dependencies": {
-    "@aztec/bb.js": "0.11.0",
+    "@aztec/bb.js": "0.12.0",
     "@noir-lang/types": "workspace:*",
     "fflate": "^0.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,9 +221,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aztec/bb.js@npm:0.11.0":
-  version: 0.11.0
-  resolution: "@aztec/bb.js@npm:0.11.0"
+"@aztec/bb.js@npm:0.12.0":
+  version: 0.12.0
+  resolution: "@aztec/bb.js@npm:0.12.0"
   dependencies:
     comlink: ^4.4.1
     commander: ^10.0.1
@@ -231,7 +231,7 @@ __metadata:
     tslib: ^2.4.0
   bin:
     bb.js: dest/node/main.js
-  checksum: fff6813458dfa654210859dbf32abcb6c520ef8b3c4896535afa1bbc4a1a6dc77fd5626051fe0017de2f4b03d09bd9629fa1a144df2af3270a2e00faa779362d
+  checksum: d9d57b893b9b1c61949cb9bd911d4b7e1ece34965ccb9e122b39cd4e2edac9f06858abbe05c23f66141c9a74ff4861a354bfc5d62e5dcf772cfe8d1c783e2562
   languageName: node
   linkType: hard
 
@@ -3434,7 +3434,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@noir-lang/backend_barretenberg@workspace:tooling/noir_js_backend_barretenberg"
   dependencies:
-    "@aztec/bb.js": 0.11.0
+    "@aztec/bb.js": 0.12.0
     "@noir-lang/types": "workspace:*"
     "@types/node": ^20.6.2
     "@types/prettier": ^3


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR bumps bb to a version which will work on mainframe. I've tested this and it works.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
