### PR TITLE
fix: docker builds

### DIFF
--- a/scripts/bootstrap_native.sh
+++ b/scripts/bootstrap_native.sh
@@ -4,11 +4,13 @@ set -eu
 cd $(dirname "$0")/..
 
 # If this project has been subrepod into another project, set build data manually.
+export SOURCE_DATE_EPOCH=$(date +%s)
+export GIT_DIRTY=false
 if [ -f ".gitrepo" ]; then
-  export SOURCE_DATE_EPOCH=$(date +%s)
-  export GIT_DIRTY=false
   export GIT_COMMIT=$(awk '/commit =/ {print $3}' .gitrepo)
+else
+  export GIT_COMMIT=$(git rev-parse --verify HEAD)
 fi
 
 # Build native.
-cargo build --features="noirc_frontend/aztec" --release
+cargo build --features="noirc_driver/aztec" --release

--- a/scripts/bootstrap_packages.sh
+++ b/scripts/bootstrap_packages.sh
@@ -6,13 +6,15 @@ cd $(dirname "$0")/..
 ./scripts/install_wasm-bindgen.sh
 
 # If this project has been subrepod into another project, set build data manually.
+export SOURCE_DATE_EPOCH=$(date +%s)
+export GIT_DIRTY=false
 if [ -f ".gitrepo" ]; then
-  export SOURCE_DATE_EPOCH=$(date +%s)
-  export GIT_DIRTY=false
   export GIT_COMMIT=$(awk '/commit =/ {print $3}' .gitrepo)
+else
+  export GIT_COMMIT=$(git rev-parse --verify HEAD)
 fi
 
-export cargoExtraArgs="--features noirc_frontend/aztec"
+export cargoExtraArgs="--features noirc_driver/aztec"
 
 yarn
 yarn build


### PR DESCRIPTION
# Description

Fixing docker builds

## Problem\*

Currently Docker does not build correctly due to .gitrepo not being present in a standalone context, thus leaving necessary env vars unset

## Summary\*

This change fixes the issue above, and keeps functionality for building from a subrepo

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
