### PR TITLE
feat: Enhance test information output

### DIFF
--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -127,14 +127,14 @@ fn run_tests<S: BlackBoxFunctionSolver>(
 
         match run_test(blackbox_solver, &context, test_function, show_output, compile_options) {
             TestStatus::Pass { .. } => {
-                writer.set_color(ColorSpec::new()
-                    .set_fg(Some(Color::Green)))
+                writer
+                    .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
                     .expect("Failed to set color");
                 writeln!(writer, "ok").expect("Failed to write to stdout");
             }
             TestStatus::Fail { message, error_diagnostic } => {
-                writer.set_color(ColorSpec::new()
-                    .set_fg(Some(Color::Red)))
+                writer
+                    .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
                     .expect("Failed to set color");
                 writeln!(writer, "{message}\n").expect("Failed to write to stdout");
                 if let Some(diag) = error_diagnostic {


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/3686

## Summary\*

Improved the output of tests by including passed/failed count in the last line print.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
