### PR TITLE
chore: abstract away subtractions from `OR` implementation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -454,14 +454,11 @@ impl AcirContext {
             self.sub_var(sum, mul)
         } else {
             // Implement OR in terms of AND
-            // max - ((max - a) AND (max -b))
-            // Subtracting from max flips the bits, so this is effectively:
-            // (NOT a) NAND (NOT b)
-            let max = self.add_constant((1_u128 << bit_size) - 1);
-            let a = self.sub_var(max, lhs)?;
-            let b = self.sub_var(max, rhs)?;
-            let a_and_b = self.and_var(a, b, typ)?;
-            self.sub_var(max, a_and_b)
+            // (NOT a) NAND (NOT b) => a OR b
+            let a = self.not_var(lhs, typ.clone())?;
+            let b = self.not_var(rhs, typ.clone())?;
+            let a_and_b = self.and_var(a, b, typ.clone())?;
+            self.not_var(a_and_b, typ)
         }
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is just a small cleanup so that we can think in terms of logic operators rather than subtractions here.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
