### PR TITLE
feat: Add generic count check for trait methods

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -1068,7 +1068,7 @@ fn check_methods_signatures(
                 impl_method.typ.generic_count() - trait_impl_generic_count;
             let trait_method_generic_count = trait_method.generics.len();
 
-            if dbg!(impl_method_generic_count) != dbg!(trait_method_generic_count) {
+            if impl_method_generic_count != trait_method_generic_count {
                 let error = DefCollectorErrorKind::MismatchTraitImplementationNumGenerics {
                     impl_method_generic_count,
                     trait_method_generic_count,

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -41,10 +41,18 @@ pub enum DefCollectorErrorKind {
     OverlappingImplNote { span: Span },
     #[error("Cannot `impl` a type defined outside the current crate")]
     ForeignImpl { span: Span, type_name: String },
-    #[error("Mismatch number of parameters in of trait implementation")]
+    #[error("Mismatched number of parameters in trait implementation")]
     MismatchTraitImplementationNumParameters {
         actual_num_parameters: usize,
         expected_num_parameters: usize,
+        trait_name: String,
+        method_name: String,
+        span: Span,
+    },
+    #[error("Mismatched number of generics in impl method")]
+    MismatchTraitImplementationNumGenerics {
+        impl_method_generic_count: usize,
+        trait_method_generic_count: usize,
         trait_name: String,
         method_name: String,
         span: Span,
@@ -174,8 +182,21 @@ impl From<DefCollectorErrorKind> for Diagnostic {
                 method_name,
                 span,
             } => {
+                let plural = if expected_num_parameters == 1 { "" } else { "s" };
                 let primary_message = format!(
-                    "Method `{method_name}` of trait `{trait_name}` needs {expected_num_parameters} parameters, but has {actual_num_parameters}");
+                    "`{trait_name}::{method_name}` expects {expected_num_parameters} parameter{plural}, but this method has {actual_num_parameters}");
+                Diagnostic::simple_error(primary_message, "".to_string(), span)
+            }
+            DefCollectorErrorKind::MismatchTraitImplementationNumGenerics {
+                impl_method_generic_count,
+                trait_method_generic_count,
+                trait_name,
+                method_name,
+                span,
+            } => {
+                let plural = if trait_method_generic_count == 1 { "" } else { "s" };
+                let primary_message = format!(
+                    "`{trait_name}::{method_name}` expects {trait_method_generic_count} generic{plural}, but this method has {impl_method_generic_count}");
                 Diagnostic::simple_error(primary_message, "".to_string(), span)
             }
             DefCollectorErrorKind::MethodNotInTrait { trait_name, impl_method } => {

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -560,6 +560,21 @@ impl Type {
                 .all(|(_, field)| field.is_valid_for_program_input()),
         }
     }
+
+    /// Returns the number of `Forall`-quantified type variables on this type.
+    /// Returns 0 if this is not a Type::Forall
+    pub fn generic_count(&self) -> usize {
+        match self {
+            Type::Forall(generics, _) => generics.len(),
+            Type::TypeVariable(type_variable, _) | Type::NamedGeneric(type_variable, _) => {
+                match &*type_variable.borrow() {
+                    TypeBinding::Bound(binding) => binding.generic_count(),
+                    TypeBinding::Unbound(_) => 0,
+                }
+            }
+            _ => 0,
+        }
+    }
 }
 
 impl std::fmt::Display for Type {

--- a/tooling/nargo_cli/tests/compile_failure/trait_incorrect_generic_count/Nargo.toml
+++ b/tooling/nargo_cli/tests/compile_failure/trait_incorrect_generic_count/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "trait_incorrect_generic_count"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.18.0"
+
+[dependencies]

--- a/tooling/nargo_cli/tests/compile_failure/trait_incorrect_generic_count/src/main.nr
+++ b/tooling/nargo_cli/tests/compile_failure/trait_incorrect_generic_count/src/main.nr
@@ -1,0 +1,13 @@
+
+fn main(){
+    let x: u32 = 0;
+    x.trait_fn();
+}
+
+trait Trait {
+    fn trait_fn<T>(x: T) -> T {}
+}
+
+impl Trait for u32 {
+    fn trait_fn<A, B>(x: A) -> A { x }
+}


### PR DESCRIPTION
# Description

## Summary\*

Adds a check that trait impl methods have the same number of generics as the trait they implement.

## Additional Context

Note that in the corner case of:

```rs
trait Trait {
    fn trait_fn<T>(x: T) -> T;
}

impl<T> Trait for T {
    fn trait_fn(x: T) -> T { x }
}
```

We match rust's behavior in disallowing this. 

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
