### PR TITLE
chore: rename aztec macro errors

### DIFF
--- a/aztec_macros/src/lib.rs
+++ b/aztec_macros/src/lib.rs
@@ -36,32 +36,38 @@ const MAX_CONTRACT_FUNCTIONS: usize = 2_usize.pow(FUNCTION_TREE_HEIGHT);
 
 #[derive(Debug, Clone)]
 pub enum AztecMacroError {
-    AztecNotFound,
-    AztecComputeNoteHashAndNullifierNotFound { span: Span },
-    AztecContractHasTooManyFunctions { span: Span },
-    AztecContractConstructorMissing { span: Span },
+    AztecDepNotFound,
+    ComputeNoteHashAndNullifierNotFound { span: Span },
+    ContractHasTooManyFunctions { span: Span },
+    ContractConstructorMissing { span: Span },
+    UnsupportedFunctionArgumentType { span: Span, typ: UnresolvedTypeData },
 }
 
 impl From<AztecMacroError> for MacroError {
     fn from(err: AztecMacroError) -> Self {
         match err {
-            AztecMacroError::AztecNotFound {} => MacroError {
+            AztecMacroError::AztecDepNotFound {} => MacroError {
                 primary_message: "Aztec dependency not found. Please add aztec as a dependency in your Cargo.toml. For more information go to https://docs.aztec.network/dev_docs/debugging/aztecnr-errors#aztec-dependency-not-found-please-add-aztec-as-a-dependency-in-your-nargotoml".to_owned(),
                 secondary_message: None,
                 span: None,
             },
-            AztecMacroError::AztecComputeNoteHashAndNullifierNotFound { span } => MacroError {
+            AztecMacroError::ComputeNoteHashAndNullifierNotFound { span } => MacroError {
                 primary_message: "compute_note_hash_and_nullifier function not found. Define it in your contract. For more information go to https://docs.aztec.network/dev_docs/debugging/aztecnr-errors#compute_note_hash_and_nullifier-function-not-found-define-it-in-your-contract".to_owned(),
                 secondary_message: None,
                 span: Some(span),
             },
-            AztecMacroError::AztecContractHasTooManyFunctions { span } => MacroError {
+            AztecMacroError::ContractHasTooManyFunctions { span } => MacroError {
                 primary_message: format!("Contract can only have a maximum of {} functions", MAX_CONTRACT_FUNCTIONS),
                 secondary_message: None,
                 span: Some(span),
             },
-            AztecMacroError::AztecContractConstructorMissing { span } => MacroError {
+            AztecMacroError::ContractConstructorMissing { span } => MacroError {
                 primary_message: "Contract must have a constructor function".to_owned(),
+                secondary_message: None,
+                span: Some(span),
+            },
+            AztecMacroError::UnsupportedFunctionArgumentType { span, typ } => MacroError {
+                primary_message: format!("Provided parameter type `{typ:?}` is not supported in Aztec contract interface"),
                 secondary_message: None,
                 span: Some(span),
             },
@@ -216,7 +222,9 @@ fn transform(
 
     // Covers all functions in the ast
     for submodule in ast.submodules.iter_mut().filter(|submodule| submodule.is_contract) {
-        if transform_module(&mut submodule.contents, crate_id, context)? {
+        if transform_module(&mut submodule.contents, crate_id, context)
+            .map_err(|(err, file_id)| (err.into(), file_id))?
+        {
             check_for_aztec_dependency(crate_id, context)?;
             include_relevant_imports(&mut submodule.contents);
         }
@@ -258,7 +266,7 @@ fn check_for_aztec_dependency(
     if has_aztec_dependency {
         Ok(())
     } else {
-        Err((AztecMacroError::AztecNotFound.into(), crate_graph.root_file_id))
+        Err((AztecMacroError::AztecDepNotFound.into(), crate_graph.root_file_id))
     }
 }
 
@@ -317,7 +325,7 @@ fn transform_module(
     module: &mut SortedModule,
     crate_id: &CrateId,
     context: &HirContext,
-) -> Result<bool, (MacroError, FileId)> {
+) -> Result<bool, (AztecMacroError, FileId)> {
     let mut has_transformed_module = false;
 
     // Check for a user defined storage struct
@@ -326,8 +334,7 @@ fn transform_module(
     if storage_defined && !check_for_compute_note_hash_and_nullifier_definition(module) {
         let crate_graph = &context.crate_graph[crate_id];
         return Err((
-            AztecMacroError::AztecComputeNoteHashAndNullifierNotFound { span: Span::default() }
-                .into(),
+            AztecMacroError::ComputeNoteHashAndNullifierNotFound { span: Span::default() },
             crate_graph.root_file_id,
         ));
     }
@@ -341,11 +348,14 @@ fn transform_module(
 
     for func in module.functions.iter_mut() {
         for secondary_attribute in func.def.attributes.secondary.clone() {
+            let crate_graph = &context.crate_graph[crate_id];
             if is_custom_attribute(&secondary_attribute, "aztec(private)") {
-                transform_function("Private", func, storage_defined);
+                transform_function("Private", func, storage_defined)
+                    .map_err(|err| (err, crate_graph.root_file_id))?;
                 has_transformed_module = true;
             } else if is_custom_attribute(&secondary_attribute, "aztec(public)") {
-                transform_function("Public", func, storage_defined);
+                transform_function("Public", func, storage_defined)
+                    .map_err(|err| (err, crate_graph.root_file_id))?;
                 has_transformed_module = true;
             }
         }
@@ -362,7 +372,7 @@ fn transform_module(
         if module.functions.len() > MAX_CONTRACT_FUNCTIONS {
             let crate_graph = &context.crate_graph[crate_id];
             return Err((
-                AztecMacroError::AztecContractHasTooManyFunctions { span: Span::default() }.into(),
+                AztecMacroError::ContractHasTooManyFunctions { span: Span::default() },
                 crate_graph.root_file_id,
             ));
         }
@@ -371,7 +381,7 @@ fn transform_module(
         if !constructor_defined {
             let crate_graph = &context.crate_graph[crate_id];
             return Err((
-                AztecMacroError::AztecContractConstructorMissing { span: Span::default() }.into(),
+                AztecMacroError::ContractConstructorMissing { span: Span::default() },
                 crate_graph.root_file_id,
             ));
         }
@@ -384,7 +394,11 @@ fn transform_module(
 /// - A new Input that is provided for a kernel app circuit, named: {Public/Private}ContextInputs
 /// - Hashes all of the function input variables
 ///     - This instantiates a helper function  
-fn transform_function(ty: &str, func: &mut NoirFunction, storage_defined: bool) {
+fn transform_function(
+    ty: &str,
+    func: &mut NoirFunction,
+    storage_defined: bool,
+) -> Result<(), AztecMacroError> {
     let context_name = format!("{}Context", ty);
     let inputs_name = format!("{}ContextInputs", ty);
     let return_type_name = format!("{}CircuitPublicInputs", ty);
@@ -396,7 +410,7 @@ fn transform_function(ty: &str, func: &mut NoirFunction, storage_defined: bool) 
     }
 
     // Insert the context creation as the first action
-    let create_context = create_context(&context_name, &func.def.parameters);
+    let create_context = create_context(&context_name, &func.def.parameters)?;
     func.def.body.0.splice(0..0, (create_context).iter().cloned());
 
     // Add the inputs to the params
@@ -423,6 +437,8 @@ fn transform_function(ty: &str, func: &mut NoirFunction, storage_defined: bool) 
         "Public" => func.def.is_open = true,
         _ => (),
     }
+
+    Ok(())
 }
 
 /// Transform Unconstrained
@@ -621,7 +637,7 @@ fn create_inputs(ty: &str) -> Param {
 ///     let mut context = PrivateContext::new(inputs, hasher.hash());
 /// }
 /// ```
-fn create_context(ty: &str, params: &[Param]) -> Vec<Statement> {
+fn create_context(ty: &str, params: &[Param]) -> Result<Vec<Statement>, AztecMacroError> {
     let mut injected_expressions: Vec<Statement> = vec![];
 
     // `let mut hasher = Hasher::new();`
@@ -637,7 +653,7 @@ fn create_context(ty: &str, params: &[Param]) -> Vec<Statement> {
     injected_expressions.push(let_hasher);
 
     // Iterate over each of the function parameters, adding to them to the hasher
-    params.iter().for_each(|Param { pattern, typ, span: _, visibility: _ }| {
+    for Param { pattern, typ, span, .. } in params {
         match pattern {
             Pattern::Identifier(identifier) => {
                 // Match the type to determine the padding to do
@@ -666,16 +682,18 @@ fn create_context(ty: &str, params: &[Param]) -> Vec<Statement> {
                             },
                         )
                     }
-                    _ => panic!(
-                        "[Aztec Noir] Provided parameter type: {:?} is not supported",
-                        unresolved_type
-                    ),
+                    _ => {
+                        return Err(AztecMacroError::UnsupportedFunctionArgumentType {
+                            typ: unresolved_type.clone(),
+                            span: *span,
+                        })
+                    }
                 };
                 injected_expressions.push(expression);
             }
             _ => todo!(), // Maybe unreachable?
         }
-    });
+    }
 
     // Create the inputs to the context
     let inputs_expression = variable("inputs");
@@ -697,7 +715,7 @@ fn create_context(ty: &str, params: &[Param]) -> Vec<Statement> {
     injected_expressions.push(let_context);
 
     // Return all expressions that will be injected by the hasher
-    injected_expressions
+    Ok(injected_expressions)
 }
 
 /// Abstract Return Type


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This enum is dangerously close to triggering https://rust-lang.github.io/rust-clippy/master/#/clippy::enum_variant_names so I've renamed some things.  I've also delayed where we convert from an `AztecMacroError` to a `MacroError` to avoid a number of `into()`s

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
