### PR TITLE
chore(ci): fix rebuild acir artifacts workflow

### DIFF
--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -37,6 +37,7 @@ jobs:
           
   build-nargo:
     name: Build nargo binary
+    if:  ${{ needs.check-artifacts-requested.outputs.publish == 'true' }}
     runs-on: ubuntu-22.04
     needs: [check-artifacts-requested]
     strategy:
@@ -74,7 +75,7 @@ jobs:
 
   auto-pr-rebuild-script:
     name: Rebuild ACIR artifacts
-    needs: [check-artifacts-requested, build-nargo]
+    needs: [build-nargo]
     runs-on: ubuntu-latest
 
     steps:
@@ -105,7 +106,6 @@ jobs:
 
       - name: Upload ACIR artifacts
         uses: actions/upload-artifact@v3
-        if:  ${{ needs.check-artifacts-requested.outputs.publish == 'true' }}
         with:
           name: acir-artifacts
           path: ./tooling/nargo_cli/tests/acir_artifacts
@@ -116,7 +116,6 @@ jobs:
         if: ${{ github.ref_name }} == "master"
         run: |
           git diff --quiet tooling/nargo_cli/tests/acir_artifacts/ || echo "::set-output name=changes::true"
-
           
       - name: Create or Update PR
         if: steps.check_changes.outputs.changes == 'true'

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -22,12 +22,15 @@ jobs:
           script: |
             const { REF_NAME } = process.env;
             if (REF_NAME == "master") {
-              return true;
+              console.log(`publish = ${publish}`)
+              return publish;
             }
 
             const labels = context.payload.pull_request.labels.map(label => label.name);
-            console.log(labels)
-            return labels.includes('publish-acir');
+            const publish = labels.includes('publish-acir');
+
+            console.log(`publish = ${publish}`)
+            return publish;
           result-encoding: string
         env:
           REF_NAME: ${{ github.ref_name }}
@@ -102,7 +105,7 @@ jobs:
 
       - name: Upload ACIR artifacts
         uses: actions/upload-artifact@v3
-        if:  ${{ needs.check-artifacts-requested.outputs.publish == true }}
+        if:  ${{ needs.check-artifacts-requested.outputs.publish == 'true' }}
         with:
           name: acir-artifacts
           path: ./tooling/nargo_cli/tests/acir_artifacts

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check if artifacts should be published
     runs-on: ubuntu-22.04
     outputs:
-      publish: ${{ steps.check.outputs.publish }}
+      publish: ${{ steps.check.outputs.result }}
     
     steps:
       - name: Check if artifacts should be published

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -26,6 +26,7 @@ jobs:
             }
 
             const labels = context.payload.pull_request.labels.map(label => label.name);
+            console.log(labels)
             return labels.includes('publish-acir');
           result-encoding: string
         env:

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -35,7 +35,6 @@ jobs:
     name: Build nargo binary
     runs-on: ubuntu-22.04
     needs: [check-artifacts-requested]
-    if:  ${{ needs.check-artifacts-requested.outputs.publish == true }}
     strategy:
       matrix:
         target: [x86_64-unknown-linux-gnu]
@@ -71,7 +70,7 @@ jobs:
 
   auto-pr-rebuild-script:
     name: Rebuild ACIR artifacts
-    needs: [build-nargo]
+    needs: [check-artifacts-requested, build-nargo]
     runs-on: ubuntu-latest
 
     steps:
@@ -102,6 +101,7 @@ jobs:
 
       - name: Upload ACIR artifacts
         uses: actions/upload-artifact@v3
+        if:  ${{ needs.check-artifacts-requested.outputs.publish == true }}
         with:
           name: acir-artifacts
           path: ./tooling/nargo_cli/tests/acir_artifacts

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download nargo binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/auto-pr-rebuild-script.yml
+++ b/.github/workflows/auto-pr-rebuild-script.yml
@@ -22,8 +22,8 @@ jobs:
           script: |
             const { REF_NAME } = process.env;
             if (REF_NAME == "master") {
-              console.log(`publish = ${publish}`)
-              return publish;
+              console.log(`publish = true`)
+              return true;
             }
 
             const labels = context.payload.pull_request.labels.map(label => label.name);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently don't run the `auto-pr-rebuild-script` job on master for reason connected to how github actions handles conditions. This PR moves this condition to only cover the artifact upload so I can debug it more easily.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
