### PR TITLE
chore(docs): Document signed integers and integer overflow behavior

### DIFF
--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -4,38 +4,38 @@ description: Explore the Integer data type in Noir. Learn about its methods, see
 keywords: [noir, integer types, methods, examples, arithmetic]
 ---
 
-An integer type is a range constrained field type. The Noir frontend currently supports arbitrary-sized, both unsigned and signed integer types.
+An integer type is a range constrained field type. The Noir frontend supports arbitrarily-sized, both unsigned and signed integer types.
 
-When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
+> **Note:** When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
 
 ## Unsigned Integers
 
-An unsigned integer type is specified first with the letter `u`, indicating its unsigned nature, followed by
-its length in bits (e.g. `8`). For example, a `u8` variable can store a value in the range of
-$\\([0,2^{8}-1]\\)$.
-
-> **Note:** The default proving backend supports both even (e.g. _u2_, _u32_) and odd (e.g. _u3_, _u127_) sized integer types.
-
-Taking a look of how the type is used:
+An unsigned integer type is specified first with the letter `u`, indicating its unsigned nature, followed by its length in bits (e.g. `8`):
 
 ```rust
-fn main(x : Field, y : u8) {
-    let z = x as u8 + y;
-    assert (z > 0);
+fn main() {
+    let x : u8 = 1;
+    let y : u8 = 1;
+    let z = x + y;
+    assert (z == 2);
 }
 ```
 
-Note that _x_, _y_ and _z_ are all private values in this example, where _x_ is a field while _y_ and _z_
-are unsigned 8-bit integers.
+The length in bits determines the boundaries the integer type can store. For example, a `u8` variable can store a value in the range of 0 to 255 (i.e. $\\2^{8}-1\\$).
 
-If _y_ or _z_ exceeds the range $\\([0,2^{8}-1]\\)$, proofs created
-will be rejected by the verifier.
+Computations that exceed the type boundaries would result in overflow errors. For example, attempting to prove:
 
-For example, attempting to prove the above code with the following inputs:
+```rust
+fn main(x : u8, y : u8) {
+    let z = x + y;
+}
+```
+
+With:
 
 ```toml
-x = "1"
-y = "255"
+x = "255"
+y = "1"
 ```
 
 Would result in:
@@ -43,22 +43,20 @@ Would result in:
 ```
 $ nargo prove
 error: Assertion failed: 'attempt to add with overflow'
-┌─ ~/src/main.nr:2:13
+┌─ ~/src/main.nr:9:13
 │
-│     let z = x as u8 + y;
-│             -----------
+│     let z = x + y;
+│             -----
 │
 = Call stack:
   ...
 ```
 
+> **Note:** The default proving backend supports both even (e.g. _u2_) and odd (e.g. _u3_) arbitrarily-sized integer types up to _u127_.
+
 ## Signed Integers
 
-A signed integer type is specified first with the letter `i`, followed by
-its length in bits (e.g. `8`). For example, a `i8` variable can store a value in the range of
-$\\([-2^{7}+1,2^{7}-1]\\)$.
-
-An example of how the type is used:
+A signed integer type is specified first with the letter `i`, stands for integer, followed by its length in bits (e.g. `8`):
 
 ```rust
 fn main() {
@@ -69,14 +67,14 @@ fn main() {
 }
 ```
 
-Similar to unsigned integers, signed integers are also range constrained.
+The length in bits determines the boundaries the integer type can store. For example, a `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
 
-For example, attempting to prove:
+Computations that exceed the type boundaries would result in overflow errors. For example, attempting to prove:
 
 ```rust
 fn main() {
-    let x : i8 = -127;
-    let y : i8 = -10;
+    let x : i8 = -118;
+    let y : i8 = -11;
     let z = x + y;
 }
 ```
@@ -94,3 +92,5 @@ error: Assertion failed: 'attempt to add with overflow'
 = Call stack:
   ...
 ```
+
+> **Note:** The default proving backend supports both even (e.g. _i2_) and odd (e.g. _i3_) arbitrarily-sized integer types up to _i127_.

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -4,10 +4,11 @@ description: Explore the Integer data type in Noir. Learn about its methods, see
 keywords: [noir, integer types, methods, examples, arithmetic]
 ---
 
