### PR TITLE
chore: support directives to control whether noirfmt runs on a section of code 

### DIFF
--- a/tooling/nargo_fmt/tests/expected/ignore.nr
+++ b/tooling/nargo_fmt/tests/expected/ignore.nr
@@ -1,0 +1,26 @@
+fn main() {
+    // noir-fmt:ignore
+    assert( x != y );
+    assert(x != y);
+    {
+        // noir-fmt:ignore
+    };
+    assert(x != y);
+}
+// noir-fmt:ignore
+fn main() {
+1;
+2;
+3;
+}
+// noir-fmt:ignore
+mod items {
+fn hello() {}
+}
+
+fn mk_array() {
+    // noir-fmt:ignore
+    let array = [1,
+                ];
+    let array = [1];
+}

--- a/tooling/nargo_fmt/tests/input/ignore.nr
+++ b/tooling/nargo_fmt/tests/input/ignore.nr
@@ -1,0 +1,27 @@
+fn main() {
+    // noir-fmt:ignore
+    assert( x != y );
+    assert( x != y );
+    {
+        // noir-fmt:ignore
+    };
+    assert( x != y );
+}
+// noir-fmt:ignore
+fn main() {
+1;
+2;
+3;
+}
+// noir-fmt:ignore
+mod items {
+fn hello() {}
+}
+
+fn mk_array() {
+    // noir-fmt:ignore
+    let array = [1,
+                ];
+    let array = [1,
+                ];
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #3244 

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
