### PR TITLE
chore(github): Add manual trigger for building docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,6 +2,7 @@ name: Build docs
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   add_label:


### PR DESCRIPTION
# Description

## Problem\*

Further to https://github.com/noir-lang/noir/pull/3349, part of our docs are now automatically generated instead of manually written.

At times we might want the flexibility to trigger a doc build manually to e.g. gather such generated docs (in addition to building docs along Noir pre-releases), but we currently don't have the option.

## Summary\*

This PR adds the ability to manually run the "Build docs" action.

## Additional Context

Reference: [Manually running a workflow | GitHub Docs](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow)

Demo: https://github.com/noir-lang-test/noir/actions/workflows/build-docs.yml

The demo workflow failed as actions are not properly set up in the test repo, but with this PR merged we will get the same "Run workflow" button.

<img width="714" alt="image" src="https://github.com/noir-lang/noir/assets/72797635/c14d6d8a-3df8-456f-be56-a29e6f6af775">

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
