### PR TITLE
feat: add --check option to nargo fmt for dry-run formatting verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2436,6 +2436,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
+ "similar-asserts",
  "tempfile",
  "termcolor",
  "test-binary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ hex = "0.4.2"
 const_format = "0.2.30"
 num-bigint = "0.4"
 num-traits = "0.2"
+similar-asserts = "1.5.0"
 
 [profile.dev]
 # This is required to be able to run `cargo test` in acvm_js due to the `locals exceeds maximum` error.

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -43,6 +43,7 @@ tower.workspace = true
 async-lsp = { workspace = true, features = ["client-monitor", "stdio", "tracing", "tokio"] }
 const_format.workspace = true
 hex.workspace = true
+similar-asserts.workspace = true
 termcolor = "1.1.2"
 color-eyre = "0.6.2"
 tokio = { version = "1.0", features = ["io-std"] }

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -91,7 +91,7 @@ pub(crate) fn run(args: FormatCommand, config: NargoConfig) -> Result<(), CliErr
 
     if check_exit_code_one {
         std::process::exit(1);
-    } else {
+    } else if check_mode {
         println!("No formatting changes were detected");
     }
 

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -14,7 +14,7 @@ use super::NargoConfig;
 /// Format the Noir files in a workspace
 #[derive(Debug, Clone, Args)]
 pub(crate) struct FormatCommand {
-    /// Run nargofmt in check mode
+    /// Run noirfmt in check mode
     #[arg(long)]
     check: bool,
 }

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -65,7 +65,9 @@ pub(crate) fn run(args: FormatCommand, config: NargoConfig) -> Result<(), CliErr
             let formatted = nargo_fmt::format(original, parsed_module, &config);
 
             if check_mode {
-                exit_code_one = original != formatted;
+                if !exit_code_one {
+                    exit_code_one = original != formatted;
+                }
 
                 let diff = similar_asserts::SimpleDiff::from_str(
                     original,

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -73,7 +73,7 @@ pub(crate) fn run(args: FormatCommand, config: NargoConfig) -> Result<(), CliErr
                 )
                 .to_string();
 
-                if !diff.contains("Invisible differences") {
+                if !diff.lines().next().is_some_and(|line| line.contains("Invisible differences")) {
                     if !check_exit_code_one {
                         check_exit_code_one = true;
                     }

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -68,7 +68,7 @@ pub(crate) fn run(args: FormatCommand, config: NargoConfig) -> Result<(), CliErr
                 exit_code_one = original != formatted;
 
                 let diff = similar_asserts::SimpleDiff::from_str(
-                    &original,
+                    original,
                     &formatted,
                     "original",
                     "formatted",

--- a/tooling/nargo_fmt/Cargo.toml
+++ b/tooling/nargo_fmt/Cargo.toml
@@ -13,4 +13,4 @@ toml.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-similar-asserts = "1.5.0"
+similar-asserts.workspace = true


### PR DESCRIPTION
# Description

```bash
❯ cargo r -- fmt --check
Differences (-original|+formatted):
 fn main() {
     let _callStackItem3 = context.call_private_function(
-        
         inputs.call_context.storage_contract_address,
         get_note_zero_fn_selector,
         [owner]
     );


❯ echo $?
1
```

```bash
❯ cargo r -- fmt --check
No formatting changes were detected

❯ echo $?
0
```

## Problem

Resolves #3520 


## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
