### PR TITLE
chore(github): Revert "Add manual trigger for building docs"

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,6 @@ name: Build docs
 
 on:
   pull_request:
-  workflow_dispatch:
 
 jobs:
   add_label:


### PR DESCRIPTION
Reverts noir-lang/noir#3439.

[Publish Docs](https://github.com/noir-lang/noir/actions/workflows/publish-docs.yml) rather than Build docs should actually be used for manually publishing new docs.