### PR TITLE
chore: allow common ascii punctuation in attributes

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -633,15 +633,15 @@ mod tests {
     }
 
     #[test]
-    fn test_attribute_with_apostrophe() {
-        let input = r#"#[test(should_fail_with = "the eagle's feathers")]"#;
+    fn test_attribute_with_common_punctuation() {
+        let input = r#"#[test(should_fail_with = "stmt. q? exclaim! & symbols, 1% shouldn't fail")]"#;
         let mut lexer = Lexer::new(input);
 
         let token = lexer.next_token().unwrap().token().clone();
         assert_eq!(
             token,
             Token::Attribute(Attribute::Function(FunctionAttribute::Test(
-                TestScope::ShouldFailWith { reason: "the eagle's feathers".to_owned().into() }
+                TestScope::ShouldFailWith { reason: "stmt. q? exclaim! & symbols, 1% shouldn't fail".to_owned().into() }
             )))
         );
     }

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -634,14 +634,17 @@ mod tests {
 
     #[test]
     fn test_attribute_with_common_punctuation() {
-        let input = r#"#[test(should_fail_with = "stmt. q? exclaim! & symbols, 1% shouldn't fail")]"#;
+        let input =
+            r#"#[test(should_fail_with = "stmt. q? exclaim! & symbols, 1% shouldn't fail")]"#;
         let mut lexer = Lexer::new(input);
 
         let token = lexer.next_token().unwrap().token().clone();
         assert_eq!(
             token,
             Token::Attribute(Attribute::Function(FunctionAttribute::Test(
-                TestScope::ShouldFailWith { reason: "stmt. q? exclaim! & symbols, 1% shouldn't fail".to_owned().into() }
+                TestScope::ShouldFailWith {
+                    reason: "stmt. q? exclaim! & symbols, 1% shouldn't fail".to_owned().into()
+                }
             )))
         );
     }

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -468,13 +468,8 @@ impl Attribute {
                 .all(|ch| {
                     ch.is_ascii_alphabetic()
                         || ch.is_numeric()
-                        || ch == '_'
-                        || ch == '('
-                        || ch == ')'
-                        || ch == '='
-                        || ch == '"'
+                        || ch.is_ascii_punctuation()
                         || ch == ' '
-                        || ch == '\''
                 })
                 .then_some(());
 


### PR DESCRIPTION
# Description

spotted an issue with punctuation inside a `#[test(should_fail_with = "")]` block ([comment on original issue](https://github.com/noir-lang/noir/issues/3372#issuecomment-1845660516))

## Problem\*

Resolves #3372 (an extension of this original issue)

## Summary\*

I built off of the original work done over here #3374 but simplified things down to just cover all common punctuation

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
