### PR TITLE
chore: Remove panic on arm64 linux builds for bb binary at compile time

### DIFF
--- a/tooling/bb_abstraction_leaks/build.rs
+++ b/tooling/bb_abstraction_leaks/build.rs
@@ -30,8 +30,10 @@ fn main() -> Result<(), String> {
     };
 
     // Arm builds of linux are not supported
+    // We do not panic because we allow users to run nargo without a backend.
     if let (Os::Linux, Arch::AARCH64) = (&os, &arch) {
-        panic!("ARM64 builds of linux are not supported")
+        println!("cargo:warning=ARM64 builds of linux are not supported for the barretenberg binary");
+        return Ok(());
     };
 
     println!("cargo:rustc-env=BB_BINARY_URL={}", get_bb_download_url(arch, os));

--- a/tooling/bb_abstraction_leaks/build.rs
+++ b/tooling/bb_abstraction_leaks/build.rs
@@ -32,7 +32,9 @@ fn main() -> Result<(), String> {
     // Arm builds of linux are not supported
     // We do not panic because we allow users to run nargo without a backend.
     if let (Os::Linux, Arch::AARCH64) = (&os, &arch) {
-        println!("cargo:warning=ARM64 builds of linux are not supported for the barretenberg binary");
+        println!(
+            "cargo:warning=ARM64 builds of linux are not supported for the barretenberg binary"
+        );
         return Ok(());
     };
 


### PR DESCRIPTION
# Description

With the addition of #3437 -- we can compile without a backend. If one is on an arm64 linux build, they will get a compile time panic. This PR changes it to a warning and just doesn't set the environment variables for the bb binary.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
