### PR TITLE
chore: add dependency on noir_js from docs package

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -55,7 +55,7 @@ jobs:
     if: needs.add_label.outputs.has_label == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
     
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -71,20 +71,8 @@ jobs:
         run: |
           npm i wasm-opt -g
 
-      - name: Install dependencies
-        run: yarn
-
-      - name: Build acvm_js
-        run: yarn workspace @noir-lang/acvm_js build
-
-      - name: Build noirc_abi
-        run: yarn workspace @noir-lang/noirc_abi build
-
-      - name: Build noir_js_types
-        run: yarn workspace @noir-lang/types build
-
-      - name: Build barretenberg wrapper
-        run: yarn workspace @noir-lang/backend_barretenberg build
+      - name: Install Yarn dependencies
+        uses: ./.github/actions/setup
 
       - name: Run noir_js
         run: |
@@ -97,8 +85,9 @@ jobs:
         run: yarn setStable
     
       - name: Build docs
+        working-directory: docs
         run: 
-          yarn workspace docs build
+          yarn workspaces foreach -Rt run build
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v2.1

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -74,10 +74,6 @@ jobs:
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
 
-      - name: Run noir_js
-        run: |
-          yarn workspace @noir-lang/noir_js build
-
       - name: Remove pre-releases
         working-directory: docs
         env: 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "@docusaurus/preset-classic": "^2.4.0",
     "@easyops-cn/docusaurus-search-local": "^0.35.0",
     "@mdx-js/react": "^1.6.22",
+    "@noir-lang/noir_js": "workspace:*",
     "axios": "^1.4.0",
     "clsx": "^1.2.1",
     "docusaurus-plugin-typedoc": "1.0.0-next.18",

--- a/tooling/noir_js_types/package.json
+++ b/tooling/noir_js_types/package.json
@@ -19,7 +19,8 @@
     "build": "yarn run build:cjs && yarn run build:esm",
     "nightly:version": "jq --arg new_version \"-$(git rev-parse --short HEAD)$1\" '.version = .version + $new_version' package.json > package-tmp.json && mv package-tmp.json package.json",
     "publish": "echo 📡 publishing `$npm_package_name` && yarn npm publish",
-    "lint": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ./.eslintignore  --max-warnings 0"
+    "lint": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ./.eslintignore  --max-warnings 0",
+    "clean": "rm -rf ./lib"
   },
   "exports": {
     ".": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8290,6 +8290,7 @@ __metadata:
     "@docusaurus/preset-classic": ^2.4.0
     "@easyops-cn/docusaurus-search-local": ^0.35.0
     "@mdx-js/react": ^1.6.22
+    "@noir-lang/noir_js": "workspace:*"
     axios: ^1.4.0
     clsx: ^1.2.1
     docusaurus-plugin-typedoc: 1.0.0-next.18


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The docs package requires noir_js build artifacts in order to codegen the docs but it doesn't have a dependency set up which causes a `yarn build` from a fresh repo to fail.

I've thrown in a refactor of the docs PR workflow to build the docs's dependencies automatically.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
