### PR TITLE
chore: replace explicit subtractions with nots

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -369,10 +369,10 @@ impl FunctionBuilder {
                 let idx = self.field_constant(FieldElement::from((bit_size - i) as i128));
                 let b = self.insert_array_get(rhs_bits, idx, Type::bool());
                 let not_b = self.insert_not(b);
-                let b_as_field = self.insert_cast(b, Type::field());
-                let not_b_as_field = self.insert_cast(not_b, Type::field());
-                let r1 = self.insert_binary(a, BinaryOp::Mul, b_as_field);
-                let r2 = self.insert_binary(not_b_as_field, BinaryOp::Mul, r_squared);
+                let b = self.insert_cast(b, Type::field());
+                let not_b = self.insert_cast(not_b, Type::field());
+                let r1 = self.insert_binary(a, BinaryOp::Mul, b);
+                let r2 = self.insert_binary(r_squared, BinaryOp::Mul, not_b);
                 r = self.insert_binary(r1, BinaryOp::Add, r2);
             }
             r

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -367,7 +367,7 @@ impl FunctionBuilder {
                 let r_squared = self.insert_binary(r, BinaryOp::Mul, r);
                 let a = self.insert_binary(r_squared, BinaryOp::Mul, lhs);
                 let idx = self.field_constant(FieldElement::from((bit_size - i) as i128));
-                let b = self.insert_array_get(rhs_bits, idx, Type::field());
+                let b = self.insert_array_get(rhs_bits, idx, Type::bool());
                 let not_b = self.insert_not(b);
                 let r1 = self.insert_binary(a, BinaryOp::Mul, b);
                 let r2 = self.insert_binary(not_b, BinaryOp::Mul, r_squared);

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -368,9 +368,9 @@ impl FunctionBuilder {
                 let a = self.insert_binary(r_squared, BinaryOp::Mul, lhs);
                 let idx = self.field_constant(FieldElement::from((bit_size - i) as i128));
                 let b = self.insert_array_get(rhs_bits, idx, Type::field());
+                let not_b = self.insert_not(b);
                 let r1 = self.insert_binary(a, BinaryOp::Mul, b);
-                let c = self.insert_binary(one, BinaryOp::Sub, b);
-                let r2 = self.insert_binary(c, BinaryOp::Mul, r_squared);
+                let r2 = self.insert_binary(not_b, BinaryOp::Mul, r_squared);
                 r = self.insert_binary(r1, BinaryOp::Add, r2);
             }
             r

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -369,8 +369,10 @@ impl FunctionBuilder {
                 let idx = self.field_constant(FieldElement::from((bit_size - i) as i128));
                 let b = self.insert_array_get(rhs_bits, idx, Type::bool());
                 let not_b = self.insert_not(b);
-                let r1 = self.insert_binary(a, BinaryOp::Mul, b);
-                let r2 = self.insert_binary(not_b, BinaryOp::Mul, r_squared);
+                let b_as_field = self.insert_cast(b, Type::field());
+                let not_b_as_field = self.insert_cast(not_b, Type::field());
+                let r1 = self.insert_binary(a, BinaryOp::Mul, b_as_field);
+                let r2 = self.insert_binary(not_b_as_field, BinaryOp::Mul, r_squared);
                 r = self.insert_binary(r1, BinaryOp::Add, r2);
             }
             r


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Small PR to replace usage of `(1-x)` instead of `not(x)` for boolean `x`. This improves readability of the codegen imo.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
