### PR TITLE
feat: reuse witnesses more when interacting with memory

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -877,7 +877,8 @@ impl AcirContext {
     /// Converts the `AcirVar` to a `Witness` if it hasn't been already, and appends it to the
     /// `GeneratedAcir`'s return witnesses.
     pub(crate) fn return_var(&mut self, acir_var: AcirVar) -> Result<(), InternalError> {
-        let witness = self.var_to_witness(acir_var)?;
+        let return_var = self.get_or_create_witness_var(acir_var)?;
+        let witness = self.var_to_witness(return_var)?;
         self.acir_ir.push_return_witness(witness);
         Ok(())
     }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -1425,7 +1425,8 @@ impl AcirContext {
         index: &AcirVar,
     ) -> Result<AcirVar, InternalError> {
         // Fetch the witness corresponding to the index
-        let index_witness = self.var_to_witness(*index)?;
+        let index_var = self.get_or_create_witness_var(*index)?;
+        let index_witness = self.var_to_witness(index_var)?;
 
         // Create a Variable to hold the result of the read and extract the corresponding Witness
         let value_read_var = self.add_variable();
@@ -1446,11 +1447,12 @@ impl AcirContext {
         value: &AcirVar,
     ) -> Result<(), InternalError> {
         // Fetch the witness corresponding to the index
-        //
-        let index_witness = self.var_to_witness(*index)?;
+        let index_var = self.get_or_create_witness_var(*index)?;
+        let index_witness = self.var_to_witness(index_var)?;
 
         // Fetch the witness corresponding to the value to be written
-        let value_write_witness = self.var_to_witness(*value)?;
+        let value_write_var = self.get_or_create_witness_var(*value)?;
+        let value_write_witness = self.var_to_witness(value_write_var)?;
 
         // Add the memory write operation to the list of opcodes
         let op = MemOp::write_to_mem_index(index_witness.into(), value_write_witness.into());
@@ -1492,6 +1494,7 @@ impl AcirContext {
     ) -> Result<(), InternalError> {
         match input {
             AcirValue::Var(var, _) => {
+                let var = self.get_or_create_witness_var(var)?;
                 witnesses.push(self.var_to_witness(var)?);
             }
             AcirValue::Array(values) => {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds more checks to see if we have an existing witness with the same value before we add a new one.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
