### PR TITLE
chore: add test case showing reexports

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -64,6 +64,7 @@ pub struct CrateDefMap {
 
     pub(crate) krate: CrateId,
 
+    /// Maps an external dependency's name to its root module id.
     pub(crate) extern_prelude: BTreeMap<String, ModuleId>,
 }
 

--- a/test_programs/compile_success_empty/reexports/Nargo.toml
+++ b/test_programs/compile_success_empty/reexports/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "reexports"
+type = "bin"
+authors = [""]
+
+[dependencies]
+reexporting_lib = { path = "../../test_libraries/reexporting_lib" }

--- a/test_programs/compile_success_empty/reexports/src/main.nr
+++ b/test_programs/compile_success_empty/reexports/src/main.nr
@@ -1,0 +1,8 @@
+use dep::reexporting_lib::{FooStruct, MyStruct, is_struct_zero};
+
+fn main() {
+    let x: FooStruct = MyStruct {
+        inner: 0
+    };
+    assert(is_struct_zero(x));
+}

--- a/test_programs/compile_success_empty/reexports/src/main.nr
+++ b/test_programs/compile_success_empty/reexports/src/main.nr
@@ -1,8 +1,8 @@
-use dep::reexporting_lib::{FooStruct, MyStruct, is_struct_zero};
+use dep::reexporting_lib::{FooStruct, MyStruct, lib};
 
 fn main() {
     let x: FooStruct = MyStruct {
         inner: 0
     };
-    assert(is_struct_zero(x));
+    assert(lib::is_struct_zero(x));
 }

--- a/test_programs/test_libraries/exporting_lib/Nargo.toml
+++ b/test_programs/test_libraries/exporting_lib/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "exporting_lib"
+type = "lib"
+authors = [""]
+
+[dependencies]

--- a/test_programs/test_libraries/exporting_lib/src/lib.nr
+++ b/test_programs/test_libraries/exporting_lib/src/lib.nr
@@ -1,0 +1,10 @@
+
+struct MyStruct {
+    inner: Field
+}
+
+type FooStruct = MyStruct;
+
+fn is_struct_zero(val: MyStruct) -> bool {
+    val.inner == 0
+}

--- a/test_programs/test_libraries/reexporting_lib/Nargo.toml
+++ b/test_programs/test_libraries/reexporting_lib/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "reexporting_lib"
+type = "lib"
+authors = [""]
+
+[dependencies]
+exporting_lib = { path = "../exporting_lib" }

--- a/test_programs/test_libraries/reexporting_lib/src/lib.nr
+++ b/test_programs/test_libraries/reexporting_lib/src/lib.nr
@@ -1,1 +1,3 @@
-use dep::exporting_lib::{MyStruct, FooStruct, is_struct_zero};
+use dep::exporting_lib::{MyStruct, FooStruct};
+
+use dep::exporting_lib as lib;

--- a/test_programs/test_libraries/reexporting_lib/src/lib.nr
+++ b/test_programs/test_libraries/reexporting_lib/src/lib.nr
@@ -1,0 +1,1 @@
+use dep::exporting_lib::{MyStruct, FooStruct, is_struct_zero};


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a test case to just show the current state of reexports across libraries.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
