### PR TITLE
fix: fixup exports from `noir_wasm`

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -80,7 +80,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm/{dist,build}
+          path: |
+            ./compiler/wasm/dist
+            ./compiler/wasm/build
           retention-days: 3
 
   build-acvm-js:
@@ -294,7 +296,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm/{dist,build}
+          path: ./compiler/
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
@@ -398,7 +400,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm/
+          path: ./compiler/
 
       - name: Download noirc_abi package artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -9,7 +9,7 @@ on:
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || gitdisthub.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -9,7 +9,7 @@ on:
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || gitdisthub.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -80,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm
+          path: ./compiler/wasm/dist
           retention-days: 3
 
   build-acvm-js:
@@ -294,7 +294,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm
+          path: ./compiler/wasm/dist
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
@@ -398,7 +398,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm
+          path: ./compiler/wasm/dist
 
       - name: Download noirc_abi package artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -296,7 +296,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/
+          path: ./compiler/wasm
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
@@ -400,7 +400,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/
+          path: ./compiler/wasm
 
       - name: Download noirc_abi package artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm/dist
+          path: ./compiler/wasm/{dist,build}
           retention-days: 3
 
   build-acvm-js:
@@ -294,7 +294,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm/dist
+          path: ./compiler/wasm/{dist,build}
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
@@ -398,7 +398,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm/dist
+          path: ./compiler/wasm/{dist,build}
 
       - name: Download noirc_abi package artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -398,7 +398,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: noir_wasm
-          path: ./compiler/wasm/{dist,build}
+          path: ./compiler/wasm/
 
       - name: Download noirc_abi package artifact
         uses: actions/download-artifact@v3

--- a/compiler/wasm/.gitignore
+++ b/compiler/wasm/.gitignore
@@ -1,3 +1,2 @@
-noir-script/target
 dist
 build

--- a/compiler/wasm/package.json
+++ b/compiler/wasm/package.json
@@ -9,9 +9,10 @@
   "types": "./dist/types/src/index.d.cts",
   "exports": {
     "node": "./dist/node/main.js",
-    "default": "./dist/web/main.mjs",
     "import": "./dist/web/main.mjs",
-    "require": "./dist/node/main.js"
+    "require": "./dist/node/main.js",
+    "types": "./dist/types/src/index.d.cts",
+    "default": "./dist/web/main.mjs"
   },
   "files": [
     "dist",


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The ordering on `exports` is important plus we have `types` missing which was causing issues in `aztec-packages`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
