### PR TITLE
chore(ci): enforce timeouts on build and test workflows

### DIFF
--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -30,6 +30,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -120,6 +121,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build-nargo:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Noir repo
@@ -47,6 +48,7 @@ jobs:
 
   build-noir-wasm:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout sources
@@ -76,6 +78,8 @@ jobs:
 
   build-acvm-js:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -103,6 +107,7 @@ jobs:
 
   build-noirc-abi:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout sources
@@ -133,6 +138,7 @@ jobs:
     needs: [build-acvm-js]
     name: ACVM JS (Node.js)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout sources
@@ -154,6 +160,7 @@ jobs:
     needs: [build-acvm-js]
     name: ACVM JS (Browser)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout sources
@@ -180,6 +187,7 @@ jobs:
     needs: [build-noirc-abi]
     name: noirc_abi
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout sources
@@ -265,12 +273,12 @@ jobs:
           yarn workspace @noir-lang/noir_js build
           yarn workspace @noir-lang/noir_js test
 
-  
-
   test-noir-wasm:
     needs: [build-noir-wasm, build-nargo]
     name: noir_wasm
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -314,6 +322,8 @@ jobs:
     needs: [build-acvm-js, build-noirc-abi]
     name: noir_codegen
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -346,7 +356,8 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [build-acvm-js, build-noir-wasm, build-nargo, build-noirc-abi]
-   
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a timeout to all of the jobs which are likely to spin out for a long time.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
