### PR TITLE
chore: Add build profiles that optimize for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,3 +123,16 @@ num-traits = "0.2"
 # This is required to be able to run `cargo test` in acvm_js due to the `locals exceeds maximum` error.
 # See https://ritik-mishra.medium.com/resolving-the-wasm-pack-error-locals-exceed-maximum-ec3a9d96685b
 opt-level = 1
+
+
+[profile.size]
+inherits = "release"
+lto = true
+opt-level = "z"
+
+[profile.size-aggressive]
+inherits = "release"
+strip = true
+lto = true
+panic = "abort"
+opt-level = "z"


### PR DESCRIPTION
# Description


This PR adds two size profiles to compilation, `size` and `size-aggressive`.

If you want to use them you can do : `cargo build --profile size` or `cargo build --profile size-aggressive`


## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
