### PR TITLE
chore(ci): correct how docs are build for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,11 @@ jobs:
   update-docs:
     name: Update docs
     needs: [release-please, update-lockfile]
-    if: ${{ needs.release-please.outputs.tag-name }}
+    if: ${{ needs.release-please.outputs.release-pr }}
     runs-on: ubuntu-latest
+    env:
+      PENDING_RELEASE_SEMVER: v${{ needs.release-please.outputs.major }}.${{needs.release-please.outputs.minor}}.${{needs.release-please.outputs.patch}}
+
     steps:
       - name: Checkout release branch
         uses: actions/checkout@v4
@@ -102,7 +105,7 @@ jobs:
 
       - name: Cut a new version
         working-directory: ./docs
-        run: yarn docusaurus docs:version ${{ needs.release-please.outputs.tag-name }}
+        run: yarn docusaurus docs:version ${{ env.PENDING_RELEASE_SEMVER }}
 
       - name: Configure git
         run: |
@@ -112,7 +115,7 @@ jobs:
       - name: Commit new documentation version
         run: |
           git add .
-          git commit -m "chore(docs): cut new docs version for tag ${{ needs.release-please.outputs.tag-name }}"
+          git commit -m "chore(docs): cut new docs version for tag ${{ env.PENDING_RELEASE_SEMVER }}"
           git push
 
   build-binaries:


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR moves the cutting of a new docs version to happen within the release-please PR.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
