### PR TITLE
chore: add test to disallow stdlib producing warnings

### DIFF
--- a/compiler/noirc_driver/tests/stdlib_warnings.rs
+++ b/compiler/noirc_driver/tests/stdlib_warnings.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+use noirc_driver::{file_manager_with_stdlib, prepare_crate, ErrorsAndWarnings};
+use noirc_frontend::hir::Context;
+
+#[test]
+fn stdlib_does_not_produce_constant_warnings() -> Result<(), ErrorsAndWarnings> {
+    // We use a minimal source file so that if stdlib produces warnings then we can expect these warnings to _always_
+    // be emitted.
+    let source = "fn main() {}";
+
+    let root = Path::new("");
+    let file_name = Path::new("main.nr");
+    let mut file_manager = file_manager_with_stdlib(root);
+    file_manager.add_file_with_source(file_name, source.to_owned()).expect(
+        "Adding source buffer to file manager should never fail when file manager is empty",
+    );
+
+    let mut context = Context::new(file_manager);
+    let root_crate_id = prepare_crate(&mut context, file_name);
+
+    let ((), warnings) = noirc_driver::check_crate(&mut context, root_crate_id, false, false)?;
+
+    assert_eq!(warnings, Vec::new(), "stdlib is producing warnings");
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We've had a number of occasions where a feature is added which causes the stdlib to produce warnings on every compilation. This isn't great so we should catch and fix those warnings as we create them.

This PR adds a test which compiles a very simple program and asserts that no warnings are omitted.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
