### PR TITLE
chore: update acvm workspace root versions in release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,36 @@ jobs:
           token: ${{ secrets.NOIR_RELEASES_TOKEN }}
           command: manifest
 
+  update-acvm-workspace-package-versions:
+    name: Update acvm workspace package versions
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release-pr }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.release-pr).headBranchName }}
+          token: ${{ secrets.NOIR_RELEASES_TOKEN }}
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@1.65.0
+
+      - name: Update ACVM workspace root versions
+        run: |
+          ./scripts/update-acvm-workspace-versions.sh
+
+      - name: Configure git
+        run: |
+          git config user.name kevaundray
+          git config user.email kevtheappdev@gmail.com
+
+      - name: Commit updates
+        run: |
+          git add Cargo.toml
+          git commit -m 'chore: Update root workspace acvm versions'
+          git push
+  
   update-lockfile:
     name: Update lockfile
     needs: [release-please]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ repository = "https://github.com/noir-lang/noir/"
 [workspace.dependencies]
 
 # ACVM workspace dependencies
-acir_field = { version = "0.31.0", path = "acvm-repo/acir_field", default-features = false }
-acir = { version = "0.31.0", path = "acvm-repo/acir", default-features = false }
-acvm = { version = "0.31.0", path = "acvm-repo/acvm" }
-stdlib = { version = "0.31.0", package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
-brillig = { version = "0.31.0", path = "acvm-repo/brillig", default-features = false }
-brillig_vm = { version = "0.31.0", path = "acvm-repo/brillig_vm", default-features = false }
-acvm_blackbox_solver = { version = "0.31.0", path = "acvm-repo/blackbox_solver", default-features = false }
-barretenberg_blackbox_solver = { version = "0.31.0", path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
+acir_field = { version = "0.37.0", path = "acvm-repo/acir_field", default-features = false }
+acir = { version = "0.37.0", path = "acvm-repo/acir", default-features = false }
+acvm = { version = "0.37.0", path = "acvm-repo/acvm" }
+stdlib = { version = "0.37.0", package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
+brillig = { version = "0.37.0", path = "acvm-repo/brillig", default-features = false }
+brillig_vm = { version = "0.37.0", path = "acvm-repo/brillig_vm", default-features = false }
+acvm_blackbox_solver = { version = "0.37.0", path = "acvm-repo/blackbox_solver", default-features = false }
+barretenberg_blackbox_solver = { version = "0.37.0", path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
 
 # Noir compiler workspace dependencies
 arena = { path = "compiler/utils/arena" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ repository = "https://github.com/noir-lang/noir/"
 [workspace.dependencies]
 
 # ACVM workspace dependencies
-acir_field = { path = "acvm-repo/acir_field", default-features = false }
-acir = {  path = "acvm-repo/acir", default-features = false }
-acvm = {  path = "acvm-repo/acvm" }
-stdlib = {  package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
-brillig = { path = "acvm-repo/brillig", default-features = false }
-brillig_vm = {  path = "acvm-repo/brillig_vm", default-features = false }
-acvm_blackbox_solver = { path = "acvm-repo/blackbox_solver", default-features = false }
-barretenberg_blackbox_solver = { path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
+acir_field = { version = "0.31.0", path = "acvm-repo/acir_field", default-features = false }
+acir = { version = "0.31.0", path = "acvm-repo/acir", default-features = false }
+acvm = { version = "0.31.0", path = "acvm-repo/acvm" }
+stdlib = { version = "0.31.0", package = "acvm_stdlib", path = "acvm-repo/stdlib", default-features = false }
+brillig = { version = "0.31.0", path = "acvm-repo/brillig", default-features = false }
+brillig_vm = { version = "0.31.0", path = "acvm-repo/brillig_vm", default-features = false }
+acvm_blackbox_solver = { version = "0.31.0", path = "acvm-repo/blackbox_solver", default-features = false }
+barretenberg_blackbox_solver = { version = "0.31.0", path = "acvm-repo/barretenberg_blackbox_solver", default-features = false }
 
 # Noir compiler workspace dependencies
 arena = { path = "compiler/utils/arena" }

--- a/scripts/update-acvm-workspace-versions.sh
+++ b/scripts/update-acvm-workspace-versions.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Path to the top-level Cargo.toml
+TOP_LEVEL_CARGO_TOML="Cargo.toml"
+
+# Temporary file to store paths
+TEMP_PATHS_FILE="temp_paths.txt"
+
+# Extract local dependencies paths that start with "acvm-repo"
+grep 'path = "acvm-repo' "$TOP_LEVEL_CARGO_TOML" | sed -E 's/.*path = "([^"]+)".*/\1/' > "$TEMP_PATHS_FILE"
+
+# Read each path and update the version in the top level workspace Cargo.toml file
+# to match the version in the component's Cargo.toml
+while IFS= read -r component_path; do
+    # Extract the component name
+    # This is acir_field for example or stdlib
+    component_name=$(basename "$component_path")
+
+    # Extract the version from the component's Cargo.toml
+    # This is acvm-repo/acir_field for example
+    component_version=$(grep '^version =' "$component_path/Cargo.toml" | sed -E 's/version = "([^"]+)"/\1/')
+
+    if [ -z "$component_version" ]; then
+        echo "Error: Unable to extract version for $component_name from $component_path/Cargo.toml"
+        continue
+    fi
+
+    # Update the version in the top-level Cargo.toml
+    sed -i.bak -E "s|($component_name[[:space:]]*=[[:space:]]*\{[[:space:]]*version[[:space:]]*=[[:space:]]*\")([^\"]+)(\".*)|\1$component_version\3|" "$TOP_LEVEL_CARGO_TOML"
+
+    if [ $? -ne 0 ]; then
+        echo "Error: Unable to update version for $component_name in $TOP_LEVEL_CARGO_TOML"
+    else
+        echo "Version for $component_name updated successfully to $component_version in $TOP_LEVEL_CARGO_TOML"
+    fi
+done < "$TEMP_PATHS_FILE"
+
+# Remove temporary file and backup file
+rm "$TEMP_PATHS_FILE"
+rm "${TOP_LEVEL_CARGO_TOML}.bak"


### PR DESCRIPTION
# Description

There doesn't seem to be a way to do this, given that a Cargo workspace is meant to have a single version assosciated with it. So the acvm version needs to be modified similar to the Cargo.toml

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
