### PR TITLE
fix: Prevent panic on unsupported BB function in ACIR gen

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -1605,28 +1605,40 @@ fn execute_brillig(
             _signature: &[u8],
             _message: &[u8],
         ) -> Result<bool, BlackBoxResolutionError> {
-            unimplemented!("SchnorrVerify is not supported")
+            Err(BlackBoxResolutionError::Failed(
+                BlackBoxFunc::SchnorrVerify,
+                "SchnorrVerify is not supported".to_string(),
+            ))
         }
         fn pedersen_commitment(
             &self,
             _inputs: &[FieldElement],
             _domain_separator: u32,
         ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
-            unimplemented!("PedersenCommitment is not supported")
+            Err(BlackBoxResolutionError::Failed(
+                BlackBoxFunc::PedersenCommitment,
+                "PedersenCommitment is not supported".to_string(),
+            ))
         }
         fn pedersen_hash(
             &self,
             _inputs: &[FieldElement],
             _domain_separator: u32,
         ) -> Result<FieldElement, BlackBoxResolutionError> {
-            unimplemented!("PedersenHash is not supported")
+            Err(BlackBoxResolutionError::Failed(
+                BlackBoxFunc::PedersenHash,
+                "PedersenHash is not supported".to_string(),
+            ))
         }
         fn fixed_base_scalar_mul(
             &self,
             _low: &FieldElement,
             _high: &FieldElement,
         ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
-            unimplemented!("FixedBaseScalarMul is not supported")
+            Err(BlackBoxResolutionError::Failed(
+                BlackBoxFunc::FixedBaseScalarMul,
+                "FixedBaseScalarMul is not supported".to_string(),
+            ))
         }
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3865

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
