### PR TITLE
feat: Optimize array ops for arrays of structs

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -2431,8 +2431,7 @@ impl Context {
     }
 }
 
-// We can omit the element size array for arrays which have elements of size 1 and do not contain slices.
-// TODO: remove restriction on size 1 elements.
+// We can omit the element size array for arrays which don't contain arrays or slices.
 fn can_omit_element_sizes_array(array_typ: &Type) -> bool {
     if array_typ.contains_slice_element() {
         return false;
@@ -2441,5 +2440,5 @@ fn can_omit_element_sizes_array(array_typ: &Type) -> bool {
         panic!("ICE: expected array type");
     };
 
-    types.len() == 1 && types[0].flattened_size() == 1
+    !types.iter().any(|typ| typ.contains_an_array())
 }


### PR DESCRIPTION
# Description
Omit the mapping of SSA indexes to flat indexes for arrays of structs.
## Problem\*
## Summary\*
The mapping of SSA indexes to flat indexes is only necessary when arrays contain arrays or slices. The SSA indexing is a flat indexing for arrays that do not contain arrays in them. This PR omits the mapping for arrays of structs (that do not contain arrays in them), that previously were generating an identity mapping, increasing the number of constraints.



## Additional Context
This reduces significantly the constraint counts in aztec protocol circuits:

### 🧾 Summary (100% most significant diffs)

| Program | ACIR opcodes (+/-) | % | Circuit size (+/-) | % |
|:-|-:|-:|-:|-:|
| **private_kernel_init** | -11,663 ✅ | **-24.27%** | -45,467 ✅ | **-11.89%** |
| **rollup_base** | -55,441 ✅ | **-18.84%** | -221,585 ✅ | **-13.26%** |
| **private_kernel_inner** | -58,582 ✅ | **-38.79%** | -231,376 ✅ | **-30.70%** |
| **public_kernel_private_previous** | -34,847 ✅ | **-42.62%** | -136,451 ✅ | **-32.68%** |
| **public_kernel_public_previous** | -34,847 ✅ | **-42.63%** | -136,451 ✅ | **-32.68%** |
| **private_kernel_ordering** | -101,425 ✅ | **-34.13%** | -430,563 ✅ | **-46.33%** |
---

<details>
<summary><strong>Full diff report</strong> 👇</summary>
<br />

| Program | ACIR opcodes (+/-) | % | Circuit size (+/-) | % |
|:-|-:|-:|-:|-:|
| **private_kernel_init** | 36,399&nbsp;(-11,663) | **-24.27%** | 337,069&nbsp;(-45,467) | **-11.89%** |
| **rollup_base** | 238,760&nbsp;(-55,441) | **-18.84%** | 1,449,334&nbsp;(-221,585) | **-13.26%** |
| **private_kernel_inner** | 92,434&nbsp;(-58,582) | **-38.79%** | 522,230&nbsp;(-231,376) | **-30.70%** |
| **public_kernel_private_previous** | 46,913&nbsp;(-34,847) | **-42.62%** | 281,066&nbsp;(-136,451) | **-32.68%** |
| **public_kernel_public_previous** | 46,905&nbsp;(-34,847) | **-42.63%** | 281,058&nbsp;(-136,451) | **-32.68%** |
| **private_kernel_ordering** | 195,747&nbsp;(-101,425) | **-34.13%** | 498,850&nbsp;(-430,563) | **-46.33%** |
</details>

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
