### PR TITLE
feat: Expand trait impl overlap check to cover generic types

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -35,7 +35,7 @@ pub enum DefCollectorErrorKind {
     NonStructTypeInImpl { span: Span },
     #[error("Cannot implement trait on a mutable reference type")]
     MutableReferenceInTraitImpl { span: Span },
-    #[error("Impl overlaps with existing impl for type {typ}")]
+    #[error("Impl for type `{typ}` overlaps with existing impl")]
     OverlappingImpl { span: Span, typ: crate::Type },
     #[error("Previous impl defined here")]
     OverlappingImplNote { span: Span },
@@ -141,7 +141,7 @@ impl From<DefCollectorErrorKind> for Diagnostic {
             ),
             DefCollectorErrorKind::OverlappingImpl { span, typ } => {
                 Diagnostic::simple_error(
-                    format!("Impl overlaps with existing impl for type `{typ}`"),
+                    format!("Impl for type `{typ}` overlaps with existing impl"),
                     "Overlapping impl".into(),
                     span,
                 )

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1119,7 +1119,7 @@ impl Type {
                 env.find_all_unbound_type_variables(interner, bindings);
             }
             Type::MutableReference(elem) => {
-                elem.find_all_unbound_type_variables(interner, bindings)
+                elem.find_all_unbound_type_variables(interner, bindings);
             }
             Type::Forall(_, typ) => typ.find_all_unbound_type_variables(interner, bindings),
             Type::TypeVariable(type_variable, _) | Type::NamedGeneric(type_variable, _) => {

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1069,6 +1069,75 @@ impl Type {
         }
     }
 
+    /// Replace each NamedGeneric (and TypeVariable) in this type with a fresh type variable
+    pub(crate) fn instantiate_named_generics(&self, interner: &NodeInterner) -> Type {
+        let mut substitutions = HashMap::new();
+        self.find_all_unbound_type_variables(interner, &mut substitutions);
+        self.substitute(&substitutions)
+    }
+
+    /// Returns a list of substituions from each unbound type variable in the current type
+    /// to a fresh type variable
+    fn find_all_unbound_type_variables(
+        &self,
+        interner: &NodeInterner,
+        bindings: &mut TypeBindings,
+    ) {
+        match self {
+            Type::FieldElement
+            | Type::Integer(_, _)
+            | Type::Bool
+            | Type::Unit
+            | Type::TraitAsType(_)
+            | Type::Constant(_)
+            | Type::NotConstant
+            | Type::Error => (),
+            Type::Array(length, elem) => {
+                length.find_all_unbound_type_variables(interner, bindings);
+                elem.find_all_unbound_type_variables(interner, bindings);
+            }
+            Type::String(length) => length.find_all_unbound_type_variables(interner, bindings),
+            Type::FmtString(length, env) => {
+                length.find_all_unbound_type_variables(interner, bindings);
+                env.find_all_unbound_type_variables(interner, bindings);
+            }
+            Type::Struct(_, generics) => {
+                for generic in generics {
+                    generic.find_all_unbound_type_variables(interner, bindings);
+                }
+            }
+            Type::Tuple(fields) => {
+                for field in fields {
+                    field.find_all_unbound_type_variables(interner, bindings);
+                }
+            }
+            Type::Function(args, ret, env) => {
+                for arg in args {
+                    arg.find_all_unbound_type_variables(interner, bindings);
+                }
+                ret.find_all_unbound_type_variables(interner, bindings);
+                env.find_all_unbound_type_variables(interner, bindings);
+            }
+            Type::MutableReference(elem) => {
+                elem.find_all_unbound_type_variables(interner, bindings)
+            }
+            Type::Forall(_, typ) => typ.find_all_unbound_type_variables(interner, bindings),
+            Type::TypeVariable(type_variable, _) | Type::NamedGeneric(type_variable, _) => {
+                match &*type_variable.borrow() {
+                    TypeBinding::Bound(binding) => {
+                        binding.find_all_unbound_type_variables(interner, bindings);
+                    }
+                    TypeBinding::Unbound(id) => {
+                        if !bindings.contains_key(id) {
+                            let fresh_type_variable = interner.next_type_variable();
+                            bindings.insert(*id, (type_variable.clone(), fresh_type_variable));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /// Substitute any type variables found within this type with the
     /// given bindings if found. If a type variable is not found within
     /// the given TypeBindings, it is unchanged.

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1076,8 +1076,8 @@ impl Type {
         self.substitute(&substitutions)
     }
 
-    /// Returns a list of substituions from each unbound type variable in the current type
-    /// to a fresh type variable
+    /// For each unbound type variable in the current type, add a type binding to the given list
+    /// to bind the unbound type variable to a fresh type variable.
     fn find_all_unbound_type_variables(
         &self,
         interner: &NodeInterner,

--- a/tooling/nargo_cli/tests/compile_failure/overlapping_generic_impls/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_failure/overlapping_generic_impls/src/main.nr
@@ -2,7 +2,6 @@
 trait Trait { fn t(self); }
 
 impl<T> Trait for T { fn t(self){} }
-
-impl<T> Trait for T { fn t(self){} }
+impl Trait for u32 { fn t(self){} }
 
 fn main() {}


### PR DESCRIPTION
# Description

## Problem\*

Fixes the final part of the overlap check from https://github.com/noir-lang/noir/pull/3307 to work for all generic types.

## Summary\*

https://github.com/noir-lang/noir/pull/3307 implemented the overlap check for traits and most of the infrastructure required for it, but it was largely identical to the previous check we had which checked types via basic equality without handling type variables. So previously if you had an impl for `impl<T> Foo for T` and `impl Foo for u32`, they would not be caught as overlapping.

This PR implements the final key to the overlap check which is instantiating the generics in the type before trying to unify them. With this, the above error is caught.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
