### PR TITLE
fix: corrected the formatting of error message parameters in index out of bounds error

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -26,7 +26,7 @@ pub enum RuntimeError {
     },
     #[error(transparent)]
     InternalError(#[from] InternalError),
-    #[error("Index out of bounds, array has size {index:?}, but index was {array_size:?}")]
+    #[error("Index out of bounds, array has size {array_size}, but index was {index}")]
     IndexOutOfBounds { index: usize, array_size: usize, call_stack: CallStack },
     #[error("Range constraint of {num_bits} bits is too large for the Field size")]
     InvalidRangeConstraint { num_bits: u32, call_stack: CallStack },


### PR DESCRIPTION
# Description

corrected the formatting of error message parameters in index out of bounds error

## Problem

Resolves #3629 

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
