### PR TITLE
chore: add `insert_range_check` method to `FunctionBuilder`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -255,6 +255,19 @@ impl FunctionBuilder {
         self.insert_instruction(Instruction::Constrain(lhs, rhs, assert_message), None);
     }
 
+    /// Insert a [`Instruction::RangeCheck`] instruction at the end of the current block.
+    pub(crate) fn insert_range_check(
+        &mut self,
+        value: ValueId,
+        max_bit_size: u32,
+        assert_message: Option<String>,
+    ) {
+        self.insert_instruction(
+            Instruction::RangeCheck { value, max_bit_size, assert_message },
+            None,
+        );
+    }
+
     /// Insert a call instruction at the end of the current block and return
     /// the results of the call.
     pub(crate) fn insert_call(

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -349,12 +349,11 @@ impl<'a> FunctionContext<'a> {
                     self.check_shift_overflow(result, rhs, bit_size, location, false)
                 } else {
                     let message = format!("attempt to {} with overflow", op_name);
-                    let range_constraint = Instruction::RangeCheck {
-                        value: result,
-                        max_bit_size: bit_size,
-                        assert_message: Some(message),
-                    };
-                    self.builder.set_location(location).insert_instruction(range_constraint, None);
+                    self.builder.set_location(location).insert_range_check(
+                        result,
+                        bit_size,
+                        Some(message),
+                    );
                     result
                 }
             }
@@ -464,12 +463,11 @@ impl<'a> FunctionContext<'a> {
                 let product_field = self.builder.insert_binary(lhs_abs, BinaryOp::Mul, rhs_abs);
                 // It must not already overflow the bit_size
                 let message = "attempt to multiply with overflow".to_string();
-                let size_overflow = Instruction::RangeCheck {
-                    value: product_field,
-                    max_bit_size: bit_size,
-                    assert_message: Some(message.clone()),
-                };
-                self.builder.set_location(location).insert_instruction(size_overflow, None);
+                self.builder.set_location(location).insert_range_check(
+                    product_field,
+                    bit_size,
+                    Some(message.clone()),
+                );
                 let product = self.builder.insert_cast(product_field, Type::unsigned(bit_size));
 
                 // Then we check the signed product fits in a signed integer of bit_size-bits


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR gives an `insert_range_check` method for consistency with the other `Instruction`s.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
