### PR TITLE
fix: Stop cloning Traits!

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -349,7 +349,7 @@ impl<'a> ModCollector<'a> {
             let name = trait_definition.name.clone();
 
             // Create the corresponding module for the trait namespace
-            let id = match self.push_child_module(&name, self.file_id, false, false) {
+            let trait_id = match self.push_child_module(&name, self.file_id, false, false) {
                 Ok(local_id) => TraitId(ModuleId { krate, local_id }),
                 Err(error) => {
                     errors.push((error.into(), self.file_id));
@@ -359,7 +359,7 @@ impl<'a> ModCollector<'a> {
 
             // Add the trait to scope so its path can be looked up later
             let result =
-                self.def_collector.def_map.modules[self.module_id.0].declare_trait(name, id);
+                self.def_collector.def_map.modules[self.module_id.0].declare_trait(name, trait_id);
 
             if let Err((first_def, second_def)) = result {
                 let error = DefCollectorErrorKind::Duplicate {
@@ -400,9 +400,9 @@ impl<'a> ModCollector<'a> {
                         let location = Location::new(name.span(), self.file_id);
                         context
                             .def_interner
-                            .push_function_definition(func_id, modifiers, id.0, location);
+                            .push_function_definition(func_id, modifiers, trait_id.0, location);
 
-                        match self.def_collector.def_map.modules[id.0.local_id.0]
+                        match self.def_collector.def_map.modules[trait_id.0.local_id.0]
                             .declare_function(name.clone(), func_id)
                         {
                             Ok(()) => {
@@ -437,7 +437,7 @@ impl<'a> ModCollector<'a> {
                         let stmt_id = context.def_interner.push_empty_global();
 
                         if let Err((first_def, second_def)) = self.def_collector.def_map.modules
-                            [id.0.local_id.0]
+                            [trait_id.0.local_id.0]
                             .declare_global(name.clone(), stmt_id)
                         {
                             let error = DefCollectorErrorKind::Duplicate {
@@ -451,7 +451,7 @@ impl<'a> ModCollector<'a> {
                     TraitItem::Type { name } => {
                         // TODO(nickysn or alexvitkov): implement context.def_interner.push_empty_type_alias and get an id, instead of using TypeAliasId::dummy_id()
                         if let Err((first_def, second_def)) = self.def_collector.def_map.modules
-                            [id.0.local_id.0]
+                            [trait_id.0.local_id.0]
                             .declare_type_alias(name.clone(), TypeAliasId::dummy_id())
                         {
                             let error = DefCollectorErrorKind::Duplicate {
@@ -473,7 +473,7 @@ impl<'a> ModCollector<'a> {
                 trait_def: trait_definition,
                 fns_with_default_impl: unresolved_functions,
             };
-            self.def_collector.collected_traits.insert(id, unresolved);
+            self.def_collector.collected_traits.insert(trait_id, unresolved);
         }
         errors
     }

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -200,28 +200,6 @@ impl<'a> Resolver<'a> {
         (hir_func, func_meta, self.errors)
     }
 
-    pub fn resolve_trait_function(
-        mut self,
-        func: NoirFunction,
-        func_id: FuncId,
-    ) -> (HirFunction, FuncMeta, Vec<ResolverError>) {
-        self.scopes.start_function();
-
-        // Check whether the function has globals in the local module and add them to the scope
-        self.resolve_local_globals();
-
-        self.add_generics(&func.def.generics);
-        self.trait_bounds = func.def.where_clause.clone();
-
-        let (hir_func, func_meta) = self.intern_function(func, func_id);
-        let func_scope_tree = self.scopes.end_function();
-
-        self.check_for_unused_variables_in_scope_tree(func_scope_tree);
-
-        self.trait_bounds.clear();
-        (hir_func, func_meta, self.errors)
-    }
-
     fn check_for_unused_variables_in_scope_tree(&mut self, scope_decls: ScopeTree) {
         let mut unused_vars = Vec::new();
         for scope in scope_decls.0.into_iter() {

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -891,7 +891,9 @@ impl<'interner> TypeChecker<'interner> {
                     }
                 }
             }
-            Type::TraitAsType(_trait) => {
+            // TODO: We should allow method calls on `impl Trait`s eventually.
+            //       For now it is fine since they are only allowed on return types.
+            Type::TraitAsType(..) => {
                 self.errors.push(TypeCheckError::UnresolvedMethodCall {
                     method_name: method_name.to_string(),
                     object_type: object_type.clone(),

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -101,8 +101,8 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     if !can_ignore_ret {
         let (expr_span, empty_function) = function_info(interner, function_body_id);
         let func_span = interner.expr_span(function_body_id); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
-        if let Type::TraitAsType(t) = &declared_return_type {
-            if interner.lookup_trait_implementation(&function_last_type, t.id).is_err() {
+        if let Type::TraitAsType(trait_id, _) = &declared_return_type {
+            if interner.lookup_trait_implementation(&function_last_type, *trait_id).is_err() {
                 let error = TypeCheckError::TypeMismatchWithSource {
                     expected: declared_return_type.clone(),
                     actual: function_last_type,

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -35,7 +35,7 @@ pub struct TraitType {
 /// Represents a trait in the type system. Each instance of this struct
 /// will be shared across all Type::Trait variants that represent
 /// the same trait.
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Eq)]
 pub struct Trait {
     /// A unique id representing this trait type. Used to check if two
     /// struct traits are equal.

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::{
     graph::CrateId,
     node_interner::{FuncId, TraitId, TraitMethodId},
@@ -44,12 +42,6 @@ pub struct Trait {
     pub crate_id: CrateId,
 
     pub methods: Vec<TraitFunction>,
-
-    /// Maps method_name -> method id.
-    /// This map is separate from methods since TraitFunction ids
-    /// are created during collection where we don't yet have all
-    /// the information needed to create the full TraitFunction.
-    pub method_ids: HashMap<String, FuncId>,
 
     pub constants: Vec<TraitConstant>,
     pub types: Vec<TraitType>,
@@ -121,7 +113,6 @@ impl Trait {
             crate_id,
             span,
             methods: Vec::new(),
-            method_ids: HashMap::new(),
             constants: Vec::new(),
             types: Vec::new(),
             generics,

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{
     graph::CrateId,
     node_interner::{FuncId, TraitId, TraitMethodId},
@@ -42,6 +44,13 @@ pub struct Trait {
     pub crate_id: CrateId,
 
     pub methods: Vec<TraitFunction>,
+
+    /// Maps method_name -> method id.
+    /// This map is separate from methods since TraitFunction ids
+    /// are created during collection where we don't yet have all
+    /// the information needed to create the full TraitFunction.
+    pub method_ids: HashMap<String, FuncId>,
+
     pub constants: Vec<TraitConstant>,
     pub types: Vec<TraitType>,
 
@@ -112,6 +121,7 @@ impl Trait {
             crate_id,
             span,
             methods: Vec::new(),
+            method_ids: HashMap::new(),
             constants: Vec::new(),
             types: Vec::new(),
             generics,
@@ -124,9 +134,9 @@ impl Trait {
         self.methods = methods;
     }
 
-    pub fn find_method(&self, name: Ident) -> Option<TraitMethodId> {
+    pub fn find_method(&self, name: &str) -> Option<TraitMethodId> {
         for (idx, method) in self.methods.iter().enumerate() {
-            if method.name == name {
+            if &method.name == name {
                 return Some(TraitMethodId { trait_id: self.id, method_index: idx });
             }
         }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -231,7 +231,7 @@ impl<'interner> Monomorphizer<'interner> {
         let body_expr_id = *self.interner.function(&f).as_expr();
         let body_return_type = self.interner.id_type(body_expr_id);
         let return_type = self.convert_type(match meta.return_type() {
-            Type::TraitAsType(_) => &body_return_type,
+            Type::TraitAsType(..) => &body_return_type,
             _ => meta.return_type(),
         });
 
@@ -720,7 +720,7 @@ impl<'interner> Monomorphizer<'interner> {
                     ast::Type::Slice(element)
                 }
             }
-            HirType::TraitAsType(_) => {
+            HirType::TraitAsType(..) => {
                 unreachable!("All TraitAsType should be replaced before calling convert_type");
             }
             HirType::NamedGeneric(binding, _) => {

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -757,6 +757,9 @@ impl NodeInterner {
 
     /// Returns the interned meta data corresponding to `func_id`
     pub fn function_meta(&self, func_id: &FuncId) -> FuncMeta {
+        if !self.func_meta.contains_key(func_id) {
+            eprintln!("No entry for key {:?}", func_id);
+        }
         self.func_meta.get(func_id).cloned().expect("ice: all function ids should have metadata")
     }
 
@@ -863,12 +866,16 @@ impl NodeInterner {
         self.structs[&id].clone()
     }
 
-    pub fn get_trait(&self, id: TraitId) -> Trait {
-        self.traits[&id].clone()
+    pub fn get_trait(&self, id: TraitId) -> &Trait {
+        &self.traits[&id]
     }
 
-    pub fn try_get_trait(&self, id: TraitId) -> Option<Trait> {
-        self.traits.get(&id).cloned()
+    pub fn get_trait_mut(&mut self, id: TraitId) -> &mut Trait {
+        self.traits.get_mut(&id).expect("get_trait_mut given invalid TraitId")
+    }
+
+    pub fn try_get_trait(&self, id: TraitId) -> Option<&Trait> {
+        self.traits.get(&id)
     }
 
     pub fn get_type_alias(&self, id: TypeAliasId) -> &TypeAliasType {
@@ -892,7 +899,7 @@ impl NodeInterner {
         let typ = self.id_type(def_id);
         if let Type::Function(args, ret, env) = &typ {
             let def = self.definition(def_id);
-            if let Type::TraitAsType(_trait) = ret.as_ref() {
+            if let Type::TraitAsType(..) = ret.as_ref() {
                 if let DefinitionKind::Function(func_id) = def.kind {
                     let f = self.function(&func_id);
                     let func_body = f.as_expr();
@@ -1382,6 +1389,6 @@ fn get_type_method_key(typ: &Type) -> Option<TypeMethodKey> {
         | Type::Error
         | Type::NotConstant
         | Type::Struct(_, _)
-        | Type::TraitAsType(_) => None,
+        | Type::TraitAsType(..) => None,
     }
 }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -757,9 +757,6 @@ impl NodeInterner {
 
     /// Returns the interned meta data corresponding to `func_id`
     pub fn function_meta(&self, func_id: &FuncId) -> FuncMeta {
-        if !self.func_meta.contains_key(func_id) {
-            eprintln!("No entry for key {:?}", func_id);
-        }
         self.func_meta.get(func_id).cloned().expect("ice: all function ids should have metadata")
     }
 

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -161,7 +161,7 @@ impl AbiType {
             Type::Error => unreachable!(),
             Type::Unit => unreachable!(),
             Type::Constant(_) => unreachable!(),
-            Type::TraitAsType(_) => unreachable!(),
+            Type::TraitAsType(..) => unreachable!(),
             Type::Struct(def, ref args) => {
                 let struct_type = def.borrow();
                 let fields = struct_type.get_fields(args);


### PR DESCRIPTION
# Description

## Problem\*

The `Trait` struct is quite large and was being cloned every time `get_trait` was called in the NodeResolver, which was somewhat often.

## Summary\*

Stops the cloning of traits! The `Clone` derive is removed entirely and when needed for ownership reasons we either re-retrieve the trait by calling `get_trait` again (which now returns a reference), or we temporarily take ownership of the trait's methods.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
