### PR TITLE
feat: implement `Eq` trait on curve points

### DIFF
--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -12,6 +12,8 @@ mod affine {
     use crate::ec::safe_inverse;
     use crate::ec::sqrt;
     use crate::ec::ZETA;
+    use crate::cmp::Eq;
+
     // Curve specification
     struct Curve { // Montgomery Curve configuration (ky^2 = x^3 + j*x^2 + x)
         j: Field,
@@ -221,6 +223,7 @@ mod curvegroup {
     use crate::ec::swcurve::curvegroup::Point as SWPoint;
     use crate::ec::tecurve::curvegroup::Curve as TECurve;
     use crate::ec::tecurve::curvegroup::Point as TEPoint;
+    use crate::cmp::Eq;
 
     struct Curve { // Montgomery Curve configuration (ky^2 z = x*(x^2 + j*x*z + z*z))
         j: Field,

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -277,7 +277,6 @@ mod curvegroup {
     }
 
     impl Eq for Point {
-        // Check for equality
         fn eq(self, p: Self) -> bool {
              (self.z == p.z) | (((self.x * self.z) == (p.x * p.z)) & ((self.y * self.z) == (p.y * p.z)))
         }

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -32,11 +32,6 @@ mod affine {
             Self {x, y, infty: false}
         }
 
-        // Check for equality
-        fn eq(self, p: Self) -> bool {
-            (self.infty & p.infty) | (!self.infty & !p.infty & (self.x == p.x) & (self.y == p.y))
-        }
-
         // Check if zero
         pub fn is_zero(self) -> bool {
             self.infty
@@ -73,6 +68,13 @@ mod affine {
             } else {
                 TEPoint::new(x/y, (x-1)/(x+1))
             }
+        }
+    }
+
+    impl Eq for Point {
+        // Check for equality
+        fn eq(self, p: Self) -> bool {
+            (self.infty & p.infty) | (!self.infty & !p.infty & (self.x == p.x) & (self.y == p.y))
         }
     }
 
@@ -239,11 +241,6 @@ mod curvegroup {
             Self {x, y, z}
         }
 
-        // Check for equality
-        fn eq(self, p: Self) -> bool {
-            (self.z == p.z) | (((self.x * self.z) == (p.x * p.z)) & ((self.y * self.z) == (p.y * p.z)))
-        }
-
         // Check if zero
         pub fn is_zero(self) -> bool {
             self.z == 0
@@ -274,6 +271,13 @@ mod curvegroup {
         // Map into equivalent Twisted Edwards curve
         fn into_tecurve(self) -> TEPoint {
             self.into_affine().into_tecurve().into_group()
+        }
+    }
+
+    impl Eq for Point {
+        // Check for equality
+        fn eq(self, p: Self) -> bool {
+             (self.z == p.z) | (((self.x * self.z) == (p.x * p.z)) & ((self.y * self.z) == (p.y * p.z)))
         }
     }
 

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -74,7 +74,6 @@ mod affine {
     }
 
     impl Eq for Point {
-        // Check for equality
         fn eq(self, p: Self) -> bool {
             (self.infty & p.infty) | (!self.infty & !p.infty & (self.x == p.x) & (self.y == p.y))
         }

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -238,7 +238,6 @@ mod curvegroup {
     }
 
     impl Eq for Point {
-        // Check for equality
         fn eq(self, p: Self) -> bool {
                let Self {x: x1, y: y1, z: z1} = self;
             let Self {x: x2, y: y2, z: z2} = p;

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -28,15 +28,6 @@ mod affine {
             Self {x, y, infty: false}
         }
 
-        // Check for equality
-        fn eq(self, p: Point) -> bool {
-            let Self {x: x1, y: y1, infty: inf1} = self;
-            let Self {x: x2, y: y2, infty: inf2} = p;
-
-            (inf1 & inf2)
-                | (!inf1 & !inf2 & (x1 == x2) & (y1 == y2))
-        }
-
         // Check if zero
         pub fn is_zero(self) -> bool {
             self.eq(Point::zero())
@@ -62,6 +53,17 @@ mod affine {
         fn negate(self) -> Self {
             let Self {x, y, infty} = self;
             Self {x, y: 0-y, infty}
+        }
+    }
+
+    impl Eq for Point {
+        // Check for equality
+        fn eq(self, p: Self) -> bool {
+             let Self {x: x1, y: y1, infty: inf1} = self;
+            let Self {x: x2, y: y2, infty: inf2} = p;
+
+            (inf1 & inf2)
+                | (!inf1 & !inf2 & (x1 == x2) & (y1 == y2))
         }
     }
 
@@ -203,14 +205,6 @@ mod curvegroup {
             Self {x, y, z}
         }
 
-        // Check for equality
-        fn eq(self, p: Point) -> bool {
-            let Self {x: x1, y: y1, z: z1} = self;
-            let Self {x: x2, y: y2, z: z2} = p;
-
-            ((z1 == 0) & (z2 == 0)) | ((z1 != 0) & (z2 != 0) & (x1*z2*z2 == x2*z1*z1) & (y1*z2*z2*z2 == y2*z1*z1*z1))
-        }
-
         // Check if zero
         pub fn is_zero(self) -> bool {
             self.eq(Point::zero())
@@ -237,6 +231,16 @@ mod curvegroup {
         fn negate(self) -> Self {
             let Self {x, y, z} = self;
             Self {x, y: 0-y, z}
+        }
+    }
+
+    impl Eq for Point {
+        // Check for equality
+        fn eq(self, p: Self) -> bool {
+               let Self {x: x1, y: y1, z: z1} = self;
+            let Self {x: x2, y: y2, z: z2} = p;
+
+            ((z1 == 0) & (z2 == 0)) | ((z1 != 0) & (z2 != 0) & (x1*z2*z2 == x2*z1*z1) & (y1*z2*z2*z2 == y2*z1*z1*z1))
         }
     }
 

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -7,6 +7,8 @@ mod affine {
     use crate::ec::safe_inverse;
     use crate::ec::is_square;
     use crate::ec::sqrt;
+    use crate::cmp::Eq;
+
     // Curve specification
     struct Curve { // Short Weierstraß curve
         // Coefficients in defining equation y^2 = x^3 + ax + b
@@ -184,6 +186,8 @@ mod curvegroup {
     // Points are represented by three-dimensional Jacobian coordinates.
     // See <https://en.wikibooks.org/wiki/Cryptography/Prime_Curve/Jacobian_Coordinates> for details.
     use crate::ec::swcurve::affine;
+    use crate::cmp::Eq;
+
     // Curve specification
     struct Curve { // Short Weierstraß curve
         // Coefficients in defining equation y^2 = x^3 + axz^4 + bz^6

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -59,7 +59,6 @@ mod affine {
     }
 
     impl Eq for Point {
-        // Check for equality
         fn eq(self, p: Self) -> bool {
              let Self {x: x1, y: y1, infty: inf1} = self;
             let Self {x: x2, y: y2, infty: inf2} = p;

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -29,14 +29,6 @@ mod affine {
             Self { x, y }
         }
 
-        // Check for equality
-        fn eq(self, p: Point) -> bool {
-            let Self {x: x1, y: y1} = self;
-            let Self {x: x2, y: y2} = p;
-
-            (x1 == x2) & (y1 == y2)
-        }
-
         // Check if zero
         pub fn is_zero(self) -> bool {
             self.eq(Point::zero())
@@ -71,6 +63,16 @@ mod affine {
 
                 MPoint::new(x0,y0)
             }
+        }
+    }
+
+    impl Eq for Point {
+        // Check for equality
+        fn eq(self, p: Self) -> bool {
+             let Self {x: x1, y: y1} = self;
+            let Self {x: x2, y: y2} = p;
+
+            (x1 == x2) & (y1 == y2)
         }
     }
 
@@ -220,14 +222,6 @@ mod curvegroup {
             Self {x, y, t, z}
         }
 
-        // Check for equality
-        fn eq(self, p: Point) -> bool {
-            let Self {x: x1, y: y1, t: _t1, z: z1} = self;
-            let Self {x: x2, y: y2, t: _t2, z:z2} = p;
-
-            (x1*z2 == x2*z1) & (y1*z2 == y2*z1)
-        }
-
         // Check if zero
         pub fn is_zero(self) -> bool {
             let Self {x, y, t, z} = self;
@@ -256,6 +250,16 @@ mod curvegroup {
         // Map into prime-order subgroup of equivalent Montgomery curve
         fn into_montcurve(self) -> MPoint {
             self.into_affine().into_montcurve().into_group()
+        }
+    }
+
+    impl Eq for Point {
+        // Check for equality
+        fn eq(self, p: Self) -> bool {
+            let Self {x: x1, y: y1, t: _t1, z: z1} = self;
+            let Self {x: x2, y: y2, t: _t2, z:z2} = p;
+
+            (x1*z2 == x2*z1) & (y1*z2 == y2*z1)
         }
     }
 

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -9,6 +9,8 @@ mod affine {
     use crate::ec::montcurve::affine::Point as MPoint;
     use crate::ec::swcurve::affine::Curve as SWCurve;
     use crate::ec::swcurve::affine::Point as SWPoint;
+    use crate::cmp::Eq;
+
     // Curve specification
     struct Curve { // Twisted Edwards curve
         // Coefficients in defining equation ax^2 + y^2 = 1 + dx^2y^2
@@ -200,6 +202,8 @@ mod curvegroup {
     use crate::ec::montcurve::curvegroup::Point as MPoint;
     use crate::ec::swcurve::curvegroup::Curve as SWCurve;
     use crate::ec::swcurve::curvegroup::Point as SWPoint;
+    use crate::cmp::Eq;
+
     // Curve specification
     struct Curve { // Twisted Edwards curve
         // Coefficients in defining equation a(x^2 + y^2)z^2 = z^4 + dx^2y^2

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -69,7 +69,6 @@ mod affine {
     }
 
     impl Eq for Point {
-        // Check for equality
         fn eq(self, p: Self) -> bool {
              let Self {x: x1, y: y1} = self;
             let Self {x: x2, y: y2} = p;

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -257,7 +257,6 @@ mod curvegroup {
     }
 
     impl Eq for Point {
-        // Check for equality
         fn eq(self, p: Self) -> bool {
             let Self {x: x1, y: y1, t: _t1, z: z1} = self;
             let Self {x: x2, y: y2, t: _t2, z:z2} = p;


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR just moves the `eq` methods on the ec point structs into `Eq` trait impls.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
