### PR TITLE
fix: add missing assertion to test

### DIFF
--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -297,7 +297,6 @@ mod test {
     #[test]
     fn rejects_noncanonical_fields() {
         let noncanonical_field = FieldElement::modulus().to_string();
-        let parsed_field = parse_str_to_field(&noncanonical_field);
-        println!("{parsed_field:?}");
+        assert!(parse_str_to_field(&noncanonical_field).is_err());
     }
 }


### PR DESCRIPTION
# Description

The test should be asserting that the parse method returns an error

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
