### PR TITLE
fix: Allow trait method references from the trait name

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -334,6 +334,7 @@ pub fn compile_no_check(
     force_compile: bool,
 ) -> Result<CompiledProgram, RuntimeError> {
     let program = monomorphize(main_function, &context.def_interner);
+    println!("{}", program);
 
     let hash = fxhash::hash64(&program);
     let hashes_match = cached_program.as_ref().map_or(false, |program| program.hash == hash);

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -81,6 +81,7 @@ pub struct UnresolvedTrait {
     pub module_id: LocalModuleId,
     pub crate_id: CrateId,
     pub trait_def: NoirTrait,
+    pub method_ids: HashMap<String, FuncId>,
     pub fns_with_default_impl: UnresolvedFunctions,
 }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1,4 +1,4 @@
-use std::{vec, collections::HashMap};
+use std::{collections::HashMap, vec};
 
 use acvm::acir::acir_field::FieldOptions;
 use fm::FileId;

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1,4 +1,4 @@
-use std::vec;
+use std::{vec, collections::HashMap};
 
 use acvm::acir::acir_field::FieldOptions;
 use fm::FileId;
@@ -376,6 +376,8 @@ impl<'a> ModCollector<'a> {
                 functions: Vec::new(),
                 trait_id: None,
             };
+
+            let mut method_ids = HashMap::new();
             for trait_item in &trait_definition.items {
                 match trait_item {
                     TraitItem::Function {
@@ -387,6 +389,8 @@ impl<'a> ModCollector<'a> {
                         body,
                     } => {
                         let func_id = context.def_interner.push_empty_fn();
+                        method_ids.insert(name.to_string(), func_id);
+
                         let modifiers = FunctionModifiers {
                             name: name.to_string(),
                             visibility: crate::FunctionVisibility::Public,
@@ -401,9 +405,6 @@ impl<'a> ModCollector<'a> {
                         context
                             .def_interner
                             .push_function_definition(func_id, modifiers, trait_id.0, location);
-
-                        let the_trait = context.def_interner.get_trait_mut(trait_id);
-                        the_trait.method_ids.insert(name.to_string(), func_id);
 
                         match self.def_collector.def_map.modules[trait_id.0.local_id.0]
                             .declare_function(name.clone(), func_id)
@@ -474,6 +475,7 @@ impl<'a> ModCollector<'a> {
                 module_id: self.module_id,
                 crate_id: krate,
                 trait_def: trait_definition,
+                method_ids,
                 fns_with_default_impl: unresolved_functions,
             };
             self.def_collector.collected_traits.insert(trait_id, unresolved);

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -402,6 +402,9 @@ impl<'a> ModCollector<'a> {
                             .def_interner
                             .push_function_definition(func_id, modifiers, trait_id.0, location);
 
+                        let the_trait = context.def_interner.get_trait_mut(trait_id);
+                        the_trait.method_ids.insert(name.to_string(), func_id);
+
                         match self.def_collector.def_map.modules[trait_id.0.local_id.0]
                             .declare_function(name.clone(), func_id)
                         {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -349,7 +349,7 @@ impl<'a> ModCollector<'a> {
             let name = trait_definition.name.clone();
 
             // Create the corresponding module for the trait namespace
-            let id = match self.push_child_module(&name, self.file_id, false, false) {
+            let trait_id = match self.push_child_module(&name, self.file_id, false, false) {
                 Ok(local_id) => TraitId(ModuleId { krate, local_id }),
                 Err(error) => {
                     errors.push((error.into(), self.file_id));
@@ -359,7 +359,7 @@ impl<'a> ModCollector<'a> {
 
             // Add the trait to scope so its path can be looked up later
             let result =
-                self.def_collector.def_map.modules[self.module_id.0].declare_trait(name, id);
+                self.def_collector.def_map.modules[self.module_id.0].declare_trait(name, trait_id);
 
             if let Err((first_def, second_def)) = result {
                 let error = DefCollectorErrorKind::Duplicate {
@@ -400,9 +400,9 @@ impl<'a> ModCollector<'a> {
                         let location = Location::new(name.span(), self.file_id);
                         context
                             .def_interner
-                            .push_function_definition(func_id, modifiers, id.0, location);
+                            .push_function_definition(func_id, modifiers, trait_id.0, location);
 
-                        match self.def_collector.def_map.modules[id.0.local_id.0]
+                        match self.def_collector.def_map.modules[trait_id.0.local_id.0]
                             .declare_function(name.clone(), func_id)
                         {
                             Ok(()) => {
@@ -437,7 +437,7 @@ impl<'a> ModCollector<'a> {
                         let stmt_id = context.def_interner.push_empty_global();
 
                         if let Err((first_def, second_def)) = self.def_collector.def_map.modules
-                            [id.0.local_id.0]
+                            [trait_id.0.local_id.0]
                             .declare_global(name.clone(), stmt_id)
                         {
                             let error = DefCollectorErrorKind::Duplicate {
@@ -451,7 +451,7 @@ impl<'a> ModCollector<'a> {
                     TraitItem::Type { name } => {
                         // TODO(nickysn or alexvitkov): implement context.def_interner.push_empty_type_alias and get an id, instead of using TypeAliasId::dummy_id()
                         if let Err((first_def, second_def)) = self.def_collector.def_map.modules
-                            [id.0.local_id.0]
+                            [trait_id.0.local_id.0]
                             .declare_type_alias(name.clone(), TypeAliasId::dummy_id())
                         {
                             let error = DefCollectorErrorKind::Duplicate {
@@ -473,7 +473,7 @@ impl<'a> ModCollector<'a> {
                 trait_def: trait_definition,
                 fns_with_default_impl: unresolved_functions,
             };
-            self.def_collector.collected_traits.insert(id, unresolved);
+            self.def_collector.collected_traits.insert(trait_id, unresolved);
         }
         errors
     }

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -205,7 +205,7 @@ impl<'a> Resolver<'a> {
         name: &Ident,
         parameters: &[(Ident, UnresolvedType)],
         return_type: &FunctionReturnType,
-        where_clause: &Vec<UnresolvedTraitConstraint>,
+        where_clause: &[UnresolvedTraitConstraint],
         func_id: FuncId,
     ) -> (HirFunction, FuncMeta) {
         self.scopes.start_function();
@@ -213,7 +213,7 @@ impl<'a> Resolver<'a> {
         // Check whether the function has globals in the local module and add them to the scope
         self.resolve_local_globals();
 
-        self.trait_bounds = where_clause.clone();
+        self.trait_bounds = where_clause.to_vec();
 
         let kind = FunctionKind::Normal;
         let def = FunctionDefinition {
@@ -232,7 +232,7 @@ impl<'a> Resolver<'a> {
             }),
             body: BlockExpression(Vec::new()),
             span: name.span(),
-            where_clause: where_clause.clone(),
+            where_clause: where_clause.to_vec(),
             return_type: return_type.clone(),
             return_visibility: Visibility::Private,
             return_distinctness: Distinctness::DuplicationAllowed,
@@ -1662,7 +1662,7 @@ impl<'a> Resolver<'a> {
             let the_trait = self.interner.get_trait(trait_id);
 
             if let Some(method) = the_trait.find_method(method.0.contents.as_str()) {
-                let self_type = self.interner.next_type_variable();
+                let self_type = Type::type_variable(the_trait.self_type_typevar_id);
                 return Some((HirExpression::TraitMethodReference(method), self_type));
             }
         }

--- a/compiler/noirc_frontend/src/hir/resolution/traits.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/traits.rs
@@ -110,7 +110,13 @@ fn resolve_trait_methods(
             resolver.set_self_type(Some(self_type));
 
             let func_id = unresolved_trait.method_ids[&name.0.contents];
-            let (_, func_meta) = resolver.resolve_trait_function(name, parameters, return_type, where_clause, func_id);
+            let (_, func_meta) = resolver.resolve_trait_function(
+                name,
+                parameters,
+                return_type,
+                where_clause,
+                func_id,
+            );
             resolver.interner.push_fn_meta(func_meta, func_id);
 
             let arguments = vecmap(parameters, |param| resolver.resolve_type(param.1.clone()));
@@ -154,9 +160,12 @@ fn resolve_trait_methods(
                 default_impl_module_id: unresolved_trait.module_id,
             };
             functions.push(f);
-            resolver_errors.extend(resolver.take_errors()
-                .into_iter()
-                .map(|resolution_error| (resolution_error.into(), file)))
+            resolver_errors.extend(
+                resolver
+                    .take_errors()
+                    .into_iter()
+                    .map(|resolution_error| (resolution_error.into(), file)),
+            )
         }
     }
     (functions, resolver_errors)

--- a/compiler/noirc_frontend/src/hir/resolution/traits.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/traits.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use fm::FileId;
 use iter_extended::vecmap;
-use noirc_errors::{Location, Span};
+use noirc_errors::Location;
 
 use crate::{
     graph::CrateId,
@@ -133,14 +133,13 @@ fn resolve_trait_methods(
             let the_trait = resolver.interner.get_trait(trait_id);
             generics.push((the_trait.self_type_typevar_id, the_trait.self_type_typevar.clone()));
 
-            let name = name.clone();
-            let span: Span = name.span();
             let default_impl_list: Vec<_> = unresolved_trait
                 .fns_with_default_impl
                 .functions
                 .iter()
                 .filter(|(_, _, q)| q.name() == name.0.contents)
                 .collect();
+
             let default_impl = if default_impl_list.len() == 1 {
                 Some(Box::new(default_impl_list[0].2.clone()))
             } else {
@@ -149,23 +148,18 @@ fn resolve_trait_methods(
 
             let no_environment = Box::new(Type::Unit);
             let function_type = Type::Function(arguments, Box::new(return_type), no_environment);
-            let typ = Type::Forall(generics, Box::new(function_type));
 
-            let f = TraitFunction {
-                name,
-                typ,
-                span,
+            functions.push(TraitFunction {
+                name: name.clone(),
+                typ: Type::Forall(generics, Box::new(function_type)),
+                span: name.span(),
                 default_impl,
                 default_impl_file_id: unresolved_trait.file_id,
                 default_impl_module_id: unresolved_trait.module_id,
-            };
-            functions.push(f);
-            resolver_errors.extend(
-                resolver
-                    .take_errors()
-                    .into_iter()
-                    .map(|resolution_error| (resolution_error.into(), file)),
-            )
+            });
+
+            let errors = resolver.take_errors().into_iter();
+            resolver_errors.extend(errors.map(|resolution_error| (resolution_error.into(), file)));
         }
     }
     (functions, resolver_errors)

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -891,7 +891,9 @@ impl<'interner> TypeChecker<'interner> {
                     }
                 }
             }
-            Type::TraitAsType(_trait) => {
+            // TODO: We should allow method calls on `impl Trait`s eventually.
+            //       For now it is fine since they are only allowed on return types.
+            Type::TraitAsType(..) => {
                 self.errors.push(TypeCheckError::UnresolvedMethodCall {
                     method_name: method_name.to_string(),
                     object_type: object_type.clone(),

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -101,8 +101,8 @@ pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<Type
     if !can_ignore_ret {
         let (expr_span, empty_function) = function_info(interner, function_body_id);
         let func_span = interner.expr_span(function_body_id); // XXX: We could be more specific and return the span of the last stmt, however stmts do not have spans yet
-        if let Type::TraitAsType(t) = &declared_return_type {
-            if interner.lookup_trait_implementation(&function_last_type, t.id).is_err() {
+        if let Type::TraitAsType(trait_id, _) = &declared_return_type {
+            if interner.lookup_trait_implementation(&function_last_type, *trait_id).is_err() {
                 let error = TypeCheckError::TypeMismatchWithSource {
                     expected: declared_return_type.clone(),
                     actual: function_last_type,

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -106,30 +106,6 @@ impl PartialEq for Trait {
 }
 
 impl Trait {
-    pub fn new(
-        id: TraitId,
-        name: Ident,
-        crate_id: CrateId,
-        span: Span,
-        generics: Generics,
-        self_type_typevar_id: TypeVariableId,
-        self_type_typevar: TypeVariable,
-    ) -> Trait {
-        Trait {
-            id,
-            name,
-            crate_id,
-            span,
-            methods: Vec::new(),
-            method_ids: HashMap::new(),
-            constants: Vec::new(),
-            types: Vec::new(),
-            generics,
-            self_type_typevar_id,
-            self_type_typevar,
-        }
-    }
-
     pub fn set_methods(&mut self, methods: Vec<TraitFunction>) {
         self.methods = methods;
     }

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -35,7 +35,7 @@ pub struct TraitType {
 /// Represents a trait in the type system. Each instance of this struct
 /// will be shared across all Type::Trait variants that represent
 /// the same trait.
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Eq)]
 pub struct Trait {
     /// A unique id representing this trait type. Used to check if two
     /// struct traits are equal.

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{
     graph::CrateId,
     node_interner::{FuncId, TraitId, TraitMethodId},
@@ -42,6 +44,13 @@ pub struct Trait {
     pub crate_id: CrateId,
 
     pub methods: Vec<TraitFunction>,
+
+    /// Maps method_name -> method id.
+    /// This map is separate from methods since TraitFunction ids
+    /// are created during collection where we don't yet have all
+    /// the information needed to create the full TraitFunction.
+    pub method_ids: HashMap<String, FuncId>,
+
     pub constants: Vec<TraitConstant>,
     pub types: Vec<TraitType>,
 
@@ -112,6 +121,7 @@ impl Trait {
             crate_id,
             span,
             methods: Vec::new(),
+            method_ids: HashMap::new(),
             constants: Vec::new(),
             types: Vec::new(),
             generics,
@@ -124,9 +134,9 @@ impl Trait {
         self.methods = methods;
     }
 
-    pub fn find_method(&self, name: Ident) -> Option<TraitMethodId> {
+    pub fn find_method(&self, name: &str) -> Option<TraitMethodId> {
         for (idx, method) in self.methods.iter().enumerate() {
-            if method.name == name {
+            if &method.name == name {
                 return Some(TraitMethodId { trait_id: self.id, method_index: idx });
             }
         }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -231,7 +231,7 @@ impl<'interner> Monomorphizer<'interner> {
         let body_expr_id = *self.interner.function(&f).as_expr();
         let body_return_type = self.interner.id_type(body_expr_id);
         let return_type = self.convert_type(match meta.return_type() {
-            Type::TraitAsType(_) => &body_return_type,
+            Type::TraitAsType(..) => &body_return_type,
             _ => meta.return_type(),
         });
 
@@ -720,7 +720,7 @@ impl<'interner> Monomorphizer<'interner> {
                     ast::Type::Slice(element)
                 }
             }
-            HirType::TraitAsType(_) => {
+            HirType::TraitAsType(..) => {
                 unreachable!("All TraitAsType should be replaced before calling convert_type");
             }
             HirType::NamedGeneric(binding, _) => {

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -757,6 +757,9 @@ impl NodeInterner {
 
     /// Returns the interned meta data corresponding to `func_id`
     pub fn function_meta(&self, func_id: &FuncId) -> FuncMeta {
+        if !self.func_meta.contains_key(func_id) {
+            eprintln!("No entry for key {:?}", func_id);
+        }
         self.func_meta.get(func_id).cloned().expect("ice: all function ids should have metadata")
     }
 
@@ -863,12 +866,16 @@ impl NodeInterner {
         self.structs[&id].clone()
     }
 
-    pub fn get_trait(&self, id: TraitId) -> Trait {
-        self.traits[&id].clone()
+    pub fn get_trait(&self, id: TraitId) -> &Trait {
+        &self.traits[&id]
     }
 
-    pub fn try_get_trait(&self, id: TraitId) -> Option<Trait> {
-        self.traits.get(&id).cloned()
+    pub fn get_trait_mut(&mut self, id: TraitId) -> &mut Trait {
+        self.traits.get_mut(&id).expect("get_trait_mut given invalid TraitId")
+    }
+
+    pub fn try_get_trait(&self, id: TraitId) -> Option<&Trait> {
+        self.traits.get(&id)
     }
 
     pub fn get_type_alias(&self, id: TypeAliasId) -> &TypeAliasType {
@@ -892,7 +899,7 @@ impl NodeInterner {
         let typ = self.id_type(def_id);
         if let Type::Function(args, ret, env) = &typ {
             let def = self.definition(def_id);
-            if let Type::TraitAsType(_trait) = ret.as_ref() {
+            if let Type::TraitAsType(..) = ret.as_ref() {
                 if let DefinitionKind::Function(func_id) = def.kind {
                     let f = self.function(&func_id);
                     let func_body = f.as_expr();
@@ -1382,6 +1389,6 @@ fn get_type_method_key(typ: &Type) -> Option<TypeMethodKey> {
         | Type::Error
         | Type::NotConstant
         | Type::Struct(_, _)
-        | Type::TraitAsType(_) => None,
+        | Type::TraitAsType(..) => None,
     }
 }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1258,11 +1258,19 @@ impl NodeInterner {
         self.selected_trait_implementations.insert(ident_id, trait_impl);
     }
 
-    /// Tags the given identifier with the selected trait_impl so that monomorphization
-    /// can later recover which impl was selected, or alternatively see if it needs to
-    /// decide which (because the impl was Assumed).
+    /// Retrieves the impl selected for a given IdentId during name resolution.
+    /// From type checking and on, the "ident" referred to is changed to a TraitMethodReference node.
     pub fn get_selected_impl_for_ident(&self, ident_id: ExprId) -> Option<TraitImplKind> {
         self.selected_trait_implementations.get(&ident_id).cloned()
+    }
+
+    /// Retrieves a mutable reference to the impl selected for a given IdentId during name resolution.
+    /// From type checking and on, the "ident" referred to is changed to a TraitMethodReference node.
+    pub fn get_selected_impl_for_ident_mut(
+        &mut self,
+        ident_id: ExprId,
+    ) -> Option<&mut TraitImplKind> {
+        self.selected_trait_implementations.get_mut(&ident_id)
     }
 
     /// For a given [Index] we return [Location] to which we resolved to

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -161,7 +161,7 @@ impl AbiType {
             Type::Error => unreachable!(),
             Type::Unit => unreachable!(),
             Type::Constant(_) => unreachable!(),
-            Type::TraitAsType(_) => unreachable!(),
+            Type::TraitAsType(..) => unreachable!(),
             Type::Struct(def, ref args) => {
                 let struct_type = def.borrow();
                 let fields = struct_type.get_fields(args);


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3773

## Summary\*

This PR implements the ability to be able to call trait methods such as `Default::default()` where previously we required `StructName::default()`. The specific impl is selected via type inference. Previously, this resulted in a compiler panic.

## Additional Context

When a trait method's type isn't constrained enough or is otherwise still ambiguous after type inference, the compiler currently just selects the first trait implementation that matches. E.g. `let _ = Default::default();`. This is a separate issue, so I'll create a new issue for this.

## Documentation\*

Check one:
- [ ] No documentation needed. 
- [ ] Documentation included in this PR.
- [x] **[Exceptional Case]** Documentation to be submitted in a separate PR.
  - I think traits are finally stable enough to start writing documentation for. I'm going to submit another PR to remove some of the experimental warnings the compiler has for traits, and with it add documentation for traits as well. This wouldn't stabilize all trait features (e.g. associated types are still unimplemented), but users will now be able to use basic traits with functions without warnings. Any unimplemented trait items (associated types again) will not be included in the documentation.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
