### PR TITLE
chore: refactor `FileManager` initialization and introduce `with_reader` constructor

### DIFF
--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -37,7 +37,11 @@ impl std::fmt::Debug for FileManager {
 }
 
 impl FileManager {
-    pub fn new(root: &Path, file_reader: Box<FileReader>) -> Self {
+    pub fn new(root: &Path) -> Self {
+        Self::with_reader(root, Box::new(|path| std::fs::read_to_string(path)))
+    }
+
+    pub fn with_reader(root: &Path, file_reader: Box<FileReader>) -> Self {
         Self {
             root: root.normalize(),
             file_map: Default::default(),
@@ -224,7 +228,7 @@ mod tests {
         let entry_file_name = Path::new("my_dummy_file.nr");
         create_dummy_file(&dir, entry_file_name);
 
-        let mut fm = FileManager::new(dir.path(), Box::new(|path| std::fs::read_to_string(path)));
+        let mut fm = FileManager::new(dir.path());
 
         let file_id = fm.add_file(entry_file_name).unwrap();
 
@@ -239,7 +243,7 @@ mod tests {
         let file_name = Path::new("foo.nr");
         create_dummy_file(&dir, file_name);
 
-        let mut fm = FileManager::new(dir.path(), Box::new(|path| std::fs::read_to_string(path)));
+        let mut fm = FileManager::new(dir.path());
 
         let file_id = fm.add_file(file_name).unwrap();
 
@@ -249,7 +253,7 @@ mod tests {
     #[test]
     fn path_resolve_sub_module() {
         let dir = tempdir().unwrap();
-        let mut fm = FileManager::new(dir.path(), Box::new(|path| std::fs::read_to_string(path)));
+        let mut fm = FileManager::new(dir.path());
 
         // Create a lib.nr file at the root.
         // we now have dir/lib.nr
@@ -295,7 +299,7 @@ mod tests {
         let sub_dir = TempDir::new_in(&dir).unwrap();
         let sub_sub_dir = TempDir::new_in(&sub_dir).unwrap();
 
-        let mut fm = FileManager::new(dir.path(), Box::new(|path| std::fs::read_to_string(path)));
+        let mut fm = FileManager::new(dir.path());
 
         // Create a lib.nr file at the root.
         let file_name = Path::new("lib.nr");

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -58,7 +58,7 @@ mod test {
         src: &str,
     ) -> (ParsedModule, Context, Vec<(CompilationError, FileId)>) {
         let root = std::path::Path::new("/");
-        let fm = FileManager::new(root, Box::new(|path| std::fs::read_to_string(path)));
+        let fm = FileManager::new(root);
         //let fm = FileManager::new(root,  Box::new(get_non_stdlib_asset));
         let graph = CrateGraph::default();
         let mut context = Context::new(fm, graph);

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -147,7 +147,7 @@ pub fn compile(
     };
 
     let root = Path::new("/");
-    let fm = FileManager::new(root, Box::new(get_non_stdlib_asset));
+    let fm = FileManager::with_reader(root, Box::new(get_non_stdlib_asset));
     let graph = CrateGraph::default();
     let mut context = Context::new(fm, graph);
 
@@ -320,7 +320,7 @@ mod test {
     }
 
     fn setup_test_context() -> Context {
-        let fm = FileManager::new(Path::new("/"), Box::new(mock_get_non_stdlib_asset));
+        let fm = FileManager::with_reader(Path::new("/"), Box::new(mock_get_non_stdlib_asset));
         let graph = CrateGraph::default();
         let mut context = Context::new(fm, graph);
 

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -1,7 +1,7 @@
 use std::ops::ControlFlow;
 
 use async_lsp::{ErrorCode, LanguageClient, ResponseError};
-use nargo::prepare_package;
+use nargo::prepare_package_with_reader;
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{check_crate, NOIR_ARTIFACT_VERSION_STRING};
 use noirc_errors::{DiagnosticKind, FileDiagnostic};
@@ -107,7 +107,8 @@ pub(super) fn on_did_save_text_document(
     let diagnostics: Vec<_> = workspace
         .into_iter()
         .flat_map(|package| -> Vec<Diagnostic> {
-            let (mut context, crate_id) = prepare_package(package, Box::new(get_non_stdlib_asset));
+            let (mut context, crate_id) =
+                prepare_package_with_reader(package, Box::new(get_non_stdlib_asset));
 
             let file_diagnostics = match check_crate(&mut context, crate_id, false) {
                 Ok(((), warnings)) => warnings,

--- a/tooling/lsp/src/requests/code_lens_request.rs
+++ b/tooling/lsp/src/requests/code_lens_request.rs
@@ -2,7 +2,7 @@ use std::future::{self, Future};
 
 use async_lsp::{ErrorCode, LanguageClient, ResponseError};
 
-use nargo::{package::Package, prepare_package, workspace::Workspace};
+use nargo::{package::Package, prepare_package_with_reader, workspace::Workspace};
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{check_crate, NOIR_ARTIFACT_VERSION_STRING};
 use noirc_frontend::hir::FunctionNameMatch;
@@ -80,7 +80,8 @@ fn on_code_lens_request_inner(
     let mut lenses: Vec<CodeLens> = vec![];
 
     for package in &workspace {
-        let (mut context, crate_id) = prepare_package(package, Box::new(get_non_stdlib_asset));
+        let (mut context, crate_id) =
+            prepare_package_with_reader(package, Box::new(get_non_stdlib_asset));
         // We ignore the warnings and errors produced by compilation for producing code lenses
         // because we can still get the test functions even if compilation fails
         let _ = check_crate(&mut context, crate_id, false);

--- a/tooling/lsp/src/requests/test_run.rs
+++ b/tooling/lsp/src/requests/test_run.rs
@@ -3,7 +3,7 @@ use std::future::{self, Future};
 use async_lsp::{ErrorCode, ResponseError};
 use nargo::{
     ops::{run_test, TestStatus},
-    prepare_package,
+    prepare_package_with_reader,
 };
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{check_crate, CompileOptions, NOIR_ARTIFACT_VERSION_STRING};
@@ -51,7 +51,8 @@ fn on_test_run_request_inner(
     // Since we filtered on crate name, this should be the only item in the iterator
     match workspace.into_iter().next() {
         Some(package) => {
-            let (mut context, crate_id) = prepare_package(package, Box::new(get_non_stdlib_asset));
+            let (mut context, crate_id) =
+                prepare_package_with_reader(package, Box::new(get_non_stdlib_asset));
             if check_crate(&mut context, crate_id, false).is_err() {
                 let result = NargoTestRunResult {
                     id: params.id.clone(),

--- a/tooling/lsp/src/requests/tests.rs
+++ b/tooling/lsp/src/requests/tests.rs
@@ -2,7 +2,7 @@ use std::future::{self, Future};
 
 use async_lsp::{ErrorCode, LanguageClient, ResponseError};
 use lsp_types::{LogMessageParams, MessageType};
-use nargo::prepare_package;
+use nargo::prepare_package_with_reader;
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{check_crate, NOIR_ARTIFACT_VERSION_STRING};
 
@@ -53,7 +53,8 @@ fn on_tests_request_inner(
     let package_tests: Vec<_> = workspace
         .into_iter()
         .filter_map(|package| {
-            let (mut context, crate_id) = prepare_package(package, Box::new(get_non_stdlib_asset));
+            let (mut context, crate_id) =
+                prepare_package_with_reader(package, Box::new(get_non_stdlib_asset));
             // We ignore the warnings and errors produced by compilation for producing tests
             // because we can still get the test functions even if compilation fails
             let _ = check_crate(&mut context, crate_id, false);

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -42,9 +42,12 @@ pub fn prepare_dependencies(
     }
 }
 
-pub fn prepare_package(package: &Package, file_reader: Box<FileReader>) -> (Context, CrateId) {
+pub fn prepare_package_with_reader(
+    package: &Package,
+    file_reader: Box<FileReader>,
+) -> (Context, CrateId) {
     // TODO: FileManager continues to leak into various crates
-    let fm = FileManager::new(&package.root_dir, file_reader);
+    let fm = FileManager::with_reader(&package.root_dir, file_reader);
     let graph = CrateGraph::default();
     let mut context = Context::new(fm, graph);
 
@@ -53,4 +56,8 @@ pub fn prepare_package(package: &Package, file_reader: Box<FileReader>) -> (Cont
     prepare_dependencies(&mut context, crate_id, &package.dependencies);
 
     (context, crate_id)
+}
+
+pub fn prepare_package(package: &Package) -> (Context, CrateId) {
+    prepare_package_with_reader(package, Box::new(|path| std::fs::read_to_string(path)))
 }

--- a/tooling/nargo_cli/src/cli/check_cmd.rs
+++ b/tooling/nargo_cli/src/cli/check_cmd.rs
@@ -55,8 +55,7 @@ pub(crate) fn run(
 }
 
 fn check_package(package: &Package, compile_options: &CompileOptions) -> Result<(), CompileError> {
-    let (mut context, crate_id) =
-        prepare_package(package, Box::new(|path| std::fs::read_to_string(path)));
+    let (mut context, crate_id) = prepare_package(package);
     check_crate_and_report_errors(
         &mut context,
         crate_id,

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -176,8 +176,7 @@ fn compile_program(
     np_language: Language,
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> (FileManager, CompilationResult<CompiledProgram>) {
-    let (mut context, crate_id) =
-        prepare_package(package, Box::new(|path| std::fs::read_to_string(path)));
+    let (mut context, crate_id) = prepare_package(package);
 
     let program_artifact_path = workspace.package_build_path(package);
     let mut debug_artifact_path = program_artifact_path.clone();
@@ -239,8 +238,7 @@ fn compile_contract(
     np_language: Language,
     is_opcode_supported: &impl Fn(&Opcode) -> bool,
 ) -> (FileManager, CompilationResult<CompiledContract>) {
-    let (mut context, crate_id) =
-        prepare_package(package, Box::new(|path| std::fs::read_to_string(path)));
+    let (mut context, crate_id) = prepare_package(package);
     let (contract, warnings) =
         match noirc_driver::compile_contract(&mut context, crate_id, compile_options) {
             Ok(contracts_and_warnings) => contracts_and_warnings,

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -26,8 +26,7 @@ pub(crate) fn run(_args: FormatCommand, config: NargoConfig) -> Result<(), CliEr
         .map_err(|err| CliError::Generic(err.to_string()))?;
 
     for package in &workspace {
-        let mut file_manager =
-            FileManager::new(&package.root_dir, Box::new(|path| std::fs::read_to_string(path)));
+        let mut file_manager = FileManager::new(&package.root_dir);
 
         visit_noir_files(&package.root_dir.join("src"), &mut |entry| {
             let file_id = file_manager.add_file(&entry.path()).expect("file exists");

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -86,8 +86,7 @@ fn run_tests<S: BlackBoxFunctionSolver>(
     show_output: bool,
     compile_options: &CompileOptions,
 ) -> Result<(), CliError> {
-    let (mut context, crate_id) =
-        prepare_package(package, Box::new(|path| std::fs::read_to_string(path)));
+    let (mut context, crate_id) = prepare_package(package);
     check_crate_and_report_errors(
         &mut context,
         crate_id,


### PR DESCRIPTION
# Description

FileManager Refactoring: The FileManager::new function was refactored. Previously, it required a Box<FileReader> as a parameter for file reading. Now, it has been split into two methods:
- FileManager::new, which no longer takes a Box<FileReader> and uses std::fs::read_to_string by default.
- FileManager::with_reader, which takes a Box<FileReader> to allow custom file reading.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
