### PR TITLE
chore: Fix undesirable line break before '{' in function signature with comments

### DIFF
--- a/tooling/nargo_fmt/src/utils.rs
+++ b/tooling/nargo_fmt/src/utils.rs
@@ -244,3 +244,7 @@ pub(crate) fn first_line_width(exprs: &str) -> usize {
 pub(crate) fn is_single_line(s: &str) -> bool {
     !s.chars().any(|c| c == '\n')
 }
+
+pub(crate) fn last_line_contains_single_line_comment(s: &str) -> bool {
+    s.lines().last().map_or(false, |line| line.contains("//"))
+}

--- a/tooling/nargo_fmt/tests/expected/fn.nr
+++ b/tooling/nargo_fmt/tests/expected/fn.nr
@@ -1,1 +1,14 @@
 fn main(x: pub u8, y: u8) {}
+
+fn main()
+// hello
+{}
+
+fn main(
+    // hello
+) {}
+
+fn main(
+    // hello
+    unit: ()
+) {}

--- a/tooling/nargo_fmt/tests/input/fn.nr
+++ b/tooling/nargo_fmt/tests/input/fn.nr
@@ -1,1 +1,14 @@
 fn main(x: pub u8, y: u8) {}
+
+fn main()
+// hello
+{}
+
+fn main(
+    // hello
+) {}
+
+fn main(
+    // hello
+    unit: ()
+) {}


### PR DESCRIPTION
# Description

Fix undesirable line break before '{' in function signature with comments

## Problem

Resolves #3310 

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
