### PR TITLE
chore(docs): adding quick reference to oracles, guide and explainer to follow

### DIFF
--- a/docs/docs/noir/concepts/comments.md
+++ b/docs/docs/noir/concepts/comments.md
@@ -5,7 +5,7 @@ description:
   ignored by the compiler, but it can be read by programmers. Single-line and multi-line comments
   are supported in Noir.
 keywords: [Noir programming language, comments, single-line comments, multi-line comments]
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 A comment is a line in your codebase which the compiler ignores, however it can be read by

--- a/docs/docs/noir/concepts/data_bus.md
+++ b/docs/docs/noir/concepts/data_bus.md
@@ -1,6 +1,6 @@
 ---
 title: Data Bus
-sidebar_position: 12
+sidebar_position: 13
 ---
 **Disclaimer** this feature is experimental, do not use it!
 

--- a/docs/docs/noir/concepts/distinct.md
+++ b/docs/docs/noir/concepts/distinct.md
@@ -1,6 +1,6 @@
 ---
 title: Distinct Witnesses
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 The `distinct` keyword prevents repetitions of witness indices in the program's ABI. This ensures

--- a/docs/docs/noir/concepts/generics.md
+++ b/docs/docs/noir/concepts/generics.md
@@ -2,7 +2,7 @@
 title: Generics
 description: Learn how to use Generics in Noir
 keywords: [Noir, Rust, generics, functions, structs]
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 Generics allow you to use the same functions with multiple different concrete data types. You can

--- a/docs/docs/noir/concepts/lambdas.md
+++ b/docs/docs/noir/concepts/lambdas.md
@@ -2,7 +2,7 @@
 title: Lambdas
 description: Learn how to use anonymous functions in Noir programming language.
 keywords: [Noir programming language, lambda, closure, function, anonymous function]
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 ## Introduction

--- a/docs/docs/noir/concepts/mutability.md
+++ b/docs/docs/noir/concepts/mutability.md
@@ -4,7 +4,7 @@ description:
   Learn about mutable variables, constants, and globals in Noir programming language. Discover how
   to declare, modify, and use them in your programs.
 keywords: [noir programming language, mutability in noir, mutable variables, constants, globals]
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 Variables in noir can be declared mutable via the `mut` keyword. Mutable variables can be reassigned

--- a/docs/docs/noir/concepts/oracles.md
+++ b/docs/docs/noir/concepts/oracles.md
@@ -1,0 +1,23 @@
+---
+title: Understanding Oracles in Noir - A Comprehensive Guide
+description: Dive into how Noir supports Oracles via RPC calls, and learn how to declare an Oracle in Noir with our comprehensive guide.
+keywords:
+  - Noir
+  - Oracles
+  - RPC Calls
+  - Unconstrained Functions
+  - Programming
+  - Blockchain
+sidebar_position: 6
+---
+
+Noir has support for Oracles via RPC calls. This means Noir will make an RPC call and use the return value for proof generation.
+
+Since Oracles are not resolved by Noir, they are obviously [`unconstrained` functions](./unconstrained.md)
+
+You can declare an Oracle through the `#[oracle(<name>)]` flag. Example:
+
+```rust
+#[oracle(get_number_sequence)]
+unconstrained fn get_number_sequence(_size: Field) -> [Field] {}
+```

--- a/docs/docs/noir/concepts/shadowing.md
+++ b/docs/docs/noir/concepts/shadowing.md
@@ -1,6 +1,6 @@
 ---
 title: Shadowing
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 Noir allows for inheriting variables' values and re-declaring them with the same name similar to Rust, known as shadowing.

--- a/docs/docs/noir/concepts/traits.md
+++ b/docs/docs/noir/concepts/traits.md
@@ -4,6 +4,7 @@ description:
   Traits in Noir can be used to abstract out a common interface for functions across
   several data types.
 keywords: [noir programming language, traits, interfaces, generic, protocol]
+sidebar_position: 14
 ---
 
 ## Overview


### PR DESCRIPTION
# Description

Adds almost a "dummy" page on Oracles to the reference section (here called "concepts" due to the almost inevitable mix between explanations and language reference)

## Problem\*

Closes #3971 

## Summary\*

- Adds an "oracles" page to the concepts section simply explaining how to use the flag and mentioning the RPC server. Intentionally, there is no info on how to write the RPC server and how to pass it to the oracle function, as that falls outside of the scope of the language, and thus should be part of a how-to guide
- Updates sibebar item order and adds it to Traits. This is mostly unecessary but for the time being we can totally manage them and profit from controlling sidebar ordering

## Additional Context

We can almost consider this 1/3 of the work, so I'm glad making it a draft now and add it to a bigger PR with the guide/explainer. Just wanted to close #3971 for the time being
