### PR TITLE
chore(docs): correction of data type of loop index

### DIFF
--- a/docs/docs/language_concepts/02_control_flow.md
+++ b/docs/docs/language_concepts/02_control_flow.md
@@ -19,7 +19,7 @@ for i in 0..10 {
 };
 ```
 
-The index for loops is of type `u64`.
+The index for loops is of type `field`.
 
 ## If Expressions
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves  #3315 

## Summary\*

This PR replaces `u64` for `field` in the description of the loop index `i`.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
