### PR TITLE
chore: force programs to be fully rebuilt in integration tests

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -75,7 +75,7 @@ fn execution_success_{test_name}() {{
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("execute");
+    cmd.arg("execute").arg("--force");
 
     cmd.assert().success();
 }}
@@ -194,6 +194,7 @@ fn compile_success_empty_{test_name}() {{
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("info");
     cmd.arg("--json");
+    cmd.arg("--force");
 
     let output = cmd.output().expect("Failed to execute command");
 
@@ -242,7 +243,7 @@ fn compile_success_contract_{test_name}() {{
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("compile");
+    cmd.arg("compile").arg("--force");
 
     cmd.assert().success();
 }}
@@ -280,7 +281,7 @@ fn compile_failure_{test_name}() {{
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("execute");
+    cmd.arg("execute").arg("--force");
 
     cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
 }}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

It's currently possible for an integration test to report true due to the integration test using a cached artifact. This isn't an issue in CI as no cached artifacts exist there but it can results in strange behaviour locally.

This PR addresses this issue by forcing a full recompile.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
