### PR TITLE
feat: Add check for overlapping generic traits

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -151,7 +151,7 @@ impl From<DefCollectorErrorKind> for Diagnostic {
                 // This must be an error to appear next to the previous OverlappingImpl
                 // error since we sort warnings first.
                 Diagnostic::simple_error(
-                    format!("Previous impl defined here"),
+                    "Previous impl defined here".into(),
                     "Previous impl defined here".into(),
                     span,
                 )

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -880,20 +880,14 @@ impl<'interner> TypeChecker<'interner> {
             // This may be a struct or a primitive type.
             Type::MutableReference(element) => self
                 .interner
-                .lookup_mut_primitive_trait_method(element.as_ref(), method_name)
+                .lookup_primitive_trait_method_mut(element.as_ref(), method_name)
                 .map(HirMethodReference::FuncId)
                 .or_else(|| self.lookup_method(element, method_name, expr_id)),
             // If we fail to resolve the object to a struct type, we have no way of type
             // checking its arguments as we can't even resolve the name of the function
             Type::Error => None,
 
-            // In the future we could support methods for non-struct types if we have a context
-            // (in the interner?) essentially resembling HashMap<Type, Methods>
-            other => match self
-                .interner
-                .lookup_primitive_method(other, method_name)
-                .or_else(|| self.interner.lookup_primitive_trait_method(other, method_name))
-            {
+            other => match self.interner.lookup_primitive_method(other, method_name) {
                 Some(method_id) => Some(HirMethodReference::FuncId(method_id)),
                 None => {
                     self.errors.push(TypeCheckError::UnresolvedMethodCall {

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -15,7 +15,7 @@ pub use errors::TypeCheckError;
 
 use crate::{
     hir_def::{expr::HirExpression, stmt::HirStatement},
-    node_interner::{ExprId, FuncId, NodeInterner, StmtId, TraitImplKey},
+    node_interner::{ExprId, FuncId, NodeInterner, StmtId},
     Type,
 };
 
@@ -65,8 +65,10 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
         let (expr_span, empty_function) = function_info(interner, function_body_id);
         let func_span = interner.expr_span(function_body_id); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
         if let Type::TraitAsType(t) = &declared_return_type {
-            let key = TraitImplKey { typ: function_last_type.follow_bindings(), trait_id: t.id };
-            if interner.get_trait_implementation(&key).is_none() {
+            if interner
+                .lookup_trait_implementation(function_last_type.follow_bindings(), t.id)
+                .is_none()
+            {
                 let error = TypeCheckError::TypeMismatchWithSource {
                     expected: declared_return_type.clone(),
                     actual: function_last_type.clone(),

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -3,6 +3,7 @@ use crate::{
     node_interner::{FuncId, TraitId, TraitMethodId},
     Generics, Ident, NoirFunction, Type, TypeVariable, TypeVariableId,
 };
+use fm::FileId;
 use noirc_errors::Span;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -62,6 +63,7 @@ pub struct TraitImpl {
     pub ident: Ident,
     pub typ: Type,
     pub trait_id: TraitId,
+    pub file: FileId,
     pub methods: Vec<FuncId>, // methods[i] is the implementation of trait.methods[i] for Type typ
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         stmt::{HirAssignStatement, HirLValue, HirLetStatement, HirPattern, HirStatement},
         types,
     },
-    node_interner::{self, DefinitionKind, NodeInterner, StmtId, TraitImplKey, TraitMethodId},
+    node_interner::{self, DefinitionKind, NodeInterner, StmtId, TraitMethodId},
     token::FunctionAttribute,
     ContractFunctionType, FunctionKind, Type, TypeBinding, TypeBindings, TypeVariableKind,
     Visibility,
@@ -820,10 +820,7 @@ impl<'interner> Monomorphizer<'interner> {
 
         let trait_impl = self
             .interner
-            .get_trait_implementation(&TraitImplKey {
-                typ: self_type.follow_bindings(),
-                trait_id: method.trait_id,
-            })
+            .lookup_trait_implementation(self_type.follow_bindings(), method.trait_id)
             .expect("ICE: missing trait impl - should be caught during type checking");
 
         let hir_func_id = trait_impl.borrow().methods[method.method_index];

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -953,7 +953,7 @@ impl NodeInterner {
     ) -> Option<Shared<TraitImpl>> {
         let impls = self.trait_implementation_map.get(&trait_id)?;
         for (existing_object_type, impl_id) in impls {
-            if object_type.try_unify(&existing_object_type).is_ok() {
+            if object_type.try_unify(existing_object_type).is_ok() {
                 return Some(self.get_trait_implementation(*impl_id));
             }
         }
@@ -974,7 +974,7 @@ impl NodeInterner {
 
         // Check that this new impl does not overlap with any existing impls first
         for (existing_object_type, existing_impl_id) in entries {
-            if object_type.try_unify(&existing_object_type).is_ok() {
+            if object_type.try_unify(existing_object_type).is_ok() {
                 // Overlapping impl
                 let existing_impl = &self.trait_implementations[existing_impl_id.0];
                 let existing_impl = existing_impl.borrow();

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -25,13 +25,6 @@ use crate::{
     TypeBinding, TypeBindings, TypeVariable, TypeVariableId, TypeVariableKind,
 };
 
-#[derive(Eq, PartialEq, Hash, Clone)]
-pub struct TraitImplKey {
-    pub typ: Type,
-    pub trait_id: TraitId,
-    // pub generics: Generics - TODO
-}
-
 type StructAttributes = Vec<SecondaryAttribute>;
 
 /// The node interner is the central storage location of all nodes in Noir's Hir (the
@@ -92,7 +85,19 @@ pub struct NodeInterner {
     // Trait implementation map
     // For each type that implements a given Trait ( corresponding TraitId), there should be an entry here
     // The purpose for this hashmap is to detect duplication of trait implementations ( if any )
-    trait_implementations: HashMap<TraitImplKey, Shared<TraitImpl>>,
+    //
+    // Indexed by TraitImplIds
+    trait_implementations: Vec<Shared<TraitImpl>>,
+
+    /// Trait implementations on each type. This is expected to always have the same length as
+    /// `self.trait_implementations`.
+    ///
+    /// For lack of a better name, this maps a trait id and type combination
+    /// to a corresponding impl if one is available for the type. Due to generics,
+    /// we cannot map from Type directly to impl, we need to iterate a Vec of all impls
+    /// of that trait to see if any type may match. This can be further optimized later
+    /// by splitting it up by type.
+    trait_implementation_map: HashMap<TraitId, Vec<(Type, TraitImplId)>>,
 
     /// Map from ExprId (referring to a Function/Method call) to its corresponding TypeBindings,
     /// filled out during type checking from instantiated variables. Used during monomorphization
@@ -113,16 +118,27 @@ pub struct NodeInterner {
     /// may have both `impl Struct<u32> { fn foo(){} }` and `impl Struct<u8> { fn foo(){} }`.
     /// If this happens, the returned Vec will have 2 entries and we'll need to further
     /// disambiguate them by checking the type of each function.
-    struct_methods: HashMap<(StructId, String), Vec<FuncId>>,
+    struct_methods: HashMap<(StructId, String), Methods>,
 
     /// Methods on primitive types defined in the stdlib.
-    primitive_methods: HashMap<(TypeMethodKey, String), FuncId>,
+    primitive_methods: HashMap<(TypeMethodKey, String), Methods>,
 
     // For trait implementation functions, this is their self type and trait they belong to
     func_id_to_trait: HashMap<FuncId, (Type, TraitId)>,
+}
 
-    /// Trait implementations on primitive types
-    primitive_trait_impls: HashMap<(Type, String), FuncId>,
+/// Represents the methods on a given type that each share the same name.
+///
+/// Methods are split into inherent methods and trait methods. If there is
+/// ever a name that is defined on both a type directly, and defined indirectly
+/// via a trait impl, the direct (inherent) name will always take precedence.
+///
+/// Additionally, types can define specialized impls with methods of the same name
+/// as long as these specialized impls do not overlap. E.g. `impl Struct<u32>` and `impl Struct<u64>`
+#[derive(Default)]
+pub struct Methods {
+    direct: Vec<FuncId>,
+    trait_impl_methods: Vec<FuncId>,
 }
 
 /// All the information from a function that is filled out during definition collection rather than
@@ -257,6 +273,9 @@ impl TraitId {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub struct TraitImplId(usize);
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TraitMethodId {
     pub trait_id: TraitId,
@@ -380,14 +399,14 @@ impl Default for NodeInterner {
             struct_attributes: HashMap::new(),
             type_aliases: Vec::new(),
             traits: HashMap::new(),
-            trait_implementations: HashMap::new(),
+            trait_implementations: Vec::new(),
+            trait_implementation_map: HashMap::new(),
             instantiation_bindings: HashMap::new(),
             field_indices: HashMap::new(),
             next_type_variable_id: std::cell::Cell::new(0),
             globals: HashMap::new(),
             struct_methods: HashMap::new(),
             primitive_methods: HashMap::new(),
-            primitive_trait_impls: HashMap::new(),
         };
 
         // An empty block expression is used often, we add this into the `node` on startup
@@ -891,6 +910,7 @@ impl NodeInterner {
         self_type: &Type,
         method_name: String,
         method_id: FuncId,
+        is_trait_method: bool,
     ) -> Option<FuncId> {
         match self_type {
             Type::Struct(struct_type, _generics) => {
@@ -901,68 +921,75 @@ impl NodeInterner {
                 }
 
                 let key = (id, method_name);
-                self.struct_methods.entry(key).or_default().push(method_id);
+                self.struct_methods.entry(key).or_default().add_method(method_id, is_trait_method);
                 None
             }
             Type::Error => None,
+            Type::MutableReference(element) => {
+                self.add_method(element, method_name, method_id, is_trait_method)
+            }
 
             other => {
                 let key = get_type_method_key(self_type).unwrap_or_else(|| {
                     unreachable!("Cannot add a method to the unsupported type '{}'", other)
                 });
-                self.primitive_methods.insert((key, method_name), method_id)
+                self.primitive_methods
+                    .entry((key, method_name))
+                    .or_default()
+                    .add_method(method_id, is_trait_method);
+                None
             }
         }
     }
 
-    pub fn get_trait_implementation(&self, key: &TraitImplKey) -> Option<Shared<TraitImpl>> {
-        self.trait_implementations.get(key).cloned()
+    pub fn get_trait_implementation(&self, id: TraitImplId) -> Shared<TraitImpl> {
+        self.trait_implementations[id.0].clone()
+    }
+
+    pub fn lookup_trait_implementation(
+        &self,
+        object_type: Type,
+        trait_id: TraitId,
+    ) -> Option<Shared<TraitImpl>> {
+        let impls = self.trait_implementation_map.get(&trait_id)?;
+        for (existing_object_type, impl_id) in impls {
+            if object_type.try_unify(&existing_object_type).is_ok() {
+                return Some(self.get_trait_implementation(*impl_id));
+            }
+        }
+        None
     }
 
     pub fn add_trait_implementation(
         &mut self,
-        key: &TraitImplKey,
+        object_type: Type,
+        trait_id: TraitId,
         trait_impl: Shared<TraitImpl>,
-    ) -> bool {
-        self.trait_implementations.insert(key.clone(), trait_impl.clone());
-        match &key.typ {
-            Type::Struct(..) => {
-                for func_id in &trait_impl.borrow().methods {
-                    let method_name = self.function_name(func_id).to_owned();
-                    self.add_method(&key.typ, method_name, *func_id);
-                }
-                true
+    ) -> Option<(Span, FileId)> {
+        let id = TraitImplId(self.trait_implementations.len());
+
+        self.trait_implementations.push(trait_impl.clone());
+
+        let entries = self.trait_implementation_map.entry(trait_id).or_default();
+
+        // Check that this new impl does not overlap with any existing impls first
+        for (existing_object_type, existing_impl_id) in entries {
+            if object_type.try_unify(&existing_object_type).is_ok() {
+                // Overlapping impl
+                let existing_impl = &self.trait_implementations[existing_impl_id.0];
+                let existing_impl = existing_impl.borrow();
+                return Some((existing_impl.ident.span(), existing_impl.file));
             }
-            Type::FieldElement
-            | Type::Unit
-            | Type::Array(..)
-            | Type::Integer(..)
-            | Type::Bool
-            | Type::Tuple(..)
-            | Type::String(..)
-            | Type::FmtString(..)
-            | Type::Function(..)
-            | Type::MutableReference(..) => {
-                for func_id in &trait_impl.borrow().methods {
-                    let method_name = self.function_name(func_id).to_owned();
-                    let key = (key.typ.clone(), method_name);
-                    self.primitive_trait_impls.insert(key, *func_id);
-                }
-                true
-            }
-            // We should allow implementing traits NamedGenerics will also eventually be possible once we support generics
-            // impl<T> Foo for T
-            // but it's fine not to include these until we do.
-            Type::NamedGeneric(..) => false,
-            // prohibited are internal types (like NotConstant, TypeVariable, Forall, and Error) that
-            // aren't possible for users to write anyway
-            Type::TypeVariable(..)
-            | Type::Forall(..)
-            | Type::NotConstant
-            | Type::Constant(..)
-            | Type::TraitAsType(..)
-            | Type::Error => false,
         }
+
+        for method in &trait_impl.borrow().methods {
+            let method_name = self.function_name(method).to_owned();
+            self.add_method(&object_type, method_name, *method, true);
+        }
+
+        let entries = self.trait_implementation_map.entry(trait_id).or_default();
+        entries.push((object_type, id));
+        None
     }
 
     /// Search by name for a method on the given struct.
@@ -981,25 +1008,94 @@ impl NodeInterner {
         typ: &Type,
         id: StructId,
         method_name: &str,
-        check_type: bool,
+        force_type_check: bool,
     ) -> Option<FuncId> {
         let methods = self.struct_methods.get(&(id, method_name.to_owned()))?;
 
         // If there is only one method, just return it immediately.
         // It will still be typechecked later.
-        if !check_type && methods.len() == 1 {
-            return Some(methods[0]);
+        if !force_type_check {
+            if let Some(method) = methods.get_unambiguous() {
+                return Some(method);
+            }
         }
 
+        self.find_matching_method(typ, methods, method_name)
+    }
+
+    /// Select the 1 matching method with an object type matching `typ`
+    fn find_matching_method(
+        &self,
+        typ: &Type,
+        methods: &Methods,
+        method_name: &str,
+    ) -> Option<FuncId> {
+        if let Some(method) = methods.find_matching_method(typ, self) {
+            Some(method)
+        } else {
+            // Failed to find a match for the type in question, switch to looking at impls
+            // for all types `T`, e.g. `impl<T> Foo for T`
+            let key = &(TypeMethodKey::Generic, method_name.to_owned());
+            let global_methods = self.primitive_methods.get(key)?;
+            global_methods.find_matching_method(typ, self)
+        }
+    }
+
+    /// Looks up a given method name on the given primitive type.
+    pub fn lookup_primitive_method(&self, typ: &Type, method_name: &str) -> Option<FuncId> {
+        let key = get_type_method_key(typ)?;
+        let methods = self.primitive_methods.get(&(key, method_name.to_owned()))?;
+        self.find_matching_method(typ, methods, method_name)
+    }
+
+    pub fn lookup_primitive_trait_method_mut(
+        &self,
+        typ: &Type,
+        method_name: &str,
+    ) -> Option<FuncId> {
+        let typ = Type::MutableReference(Box::new(typ.clone()));
+        self.lookup_primitive_method(&typ, method_name)
+    }
+}
+
+impl Methods {
+    /// Get a single, unambiguous reference to a name if one exists.
+    /// If not, there may be multiple methods of the same name for a given
+    /// type or there may be no methods at all.
+    fn get_unambiguous(&self) -> Option<FuncId> {
+        if self.direct.len() == 1 {
+            Some(self.direct[0])
+        } else if self.direct.is_empty() && self.trait_impl_methods.len() == 1 {
+            Some(self.trait_impl_methods[0])
+        } else {
+            None
+        }
+    }
+
+    fn add_method(&mut self, method: FuncId, is_trait_method: bool) {
+        if is_trait_method {
+            self.trait_impl_methods.push(method);
+        } else {
+            self.direct.push(method);
+        }
+    }
+
+    /// Iterate through each method, starting with the direct methods
+    fn iter(&self) -> impl Iterator<Item = FuncId> + '_ {
+        self.direct.iter().copied().chain(self.trait_impl_methods.iter().copied())
+    }
+
+    /// Select the 1 matching method with an object type matching `typ`
+    fn find_matching_method(&self, typ: &Type, interner: &NodeInterner) -> Option<FuncId> {
         // When adding methods we always check they do not overlap, so there should be
         // at most 1 matching method in this list.
-        for method in methods {
-            match self.function_meta(method).typ.instantiate(self).0 {
+        for method in self.iter() {
+            match interner.function_meta(&method).typ.instantiate(interner).0 {
                 Type::Function(args, _, _) => {
                     if let Some(object) = args.get(0) {
                         // TODO #3089: This is dangerous! try_unify may commit type bindings even on failure
                         if object.try_unify(typ).is_ok() {
-                            return Some(*method);
+                            return Some(method);
                         }
                     }
                 }
@@ -1007,28 +1103,7 @@ impl NodeInterner {
                 other => unreachable!("Expected function type, found {other}"),
             }
         }
-
         None
-    }
-
-    /// Looks up a given method name on the given primitive type.
-    pub fn lookup_primitive_method(&self, typ: &Type, method_name: &str) -> Option<FuncId> {
-        get_type_method_key(typ)
-            .and_then(|key| self.primitive_methods.get(&(key, method_name.to_owned())).copied())
-    }
-
-    pub fn lookup_primitive_trait_method(&self, typ: &Type, method_name: &str) -> Option<FuncId> {
-        self.primitive_trait_impls.get(&(typ.clone(), method_name.to_string())).copied()
-    }
-
-    pub fn lookup_mut_primitive_trait_method(
-        &self,
-        typ: &Type,
-        method_name: &str,
-    ) -> Option<FuncId> {
-        self.primitive_trait_impls
-            .get(&(Type::MutableReference(Box::new(typ.clone())), method_name.to_string()))
-            .copied()
     }
 }
 
@@ -1041,9 +1116,11 @@ enum TypeMethodKey {
     Array,
     Bool,
     String,
+    FmtString,
     Unit,
     Tuple,
     Function,
+    Generic,
 }
 
 fn get_type_method_key(typ: &Type) -> Option<TypeMethodKey> {
@@ -1056,20 +1133,20 @@ fn get_type_method_key(typ: &Type) -> Option<TypeMethodKey> {
         Type::TypeVariable(_, TypeVariableKind::IntegerOrField) => Some(FieldOrInt),
         Type::Bool => Some(Bool),
         Type::String(_) => Some(String),
+        Type::FmtString(_, _) => Some(FmtString),
         Type::Unit => Some(Unit),
         Type::Tuple(_) => Some(Tuple),
         Type::Function(_, _, _) => Some(Function),
+        Type::NamedGeneric(_, _) => Some(Generic),
         Type::MutableReference(element) => get_type_method_key(element),
 
         // We do not support adding methods to these types
         Type::TypeVariable(_, _)
-        | Type::NamedGeneric(_, _)
         | Type::Forall(_, _)
         | Type::Constant(_)
         | Type::Error
         | Type::NotConstant
         | Type::Struct(_, _)
-        | Type::TraitAsType(_)
-        | Type::FmtString(_, _) => None,
+        | Type::TraitAsType(_) => None,
     }
 }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -537,14 +537,9 @@ mod test {
         ";
         let errors = get_program_errors(src);
         assert!(!has_parser_error(&errors));
-        assert!(errors.len() == 2, "Expected 2 errors, got: {:?}", errors);
+        assert!(errors.len() == 1, "Expected 1 error, got: {:?}", errors);
         for (err, _file_id) in errors {
             match &err {
-                CompilationError::DefinitionError(
-                    DefCollectorErrorKind::TraitImplNotAllowedFor { trait_path, span: _ },
-                ) => {
-                    assert_eq!(trait_path.as_string(), "Default");
-                }
                 CompilationError::ResolverError(ResolverError::Expected {
                     expected, got, ..
                 }) => {
@@ -663,18 +658,15 @@ mod test {
         ";
         let errors = get_program_errors(src);
         assert!(!has_parser_error(&errors));
-        assert!(errors.len() == 1, "Expected 1 error, got: {:?}", errors);
+        assert!(errors.len() == 2, "Expected 2 errors, got: {:?}", errors);
         for (err, _file_id) in errors {
             match &err {
-                CompilationError::DefinitionError(DefCollectorErrorKind::Duplicate {
-                    typ,
-                    first_def,
-                    second_def,
-                }) => {
-                    assert_eq!(typ, &DuplicateType::TraitImplementation);
-                    assert_eq!(first_def, "Default");
-                    assert_eq!(second_def, "Default");
-                }
+                CompilationError::DefinitionError(DefCollectorErrorKind::OverlappingImpl {
+                    ..
+                }) => (),
+                CompilationError::DefinitionError(DefCollectorErrorKind::OverlappingImplNote {
+                    ..
+                }) => (),
                 _ => {
                     panic!("No other errors are expected! Found = {:?}", err);
                 }
@@ -704,18 +696,15 @@ mod test {
         ";
         let errors = get_program_errors(src);
         assert!(!has_parser_error(&errors));
-        assert!(errors.len() == 1, "Expected 1 error, got: {:?}", errors);
+        assert!(errors.len() == 2, "Expected 2 errors, got: {:?}", errors);
         for (err, _file_id) in errors {
             match &err {
-                CompilationError::DefinitionError(DefCollectorErrorKind::Duplicate {
-                    typ,
-                    first_def,
-                    second_def,
-                }) => {
-                    assert_eq!(typ, &DuplicateType::TraitImplementation);
-                    assert_eq!(first_def, "Default");
-                    assert_eq!(second_def, "Default");
-                }
+                CompilationError::DefinitionError(DefCollectorErrorKind::OverlappingImpl {
+                    ..
+                }) => (),
+                CompilationError::DefinitionError(DefCollectorErrorKind::OverlappingImplNote {
+                    ..
+                }) => (),
                 _ => {
                     panic!("No other errors are expected! Found = {:?}", err);
                 }

--- a/tooling/nargo_cli/tests/compile_failure/overlapping_generic_impls/Nargo.toml
+++ b/tooling/nargo_cli/tests/compile_failure/overlapping_generic_impls/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "overlapping_generic_impls"
+type = "bin"
+authors = [""]
+compiler_version = "0.18.0"
+
+[dependencies]

--- a/tooling/nargo_cli/tests/compile_failure/overlapping_generic_impls/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_failure/overlapping_generic_impls/src/main.nr
@@ -1,0 +1,8 @@
+
+trait Trait { fn t(self); }
+
+impl<T> Trait for T { fn t(self){} }
+
+impl<T> Trait for T { fn t(self){} }
+
+fn main() {}

--- a/tooling/nargo_cli/tests/compile_success_empty/trait_override_implementation/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/trait_override_implementation/src/main.nr
@@ -4,9 +4,8 @@ trait Default {
     fn default(x: Field, y: Field) -> Self;
 
     fn method2(x: Field) -> Field {
-	x
+        x
     }
-
 }
 
 struct Foo {
@@ -20,7 +19,7 @@ impl Default for Foo {
     }
 
     fn method2(x: Field) -> Field {
-	x * 3
+        x * 3
     }
 }
 
@@ -40,32 +39,35 @@ impl F for Bar {
     fn f3(self) -> Field { 30 }
 }
 
-impl F for &mut Bar {
-    fn f1(self) -> Field { 101 }
-    fn f5(self) -> Field { 505 }
-}
+// Impls on mutable references are temporarily disabled
+// impl F for &mut Bar {
+//     fn f1(self) -> Field { 101 }
+//     fn f5(self) -> Field { 505 }
+// }
 
 fn main(x: Field) {
     let first = Foo::method2(x);
     assert(first == 3 * x);
 
     let bar = Bar{};
-    assert(bar.f1() == 10);
-    assert(bar.f2() == 2);
-    assert(bar.f3() == 30);
-    assert(bar.f4() == 4);
-    assert(bar.f5() == 50);
+    assert(bar.f1() == 10, "1");
+    assert(bar.f2() == 2, "2");
+    assert(bar.f3() == 30, "3");
+    assert(bar.f4() == 4, "4");
+    assert(bar.f5() == 50, "5");
 
     let mut bar_mut = Bar{};
-    assert((&mut bar_mut).f1() == 101);
-    assert((&mut bar_mut).f2() == 2);
-    assert((&mut bar_mut).f3() == 3);
-    assert((&mut bar_mut).f4() == 4);
-    assert((&mut bar_mut).f5() == 505);
 
-    assert(bar_mut.f1() == 10);
-    assert(bar_mut.f2() == 2);
-    assert(bar_mut.f3() == 30);
-    assert(bar_mut.f4() == 4);
-    assert(bar_mut.f5() == 50);
+    // Impls on mutable references are temporarily disabled
+    // assert_eq((&mut bar_mut).f1(), 101);
+    // assert((&mut bar_mut).f2() == 2, "7");
+    // assert((&mut bar_mut).f3() == 3, "8");
+    // assert((&mut bar_mut).f4() == 4, "9");
+    // assert((&mut bar_mut).f5() == 505, "10");
+
+    assert(bar_mut.f1() == 10, "10");
+    assert(bar_mut.f2() == 2, "12");
+    assert(bar_mut.f3() == 30, "13");
+    assert(bar_mut.f4() == 4, "14");
+    assert(bar_mut.f5() == 50, "15");
 }

--- a/tooling/nargo_cli/tests/execution_success/trait_impl_base_type/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/trait_impl_base_type/src/main.nr
@@ -81,26 +81,6 @@ fn some_func(x: u32) -> u32 {
 }
 
 
-trait MutFieldable {
-    fn mut_to_field(self) -> Field;
-}
-
-impl MutFieldable for &mut u64 {
-    fn mut_to_field(self) -> Field {
-        1337 as Field
-    }
-}
-
-fn a(y: &mut u64) -> Field {
-    y.mut_to_field()
-}
-
-impl Fieldable for &mut u64 {
-    fn to_field(self) -> Field {
-        777 as Field
-    }
-}
-
 impl Fieldable for u64 {
     fn to_field(self) -> Field {
         66 as Field
@@ -134,8 +114,5 @@ fn main(x: u32) {
     assert(some_func.to_field() == 17);
 
     let mut y = 0 as u64;
-    assert(a(&mut y) == 1337);
-    assert((&mut y).mut_to_field() == 1337);
-    assert((&mut y).to_field() == 777);
     assert(y.to_field() == 66);
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Adds a check for overlapping generic traits such as two `impl<T> Foo for T` impls. This PR also does some refactoring to slowly move impl selection into the name resolver / type checker. Notably, struct and primitive impls are treated more uniformly in that they both allow for multiple methods of the same name to be implemented on them. This is important not only for implementing the same trait e.g. `impl Foo for Bar<u32>` and `impl Foo for Bar<u64>`, but also for implementing multiple traits on the same type which happen to share method names.

## Additional Context

This PR does not go all the way in the overlap checking. Notably the unification check needs to be changed to instantiate any named generics. I'll do this in a PR tomorrow. Once this is done we'll have overlap checking for generics in general, e.g. `impl<T> Foo for T` and `impl Foo for u32`.

This PR also temporarily disables implementing traits for `&mut` due to conflicts in impl resolution and auto-dereferencing. This will also be addressed in another PR. For now, I've made a new compiler error for it so we will issue an error instead of select the wrong impl.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
