### PR TITLE
fix(debugger): crash when stepping through locations spanning multiple lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
  "noirc_printable_type",
  "owo-colors",
  "serde_json",
+ "tempfile",
  "thiserror",
 ]
 

--- a/tooling/debugger/Cargo.toml
+++ b/tooling/debugger/Cargo.toml
@@ -21,3 +21,6 @@ dap.workspace = true
 easy-repl = "0.2.1"
 owo-colors = "3"
 serde_json.workspace = true
+
+[dev_dependencies]
+tempfile.workspace = true

--- a/tooling/debugger/src/lib.rs
+++ b/tooling/debugger/src/lib.rs
@@ -1,6 +1,7 @@
 mod context;
 mod dap;
 mod repl;
+mod source_code_printer;
 
 use std::io::{Read, Write};
 

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -9,12 +9,7 @@ use nargo::{artifacts::debug::DebugArtifact, ops::DefaultForeignCallExecutor, Na
 use easy_repl::{command, CommandStatus, Repl};
 use std::cell::RefCell;
 
-use codespan_reporting::files::Files;
-use noirc_errors::Location;
-
-use owo_colors::OwoColorize;
-
-use std::ops::Range;
+use crate::source_code_printer::print_source_code_location;
 
 pub struct ReplDebugger<'a, B: BlackBoxFunctionSolver> {
     context: DebugContext<'a, B>,
@@ -70,96 +65,7 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                         );
                     }
                 }
-                self.show_source_code_location(&location);
-            }
-        }
-    }
-
-    fn print_location_path(&self, loc: Location) {
-        let line_number = self.debug_artifact.location_line_number(loc).unwrap();
-        let column_number = self.debug_artifact.location_column_number(loc).unwrap();
-
-        println!(
-            "At {}:{line_number}:{column_number}",
-            self.debug_artifact.name(loc.file).unwrap()
-        );
-    }
-
-    fn show_source_code_location(&self, location: &OpcodeLocation) {
-        let locations = self.debug_artifact.debug_symbols[0].opcode_location(location);
-        let Some(locations) = locations else { return };
-        for loc in locations {
-            self.print_location_path(loc);
-
-            let loc_line_index = self.debug_artifact.location_line_index(loc).unwrap();
-            let loc_end_line_index = self.debug_artifact.location_end_line_index(loc).unwrap();
-
-            // How many lines before or after the location's line we
-            // print
-            let context_lines = 5;
-
-            let first_line_to_print =
-                if loc_line_index < context_lines { 0 } else { loc_line_index - context_lines };
-
-            let last_line_index = self.debug_artifact.last_line_index(loc).unwrap();
-
-            // Print all lines that the current location spans
-            let last_line_to_print =
-                std::cmp::min(loc_end_line_index + context_lines, last_line_index);
-
-            let source = self.debug_artifact.location_source_code(loc).unwrap();
-
-            for (current_line_index, line) in source.lines().enumerate() {
-                let current_line_number = current_line_index + 1;
-
-                if current_line_index < first_line_to_print {
-                    // Ignore lines before range starts
-                    continue;
-                } else if current_line_index == first_line_to_print && current_line_index > 0 {
-                    // Denote that there's more lines before but we're not showing them
-                    print_line_of_ellipsis(current_line_index);
-                }
-
-                if current_line_index > last_line_to_print {
-                    // Denote that there's more lines after but we're not showing them,
-                    // and stop printing
-                    print_line_of_ellipsis(current_line_number);
-                    break;
-                }
-
-                if current_line_index == loc_line_index {
-                    let Range { start: loc_start, end: loc_end } =
-                        self.debug_artifact.location_in_line(loc).unwrap();
-
-                    // Highlight current location from where it starts
-                    // to the end of the current line
-                    println!(
-                        "{:>3} {:2} {}{}{}",
-                        current_line_number,
-                        "->",
-                        &line[0..loc_start].to_string().dimmed(),
-                        &line[loc_start..loc_end],
-                        &line[loc_end..].to_string().dimmed()
-                    );
-                } else if current_line_index < loc_end_line_index {
-                    // Highlight current line if it's contained by the current location
-                    println!("{:>3} {:2} {}", current_line_number, "", line);
-                } else if current_line_index == loc_end_line_index {
-                    let Range { start: loc_start, end: loc_end } =
-                        self.debug_artifact.location_in_end_line(loc).unwrap();
-
-                    // Highlight current location from the beginning
-                    // of the line until the location's own end
-                    println!(
-                        "{:>3} {:2} {}{}",
-                        current_line_number,
-                        "",
-                        &line[loc_start..loc_end],
-                        &line[loc_end..].to_string().dimmed()
-                    );
-                } else {
-                    print_dimmed_line(current_line_number, line);
-                }
+                print_source_code_location(self.debug_artifact, &location);
             }
         }
     }
