### PR TITLE
chore: fix broken onboarding link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This crate's minimum supported rustc version is 1.71.1.
 
 ## Working on this project
 
-This project uses [Nix](https://nixos.org/) and [direnv](https://direnv.net/) to streamline the development experience. Please follow [our guidelines](https://noir-lang.org/getting_started/nargo_installation/#option-4-compile-from-source) to setup your environment for working on the project.
+This project uses [Nix](https://nixos.org/) and [direnv](https://direnv.net/) to streamline the development experience. Please follow [our guidelines](https://noir-lang.org/getting_started/nargo_installation/#option-3-compile-from-source) to setup your environment for working on the project.
 
 ### Building against a different local/remote version of Barretenberg
 


### PR DESCRIPTION
# Description

was onboarding this morning to tackle [a quick issue over here](https://github.com/noir-lang/noir/issues/3372)

and noticed this link broke in the top level README
https://github.com/noir-lang/noir?tab=readme-ov-file#working-on-this-project

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
