### PR TITLE
chore: `fetch_file` now returns ` &str` instead of a `File`

### DIFF
--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -88,9 +88,9 @@ impl FileManager {
         assert!(old_value.is_none(), "ice: the same path was inserted into the file manager twice");
     }
 
-    pub fn fetch_file(&self, file_id: FileId) -> File {
+    pub fn fetch_file(&self, file_id: FileId) -> &str {
         // Unwrap as we ensure that all file_id's map to a corresponding file in the file map
-        self.file_map.get_file(file_id).unwrap()
+        self.file_map.get_file(file_id).unwrap().source()
     }
 
     pub fn path(&self, file_id: FileId) -> &Path {

--- a/compiler/noirc_driver/src/debug.rs
+++ b/compiler/noirc_driver/src/debug.rs
@@ -31,7 +31,7 @@ pub(crate) fn filter_relevant_files(
     let mut file_map = BTreeMap::new();
 
     for file_id in files_with_debug_symbols {
-        let file_source = file_manager.fetch_file(file_id).source();
+        let file_source = file_manager.fetch_file(file_id);
 
         file_map.insert(
             file_id,

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -270,8 +270,8 @@ pub struct Contract {
 
 /// Given a FileId, fetch the File, from the FileManager and parse it's content
 pub fn parse_file(fm: &FileManager, file_id: FileId) -> (ParsedModule, Vec<ParserError>) {
-    let file = fm.fetch_file(file_id);
-    parse_program(file.source())
+    let file_source = fm.fetch_file(file_id);
+    parse_program(file_source)
 }
 
 impl std::ops::Index<LocalModuleId> for CrateDefMap {

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -34,7 +34,7 @@ impl DebugArtifact {
             .collect();
 
         for file_id in files_with_debug_symbols {
-            let file_source = file_manager.fetch_file(file_id).source();
+            let file_source = file_manager.fetch_file(file_id);
 
             file_map.insert(
                 file_id,

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -62,7 +62,7 @@ pub(crate) fn run(args: FormatCommand, config: NargoConfig) -> Result<(), CliErr
                 return Ok(());
             }
 
-            let original = file_manager.fetch_file(file_id).source();
+            let original = file_manager.fetch_file(file_id);
             let formatted = nargo_fmt::format(original, parsed_module, &config);
 
             if check_mode {


### PR DESCRIPTION
# Description

This makes the API more uniform because to add a file, we call:

```
    pub fn add_file_with_source(&mut self, file_name: &Path, source: String) -> Option<FileId> {
```

and now to fetch a file we call:

```
    pub fn fetch_file(&self, file_id: FileId) -> &str;
```


Instead of returning a `File` which was not present when we were adding a File

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
