### PR TITLE
fix(lsp): package resolution on save

### DIFF
--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -24,6 +24,27 @@ mod semver;
 pub use errors::ManifestError;
 use git::clone_git_repo;
 
+/// Searches for a `Nargo.toml` file in the current directory and all parent directories.
+/// For example, if the current directory is `/workspace/package/src`, then this function
+/// will search for a `Nargo.toml` file in
+/// * `/workspace/package/src`,
+/// * `/workspace/package`,
+/// * `/workspace`.
+///
+/// Returns the [PathBuf] of the `Nargo.toml` file if found, otherwise returns None.
+///
+/// It will return innermost `Nargo.toml` file, which is the one closest to the current directory.
+/// For example, if the current directory is `/workspace/package/src`, then this function
+/// will return the `Nargo.toml` file in `/workspace/package/Nargo.toml`
+pub fn find_file_manifest(current_path: &Path) -> Option<PathBuf> {
+    for path in current_path.ancestors() {
+        if let Ok(toml_path) = get_package_manifest(path) {
+            return Some(toml_path);
+        }
+    }
+    None
+}
+
 /// Returns the [PathBuf] of the directory containing the `Nargo.toml` by searching from `current_path` to the root of its [Path].
 ///
 /// Returns a [ManifestError] if no parent directories of `current_path` contain a manifest file.


### PR DESCRIPTION

# Description

## Problem\*

## Summary\*

While saving file - procedure of compiling package should be applied to single package rather than all packages available in workspace.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
