### PR TITLE
chore: scope API usage for CrateData

### DIFF
--- a/aztec_macros/src/lib.rs
+++ b/aztec_macros/src/lib.rs
@@ -238,12 +238,14 @@ fn check_for_aztec_dependency(
     crate_id: &CrateId,
     context: &HirContext,
 ) -> Result<(), (MacroError, FileId)> {
-    let crate_graph = &context.crate_graph[crate_id];
-    let has_aztec_dependency = crate_graph.dependencies.iter().any(|dep| dep.as_name() == "aztec");
+    let crate_root_file_id = &context.crate_graph.root_file_id(*crate_id);
+    let crate_dependencies = &context.crate_graph.dependencies(*crate_id);
+
+    let has_aztec_dependency = crate_dependencies.iter().any(|dep| dep.as_name() == "aztec");
     if has_aztec_dependency {
         Ok(())
     } else {
-        Err((AztecMacroError::AztecNotFound.into(), crate_graph.root_file_id))
+        Err((AztecMacroError::AztecNotFound.into(), *crate_root_file_id))
     }
 }
 
@@ -306,11 +308,11 @@ fn transform_module(
     let storage_defined = check_for_storage_definition(module);
 
     if storage_defined && !check_for_compute_note_hash_and_nullifier_definition(module) {
-        let crate_graph = &context.crate_graph[crate_id];
+        let root_file_id = context.crate_graph.root_file_id(*crate_id);
         return Err((
             AztecMacroError::AztecComputeNoteHashAndNullifierNotFound { span: Span::default() }
                 .into(),
-            crate_graph.root_file_id,
+            root_file_id,
         ));
     }
 

--- a/compiler/fm/src/file_map.rs
+++ b/compiler/fm/src/file_map.rs
@@ -44,7 +44,7 @@ pub struct FileId(usize);
 
 impl FileId {
     //XXX: find a way to remove the need for this. Errors do not need to attach their FileIds immediately!
-    pub fn as_usize(&self) -> usize {
+    fn as_usize(&self) -> usize {
         self.0
     }
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -90,7 +90,6 @@ pub fn prepare_crate(context: &mut Context, file_name: &Path) -> CrateId {
 // Adds the file from the file system at `Path` to the crate graph
 pub fn prepare_dependency(context: &mut Context, file_name: &Path) -> CrateId {
     let root_file_id = context.file_manager.add_file(file_name).unwrap();
-
     let crate_id = context.crate_graph.add_crate(root_file_id);
 
     // Every dependency has access to stdlib

--- a/compiler/noirc_frontend/src/graph/mod.rs
+++ b/compiler/noirc_frontend/src/graph/mod.rs
@@ -110,8 +110,8 @@ pub const CHARACTER_BLACK_LIST: [char; 1] = ['-'];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrateData {
-    pub root_file_id: FileId,
-    pub dependencies: Vec<Dependency>,
+    root_file_id: FileId,
+    dependencies: Vec<Dependency>,
 }
 
 /// A dependency is a crate name and a crate_id
@@ -134,6 +134,31 @@ impl CrateGraph {
             .keys()
             .find(|crate_id| crate_id.is_root())
             .expect("ICE: A root crate should exist in the CrateGraph")
+    }
+
+    // Returns the root file id for a given crate id.
+    //
+    // Every crate has a root file which defines its module dependency graph.
+    //
+    // Note: Since there is a 1-1 link between the root file id and the crate id,
+    // the root file id can also be seen as an identifier for a crate.
+    //
+    // This method is especially needed when parsing a crate and figuring out
+    // where to start parsing from.
+    //
+    // Only the files that are indirectly or directly referenced by the root file
+    // will be parsed.
+    pub fn root_file_id(&self, crate_id: CrateId) -> FileId {
+        self[crate_id].root_file_id
+    }
+
+    // Returns all of the dependencies for a given crate id
+    //
+    // This is needed for dependency resolution;
+    // when compiling a crate, its dependencies must be resolved 
+    // and compiled first.
+    pub fn dependencies(&self, crate_id: CrateId) -> &[Dependency] {
+        &self[crate_id].dependencies
     }
 
     pub fn stdlib_crate_id(&self) -> &CrateId {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -208,9 +208,9 @@ impl DefCollector {
         // Dependencies are fetched from the crate graph
         // Then added these to the context of DefMaps once they are resolved
         //
-        let crate_graph = &context.crate_graph[crate_id];
+        let crate_dependencies = context.crate_graph.dependencies(crate_id).to_vec();
 
-        for dep in crate_graph.dependencies.clone() {
+        for dep in crate_dependencies {
             errors.extend(CrateDefMap::collect_defs(
                 dep.crate_id,
                 context,

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -85,7 +85,7 @@ impl CrateDefMap {
         }
 
         // First parse the root file.
-        let root_file_id = context.crate_graph[crate_id].root_file_id;
+        let root_file_id = context.crate_graph.root_file_id(crate_id);
         let (ast, parsing_errors) = parse_file(&context.file_manager, root_file_id);
         let mut ast = ast.into_sorted();
 

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -126,7 +126,7 @@ impl Context {
         crate_id: &CrateId,
         target_crate_id: &CrateId,
     ) -> Option<Vec<String>> {
-        for dep in &self.crate_graph[crate_id].dependencies {
+        for dep in self.crate_graph.dependencies(*crate_id) {
             if &dep.crate_id == target_crate_id {
                 return Some(vec![dep.name.to_string()]);
             }


### PR DESCRIPTION
# Description

This just reels in the API scope of CrateData a bit. I'm gonna leave this in draft as its not super important. 

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
