### PR TITLE
chore: fixing autogenned docs for publish-docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,7 +28,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '18'
-      
+
+      - name: Install wasm-bindgen-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.86
+
+      - name: Install wasm-opt
+        run: |
+          npm i wasm-opt -g
+
       - name: Install Yarn
         run: npm install -g yarn
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,6 +35,22 @@ jobs:
       - name: Install Yarn dependencies
         run: yarn
     
+      - name: Build acvm_js
+        run: yarn workspace @noir-lang/acvm_js build
+
+      - name: Build noirc_abi
+        run: yarn workspace @noir-lang/noirc_abi build
+
+      - name: Build noir_js_types
+        run: yarn workspace @noir-lang/types build
+
+      - name: Build barretenberg wrapper
+        run: yarn workspace @noir-lang/backend_barretenberg build
+
+      - name: Run noir_js
+        run: |
+          yarn workspace @noir-lang/noir_js build
+
       - name: Cut a new version
         working-directory: ./docs
         run: yarn docusaurus docs:version ${{ inputs.tag }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           yarn workspace @noir-lang/noir_js build
 
+      - name: Build docs
+        run: 
+          yarn workspace docs build
+
       - name: Cut a new version
         working-directory: ./docs
         run: yarn docusaurus docs:version ${{ inputs.tag }}


### PR DESCRIPTION
# Description

This PR fixes the publish-docs workflow to fit the autogeneration of noirjs docs

## Problem\*

Publish-docs fails


## Summary\*

For the autogeneration, a build must be present. That wasn't required previously, so this PR adds it

