### PR TITLE
fix: Improve `nargo test` output

### DIFF
--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -144,7 +144,7 @@ fn run_tests<S: BlackBoxFunctionSolver>(
 
     for (test_name, test_function) in test_functions {
         write!(writer, "[{}] Testing {test_name}... ", package.name)
-            .expect("Failed to write to stdout");
+            .expect("Failed to write to stderr");
         writer.flush().expect("Failed to flush writer");
 
         match run_test(
@@ -159,13 +159,13 @@ fn run_tests<S: BlackBoxFunctionSolver>(
                 writer
                     .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
                     .expect("Failed to set color");
-                writeln!(writer, "ok").expect("Failed to write to stdout");
+                writeln!(writer, "ok").expect("Failed to write to stderr");
             }
             TestStatus::Fail { message, error_diagnostic } => {
                 writer
                     .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
                     .expect("Failed to set color");
-                writeln!(writer, "{message}\n").expect("Failed to write to stdout");
+                writeln!(writer, "FAIL\n{message}\n").expect("Failed to write to stderr");
                 if let Some(diag) = error_diagnostic {
                     noirc_errors::reporter::report_all(
                         context.file_manager.as_file_map(),
@@ -189,12 +189,13 @@ fn run_tests<S: BlackBoxFunctionSolver>(
         writer.reset().expect("Failed to reset writer");
     }
 
-    write!(writer, "[{}] ", package.name).expect("Failed to write to stdout");
+    write!(writer, "[{}] ", package.name).expect("Failed to write to stderr");
 
     if count_failed == 0 {
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Green))).expect("Failed to set color");
-        writeln!(writer, "{count_all} test{plural} passed").expect("Failed to write to stdout");
+        write!(writer, "{count_all} test{plural} passed").expect("Failed to write to stderr");
         writer.reset().expect("Failed to reset writer");
+        writeln!(writer).expect("Failed to write to stderr");
 
         Ok(())
     } else {
@@ -207,13 +208,15 @@ fn run_tests<S: BlackBoxFunctionSolver>(
                 .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
                 .expect("Failed to set color");
             write!(writer, "{count_passed} test{plural_passed} passed, ",)
-                .expect("Failed to write to stdout");
+                .expect("Failed to write to stderr");
         }
+
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Red))).expect("Failed to set color");
-        writeln!(writer, "{count_failed} test{plural_failed} failed")
-            .expect("Failed to write to stdout");
+        write!(writer, "{count_failed} test{plural_failed} failed")
+            .expect("Failed to write to stderr");
         writer.reset().expect("Failed to reset writer");
 
+        // Writes final newline.
         Err(CliError::Generic(String::new()))
     }
 }


### PR DESCRIPTION
# Description

- Currently the `writeln!` macro is used before `writer.reset()` so the ANSI escape code to reset terminal colours to their default is printed on a new line that is left empty.
- This PR moves the ANSI colour reset code to the end of the last line of the test commands' output.
- Add `FAIL` to test result before messages from the compiler are inlined on the following line.
- Minor fix in code where mentions of printing to `stdout` are made when in-fact `writer` is outputting to `stderr`.

## Problem\*

Currently Nargo's output with scripts breaks terminal colours under certain scenarios. Mostly in combination with tools that re-run commands on file change like `wgo`, `entr`, or `watchman` when used with shell scripts.

Special checks and logic (in said shell scripts) must be added to spawn the process in a subshell with merged stdin and stdout from the parent shell, and to continue from the empty ANSI-reset-prefixed line Nargo outputs. If you do not do this you get green text in the case of passing tests until the next ANSI code is encountered.

This isn't helped by the fact that an extra newline is added for all output except all tests passing, so trimming empty lines is dangerous (prefixed ANSI colour reset gets removed).

## Summary\*

### Escape codes:

#### Before:

![before_escape_codes](https://github.com/noir-lang/noir/assets/4571498/98359cb2-8b88-4c10-9f86-c00948862597)

#### After:

![after_escape_codes](https://github.com/noir-lang/noir/assets/4571498/b82201ce-4afb-496c-87e7-9a3f3223fb18)

### Colours and `FAIL`:

#### Before 'all passing tests':

![before_naked_pass](https://github.com/noir-lang/noir/assets/4571498/798010c2-5377-44c4-bf5e-387273627d17)

#### After 'all passing tests':

![after_naked_pass](https://github.com/noir-lang/noir/assets/4571498/94e2867c-6b2c-4daf-ac37-b7eb85c64ac6)
_no visible change here, I could add a script run to show the 'green corruption' but the escape code is now at the end of the final line per this pr_

#### Before 'all failing tests':

![before_naked_fail](https://github.com/noir-lang/noir/assets/4571498/30ce27b1-9147-49de-a957-017eb332f857)

#### After 'all failing tests':

![after_naked_fail](https://github.com/noir-lang/noir/assets/4571498/679ff336-8d5d-425e-95a4-7ff387faff0d)

#### Before 'mixed pass/fail tests':

![before_naked_pass_fail](https://github.com/noir-lang/noir/assets/4571498/c7f0206d-1c85-4e2c-a9e5-ab4c82ecea52)

#### After 'mixed pass/fail tests':

![after_naked_pass_fail](https://github.com/noir-lang/noir/assets/4571498/fe6b204f-52dd-48a0-bcd0-043b0e3958fe)

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
