### PR TITLE
chore: use `tsx` instead of `ts-node` for `noir_js`

### DIFF
--- a/tooling/noir_js/.mocharc.json
+++ b/tooling/noir_js/.mocharc.json
@@ -1,6 +1,5 @@
 {
-  "require": "ts-node/register",
-  "loader": "ts-node/esm",
+  "require": "tsx",
   "extensions": ["ts", "cjs"],
   "spec": [
     "test/node/**/*.test.ts*"

--- a/tooling/noir_js/package.json
+++ b/tooling/noir_js/package.json
@@ -50,6 +50,7 @@
     "prettier": "3.0.3",
     "ts-node": "^10.9.1",
     "tsc-multi": "^1.1.0",
+    "tsx": "^4.6.2",
     "typescript": "^5.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3715,6 +3715,7 @@ __metadata:
     prettier: 3.0.3
     ts-node: ^10.9.1
     tsc-multi: ^1.1.0
+    tsx: ^4.6.2
     typescript: ^5.2.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Description

This gets rid of the experimental loader warning, as tsx does not require it. 

This experimental loader feature is unstable and just to rule it out, could be one of the reasons why tests have become a bit flaky.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
