### PR TITLE
chore!: Change Language -> ExpressionWidth and put ExpressionWidth into Circuit

### DIFF
--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -1,6 +1,4 @@
-use acir::circuit::{Circuit, OpcodeLocation};
-
-use crate::Language;
+use acir::circuit::{Circuit, ExpressionWidth, OpcodeLocation};
 
 // The various passes that we can use over ACIR
 mod optimizers;
@@ -57,11 +55,14 @@ fn transform_assert_messages(
 }
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
-pub fn compile(acir: Circuit, np_language: Language) -> (Circuit, AcirTransformationMap) {
+pub fn compile(
+    acir: Circuit,
+    expression_width: ExpressionWidth,
+) -> (Circuit, AcirTransformationMap) {
     let (acir, AcirTransformationMap { acir_opcode_positions }) = optimize_internal(acir);
 
     let (mut acir, transformation_map) =
-        transform_internal(acir, np_language, acir_opcode_positions);
+        transform_internal(acir, expression_width, acir_opcode_positions);
 
     acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
 

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -152,7 +152,7 @@ mod tests {
     use acir::{
         circuit::{
             opcodes::{BlackBoxFuncCall, FunctionInput},
-            Circuit, Opcode, PublicInputs,
+            Circuit, ExpressionWidth, Opcode, PublicInputs,
         },
         native_types::{Expression, Witness},
     };
@@ -176,6 +176,7 @@ mod tests {
             public_parameters: PublicInputs::default(),
             return_values: PublicInputs::default(),
             assert_messages: Default::default(),
+            program_width: ExpressionWidth::Unbounded,
         }
     }
 

--- a/acvm-repo/acvm/src/lib.rs
+++ b/acvm-repo/acvm/src/lib.rs
@@ -7,7 +7,6 @@ pub mod compiler;
 pub mod pwg;
 
 pub use acvm_blackbox_solver::{BlackBoxFunctionSolver, BlackBoxResolutionError};
-use core::fmt::Debug;
 use pwg::OpcodeResolutionError;
 
 // re-export acir
@@ -17,11 +16,3 @@ pub use acir::FieldElement;
 pub use brillig_vm;
 // re-export blackbox solver
 pub use acvm_blackbox_solver as blackbox_solver;
-
-/// Supported NP complete languages
-/// This might need to be in ACIR instead
-#[derive(Debug, Clone, Copy)]
-pub enum Language {
-    R1CS,
-    PLONKCSat { width: usize },
-}

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -14,7 +14,7 @@ use crate::{
     errors::{RuntimeError, SsaReport},
 };
 use acvm::acir::{
-    circuit::{Circuit, PublicInputs},
+    circuit::{Circuit, ExpressionWidth, PublicInputs},
     native_types::Witness,
 };
 
@@ -119,6 +119,9 @@ pub fn create_circuit(
         public_parameters,
         return_values,
         assert_messages: assert_messages.into_iter().collect(),
+        // At this point, we have not yet performed any optimizations
+        // on the ACIR.
+        program_width: ExpressionWidth::Unbounded,
     };
 
     // This converts each im::Vector in the BTreeMap to a Vec

--- a/tooling/backend_interface/src/cli/info.rs
+++ b/tooling/backend_interface/src/cli/info.rs
@@ -1,4 +1,4 @@
-use acvm::Language;
+use acvm::acir::circuit::ExpressionWidth;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
@@ -28,7 +28,7 @@ struct LanguageResponse {
 }
 
 impl InfoCommand {
-    pub(crate) fn run(self, binary_path: &Path) -> Result<Language, BackendError> {
+    pub(crate) fn run(self, binary_path: &Path) -> Result<ExpressionWidth, BackendError> {
         let mut command = std::process::Command::new(binary_path);
 
         command.arg("info").arg("-c").arg(self.crs_path).arg("-o").arg("-");
@@ -41,13 +41,13 @@ impl InfoCommand {
 
         let backend_info: InfoResponse =
             serde_json::from_slice(&output.stdout).expect("Backend should return valid json");
-        let language: Language = match backend_info.language.name.as_str() {
+        let language: ExpressionWidth = match backend_info.language.name.as_str() {
             "PLONK-CSAT" => {
                 let width = backend_info.language.width.unwrap();
-                Language::PLONKCSat { width }
+                ExpressionWidth::Bounded { width }
             }
-            "R1CS" => Language::R1CS,
-            _ => panic!("Unknown langauge"),
+            "R1CS" => ExpressionWidth::Unbounded,
+            _ => panic!("Unknown expression width"),
         };
 
         Ok(language)
@@ -61,7 +61,7 @@ fn info_command() -> Result<(), BackendError> {
 
     let language = InfoCommand { crs_path }.run(backend.binary_path())?;
 
-    assert!(matches!(language, Language::PLONKCSat { width: 3 }));
+    assert!(matches!(language, ExpressionWidth::Bounded { width: 3 }));
 
     Ok(())
 }

--- a/tooling/backend_interface/src/proof_system.rs
+++ b/tooling/backend_interface/src/proof_system.rs
@@ -2,9 +2,9 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
+use acvm::acir::circuit::ExpressionWidth;
 use acvm::acir::{circuit::Circuit, native_types::WitnessMap};
 use acvm::FieldElement;
-use acvm::Language;
 use tempfile::tempdir;
 
 use crate::cli::{
@@ -30,7 +30,7 @@ impl Backend {
             .run(binary_path)
     }
 
-    pub fn get_backend_info(&self) -> Result<Language, BackendError> {
+    pub fn get_backend_info(&self) -> Result<ExpressionWidth, BackendError> {
         let binary_path = self.assert_binary_exists()?;
         self.assert_correct_version()?;
         InfoCommand { crs_path: self.crs_directory() }.run(binary_path)
@@ -38,12 +38,12 @@ impl Backend {
 
     /// If we cannot get a valid backend, returns Plonk with width 3
     /// The function also prints a message saying we could not find a backend
-    pub fn get_backend_info_or_default(&self) -> Language {
+    pub fn get_backend_info_or_default(&self) -> ExpressionWidth {
         if let Ok(language) = self.get_backend_info() {
             language
         } else {
             log::warn!("No valid backend found, defaulting to Plonk with width 3");
-            Language::PLONKCSat { width: 3 }
+            ExpressionWidth::Bounded { width: 3 }
         }
     }
 

--- a/tooling/backend_interface/src/smart_contract.rs
+++ b/tooling/backend_interface/src/smart_contract.rs
@@ -38,7 +38,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use acvm::acir::{
-        circuit::{Circuit, Opcode, PublicInputs},
+        circuit::{Circuit, ExpressionWidth, Opcode, PublicInputs},
         native_types::{Expression, Witness},
     };
 
@@ -56,6 +56,7 @@ mod tests {
             public_parameters: PublicInputs::default(),
             return_values: PublicInputs::default(),
             assert_messages: Default::default(),
+            program_width: ExpressionWidth::Unbounded,
         };
 
         let contract = get_mock_backend()?.eth_contract(&circuit)?;

--- a/tooling/lsp/src/requests/profile_run.rs
+++ b/tooling/lsp/src/requests/profile_run.rs
@@ -3,7 +3,7 @@ use std::{
     future::{self, Future},
 };
 
-use acvm::Language;
+use acvm::acir::circuit::ExpressionWidth;
 use async_lsp::{ErrorCode, ResponseError};
 use nargo::artifacts::debug::DebugArtifact;
 use nargo_toml::{find_package_manifest, resolve_workspace_from_toml, PackageSelection};
@@ -57,7 +57,7 @@ fn on_profile_run_request_inner(
                 .cloned()
                 .partition(|package| package.is_binary());
 
-            let np_language = Language::PLONKCSat { width: 3 };
+            let np_language = ExpressionWidth::Bounded { width: 3 };
 
             let (compiled_programs, compiled_contracts) = nargo::ops::compile_workspace(
                 &workspace,

--- a/tooling/nargo/src/ops/optimize.rs
+++ b/tooling/nargo/src/ops/optimize.rs
@@ -1,19 +1,19 @@
-use acvm::Language;
+use acvm::acir::circuit::ExpressionWidth;
 use iter_extended::vecmap;
 use noirc_driver::{CompiledContract, CompiledProgram};
 
-pub fn optimize_program(mut program: CompiledProgram, np_language: Language) -> CompiledProgram {
-    let (optimized_circuit, location_map) = acvm::compiler::compile(program.circuit, np_language);
+pub fn optimize_program(mut program: CompiledProgram, expression_width: ExpressionWidth) -> CompiledProgram {
+    let (optimized_circuit, location_map) = acvm::compiler::compile(program.circuit, expression_width);
 
     program.circuit = optimized_circuit;
     program.debug.update_acir(location_map);
     program
 }
 
-pub fn optimize_contract(contract: CompiledContract, np_language: Language) -> CompiledContract {
+pub fn optimize_contract(contract: CompiledContract, expression_width: ExpressionWidth) -> CompiledContract {
     let functions = vecmap(contract.functions, |mut func| {
         let (optimized_bytecode, location_map) =
-            acvm::compiler::compile(func.bytecode, np_language);
+            acvm::compiler::compile(func.bytecode, expression_width);
         func.bytecode = optimized_bytecode;
         func.debug.update_acir(location_map);
         func

--- a/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::backends::Backend;
 use crate::errors::CliError;
 
-use acvm::Language;
+use acvm::acir::circuit::ExpressionWidth;
 use bb_abstraction_leaks::ACVM_BACKEND_BARRETENBERG;
 use clap::Args;
 use nargo::package::Package;
@@ -71,9 +71,9 @@ fn smart_contract_for_package(
     backend: &Backend,
     package: &Package,
     compile_options: &CompileOptions,
-    np_language: Language,
+    expression_width: ExpressionWidth,
 ) -> Result<String, CliError> {
-    let program = compile_bin_package(workspace, package, compile_options, np_language)?;
+    let program = compile_bin_package(workspace, package, compile_options, expression_width)?;
 
     let mut smart_contract_string = backend.eth_contract(&program.circuit)?;
 

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use acvm::Language;
+use acvm::acir::circuit::ExpressionWidth;
 use fm::FileManager;
 use iter_extended::vecmap;
 use nargo::artifacts::contract::PreprocessedContract;
@@ -88,18 +88,18 @@ pub(super) fn compile_workspace(
     workspace: &Workspace,
     binary_packages: &[Package],
     contract_packages: &[Package],
-    np_language: Language,
+    expression_width: ExpressionWidth,
     compile_options: &CompileOptions,
 ) -> Result<(Vec<CompiledProgram>, Vec<CompiledContract>), CliError> {
     // Compile all of the packages in parallel.
     let program_results: Vec<(FileManager, CompilationResult<CompiledProgram>)> = binary_packages
         .par_iter()
-        .map(|package| compile_program(workspace, package, compile_options, np_language))
+        .map(|package| compile_program(workspace, package, compile_options, expression_width))
         .collect();
     let contract_results: Vec<(FileManager, CompilationResult<CompiledContract>)> =
         contract_packages
             .par_iter()
-            .map(|package| compile_contract(package, compile_options, np_language))
+            .map(|package| compile_contract(package, compile_options, expression_width))
             .collect();
 
     // Report any warnings/errors which were encountered during compilation.
@@ -133,14 +133,14 @@ pub(crate) fn compile_bin_package(
     workspace: &Workspace,
     package: &Package,
     compile_options: &CompileOptions,
-    np_language: Language,
+    expression_width: ExpressionWidth,
 ) -> Result<CompiledProgram, CliError> {
     if package.is_library() {
         return Err(CompileError::LibraryCrate(package.name.clone()).into());
     }
 
     let (file_manager, compilation_result) =
-        compile_program(workspace, package, compile_options, np_language);
+        compile_program(workspace, package, compile_options, expression_width);
 
     let program = report_errors(
         compilation_result,
@@ -156,7 +156,7 @@ fn compile_program(
     workspace: &Workspace,
     package: &Package,
     compile_options: &CompileOptions,
-    np_language: Language,
+    expression_width: ExpressionWidth,
 ) -> (FileManager, CompilationResult<CompiledProgram>) {
     let (mut context, crate_id) = prepare_package(package);
 
@@ -196,7 +196,7 @@ fn compile_program(
     };
 
     // Apply backend specific optimizations.
-    let optimized_program = nargo::ops::optimize_program(program, np_language);
+    let optimized_program = nargo::ops::optimize_program(program, expression_width);
     let only_acir = compile_options.only_acir;
     save_program(optimized_program.clone(), package, &workspace.target_directory_path(), only_acir);
 
@@ -206,7 +206,7 @@ fn compile_program(
 fn compile_contract(
     package: &Package,
     compile_options: &CompileOptions,
-    np_language: Language,
+    expression_width: ExpressionWidth,
 ) -> (FileManager, CompilationResult<CompiledContract>) {
     let (mut context, crate_id) = prepare_package(package);
     let (contract, warnings) =
@@ -217,7 +217,7 @@ fn compile_contract(
             }
         };
 
-    let optimized_contract = nargo::ops::optimize_contract(contract, np_language);
+    let optimized_contract = nargo::ops::optimize_contract(contract, expression_width);
 
     (context.file_manager, Ok((optimized_contract, warnings)))
 }

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use acvm::Language;
+use acvm::acir::circuit::ExpressionWidth;
 use backend_interface::BackendError;
 use clap::Args;
 use iter_extended::vecmap;
@@ -202,7 +202,7 @@ struct InfoReport {
 struct ProgramInfo {
     name: String,
     #[serde(skip)]
-    language: Language,
+    expression_width: ExpressionWidth,
     acir_opcodes: usize,
     circuit_size: u32,
 }
@@ -211,7 +211,7 @@ impl From<ProgramInfo> for Row {
     fn from(program_info: ProgramInfo) -> Self {
         row![
             Fm->format!("{}", program_info.name),
-            format!("{:?}", program_info.language),
+            format!("{:?}", program_info.expression_width),
             Fc->format!("{}", program_info.acir_opcodes),
             Fc->format!("{}", program_info.circuit_size),
         ]
@@ -222,7 +222,7 @@ impl From<ProgramInfo> for Row {
 struct ContractInfo {
     name: String,
     #[serde(skip)]
-    language: Language,
+    expression_width: ExpressionWidth,
     functions: Vec<FunctionInfo>,
 }
 
@@ -239,7 +239,7 @@ impl From<ContractInfo> for Vec<Row> {
             row![
                 Fm->format!("{}", contract_info.name),
                 Fc->format!("{}", function.name),
-                format!("{:?}", contract_info.language),
+                format!("{:?}", contract_info.expression_width),
                 Fc->format!("{}", function.acir_opcodes),
                 Fc->format!("{}", function.circuit_size),
             ]
@@ -251,11 +251,11 @@ fn count_opcodes_and_gates_in_program(
     backend: &Backend,
     compiled_program: CompiledProgram,
     package: &Package,
-    language: Language,
+    expression_width: ExpressionWidth,
 ) -> Result<ProgramInfo, CliError> {
     Ok(ProgramInfo {
         name: package.name.to_string(),
-        language,
+        expression_width,
         acir_opcodes: compiled_program.circuit.opcodes.len(),
         circuit_size: backend.get_exact_circuit_size(&compiled_program.circuit)?,
     })
@@ -264,7 +264,7 @@ fn count_opcodes_and_gates_in_program(
 fn count_opcodes_and_gates_in_contract(
     backend: &Backend,
     contract: CompiledContract,
-    language: Language,
+    expression_width: ExpressionWidth,
 ) -> Result<ContractInfo, CliError> {
     let functions = contract
         .functions
@@ -278,5 +278,5 @@ fn count_opcodes_and_gates_in_contract(
         })
         .collect::<Result<_, _>>()?;
 
-    Ok(ContractInfo { name: contract.name, language, functions })
+    Ok(ContractInfo { name: contract.name, expression_width, functions })
 }


### PR DESCRIPTION
# Description

This changes the naming of NpLanguage to ExpressionWidth and then puts it into Circuit, so that its always apparent when a circuit has been reduced 

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
