### PR TITLE
Fix `wrapping_add` example code

### DIFF
--- a/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/01_integers.md
+++ b/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/01_integers.md
@@ -107,6 +107,6 @@ Example of how it is used:
 use dep::std;
 
 fn main(x: u8, y: u8) -> pub u8 {
-    std::wrapping_add(x + y)
+    std::wrapping_add(x, y)
 }
 ```


### PR DESCRIPTION
# Description

## Problem\*

Documentation has a slight typo wrt `wrapping_add` function which takes two params, `x` and `y` separately instead of the addition of the two as that would defeat the purpose of it. 


## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
