### PR TITLE
feat: assert maximum bit size when creating a U128 from an integer

### DIFF
--- a/noir_stdlib/src/uint128.nr
+++ b/noir_stdlib/src/uint128.nr
@@ -116,6 +116,8 @@ impl U128 {
 
     pub fn from_integer<T>(i: T) -> U128 {
         let f = crate::as_field(i);
+        // Reject values which would overflow a u128
+        f.assert_max_bit_size(128);
         let lo = f as u64 as Field;
         let hi = (f-lo) / pow64;
         U128 {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a range check to `U128::from_integer` as this method accepts an arbitrary field and so is unsafe.

## Additional Context

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
