### PR TITLE
feat: handle constant index operations on simple slices

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -658,7 +658,8 @@ impl Context {
         store_value: Option<ValueId>,
     ) -> Result<bool, RuntimeError> {
         let index_const = dfg.get_numeric_constant(index);
-        let (Type::Array(element_types, _) | Type::Slice(element_types)) = dfg.type_of_value(array) else {
+        let value_type = dfg.type_of_value(array);
+        let (Type::Array(element_types, _) | Type::Slice(element_types)) = &value_type else {
             unreachable!("ICE: expected array or slice type");
 
         };
@@ -667,9 +668,9 @@ impl Context {
         // constraint sizes of nested slices
         // This can only be done if we accurately flatten nested slices as other we will reach
         // index out of bounds errors. If the slice is already flat then we can treat them similarly to arrays.
-        //
-        // This check does not affect `Type::Array`s as they do not contain slices.
-        if element_types.iter().any(|element| element.contains_slice_element()) {
+        if matches!(value_type, Type::Slice(_))
+            && element_types.iter().any(|element| element.contains_slice_element())
+        {
             return Ok(false);
         }
 

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -658,75 +658,75 @@ impl Context {
         store_value: Option<ValueId>,
     ) -> Result<bool, RuntimeError> {
         let index_const = dfg.get_numeric_constant(index);
-        match dfg.type_of_value(array) {
-            Type::Array(_, _) => {
-                match self.convert_value(array, dfg) {
-                    AcirValue::Var(acir_var, _) => {
-                        return Err(RuntimeError::InternalError(InternalError::UnExpected {
-                            expected: "an array value".to_string(),
-                            found: format!("{acir_var:?}"),
-                            call_stack: self.acir_context.get_call_stack(),
-                        }))
-                    }
-                    AcirValue::Array(array) => {
-                        if let Some(index_const) = index_const {
-                            let array_size = array.len();
-                            let index = match index_const.try_to_u64() {
-                                Some(index_const) => index_const as usize,
-                                None => {
-                                    let call_stack = self.acir_context.get_call_stack();
-                                    return Err(RuntimeError::TypeConversion {
-                                        from: "array index".to_string(),
-                                        into: "u64".to_string(),
-                                        call_stack,
-                                    });
-                                }
-                            };
-                            if self
-                                .acir_context
-                                .is_constant_one(&self.current_side_effects_enabled_var)
-                            {
-                                // Report the error if side effects are enabled.
-                                if index >= array_size {
-                                    let call_stack = self.acir_context.get_call_stack();
-                                    return Err(RuntimeError::IndexOutOfBounds {
-                                        index,
-                                        array_size,
-                                        call_stack,
-                                    });
-                                } else {
-                                    let value = match store_value {
-                                        Some(store_value) => {
-                                            let store_value = self.convert_value(store_value, dfg);
-                                            AcirValue::Array(array.update(index, store_value))
-                                        }
-                                        None => array[index].clone(),
-                                    };
+        let (Type::Array(element_types, _) | Type::Slice(element_types)) = dfg.type_of_value(array) else {
+            unreachable!("ICE: expected array or slice type");
 
-                                    self.define_result(dfg, instruction, value);
-                                    return Ok(true);
+        };
+
+        // TODO(#3188): Need to be able to handle constant index for slices to seriously reduce
+        // constraint sizes of nested slices
+        // This can only be done if we accurately flatten nested slices as other we will reach
+        // index out of bounds errors. If the slice is already flat then we can treat them similarly to arrays.
+        //
+        // This check does not affect `Type::Array`s as they do not contain slices.
+        if element_types.iter().any(|element| element.contains_slice_element()) {
+            return Ok(false);
+        }
+
+        match self.convert_value(array, dfg) {
+            AcirValue::Var(acir_var, _) => {
+                return Err(RuntimeError::InternalError(InternalError::UnExpected {
+                    expected: "an array value".to_string(),
+                    found: format!("{acir_var:?}"),
+                    call_stack: self.acir_context.get_call_stack(),
+                }))
+            }
+            AcirValue::Array(array) => {
+                if let Some(index_const) = index_const {
+                    let array_size = array.len();
+                    let index = match index_const.try_to_u64() {
+                        Some(index_const) => index_const as usize,
+                        None => {
+                            let call_stack = self.acir_context.get_call_stack();
+                            return Err(RuntimeError::TypeConversion {
+                                from: "array index".to_string(),
+                                into: "u64".to_string(),
+                                call_stack,
+                            });
+                        }
+                    };
+                    if self.acir_context.is_constant_one(&self.current_side_effects_enabled_var) {
+                        // Report the error if side effects are enabled.
+                        if index >= array_size {
+                            let call_stack = self.acir_context.get_call_stack();
+                            return Err(RuntimeError::IndexOutOfBounds {
+                                index,
+                                array_size,
+                                call_stack,
+                            });
+                        } else {
+                            let value = match store_value {
+                                Some(store_value) => {
+                                    let store_value = self.convert_value(store_value, dfg);
+                                    AcirValue::Array(array.update(index, store_value))
                                 }
-                            }
-                            // If there is a predicate and the index is not out of range, we can directly perform the read
-                            else if index < array_size && store_value.is_none() {
-                                self.define_result(dfg, instruction, array[index].clone());
-                                return Ok(true);
-                            }
+                                None => array[index].clone(),
+                            };
+
+                            self.define_result(dfg, instruction, value);
+                            return Ok(true);
                         }
                     }
-                    AcirValue::DynamicArray(_) => (),
+                    // If there is a predicate and the index is not out of range, we can directly perform the read
+                    else if index < array_size && store_value.is_none() {
+                        self.define_result(dfg, instruction, array[index].clone());
+                        return Ok(true);
+                    }
                 }
             }
-            Type::Slice(_) => {
-                // TODO(#3188): Need to be able to handle constant index for slices to seriously reduce
-                // constraint sizes of nested slices
-                // This can only be done if we accurately flatten nested slices as other we will reach
-                // index out of bounds errors.
+            AcirValue::DynamicArray(_) => (),
+        };
 
-                // Do nothing we only want dynamic checks for slices
-            }
-            _ => unreachable!("ICE: expected array or slice type"),
-        }
         Ok(false)
     }
 

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -666,7 +666,7 @@ impl Context {
 
         // TODO(#3188): Need to be able to handle constant index for slices to seriously reduce
         // constraint sizes of nested slices
-        // This can only be done if we accurately flatten nested slices as other we will reach
+        // This can only be done if we accurately flatten nested slices as otherwise we will reach
         // index out of bounds errors. If the slice is already flat then we can treat them similarly to arrays.
         if matches!(value_type, Type::Slice(_))
             && element_types.iter().any(|element| element.contains_slice_element())


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR allows us to handle constant array indices on flat slices. We previously disabled constant index handling due to potential index-out-of-bounds errors but this is not a concern on flat slices.

This means that we can optimize out these array reads without the associated risk of errors from nested slices.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
