### PR TITLE
fix: remove `noirc_driver/aztec` feature flag in docker

### DIFF
--- a/.github/workflows/test-cargo.yml
+++ b/.github/workflows/test-cargo.yml
@@ -1,9 +1,16 @@
 name: Test cargo
 
 on:
+  pull_request:
+  merge_group:
   push:
     branches:
-      - 'master'
+      - master
+
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -1,9 +1,17 @@
 name: Test JS packages
 
 on:
+  pull_request:
+  merge_group:
   push:
     branches:
-      - 'master'
+      - master
+
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 
 jobs:
   build:

--- a/scripts/bootstrap_native.sh
+++ b/scripts/bootstrap_native.sh
@@ -13,4 +13,4 @@ else
 fi
 
 # Build native.
-cargo build --features="noirc_driver/aztec" --release
+cargo build --release

--- a/scripts/bootstrap_packages.sh
+++ b/scripts/bootstrap_packages.sh
@@ -14,8 +14,6 @@ else
   export GIT_COMMIT=$(git rev-parse --verify HEAD)
 fi
 
-export cargoExtraArgs="--features noirc_driver/aztec"
-
 yarn
 yarn build
 

--- a/scripts/test_js_packages.sh
+++ b/scripts/test_js_packages.sh
@@ -14,9 +14,7 @@ else
   export GIT_COMMIT=$(git rev-parse --verify HEAD)
 fi
 
-export cargoExtraArgs="--features noirc_driver/aztec"
-
-cargo build --features="noirc_driver/aztec" --release
+cargo build --release
 export PATH="${PATH}:/usr/src/noir/target/release/"
 
 yarn


### PR DESCRIPTION
# Description

This was not caught because the docker tests are not required checks and it was only being ran on master. 

They are not required because they need to be optimized a bit more with caching. I don't expect them to fail often, so in the interim, its okay to not have these as required (If this happens again and we have not migrated, then we can revisit)

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
