### PR TITLE
chore: add publish-acvm to release workflow

### DIFF
--- a/.github/workflows/publish-acvm.yml
+++ b/.github/workflows/publish-acvm.yml
@@ -3,7 +3,7 @@ name: Publish ACVM crates
 on:
   workflow_dispatch:
     inputs:
-      acvm-ref:
+      noir-ref:
         description: The acvm reference to checkout
         required: true
 
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.acvm-ref }}
+          ref: ${{ inputs.noir-ref }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.71.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,3 +129,18 @@ jobs:
           ref: master
           token: ${{ secrets.NOIR_REPO_TOKEN }}
           inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}" }'
+
+  publish-acvm:
+    name: Publish acvm
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.tag-name }}
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Dispatch to publish-acvm
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: publish-acvm.yml
+          ref: master
+          token: ${{ secrets.NOIR_REPO_TOKEN }}
+          inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}" }'


### PR DESCRIPTION
# Description

Without this, release-please does not publish the ACVM packages

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
