### PR TITLE
chore(ci): link to workflow run in `docs-dead-links.yml`

### DIFF
--- a/.github/workflows/docs-dead-links.yml
+++ b/.github/workflows/docs-dead-links.yml
@@ -29,7 +29,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WORKFLOW_NAME: ${{ github.workflow }}
-        WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }}
+        WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       with:
         update_existing: true
         filename: .github/DEAD_LINKS_IN_DOCS.md


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

As @critesjosh mentioned in #3999, this link currently 404s because github doesn't allow getting the job id necessary to construct this URL using the context api.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
