### PR TITLE
fix: Don't fail if no tests and the user didn't provide a pattern

### DIFF
--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -98,18 +98,21 @@ fn run_tests<S: BlackBoxFunctionSolver>(
     let test_functions = context.get_all_test_functions_in_crate_matching(&crate_id, fn_name);
     let count_all = test_functions.len();
     if count_all == 0 {
-        return match &fn_name {
-            FunctionNameMatch::Anything => {
-                Err(CliError::Generic(format!("[{}] Found 0 tests.", package.name)))
+        match &fn_name {
+            FunctionNameMatch::Exact(pattern) => {
+                return Err(CliError::Generic(format!(
+                    "[{}] Found 0 tests matching input '{pattern}'.",
+                    package.name
+                )))
             }
-            FunctionNameMatch::Exact(pattern) => Err(CliError::Generic(format!(
-                "[{}] Found 0 tests matching input '{pattern}'.",
-                package.name
-            ))),
-            FunctionNameMatch::Contains(pattern) => Err(CliError::Generic(format!(
-                "[{}] Found 0 tests containing '{pattern}'.",
-                package.name
-            ))),
+            FunctionNameMatch::Contains(pattern) => {
+                return Err(CliError::Generic(format!(
+                    "[{}] Found 0 tests containing '{pattern}'.",
+                    package.name
+                )))
+            }
+            // If we are running all tests in a crate, having none is not an error
+            FunctionNameMatch::Anything => {}
         };
     }
 


### PR DESCRIPTION
# Description

Workspaces typically contain some crates with no tests (especially binary crates that are only entry points). Running tests without specifying a test name on a crate won't fail with this PR if that crate has no tests. 

## Problem\*

Possible approach to #3863

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
