### PR TITLE
feat: avoid overflow checks on boolean multiplication

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -365,7 +365,9 @@ impl<'a> FunctionContext<'a> {
                     _ => unreachable!("operator {} should not overflow", operator),
                 };
 
-                if operator == BinaryOpKind::ShiftLeft {
+                if operator == BinaryOpKind::Multiply && bit_size == 1 {
+                    results
+                } else if operator == BinaryOpKind::ShiftLeft {
                     self.check_left_shift_overflow(result, rhs, bit_size, location)
                 } else {
                     let message = format!("attempt to {} with overflow", op_name);

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -366,7 +366,7 @@ impl<'a> FunctionContext<'a> {
                 };
 
                 if operator == BinaryOpKind::Multiply && bit_size == 1 {
-                    results
+                    result
                 } else if operator == BinaryOpKind::ShiftLeft {
                     self.check_left_shift_overflow(result, rhs, bit_size, location)
                 } else {


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

Currently multiplication of booleans adds in a range check which is unnecessary as the result cannot be larger than the inputs.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
