### PR TITLE
fix: remove include-keys option

### DIFF
--- a/docs/docs/nargo/01_commands.md
+++ b/docs/docs/nargo/01_commands.md
@@ -100,7 +100,6 @@ You can also use "build" as an alias for compile (e.g. `nargo build`).
 
 | Option                | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| `--include-keys`      | Include Proving and Verification keys in the build artifacts |
 | `--package <PACKAGE>` | The name of the package to compile                           |
 | `--workspace`         | Compile all packages in the workspace                        |
 | `--print-acir`        | Display the ACIR for compiled circuit                        |

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -37,10 +37,6 @@ const BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
 /// Compile the program and its secret execution trace into ACIR format
 #[derive(Debug, Clone, Args)]
 pub(crate) struct CompileCommand {
-    /// Include Proving and Verification keys in the build artifacts.
-    #[arg(long)]
-    include_keys: bool,
-
     /// The name of the package to compile
     #[clap(long, conflicts_with = "workspace")]
     package: Option<CrateName>,


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3488 

## Summary\*

Keys have been removed from the artefacts, so we need to remove the option to add them as well.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
