### PR TITLE
chore: update nix cache name in workflows

### DIFF
--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Enable aztec features
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
           
       - name: Build wasm package
@@ -84,7 +84,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Build wasm package

--- a/.github/workflows/test-abi_wasm.yml
+++ b/.github/workflows/test-abi_wasm.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Build noirc_abi_wasm

--- a/.github/workflows/test-acvm-js.yml
+++ b/.github/workflows/test-acvm-js.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Build acvm-js

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Build acvm-js
@@ -81,7 +81,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Build wasm package
@@ -109,7 +109,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Build noirc_abi_wasm

--- a/.github/workflows/test-noir_wasm.yml
+++ b/.github/workflows/test-noir_wasm.yml
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-cache-name: ${{ vars.NIX_CACHE_NAME }}
+          nix-cache-name: "noir"
           cachix-auth-token: ${{ secrets.CACHIXAUTHTOKEN }}
 
       - name: Build wasm package


### PR DESCRIPTION
# Description

Replace NIX_CACHE_NAME with "noir" in CI to resolve the accessibility issue for forked repositories.

## Problem

The problem is that the `vars.NIX_CACHE_NAME` variable is not accessible to forks of the repository, leading to inconsistency and potential workflow failures for those who depend on this variable. 

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
