### PR TITLE
fix: Make trait functions generic over `Self`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -591,7 +591,6 @@ impl<'a> FunctionContext<'a> {
         }
 
         self.codegen_intrinsic_call_checks(function, &arguments, call.location);
-
         Ok(self.insert_call(function, arguments, &call.return_type, call.location))
     }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -433,7 +433,10 @@ pub(crate) fn check_methods_signatures(
 
             let impl_method_generic_count =
                 impl_method.typ.generic_count() - trait_impl_generic_count;
-            let trait_method_generic_count = trait_method.generics.len();
+
+            // We subtract 1 here to account for the implicit generic `Self` type that is on all
+            // traits (and thus trait methods) but is not required (or allowed) for users to specify.
+            let trait_method_generic_count = trait_method.generics().len() - 1;
 
             if impl_method_generic_count != trait_method_generic_count {
                 let error = DefCollectorErrorKind::MismatchTraitImplementationNumGenerics {
@@ -447,9 +450,9 @@ pub(crate) fn check_methods_signatures(
             }
 
             if let Type::Function(impl_params, _, _) = impl_function_type.0 {
-                if trait_method.arguments.len() == impl_params.len() {
+                if trait_method.arguments().len() == impl_params.len() {
                     // Check the parameters of the impl method against the parameters of the trait method
-                    let args = trait_method.arguments.iter();
+                    let args = trait_method.arguments().iter();
                     let args_and_params = args.zip(&impl_params).zip(&impl_method.parameters.0);
 
                     for (parameter_index, ((expected, actual), (hir_pattern, _, _))) in
@@ -468,7 +471,7 @@ pub(crate) fn check_methods_signatures(
                 } else {
                     let error = DefCollectorErrorKind::MismatchTraitImplementationNumParameters {
                         actual_num_parameters: impl_method.parameters.0.len(),
-                        expected_num_parameters: trait_method.arguments.len(),
+                        expected_num_parameters: trait_method.arguments().len(),
                         trait_name: the_trait.name.to_string(),
                         method_name: func_name.to_string(),
                         span: impl_method.location.span,
@@ -481,11 +484,12 @@ pub(crate) fn check_methods_signatures(
             let resolved_return_type =
                 resolver.resolve_type(impl_method.return_type.get_type().into_owned());
 
-            trait_method.return_type.unify(&resolved_return_type, &mut typecheck_errors, || {
+            // TODO: This is not right since it may bind generic return types
+            trait_method.return_type().unify(&resolved_return_type, &mut typecheck_errors, || {
                 let ret_type_span = impl_method.return_type.get_type().span;
                 let expr_span = ret_type_span.expect("return type must always have a span");
 
-                let expected_typ = trait_method.return_type.to_string();
+                let expected_typ = trait_method.return_type().to_string();
                 let expr_typ = impl_method.return_type().to_string();
                 TypeCheckError::TypeMismatch { expr_typ, expected_typ, expr_span }
             });

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -289,14 +289,7 @@ impl<'interner> TypeChecker<'interner> {
             }
             HirExpression::TraitMethodReference(method) => {
                 let the_trait = self.interner.get_trait(method.trait_id);
-                let method = &the_trait.methods[method.method_index];
-
-                let typ = Type::Function(
-                    method.arguments.clone(),
-                    Box::new(method.return_type.clone()),
-                    Box::new(Type::Unit),
-                );
-
+                let typ = &the_trait.methods[method.method_index].typ;
                 let (typ, bindings) = typ.instantiate(self.interner);
                 self.interner.store_instantiation_bindings(*expr_id, bindings);
                 typ
@@ -546,7 +539,7 @@ impl<'interner> TypeChecker<'interner> {
             HirMethodReference::TraitMethodId(method) => {
                 let the_trait = self.interner.get_trait(method.trait_id);
                 let method = &the_trait.methods[method.method_index];
-                (method.get_type(), method.arguments.len())
+                (method.typ.clone(), method.arguments().len())
             }
         };
 

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use crate::{
     graph::CrateId,
     node_interner::{FuncId, TraitId, TraitMethodId},
@@ -11,9 +9,7 @@ use noirc_errors::Span;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TraitFunction {
     pub name: Ident,
-    pub generics: Vec<(Rc<String>, TypeVariable, Span)>,
-    pub arguments: Vec<Type>,
-    pub return_type: Type,
+    pub typ: Type,
     pub span: Span,
     pub default_impl: Option<Box<NoirFunction>>,
     pub default_impl_file_id: fm::FileId,
@@ -145,12 +141,33 @@ impl std::fmt::Display for Trait {
 }
 
 impl TraitFunction {
-    pub fn get_type(&self) -> Type {
-        Type::Function(
-            self.arguments.clone(),
-            Box::new(self.return_type.clone()),
-            Box::new(Type::Unit),
-        )
-        .generalize()
+    pub fn arguments(&self) -> &[Type] {
+        match &self.typ {
+            Type::Function(args, _, _) => args,
+            Type::Forall(_, typ) => match typ.as_ref() {
+                Type::Function(args, _, _) => args,
+                _ => unreachable!("Trait function does not have a function type"),
+            },
+            _ => unreachable!("Trait function does not have a function type"),
+        }
+    }
+
+    pub fn generics(&self) -> &[(TypeVariableId, TypeVariable)] {
+        match &self.typ {
+            Type::Function(..) => &[],
+            Type::Forall(generics, _) => generics,
+            _ => unreachable!("Trait function does not have a function type"),
+        }
+    }
+
+    pub fn return_type(&self) -> &Type {
+        match &self.typ {
+            Type::Function(_, return_type, _) => return_type,
+            Type::Forall(_, typ) => match typ.as_ref() {
+                Type::Function(_, return_type, _) => return_type,
+                _ => unreachable!("Trait function does not have a function type"),
+            },
+            _ => unreachable!("Trait function does not have a function type"),
+        }
     }
 }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -75,7 +75,7 @@ pub enum Type {
     /// the environment should be `Unit` by default,
     /// for closures it should contain a `Tuple` type with the captured
     /// variable types.
-    Function(Vec<Type>, Box<Type>, Box<Type>),
+    Function(Vec<Type>, /*return_type:*/ Box<Type>, /*environment:*/ Box<Type>),
 
     /// &mut T
     MutableReference(Box<Type>),
@@ -668,30 +668,11 @@ impl Type {
         }
     }
 
-    /// Takes a monomorphic type and generalizes it over each of the given type variables.
-    pub(crate) fn generalize_from_variables(
-        self,
-        type_vars: HashMap<TypeVariableId, TypeVariable>,
-    ) -> Type {
-        let polymorphic_type_vars = vecmap(type_vars, |type_var| type_var);
-        Type::Forall(polymorphic_type_vars, Box::new(self))
-    }
-
     /// Takes a monomorphic type and generalizes it over each of the type variables in the
     /// given type bindings, ignoring what each type variable is bound to in the TypeBindings.
     pub(crate) fn generalize_from_substitutions(self, type_bindings: TypeBindings) -> Type {
         let polymorphic_type_vars = vecmap(type_bindings, |(id, (type_var, _))| (id, type_var));
         Type::Forall(polymorphic_type_vars, Box::new(self))
-    }
-
-    /// Takes a monomorphic type and generalizes it over each type variable found within.
-    ///
-    /// Note that Noir's type system assumes any Type::Forall are only present at top-level,
-    /// and thus all type variable's within a type are free.
-    pub(crate) fn generalize(self) -> Type {
-        let mut type_variables = HashMap::new();
-        self.find_all_unbound_type_variables(&mut type_variables);
-        self.generalize_from_variables(type_variables)
     }
 }
 


### PR DESCRIPTION
# Description

## Problem & Summary

Checking a trait function's type previously was very ad-hoc. When a `TraitMethodReference` was found, it'd manually create a function type from the trait function's definition and instantiate it - even though instantiating a `Type::Function` does nothing.

I've changed the TraitFunction struct to add a `Type` field for the whole function type, which includes generics. The type now should usually be a `Type::Forall`. In addition, I've added the trait's `Self` type to the list of generics in the Type::Forall.

This fixes the issue where the `Self` type would be bound after certain function calls which would affect callsites but not a function body leading to a type mismatch between function return type and a call's return type. This is the issue we were encountering after adding traits to noir-protocol-circuits.

## Additional Information

No tests are provided since I was unable to make a minimal repro from the thousands of lines of noir-protocol-circuits unfortunately. I'll keep experimenting while this PR is up.

I'm also merging into jf/fix-3089 since this was somewhat accidentally built on top of it. The two changes are otherwise unrelated.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
