### PR TITLE
fix: save the data bus to the current function before generating others

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -96,6 +96,9 @@ pub(crate) fn generate_ssa(program: Program) -> Result<Ssa, RuntimeError> {
             _ => unreachable!("ICE - expect return on the last block"),
         }
     }
+    // we save the data bus inside the dfg
+    function_context.builder.current_function.dfg.data_bus =
+        DataBus::get_data_bus(call_data, return_data);
 
     // Main has now been compiled and any other functions referenced within have been added to the
     // function queue as they were found in codegen_ident. This queueing will happen each time a
@@ -106,9 +109,6 @@ pub(crate) fn generate_ssa(program: Program) -> Result<Ssa, RuntimeError> {
         function_context.new_function(dest_id, function);
         function_context.codegen_function_body(&function.body)?;
     }
-    // we save the data bus inside the dfg
-    function_context.builder.current_function.dfg.data_bus =
-        DataBus::get_data_bus(call_data, return_data);
 
     Ok(function_context.builder.finish())
 }

--- a/test_programs/execution_success/databus/src/main.nr
+++ b/test_programs/execution_success/databus/src/main.nr
@@ -1,10 +1,12 @@
-// Test unsafe integer multiplication with overflow: 12^8 = 429 981 696
-// The circuit should handle properly the growth of the bit size
 use dep::std;
 
-fn main(mut x: u32, y: call_data u32, z: call_data [u32;4] ) -> return_data u32 {
-
-let a = z[x];
-  a+y
-
+fn main(mut x: u32, y: call_data u32, z: call_data [u32;4]) -> return_data u32 {
+  let a = z[x];
+  a+foo(y)
 }
+
+// Use an unconstrained function to force the compiler to avoid inlining
+unconstrained fn foo(x: u32) -> u32 {
+  x+1
+}
+


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4046 

## Summary\*

This PR changes saves the data bus configuration before processing the other queued functions during SSA gen phase.

## Additional Context

With the current implementation the databus will be incorrectly saved to the last generated function instead of the main function, causing a panic in a later optimization phase.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
