### PR TITLE
chore: Compare noir versions when testing that the wasm compiled artefact is equal to the natively compiled artefact

### DIFF
--- a/compiler/wasm/test/browser/index.test.ts
+++ b/compiler/wasm/test/browser/index.test.ts
@@ -39,6 +39,7 @@ describe('noir wasm', () => {
       }
 
       // We don't expect the hashes to match due to how `noir_wasm` handles dependencies
+      expect(wasmCircuit.program.noir_version).to.eq(cliCircuit.noir_version);
       expect(wasmCircuit.program.bytecode).to.eq(cliCircuit.bytecode);
       expect(wasmCircuit.program.abi).to.deep.eq(cliCircuit.abi);
       expect(wasmCircuit.program.backend).to.eq(cliCircuit.backend);
@@ -77,6 +78,7 @@ describe('noir wasm', () => {
       const cliCircuit = await getPrecompiledSource(depsScriptExpectedArtifact);
 
       // We don't expect the hashes to match due to how `noir_wasm` handles dependencies
+      expect(wasmCircuit.program.noir_version).to.eq(cliCircuit.noir_version);
       expect(wasmCircuit.program.bytecode).to.eq(cliCircuit.bytecode);
       expect(wasmCircuit.program.abi).to.deep.eq(cliCircuit.abi);
       expect(wasmCircuit.program.backend).to.eq(cliCircuit.backend);

--- a/compiler/wasm/test/node/index.test.ts
+++ b/compiler/wasm/test/node/index.test.ts
@@ -33,6 +33,7 @@ describe('noir wasm compilation', () => {
       }
 
       // We don't expect the hashes to match due to how `noir_wasm` handles dependencies
+      expect(wasmCircuit.program.noir_version).to.eq(cliCircuit.noir_version);
       expect(wasmCircuit.program.bytecode).to.eq(cliCircuit.bytecode);
       expect(wasmCircuit.program.abi).to.deep.eq(cliCircuit.abi);
       expect(wasmCircuit.program.backend).to.eq(cliCircuit.backend);
@@ -67,6 +68,7 @@ describe('noir wasm compilation', () => {
       }
 
       // We don't expect the hashes to match due to how `noir_wasm` handles dependencies
+      expect(wasmCircuit.program.noir_version).to.eq(cliCircuit.noir_version);
       expect(wasmCircuit.program.bytecode).to.eq(cliCircuit.bytecode);
       expect(wasmCircuit.program.abi).to.deep.eq(cliCircuit.abi);
       expect(wasmCircuit.program.backend).to.eq(cliCircuit.backend);


### PR DESCRIPTION
# Description

Since we don't want these checked in and these are compiled manually, they can get out of sync if you build the wasm and do not do `noirup -p .` and then recompile the example programs.

The error message will say that the bytecodes produced are different, with this change the test will first tell you that the versions are different. 

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
