### PR TITLE
chore(ci): Fix publishing of ACVM crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ repository = "https://github.com/noir-lang/noir/"
 [workspace.dependencies]
 
 # ACVM workspace dependencies
-acir = { path = "acvm-repo/acir", default-features = false }
-acvm = { path = "acvm-repo/acvm" }
-acir_field = { path = "acvm-repo/acir_field", default-features = false }
-stdlib = { package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
-brillig = { path = "acvm-repo/brillig", default-features = false }
-brillig_vm = { path = "acvm-repo/brillig_vm", default-features = false }
-acvm_blackbox_solver = { path = "acvm-repo/blackbox_solver", default-features = false }
-barretenberg_blackbox_solver = { path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
+acir_field = { version = "0.35.0", path = "acvm-repo/acir_field", default-features = false }
+acir = { version = "0.35.0", path = "acvm-repo/acir", default-features = false }
+acvm = { version = "0.35.0", path = "acvm-repo/acvm" }
+stdlib = { version = "0.35.0", package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
+brillig = { version = "0.35.0", path = "acvm-repo/brillig", default-features = false }
+brillig_vm = { version = "0.35.0", path = "acvm-repo/brillig_vm", default-features = false }
+acvm_blackbox_solver = { version = "0.35.0", path = "acvm-repo/blackbox_solver", default-features = false }
+barretenberg_blackbox_solver = { version = "0.35.0", path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
 
 # Noir compiler workspace dependencies
 arena = { path = "compiler/utils/arena" }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -71,6 +71,46 @@
           "type": "json",
           "path": "acvm_js/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "../Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.acir.version"
+        },
+        {
+          "type": "toml",
+          "path": "../Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.acir_field.version"
+        },
+        {
+          "type": "toml",
+          "path": "../Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.stdlib.version"
+        },
+        {
+          "type": "toml",
+          "path": "../Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.brillig.version"
+        },
+        {
+          "type": "toml",
+          "path": "../Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.brillig_vm.version"
+        },
+        {
+          "type": "toml",
+          "path": "../Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.acvm_blackbox_solver.version"
+        },
+        {
+          "type": "toml",
+          "path": "../Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.barretenberg_blackbox_solver.version"
+        },
+        {
+          "type": "json",
+          "path": "acvm_js/package.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR does an "I reckon" fix to publishing ACVM crates.

I've added a version number to the workspace `Cargo.toml` so that these crates can be pushed to crates.io. The issue then is that we require these to be bumped appropriately by the release-please PR.

I imagine the reason why this wasn't done originally is that it requires the `acvm-repo` release-please package to change files outside of its directory. I've given this a go however and we can check whether the PR gets updated correctly after this is merged.

cc @kevaundray as he set up the original release please setup for ACVM.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
