### PR TITLE
fix(docs): trigger `update-docs` workflow when the `release-please` PR gets merged and not on every merge to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
   update-docs:
     name: Update docs
     needs: [release-please, update-lockfile]
-    if: ${{ needs.release-please.outputs.release-pr }}
+    if: ${{ needs.release-please.outputs.tag-name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release branch


### PR DESCRIPTION
# Description

Currently we are triggering the update-docs workflow when there is a change on the release-please PR branch, this is okay for workflows like update-lockfile. However, it doesn't work for update-docs because it uses `needs.release-please.outputs.release-tag-name` which depends on the release-please tag which we get after we have merged the release-please PR into master.

See [here](https://github.com/noir-lang/noir/actions/runs/7024781896/job/19114307821) for example where update lockfile is ran on master.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
