### PR TITLE
chore: recrawl docs on merge

### DIFF
--- a/.github/workflows/recrawler.yml
+++ b/.github/workflows/recrawler.yml
@@ -1,0 +1,22 @@
+name: Algolia Recrawl
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  algolia_recrawl:
+    name: Algolia Recrawl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Algolia crawler creation and crawl
+        uses: algolia/algoliasearch-crawler-github-actions@v1.1.0
+        id: algolia_crawler
+        with:
+          crawler-user-id: ${{ secrets.CRAWLER_USER_ID }}
+          crawler-api-key: ${{ secrets.CRAWLER_API_KEY }}
+          algolia-app-id: ${{ secrets.ALGOLIA_APP_ID }}
+          algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
+          site-url: 'https://noir-lang.org/'
+          crawler-name: noir-lang
+          override-config: false


### PR DESCRIPTION
# Description

This PR adds a workflow to request a docs website recrawl

## Problem\*

We kind of missed this when we merged docs to the monorepo, so search on the docs can be out of date sometimes. Manual triggering was needed

## Summary\*

 With this action, crawling will be triggered automatically
