### PR TITLE
chore: remove `get_number_sequence` foreign calls

### DIFF
--- a/test_programs/execution_success/brillig_oracle/src/main.nr
+++ b/test_programs/execution_success/brillig_oracle/src/main.nr
@@ -1,25 +1,41 @@
 use dep::std::slice;
+use dep::std::test::OracleMock;
+
 // Tests oracle usage in brillig/unconstrained functions
 fn main(x: Field) {
-    get_number_sequence_wrapper(20);
+    let size = 20;
+    // TODO: Add a method along the lines of `(0..size).to_array()`.
+    let mut mock_oracle_response = [0; 20];
+    // TODO: Add an `array.reverse()` method.
+    let mut reversed_mock_oracle_response = [0; 20];
+    for i in 0..size {
+        mock_oracle_response[i] = i;
+        reversed_mock_oracle_response[19 - i] = i;
+    }
+
+    // TODO: this method of returning a slice feels hacky.
+    let _ = OracleMock::mock("get_number_sequence").with_params(size).returns((20, mock_oracle_response));
+    let _ = OracleMock::mock("get_reverse_number_sequence").with_params(size).returns((20, reversed_mock_oracle_response));
+
+    get_number_sequence_wrapper(size);
 }
-// TODO(#1911): This function does not need to be an oracle but acts 
-// as a useful test while we finalize code generation for slices in Brillig
+
+// Define oracle functions which we have mocked above
 #[oracle(get_number_sequence)]
 unconstrained fn get_number_sequence(_size: Field) -> [Field] {}
-// TODO(#1911)
+
 #[oracle(get_reverse_number_sequence)]
 unconstrained fn get_reverse_number_sequence(_size: Field) -> [Field] {}
 
 unconstrained fn get_number_sequence_wrapper(size: Field) {
     let slice = get_number_sequence(size);
-    for i in 0..19 as u32 {
+    for i in 0..20 as u32 {
         assert(slice[i] == i as Field);
     }
 
     let reversed_slice = get_reverse_number_sequence(size);
     // Regression test that we have not overwritten memory
-    for i in 0..19 as u32 {
+    for i in 0..20 as u32 {
         assert(slice[i] == reversed_slice[19 - i]);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #1911 

## Summary\*

This PR removes the `get_number_sequence` and `get_reverse_number_sequence` foreign calls and replaces their usage in tests with a mocked foreign call.

I'm leaving this as non-breaking as we make no guarantees about these functions and anyone relying on a foreign call to create an array of increasing numbers... shouldn't.

## Additional Context

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
