### PR TITLE
chore(docs/docs/language_concepts): typo fix

### DIFF
--- a/docs/docs/language_concepts/03_ops.md
+++ b/docs/docs/language_concepts/03_ops.md
@@ -62,7 +62,7 @@ fn main(x : Field) {
 
 Noir has no support for the logical operators `||` and `&&`. This is because encoding the
 short-circuiting that these operators require can be inefficient for Noir's backend. Instead you can
-use the bitwise operators `|` and `&` which operate indentically for booleans, just without the
+use the bitwise operators `|` and `&` which operate identically for booleans, just without the
 short-circuiting.
 
 ```rust

--- a/docs/docs/language_concepts/data_types.md
+++ b/docs/docs/language_concepts/data_types.md
@@ -93,4 +93,4 @@ fn main() {
 
 ### BigInt
 
-You can acheive BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.
+You can achieve BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.


### PR DESCRIPTION
minor typo fix in docs, nothing important

