### PR TITLE
chore: Allow apostrophes in attributes

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -542,15 +542,15 @@ mod tests {
     }
 
     #[test]
-    fn test_attribute_with_speed_marks() {
-        let input = r#"#[test(should_fail_with = "this can't compile")]"#;
+    fn test_attribute_with_apostrophe() {
+        let input = r#"#[test(should_fail_with = "the eagle's feathers")]"#;
         let mut lexer = Lexer::new(input);
 
         let token = lexer.next_token().unwrap().token().clone();
         assert_eq!(
             token,
             Token::Attribute(Attribute::Function(FunctionAttribute::Test(
-                TestScope::ShouldFailWith { reason: "this can't compile".to_owned().into() }
+                TestScope::ShouldFailWith { reason: "the eagle's feathers".to_owned().into() }
             )))
         );
     }

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -542,6 +542,20 @@ mod tests {
     }
 
     #[test]
+    fn test_attribute_with_speed_marks() {
+        let input = r#"#[test(should_fail_with = "this can't compile")]"#;
+        let mut lexer = Lexer::new(input);
+
+        let token = lexer.next_token().unwrap().token().clone();
+        assert_eq!(
+            token,
+            Token::Attribute(Attribute::Function(FunctionAttribute::Test(
+                TestScope::ShouldFailWith { reason: "this can't compile".to_owned().into() }
+            )))
+        );
+    }
+
+    #[test]
     fn deprecated_attribute_with_note() {
         let input = r#"#[deprecated("hello")]"#;
         let mut lexer = Lexer::new(input);

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -462,6 +462,7 @@ impl Attribute {
                         || ch == '='
                         || ch == '"'
                         || ch == ' '
+                        || ch == '\''
                 })
                 .then_some(());
 


### PR DESCRIPTION
# Description

## Problem

#3372 

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
