### PR TITLE
chore: add env var for test updates in nargo_fmt

### DIFF
--- a/tooling/nargo_fmt/build.rs
+++ b/tooling/nargo_fmt/build.rs
@@ -58,12 +58,14 @@ fn format_{test_name}() {{
     let expected_output = r#"{output_source}"#;
 
 
-    let (parsed_module, errors) = noirc_frontend::parse_program(&input);
+    let (parsed_module, _errors) = noirc_frontend::parse_program(&input);
 
     let config = nargo_fmt::Config::of("{config}").unwrap();
     let fmt_text = nargo_fmt::format(&input, parsed_module, &config);
 
-    std::fs::write("{output_source_path}", fmt_text.clone());
+    if std::env::var("UPDATE_EXPECT").is_ok() {{
+        std::fs::write("{output_source_path}", fmt_text.clone()).unwrap();
+    }}
 
     similar_asserts::assert_eq!(fmt_text, expected_output);
 }}


### PR DESCRIPTION
# Description

Introduced an environment variable UPDATE_EXPECT in nargo_fmt build script to allow automatic updating of test outputs.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
