### PR TITLE
fix: Compiler version error message

### DIFF
--- a/tooling/nargo_toml/src/errors.rs
+++ b/tooling/nargo_toml/src/errors.rs
@@ -73,7 +73,7 @@ pub enum ManifestError {
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum SemverError {
-    #[error("Incompatible compiler version in package {package_name}. Required compiler version is {required_compiler_version} but the compiler version is {compiler_version_found}.\n Update the compiler_version field in Nargo.toml to >={compiler_version_found} or compile this project with version {compiler_version_found}")]
+    #[error("Incompatible compiler version in package {package_name}. Required compiler version is {required_compiler_version} but the compiler version is {compiler_version_found}.\n Update the compiler_version field in Nargo.toml to >={required_compiler_version} or compile this project with version {required_compiler_version}")]
     IncompatibleVersion {
         package_name: CrateName,
         required_compiler_version: String,


### PR DESCRIPTION
# Description
When a package has a compiler version requirement incompatible with the current version, an error message is produced that contains the wrong suggested versions.

## Problem\*

The current version reads:
```
Incompatible compiler version in package ecrecover. Required compiler version is 0.10.1 but the compiler version is 0.19.2.
 Update the compiler_version field in Nargo.toml to >=0.19.2 or compile this project with version 0.19.2
```

While this isn't strictly wrong, it's an unintuitive suggestion versus one that refers to the package required versions like this:
```
Update the compiler_version field in Nargo.toml to >=0.10.1 or compile this project with version 0.10.1
```

This suggests the user to either update the package to accept later compiler version that's currently active (`>=0.10.1`) or to downgrade the compiler version (`0.10.1`).

## Summary\*
The correct variables are already available, so this just updates them to the right suggestions.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
