### PR TITLE
feat!: update `compute_note_hash_and_nullifier` compiler check

### DIFF
--- a/aztec_macros/src/lib.rs
+++ b/aztec_macros/src/lib.rs
@@ -252,12 +252,15 @@ fn check_for_storage_definition(module: &SortedModule) -> bool {
     module.types.iter().any(|r#struct| r#struct.name.0.contents == "Storage")
 }
 
-// Check if "compute_note_hash_and_nullifier(Field,Field,Field,[Field; N]) -> [Field; 4]" is defined
+// Check if "compute_note_hash_and_nullifier(AztecAddress,Field,Field,[Field; N]) -> [Field; 4]" is defined
 fn check_for_compute_note_hash_and_nullifier_definition(module: &SortedModule) -> bool {
     module.functions.iter().any(|func| {
         func.def.name.0.contents == "compute_note_hash_and_nullifier"
                 && func.def.parameters.len() == 4
-                && func.def.parameters[0].typ.typ == UnresolvedTypeData::FieldElement
+                && match &func.def.parameters[0].typ.typ {
+                    UnresolvedTypeData::Named(path, _) => path.segments.last().unwrap().0.contents == "AztecAddress",
+                    _ => false,
+                }
                 && func.def.parameters[1].typ.typ == UnresolvedTypeData::FieldElement
                 && func.def.parameters[2].typ.typ == UnresolvedTypeData::FieldElement
                 // checks if the 4th parameter is an array and the Box<UnresolvedType> in


### PR DESCRIPTION
Fixes https://github.com/AztecProtocol/aztec-packages/issues/3669

It's desirable to have nicely typed args in our noir contracts and for this reason I want to change signature of `compute_note_hash_and_nullifier` from:
`compute_note_hash_and_nullifier(Field,Field,Field,[Field; N]) -> [Field; 4]`

to:
`compute_note_hash_and_nullifier(AztecAddress,Field,Field,[Field; N]) -> [Field; 4]`

This PR updates the corresponding compiler check so that this can be achieved.