### PR TITLE
chore: creating a workflow for the release trigger

### DIFF
--- a/.github/workflows/docs-new-version.yml
+++ b/.github/workflows/docs-new-version.yml
@@ -1,4 +1,4 @@
-name: Publish Docs
+name: Cut a new version of the docs
 
 on:
   workflow_dispatch:
@@ -90,7 +90,6 @@ jobs:
             --body "Updates documentation to new version for tag ${{ github.event.inputs.tag }}." \
             --base master \
             --head new-docs-version-${{ github.event.inputs.tag }} \
-            --label documentation
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,4 +1,4 @@
-name: Build docs
+name: Deploy preview for PR
 
 on:
   pull_request:
@@ -47,7 +47,7 @@ jobs:
             })
           }
 
-  build_and_deploy:
+  build_and_deploy_preview:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -2,6 +2,7 @@ name: Rebuild docs with the latest release
 
 on:
   release:
+    types: [released]
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,70 @@
+name: Rebuild docs with the latest release
+
+on:
+  release:
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+    
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install wasm-bindgen-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.86
+
+      - name: Install wasm-opt
+        run: |
+          npm i wasm-opt -g
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build acvm_js
+        run: yarn workspace @noir-lang/acvm_js build
+
+      - name: Build noirc_abi
+        run: yarn workspace @noir-lang/noirc_abi build
+
+      - name: Build noir_js_types
+        run: yarn workspace @noir-lang/types build
+
+      - name: Build barretenberg wrapper
+        run: yarn workspace @noir-lang/backend_barretenberg build
+
+      - name: Run noir_js
+        run: |
+          yarn workspace @noir-lang/noir_js build
+
+      - name: Build docs
+        run: 
+          yarn workspace docs build
+
+      - name: Remove pre-releases
+        working-directory: docs
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn setStable
+    
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v2.1
+        with:
+          publish-dir: './docs/build'
+          production-branch: master
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-github-deployment: false
+          deploy-message: "Deploy from GitHub Actions for release"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Dispatch to publish workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: publish-docs.yml
+          workflow: docs-new-version.yml
           repo: noir-lang/noir
           ref: master
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This adds a new workflow to run on the "release" event.

## Problem\*

When we make a release "stable", no event runs (except release-please, which is ignored). So the docs are not rebuilt with the latest stable.
