### PR TITLE
feat: Support printing more types

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1612,8 +1612,10 @@ impl From<&Type> for PrintableType {
                 let fields = vecmap(fields, |(name, typ)| (name, typ.into()));
                 PrintableType::Struct { fields, name: struct_type.name.to_string() }
             }
-            Type::TraitAsType(..) => unreachable!(),
-            Type::Tuple(_) => todo!("printing tuple types is not yet implemented"),
+            Type::TraitAsType(_) => unreachable!(),
+            Type::Tuple(types) => {
+                PrintableType::Tuple { types: vecmap(types, |typ| typ.into()) }
+            }
             Type::TypeVariable(_, _) => unreachable!(),
             Type::NamedGeneric(..) => unreachable!(),
             Type::Forall(..) => unreachable!(),

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1613,9 +1613,7 @@ impl From<&Type> for PrintableType {
                 PrintableType::Struct { fields, name: struct_type.name.to_string() }
             }
             Type::TraitAsType(_, _, _) => unreachable!(),
-            Type::Tuple(types) => {
-                PrintableType::Tuple { types: vecmap(types, |typ| typ.into()) }
-            }
+            Type::Tuple(types) => PrintableType::Tuple { types: vecmap(types, |typ| typ.into()) },
             Type::TypeVariable(_, _) => unreachable!(),
             Type::NamedGeneric(..) => unreachable!(),
             Type::Forall(..) => unreachable!(),

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1583,7 +1583,7 @@ impl From<&Type> for PrintableType {
         match value {
             Type::FieldElement => PrintableType::Field,
             Type::Array(size, typ) => {
-                let length = size.evaluate_to_u64().expect("Cannot print variable sized arrays");
+                let length = size.evaluate_to_u64();
                 let typ = typ.as_ref();
                 PrintableType::Array { length, typ: Box::new(typ.into()) }
             }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1619,7 +1619,7 @@ impl From<&Type> for PrintableType {
             Type::TypeVariable(_, _) => unreachable!(),
             Type::NamedGeneric(..) => unreachable!(),
             Type::Forall(..) => unreachable!(),
-            Type::Function(_, _, _) => unreachable!(),
+            Type::Function(_, _, _) => PrintableType::Function,
             Type::MutableReference(_) => unreachable!("cannot print &mut"),
             Type::NotConstant => unreachable!(),
         }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1612,7 +1612,7 @@ impl From<&Type> for PrintableType {
                 let fields = vecmap(fields, |(name, typ)| (name, typ.into()));
                 PrintableType::Struct { fields, name: struct_type.name.to_string() }
             }
-            Type::TraitAsType(_) => unreachable!(),
+            Type::TraitAsType(_, _, _) => unreachable!(),
             Type::Tuple(types) => {
                 PrintableType::Tuple { types: vecmap(types, |typ| typ.into()) }
             }
@@ -1620,7 +1620,7 @@ impl From<&Type> for PrintableType {
             Type::NamedGeneric(..) => unreachable!(),
             Type::Forall(..) => unreachable!(),
             Type::Function(_, _, _) => PrintableType::Function,
-            Type::MutableReference(_) => unreachable!("cannot print &mut"),
+            Type::MutableReference(_) => PrintableType::MutableReference,
             Type::NotConstant => unreachable!(),
         }
     }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1604,7 +1604,7 @@ impl From<&Type> for PrintableType {
             }
             Type::FmtString(_, _) => unreachable!("format strings cannot be printed"),
             Type::Error => unreachable!(),
-            Type::Unit => unreachable!(),
+            Type::Unit => PrintableType::Unit,
             Type::Constant(_) => unreachable!(),
             Type::Struct(def, ref args) => {
                 let struct_type = def.borrow();
@@ -1617,8 +1617,12 @@ impl From<&Type> for PrintableType {
             Type::TypeVariable(_, _) => unreachable!(),
             Type::NamedGeneric(..) => unreachable!(),
             Type::Forall(..) => unreachable!(),
-            Type::Function(_, _, _) => PrintableType::Function,
-            Type::MutableReference(_) => PrintableType::MutableReference,
+            Type::Function(_, _, env) => {
+                PrintableType::Function { env: Box::new(env.as_ref().into()) }
+            }
+            Type::MutableReference(typ) => {
+                PrintableType::MutableReference { typ: Box::new(typ.as_ref().into()) }
+            }
             Type::NotConstant => unreachable!(),
         }
     }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1029,11 +1029,6 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     fn append_printable_type_info_inner(typ: &Type, arguments: &mut Vec<ast::Expression>) {
-        if let HirType::Array(size, _) = typ {
-            if let HirType::NotConstant = **size {
-                unreachable!("println does not support slices. Convert the slice to an array before passing it to println");
-            }
-        }
         let printable_type: PrintableType = typ.into();
         let abi_as_string = serde_json::to_string(&printable_type)
             .expect("ICE: expected PrintableType to serialize");

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -32,6 +32,7 @@ pub enum PrintableType {
     String {
         length: u64,
     },
+    Function,
 }
 
 impl PrintableType {
@@ -41,7 +42,8 @@ impl PrintableType {
             Self::Field
             | Self::SignedInteger { .. }
             | Self::UnsignedInteger { .. }
-            | Self::Boolean => Some(1),
+            | Self::Boolean
+            | Self::Function => Some(1),
             Self::Array { length, typ } => {
                 length.and_then(|len| {
                     typ.field_count().map(|x| x*(len as u32))
@@ -213,6 +215,9 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
                 output.push_str("false");
             }
         }
+        (PrintableValue::Field(_), PrintableType::Function) => {
+            output.push_str("<<function>>");
+        }
         (PrintableValue::Vec(vector), PrintableType::Array { typ, .. }) => {
             output.push('[');
             let mut values = vector.iter().peekable();
@@ -320,7 +325,8 @@ fn decode_value(
         PrintableType::Field
         | PrintableType::SignedInteger { .. }
         | PrintableType::UnsignedInteger { .. }
-        | PrintableType::Boolean => {
+        | PrintableType::Boolean
+        | PrintableType::Function => {
             let field_element = field_iterator.next().unwrap();
 
             PrintableValue::Field(field_element)

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -255,6 +255,20 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
             output.push_str(" }");
         }
 
+        (PrintableValue::Vec(values), PrintableType::Tuple { types }) => {
+            output.push_str("(");
+            let mut elems = values.iter().zip(types).peekable();
+            while let Some((value, typ)) = elems.next() {
+                output.push_str(
+                    &PrintableValueDisplay::Plain(value.clone(), typ.clone()).to_string(),
+                );
+                if elems.peek().is_some() {
+                    output.push_str(", ");
+                }
+            }
+            output.push_str(")");
+        }
+
         _ => return None,
     };
 

--- a/test_programs/execution_success/debug_logs/src/main.nr
+++ b/test_programs/execution_success/debug_logs/src/main.nr
@@ -59,8 +59,6 @@ fn main(x: Field, y: pub Field) {
     let closured_lambda = |x| x + one;
     std::println(f"closured_lambda: {closured_lambda}, sentinel: {sentinel}");
     std::println(closured_lambda);
-
-    types_printable_in_brillig_only();
 }
 
 fn string_identity(string: fmtstr<14, (Field, Field)>) -> fmtstr<14, (Field, Field)> {
@@ -101,21 +99,3 @@ fn regression_2906() {
     dep::std::println(f"array_five_vals: {array_five_vals}, label_five_vals: {label_five_vals}");
 }
 
-unconstrained fn types_printable_in_brillig_only() {
-    let mut a_tuple = (1,2,3);
-    let mut tuple_mut_ref = &mut a_tuple;
-    let sentinel: u32 = 8888;
-    std::println(f"tuple_mut_ref: {tuple_mut_ref}, sentinel: {sentinel}");
-    std::println(tuple_mut_ref);
-
-    let mut a_vector: Vec<Field> = Vec::new();
-    a_vector.push(10);
-    a_vector.push(20);
-    a_vector.push(30);
-    std::println(f"a_vector: {a_vector}, sentinel: {sentinel}");
-    std::println(a_vector);
-
-    let vec_slice = a_vector.slice;
-    std::println(f"vec_slice: {vec_slice}, sentinel: {sentinel}");
-    std::println(vec_slice);
-}

--- a/test_programs/execution_success/debug_logs/src/main.nr
+++ b/test_programs/execution_success/debug_logs/src/main.nr
@@ -39,7 +39,28 @@ fn main(x: Field, y: pub Field) {
     let struct_string = if x != 5 { f"{foo}" } else { f"{bar}" };
     std::println(struct_string);
 
+    let one_tuple = (1, 2, 3);
+    let another_tuple = (4, 5, 6);
+    std::println(f"one_tuple: {one_tuple}, another_tuple: {another_tuple}");
+    std::println(one_tuple);
+
+    let tuples_nested = (one_tuple, another_tuple);
+    std::println(f"tuples_nested: {tuples_nested}");
+    std::println(tuples_nested);
+
     regression_2906();
+
+    let free_lambda = |x| x + 1;
+    let sentinel: u32 = 8888;
+    std::println(f"free_lambda: {free_lambda}, sentinel: {sentinel}");
+    std::println(free_lambda);
+
+    let one = 1;
+    let closured_lambda = |x| x + one;
+    std::println(f"closured_lambda: {closured_lambda}, sentinel: {sentinel}");
+    std::println(closured_lambda);
+
+    types_printable_in_brillig_only();
 }
 
 fn string_identity(string: fmtstr<14, (Field, Field)>) -> fmtstr<14, (Field, Field)> {
@@ -78,4 +99,23 @@ fn regression_2906() {
     dep::std::println(f"label_five_vals: {label_five_vals}");
 
     dep::std::println(f"array_five_vals: {array_five_vals}, label_five_vals: {label_five_vals}");
+}
+
+unconstrained fn types_printable_in_brillig_only() {
+    let mut a_tuple = (1,2,3);
+    let mut tuple_mut_ref = &mut a_tuple;
+    let sentinel: u32 = 8888;
+    std::println(f"tuple_mut_ref: {tuple_mut_ref}, sentinel: {sentinel}");
+    std::println(tuple_mut_ref);
+
+    let mut a_vector: Vec<Field> = Vec::new();
+    a_vector.push(10);
+    a_vector.push(20);
+    a_vector.push(30);
+    std::println(f"a_vector: {a_vector}, sentinel: {sentinel}");
+    std::println(a_vector);
+
+    let vec_slice = a_vector.slice;
+    std::println(f"vec_slice: {vec_slice}, sentinel: {sentinel}");
+    std::println(vec_slice);
 }


### PR DESCRIPTION
# Description

## Problem\*

As part of our debugger implementation (see #3015) we need to extend the supported types that can be printed. We are using `noirc_printable_type` to keep values of variables at runtime for debug inspection.

Also resolves #4073

## Summary\*

This PR adds support for converting these new types:

- Tuples
- Slices: lift the restriction to print them and handle arrays with dynamic size (flagging them with a `None` length in the type)
- Functions: printed as an opaque `<<function>>` tag for now
- Mutable references: printed as an opaque `<<mutable ref>>` tag for now
- Unit: this is actually required to fully support function type conversion, for non-closured function references (ie. the environment is `()` in that case)

The PR also fixes a preexisting bug when printing multiple values using formatted strings with the first ones being structs. Since structs are expanded into tuples which take up more than one field, the printing code would fail to skip over all the fields of the struct.

## Additional Context

I've been using [this program](https://gist.github.com/ggiraldez/e3709def6c26e7585d12002fc8a0a216) to test this functionality. If it makes sense, I can add it as an integration test to `test_programs/execution_success`.

The program produces this output:
```
(0x01, 0x02, 0x03)
0xbbbb # a = (0x01, 0x02, 0x03) # 0xeeee
(0x01, 0x02, 0x03) == (0x01, 0x02, 0x03)

((0x01, 0x02, 0x03), 0x04, 0x05, 0x06)
0xbbbb # b = ((0x01, 0x02, 0x03), 0x04, 0x05, 0x06) # 0xeeee
((0x01, 0x02, 0x03), 0x04, 0x05, 0x06) == ((0x01, 0x02, 0x03), 0x04, 0x05, 0x06)

<<mutable ref>>
0xbbbb # c = <<mutable ref>> # 0xeeee

<<function>>
0xbbbb # d = <<function>> # 0xeeee

<<function>>
0xbbbb # f = <<function>> # 0xeeee

[0x01, 0x02, 0x03]
0xbbbb # g = [0x01, 0x02, 0x03] # 0xeeee
[0x01, 0x02, 0x03] == [0x01, 0x02, 0x03]

Foo { x: 555, y: 666 } == Foo { x: 555, y: 666 }

Vec { slice: [0x01, 0x02] }
0xbbbb # h = Vec { slice: [0x01, 0x02] } # 0xeeee

[0x01, 0x02]
0xbbbb # j = [0x01, 0x02] # 0xeeee
[0x01, 0x02] == [0x01, 0x02]

[printable_types] Circuit witness successfully solved
```

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
