### PR TITLE
fix: initialise strings as u8 array

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -224,8 +224,9 @@ impl<'a> FunctionContext<'a> {
     }
 
     fn codegen_string(&mut self, string: &str) -> Values {
-        let elements =
-            vecmap(string.as_bytes(), |byte| self.builder.field_constant(*byte as u128).into());
+        let elements = vecmap(string.as_bytes(), |byte| {
+            self.builder.numeric_constant(*byte as u128, Type::unsigned(8)).into()
+        });
         let typ = Self::convert_non_tuple_type(&ast::Type::String(elements.len() as u64));
         self.codegen_array(elements, typ)
     }

--- a/test_programs/execution_success/regression_3635/Nargo.toml
+++ b/test_programs/execution_success/regression_3635/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_3635"
+version = "0.1.0"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_3635/src/main.nr
+++ b/test_programs/execution_success/regression_3635/src/main.nr
@@ -1,5 +1,3 @@
-// Test unsafe integer multiplication with overflow: 12^8 = 429 981 696
-// The circuit should handle properly the growth of the bit size
 use dep::std;
 
 fn main() {

--- a/test_programs/execution_success/regression_3635/src/main.nr
+++ b/test_programs/execution_success/regression_3635/src/main.nr
@@ -1,0 +1,10 @@
+// Test unsafe integer multiplication with overflow: 12^8 = 429 981 696
+// The circuit should handle properly the growth of the bit size
+use dep::std;
+
+fn main() {
+    let x: u8 = 0x61;
+    let y: u8 = "a".as_bytes()[0];
+    assert_eq(x, y);
+    assert_eq(x >> 1, y >> 1);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3635 

## Summary\*

String literals were initialised as field array instead of array of u8.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
