### PR TITLE
chore: Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,10 @@ This strategy avoids scenarios where pull requests grow too large/out-of-scope a
 
 The easiest way to do this is to have multiple Conventional Commits while you work and then you can cherry-pick the smaller changes into separate branches for pull requesting.
 
+### Typos and other small changes
+
+Significant changes, like new features or important bug fixes, typically have a more pronounced impact on the project’s overall development. For smaller fixes, such as typos, we encourage you to report them instead of opening PRs. This approach helps us manage our resources effectively and ensures that every change contributes meaningfully to the project. PRs involving such smaller fixes will likely be closed and incorporated in PRs authored by the core team.
+
 ### Reviews
 
 For any repository in the noir-lang organization, we require code review & approval by __one__ Noir team member before the changes are merged, as enforced by GitHub branch protection. Non-breaking pull requests may be merged at any time. Breaking pull requests should only be merged when the team has general agreement of the changes and is preparing a breaking release.


### PR DESCRIPTION

# Description

This PR makes changes to the contribution guide in order to make clear the usage of PRs as a metric is not encouraged

## Problem\*

We have been getting a lot of PRs opened for typos and other small fixes that, despite being valuable, would not be relevant enough to be included in separate PRs