### PR TITLE
chore(ci): update `yarn.lock` on release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,15 @@ jobs:
         run: |
             cargo update --workspace
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.17.1
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+      
+      - name: Update yarn.lock
+        run: yarn
+        
       - name: Configure git
         run: |
           git config user.name kevaundray


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR should resolve the CI failures on the release-please PR. This is because the Noir playground uses a fixed version of noir packages and so results in new entries in the yarn.lock file as we update everything else.

The Noir playground should be updated so that it doesn't bring in its own dependencies to fix this properly.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