-An integer type is a range constrained field type. The Noir frontend currently supports unsigned,
-arbitrary-sized integer types.
+An integer type is a range constrained field type. The Noir frontend currently supports arbitrary-sized, both unsigned and signed integer types.
 
 When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
+
+## Unsigned Integers
 
 An unsigned integer type is specified first with the letter `u`, indicating its unsigned nature, followed by
 its length in bits (e.g. `8`). For example, a `u8` variable can store a value in the range of
@@ -42,11 +43,54 @@ Would result in:
 ```
 $ nargo prove
 error: Assertion failed: 'attempt to add with overflow'
-  ┌─ ~/src/main.nr:2:13
-  │
-2 │     let z = x as u8 + y;
-  │             -----------
-  │
-  = Call stack:
-    ...
+┌─ ~/src/main.nr:2:13
+│
+│     let z = x as u8 + y;
+│             -----------
+│
+= Call stack:
+  ...
+```
+
+## Signed Integers
+
+A signed integer type is specified first with the letter `i`, followed by
+its length in bits (e.g. `8`). For example, a `i8` variable can store a value in the range of
+$\\([-2^{7}+1,2^{7}-1]\\)$.
+
+An example of how the type is used:
+
+```rust
+fn main() {
+    let x : i8 = -1;
+    let y : i8 = -1;
+    let z = x + y;
+    assert (z == -2);
+}
+```
+
+Similar to unsigned integers, signed integers are also range constrained.
+
+For example, attempting to prove:
+
+```rust
+fn main() {
+    let x : i8 = -127;
+    let y : i8 = -10;
+    let z = x + y;
+}
+```
+
+Would result in:
+
+```
+$ nargo prove
+error: Assertion failed: 'attempt to add with overflow'
+┌─ ~/src/main.nr:4:13
+│
+│     let z = x + y;
+│             -----
+│
+= Call stack:
+  ...
 ```

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -91,7 +91,7 @@ fn wrapping_sub<T>(x: T, y: T) -> T;
 fn wrapping_mul<T>(x: T, y: T) -> T;
 ```
 
-example usage:
+Example of how it is used:
 
 ```rust
 use dep::std;

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -10,7 +10,7 @@ An integer type is a range constrained field type. The Noir frontend supports ar
 
 ## Unsigned Integers
 
