### PR TITLE
feat: perform noop check for truncations inside `AcirContext`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -969,6 +969,11 @@ impl AcirContext {
         rhs: u32,
         max_bit_size: u32,
     ) -> Result<AcirVar, RuntimeError> {
+        if max_bit_size <= rhs {
+            // Incoming variable already fits into target bit size -  this is a no-op
+            return Ok(lhs);
+        }
+
         // 2^{rhs}
         let divisor =
             self.add_constant(FieldElement::from(2_u128).pow(&FieldElement::from(rhs as u128)));

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -1664,10 +1664,6 @@ impl Context {
             }
             NumericType::Unsigned { bit_size } | NumericType::Signed { bit_size } => {
                 let max_bit_size = incoming_type.bit_size();
-                if max_bit_size <= *bit_size {
-                    // Incoming variable already fits into target bit size -  this is a no-op
-                    return Ok(variable);
-                }
                 self.acir_context.truncate_var(variable, *bit_size, max_bit_size)
             }
         }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR pushes a check for whether a truncation is a noop inside the `AcirContext` so that it applies to all truncations.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
