### PR TITLE
chore(docs): address visibility issues in docs

### DIFF
--- a/docs/docs/language_concepts/01_functions.md
+++ b/docs/docs/language_concepts/01_functions.md
@@ -30,7 +30,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -38,7 +38,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/docs/language_concepts/07_mutability.md
+++ b/docs/docs/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.10.5/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.10.5/language_concepts/01_functions.md
@@ -18,7 +18,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -26,7 +26,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.10.5/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.10.5/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.17.0/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.17.0/language_concepts/01_functions.md
@@ -30,7 +30,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -38,7 +38,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.17.0/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.17.0/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.19.0/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.19.0/language_concepts/01_functions.md
@@ -30,7 +30,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -38,7 +38,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.19.0/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.19.0/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.19.1/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.19.1/language_concepts/01_functions.md
@@ -30,7 +30,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -38,7 +38,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.19.1/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.19.1/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.19.2/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.19.2/language_concepts/01_functions.md
@@ -30,7 +30,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -38,7 +38,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.19.2/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.19.2/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.19.3/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.19.3/language_concepts/01_functions.md
@@ -30,7 +30,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -38,7 +38,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.19.3/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.19.3/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.19.4/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.19.4/language_concepts/01_functions.md
@@ -30,7 +30,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -38,7 +38,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.19.4/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.19.4/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.6.0/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.6.0/language_concepts/01_functions.md
@@ -18,7 +18,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -26,7 +26,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.6.0/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.6.0/language_concepts/07_mutability.md
@@ -39,7 +39,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.7.1/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.7.1/language_concepts/01_functions.md
@@ -18,7 +18,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -26,7 +26,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.7.1/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.7.1/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3

--- a/docs/versioned_docs/version-v0.9.0/language_concepts/01_functions.md
+++ b/docs/versioned_docs/version-v0.9.0/language_concepts/01_functions.md
@@ -18,7 +18,7 @@ All parameters in a function must have a type and all types are known at compile
 is pre-pended with a colon and the parameter type. Multiple parameters are separated using a comma.
 
 ```rust
-fn foo(x : Field, y : pub Field){}
+fn foo(x : Field, y : Field){}
 ```
 
 The return type of a function can be stated by using the `->` arrow notation. The function below
@@ -26,7 +26,7 @@ states that the foo function must return a `Field`. If the function returns no v
 is omitted.
 
 ```rust
-fn foo(x : Field, y : pub Field) -> Field {
+fn foo(x : Field, y : Field) -> Field {
     x + y
 }
 ```

--- a/docs/versioned_docs/version-v0.9.0/language_concepts/07_mutability.md
+++ b/docs/versioned_docs/version-v0.9.0/language_concepts/07_mutability.md
@@ -37,7 +37,7 @@ Note that mutability in noir is local and everything is passed by value, so if a
 mutates its parameters then the parent function will keep the old value of the parameters.
 
 ```rust
-fn main() -> Field {
+fn main() -> pub Field {
     let x = 3;
     helper(x);
     x // x is still 3


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3452

## Summary\*

This PR makes two changes in the docs:
1. I've removed the visibility modifier on an argument to the non-entrypoint function `foo`. This code would compile but would also raise a warning on `pub` being unnecessary and misleading so we should just remove it.
2. `pub` was missing on a `main` function return value in `7_mutability.md`.


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
