### PR TITLE
fix: allow abi encoding tuples from JS

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -36,6 +36,7 @@
         "cpus",
         "cranelift",
         "curvegroup",
+        "databus",
         "deflatten",
         "deflattened",
         "deflattening",

--- a/tooling/noirc_abi_wasm/src/lib.rs
+++ b/tooling/noirc_abi_wasm/src/lib.rs
@@ -27,7 +27,7 @@ use js_witness_map::JsWitnessMap;
 #[wasm_bindgen(typescript_custom_section)]
 const INPUT_MAP: &'static str = r#"
 export type Field = string | number | boolean;
-export type InputValue = Field | Field[] | InputMap | InputMap[];
+export type InputValue = Field | InputMap | (Field | InputMap)[];
 export type InputMap = { [key: string]: InputValue };
 "#;
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently disallow abi encoding tuples which contain a mix of primitive types, arrays and structs due to the types which have been applied. This PR loosens the types so that we can pass a mix of these types as a tuple.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
