### PR TITLE
fix: Fix remaining issues in Brillig's copy on write arrays

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -489,15 +489,18 @@ impl<'block> BrilligBlock<'block> {
                     );
                     let target_len = target_len_variable.extract_register();
 
-                    let target_vector = self
-                        .variables
-                        .define_variable(
-                            self.function_context,
-                            self.brillig_context,
-                            results[1],
-                            dfg,
-                        )
-                        .extract_vector();
+                    let target_vector = match self.variables.define_variable(
+                        self.function_context,
+                        self.brillig_context,
+                        results[1],
+                        dfg,
+                    ) {
+                        BrilligVariable::BrilligArray(array) => {
+                            self.brillig_context.array_to_vector(&array)
+                        }
+                        BrilligVariable::BrilligVector(vector) => vector,
+                        BrilligVariable::Simple(..) => unreachable!("ICE: ToBits on non-array"),
+                    };
 
                     let radix = self.brillig_context.make_constant(2_usize.into());
 

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -462,11 +462,6 @@ impl FunctionBuilder {
     /// within the given value. If the given value is not an array and does not contain
     /// any arrays, this does nothing.
     pub(crate) fn increment_array_reference_count(&mut self, value: ValueId) {
-        // Reference-counted arrays are only needed for Brillig's copy on write optimization.
-        if self.current_function.runtime() != RuntimeType::Brillig {
-            return;
-        }
-
         match self.type_of_value(value) {
             Type::Numeric(_) => (),
             Type::Function => (),

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -275,10 +275,15 @@ impl Instruction {
             | ArrayGet { .. }
             | ArraySet { .. } => false,
 
+            // IncrementRc is not counted as having side effects since we still
+            // want it to be removed by the DIE pass if its parameter is unused.
+            // At the time of writing has_side_effects is only used by DIE but
+            // we should keep this in mind (or rename this method?) if it is ever used elsewhere.
+            IncrementRc { .. } => false,
+
             Constrain(..)
             | Store { .. }
             | EnableSideEffects { .. }
-            | IncrementRc { .. }
             | RangeCheck { .. } => true,
 
             // Some `Intrinsic`s have side effects so we must check what kind of `Call` this is.

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -275,15 +275,10 @@ impl Instruction {
             | ArrayGet { .. }
             | ArraySet { .. } => false,
 
-            // IncrementRc is not counted as having side effects since we still
-            // want it to be removed by the DIE pass if its parameter is unused.
-            // At the time of writing has_side_effects is only used by DIE but
-            // we should keep this in mind (or rename this method?) if it is ever used elsewhere.
-            IncrementRc { .. } => false,
-
             Constrain(..)
             | Store { .. }
             | EnableSideEffects { .. }
+            | IncrementRc { .. }
             | RangeCheck { .. } => true,
 
             // Some `Intrinsic`s have side effects so we must check what kind of `Call` this is.

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -356,7 +356,7 @@ impl<'a> FunctionContext<'a> {
 
             // Reference counting in brillig relies on us incrementing reference
             // counts when nested arrays/slices are constructed or indexed. This
-            // has not effect in ACIR code.
+            // has no effect in ACIR code.
             let result = self.builder.insert_array_get(array, offset, typ);
             self.builder.increment_array_reference_count(result);
             result.into()

--- a/tooling/nargo_cli/tests/execution_success/brillig_cow/Nargo.toml
+++ b/tooling/nargo_cli/tests/execution_success/brillig_cow/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "brillig_cow"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/tooling/nargo_cli/tests/execution_success/brillig_cow/Prover.toml
+++ b/tooling/nargo_cli/tests/execution_success/brillig_cow/Prover.toml
@@ -1,0 +1,7 @@
+original = [0, 1, 2, 3, 4]
+index = 2
+
+[expected_result]
+original = [0, 1, 2, 3, 4]
+modified_once = [0, 1, 27, 3, 4]
+modified_twice = [0, 1, 27, 27, 4]

--- a/tooling/nargo_cli/tests/execution_success/brillig_cow/src/main.nr
+++ b/tooling/nargo_cli/tests/execution_success/brillig_cow/src/main.nr
@@ -1,0 +1,54 @@
+// Tests the copy on write optimization for arrays. We look for cases where we are modifying an array in place when we shouldn't.
+
+global ARRAY_SIZE = 5;
+
+struct ExecutionResult {
+    original: [Field; ARRAY_SIZE],
+    modified_once: [Field; ARRAY_SIZE],
+    modified_twice: [Field; ARRAY_SIZE],
+}
+
+impl ExecutionResult {
+    fn is_equal(self, other: ExecutionResult) -> bool {
+        (self.original == other.original) &
+        (self.modified_once == other.modified_once) &
+        (self.modified_twice == other.modified_twice)
+    }
+}
+
+fn modify_in_inlined_constrained(original: [Field; ARRAY_SIZE], index: u64) -> ExecutionResult {
+    let mut modified = original;
+    
+    modified[index] = 27;
+
+    let modified_once = modified;
+
+    modified[index+1] = 27;
+
+    ExecutionResult {
+        original,
+        modified_once,
+        modified_twice: modified
+    }
+}
+
+unconstrained fn modify_in_unconstrained(original: [Field; ARRAY_SIZE], index: u64) -> ExecutionResult {
+    let mut modified = original;
+    
+    modified[index] = 27;
+
+    let modified_once = modified;
+
+    modified[index+1] = 27;
+
+    ExecutionResult {
+        original,
+        modified_once,
+        modified_twice: modified
+    }
+}
+
+unconstrained fn main(original: [Field; ARRAY_SIZE], index: u64, expected_result: ExecutionResult) {
+    assert(expected_result.is_equal(modify_in_unconstrained(original, index)));
+    assert(expected_result.is_equal(modify_in_inlined_constrained(original, index)));
+}


### PR DESCRIPTION
# Description

## Problem\*

Fixes remaining `todo` and some panics in https://github.com/noir-lang/noir/pull/3522

## Summary\*

I'm not sure if unpacking the entire slice recursively to complete the `todo!()` is even possible so I tried a different (hopefully sound) approach of incrementing the Rc for sub-arrays on each `ArrayGet` and when constructing the array. I've also disabled the `IncrementRc` instruction when not in Brillig code since it is unneeded.

## Additional Context

I'm targetting @sirasistant's PR so that it is easier to see the changes I made to it. If all is well, we can merge this PR and then his afterward to get the feature in.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
