### PR TITLE
chore(docs): Update link to docs' GitHub

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -70,7 +70,7 @@ const config = {
         },
         items: [
           {
-            href: 'https://github.com/noir-lang/docs',
+            href: 'https://github.com/noir-lang/noir/tree/master/docs',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
# Description

## Summary\*

As the docs repo is now migrated into this noir repo, this PR updates the link in the docs from pointing to https://github.com/noir-lang/docs to https://github.com/noir-lang/noir/tree/master/docs.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
