### PR TITLE
chore: fix un-needed fully qualified path

### DIFF
--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -19,7 +19,7 @@ pub const FILE_EXTENSION: &str = "nr";
 
 pub struct FileManager {
     root: PathBuf,
-    file_map: file_map::FileMap,
+    file_map: FileMap,
     id_to_path: HashMap<FileId, PathBuf>,
     path_to_id: HashMap<PathBuf, FileId>,
     file_reader: Box<FileReader>,


### PR DESCRIPTION
# Description

Since we already import FileMap with the usepath, using fm::FileMap is redundant

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
