### PR TITLE
chore: fix `should_fail_mismatch` test to use correct pedersen return type

### DIFF
--- a/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
+++ b/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
@@ -10,5 +10,6 @@ fn test_with_extra_space() {
 // The assert message has a space
 #[test(should_fail_with = "Not equal")]
 fn test_runtime_mismatch() {
+    // We use a pedersen commitment here so that the assertion failure is onlyw known at runtime.
     assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0, "Not equal ");
 }

--- a/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
+++ b/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
@@ -10,5 +10,5 @@ fn test_with_extra_space() {
 // The assert message has a space
 #[test(should_fail_with = "Not equal")]
 fn test_runtime_mismatch() {
-    assert_eq(dep::std::hash::pedersen_commitment([27])[0], 0, "Not equal ");
+    assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0, "Not equal ");
 }

--- a/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
+++ b/test_programs/noir_test_failure/should_fail_mismatch/src/main.nr
@@ -10,6 +10,6 @@ fn test_with_extra_space() {
 // The assert message has a space
 #[test(should_fail_with = "Not equal")]
 fn test_runtime_mismatch() {
-    // We use a pedersen commitment here so that the assertion failure is onlyw known at runtime.
+    // We use a pedersen commitment here so that the assertion failure is only known at runtime.
     assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0, "Not equal ");
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the `should_fail_mismatch` test to use the correct return type from the `pedersen_commitment` function. Previously the test was failing due to this type error and not from the fact that the assertion was failing.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
