### PR TITLE
docs : correction of Inconsistency in `poseidon hash` in standard_library

### DIFF
--- a/docs/docs/standard_library/cryptographic_primitives/00_hashes.mdx
+++ b/docs/docs/standard_library/cryptographic_primitives/00_hashes.mdx
@@ -124,8 +124,8 @@ example:
 ```rust
 fn main()
 {
-  let hash1 = std::hash::poseidon::bn254::hash_2([1, 2]);
-  assert(hash1 == 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a);
+  let hash_2 = std::hash::poseidon::bn254::hash_2([1, 2]);
+  assert(hash2 == 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a);
 }
 ```
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3337 

## Summary\*

This PR modifies `hash1` for `hash2` to make examples consistent.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
