### PR TITLE
fix: allow lsp to run inside of a docker container

### DIFF
--- a/tooling/nargo_cli/src/cli/lsp_cmd.rs
+++ b/tooling/nargo_cli/src/cli/lsp_cmd.rs
@@ -1,6 +1,6 @@
 use async_lsp::{
-    client_monitor::ClientProcessMonitorLayer, concurrency::ConcurrencyLayer,
-    panic::CatchUnwindLayer, server::LifecycleLayer, tracing::TracingLayer,
+    concurrency::ConcurrencyLayer, panic::CatchUnwindLayer, server::LifecycleLayer,
+    tracing::TracingLayer,
 };
 use clap::Args;
 use noir_lsp::NargoLspService;
@@ -39,7 +39,6 @@ pub(crate) fn run(
                 .layer(LifecycleLayer::default())
                 .layer(CatchUnwindLayer::default())
                 .layer(ConcurrencyLayer::default())
-                .layer(ClientProcessMonitorLayer::new(client))
                 .service(router)
         });
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR re-adds a change which was removed from #3875 which is required for the LSP to run inside of a docker container.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
