### PR TITLE
chore: remove special casing for `pedersen_hash` black box function

### DIFF
--- a/tooling/nargo/src/ops/compile.rs
+++ b/tooling/nargo/src/ops/compile.rs
@@ -85,21 +85,11 @@ pub fn compile_program(
             }
         };
 
-    // TODO: we say that pedersen hashing is supported by all backends for now
-    let is_opcode_supported_pedersen_hash = |opcode: &Opcode| -> bool {
-        if let Opcode::BlackBoxFuncCall(
-            acvm::acir::circuit::opcodes::BlackBoxFuncCall::PedersenHash { .. },
-        ) = opcode
-        {
-            true
-        } else {
-            is_opcode_supported(opcode)
-        }
-    };
+
 
     // Apply backend specific optimizations.
     let optimized_program =
-        crate::ops::optimize_program(program, np_language, &is_opcode_supported_pedersen_hash)
+        crate::ops::optimize_program(program, np_language, is_opcode_supported)
             .expect("Backend does not support an opcode that is in the IR");
 
     (context.file_manager, Ok((optimized_program, warnings)))

--- a/tooling/nargo/src/ops/compile.rs
+++ b/tooling/nargo/src/ops/compile.rs
@@ -85,12 +85,9 @@ pub fn compile_program(
             }
         };
 
-
-
     // Apply backend specific optimizations.
-    let optimized_program =
-        crate::ops::optimize_program(program, np_language, is_opcode_supported)
-            .expect("Backend does not support an opcode that is in the IR");
+    let optimized_program = crate::ops::optimize_program(program, np_language, is_opcode_supported)
+        .expect("Backend does not support an opcode that is in the IR");
 
     (context.file_manager, Ok((optimized_program, warnings)))
 }

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use acvm::acir::circuit::opcodes::BlackBoxFuncCall;
 use acvm::acir::circuit::Opcode;
 use acvm::Language;
 use backend_interface::BackendOpcodeSupport;

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -213,18 +213,9 @@ fn compile_program(
         }
     };
 
-    // TODO: we say that pedersen hashing is supported by all backends for now
-    let is_opcode_supported_pedersen_hash = |opcode: &Opcode| -> bool {
-        if let Opcode::BlackBoxFuncCall(BlackBoxFuncCall::PedersenHash { .. }) = opcode {
-            true
-        } else {
-            is_opcode_supported(opcode)
-        }
-    };
-
     // Apply backend specific optimizations.
     let optimized_program =
-        nargo::ops::optimize_program(program, np_language, &is_opcode_supported_pedersen_hash)
+        nargo::ops::optimize_program(program, np_language, is_opcode_supported)
             .expect("Backend does not support an opcode that is in the IR");
 
     save_program(optimized_program.clone(), package, &workspace.target_directory_path());

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -213,9 +213,8 @@ fn compile_program(
     };
 
     // Apply backend specific optimizations.
-    let optimized_program =
-        nargo::ops::optimize_program(program, np_language, is_opcode_supported)
-            .expect("Backend does not support an opcode that is in the IR");
+    let optimized_program = nargo::ops::optimize_program(program, np_language, is_opcode_supported)
+        .expect("Backend does not support an opcode that is in the IR");
 
     save_program(optimized_program.clone(), package, &workspace.target_directory_path());
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3370 

## Summary\*

This PR removes the special case which says all backends support the pedersen hash black box function.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
