### PR TITLE
chore: add back algolia recrawler

### DIFF
--- a/.github/workflows/recrawler.yml
+++ b/.github/workflows/recrawler.yml
@@ -1,7 +1,7 @@
 name: Algolia Recrawl
 on:
   push:
-    branches: [ kw/add-back-recrawler ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/recrawler.yml
+++ b/.github/workflows/recrawler.yml
@@ -1,7 +1,7 @@
 name: Algolia Recrawl
 on:
   push:
-    branches: [ master ]
+    branches: [ kw/add-back-recrawler ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Description

Once #3330 is merged, we won't have the recrawler. This PR adds it back.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
