### PR TITLE
Enable the `fmt` command in the help menu

### DIFF
--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -10,6 +10,7 @@ use crate::errors::CliError;
 
 use super::NargoConfig;
 
+/// Format the Noir files in a workspace
 #[derive(Debug, Clone, Args)]
 pub(crate) struct FormatCommand {}
 

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -60,7 +60,6 @@ pub(crate) struct NargoConfig {
 enum NargoCommand {
     Backend(backend_cmd::BackendCommand),
     Check(check_cmd::CheckCommand),
-    #[command(hide = true)] // Hidden while the feature has not been extensively tested
     Fmt(fmt_cmd::FormatCommand),
     CodegenVerifier(codegen_verifier_cmd::CodegenVerifierCommand),
     #[command(alias = "build")]


### PR DESCRIPTION
# Description
This PR enables the fmt command to appear in the help menu for nargo as requested in issue #3261.


Resolves #3261 



## Additional Context
This is my first PR to the Noir repo, so I may be lacking additional context around this particular command and its desired behaviour which needs to be documented in the command-specific help menu.


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
