### PR TITLE
chore: Remove `ssa::value::Value` to greatly reduce memory usage

### DIFF
--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Clone, Debug, Hash, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, Copy, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 #[cfg_attr(test, derive(EnumIter))]
 pub enum BlackBoxFunc {
     /// Bitwise AND.

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -46,7 +46,7 @@ pub(crate) fn optimize_into_acir(
         .run_pass(Ssa::defunctionalize, "After Defunctionalization:")
         .run_pass(Ssa::inline_functions, "After Inlining:")
         // Run mem2reg with the CFG separated into blocks
-        .run_pass(Ssa::mem2reg, "After Mem2Reg:")
+        // .run_pass(Ssa::mem2reg, "After Mem2Reg:")
         .try_run_pass(Ssa::evaluate_assert_constant, "After Assert Constant:")?
         .try_run_pass(Ssa::unroll_loops, "After Unrolling:")?
         .run_pass(Ssa::simplify_cfg, "After Simplifying:")
@@ -179,6 +179,7 @@ impl SsaBuilder {
 
     /// Runs the given SSA pass and prints the SSA afterward if `print_ssa_passes` is true.
     fn run_pass(mut self, pass: fn(Ssa) -> Ssa, msg: &str) -> Self {
+        println!("On pass {msg}");
         self.ssa = pass(self.ssa);
         self.print(msg)
     }
@@ -189,6 +190,7 @@ impl SsaBuilder {
         pass: fn(Ssa) -> Result<Ssa, RuntimeError>,
         msg: &str,
     ) -> Result<Self, RuntimeError> {
+        println!("On pass {msg}");
         self.ssa = pass(self.ssa)?;
         Ok(self.print(msg))
     }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -92,9 +92,7 @@ impl<'a> From<&'a SsaType> for AcirType {
 /// `Variables`(AcirVar) and types such as `Expression` and `Witness`
 /// which are placed into ACIR.
 pub(crate) struct AcirContext {
-    /// Two-way map that links `AcirVar` to `AcirVarData`.
-    ///
-    /// The vars object is an instance of the `TwoWayMap`, which provides a bidirectional mapping between `AcirVar` and `AcirVarData`.
+    /// Map that links `AcirVar` to `AcirVarData`.
     vars: HashMap<AcirVar, AcirVarData>,
 
     constant_witnesses: HashMap<FieldElement, Witness>,

--- a/compiler/noirc_evaluator/src/ssa/ir/basic_block.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/basic_block.rs
@@ -2,6 +2,7 @@ use super::{
     dfg::CallStack,
     instruction::{InstructionId, TerminatorInstruction},
     map::Id,
+    types::Type,
     value::ValueId,
 };
 
@@ -14,7 +15,7 @@ use super::{
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) struct BasicBlock {
     /// Parameters to the basic block.
-    parameters: Vec<ValueId>,
+    parameter_types: Vec<Type>,
 
     /// Instructions in the basic block.
     instructions: Vec<InstructionId>,
@@ -33,30 +34,28 @@ impl BasicBlock {
     /// Create a new BasicBlock with the given parameters.
     /// Parameters can also be added later via BasicBlock::add_parameter
     pub(crate) fn new() -> Self {
-        Self { parameters: Vec::new(), instructions: Vec::new(), terminator: None }
+        Self { parameter_types: Vec::new(), instructions: Vec::new(), terminator: None }
     }
 
-    /// Returns the parameters of this block
-    pub(crate) fn parameters(&self) -> &[ValueId] {
-        &self.parameters
-    }
-
-    /// Removes all the parameters of this block
-    pub(crate) fn take_parameters(&mut self) -> Vec<ValueId> {
-        std::mem::take(&mut self.parameters)
+    /// The number of parameters this basic block has
+    pub(crate) fn parameter_count(&self) -> u32 {
+        self.parameter_types.len() as u32
     }
 
     /// Adds a parameter to this BasicBlock.
-    /// Expects that the ValueId given should refer to a Value::Param
-    /// instance with its position equal to self.parameters.len().
-    pub(crate) fn add_parameter(&mut self, parameter: ValueId) {
-        self.parameters.push(parameter);
+    pub(crate) fn add_parameter(&mut self, parameter_type: Type) {
+        self.parameter_types.push(parameter_type);
     }
 
-    /// Replace this block's current parameters with that of the given Vec.
-    /// This does not perform any checks that any previous parameters were unused.
-    pub(crate) fn set_parameters(&mut self, parameters: Vec<ValueId>) {
-        self.parameters = parameters;
+    /// Returns the types of this block's parameters
+    pub(crate) fn get_parameter_types(&self) -> &[Type] {
+        &self.parameter_types
+    }
+
+    /// Replace this block's current parameter types with that of the given Vec.
+    /// The given Vec is allowed to be a different number of parameters than the block originally had.
+    pub(crate) fn set_parameter_types(&mut self, parameter_types: Vec<Type>) {
+        self.parameter_types = parameter_types;
     }
 
     /// Insert an instruction at the end of this block

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -8,9 +8,9 @@ use super::{
     instruction::{
         Instruction, InstructionId, InstructionResultType, Intrinsic, TerminatorInstruction,
     },
-    map::DenseMap,
+    map::{DenseMap, TwoWayMap},
     types::Type,
-    value::{Value, ValueId},
+    value::{ValueId, NumericConstantId, NumericConstant, ForeignFunctionNameId, ForeignFunctionName, ArrayId, ArrayOrSlice},
 };
 
 use acvm::FieldElement;
@@ -27,39 +27,17 @@ pub(crate) struct DataFlowGraph {
     /// All of the instructions in a function
     instructions: DenseMap<Instruction>,
 
-    /// Stores the results for a particular instruction.
-    ///
-    /// An instruction may return multiple values
-    /// and for this, we will also use the cranelift strategy
-    /// to fetch them via indices.
-    ///
-    /// Currently, we need to define them in a better way
-    /// Call instructions require the func signature, but
-    /// other instructions may need some more reading on my part
-    results: HashMap<InstructionId, Vec<ValueId>>,
-
-    /// Storage for all of the values defined in this
-    /// function.
-    values: DenseMap<Value>,
-
     /// Each constant is unique, attempting to insert the same constant
     /// twice will return the same ValueId.
-    constants: HashMap<(FieldElement, Type), ValueId>,
-
-    /// Contains each function that has been imported into the current function.
-    /// Each function's Value::Function is uniqued here so any given FunctionId
-    /// will always have the same ValueId within this function.
-    functions: HashMap<FunctionId, ValueId>,
-
-    /// Contains each intrinsic that has been imported into the current function.
-    /// This map is used to ensure that the ValueId for any given intrinsic is always
-    /// represented by only 1 ValueId within this function.
-    intrinsics: HashMap<Intrinsic, ValueId>,
+    numeric_constants: TwoWayMap<NumericConstantId, NumericConstant>,
 
     /// Contains each foreign function that has been imported into the current function.
     /// This map is used to ensure that the ValueId for any given foreign functôn is always
     /// represented by only 1 ValueId within this function.
-    foreign_functions: HashMap<String, ValueId>,
+    foreign_functions: TwoWayMap<ForeignFunctionNameId, ForeignFunctionName>,
+
+    /// Each array that may be used by this IR
+    arrays: DenseMap<ArrayOrSlice>,
 
     /// All blocks in a function
     blocks: DenseMap<BasicBlock>,

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -29,7 +29,7 @@ pub(crate) type InstructionId = Id<Instruction>;
 /// - Opcodes which have no function definition in the
 /// source code and must be processed by the IR. An example
 /// of this is println.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum Intrinsic {
     Sort,
     ArrayLen,
@@ -125,7 +125,7 @@ impl Intrinsic {
 }
 
 /// The endian-ness of bits when encoding values as bits in e.g. ToBits or ToRadix
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Endian {
     Big,
     Little,

--- a/compiler/noirc_evaluator/src/ssa/ir/map.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/map.rs
@@ -1,7 +1,7 @@
 use fxhash::FxHashMap as HashMap;
 use std::{
     hash::Hash,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
 };
 
 /// A unique ID corresponding to a value of type T.
@@ -13,7 +13,7 @@ use std::{
 /// particular map type, users need to take care not to use it with
 /// another map where it will likely be invalid.
 pub(crate) struct Id<T> {
-    index: usize,
+    index: u32,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -21,12 +21,12 @@ impl<T> Id<T> {
     /// Constructs a new Id for the given index.
     /// This constructor is deliberately private to prevent
     /// constructing invalid IDs.
-    fn new(index: usize) -> Self {
+    fn new(index: u32) -> Self {
         Self { index, _marker: std::marker::PhantomData }
     }
 
     /// Returns the underlying index of this Id.
-    pub(crate) fn to_usize(self) -> usize {
+    pub(crate) fn to_u32(self) -> u32 {
         self.index
     }
 
@@ -34,9 +34,9 @@ impl<T> Id<T> {
     /// The name of this function makes it apparent it should only
     /// be used for testing. Obtaining Ids in this way should be avoided
     /// as unlike DenseMap::push and SparseMap::push, the Ids created
-    /// here are likely invalid for any particularly map.
+    /// here may be invalid for a map without additional work.
     #[cfg(test)]
-    pub(crate) fn test_new(index: usize) -> Self {
+    pub(crate) fn test_new(index: u32) -> Self {
         Self::new(index)
     }
 }
@@ -92,12 +92,6 @@ impl std::fmt::Display for Id<super::basic_block::BasicBlock> {
     }
 }
 
-impl std::fmt::Display for Id<super::value::Value> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "v{}", self.index)
-    }
-}
-
 impl std::fmt::Display for Id<super::function::Function> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "f{}", self.index)
@@ -106,7 +100,7 @@ impl std::fmt::Display for Id<super::function::Function> {
 
 impl std::fmt::Display for Id<super::instruction::Instruction> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "f{}", self.index)
+        write!(f, "i{}", self.index)
     }
 }
 
@@ -129,7 +123,7 @@ impl<T> DenseMap<T> {
     /// Adds an element to the map.
     /// Returns the identifier/reference to that element.
     pub(crate) fn insert(&mut self, element: T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len() as u32);
         self.storage.push(element);
         id
     }
@@ -137,7 +131,7 @@ impl<T> DenseMap<T> {
     /// Given the Id of the element being created, adds the element
     /// returned by the given function to the map
     pub(crate) fn insert_with_id(&mut self, f: impl FnOnce(Id<T>) -> T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len() as u32);
         self.storage.push(f(id));
         id
     }
@@ -146,7 +140,7 @@ impl<T> DenseMap<T> {
     ///
     /// The id-element pairs are ordered by the numeric values of the ids.
     pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = (Id<T>, &T)> {
-        let ids_iter = (0..self.storage.len()).map(|idx| Id::new(idx));
+        let ids_iter = (0..self.storage.len()).map(|idx| Id::new(idx as u32));
         ids_iter.zip(self.storage.iter())
     }
 }
@@ -161,13 +155,13 @@ impl<T> std::ops::Index<Id<T>> for DenseMap<T> {
     type Output = T;
 
     fn index(&self, id: Id<T>) -> &Self::Output {
-        &self.storage[id.index]
+        &self.storage[id.index as usize]
     }
 }
 
 impl<T> std::ops::IndexMut<Id<T>> for DenseMap<T> {
     fn index_mut(&mut self, id: Id<T>) -> &mut Self::Output {
-        &mut self.storage[id.index]
+        &mut self.storage[id.index as usize]
     }
 }
 
@@ -195,7 +189,7 @@ impl<T> SparseMap<T> {
     /// Adds an element to the map.
     /// Returns the identifier/reference to that element.
     pub(crate) fn insert(&mut self, element: T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len() as u32);
         self.storage.insert(id, element);
         id
     }
@@ -203,7 +197,7 @@ impl<T> SparseMap<T> {
     /// Given the Id of the element being created, adds the element
     /// returned by the given function to the map
     pub(crate) fn insert_with_id(&mut self, f: impl FnOnce(Id<T>) -> T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len() as u32);
         self.storage.insert(id, f(id));
         id
     }
@@ -299,10 +293,10 @@ impl<K: Eq + Hash, V> std::ops::Index<&K> for TwoWayMap<K, V> {
 /// Useful for assigning ids before the storage is created or assigning ids
 /// for types that have no single owner.
 ///
-/// This type wraps an AtomicUsize so it can safely be used across threads.
+/// This type wraps an AtomicU32 so it can safely be used across threads.
 #[derive(Debug)]
 pub(crate) struct AtomicCounter<T> {
-    next: AtomicUsize,
+    next: AtomicU32,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -310,7 +304,7 @@ impl<T> AtomicCounter<T> {
     /// Create a new counter starting after the given Id.
     /// Use AtomicCounter::default() to start at zero.
     pub(crate) fn starting_after(id: Id<T>) -> Self {
-        Self { next: AtomicUsize::new(id.index + 1), _marker: Default::default() }
+        Self { next: AtomicU32::new(id.index + 1), _marker: Default::default() }
     }
 
     /// Return the next fresh id

--- a/compiler/noirc_evaluator/src/ssa/ir/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/value.rs
@@ -9,34 +9,34 @@ use super::{
     types::Type,
 };
 
-pub(crate) type ValueId = Id<Value>;
+#[derive(Debug)]
+pub(crate) struct NumericConstant {
+    constant: FieldElement,
+    typ: Type,
+}
 
-/// Value is the most basic type allowed in the IR.
-/// Transition Note: A Id<Value> is similar to `NodeId` in our previous IR.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub(crate) enum Value {
-    /// This value was created due to an instruction
-    ///
-    /// instruction -- This is the instruction which defined it
-    /// typ -- This is the `Type` of the instruction
-    /// position -- Returns the position in the results
-    /// vector that this `Value` is located.
-    /// Example, if you add two numbers together, then the resulting
-    /// value would have position `0`, the typ would be the type
-    /// of the operands, and the instruction would map to an add instruction.
-    Instruction { instruction: InstructionId, position: usize, typ: Type },
+#[derive(Debug)]
+pub(crate) struct ArrayOrSlice {
+    elements: im::Vector<ValueId>,
 
-    /// This Value originates from a block parameter. Since function parameters
-    /// are also represented as block parameters, this includes function parameters as well.
-    ///
-    /// position -- the index of this Value in the block parameters list
-    Param { block: BasicBlockId, position: usize, typ: Type },
+    /// This is expected to be either Type::Slice { .. } or Type::Array { .. }
+    typ: Type,
+}
 
-    /// This Value originates from a numeric constant
-    NumericConstant { constant: FieldElement, typ: Type },
+/// A foreign function is represented by just its name in the SSA IR
+pub(crate) type ForeignFunctionName = String;
 
-    /// Represents a constant array value
-    Array { array: im::Vector<ValueId>, typ: Type },
+pub(crate) type NumericConstantId = Id<NumericConstant>;
+pub(crate) type ForeignFunctionNameId = Id<ForeignFunctionName>;
+pub(crate) type ArrayId = Id<ArrayOrSlice>;
+
+/// ValueId is the basic type in the IR used to represent a Value.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum ValueId {
+    InstructionResult { id: InstructionId, position: u32 },
+    Param { block: BasicBlockId, position: u32 },
+
+    NumericConstant(NumericConstantId),
 
     /// This Value refers to a function in the IR.
     /// Functions always have the type Type::Function.
@@ -52,7 +52,7 @@ pub(crate) enum Value {
     /// This Value refers to an external function in the IR.
     /// ForeignFunction's always have the type Type::Function and have similar semantics to Function,
     /// other than generating different backend operations and being only accessible through Brillig.
-    ForeignFunction(String),
+    ForeignFunction(ForeignFunctionNameId),
 }
 
 impl Value {

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -16,7 +16,7 @@ use crate::ssa::{
         function::{Function, FunctionId, RuntimeType, Signature},
         instruction::{BinaryOp, Instruction},
         types::{NumericType, Type},
-        value::{Value, ValueId},
+        value::ValueId,
     },
     ssa_gen::Ssa,
 };
@@ -265,7 +265,7 @@ fn create_apply_functions(
 }
 
 fn function_id_to_field(function_id: FunctionId) -> FieldElement {
-    (function_id.to_usize() as u128).into()
+    (function_id.to_u32() as u128).into()
 }
 
 /// Creates an apply function for the given signature and variants

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -390,7 +390,13 @@ impl<'function> PerFunctionContext<'function> {
         let instruction = self.source_function.dfg[id].map_values(|id| self.translate_value(id));
 
         let mut call_stack = self.context.call_stack.clone();
-        call_stack.append(self.source_function.dfg.get_call_stack(id));
+        
+        for item in self.source_function.dfg.get_call_stack(id) {
+            if call_stack.len() >= 5 {
+                break;
+            }
+            call_stack.push_back(item);
+        }
 
         let results = self.source_function.dfg.instruction_results(id);
         let results = vecmap(results, |id| self.source_function.dfg.resolve(*id));

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -182,6 +182,10 @@ impl<'f> PerFunctionContext<'f> {
             self.remove_stores_that_do_not_alias_parameters(&references);
         }
 
+        if self.blocks.len() % 100 == 0 {
+            println!("On block {}", self.blocks.len());
+        }
+
         self.blocks.insert(block, references);
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -107,7 +107,7 @@ fn remove_block_parameters(
 ) {
     let block = &mut function.dfg[block];
 
-    if !block.parameters().is_empty() {
+    if block.parameter_count() != 0 {
         let block_params = block.take_parameters();
 
         let jump_args = match function.dfg[predecessor].unwrap_terminator_mut() {

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -119,7 +119,18 @@ impl Loops {
         function: &mut Function,
         abort_on_error: bool,
     ) -> Result<(), RuntimeError> {
+        let mut i = 1;
         while let Some(next_loop) = self.yet_to_unroll.pop() {
+            if i % 100 == 0 {
+                println!("On loop {}, total = {}", i, self.yet_to_unroll.len());
+            }
+            i += 1;
+
+            // if i >= 130000 {
+            //     println!("Too many loops!");
+            //     std::process::exit(0);
+            // }
+
             // If we've previously modified a block in this loop we need to refresh the context.
             // This happens any time we have nested loops.
             if next_loop.blocks.iter().any(|block| self.modified_blocks.contains(block)) {

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -258,10 +258,10 @@ fn unroll_loop_header<'a>(
 
     let mut context = LoopIteration::new(function, loop_, fresh_block, loop_.header);
     let source_block = &context.dfg()[context.source_block];
-    assert_eq!(source_block.parameters().len(), 1, "Expected only 1 argument in loop header");
+    assert_eq!(source_block.parameter_count(), 1, "Expected only 1 argument in loop header");
 
     // Insert the current value of the loop induction variable into our context.
-    let first_param = source_block.parameters()[0];
+    let first_param = ValueId::Param { block: context.source_block, position: 0 };
     context.inserter.try_map_value(first_param, induction_value);
     context.inline_instructions_from_block();
 


### PR DESCRIPTION
# Description

## Problem\*

Working towards reducing memory usage in SSA for #3380 

## Summary\*

This PR "inlines" the `ssa::value::Value` enum into `ssa::value::ValueId` to make the `ValueId` itself an enum and allow us to remove `Value` entirely. Doing this eliminates a large portion of memory usage as we no longer need to store values in separate maps at all. As an example, `instruction_results: HashMap<InstructionId, Vec<Value>>` alone takes up over 30% of the memory usage in #3380. In general, since `ValueId`s can be stored directly on Instructions, they are easier to free after each pass is finished so the total memory usage of the SSA representation grows less after each pass.

## Additional Context

This PR is to better keep track of this change which currently is not close to completion.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
