### PR TITLE
chore: re-export the items needed for the lsp from the fm crate instead of importing codespan_reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,6 @@ dependencies = [
  "async-lsp",
  "cfg-if",
  "codespan-lsp",
- "codespan-reporting",
  "fm",
  "lsp-types 0.94.1",
  "nargo",

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -7,6 +7,10 @@ mod file_map;
 mod file_reader;
 
 pub use file_map::{File, FileId, FileMap, PathString};
+
+// Re-export for the lsp
+pub use codespan_reporting::files as codespan_files;
+
 use file_reader::is_stdlib_asset;
 pub use file_reader::FileReader;
 

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace = true
 [dependencies]
 acvm.workspace = true
 codespan-lsp.workspace = true
-codespan-reporting.workspace = true
 lsp-types.workspace = true
 nargo.workspace = true
 nargo_fmt.workspace = true

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -17,7 +17,7 @@ use async_lsp::{
     router::Router, AnyEvent, AnyNotification, AnyRequest, ClientSocket, Error, LspService,
     ResponseError,
 };
-use codespan_reporting::files;
+use fm::codespan_files as files;
 use noirc_frontend::{
     graph::{CrateId, CrateName},
     hir::{Context, FunctionNameMatch},

--- a/tooling/lsp/src/requests/goto_definition.rs
+++ b/tooling/lsp/src/requests/goto_definition.rs
@@ -2,7 +2,7 @@ use std::future::{self, Future};
 
 use crate::{types::GotoDefinitionResult, LspState};
 use async_lsp::{ErrorCode, LanguageClient, ResponseError};
-use codespan_reporting::files::Error;
+use fm::codespan_files::Error;
 use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location};
 use lsp_types::{Position, Url};
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
@@ -98,7 +98,7 @@ fn to_lsp_location<'a, F>(
     definition_span: noirc_errors::Span,
 ) -> Option<Location>
 where
-    F: codespan_reporting::files::Files<'a> + ?Sized,
+    F: fm::codespan_files::Files<'a> + ?Sized,
 {
     let range = crate::byte_span_to_range(files, file_id, definition_span.into())?;
     let file_name = files.name(file_id).ok()?;
@@ -115,7 +115,7 @@ pub(crate) fn position_to_byte_index<'a, F>(
     position: &Position,
 ) -> Result<usize, Error>
 where
-    F: codespan_reporting::files::Files<'a> + ?Sized,
+    F: fm::codespan_files::Files<'a> + ?Sized,
 {
     let source = files.source(file_id)?;
     let source = source.as_ref();


### PR DESCRIPTION
# Description

This is a small change to control the scope of what the lsp touches and to see what the fm crate is offering to other crates in this workspace.

codespan_reporting is needed because the fm crate is using codespan

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
