### PR TITLE
chore: add bootstrap sha for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -81,5 +81,6 @@
   },
   "plugins": [
     "sentence-case"
-  ]
+  ],
+  "bootstrap-sha": "d9e8101c57cebbb5abce712ebbc0ac3d50544f47"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -82,5 +82,5 @@
   "plugins": [
     "sentence-case"
   ],
-  "bootstrap-sha": "d9e8101c57cebbb5abce712ebbc0ac3d50544f47"
+  "bootstrap-sha": "690cfc0468de0b9aee53ccfe832c71c16e61e5fc"
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a bootstrap sha which corresponds to the failed 0.19.5 release.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
