### PR TITLE
chore: remove unnecessary visibility modifiers from u128 trait impls

### DIFF
--- a/noir_stdlib/src/uint128.nr
+++ b/noir_stdlib/src/uint128.nr
@@ -146,7 +146,7 @@ impl U128 {
 }
 
 impl Add for U128 {
-    pub fn add(self: Self, b: U128) -> U128 {
+    fn add(self: Self, b: U128) -> U128 {
         let low = self.lo + b.lo;
         let lo = low as u64 as Field;
         let carry = (low - lo) / pow64;  
@@ -161,7 +161,7 @@ impl Add for U128 {
 }
 
 impl Sub for U128 {
-    pub fn sub(self: Self, b: U128) -> U128 {
+    fn sub(self: Self, b: U128) -> U128 {
         let low = pow64 + self.lo - b.lo;
         let lo = low as u64 as Field;
         let borrow = (low == lo) as Field;
@@ -176,7 +176,7 @@ impl Sub for U128 {
 }
 
 impl Mul for U128 {
-    pub fn mul(self: Self, b: U128) -> U128 {
+    fn mul(self: Self, b: U128) -> U128 {
         assert(self.hi*b.hi == 0, "attempt to multiply with overflow");
         let low = self.lo*b.lo;
         let lo = low as u64 as Field;
@@ -196,7 +196,7 @@ impl Mul for U128 {
 }
 
 impl Div for U128 {
-    pub fn div(self: Self, b: U128) -> U128 {
+    fn div(self: Self, b: U128) -> U128 {
         let (q,r) = self.unconstrained_div(b);
         let a = b * q + r;
         assert_eq(self, a);
@@ -206,7 +206,7 @@ impl Div for U128 {
 }
 
 impl Rem for U128 {
-    pub fn rem(self: Self, b: U128) -> U128 {
+    fn rem(self: Self, b: U128) -> U128 {
         let (q,r) = self.unconstrained_div(b);
         let a = b * q + r;
         assert_eq(self, a);
@@ -216,7 +216,7 @@ impl Rem for U128 {
 }
 
 impl Eq for U128 {
-    pub fn eq(self: Self, b: U128) -> bool {
+    fn eq(self: Self, b: U128) -> bool {
         (self.lo == b.lo) & (self.hi == b.hi)
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR fixes the warnings which have been caused by #3986 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
