### PR TITLE
chore: remove unnecessary instructions from `insert_wrapping_shift_left`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -309,9 +309,7 @@ impl FunctionBuilder {
                 let bit_size_var =
                     self.numeric_constant(FieldElement::from(bit_size as u128), typ.clone());
                 let overflow = self.insert_binary(rhs, BinaryOp::Lt, bit_size_var);
-                let one = self.numeric_constant(FieldElement::one(), Type::unsigned(1));
-                let predicate = self.insert_binary(overflow, BinaryOp::Eq, one);
-                let predicate = self.insert_cast(predicate, typ.clone());
+                let predicate = self.insert_cast(overflow, typ.clone());
                 // we can safely cast to unsigned because overflow_checks prevent bit-shift with a negative value
                 let rhs_unsigned = self.insert_cast(rhs, Type::unsigned(bit_size));
                 let pow = self.pow(base, rhs_unsigned);
@@ -365,7 +363,7 @@ impl FunctionBuilder {
                 let r_squared = self.insert_binary(r, BinaryOp::Mul, r);
                 let a = self.insert_binary(r_squared, BinaryOp::Mul, lhs);
                 let idx = self.field_constant(FieldElement::from((bit_size - i) as i128));
-                let b = self.insert_array_get(rhs_bits, idx, Type::field());
+                let b = self.insert_array_get(rhs_bits, idx, Type::unsigned(1));
                 let r1 = self.insert_binary(a, BinaryOp::Mul, b);
                 let c = self.insert_binary(one, BinaryOp::Sub, b);
                 let r2 = self.insert_binary(c, BinaryOp::Mul, r_squared);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR just removes some unnecessary instructions which get immediately optimised out again.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x]  I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
