### PR TITLE
chore: Add `hash_to_field` Noir alternative

### DIFF
--- a/noir_stdlib/src/field.nr
+++ b/noir_stdlib/src/field.nr
@@ -82,3 +82,20 @@ pub fn modulus_be_bytes() -> [u8] {}
 
 #[builtin(modulus_le_bytes)]
 pub fn modulus_le_bytes() -> [u8] {}
+
+// Convert a 32 byte array to a field element
+pub fn bytes32_to_field(bytes32 : [u8; 32]) -> Field {
+    // Convert it to a field element
+    let mut v = 1;
+    let mut high = 0 as Field;
+    let mut low = 0 as Field;
+
+    for i in 0..16 {
+        high = high + (bytes32[15 - i] as Field) * v;
+        low = low + (bytes32[16 + 15 - i] as Field) * v;
+        v = v * 256;
+    }
+
+    // Abuse that a % p + b % p = (a + b) % p and that low < p
+    low + high * v
+}

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -22,6 +22,19 @@ pub fn pedersen_hash_with_separator<N>(_input : [Field; N], _separator : u32) ->
 
 #[foreign(hash_to_field_128_security)]
 pub fn hash_to_field<N>(_input : [Field; N]) -> Field {}
+pub fn hash_to_field_native<N>(_input : [Field; N]) -> Field {
+    let mut inputs_as_bytes = [];
+    
+    for i in 0..N {
+        let input_bytes = _input[i].to_le_bytes(32);
+        for i in 0..32 {
+            inputs_as_bytes = inputs_as_bytes.push_back(input_bytes[i]);
+        }
+    }
+
+    let hashed_input = blake2s(inputs_as_bytes);
+    crate::field::bytes32_to_field(hashed_input)
+}
 
 #[foreign(keccak256)]
 pub fn keccak256<N>(_input : [u8; N], _message_size: u32) -> [u8; 32] {}

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -20,9 +20,7 @@ pub fn pedersen_hash<N>(input : [Field; N]) -> Field {
 #[foreign(pedersen_hash)]
 pub fn pedersen_hash_with_separator<N>(_input : [Field; N], _separator : u32) -> Field {}
 
-#[foreign(hash_to_field_128_security)]
-pub fn hash_to_field<N>(_input : [Field; N]) -> Field {}
-pub fn hash_to_field_native<N>(_input : [Field; N]) -> Field {
+pub fn hash_to_field<N>(_input : [Field; N]) -> Field {
     let mut inputs_as_bytes = [];
     
     for i in 0..N {

--- a/tooling/nargo_cli/tests/execution_success/hash_to_field/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/hash_to_field/src/main.nr
@@ -2,11 +2,7 @@ use dep::std;
 
 fn main(input : Field) -> pub Field {
     let expected = std::hash::hash_to_field([input]);
-
-    let input_bytes = input.to_le_bytes(32);
-    let blake2s = std::hash::blake2s(input_bytes);
-    let got = dep::std::field::bytes32_to_field(blake2s);
-
+    let got = std::hash::hash_to_field_native([input]);
     assert(expected == got);
     expected
 }

--- a/tooling/nargo_cli/tests/execution_success/hash_to_field/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/hash_to_field/src/main.nr
@@ -1,8 +1,5 @@
 use dep::std;
 
 fn main(input : Field) -> pub Field {
-    let expected = std::hash::hash_to_field([input]);
-    let got = std::hash::hash_to_field_native([input]);
-    assert(expected == got);
-    expected
+    std::hash::hash_to_field([input])
 }

--- a/tooling/nargo_cli/tests/execution_success/hash_to_field/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/hash_to_field/src/main.nr
@@ -1,5 +1,12 @@
 use dep::std;
 
 fn main(input : Field) -> pub Field {
-    std::hash::hash_to_field([input])
+    let expected = std::hash::hash_to_field([input]);
+
+    let input_bytes = input.to_le_bytes(32);
+    let blake2s = std::hash::blake2s(input_bytes);
+    let got = dep::std::field::bytes32_to_field(blake2s);
+
+    assert(expected == got);
+    expected
 }


### PR DESCRIPTION
# Description

Related to https://github.com/noir-lang/acvm/issues/358

This only adds a test to show that we can implement the hash_to_field blackbox function in Noir.

 Since hash_to_field takes Field elements as parameters, the decomposition shown is needed to hash a ~254 bit element instead of a single u8.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
