### PR TITLE
chore!: Remove unused methods on opcodes

### DIFF
--- a/acvm-repo/acir/src/circuit/directives.rs
+++ b/acvm-repo/acir/src/circuit/directives.rs
@@ -34,13 +34,3 @@ pub enum Directive {
         sort_by: Vec<u32>, // specify primary index to sort by, then the secondary,... For instance, if tuple is 2 and sort_by is [1,0], then a=[(a0,b0),..] is sorted by bi and then ai.
     },
 }
-
-impl Directive {
-    pub fn name(&self) -> &str {
-        match self {
-            Directive::Quotient(_) => "quotient",
-            Directive::ToLeRadix { .. } => "to_le_radix",
-            Directive::PermutationSort { .. } => "permutation_sort",
-        }
-    }
-}

--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -33,32 +33,6 @@ pub enum Opcode {
     },
 }
 
-impl Opcode {
-    // TODO We can add a domain separator by doing something like:
-    // TODO concat!("directive:", directive.name)
-    pub fn name(&self) -> &str {
-        match self {
-            Opcode::Arithmetic(_) => "arithmetic",
-            Opcode::Directive(directive) => directive.name(),
-            Opcode::BlackBoxFuncCall(g) => g.name(),
-            Opcode::Brillig(_) => "brillig",
-            Opcode::MemoryOp { .. } => "mem",
-            Opcode::MemoryInit { .. } => "init memory block",
-        }
-    }
-
-    pub fn is_arithmetic(&self) -> bool {
-        matches!(self, Opcode::Arithmetic(_))
-    }
-
-    pub fn arithmetic(self) -> Option<Expression> {
-        match self {
-            Opcode::Arithmetic(expr) => Some(expr),
-            _ => None,
-        }
-    }
-}
-
 impl std::fmt::Display for Opcode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -133,28 +133,6 @@ pub enum BrilligOpcode {
     Stop,
 }
 
-impl BrilligOpcode {
-    pub fn name(&self) -> &'static str {
-        match self {
-            BrilligOpcode::BinaryFieldOp { .. } => "binary_field_op",
-            BrilligOpcode::BinaryIntOp { .. } => "binary_int_op",
-            BrilligOpcode::JumpIfNot { .. } => "jmp_if_not",
-            BrilligOpcode::JumpIf { .. } => "jmp_if",
-            BrilligOpcode::Jump { .. } => "jmp",
-            BrilligOpcode::Call { .. } => "call",
-            BrilligOpcode::Const { .. } => "const",
-            BrilligOpcode::Return => "return",
-            BrilligOpcode::ForeignCall { .. } => "foreign_call",
-            BrilligOpcode::Mov { .. } => "mov",
-            BrilligOpcode::Load { .. } => "load",
-            BrilligOpcode::Store { .. } => "store",
-            BrilligOpcode::BlackBox(_) => "black_box",
-            BrilligOpcode::Trap => "trap",
-            BrilligOpcode::Stop => "stop",
-        }
-    }
-}
-
 /// Binary fixed-length field expressions
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BinaryFieldOp {


### PR DESCRIPTION
# Description

These were originally added for manual serialization but now we use serde. They seem like a nice to have, though I'd rather just add them back once we have a proper usecase for them

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
