### PR TITLE
feat: simplify multiplications by `0` or `1` in ACIR gen

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -533,8 +533,19 @@ impl AcirContext {
         let lhs_data = self.vars[&lhs].clone();
         let rhs_data = self.vars[&rhs].clone();
         let result = match (lhs_data, rhs_data) {
+            // (x * 1) == (1 * x) == x
+            (AcirVarData::Const(constant), _) if constant.is_one() => rhs,
+            (_, AcirVarData::Const(constant)) if constant.is_one() => lhs,
+
+            // (x * 0) == (0 * x) == 0
+            (AcirVarData::Const(constant), _) | (_, AcirVarData::Const(constant))
+                if constant.is_zero() =>
+            {
+                self.add_constant(FieldElement::zero())
+            }
+
             (AcirVarData::Const(lhs_constant), AcirVarData::Const(rhs_constant)) => {
-                self.add_data(AcirVarData::Const(lhs_constant * rhs_constant))
+                self.add_constant(lhs_constant * rhs_constant)
             }
             (AcirVarData::Witness(witness), AcirVarData::Const(constant))
             | (AcirVarData::Const(constant), AcirVarData::Witness(witness)) => {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR avoids churn on `AcirVar`s when we perform trivial multiplications. This avoids some situations where we were codegenning expressions with zero-coefficient terms.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
