### PR TITLE
feat(lsp): add goto definition for locals

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -153,7 +153,7 @@ impl<'a> ModCollector<'a> {
 
             for (_, func_id, noir_function) in &mut unresolved_functions.functions {
                 noir_function.def.where_clause.append(&mut trait_impl.where_clause.clone());
-                let location = Location { span: noir_function.def.span, file: self.file_id };
+                let location = Location::new(noir_function.def.span, self.file_id);
                 context.def_interner.push_function(*func_id, &noir_function.def, module, location);
             }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -221,7 +221,7 @@ impl<'a> ModCollector<'a> {
 
             // First create dummy function in the DefInterner
             // So that we can get a FuncId
-            let location = Location { span: function.span(), file: self.file_id };
+            let location = Location::new(function.span(), self.file_id);
             context.def_interner.push_function(func_id, &function.def, module, location);
 
             // Now link this func_id to a crate level map with the noir function and the module id

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -126,7 +126,8 @@ impl<'a> ModCollector<'a> {
 
             for method in r#impl.methods {
                 let func_id = context.def_interner.push_empty_fn();
-                context.def_interner.push_function(func_id, &method.def, module_id);
+                let location = Location::new(method.span(), self.file_id);
+                context.def_interner.push_function(func_id, &method.def, module_id, location);
                 unresolved_functions.push_fn(self.module_id, func_id, method);
             }
 
@@ -152,7 +153,8 @@ impl<'a> ModCollector<'a> {
 
             for (_, func_id, noir_function) in &mut unresolved_functions.functions {
                 noir_function.def.where_clause.append(&mut trait_impl.where_clause.clone());
-                context.def_interner.push_function(*func_id, &noir_function.def, module);
+                let location = Location { span: noir_function.def.span, file: self.file_id };
+                context.def_interner.push_function(*func_id, &noir_function.def, module, location);
             }
 
             let unresolved_trait_impl = UnresolvedTraitImpl {
@@ -185,7 +187,8 @@ impl<'a> ModCollector<'a> {
         for item in &trait_impl.items {
             if let TraitImplItem::Function(impl_method) = item {
                 let func_id = context.def_interner.push_empty_fn();
-                context.def_interner.push_function(func_id, &impl_method.def, module);
+                let location = Location { span: impl_method.span(), file: self.file_id };
+                context.def_interner.push_function(func_id, &impl_method.def, module, location);
                 unresolved_functions.push_fn(self.module_id, func_id, impl_method.clone());
             }
         }
@@ -218,7 +221,8 @@ impl<'a> ModCollector<'a> {
 
             // First create dummy function in the DefInterner
             // So that we can get a FuncId
-            context.def_interner.push_function(func_id, &function.def, module);
+            let location = Location { span: function.span(), file: self.file_id };
+            context.def_interner.push_function(func_id, &function.def, module, location);
 
             // Now link this func_id to a crate level map with the noir function and the module id
             // Encountering a NoirFunction, we retrieve it's module_data to get the namespace
@@ -266,7 +270,7 @@ impl<'a> ModCollector<'a> {
 
             // Create the corresponding module for the struct namespace
             let id = match self.push_child_module(&name, self.file_id, false, false) {
-                Ok(local_id) => context.def_interner.new_struct(&unresolved, krate, local_id),
+                Ok(local_id) => context.def_interner.new_struct(&unresolved, krate, local_id, self.file_id),
                 Err(error) => {
                     definition_errors.push((error.into(), self.file_id));
                     continue;
@@ -391,7 +395,8 @@ impl<'a> ModCollector<'a> {
                             is_internal: None,
                         };
 
-                        context.def_interner.push_function_definition(func_id, modifiers, id.0);
+                        let location = Location::new(name.span(), self.file_id);
+                        context.def_interner.push_function_definition(func_id, modifiers, id.0, location);
 
                         match self.def_collector.def_map.modules[id.0.local_id.0]
                             .declare_function(name.clone(), func_id)

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -270,7 +270,9 @@ impl<'a> ModCollector<'a> {
 
             // Create the corresponding module for the struct namespace
             let id = match self.push_child_module(&name, self.file_id, false, false) {
-                Ok(local_id) => context.def_interner.new_struct(&unresolved, krate, local_id, self.file_id),
+                Ok(local_id) => {
+                    context.def_interner.new_struct(&unresolved, krate, local_id, self.file_id)
+                }
                 Err(error) => {
                     definition_errors.push((error.into(), self.file_id));
                     continue;
@@ -396,7 +398,9 @@ impl<'a> ModCollector<'a> {
                         };
 
                         let location = Location::new(name.span(), self.file_id);
-                        context.def_interner.push_function_definition(func_id, modifiers, id.0, location);
+                        context
+                            .def_interner
+                            .push_function_definition(func_id, modifiers, id.0, location);
 
                         match self.def_collector.def_map.modules[id.0.local_id.0]
                             .declare_function(name.clone(), func_id)

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -187,7 +187,7 @@ impl<'a> ModCollector<'a> {
         for item in &trait_impl.items {
             if let TraitImplItem::Function(impl_method) = item {
                 let func_id = context.def_interner.push_empty_fn();
-                let location = Location { span: impl_method.span(), file: self.file_id };
+                let location = Location::new(impl_method.span(), self.file_id);
                 context.def_interner.push_function(func_id, &impl_method.def, module, location);
                 unresolved_functions.push_fn(self.module_id, func_id, impl_method.clone());
             }

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -256,8 +256,8 @@ impl<'a> Resolver<'a> {
             return self.add_global_variable_decl(name, definition);
         }
 
-        let id = self.interner.push_definition(name.0.contents.clone(), mutable, definition);
         let location = Location::new(name.span(), self.file);
+        let id = self.interner.push_definition(name.0.contents.clone(), mutable, definition, location);
         let ident = HirIdent { location, id };
         let resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused };
 
@@ -300,8 +300,8 @@ impl<'a> Resolver<'a> {
             ident = hir_let_stmt.ident();
             resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused: true };
         } else {
-            let id = self.interner.push_definition(name.0.contents.clone(), false, definition);
             let location = Location::new(name.span(), self.file);
+            let id = self.interner.push_definition(name.0.contents.clone(), false, definition, location);
             ident = HirIdent { location, id };
             resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused: true };
         }

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -257,7 +257,8 @@ impl<'a> Resolver<'a> {
         }
 
         let location = Location::new(name.span(), self.file);
-        let id = self.interner.push_definition(name.0.contents.clone(), mutable, definition, location);
+        let id =
+            self.interner.push_definition(name.0.contents.clone(), mutable, definition, location);
         let ident = HirIdent { location, id };
         let resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused };
 
@@ -301,7 +302,8 @@ impl<'a> Resolver<'a> {
             resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused: true };
         } else {
             let location = Location::new(name.span(), self.file);
-            let id = self.interner.push_definition(name.0.contents.clone(), false, definition, location);
+            let id =
+                self.interner.push_definition(name.0.contents.clone(), false, definition, location);
             ident = HirIdent { location, id };
             resolver_meta = ResolverMeta { num_times_used: 0, ident, warn_if_unused: true };
         }

--- a/compiler/noirc_frontend/src/hir/resolution/traits.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/traits.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use fm::FileId;
 use iter_extended::vecmap;
-use noirc_errors::{Span, Location};
+use noirc_errors::{Location, Span};
 
 use crate::{
     graph::CrateId,

--- a/compiler/noirc_frontend/src/hir/resolution/traits.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/traits.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use fm::FileId;
 use iter_extended::vecmap;
-use noirc_errors::Span;
+use noirc_errors::{Span, Location};
 
 use crate::{
     graph::CrateId,
@@ -176,7 +176,8 @@ fn collect_trait_impl_methods(
             if let Some(default_impl) = &method.default_impl {
                 let func_id = interner.push_empty_fn();
                 let module = ModuleId { local_id: trait_impl.module_id, krate: crate_id };
-                interner.push_function(func_id, &default_impl.def, module);
+                let location = Location::new(default_impl.def.span, trait_impl.file_id);
+                interner.push_function(func_id, &default_impl.def, module, location);
                 func_ids_in_trait.insert(func_id);
                 ordered_methods.push((
                     method.default_impl_module_id,

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -255,24 +255,25 @@ mod test {
     fn basic_let() {
         let mut interner = NodeInterner::default();
 
-        // Add a simple let Statement into the interner
-        // let z = x + y;
-        //
-        // Push x variable
-        let x_id = interner.push_definition("x".into(), false, DefinitionKind::Local(None));
-
         // Safety: The FileId in a location isn't used for tests
         let file = FileId::default();
         let location = Location::new(Span::default(), file);
 
+        // Add a simple let Statement into the interner
+        // let z = x + y;
+        //
+        // Push x variable
+        let x_id = interner.push_definition("x".into(), false, DefinitionKind::Local(None), location);
+
+
         let x = HirIdent { id: x_id, location };
 
         // Push y variable
-        let y_id = interner.push_definition("y".into(), false, DefinitionKind::Local(None));
+        let y_id = interner.push_definition("y".into(), false, DefinitionKind::Local(None), location);
         let y = HirIdent { id: y_id, location };
 
         // Push z variable
-        let z_id = interner.push_definition("z".into(), false, DefinitionKind::Local(None));
+        let z_id = interner.push_definition("z".into(), false, DefinitionKind::Local(None), location);
         let z = HirIdent { id: z_id, location };
 
         // Push x and y as expressions
@@ -304,7 +305,7 @@ mod test {
 
         let name = HirIdent {
             location,
-            id: interner.push_definition("test_func".into(), false, DefinitionKind::Local(None)),
+            id: interner.push_definition("test_func".into(), false, DefinitionKind::Local(None), location),
         };
 
         // Add function meta

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -263,17 +263,19 @@ mod test {
         // let z = x + y;
         //
         // Push x variable
-        let x_id = interner.push_definition("x".into(), false, DefinitionKind::Local(None), location);
-
+        let x_id =
+            interner.push_definition("x".into(), false, DefinitionKind::Local(None), location);
 
         let x = HirIdent { id: x_id, location };
 
         // Push y variable
-        let y_id = interner.push_definition("y".into(), false, DefinitionKind::Local(None), location);
+        let y_id =
+            interner.push_definition("y".into(), false, DefinitionKind::Local(None), location);
         let y = HirIdent { id: y_id, location };
 
         // Push z variable
-        let z_id = interner.push_definition("z".into(), false, DefinitionKind::Local(None), location);
+        let z_id =
+            interner.push_definition("z".into(), false, DefinitionKind::Local(None), location);
         let z = HirIdent { id: z_id, location };
 
         // Push x and y as expressions
@@ -305,7 +307,12 @@ mod test {
 
         let name = HirIdent {
             location,
-            id: interner.push_definition("test_func".into(), false, DefinitionKind::Local(None), location),
+            id: interner.push_definition(
+                "test_func".into(),
+                false,
+                DefinitionKind::Local(None),
+                location,
+            ),
         };
 
         // Add function meta

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -9,7 +9,7 @@ use crate::{
     node_interner::{ExprId, NodeInterner, TypeAliasId},
 };
 use iter_extended::vecmap;
-use noirc_errors::{Span, Location};
+use noirc_errors::{Location, Span};
 use noirc_printable_type::PrintableType;
 
 use crate::{node_interner::StructId, Ident, Signedness};
@@ -192,7 +192,6 @@ impl StructType {
         id: StructId,
         name: Ident,
 
-        
         location: Location,
         fields: Vec<(Ident, Type)>,
         generics: Generics,

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -9,7 +9,7 @@ use crate::{
     node_interner::{ExprId, NodeInterner, TypeAliasId},
 };
 use iter_extended::vecmap;
-use noirc_errors::Span;
+use noirc_errors::{Span, Location};
 use noirc_printable_type::PrintableType;
 
 use crate::{node_interner::StructId, Ident, Signedness};
@@ -166,7 +166,7 @@ pub struct StructType {
     fields: Vec<(Ident, Type)>,
 
     pub generics: Generics,
-    pub span: Span,
+    pub location: Location,
 }
 
 /// Corresponds to generic lists such as `<T, U>` in the source
@@ -191,11 +191,13 @@ impl StructType {
     pub fn new(
         id: StructId,
         name: Ident,
-        span: Span,
+
+        
+        location: Location,
         fields: Vec<(Ident, Type)>,
         generics: Generics,
     ) -> StructType {
-        StructType { id, fields, name, span, generics }
+        StructType { id, fields, name, location, generics }
     }
 
     /// To account for cyclic references between structs, a struct's

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1249,6 +1249,9 @@ impl NodeInterner {
                     DefinitionKind::Function(func_id) => {
                         Some(self.function_meta(&func_id).location)
                     }
+                    DefinitionKind::Local(_local_id) => {
+                        Some(definition_info.location)
+                    }
                     _ => None,
                 }
             }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -535,7 +535,7 @@ impl NodeInterner {
             (id, Shared::new(TypeBinding::Unbound(id)))
         });
 
-        let location = Location { span: typ.struct_def.span, file: file_id };
+        let location = Location::new(typ.struct_def.span, file_id);
         let new_struct = StructType::new(struct_id, name, location, no_fields, generics);
         self.structs.insert(struct_id, Shared::new(new_struct));
         self.struct_attributes.insert(struct_id, typ.struct_def.attributes.clone());

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1249,9 +1249,7 @@ impl NodeInterner {
                     DefinitionKind::Function(func_id) => {
                         Some(self.function_meta(&func_id).location)
                     }
-                    DefinitionKind::Local(_local_id) => {
-                        Some(definition_info.location)
-                    }
+                    DefinitionKind::Local(_local_id) => Some(definition_info.location),
                     _ => None,
                 }
             }


### PR DESCRIPTION
# Description

## Problem\*

Resolves 

feat(lsp): add goto definition for locals #3706

## Summary\*

LSP server now understands goto definition command issued by Client (ie. vscode). In case of local symbol it will jump to it's definition.

## Additional Context


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
