### PR TITLE
fix: revert chnage to modify version in workspace file for acvm dependencies

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -77,41 +77,6 @@
           "jsonpath": "$.version"
         },
         {
-          "type": "toml",
-          "path": "acir/Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.acir.version"
-        },
-        {
-          "type": "toml",
-          "path": "acir_field/Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.acir_field.version"
-        },
-        {
-          "type": "toml",
-          "path": "stdlib/Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.stdlib.version"
-        },
-        {
-          "type": "toml",
-          "path": "brillig/Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.brillig.version"
-        },
-        {
-          "type": "toml",
-          "path": "brillig_vm/Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.brillig_vm.version"
-        },
-        {
-          "type": "toml",
-          "path": "blackbox_solver/Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.acvm_blackbox_solver.version"
-        },
-        {
-          "type": "toml",
-          "path": "barretenberg_blackbox_solver/Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.barretenberg_blackbox_solver.version"
-        },
-        {
           "type": "json",
           "path": "acvm_js/package.json",
           "jsonpath": "$.version"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -71,7 +71,6 @@
         "brillig/Cargo.toml",
         "brillig_vm/Cargo.toml",
         "stdlib/Cargo.toml",
-        "flake.nix",
         {
           "type": "json",
           "path": "acvm_js/package.json",


### PR DESCRIPTION
# Description

This reverts the change done in #3645 and removes the extraneous flake.nix file

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
