### PR TITLE
feat: Implement where clauses on impls

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -145,12 +145,13 @@ impl<'a> ModCollector<'a> {
         for trait_impl in impls {
             let trait_name = trait_impl.trait_name.clone();
 
-            let unresolved_functions =
+            let mut unresolved_functions =
                 self.collect_trait_impl_function_overrides(context, &trait_impl, krate);
 
             let module = ModuleId { krate, local_id: self.module_id };
 
-            for (_, func_id, noir_function) in &unresolved_functions.functions {
+            for (_, func_id, noir_function) in &mut unresolved_functions.functions {
+                noir_function.def.where_clause.append(&mut trait_impl.where_clause.clone());
                 context.def_interner.push_function(*func_id, &noir_function.def, module);
             }
 

--- a/tooling/nargo_cli/tests/compile_success_empty/impl_with_where_clause/Nargo.toml
+++ b/tooling/nargo_cli/tests/compile_success_empty/impl_with_where_clause/Nargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "trait_generics"
+name = "impl_with_where_clause"
 type = "bin"
 authors = [""]
 compiler_version = "0.10.5"

--- a/tooling/nargo_cli/tests/compile_success_empty/impl_with_where_clause/Nargo.toml
+++ b/tooling/nargo_cli/tests/compile_success_empty/impl_with_where_clause/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "trait_generics"
+type = "bin"
+authors = [""]
+compiler_version = "0.10.5"
+
+[dependencies]

--- a/tooling/nargo_cli/tests/compile_success_empty/impl_with_where_clause/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_success_empty/impl_with_where_clause/src/main.nr
@@ -1,0 +1,29 @@
+
+fn main() {
+    let array: [Field; 3] = [1, 2, 3];
+    assert(array.eq(array));
+
+    // Ensure this still works if we have to infer the type of the integer literals
+    let array = [1, 2, 3];
+    assert(array.eq(array));
+}
+
+trait Eq {
+    fn eq(self, other: Self) -> bool;
+}
+
+impl<T, N> Eq for [T; N] where T: Eq {
+    fn eq(self, other: Self) -> bool {
+        let mut ret = true;
+        for i in 0 .. self.len() {
+            ret &= self[i].eq(other[i]);
+        }
+        ret
+    }
+}
+
+impl Eq for Field {
+    fn eq(self, other: Field) -> bool {
+        self == other
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This was a smaller change than initially expected. Since functions already allow a `where` clause, I just copied the where clause constraints on the impl itself into the function's where clause.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
