### PR TITLE
chore: Compiler `Context` instantiates a new `CrateGraph` internally

### DIFF
--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -36,7 +36,8 @@ pub enum FunctionNameMatch<'a> {
 }
 
 impl Context {
-    pub fn new(file_manager: FileManager, crate_graph: CrateGraph) -> Context {
+    pub fn new(file_manager: FileManager) -> Context {
+        let crate_graph = CrateGraph::default();
         Context {
             def_interner: NodeInterner::default(),
             def_maps: BTreeMap::new(),

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -53,8 +53,7 @@ mod test {
     ) -> (ParsedModule, Context, Vec<(CompilationError, FileId)>) {
         let root = std::path::Path::new("/");
         let fm = FileManager::new(root);
-        let graph = CrateGraph::default();
-        let mut context = Context::new(fm, graph);
+        let mut context = Context::new(fm);
         let root_file_id = FileId::dummy();
         let root_crate_id = context.crate_graph.add_crate_root(root_file_id);
         let (program, parser_errors) = parse_program(src);

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -320,10 +320,7 @@ pub(crate) fn preprocess_contract(contract: CompiledContract) -> CompileResult {
 #[cfg(test)]
 mod test {
     use noirc_driver::prepare_crate;
-    use noirc_frontend::{
-        graph::{CrateGraph, CrateName},
-        hir::Context,
-    };
+    use noirc_frontend::{graph::CrateName, hir::Context};
 
     use crate::compile::PathToFileSourceMap;
 

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -11,7 +11,7 @@ use noirc_driver::{
     CompiledContract, CompiledProgram, NOIR_ARTIFACT_VERSION_STRING,
 };
 use noirc_frontend::{
-    graph::{CrateGraph, CrateId, CrateName},
+    graph::{CrateId, CrateName},
     hir::Context,
 };
 use serde::Deserialize;
@@ -169,8 +169,7 @@ pub fn compile(
 
     let fm = file_manager_with_source_map(file_source_map);
 
-    let graph = CrateGraph::default();
-    let mut context = Context::new(fm, graph);
+    let mut context = Context::new(fm);
 
     let path = Path::new(&entry_point);
     let crate_id = prepare_crate(&mut context, path);
@@ -336,8 +335,7 @@ mod test {
         // Add this due to us calling prepare_crate on "/main.nr" below
         fm.add_file_with_source(Path::new("/main.nr"), "fn foo() {}".to_string());
 
-        let graph = CrateGraph::default();
-        let mut context = Context::new(fm, graph);
+        let mut context = Context::new(fm);
         prepare_crate(&mut context, Path::new("/main.nr"));
 
         context

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -36,7 +36,7 @@ impl CompilerContext {
     }
 
     #[cfg(test)]
-    pub(crate) fn crate_graph(&self) -> &CrateGraph {
+    pub(crate) fn crate_graph(&self) -> &noirc_frontend::graph::CrateGraph {
         &self.context.crate_graph
     }
     #[cfg(test)]
@@ -222,7 +222,7 @@ pub fn compile_(
 #[cfg(test)]
 mod test {
     use noirc_driver::prepare_crate;
-    use noirc_frontend::{graph::CrateGraph, hir::Context};
+    use noirc_frontend::hir::Context;
 
     use crate::compile::{file_manager_with_source_map, PathToFileSourceMap};
 

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -7,7 +7,7 @@ use noirc_driver::{
     add_dep, compile_contract, compile_main, prepare_crate, prepare_dependency, CompileOptions,
 };
 use noirc_frontend::{
-    graph::{CrateGraph, CrateId, CrateName},
+    graph::{CrateId, CrateName},
     hir::Context,
 };
 use std::path::Path;
@@ -32,8 +32,7 @@ impl CompilerContext {
         console_error_panic_hook::set_once();
 
         let fm = file_manager_with_source_map(source_map);
-        let graph = CrateGraph::default();
-        CompilerContext { context: Context::new(fm, graph) }
+        CompilerContext { context: Context::new(fm) }
     }
 
     #[cfg(test)]
@@ -236,8 +235,7 @@ mod test {
         // Add this due to us calling prepare_crate on "/main.nr" below
         fm.add_file_with_source(Path::new("/main.nr"), "fn foo() {}".to_string());
 
-        let graph = CrateGraph::default();
-        let mut context = Context::new(fm, graph);
+        let mut context = Context::new(fm);
         prepare_crate(&mut context, Path::new("/main.nr"));
 
         CompilerContext { context }

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use fm::FileManager;
 use noirc_driver::{add_dep, prepare_crate, prepare_dependency};
 use noirc_frontend::{
-    graph::{CrateGraph, CrateId, CrateName},
+    graph::{CrateId, CrateName},
     hir::Context,
 };
 use package::{Dependency, Package};
@@ -91,8 +91,7 @@ pub fn prepare_package(package: &Package) -> (Context, CrateId) {
     let mut fm = FileManager::new(&package.root_dir);
     insert_all_files_for_package_into_file_manager(package, &mut fm);
 
-    let graph = CrateGraph::default();
-    let mut context = Context::new(fm, graph);
+    let mut context = Context::new(fm);
 
     let crate_id = prepare_crate(&mut context, &package.entry_path);
 


### PR DESCRIPTION
# Description

This is a minor cleanup task. Everywhere we created a CompilerContext, we were passing in a default CrateGraph. 

This PR just creates the default CrateGraph internally, so that the caller does not need to. If in the future, we decide to want to pass a populated CrateGraph, we can create a `with_crate_graph` method to account for the edge case.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
