### PR TITLE
chore!: Move circuit serialization circuit into acir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "acir"
 version = "0.30.0"
 dependencies = [
  "acir_field",
+ "base64",
  "bincode",
  "brillig",
  "flate2",
@@ -2405,7 +2406,6 @@ name = "nargo"
 version = "0.18.0"
 dependencies = [
  "acvm",
- "base64",
  "codespan-reporting",
  "fm",
  "iter-extended",
@@ -2625,7 +2625,6 @@ name = "noirc_driver"
 version = "0.18.0"
 dependencies = [
  "acvm",
- "base64",
  "build-data",
  "clap",
  "fm",

--- a/acvm-repo/acir/Cargo.toml
+++ b/acvm-repo/acir/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 thiserror.workspace = true
 flate2 = "1.0.24"
 bincode.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -9,12 +9,9 @@ use thiserror::Error;
 
 use std::{io::prelude::*, num::ParseIntError, str::FromStr};
 
-use flate2::Compression;
 use base64::Engine;
-use serde::{
-    Deserialize, Deserializer, Serialize, Serializer,
-    de::Error as DeserializationError
-};
+use flate2::Compression;
+use serde::{de::Error as DeserializationError, Deserialize, Deserializer, Serialize, Serializer};
 
 use std::collections::BTreeSet;
 
@@ -158,13 +155,13 @@ impl Circuit {
     // Serialize and base64 encode circuit
     pub fn serialize_circuit_base64<S>(circuit: &Circuit, s: S) -> Result<S::Ok, S::Error>
     where
-    S: Serializer,
+        S: Serializer,
     {
         let circuit_bytes = Circuit::serialize_circuit(circuit);
         let encoded_b64 = base64::engine::general_purpose::STANDARD.encode(circuit_bytes);
         s.serialize_str(&encoded_b64)
     }
-    
+
     // Deserialize and base64 decode circuit
     pub fn deserialize_circuit_base64<'de, D>(deserializer: D) -> Result<Circuit, D::Error>
     where

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -263,9 +263,8 @@ mod tests {
         };
 
         fn read_write(circuit: Circuit) -> (Circuit, Circuit) {
-            let mut bytes = Vec::new();
-            circuit.write(&mut bytes).unwrap();
-            let got_circuit = Circuit::read(&*bytes).unwrap();
+            let bytes = Circuit::serialize_circuit(&circuit);
+            let got_circuit = Circuit::deserialize_circuit(&bytes).unwrap();
             (circuit, got_circuit)
         }
 
@@ -311,7 +310,7 @@ mod tests {
         encoder.write_all(bad_circuit).unwrap();
         encoder.finish().unwrap();
 
-        let deserialization_result = Circuit::read(&*zipped_bad_circuit);
+        let deserialization_result = Circuit::deserialize_circuit(&zipped_bad_circuit);
         assert!(deserialization_result.is_err());
     }
 }

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -149,7 +149,7 @@ impl Circuit {
     }
 
     pub fn deserialize_circuit(serialized_circuit: &[u8]) -> std::io::Result<Self> {
-        Circuit::read(&*serialized_circuit)
+        Circuit::read(serialized_circuit)
     }
 
     // Serialize and base64 encode circuit
@@ -171,7 +171,7 @@ impl Circuit {
         let circuit_bytes = base64::engine::general_purpose::STANDARD
             .decode(bytecode_b64)
             .map_err(D::Error::custom)?;
-        let circuit = Self::deserialize_circuit(&*circuit_bytes).map_err(D::Error::custom)?;
+        let circuit = Self::deserialize_circuit(&circuit_bytes).map_err(D::Error::custom)?;
         Ok(circuit)
     }
 }

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -10,8 +10,12 @@ use thiserror::Error;
 use std::{io::prelude::*, num::ParseIntError, str::FromStr};
 
 use flate2::Compression;
+use base64::Engine;
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::Error as DeserializationError
+};
 
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -125,7 +129,7 @@ impl Circuit {
         PublicInputs(public_inputs)
     }
 
-    pub fn write<W: std::io::Write>(&self, writer: W) -> std::io::Result<()> {
+    fn write<W: std::io::Write>(&self, writer: W) -> std::io::Result<()> {
         let buf = bincode::serialize(self).unwrap();
         let mut encoder = flate2::write::GzEncoder::new(writer, Compression::default());
         encoder.write_all(&buf)?;
@@ -133,12 +137,45 @@ impl Circuit {
         Ok(())
     }
 
-    pub fn read<R: std::io::Read>(reader: R) -> std::io::Result<Self> {
+    fn read<R: std::io::Read>(reader: R) -> std::io::Result<Self> {
         let mut gz_decoder = flate2::read::GzDecoder::new(reader);
         let mut buf_d = Vec::new();
         gz_decoder.read_to_end(&mut buf_d)?;
         bincode::deserialize(&buf_d)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))
+    }
+
+    pub fn serialize_circuit(circuit: &Circuit) -> Vec<u8> {
+        let mut circuit_bytes: Vec<u8> = Vec::new();
+        circuit.write(&mut circuit_bytes).expect("expected circuit to be serializable");
+        circuit_bytes
+    }
+
+    pub fn deserialize_circuit(serialized_circuit: &[u8]) -> std::io::Result<Self> {
+        Circuit::read(&*serialized_circuit)
+    }
+
+    // Serialize and base64 encode circuit
+    pub fn serialize_circuit_base64<S>(circuit: &Circuit, s: S) -> Result<S::Ok, S::Error>
+    where
+    S: Serializer,
+    {
+        let circuit_bytes = Circuit::serialize_circuit(circuit);
+        let encoded_b64 = base64::engine::general_purpose::STANDARD.encode(circuit_bytes);
+        s.serialize_str(&encoded_b64)
+    }
+    
+    // Deserialize and base64 decode circuit
+    pub fn deserialize_circuit_base64<'de, D>(deserializer: D) -> Result<Circuit, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytecode_b64: String = serde::Deserialize::deserialize(deserializer)?;
+        let circuit_bytes = base64::engine::general_purpose::STANDARD
+            .decode(bytecode_b64)
+            .map_err(D::Error::custom)?;
+        let circuit = Self::deserialize_circuit(&*circuit_bytes).map_err(D::Error::custom)?;
+        Ok(circuit)
     }
 }
 

