### PR TITLE
fix(3275): activate brillig modulo test with negative integers

### DIFF
--- a/tooling/nargo_cli/tests/compile_success_empty/brillig_modulo/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/brillig_modulo/src/main.nr
@@ -7,18 +7,16 @@ fn main() {
     assert(signed_modulo(5, 3) == 2);
     assert(signed_modulo(2, 3) == 2);
 
-    // See #3275.
-    // Commented out for now since the previous values which would overflow an i4 are now a compiler error.
-    // let minus_two: i4 = -2; // 14
-    // let minus_three: i4 = -3; // 13
-    // let minus_five: i4 = -5; // 11
+    let minus_two: i4 = -2; // 14
+    let minus_three: i4 = -3; // 13
+    let minus_five: i4 = -5; // 11
 
-    // // (5 / -3) * -3 + 2 = -1 * -3 + 2 = 3 + 2 = 5
-    // assert(signed_modulo(5, minus_three) == 2);
-    // // (-5 / 3) * 3 - 2 = -1 * 3 - 2 = -3 - 2 = -5
-    // assert(signed_modulo(minus_five, 3) == minus_two);
-    // // (-5 / -3) * -3 - 2 = 1 * -3 - 2 = -3 - 2 = -5
-    // assert(signed_modulo(minus_five, minus_three) == minus_two);
+    // (5 / -3) * -3 + 2 = -1 * -3 + 2 = 3 + 2 = 5
+    assert(signed_modulo(5, minus_three) == 2);
+    // (-5 / 3) * 3 - 2 = -1 * 3 - 2 = -3 - 2 = -5
+    assert(signed_modulo(minus_five, 3) == minus_two);
+    // (-5 / -3) * -3 - 2 = 1 * -3 - 2 = -3 - 2 = -5
+    assert(signed_modulo(minus_five, minus_three) == minus_two);
 }
 
 unconstrained fn modulo(x: u32, y: u32) -> u32 {


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3275 

## Summary\*

Activate the test with negative integers, the tests are working for me.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
