### PR TITLE
feat(lsp): goto type reference

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -710,6 +710,15 @@ impl<'a> Resolver<'a> {
         if resolved_type.is_nested_slice() {
             self.errors.push(ResolverError::NestedSlices { span: span.unwrap() });
         }
+
+        if let Some(unresolved_span) = span {
+            // Record the location of the type reference
+            self.interner.push_type_ref_location(
+                resolved_type.clone(),
+                Location::new(unresolved_span, self.file),
+            );
+        }
+
         resolved_type
     }
 

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -64,7 +64,7 @@ pub enum Type {
     TypeVariable(TypeVariable, TypeVariableKind),
 
     /// `impl Trait` when used in a type position.
-    /// These are only matched based on the TraitId. The trait name paramer is only
+    /// These are only matched based on the TraitId. The trait name parameter is only
     /// used for displaying error messages using the name of the trait.
     TraitAsType(TraitId, /*name:*/ Rc<String>, /*generics:*/ Vec<Type>),
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -142,6 +142,9 @@ pub struct NodeInterner {
 
     // For trait implementation functions, this is their self type and trait they belong to
     func_id_to_trait: HashMap<FuncId, (Type, TraitId)>,
+
+    /// Stores the [Location] of a [Type] reference
+    pub(crate) type_ref_locations: Vec<(Type, Location)>,
 }
 
 /// A trait implementation is either a normal implementation that is present in the source
@@ -450,6 +453,7 @@ impl Default for NodeInterner {
             globals: HashMap::new(),
             struct_methods: HashMap::new(),
             primitive_methods: HashMap::new(),
+            type_ref_locations: Vec::new(),
         };
 
         // An empty block expression is used often, we add this into the `node` on startup
@@ -595,6 +599,11 @@ impl NodeInterner {
     /// Store the type for an interned Identifier
     pub fn push_definition_type(&mut self, definition_id: DefinitionId, typ: Type) {
         self.id_to_type.insert(definition_id.into(), typ);
+    }
+
+    /// Store [Location] of [Type] reference
+    pub fn push_type_ref_location(&mut self, typ: Type, location: Location) {
+        self.type_ref_locations.push((typ, location));
     }
 
     pub fn push_global(&mut self, stmt_id: StmtId, ident: Ident, local_id: LocalModuleId) {

--- a/compiler/noirc_frontend/src/resolve_locations.rs
+++ b/compiler/noirc_frontend/src/resolve_locations.rs
@@ -42,6 +42,7 @@ impl NodeInterner {
             .and_then(|index| self.resolve_location(index, return_type_location_instead))
             .or_else(|| self.try_resolve_trait_impl_location(location))
             .or_else(|| self.try_resolve_trait_method_declaration(location))
+            .or_else(|| self.try_resolve_type_ref(location))
     }
 
     pub fn get_declaration_location_from(&self, location: Location) -> Option<Location> {
@@ -192,6 +193,17 @@ impl NodeInterner {
                 let method =
                     methods.find(|method| method.name.0.contents == self.function_name(func_id));
                 method.map(|method| method.location)
+            })
+    }
+
+    /// Attempts to resolve [Location] of [Type] based on [Location] of reference in code
+    pub(crate) fn try_resolve_type_ref(&self, location: Location) -> Option<Location> {
+        self.type_ref_locations
+            .iter()
+            .find(|(_typ, type_ref_location)| type_ref_location.contains(&location))
+            .and_then(|(typ, _)| match typ {
+                Type::Struct(struct_typ, _) => Some(struct_typ.borrow().location),
+                _ => None,
             })
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

feat(lsp): goto type reference #4090

## Summary\*

Allows to go to type reference from symbol, ie. function return.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
