### PR TITLE
chore: Improve error message in tests

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -201,8 +201,8 @@ fn compile_success_empty_{test_name}() {{
     }}
 
     // `compile_success_empty` tests should be able to compile down to an empty circuit.
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|| {{
-        panic!("JSON was not well-formatted {{}}",output.stdout)
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {{
+        panic!("JSON was not well-formatted {{:?}}",output.stdout)
     }});
     let num_opcodes = &json["programs"][0]["acir_opcodes"];
     assert_eq!(num_opcodes.as_u64().unwrap(), 0);

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -201,7 +201,9 @@ fn compile_success_empty_{test_name}() {{
     }}
 
     // `compile_success_empty` tests should be able to compile down to an empty circuit.
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON was not well-formatted");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|| {{
+        panic!("JSON was not well-formatted {{}}",output.stdout)
+    }});
     let num_opcodes = &json["programs"][0]["acir_opcodes"];
     assert_eq!(num_opcodes.as_u64().unwrap(), 0);
 }}


### PR DESCRIPTION
# Description

@jfecher noted that occassionally the JSON conversion method would fail. This changes `expect` to `unwrap_or_else` so that we know exactly what stdout input the error is failing on. 

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
