### PR TITLE
chore: remove early return from build.rs

### DIFF
--- a/tooling/bb_abstraction_leaks/build.rs
+++ b/tooling/bb_abstraction_leaks/build.rs
@@ -35,7 +35,6 @@ fn main() -> Result<(), String> {
         println!(
             "cargo:warning=ARM64 builds of linux are not supported for the barretenberg binary"
         );
-        return Ok(());
     };
 
     println!("cargo:rustc-env=BB_BINARY_URL={}", get_bb_download_url(arch, os));


### PR DESCRIPTION
# Description

Unfortunately, we cannot test ARM64 in CI right now. Instead of using option_env due to us early returning in build.rs, I've opted to having it set an x86_64 url. on arm64 machines it should give an error and then default to the no backend context.

I tested this on my machine by manually setting the backend to download to one that is unsupported on my machine 

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
