### PR TITLE
unsigned integers cannot be negated

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -1167,6 +1167,10 @@ impl<'interner> TypeChecker<'interner> {
 
         match op {
             crate::UnaryOp::Minus => {
+                if rhs_type.is_unsigned() {
+                    self.errors
+                        .push(TypeCheckError::InvalidUnaryOp { kind: rhs_type.to_string(), span });
+                }
                 let expected = Type::polymorphic_integer(self.interner);
                 rhs_type.unify(&expected, &mut self.errors, || TypeCheckError::InvalidUnaryOp {
                     kind: rhs_type.to_string(),

--- a/test_programs/compile_failure/negate_unsigned/Nargo.toml
+++ b/test_programs/compile_failure/negate_unsigned/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "negate_unsigned"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/negate_unsigned/src/main.nr
+++ b/test_programs/compile_failure/negate_unsigned/src/main.nr
@@ -1,0 +1,6 @@
+use dep::std;
+
+fn main() {
+    let var = -1 as u8;
+    std::println(var);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3649 

## Summary\*

Forbid negation of unsigned integers

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
