### PR TITLE
chore: remove `cargo:rerun-if-changed=tests` in noirc_driver

### DIFF
--- a/compiler/noirc_driver/build.rs
+++ b/compiler/noirc_driver/build.rs
@@ -1,9 +1,6 @@
 const GIT_COMMIT: &&str = &"GIT_COMMIT";
 
 fn main() {
-    // Rebuild if the tests have changed
-    println!("cargo:rerun-if-changed=tests");
-
     // Only use build_data if the environment variable isn't set
     // The environment variable is always set when working via Nix
     if std::env::var(GIT_COMMIT).is_err() {


### PR DESCRIPTION
# Description

## Problem

It seems that because the 'tests' folder doesn't exist, it forces Cargo to recompile every time.

Root cause: https://github.com/rust-lang/cargo/issues/4213

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
