### PR TITLE
chore(ci): ensure that acir artifacts are published on master

### DIFF
--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check if artifacts should be published
         id: check
         run: |
-          if [ ${{ github.ref_name }} == "master" ]; then
+          if [ ${{ github.ref_name }} == master ]; then
             # Always publish on master
             echo "publish=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently never publishing ACIR artifacts on master as seen in this CI run: https://github.com/noir-lang/noir/actions/runs/6699174556/job/18202815460

The issue seems to be a matter of quotation marks in the if statement so this PR removes them.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