@@ -405,14 +311,6 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
     fn finalize(self) -> WitnessMap {
         self.context.finalize()
     }
-}
-
-fn print_line_of_ellipsis(line_number: usize) {
-    println!("{}", format!("{:>3} {}", line_number, "...").dimmed());
-}
-
-fn print_dimmed_line(line_number: usize, line: &str) {
-    println!("{}", format!("{:>3} {:2} {}", line_number, "", line).dimmed());
 }
 
 pub fn run<B: BlackBoxFunctionSolver>(

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -102,6 +102,8 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                 if loc_line_index < context_lines { 0 } else { loc_line_index - context_lines };
 
             let last_line_index = self.debug_artifact.last_line_index(loc).unwrap();
+
+            // Print all lines that the current location spans
             let last_line_to_print =
                 std::cmp::min(loc_end_line_index + context_lines, last_line_index);
 
@@ -126,10 +128,11 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                 }
 
                 if current_line_index == loc_line_index {
-                    // Highlight current location
                     let Range { start: loc_start, end: loc_end } =
                         self.debug_artifact.location_in_line(loc).unwrap();
 
+                    // Highlight current location from where it starts
+                    // to the end of the current line
                     println!(
                         "{:>3} {:2} {}{}{}",
                         current_line_number,
@@ -139,12 +142,14 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                         &line[loc_end..].to_string().dimmed()
                     );
                 } else if current_line_index < loc_end_line_index {
+                    // Highlight current line if it's contained by the current location
                     println!("{:>3} {:2} {}", current_line_number, "", line);
                 } else if current_line_index == loc_end_line_index {
-                    // Highlight current location
                     let Range { start: loc_start, end: loc_end } =
                         self.debug_artifact.location_in_end_line(loc).unwrap();
 
+                    // Highlight current location from the beginning
+                    // of the line until the location's own end
                     println!(
                         "{:>3} {:2} {}{}",
                         current_line_number,
@@ -199,7 +204,7 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                 println!("       |       outputs={:?}", brillig.outputs);
                 for (brillig_index, brillig_opcode) in brillig.bytecode.iter().enumerate() {
                     println!(
-                        "{:>3}{:<2} |{:2} {:?}",
+                        "{:>3}.{:<2} |{:2} {:?}",
                         acir_index,
                         brillig_index,
                         brillig_marker(acir_index, brillig_index),

--- a/tooling/debugger/src/source_code_printer.rs
+++ b/tooling/debugger/src/source_code_printer.rs
@@ -99,11 +99,14 @@ fn render<'a>(
             .enumerate()
             .map(|(current_line_index, line)| {
                 let current_line_number = current_line_index + 1;
-                
+
                 if current_line_index < first_line_to_print {
                     // Ignore lines before the context window we choose to show
                     PrintedLine::Skip
-                } else if current_line_index == first_line_to_print && current_line_index > 0 {
+                } else if current_line_index == first_line_to_print
+                    && current_line_index > 0
+                    && current_line_index < loc_line_index
+                {
                     // Denote that there's more lines before but we're not showing them
                     PrintedLine::Ellipsis { number: current_line_number }
                 } else if current_line_index < loc_line_index {
@@ -154,7 +157,9 @@ fn render<'a>(
                         content: line,
                         highlight: None,
                     }
-                } else if current_line_index == last_line_to_print && last_line_to_print < last_line_index {
+                } else if current_line_index == last_line_to_print
+                    && last_line_to_print < last_line_index
+                {
                     // Denote that there's more lines after but we're not showing them,
                     // and stop printing
                     PrintedLine::Ellipsis { number: current_line_number }

--- a/tooling/debugger/src/source_code_printer.rs
+++ b/tooling/debugger/src/source_code_printer.rs
@@ -1,0 +1,180 @@
+use acvm::acir::circuit::OpcodeLocation;
+use codespan_reporting::files::Files;
+use nargo::artifacts::debug::DebugArtifact;
+use noirc_errors::Location;
+use owo_colors::OwoColorize;
+use std::ops::Range;
+
+#[derive(Debug)]
+struct PrintedLine<'a> {
+    number: usize,
+    cursor: &'a str,
+    content: &'a str,
+    highlight: Option<Range<usize>>,
+}
+
+impl<'a> PrintedLine<'a> {
+    fn ellipsis(line_number: usize) -> Self {
+        Self { number: line_number, cursor: "", content: "...", highlight: None }
+    }
+}
+
+#[derive(Debug)]
+struct PrintedLocation<'a> {
+    location: Location,
+    lines: Vec<PrintedLine<'a>>,
+}
+
+impl<'a> PrintedLocation<'a> {
+    fn new(loc: Location) -> Self {
+        Self { location: loc, lines: [].into() }
+    }
+
+    fn add_line(&mut self, line: PrintedLine<'a>) {
+        self.lines.push(line);
+    }
+}
+
+pub(crate) fn print_source_code_location(
+    debug_artifact: &DebugArtifact,
+    location: &OpcodeLocation,
+) {
+    let rendered_locations = render(debug_artifact, location);
+
+    for loc in rendered_locations {
+        print_location_path(debug_artifact, loc.location);
+
+        for line in loc.lines {
+            match line.highlight {
+                Some(highlight) => {
+                    println!(
+                        "{:>3} {:2} {}{}{}",
+                        line.number,
+                        line.cursor,
+                        line.content[0..highlight.start].to_string().dimmed(),
+                        &line.content[highlight.start..highlight.end],
+                        line.content[highlight.end..].to_string().dimmed(),
+                    );
+                }
+                None => {
+                    println!(
+                        "{:>3} {:2} {}",
+                        line.number.dimmed(),
+                        line.cursor.dimmed(),
+                        line.content.to_string().dimmed(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn print_location_path(debug_artifact: &DebugArtifact, loc: Location) {
+    let line_number = debug_artifact.location_line_number(loc).unwrap();
+    let column_number = debug_artifact.location_column_number(loc).unwrap();
+
+    println!("At {}:{line_number}:{column_number}", debug_artifact.name(loc.file).unwrap());
+}
+
+fn render<'a>(
+    debug_artifact: &'a DebugArtifact,
+    location: &OpcodeLocation,
+) -> Vec<PrintedLocation<'a>> {
+    let mut rendered_locations: Vec<PrintedLocation> = [].into();
+
+    let locations = debug_artifact.debug_symbols[0].opcode_location(location);
+
+    //TODO: use map instead?
+    let Some(locations) = locations else { return rendered_locations };
+
+    for loc in locations {
+        let mut rendered_loc = PrintedLocation::new(loc);
+
+        let loc_line_index = debug_artifact.location_line_index(loc).unwrap();
+        let loc_end_line_index = debug_artifact.location_end_line_index(loc).unwrap();
+
+        // How many lines before or after the location's line we
+        // print
+        let context_lines = 5;
+
+        let first_line_to_print =
+            if loc_line_index < context_lines { 0 } else { loc_line_index - context_lines };
+
+        let last_line_index = debug_artifact.last_line_index(loc).unwrap();
+
+        // Print all lines that the current location spans
+        let last_line_to_print = std::cmp::min(loc_end_line_index + context_lines, last_line_index);
+
+        let source = debug_artifact.location_source_code(loc).unwrap();
+
+        for (current_line_index, line) in source.lines().enumerate() {
+            let current_line_number = current_line_index + 1;
+
+            if current_line_index < first_line_to_print {
+                // Ignore lines before range starts
+                continue;
+            } else if current_line_index == first_line_to_print && current_line_index > 0 {
+                // Denote that there's more lines before but we're not showing them
+                rendered_loc.add_line(PrintedLine::ellipsis(current_line_number));
+                break;
+            }
+
+            if current_line_index > last_line_to_print {
+                // Denote that there's more lines after but we're not showing them,
+                // and stop printing
+                rendered_loc.add_line(PrintedLine::ellipsis(current_line_number));
+                break;
+            }
+
+            if current_line_index < loc_line_index {
+                rendered_loc.add_line(PrintedLine {
+                    number: current_line_number,
+                    cursor: "",
+                    content: line,
+                    highlight: None,
+                });
+            } else if current_line_index == loc_line_index {
+                let to_highlight = debug_artifact.location_in_line(loc).unwrap();
+
+                // Highlight current location from where it starts
+                // to the end of the current line
+                rendered_loc.add_line(PrintedLine {
+                    number: current_line_number,
+                    cursor: "->",
+                    content: line,
+                    highlight: Some(to_highlight),
+                });
+            } else if current_line_index < loc_end_line_index {
+                // Highlight current line if it's contained by the current location
+                rendered_loc.add_line(PrintedLine {
+                    number: current_line_number,
+                    cursor: "",
+                    content: line,
+                    highlight: Some(Range { start: 0, end: line.len() - 1 }),
+                });
+            } else if current_line_index == loc_end_line_index {
+                let to_highlight = debug_artifact.location_in_end_line(loc).unwrap();
+
+                // Highlight current location from the beginning
+                // of the line until the location's own end
+                rendered_loc.add_line(PrintedLine {
+                    number: current_line_number,
+                    cursor: "",
+                    content: line,
+                    highlight: Some(to_highlight),
+                });
+            } else {
+                rendered_loc.add_line(PrintedLine {
+                    number: current_line_number,
+                    cursor: "",
+                    content: line,
+                    highlight: None,
+                })
+            }
+        }
+
+        rendered_locations.push(rendered_loc);
+    }
+
+    rendered_locations
+}

--- a/tooling/debugger/src/source_code_printer.rs
+++ b/tooling/debugger/src/source_code_printer.rs
@@ -41,29 +41,10 @@ pub(crate) fn print_source_code_location(
         for line in lines {
             match line {
                 PrintedLine::Skip => {}
-                PrintedLine::Ellipsis { number } => {
-                    println!("{:>3} {:2} {}", number.dimmed(), "", "...".dimmed(),);
+                PrintedLine::Ellipsis { number } => print_ellipsis(number),
+                PrintedLine::Content { number, cursor, content, highlight } => {
+                    print_content(number, cursor, content, highlight)
                 }
-                PrintedLine::Content { number, cursor, content, highlight } => match highlight {
-                    Some(highlight) => {
-                        println!(
-                            "{:>3} {:2} {}{}{}",
-                            number,
-                            cursor,
-                            content[0..highlight.start].to_string().dimmed(),
-                            &content[highlight.start..highlight.end],
-                            content[highlight.end..].to_string().dimmed(),
-                        );
-                    }
-                    None => {
-                        println!(
-                            "{:>3} {:2} {}",
-                            number.dimmed(),
-                            cursor.dimmed(),
-                            content.to_string().dimmed(),
-                        );
-                    }
-                },
             }
         }
     }
@@ -74,6 +55,33 @@ fn print_location_path(debug_artifact: &DebugArtifact, loc: Location) {
     let column_number = debug_artifact.location_column_number(loc).unwrap();
 
     println!("At {}:{line_number}:{column_number}", debug_artifact.name(loc.file).unwrap());
+}
+
+fn print_ellipsis(number: usize) {
+    println!("{:>3} {:2} {}", number.dimmed(), "", "...".dimmed());
+}
+
+fn print_content(number: usize, cursor: &str, content: &str, highlight: Option<Range<usize>>) {
+    match highlight {
+        Some(highlight) => {
+            println!(
+                "{:>3} {:2} {}{}{}",
+                number,
+                cursor,
+                content[0..highlight.start].to_string().dimmed(),
+                &content[highlight.start..highlight.end],
+                content[highlight.end..].to_string().dimmed(),
+            );
+        }
+        None => {
+            println!(
+                "{:>3} {:2} {}",
+                number.dimmed(),
+                cursor.dimmed(),
+                content.to_string().dimmed(),
+            );
+        }
+    }
 }
 
 fn render_line(

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -59,7 +59,7 @@ impl DebugArtifact {
         self.line_index(location.file, location_start)
     }
 
-    /// Given a location, returns the index of the line it starts at
+    /// Given a location, returns the index of the line it ends at
     pub fn location_end_line_index(&self, location: Location) -> Result<usize, Error> {
         let location_end = location.span.end() as usize;
         self.line_index(location.file, location_end)
@@ -90,6 +90,9 @@ impl DebugArtifact {
 
         let line_length = line_span.end - (line_span.start + 1);
         let start_in_line = location_start - line_span.start;
+
+        // The location might continue beyond the line,
+        // so we need a bounds check
         let end_in_line = location_end - line_span.start;
         let end_in_line = std::cmp::min(end_in_line, line_length);
 

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -224,7 +224,7 @@ mod tests {
         //      consts::x5_2_config(),
         //      state)
         // ```
-        let loc = Location::new(Span::inclusive(63, 117), file_id);
+        let loc = Location::new(Span::inclusive(63, 116), file_id);
 
         // We don't care about opcodes in this context,
         // we just use a dummy to construct debug_symbols
@@ -235,6 +235,6 @@ mod tests {
         let debug_artifact = DebugArtifact::new(debug_symbols, &fm);
 
         let location_in_line = debug_artifact.location_in_line(loc).expect("Expected a range");
-        assert_eq!(location_in_line, Range { start: 12, end: 20 });
+        assert_eq!(location_in_line, Range { start: 12, end: 19 });
     }
 }

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -235,6 +235,6 @@ mod tests {
         let debug_artifact = DebugArtifact::new(debug_symbols, &fm);
 
         let location_in_line = debug_artifact.location_in_line(loc).expect("Expected a range");
-        assert_eq!(location_in_line, Range { start: 12, end: 19 });
+        assert_eq!(location_in_line, Range { start: 12, end: 20 });
     }
 }


### PR DESCRIPTION
# Description

The debugger REPL was failing under certain scenarios when a stepped location spanned multiple lines. We tracked down the failure to a missing bounds check. 

This PR fixes the issue, introduces a refactor to make the relevant code testable, and adds regression tests to prevent reoccurrence.

This PR is best reviewed as a whole instead of commit-by-commit.

## Summary

- Moves source code printing logic from the main debugger REPL module, to a new source_code_printer module.
- Decouples actual printing from rendering logic to improve testability.
- Adds regression tests

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
