### PR TITLE
Remove quotes from println output

### DIFF
--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -197,7 +197,7 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
         }
 
         (PrintableValue::String(s), PrintableType::String { .. }) => {
-            output.push_str(&format!(r#""{s}""#));
+            output.push_str(&s);
         }
 
         (PrintableValue::Struct(map), PrintableType::Struct { name, fields, .. }) => {


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/3573

## Summary\*

Fixes `println` calls to output quoteless strings

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
