### PR TITLE
chore: Add a workflow to build with feature flag

### DIFF
--- a/.github/workflows/build-aztec-feature-flag.yml
+++ b/.github/workflows/build-aztec-feature-flag.yml
@@ -1,0 +1,45 @@
+name: Build with aztec feature flag
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-aztec-feature-flag:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@1.71.1
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+          cache-on-failure: true
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: Build with feature flag
+        run: cargo build --features="noirc_frontend/aztec"


### PR DESCRIPTION
# Description

Since the feature flag is not on by default, there are cases where we make compiler changes and forget to update the code under the feature flag. These are cosmetic changes, like changing the for-loop structure. This just adds a build step.  

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