--- a/acvm-repo/acir/tests/test_program_serialization.rs
+++ b/acvm-repo/acir/tests/test_program_serialization.rs
@@ -42,8 +42,7 @@ fn addition_circuit() {
         ..Circuit::default()
     };
 
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
+    let bytes = Circuit::serialize_circuit(&circuit);
 
     let expected_serialization: Vec<u8> = vec![
         31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 173, 144, 187, 13, 192, 32, 12, 68, 249, 100, 32, 27,
@@ -73,8 +72,7 @@ fn fixed_base_scalar_mul_circuit() {
         ..Circuit::default()
     };
 
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
+    let bytes = Circuit::serialize_circuit(&circuit);
 
     let expected_serialization: Vec<u8> = vec![
         31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 77, 138, 91, 10, 0, 48, 12, 194, 178, 215, 215, 46, 189,
@@ -101,8 +99,7 @@ fn pedersen_circuit() {
         ..Circuit::default()
     };
 
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
+    let bytes = Circuit::serialize_circuit(&circuit);
 
     let expected_serialization: Vec<u8> = vec![
         31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 93, 138, 9, 10, 0, 64, 8, 2, 103, 15, 250, 255, 139,
@@ -143,8 +140,7 @@ fn schnorr_verify_circuit() {
         ..Circuit::default()
     };
 
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
+    let bytes = Circuit::serialize_circuit(&circuit);
 
     let expected_serialization: Vec<u8> = vec![
         31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 77, 210, 87, 78, 2, 1, 20, 134, 209, 177, 247, 222, 123,
@@ -197,8 +193,7 @@ fn simple_brillig_foreign_call() {
         ..Circuit::default()
     };
 
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
+    let bytes = Circuit::serialize_circuit(&circuit);
 
     let expected_serialization: Vec<u8> = vec![
         31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 173, 143, 49, 10, 64, 33, 12, 67, 99, 63, 124, 60, 142,
@@ -271,8 +266,7 @@ fn complex_brillig_foreign_call() {
         ..Circuit::default()
     };
 
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
+    let bytes = Circuit::serialize_circuit(&circuit);
 
     let expected_serialization: Vec<u8> = vec![
         31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 213, 83, 219, 10, 128, 48, 8, 117, 174, 139, 159, 179,
@@ -310,8 +304,7 @@ fn memory_op_circuit() {
         return_values: PublicInputs([Witness(4)].into()),
         ..Circuit::default()
     };
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
+    let bytes = Circuit::serialize_circuit(&circuit);
 
     let expected_serialization: Vec<u8> = vec![
         31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 213, 146, 49, 14, 0, 32, 8, 3, 139, 192, 127, 240, 7,

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -64,7 +64,8 @@ pub async fn execute_circuit_with_black_box_solver(
     foreign_call_handler: ForeignCallHandler,
 ) -> Result<JsWitnessMap, Error> {
     console_error_panic_hook::set_once();
-    let circuit: Circuit = Circuit::read(&*circuit).expect("Failed to deserialize circuit");
+    let circuit: Circuit =
+        Circuit::deserialize_circuit(&circuit).expect("Failed to deserialize circuit");
 
     let mut acvm = ACVM::new(&solver.0, &circuit.opcodes, initial_witness.into());
 

--- a/acvm-repo/acvm_js/src/public_witness.rs
+++ b/acvm-repo/acvm_js/src/public_witness.rs
@@ -30,7 +30,8 @@ pub fn get_return_witness(
     witness_map: JsWitnessMap,
 ) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
-    let circuit: Circuit = Circuit::read(&*circuit).expect("Failed to deserialize circuit");
+    let circuit: Circuit =
+        Circuit::deserialize_circuit(&circuit).expect("Failed to deserialize circuit");
     let witness_map = WitnessMap::from(witness_map);
 
     let return_witness =
@@ -50,7 +51,8 @@ pub fn get_public_parameters_witness(
     solved_witness: JsWitnessMap,
 ) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
-    let circuit: Circuit = Circuit::read(&*circuit).expect("Failed to deserialize circuit");
+    let circuit: Circuit =
+        Circuit::deserialize_circuit(&circuit).expect("Failed to deserialize circuit");
     let witness_map = WitnessMap::from(solved_witness);
 
     let public_params_witness =
@@ -70,7 +72,8 @@ pub fn get_public_witness(
     solved_witness: JsWitnessMap,
 ) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
-    let circuit: Circuit = Circuit::read(&*circuit).expect("Failed to deserialize circuit");
+    let circuit: Circuit =
+        Circuit::deserialize_circuit(&circuit).expect("Failed to deserialize circuit");
     let witness_map = WitnessMap::from(solved_witness);
 
     let public_witness =

--- a/compiler/noirc_driver/Cargo.toml
+++ b/compiler/noirc_driver/Cargo.toml
@@ -20,5 +20,4 @@ acvm.workspace = true
 iter-extended.workspace = true
 fm.workspace = true
 serde.workspace = true
-base64.workspace = true
 fxhash.workspace = true

--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -61,7 +61,10 @@ pub struct ContractFunction {
 
     pub abi: Abi,
 
-    #[serde(serialize_with = "Circuit::serialize_circuit_base64", deserialize_with = "Circuit::deserialize_circuit_base64")]
+    #[serde(
+        serialize_with = "Circuit::serialize_circuit_base64",
+        deserialize_with = "Circuit::deserialize_circuit_base64"
+    )]
     pub bytecode: Circuit,
 
     pub debug: DebugInfo,

--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -8,7 +8,6 @@ use noirc_errors::debug_info::DebugInfo;
 use noirc_evaluator::errors::SsaReport;
 
 use super::debug::DebugFile;
-use crate::program::{deserialize_circuit, serialize_circuit};
 
 /// Describes the types of smart contract functions that are allowed.
 /// Unlike the similar enum in noirc_frontend, 'open' and 'unconstrained'
@@ -62,7 +61,7 @@ pub struct ContractFunction {
 
     pub abi: Abi,
 
-    #[serde(serialize_with = "serialize_circuit", deserialize_with = "deserialize_circuit")]
+    #[serde(serialize_with = "Circuit::serialize_circuit_base64", deserialize_with = "Circuit::deserialize_circuit_base64")]
     pub bytecode: Circuit,
 
     pub debug: DebugInfo,

--- a/compiler/noirc_driver/src/program.rs
+++ b/compiler/noirc_driver/src/program.rs
@@ -18,7 +18,10 @@ pub struct CompiledProgram {
     /// Used to short-circuit compilation in the case of the source code not changing since the last compilation.
     pub hash: u64,
 
-    #[serde(serialize_with = "Circuit::serialize_circuit_base64", deserialize_with = "Circuit::deserialize_circuit_base64")]
+    #[serde(
+        serialize_with = "Circuit::serialize_circuit_base64",
+        deserialize_with = "Circuit::deserialize_circuit_base64"
+    )]
     pub circuit: Circuit,
     pub abi: noirc_abi::Abi,
     pub debug: DebugInfo,

--- a/compiler/noirc_driver/src/program.rs
+++ b/compiler/noirc_driver/src/program.rs
@@ -3,11 +3,9 @@ use std::collections::BTreeMap;
 use acvm::acir::circuit::Circuit;
 use fm::FileId;
 
-use base64::Engine;
 use noirc_errors::debug_info::DebugInfo;
 use noirc_evaluator::errors::SsaReport;
-use serde::{de::Error as DeserializationError, ser::Error as SerializationError};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use super::debug::DebugFile;
 
@@ -20,32 +18,10 @@ pub struct CompiledProgram {
     /// Used to short-circuit compilation in the case of the source code not changing since the last compilation.
     pub hash: u64,
 
-    #[serde(serialize_with = "serialize_circuit", deserialize_with = "deserialize_circuit")]
+    #[serde(serialize_with = "Circuit::serialize_circuit_base64", deserialize_with = "Circuit::deserialize_circuit_base64")]
     pub circuit: Circuit,
     pub abi: noirc_abi::Abi,
     pub debug: DebugInfo,
     pub file_map: BTreeMap<FileId, DebugFile>,
     pub warnings: Vec<SsaReport>,
-}
-
-pub(crate) fn serialize_circuit<S>(circuit: &Circuit, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut circuit_bytes: Vec<u8> = Vec::new();
-    circuit.write(&mut circuit_bytes).map_err(S::Error::custom)?;
-
-    let encoded_b64 = base64::engine::general_purpose::STANDARD.encode(circuit_bytes);
-    s.serialize_str(&encoded_b64)
-}
-
-pub(crate) fn deserialize_circuit<'de, D>(deserializer: D) -> Result<Circuit, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let bytecode_b64: String = serde::Deserialize::deserialize(deserializer)?;
-    let circuit_bytes =
-        base64::engine::general_purpose::STANDARD.decode(bytecode_b64).map_err(D::Error::custom)?;
-    let circuit = Circuit::read(&*circuit_bytes).map_err(D::Error::custom)?;
-    Ok(circuit)
 }

--- a/compiler/wasm/src/circuit.rs
+++ b/compiler/wasm/src/circuit.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn acir_read_bytes(bytes: Vec<u8>) -> JsValue {
     console_error_panic_hook::set_once();
-    let circuit = Circuit::read(&*bytes).unwrap();
+    let circuit = Circuit::deserialize_circuit(&bytes).unwrap();
     <JsValue as JsValueSerdeExt>::from_serde(&circuit).unwrap()
 }
 
@@ -14,7 +14,5 @@ pub fn acir_read_bytes(bytes: Vec<u8>) -> JsValue {
 pub fn acir_write_bytes(acir: JsValue) -> Vec<u8> {
     console_error_panic_hook::set_once();
     let circuit: Circuit = JsValueSerdeExt::into_serde(&acir).unwrap();
-    let mut bytes = Vec::new();
-    circuit.write(&mut bytes).unwrap();
-    bytes
+    Circuit::serialize_circuit(&circuit)
 }

--- a/tooling/backend_interface/src/proof_system.rs
+++ b/tooling/backend_interface/src/proof_system.rs
@@ -23,7 +23,7 @@ impl Backend {
 
         // Create a temporary file for the circuit
         let circuit_path = temp_directory.join("circuit").with_extension("bytecode");
-        let serialized_circuit = serialize_circuit(circuit);
+        let serialized_circuit = Circuit::serialize_circuit(circuit);
         write_to_file(&serialized_circuit, &circuit_path);
 
         GatesCommand { crs_path: self.crs_directory(), bytecode_path: circuit_path }
@@ -57,7 +57,7 @@ impl Backend {
         // Create a temporary file for the circuit
         //
         let bytecode_path = temp_directory.join("circuit").with_extension("bytecode");
-        let serialized_circuit = serialize_circuit(circuit);
+        let serialized_circuit = Circuit::serialize_circuit(circuit);
         write_to_file(&serialized_circuit, &bytecode_path);
 
         // Create proof and store it in the specified path
@@ -97,7 +97,7 @@ impl Backend {
 
         // Create a temporary file for the circuit
         let bytecode_path = temp_directory.join("circuit").with_extension("bytecode");
-        let serialized_circuit = serialize_circuit(circuit);
+        let serialized_circuit = Circuit::serialize_circuit(circuit);
         write_to_file(&serialized_circuit, &bytecode_path);
 
         // Create the verification key and write it to the specified path
@@ -130,7 +130,7 @@ impl Backend {
         // Create a temporary file for the circuit
         //
         let bytecode_path = temp_directory.join("circuit").with_extension("bytecode");
-        let serialized_circuit = serialize_circuit(circuit);
+        let serialized_circuit = Circuit::serialize_circuit(circuit);
         write_to_file(&serialized_circuit, &bytecode_path);
 
         // Create the verification key and write it to the specified path
@@ -173,12 +173,4 @@ pub(super) fn write_to_file(bytes: &[u8], path: &Path) -> String {
         Err(why) => panic!("couldn't write to {display}: {why}"),
         Ok(_) => display.to_string(),
     }
-}
-
-// TODO: See nargo/src/artifacts/mod.rs
-// TODO: This method should live in ACVM and be the default method for serializing/deserializing circuits
-pub(super) fn serialize_circuit(circuit: &Circuit) -> Vec<u8> {
-    let mut circuit_bytes: Vec<u8> = Vec::new();
-    circuit.write(&mut circuit_bytes).unwrap();
-    circuit_bytes
 }

--- a/tooling/backend_interface/src/smart_contract.rs
+++ b/tooling/backend_interface/src/smart_contract.rs
@@ -1,4 +1,4 @@
-use super::proof_system::{serialize_circuit, write_to_file};
+use super::proof_system::write_to_file;
 use crate::{
     cli::{ContractCommand, WriteVkCommand},
     Backend, BackendError,
@@ -16,7 +16,7 @@ impl Backend {
 
         // Create a temporary file for the circuit
         let bytecode_path = temp_directory_path.join("circuit").with_extension("bytecode");
-        let serialized_circuit = serialize_circuit(circuit);
+        let serialized_circuit = Circuit::serialize_circuit(circuit);
         write_to_file(&serialized_circuit, &bytecode_path);
 
         // Create the verification key and write it to the specified path

--- a/tooling/nargo/Cargo.toml
+++ b/tooling/nargo/Cargo.toml
@@ -23,5 +23,4 @@ noirc_printable_type.workspace = true
 iter-extended.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-base64.workspace = true
 codespan-reporting.workspace = true

--- a/tooling/nargo/src/artifacts/contract.rs
+++ b/tooling/nargo/src/artifacts/contract.rs
@@ -37,8 +37,8 @@ pub struct PreprocessedContractFunction {
     pub abi: Abi,
 
     #[serde(
-        serialize_with = "super::serialize_circuit",
-        deserialize_with = "super::deserialize_circuit"
+        serialize_with = "Circuit::serialize_circuit_base64",
+        deserialize_with = "Circuit::deserialize_circuit_base64"
     )]
     pub bytecode: Circuit,
 }

--- a/tooling/nargo/src/artifacts/mod.rs
+++ b/tooling/nargo/src/artifacts/mod.rs
@@ -3,34 +3,6 @@
 //! These artifacts are intended to remain independent of any applications being built on top of Noir.
 //! Should any projects require/desire a different artifact format, it's expected that they will write a transformer
 //! to generate them using these artifacts as a starting point.
-use acvm::acir::circuit::Circuit;
-use base64::Engine;
-use serde::{
-    de::Error as DeserializationError, ser::Error as SerializationError, Deserializer, Serializer,
-};
-
 pub mod contract;
 pub mod debug;
 pub mod program;
-
-// TODO: move these down into ACVM.
-fn serialize_circuit<S>(circuit: &Circuit, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut circuit_bytes: Vec<u8> = Vec::new();
-    circuit.write(&mut circuit_bytes).map_err(S::Error::custom)?;
-    let encoded_b64 = base64::engine::general_purpose::STANDARD.encode(circuit_bytes);
-    s.serialize_str(&encoded_b64)
-}
-
-fn deserialize_circuit<'de, D>(deserializer: D) -> Result<Circuit, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let bytecode_b64: String = serde::Deserialize::deserialize(deserializer)?;
-    let circuit_bytes =
-        base64::engine::general_purpose::STANDARD.decode(bytecode_b64).map_err(D::Error::custom)?;
-    let circuit = Circuit::read(&*circuit_bytes).map_err(D::Error::custom)?;
-    Ok(circuit)
-}

--- a/tooling/nargo/src/artifacts/program.rs
+++ b/tooling/nargo/src/artifacts/program.rs
@@ -21,8 +21,8 @@ pub struct PreprocessedProgram {
     pub abi: Abi,
 
     #[serde(
-        serialize_with = "super::serialize_circuit",
-        deserialize_with = "super::deserialize_circuit"
+        serialize_with = "Circuit::serialize_circuit_base64",
+        deserialize_with = "Circuit::deserialize_circuit_base64"
     )]
     pub bytecode: Circuit,
 }


### PR DESCRIPTION
# Description

This removes the TODO which we had regarding moving serialization logic into ACIR. 

The read and write methods have been made private, so technically this a breaking change. They were only being used for the serialize and deserialize methods., but since its on the public API I've marked this PR as breaking.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
