### PR TITLE
chore: Remove TypeVariableId from Generics

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -491,7 +491,7 @@ pub(crate) fn check_methods_signatures(
     }
 
     // We also need to bind the traits generics to the trait's generics on the impl
-    for ((_, generic), binding) in the_trait.generics.iter().zip(trait_generics) {
+    for (generic, binding) in the_trait.generics.iter().zip(trait_generics) {
         generic.bind(binding);
     }
 
@@ -599,7 +599,7 @@ pub(crate) fn check_methods_signatures(
     the_trait.set_methods(trait_methods);
     the_trait.self_type_typevar.unbind(the_trait.self_type_typevar_id);
 
-    for (old_id, generic) in &the_trait.generics {
-        generic.unbind(*old_id);
+    for generic in &the_trait.generics {
+        generic.unbind(generic.id());
     }
 }

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -595,7 +595,7 @@ impl<'interner> TypeChecker<'interner> {
                     .generics
                     .iter()
                     .zip(generics)
-                    .map(|((id, var), arg)| (*id, (var.clone(), arg)))
+                    .map(|(var, arg)| (var.id(), (var.clone(), arg)))
                     .collect();
 
                 (method.typ.clone(), method.arguments().len(), generic_bindings)

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -147,7 +147,7 @@ impl TraitFunction {
         }
     }
 
-    pub fn generics(&self) -> &[(TypeVariableId, TypeVariable)] {
+    pub fn generics(&self) -> &[TypeVariable] {
         match &self.typ {
             Type::Function(..) => &[],
             Type::Forall(generics, _) => generics,

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     node_interner::{self, DefinitionKind, NodeInterner, StmtId, TraitImplKind, TraitMethodId},
     token::FunctionAttribute,
     ContractFunctionType, FunctionKind, Type, TypeBinding, TypeBindings, TypeVariable,
-    TypeVariableId, TypeVariableKind, UnaryOp, Visibility,
+    TypeVariableKind, UnaryOp, Visibility,
 };
 
 use self::ast::{Definition, FuncId, Function, LocalId, Program};
@@ -1533,8 +1533,8 @@ impl<'interner> Monomorphizer<'interner> {
             let (generics, impl_method_type) =
                 self.interner.function_meta(&impl_method).typ.unwrap_forall();
 
-            let replace_type_variable = |(id, var): &(TypeVariableId, TypeVariable)| {
-                (*id, (var.clone(), Type::TypeVariable(var.clone(), TypeVariableKind::Normal)))
+            let replace_type_variable = |var: &TypeVariable| {
+                (var.id(), (var.clone(), Type::TypeVariable(var.clone(), TypeVariableKind::Normal)))
             };
 
             // Replace each NamedGeneric with a TypeVariable containing the same internal type variable

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -499,8 +499,7 @@ impl NodeInterner {
                 // This lets us record how many arguments the type expects so that other types
                 // can refer to it with generic arguments before the generic parameters themselves
                 // are resolved.
-                let id = TypeVariableId(0);
-                (id, TypeVariable::unbound(id))
+                TypeVariable::unbound(TypeVariableId(0))
             }),
             self_type_typevar_id,
             self_type_typevar: TypeVariable::unbound(self_type_typevar_id),
@@ -530,8 +529,7 @@ impl NodeInterner {
             // This lets us record how many arguments the type expects so that other types
             // can refer to it with generic arguments before the generic parameters themselves
             // are resolved.
-            let id = TypeVariableId(0);
-            (id, TypeVariable::unbound(id))
+            TypeVariable::unbound(TypeVariableId(0))
         });
 
         let location = Location::new(typ.struct_def.span, file_id);
@@ -549,10 +547,7 @@ impl NodeInterner {
             typ.type_alias_def.name.clone(),
             typ.type_alias_def.span,
             Type::Error,
-            vecmap(&typ.type_alias_def.generics, |_| {
-                let id = TypeVariableId(0);
-                (id, TypeVariable::unbound(id))
-            }),
+            vecmap(&typ.type_alias_def.generics, |_| TypeVariable::unbound(TypeVariableId(0))),
         ));
 
         type_id
@@ -1194,19 +1189,18 @@ impl NodeInterner {
 
         self.trait_implementations.push(trait_impl.clone());
 
-        // Ignoring overlapping TraitImplKind::Assumed impls here is perfectly fine.
-        // It should never happen since impls are defined at global scope, but even
-        // if they were, we should never prevent defining a new impl because a where
-        // clause already assumes it exists.
-
         // Replace each generic with a fresh type variable
         let substitutions = impl_generics
             .into_iter()
-            .map(|(id, typevar)| (id, (typevar, self.next_type_variable())))
+            .map(|typevar| (typevar.id(), (typevar, self.next_type_variable())))
             .collect();
 
         let instantiated_object_type = object_type.substitute(&substitutions);
 
+        // Ignoring overlapping TraitImplKind::Assumed impls here is perfectly fine.
+        // It should never happen since impls are defined at global scope, but even
+        // if they were, we should never prevent defining a new impl because a where
+        // clause already assumes it exists.
         if let Ok((TraitImplKind::Normal(existing), _)) = self.try_lookup_trait_implementation(
             &instantiated_object_type,
             trait_id,

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1197,9 +1197,9 @@ impl NodeInterner {
 
         let instantiated_object_type = object_type.substitute(&substitutions);
 
-        // Ignoring overlapping TraitImplKind::Assumed impls here is perfectly fine.
+        // Ignoring overlapping `TraitImplKind::Assumed` impls here is perfectly fine.
         // It should never happen since impls are defined at global scope, but even
-        // if they were, we should never prevent defining a new impl because a where
+        // if they were, we should never prevent defining a new impl because a 'where'
         // clause already assumes it exists.
         if let Ok((TraitImplKind::Normal(existing), _)) = self.try_lookup_trait_implementation(
             &instantiated_object_type,


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4058 

## Summary\*

Small cleanup from the trait generics PR. Since `TypeVariableId`s are no longer needed in `Generics`, this removes them.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
