### PR TITLE
fix(aztec_nr): serialise arrays of structs

### DIFF
--- a/compiler/noirc_frontend/src/hir/aztec_library.rs
+++ b/compiler/noirc_frontend/src/hir/aztec_library.rs
@@ -572,7 +572,6 @@ fn create_context(ty: &str, params: &[(Pattern, UnresolvedType, Visibility)]) ->
                 let expression = match unresolved_type {
                     // `hasher.add_multiple({ident}.serialize())`
                     UnresolvedTypeData::Named(..) => add_struct_to_hasher(identifier),
-                    // TODO: if this is an array of structs, we should call serialize on each of them (no methods currently do this yet)
                     UnresolvedTypeData::Array(_, arr_type) => {
                         add_array_to_hasher(identifier, &arr_type)
                     }


### PR DESCRIPTION
# Description
fixes: https://github.com/AztecProtocol/aztec-packages/issues/3193

locally:
- recompiled, rebased onto head of kevs hack branch, ran local aztec tests and they passed, so this does not break existing behaviour.

## Summary
Aztec macros did not gracefully handle arrays of structs yet, this pr adds that functionality

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
