### PR TITLE
chore!: rename `verify_proof` to `delayed_proof_aggregation`

### DIFF
--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -37,7 +37,7 @@ unconstrained pub fn println<T>(input: T) {
 }
 
 #[foreign(recursive_aggregation)]
-pub fn verify_proof<N>(
+pub fn delayed_proof_aggregation<N>(
     _verification_key: [Field],
     _proof: [Field],
     _public_inputs: [Field],


### PR DESCRIPTION
# Description


This is a naming suggestion for `std::verify_proof` to make it clearer that it is not verifying a proof in the circuit.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
