### PR TITLE
chore: fix project name in integration test

### DIFF
--- a/tooling/nargo_cli/tests/execution_success/conditional_regression_underflow/Nargo.toml
+++ b/tooling/nargo_cli/tests/execution_success/conditional_regression_underflow/Nargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "conditional_underflow"
+name = "conditional_regression_underflow"
 type = "bin"
 authors = [""]
 


### PR DESCRIPTION
# Description

The project name needs to match the directory name for the rebuild script to work properly.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
