### PR TITLE
chore: use the same git credentials everywhere in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --local user.name 'signorecello'
-          git config --local user.email 'github@zepedro.me'
+          git config --local user.name 'kevaundray'
+          git config --local user.email 'kevtheappdev@gmail.com'
 
       - name: Commit new documentation version
         run: |


### PR DESCRIPTION
# Description

This changes it so that there is one consistent git credential that we use in CI. Theres no way to enforce this however if we have a bot account, we can then just use that one account consistently.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