-An unsigned integer type is specified first with the letter `u`, indicating its unsigned nature, followed by its length in bits (e.g. `8`):
+An unsigned integer type is specified first with the letter `u` (indicating its unsigned nature) followed by its length in bits (e.g. `8`):
 
 ```rust
 fn main() {
@@ -25,22 +25,22 @@ The length in bits determines the boundaries the integer type can store. For exa
 
 ## Signed Integers
 
-A signed integer type is specified first with the letter `i`, stands for integer, followed by its length in bits (e.g. `8`):
+A signed integer type is specified first with the letter `i` (which stands for integer) followed by its length in bits (e.g. `8`):
 
 ```rust
 fn main() {
-    let x : i8 = -1;
-    let y : i8 = -1;
+    let x: i8 = -1;
+    let y: i8 = -1;
     let z = x + y;
     assert (z == -2);
 }
 ```
 
-The length in bits determines the boundaries the integer type can store. For example, a `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
+The bit count of the integer determines the maximum and minimum integers the type can store. For example, an `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
 
 ## Overflows
 
-Computations that exceed the type boundaries would result in overflow errors. This happens with both signed and unsigned integers. For example, attempting to prove:
+Computations that exceed the type boundaries will result in overflow errors. This happens with both signed and unsigned integers. For example, attempting to prove:
 
 ```rust
 fn main(x : u8, y : u8) {
@@ -69,12 +69,12 @@ error: Assertion failed: 'attempt to add with overflow'
   ...
 ```
 
-A similar error would happen with unsigned integers, for example while trying to prove:
+A similar error would happen with signed integers, for example while trying to prove:
 
 ```rust
 fn main() {
-    let x : i8 = -118;
-    let y : i8 = -11;
+    let x: i8 = -118;
+    let y: i8 = -11;
     let z = x + y;
 }
 ```
@@ -83,15 +83,13 @@ fn main() {
 
 ### Wrapping methods
 
-Although integer overflow is expected to error, it is understood that some use-cases may actually want to rely on wrapping.
+Although integer overflow is expected to error, some use-cases rely on wrapping. For these use-cases, the standard library provides `wrapping` variants of certain common operations:
 
-For that, you can import and use these `wrapping` functions from the standard library, which are defined as:
-
-```rust
+````rust
 wrapping_add<T>(x : T, y: T) -> T
-wrapping_sub<T>(x : T, y: T) -> T
-wrapping_mul<T>(x : T, y: T) -> T
-```
+fn wrapping_add<T>(x : T, y: T) -> T;
+fn wrapping_sub<T>(x : T, y: T) -> T;
+fn wrapping_mul<T>(x : T, y: T) -> T;
 
 example usage:
 
@@ -99,6 +97,7 @@ example usage:
 use dep::std;
 
 fn main(x : u8, y : u8) {
-    let z = std::wrapping_add(x + y);
+fn main(x : u8, y : u8) -> pub u8 {
+    std::wrapping_add(x + y)
 }
-```
+````

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -14,8 +14,8 @@ An unsigned integer type is specified first with the letter `u` (indicating its 
 
 ```rust
 fn main() {
-    let x : u8 = 1;
-    let y : u8 = 1;
+    let x: u8 = 1;
+    let y: u8 = 1;
     let z = x + y;
     assert (z == 2);
 }

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -43,7 +43,7 @@ The bit count of the integer determines the maximum and minimum integers the typ
 Computations that exceed the type boundaries will result in overflow errors. This happens with both signed and unsigned integers. For example, attempting to prove:
 
 ```rust
-fn main(x : u8, y : u8) {
+fn main(x: u8, y: u8) {
     let z = x + y;
 }
 ```

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -1,28 +1,19 @@
 ---
 title: Integers
-description:
-  Explore the Integer data type in Noir. Learn about its methods, see real-world examples, and grasp how to efficiently use Integers in your Noir code.
-keywords:
-  [
-    noir,
-    integer types,
-    methods,
-    examples,
-    arithmetic,
-  ]
+description: Explore the Integer data type in Noir. Learn about its methods, see real-world examples, and grasp how to efficiently use Integers in your Noir code.
+keywords: [noir, integer types, methods, examples, arithmetic]
 ---
 
 An integer type is a range constrained field type. The Noir frontend currently supports unsigned,
 arbitrary-sized integer types.
 
-> **Note:** When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
+When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
 
 An integer type is specified first with the letter `u`, indicating its unsigned nature, followed by
 its length in bits (e.g. `32`). For example, a `u32` variable can store a value in the range of
 $\\([0,2^{32}-1]\\)$.
 
-> **Note:** The default proving backend supports both even (e.g. `u16`, `u48`) and odd (e.g. `u5`, `u3`)
-> sized integer types.
+> **Note:** The default proving backend supports both even (e.g. `u16`, `u48`) and odd (e.g. `u5`, `u3`) sized integer types.
 
 Taking a look of how the type is used:
 
@@ -32,6 +23,8 @@ fn main(x : Field, y : u32) {
 }
 ```
 
-`x`, `y` and `z` are all private values in this example. However, `x` is a field while `y` and `z`
-are unsigned 32-bit integers. If `y` or `z` exceeds the range $\\([0,2^{32}-1]\\)$, proofs created
+Note that `x`, `y` and `z` are all private values in this example, where `x` is a field while `y` and `z`
+are unsigned 32-bit integers.
+
+If `y` or `z` exceeds the range $\\([0,2^{32}-1]\\)$, proofs created
 will be rejected by the verifier.

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -23,7 +23,24 @@ fn main() {
 
 The length in bits determines the boundaries the integer type can store. For example, a `u8` variable can store a value in the range of 0 to 255 (i.e. $\\2^{8}-1\\$).
 
-Computations that exceed the type boundaries would result in overflow errors. For example, attempting to prove:
+## Signed Integers
+
+A signed integer type is specified first with the letter `i`, stands for integer, followed by its length in bits (e.g. `8`):
+
+```rust
+fn main() {
+    let x : i8 = -1;
+    let y : i8 = -1;
+    let z = x + y;
+    assert (z == -2);
+}
+```
+
+The length in bits determines the boundaries the integer type can store. For example, a `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
+
+## Overflows
+
+Computations that exceed the type boundaries would result in overflow errors. This happens with both signed and unsigned integers. For example, attempting to prove:
 
 ```rust
 fn main(x : u8, y : u8) {
@@ -52,24 +69,7 @@ error: Assertion failed: 'attempt to add with overflow'
   ...
 ```
 
-> **Note:** The default proving backend supports both even (e.g. _u2_) and odd (e.g. _u3_) arbitrarily-sized integer types up to _u127_.
-
-## Signed Integers
-
-A signed integer type is specified first with the letter `i`, stands for integer, followed by its length in bits (e.g. `8`):
-
-```rust
-fn main() {
-    let x : i8 = -1;
-    let y : i8 = -1;
-    let z = x + y;
-    assert (z == -2);
-}
-```
-
-The length in bits determines the boundaries the integer type can store. For example, a `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
-
-Computations that exceed the type boundaries would result in overflow errors. For example, attempting to prove:
+A similar error would happen with unsigned integers, for example while trying to prove:
 
 ```rust
 fn main() {
@@ -79,18 +79,26 @@ fn main() {
 }
 ```
 
-Would result in:
+> **Note:** The default proving backend supports both even (e.g. _u2_) and odd (e.g. _u3_) arbitrarily-sized integer types up to _u127_.
 
-```
-$ nargo prove
-error: Assertion failed: 'attempt to add with overflow'
-┌─ ~/src/main.nr:4:13
-│
-│     let z = x + y;
-│             -----
-│
-= Call stack:
-  ...
+### Wrapping methods
+
+Although integer overflow is expected to error, it is understood that some use-cases may actually want to rely on wrapping.
+
+For that, you can import and use these `wrapping` functions from the standard library, which are defined as:
+
+```rust
+wrapping_add<T>(x : T, y: T) -> T
+wrapping_sub<T>(x : T, y: T) -> T
+wrapping_mul<T>(x : T, y: T) -> T
 ```
 
-> **Note:** The default proving backend supports both even (e.g. _i2_) and odd (e.g. _i3_) arbitrarily-sized integer types up to _i127_.
+example usage:
+
+```rust
+use dep::std;
+
+fn main(x : u8, y : u8) {
+    let z = std::wrapping_add(x + y);
+}
+```

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -69,7 +69,7 @@ error: Assertion failed: 'attempt to add with overflow'
   ...
 ```
 
-A similar error would happen with signed integers, for example while trying to prove:
+A similar error would happen with signed integers:
 
 ```rust
 fn main() {

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -13,7 +13,7 @@ An integer type is specified first with the letter `u`, indicating its unsigned 
 its length in bits (e.g. `32`). For example, a `u32` variable can store a value in the range of
 $\\([0,2^{32}-1]\\)$.
 
-> **Note:** The default proving backend supports both even (e.g. _u8_, _u48_) and odd (e.g. _u3_, _u61_) sized integer types.
+> **Note:** The default proving backend supports both even (e.g. _u2_, _u52_) and odd (e.g. _u3_, _u127_) sized integer types.
 
 Taking a look of how the type is used:
 

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -38,6 +38,8 @@ fn main() {
 
 The bit size determines the maximum and minimum range of value the integer type can store. For example, an `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
 
+> **Note:** If you are using the default proving backend with Noir, both even (e.g. _u2_, _i2_) and odd (e.g. _u3_, _i3_) arbitrarily-sized integer types up to 127 bits (i.e. _u127_ and _i127_) are supported.
+
 ## Overflows
 
 Computations that exceed the type boundaries will result in overflow errors. This happens with both signed and unsigned integers. For example, attempting to prove:
@@ -78,8 +80,6 @@ fn main() {
     let z = x + y;
 }
 ```
-
-> **Note:** The default proving backend supports both even (e.g. _u2_) and odd (e.g. _u3_) arbitrarily-sized integer types up to _u127_.
 
 ### Wrapping methods
 

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -10,21 +10,36 @@ arbitrary-sized integer types.
 When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
 
 An integer type is specified first with the letter `u`, indicating its unsigned nature, followed by
-its length in bits (e.g. `32`). For example, a `u32` variable can store a value in the range of
-$\\([0,2^{32}-1]\\)$.
+its length in bits (e.g. `8`). For example, a `u8` variable can store a value in the range of
+$\\([0,2^{8}-1]\\)$.
 
-> **Note:** The default proving backend supports both even (e.g. _u2_, _u52_) and odd (e.g. _u3_, _u127_) sized integer types.
+> **Note:** The default proving backend supports both even (e.g. _u2_, _u32_) and odd (e.g. _u3_, _u127_) sized integer types.
 
 Taking a look of how the type is used:
 
 ```rust
-fn main(x : Field, y : u32) {
-    let z = x as u32 + y;
+fn main(x : Field, y : u8) {
+    let z = x as u8 + y;
+    assert (z > 0);
 }
 ```
 
 Note that `x`, `y` and `z` are all private values in this example, where `x` is a field while `y` and `z`
 are unsigned 32-bit integers.
 
-If `y` or `z` exceeds the range $\\([0,2^{32}-1]\\)$, proofs created
+If `y` or `z` exceeds the range $\\([0,2^{8}-1]\\)$, proofs created
 will be rejected by the verifier.
+
+For example, attempting to prove the above code with the following inputs:
+
+```toml
+x = "1"
+y = "256"
+```
+
+Would result in:
+
+```
+$ nargo prove
+The parameter y is expected to be a Integer { sign: Unsigned, width: 8 } but found incompatible value Field(2⁸)
+```

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -6,7 +6,13 @@ keywords: [noir, integer types, methods, examples, arithmetic]
 
 An integer type is a range constrained field type. The Noir frontend supports arbitrarily-sized, both unsigned and signed integer types.
 
-> **Note:** When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
+:::info
+
+When an integer is defined in Noir without a specific type, it will default to `Field`.
+
+The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
+
+:::
 
 ## Unsigned Integers
 
@@ -38,7 +44,11 @@ fn main() {
 
 The bit size determines the maximum and minimum range of value the integer type can store. For example, an `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
 
-> **Note:** If you are using the default proving backend with Noir, both even (e.g. _u2_, _i2_) and odd (e.g. _u3_, _i3_) arbitrarily-sized integer types up to 127 bits (i.e. _u127_ and _i127_) are supported.
+:::tip
+
+If you are using the default proving backend with Noir, both even (e.g. _u2_, _i2_) and odd (e.g. _u3_, _i3_) arbitrarily-sized integer types up to 127 bits (i.e. _u127_ and _i127_) are supported.
+
+:::
 
 ## Overflows
 

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -24,10 +24,10 @@ fn main(x : Field, y : u8) {
 }
 ```
 
-Note that `x`, `y` and `z` are all private values in this example, where `x` is a field while `y` and `z`
-are unsigned 32-bit integers.
+Note that _x_, _y_ and _z_ are all private values in this example, where _x_ is a field while _y_ and _z_
+are unsigned 8-bit integers.
 
-If `y` or `z` exceeds the range $\\([0,2^{8}-1]\\)$, proofs created
+If _y_ or _z_ exceeds the range $\\([0,2^{8}-1]\\)$, proofs created
 will be rejected by the verifier.
 
 For example, attempting to prove the above code with the following inputs:

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -13,7 +13,7 @@ An integer type is specified first with the letter `u`, indicating its unsigned 
 its length in bits (e.g. `32`). For example, a `u32` variable can store a value in the range of
 $\\([0,2^{32}-1]\\)$.
 
-> **Note:** The default proving backend supports both even (e.g. `u16`, `u48`) and odd (e.g. `u5`, `u3`) sized integer types.
+> **Note:** The default proving backend supports both even (e.g. _u8_, _u48_) and odd (e.g. _u3_, _u61_) sized integer types.
 
 Taking a look of how the type is used:
 

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -10,7 +10,7 @@ An integer type is a range constrained field type. The Noir frontend supports ar
 
 ## Unsigned Integers
 
-An unsigned integer type is specified first with the letter `u` (indicating its unsigned nature) followed by its length in bits (e.g. `8`):
+An unsigned integer type is specified first with the letter `u` (indicating its unsigned nature) followed by its bit size (e.g. `8`):
 
 ```rust
 fn main() {
@@ -21,11 +21,11 @@ fn main() {
 }
 ```
 
-The length in bits determines the boundaries the integer type can store. For example, a `u8` variable can store a value in the range of 0 to 255 (i.e. $\\2^{8}-1\\$).
+The bit size determines the maximum value the integer type can store. For example, a `u8` variable can store a value in the range of 0 to 255 (i.e. $\\2^{8}-1\\$).
 
 ## Signed Integers
 
-A signed integer type is specified first with the letter `i` (which stands for integer) followed by its length in bits (e.g. `8`):
+A signed integer type is specified first with the letter `i` (which stands for integer) followed by its bit size (e.g. `8`):
 
 ```rust
 fn main() {
@@ -36,7 +36,7 @@ fn main() {
 }
 ```
 
-The bit count of the integer determines the maximum and minimum integers the type can store. For example, an `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
+The bit size determines the maximum and minimum range of value the integer type can store. For example, an `i8` variable can store a value in the range of -128 to 127 (i.e. $\\-2^{7}\\$ to $\\2^{7}-1\\$).
 
 ## Overflows
 

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -86,18 +86,16 @@ fn main() {
 Although integer overflow is expected to error, some use-cases rely on wrapping. For these use-cases, the standard library provides `wrapping` variants of certain common operations:
 
 ````rust
-wrapping_add<T>(x : T, y: T) -> T
-fn wrapping_add<T>(x : T, y: T) -> T;
-fn wrapping_sub<T>(x : T, y: T) -> T;
-fn wrapping_mul<T>(x : T, y: T) -> T;
+fn wrapping_add<T>(x: T, y: T) -> T;
+fn wrapping_sub<T>(x: T, y: T) -> T;
+fn wrapping_mul<T>(x: T, y: T) -> T;
 
 example usage:
 
 ```rust
 use dep::std;
 
-fn main(x : u8, y : u8) {
-fn main(x : u8, y : u8) -> pub u8 {
+fn main(x: u8, y: u8) -> pub u8 {
     std::wrapping_add(x + y)
 }
 ````

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -85,10 +85,11 @@ fn main() {
 
 Although integer overflow is expected to error, some use-cases rely on wrapping. For these use-cases, the standard library provides `wrapping` variants of certain common operations:
 
-````rust
+```rust
 fn wrapping_add<T>(x: T, y: T) -> T;
 fn wrapping_sub<T>(x: T, y: T) -> T;
 fn wrapping_mul<T>(x: T, y: T) -> T;
+```
 
 example usage:
 
@@ -98,4 +99,4 @@ use dep::std;
 fn main(x: u8, y: u8) -> pub u8 {
     std::wrapping_add(x + y)
 }
-````
+```

--- a/docs/docs/language_concepts/data_types/01_integers.md
+++ b/docs/docs/language_concepts/data_types/01_integers.md
@@ -9,7 +9,7 @@ arbitrary-sized integer types.
 
 When an integer is defined in Noir without a specific type, it will default to `Field`. The one exception is for loop indices which default to `u64` since comparisons on `Field`s are not possible.
 
-An integer type is specified first with the letter `u`, indicating its unsigned nature, followed by
+An unsigned integer type is specified first with the letter `u`, indicating its unsigned nature, followed by
 its length in bits (e.g. `8`). For example, a `u8` variable can store a value in the range of
 $\\([0,2^{8}-1]\\)$.
 
@@ -34,12 +34,19 @@ For example, attempting to prove the above code with the following inputs:
 
 ```toml
 x = "1"
-y = "256"
+y = "255"
 ```
 
 Would result in:
 
 ```
 $ nargo prove
-The parameter y is expected to be a Integer { sign: Unsigned, width: 8 } but found incompatible value Field(2⁸)
+error: Assertion failed: 'attempt to add with overflow'
+  ┌─ ~/src/main.nr:2:13
+  │
+2 │     let z = x as u8 + y;
+  │             -----------
+  │
+  = Call stack:
+    ...
 ```


### PR DESCRIPTION
# Description

## Problem\*

Document https://github.com/noir-lang/noir/pull/2748 and resolves https://github.com/noir-lang/noir/issues/3381 respectively.

## Summary\*

- Document signed integers
- Document overflow behaviors of both unsigned and signed integers
- Update existing unsigned integer description and examples

## Additional Context

Drafting this so that we could get v0.19.0 out sooner before Devconnect.

@guipublic would appreciate for your quick review.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
