### PR TITLE
chore: make releases pre-releases by default

### DIFF
--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -177,6 +177,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./nargo-${{ matrix.target }}.tar.gz
           asset_name: nargo-${{ matrix.target }}.tar.gz
+          prerelease: true
           overwrite: true
           tag: ${{ inputs.tag || 'nightly' }} # This will fail if `inputs.tag` is not a tag (e.g. testing a branch)
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Tom: This PR makes releases pre-releases by default. This fixes the issue where aztec releases are immediately set to be the latest release which breaks `noirup`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
