### PR TITLE
feat: Avoid unnecessary range checks by inspecting instructions for casts

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -305,17 +305,9 @@ impl FunctionBuilder {
                 }
                 let pow = self.numeric_constant(FieldElement::from(rhs_bit_size_pow_2), typ);
 
-                let mut max_lhs_bit = bit_size;
+                let max_lhs_bits = self.current_function.dfg.get_value_max_num_bits(lhs);
 
-                let dfg = &self.current_function.dfg;
-                if let Value::Instruction { instruction, .. } = dfg[lhs] {
-                    if let Instruction::Cast(original_lhs, _) = dfg[instruction] {
-                        let original_type = self.type_of_value(original_lhs);
-                        max_lhs_bit = original_type.bit_size();
-                    }
-                }
-
-                (max_lhs_bit + bit_shift_size, pow)
+                (max_lhs_bits + bit_shift_size, pow)
             } else {
                 // we use a predicate to nullify the result in case of overflow
                 let bit_size_var =

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -293,8 +293,9 @@ impl FunctionBuilder {
             if let Some(rhs_constant) = self.current_function.dfg.get_numeric_constant(rhs) {
                 // Happy case is that we know precisely by how many bits the the integer will
                 // increase: lhs_bit_size + rhs
-                let (rhs_bit_size_pow_2, overflows) =
-                    2_u128.overflowing_pow(rhs_constant.to_u128() as u32);
+                let bit_shift_size = rhs_constant.to_u128() as u32;
+
+                let (rhs_bit_size_pow_2, overflows) = 2_u128.overflowing_pow(bit_shift_size);
                 if overflows {
                     assert!(bit_size < 128, "ICE - shift left with big integers are not supported");
                     if bit_size < 128 {
@@ -303,7 +304,18 @@ impl FunctionBuilder {
                     }
                 }
                 let pow = self.numeric_constant(FieldElement::from(rhs_bit_size_pow_2), typ);
-                (bit_size + (rhs_constant.to_u128() as u32), pow)
+
+                let mut max_lhs_bit = bit_size;
+
+                let dfg = &self.current_function.dfg;
+                if let Value::Instruction { instruction, .. } = dfg[lhs] {
+                    if let Instruction::Cast(original_lhs, _) = dfg[instruction] {
+                        let original_type = self.type_of_value(original_lhs);
+                        max_lhs_bit = original_type.bit_size();
+                    }
+                }
+
+                (max_lhs_bit + bit_shift_size, pow)
             } else {
                 // we use a predicate to nullify the result in case of overflow
                 let bit_size_var =

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -337,6 +337,25 @@ impl DataFlowGraph {
         self.values[value].get_type().clone()
     }
 
+    /// Returns the maximum possible number of bits that `value` can potentially be.
+    ///
+    /// Should `value` be a numeric constant then this function will return the exact number of bits required,
+    /// otherwise it will return the minimum number of bits based on type information.
+    pub(crate) fn get_value_max_num_bits(&self, value: ValueId) -> u32 {
+        match self[value] {
+            Value::Instruction { instruction, .. } => {
+                if let Instruction::Cast(original_value, _) = self[instruction] {
+                    self.type_of_value(original_value).bit_size()
+                } else {
+                    self.type_of_value(value).bit_size()
+                }
+            }
+
+            Value::NumericConstant { constant, .. } => constant.num_bits(),
+            _ => self.type_of_value(value).bit_size(),
+        }
+    }
+
     /// True if the type of this value is Type::Reference.
     /// Using this method over type_of_value avoids cloning the value's type.
     pub(crate) fn value_is_reference(&self, value: ValueId) -> bool {

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -287,6 +287,26 @@ impl<'a> FunctionContext<'a> {
         self.builder.insert_binary(positive_predicate, BinaryOp::Add, negative_predicate)
     }
 
+    /// Returns the maximum possible number of bits that `value` can potentially be.
+    ///
+    /// Should `value` be a numeric constant then this function will return the exact number of bits required,
+    /// otherwise it will return the minimum number of bits based on type information.
+    fn get_value_max_num_bits(&self, value: ValueId) -> u32 {
+        let dfg = &self.builder.current_function.dfg;
+        match dfg[value] {
+            IrValue::Instruction { instruction, .. } => {
+                if let Instruction::Cast(original_value, _) = dfg[instruction] {
+                    self.builder.type_of_value(original_value).bit_size()
+                } else {
+                    self.builder.type_of_value(value).bit_size()
+                }
+            }
+
+            IrValue::NumericConstant { constant, .. } => constant.num_bits(),
+            _ => self.builder.type_of_value(value).bit_size(),
+        }
+    }
+
     /// Insert constraints ensuring that the operation does not overflow the bit size of the result
     ///
     /// If the result is unsigned, we simply range check against the bit size
@@ -337,31 +357,8 @@ impl<'a> FunctionContext<'a> {
             Type::Numeric(NumericType::Unsigned { bit_size }) => {
                 let dfg = &self.builder.current_function.dfg;
 
-                let max_lhs_bits = match dfg[lhs] {
-                    IrValue::Instruction { instruction, .. } => {
-                        if let Instruction::Cast(original_lhs, _) = dfg[instruction] {
-                            self.builder.type_of_value(original_lhs).bit_size()
-                        } else {
-                            self.builder.type_of_value(lhs).bit_size()
-                        }
-                    }
-
-                    IrValue::NumericConstant { constant, .. } => constant.num_bits(),
-                    _ => self.builder.type_of_value(lhs).bit_size(),
-                };
-
-                let max_rhs_bits = match dfg[rhs] {
-                    IrValue::Instruction { instruction, .. } => {
-                        if let Instruction::Cast(original_rhs, _) = dfg[instruction] {
-                            self.builder.type_of_value(original_rhs).bit_size()
-                        } else {
-                            self.builder.type_of_value(rhs).bit_size()
-                        }
-                    }
-
-                    IrValue::NumericConstant { constant, .. } => constant.num_bits(),
-                    _ => self.builder.type_of_value(rhs).bit_size(),
-                };
+                let max_lhs_bits = self.get_value_max_num_bits(lhs);
+                let max_rhs_bits = self.get_value_max_num_bits(rhs);
 
                 match operator {
                     BinaryOpKind::Add => {

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -17,7 +17,7 @@ use crate::ssa::ir::instruction::BinaryOp;
 use crate::ssa::ir::instruction::Instruction;
 use crate::ssa::ir::map::AtomicCounter;
 use crate::ssa::ir::types::{NumericType, Type};
-use crate::ssa::ir::value::{Value as IrValue, ValueId};
+use crate::ssa::ir::value::ValueId;
 
 use super::value::{Tree, Value, Values};
 use fxhash::FxHashMap as HashMap;


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes unnecessary overflow checks in more scenarios than previously. We do this by inspecting whether the inputs are `Instruction::Cast`s which allows us to determine an more restrictive upper bound on the value and reason about how this affects the result.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
