### PR TITLE
chore: conservatively use log::info instead of println for some expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "const_format",
  "dirs",
  "flate2",
+ "log",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1494,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +1934,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -1962,6 +1995,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -2160,7 +2199,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -2424,6 +2463,7 @@ dependencies = [
  "const_format",
  "criterion",
  "dirs",
+ "env_logger",
  "fm",
  "hex",
  "iai",
@@ -2744,7 +2784,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ const_format = "0.2.30"
 num-bigint = "0.4"
 num-traits = "0.2"
 similar-asserts = "1.5.0"
-log = "*" #TODO: use a specific version
+log = "0.4"
 
 [profile.dev]
 # This is required to be able to run `cargo test` in acvm_js due to the `locals exceeds maximum` error.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ const_format = "0.2.30"
 num-bigint = "0.4"
 num-traits = "0.2"
 similar-asserts = "1.5.0"
+log = "*" #TODO: use a specific version
 
 [profile.dev]
 # This is required to be able to run `cargo test` in acvm_js due to the `locals exceeds maximum` error.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ const_format = "0.2.30"
 num-bigint = "0.4"
 num-traits = "0.2"
 similar-asserts = "1.5.0"
-log = "0.4"
+log = "0.4.17"
 
 [profile.dev]
 # This is required to be able to run `cargo test` in acvm_js due to the `locals exceeds maximum` error.

--- a/acvm-repo/acvm_js/Cargo.toml
+++ b/acvm-repo/acvm_js/Cargo.toml
@@ -26,9 +26,9 @@ wasm-bindgen-futures.workspace = true
 console_error_panic_hook.workspace = true
 gloo-utils.workspace = true
 js-sys.workspace = true
+log.workspace = true
 
 serde = { version = "1.0.136", features = ["derive"] }
-log = "0.4.17"
 wasm-logger = "0.2.0"
 const-str = "0.5.5"
 

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -935,7 +935,6 @@ mod test {
         // }
         let ssa = ssa.flatten_cfg();
         let main = ssa.main();
-        println!("{ssa}");
         assert_eq!(main.reachable_blocks().len(), 1);
 
         let store_count = count_instruction(main, |ins| matches!(ins, Instruction::Store { .. }));

--- a/compiler/wasm/Cargo.toml
+++ b/compiler/wasm/Cargo.toml
@@ -24,8 +24,8 @@ js-sys.workspace = true
 cfg-if.workspace = true
 console_error_panic_hook.workspace = true
 gloo-utils.workspace = true
+log.workspace = true
 
-log = "0.4.17"
 wasm-logger = "0.2.0"
 
 # This is an unused dependency, we are adding it

--- a/tooling/backend_interface/Cargo.toml
+++ b/tooling/backend_interface/Cargo.toml
@@ -16,6 +16,7 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 bb_abstraction_leaks.workspace = true
+log.workspace = true
 
 tempfile = "3.6.0"
 

--- a/tooling/backend_interface/src/lib.rs
+++ b/tooling/backend_interface/src/lib.rs
@@ -116,7 +116,7 @@ impl Backend {
 
                 // If version doesn't match then download the correct version.
                 Ok(version_string) => {
-                    println!("`{ACVM_BACKEND_BARRETENBERG}` version `{version_string}` is different from expected `{BB_VERSION}`. Downloading expected version...");
+                    log::warn!("`{ACVM_BACKEND_BARRETENBERG}` version `{version_string}` is different from expected `{BB_VERSION}`. Downloading expected version...");
                     let bb_url = std::env::var("BB_BINARY_URL")
                         .unwrap_or_else(|_| bb_abstraction_leaks::BB_DOWNLOAD_URL.to_owned());
                     download_backend(&bb_url, binary_path)?;
@@ -124,7 +124,7 @@ impl Backend {
 
                 // If `bb` fails to report its version, then attempt to fix it by re-downloading the binary.
                 Err(_) => {
-                    println!("Could not determine version of `{ACVM_BACKEND_BARRETENBERG}`. Downloading expected version...");
+                    log::warn!("Could not determine version of `{ACVM_BACKEND_BARRETENBERG}`. Downloading expected version...");
                     let bb_url = std::env::var("BB_BINARY_URL")
                         .unwrap_or_else(|_| bb_abstraction_leaks::BB_DOWNLOAD_URL.to_owned());
                     download_backend(&bb_url, binary_path)?;

--- a/tooling/backend_interface/src/proof_system.rs
+++ b/tooling/backend_interface/src/proof_system.rs
@@ -43,7 +43,7 @@ impl Backend {
         if let Ok(backend_info) = self.get_backend_info() {
             (backend_info.0, backend_info.1)
         } else {
-            println!("No valid backend found, defaulting to Plonk with width 3 and all opcodes supported");
+            log::info!("No valid backend found, defaulting to Plonk with width 3 and all opcodes supported");
             (Language::PLONKCSat { width: 3 }, BackendOpcodeSupport::all())
         }
     }

--- a/tooling/backend_interface/src/proof_system.rs
+++ b/tooling/backend_interface/src/proof_system.rs
@@ -43,7 +43,7 @@ impl Backend {
         if let Ok(backend_info) = self.get_backend_info() {
             (backend_info.0, backend_info.1)
         } else {
-            log::info!("No valid backend found, defaulting to Plonk with width 3 and all opcodes supported");
+            log::warn!("No valid backend found, defaulting to Plonk with width 3 and all opcodes supported");
             (Language::PLONKCSat { width: 3 }, BackendOpcodeSupport::all())
         }
     }

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -46,6 +46,7 @@ hex.workspace = true
 similar-asserts.workspace = true
 termcolor = "1.1.2"
 color-eyre = "0.6.2"
+env_logger = "0.9.0"
 tokio = { version = "1.0", features = ["io-std"] }
 
 # Backends

--- a/tooling/nargo_cli/src/main.rs
+++ b/tooling/nargo_cli/src/main.rs
@@ -17,7 +17,7 @@ use env_logger::{Builder, Env};
 const PANIC_MESSAGE: &str = "This is a bug. We may have already fixed this in newer versions of Nargo so try searching for similar issues at https://github.com/noir-lang/noir/issues/.\nIf there isn't an open issue for this bug, consider opening one at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml";
 
 fn main() {
-    let env = Env::default().filter_or("NOIR_LOG", "error"); // Default to 'error' if NOIR is not set
+    let env = Env::default().filter_or("NOIR_LOG", "error"); // Default to 'error' if NOIR_LOG is not set
     Builder::from_env(env).init();
 
     // Register a panic hook to display more readable panic messages to end-users

--- a/tooling/nargo_cli/src/main.rs
+++ b/tooling/nargo_cli/src/main.rs
@@ -16,6 +16,7 @@ use color_eyre::config::HookBuilder;
 const PANIC_MESSAGE: &str = "This is a bug. We may have already fixed this in newer versions of Nargo so try searching for similar issues at https://github.com/noir-lang/noir/issues/.\nIf there isn't an open issue for this bug, consider opening one at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml";
 
 fn main() {
+    env_logger::init();
     // Register a panic hook to display more readable panic messages to end-users
     let (panic_hook, _) =
         HookBuilder::default().display_env_section(false).panic_section(PANIC_MESSAGE).into_hooks();

--- a/tooling/nargo_cli/src/main.rs
+++ b/tooling/nargo_cli/src/main.rs
@@ -12,11 +12,14 @@ mod cli;
 mod errors;
 
 use color_eyre::config::HookBuilder;
+use env_logger::{Builder, Env};
 
 const PANIC_MESSAGE: &str = "This is a bug. We may have already fixed this in newer versions of Nargo so try searching for similar issues at https://github.com/noir-lang/noir/issues/.\nIf there isn't an open issue for this bug, consider opening one at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml";
 
 fn main() {
-    env_logger::init();
+    let env = Env::default().filter_or("NOIR_LOG", "error"); // Default to 'error' if NOIR is not set
+    Builder::from_env(env).init();
+
     // Register a panic hook to display more readable panic messages to end-users
     let (panic_hook, _) =
         HookBuilder::default().display_env_section(false).panic_section(PANIC_MESSAGE).into_hooks();


### PR DESCRIPTION
# Description

If you want to see info level logs, you can do `NOIR_LOG=info nargo compile` by default if that environment variable is not set, then it will only print out error level logs

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
