### PR TITLE
chore(ci): always build docs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ description: Installs the workspace's yarn dependencies and caches them
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       id: node
       with:
         node-version: 18.17.1

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Check if label is present
       id: check-labels
-      uses: actions/github-script@v3
+      uses: actions/github-script@v7.0.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -33,7 +33,7 @@ jobs:
     
     - name: Add label if not present
       if: steps.check-labels.outputs.result == 'true'
-      uses: actions/github-script@v3
+      uses: actions/github-script@v7.0.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -21,7 +21,7 @@ jobs:
           }
 
           // Fetch the list of files changed in the PR
-          const { data: files } = await github.pulls.listFiles({
+          const { data: files } = await github.rest.pulls.listFiles({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.issue.number,

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build docs
         run: 
-          yarn workspaces foreach -Rt run build
+          yarn workspaces foreach -Rpt --from docs run build
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -47,12 +47,8 @@ jobs:
             })
           }
 
-  build_and_deploy_preview:
+  build_preview:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    needs: add_label
-    if: needs.add_label.outputs.has_label == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -78,6 +74,30 @@ jobs:
         run: 
           yarn workspaces foreach -Rt run build
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: ./docs/build/
+          retention-days: 3
+
+
+  deploy_preview:
+    needs: [build_preview, add_label]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: needs.add_label.outputs.has_label == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+    
+      - name: Download built docs
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: ./docs/build
+     
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v2.1
         with:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -24,7 +24,8 @@ jobs:
           const { data: files } = await github.pulls.listFiles({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: context.issue.number
+            pull_number: context.issue.number,
+            per_page: 100
           });
 
           // Check if any file is within the 'docs' folder

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -53,10 +53,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
     
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: '18'
+      - name: Install Yarn dependencies
+        uses: ./.github/actions/setup
 
       - name: Install wasm-bindgen-cli
         uses: taiki-e/install-action@v2
@@ -66,9 +64,6 @@ jobs:
       - name: Install wasm-opt
         run: |
           npm i wasm-opt -g
-
-      - name: Install Yarn dependencies
-        uses: ./.github/actions/setup
 
       - name: Build docs
         run: 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,10 +15,8 @@ jobs:
       - name: Checkout release branch
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: '18'
+      - name: Install Yarn dependencies
+        uses: ./.github/actions/setup
 
       - name: Install wasm-bindgen-cli
         uses: taiki-e/install-action@v2
@@ -29,9 +27,6 @@ jobs:
         run: |
           npm i wasm-opt -g
       
-      - name: Install Yarn dependencies
-        uses: ./.github/actions/setup
-
       - name: Build docs for deploying
         working-directory: docs
         run: 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,6 @@ jobs:
           ref: ${{ fromJSON(needs.release-please.outputs.release-pr).headBranchName }}
           token: ${{ secrets.NOIR_RELEASES_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: '18'
-
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR splits building and deploying a preview of the docs. This should enforce that docs are always ready to be published without generating a large number of unnecessary deploys.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
