### PR TITLE
chore!: Allow lowercase field type

### DIFF
--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -692,7 +692,7 @@ impl fmt::Display for Keyword {
             Keyword::Dep => write!(f, "dep"),
             Keyword::Distinct => write!(f, "distinct"),
             Keyword::Else => write!(f, "else"),
-            Keyword::Field => write!(f, "Field"),
+            Keyword::Field => write!(f, "field"),
             Keyword::Fn => write!(f, "fn"),
             Keyword::For => write!(f, "for"),
             Keyword::FormatString => write!(f, "fmtstr"),
@@ -735,7 +735,11 @@ impl Keyword {
             "dep" => Keyword::Dep,
             "distinct" => Keyword::Distinct,
             "else" => Keyword::Else,
+            // Currently we allow both uppercase and lowercase
+            // Fields. This will be used as a transition solution
+            // where we eventually deprecate the uppercase variant.
             "Field" => Keyword::Field,
+            "field" => Keyword::Field,
             "fn" => Keyword::Fn,
             "for" => Keyword::For,
             "fmtstr" => Keyword::FormatString,


### PR DESCRIPTION
# Description

Related to #3535 . This is breaking for users who were using field as a variable or strruct name previously.

This is not breaking for all users because we still allow the uppercase variant. The formatter should rename this to lower case variant and overtime, I expect we can whean out the uppercase variant.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
