### PR TITLE
chore: making docs always deploy on master

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,12 +1,9 @@
 name: Publish documentation
 
 on:
-  workflow_dispatch:
-    inputs:
-      noir-ref:
-        description: The noir reference to checkout
-        required: false
-        default: 'master'
+  push:
+    branches:
+      - master
 
 jobs:
   publish-docs:
@@ -16,9 +13,6 @@ jobs:
     steps:
       - name: Checkout release branch
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.noir-ref }}
-          token: ${{ secrets.NOIR_RELEASES_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+    paths: [docs/**]
 
 jobs:
   publish-docs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,21 +120,6 @@ jobs:
           token: ${{ secrets.NOIR_REPO_TOKEN }}
           inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}", "npm-tag": "latest" }'
 
-  publish-docs:
-    name: Publish docs
-    needs: [release-please]
-    if: ${{ needs.release-please.outputs.tag-name }}
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Dispatch to publish-docs
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: publish-docs.yml
-          ref: master
-          token: ${{ secrets.NOIR_REPO_TOKEN }}
-          inputs: '{ "noir-ref": "${{ needs.release-please.outputs.tag-name }}" }'
-
   publish-acvm:
     name: Publish acvm
     needs: [release-please]


### PR DESCRIPTION
# Description

This PR makes docs deploy on every merge to master.

## Problem\*

Right now docs are only deployed when the "Publish Docs" workflow runs, which is everytime a release PR is merged. There's a workflow dispatch so we can go and manually deploy it (like @kevaundray is doing here](https://github.com/noir-lang/noir/actions/runs/7251799715)

We don't like manual so we're deploying it every merge to master 😄

## Summary\*

- Makes `publish_docs` run on every merge
- Removes `publish_docs` from the release-please workflow

## Additional Context

This doesn't touch the new versioning system @TomAFrench cleverly put together. Versions are still generated each time release-please adds a new commit to its PR (I think).

This is mostly _when_ to deploy
