### PR TITLE
chore: remove version key for ACVM crates from root cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ repository = "https://github.com/noir-lang/noir/"
 [workspace.dependencies]
 
 # ACVM workspace dependencies
-acir_field = { version = "0.35.0", path = "acvm-repo/acir_field", default-features = false }
-acir = { version = "0.35.0", path = "acvm-repo/acir", default-features = false }
-acvm = { version = "0.35.0", path = "acvm-repo/acvm" }
-stdlib = { version = "0.35.0", package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
-brillig = { version = "0.35.0", path = "acvm-repo/brillig", default-features = false }
-brillig_vm = { version = "0.35.0", path = "acvm-repo/brillig_vm", default-features = false }
-acvm_blackbox_solver = { version = "0.35.0", path = "acvm-repo/blackbox_solver", default-features = false }
-barretenberg_blackbox_solver = { version = "0.35.0", path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
+acir_field = { path = "acvm-repo/acir_field", default-features = false }
+acir = {  path = "acvm-repo/acir", default-features = false }
+acvm = {  path = "acvm-repo/acvm" }
+stdlib = {  package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
+brillig = { path = "acvm-repo/brillig", default-features = false }
+brillig_vm = {  path = "acvm-repo/brillig_vm", default-features = false }
+acvm_blackbox_solver = { path = "acvm-repo/blackbox_solver", default-features = false }
+barretenberg_blackbox_solver = { path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
 
 # Noir compiler workspace dependencies
 arena = { path = "compiler/utils/arena" }


### PR DESCRIPTION
# Description

This reverts the versioning done in the root Cargo.toml [here](https://github.com/noir-lang/noir/pull/3645) 

CI is currently complaining about this

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
