### PR TITLE
feat: deduplicate `compile_program` and `compile_contract` methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,9 +4601,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-binary"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb28771e7854f02e5705f2a1b09451d932a273f5a4ec1c9fa4c65882b8b7b6ca"
+checksum = "6c7cb854285c40b61c0fade358bf63a2bb1226688a1ea11432ea65349209e6e3"
 dependencies = [
  "camino",
  "cargo_metadata",

--- a/tooling/backend_interface/test-binaries/mock_backend/Cargo.lock
+++ b/tooling/backend_interface/test-binaries/mock_backend/Cargo.lock
@@ -4,81 +4,67 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
  "windows-sys",
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
-
-[[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-
-[[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -88,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -100,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -111,60 +97,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.147"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "mock_backend"
@@ -174,40 +110,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]
@@ -218,9 +135,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -229,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "utf8parse"
@@ -241,18 +158,18 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -265,42 +182,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/tooling/lsp/src/requests/profile_run.rs
+++ b/tooling/lsp/src/requests/profile_run.rs
@@ -59,20 +59,12 @@ fn on_profile_run_request_inner(
     // Since we filtered on crate name, this should be the only item in the iterator
     match workspace.into_iter().next() {
         Some(_package) => {
-            let (binary_packages, contract_packages): (Vec<_>, Vec<_>) = workspace
-                .into_iter()
-                .filter(|package| !package.is_library())
-                .cloned()
-                .partition(|package| package.is_binary());
-
             let expression_width = ExpressionWidth::Bounded { width: 3 };
 
             let (compiled_programs, compiled_contracts) = nargo::ops::compile_workspace(
                 &workspace_file_manager,
                 &parsed_files,
                 &workspace,
-                &binary_packages,
-                &contract_packages,
                 expression_width,
                 &CompileOptions::default(),
             )

--- a/tooling/nargo/src/ops/compile.rs
+++ b/tooling/nargo/src/ops/compile.rs
@@ -34,7 +34,6 @@ pub fn compile_workspace(
             compile_program(
                 file_manager,
                 parsed_files,
-                workspace,
                 package,
                 compile_options,
                 expression_width,
@@ -79,17 +78,12 @@ pub fn compile_workspace(
 pub fn compile_program(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,
-    workspace: &Workspace,
     package: &Package,
     compile_options: &CompileOptions,
     expression_width: ExpressionWidth,
     cached_program: Option<CompiledProgram>,
 ) -> CompilationResult<CompiledProgram> {
     let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);
-
-    let program_artifact_path = workspace.package_build_path(package);
-    let mut debug_artifact_path = program_artifact_path.clone();
-    debug_artifact_path.set_file_name(format!("debug_{}.json", package.name));
 
     let (program, warnings) =
         noirc_driver::compile_main(&mut context, crate_id, compile_options, cached_program)?;

--- a/tooling/nargo/src/ops/compile.rs
+++ b/tooling/nargo/src/ops/compile.rs
@@ -109,12 +109,7 @@ pub fn compile_contract(
 ) -> CompilationResult<CompiledContract> {
     let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);
     let (contract, warnings) =
-        match noirc_driver::compile_contract(&mut context, crate_id, compile_options) {
-            Ok(contracts_and_warnings) => contracts_and_warnings,
-            Err(errors) => {
-                return Err(errors);
-            }
-        };
+        noirc_driver::compile_contract(&mut context, crate_id, compile_options)?;
 
     let optimized_contract = crate::ops::optimize_contract(contract, expression_width);
 

--- a/tooling/nargo/src/ops/mod.rs
+++ b/tooling/nargo/src/ops/mod.rs
@@ -1,4 +1,4 @@
-pub use self::compile::{compile_program, compile_workspace};
+pub use self::compile::{compile_contract, compile_program, compile_workspace};
 pub use self::execute::execute_circuit;
 pub use self::foreign_calls::{DefaultForeignCallExecutor, ForeignCallExecutor};
 pub use self::optimize::{optimize_contract, optimize_program};

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -74,7 +74,7 @@ pprof = { version = "0.12", features = [
     "criterion",
 ] }
 iai = "0.1.1"
-test-binary = "3.0.1"
+test-binary = "3.0.2"
 
 [[bench]]
 name = "criterion"

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -199,7 +199,7 @@ fn compile_success_empty_{test_name}() {{
     let output = cmd.output().expect("Failed to execute command");
 
     if !output.status.success() {{
-        panic!("`nargo info` failed with: {{}}", String::from_utf8(output.stderr).unwrap());
+        panic!("`nargo info` failed with: {{}}", String::from_utf8(output.stderr).unwrap_or_default());
     }}
 
     // `compile_success_empty` tests should be able to compile down to an empty circuit.
@@ -207,7 +207,7 @@ fn compile_success_empty_{test_name}() {{
         panic!("JSON was not well-formatted {{:?}}",output.stdout)
     }});
     let num_opcodes = &json["programs"][0]["acir_opcodes"];
-    assert_eq!(num_opcodes.as_u64().unwrap(), 0);
+    assert_eq!(num_opcodes.as_u64().expect("number of opcodes should fit in a u64"), 0);
 }}
             "#,
             test_dir = test_dir.display(),

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -5,8 +5,8 @@ use acvm::ExpressionWidth;
 use fm::FileManager;
 use nargo::artifacts::program::ProgramArtifact;
 use nargo::errors::CompileError;
+use nargo::ops::{compile_contract, compile_program};
 use nargo::package::Package;
-use nargo::prepare_package;
 use nargo::workspace::Workspace;
 use nargo::{insert_all_files_for_workspace_into_file_manager, parse_all};
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
@@ -63,24 +63,26 @@ pub(crate) fn run(
     insert_all_files_for_workspace_into_file_manager(&workspace, &mut workspace_file_manager);
     let parsed_files = parse_all(&workspace_file_manager);
 
+    let expression_width = backend.get_backend_info_or_default();
+    let (compiled_program, compiled_contracts) = compile_workspace(
+        &workspace_file_manager,
+        &parsed_files,
+        &workspace,
+        expression_width,
+        &args.compile_options,
+    )?;
+
     let (binary_packages, contract_packages): (Vec<_>, Vec<_>) = workspace
         .into_iter()
         .filter(|package| !package.is_library())
         .cloned()
         .partition(|package| package.is_binary());
 
-    let expression_width = backend.get_backend_info_or_default();
-    let (_, compiled_contracts) = compile_workspace(
-        &workspace_file_manager,
-        &parsed_files,
-        &workspace,
-        &binary_packages,
-        &contract_packages,
-        expression_width,
-        &args.compile_options,
-    )?;
-
     // Save build artifacts to disk.
+    let only_acir = args.compile_options.only_acir;
+    for (package, program) in binary_packages.into_iter().zip(compiled_program) {
+        save_program(program.clone(), &package, &workspace.target_directory_path(), only_acir);
+    }
     for (package, contract) in contract_packages.into_iter().zip(compiled_contracts) {
         save_contract(contract, &package, &circuit_dir);
     }
@@ -92,15 +94,26 @@ pub(super) fn compile_workspace(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,
     workspace: &Workspace,
-    binary_packages: &[Package],
-    contract_packages: &[Package],
     expression_width: ExpressionWidth,
     compile_options: &CompileOptions,
 ) -> Result<(Vec<CompiledProgram>, Vec<CompiledContract>), CliError> {
+    let (binary_packages, contract_packages): (Vec<_>, Vec<_>) = workspace
+        .into_iter()
+        .filter(|package| !package.is_library())
+        .cloned()
+        .partition(|package| package.is_binary());
+
     // Compile all of the packages in parallel.
     let program_results: Vec<CompilationResult<CompiledProgram>> = binary_packages
         .par_iter()
         .map(|package| {
+            let program_artifact_path = workspace.package_build_path(package);
+            let cached_program: Option<CompiledProgram> =
+                read_program_from_file(program_artifact_path)
+                    .ok()
+                    .filter(|p| p.noir_version == NOIR_ARTIFACT_VERSION_STRING)
+                    .map(|p| p.into());
+
             compile_program(
                 file_manager,
                 parsed_files,
@@ -108,6 +121,7 @@ pub(super) fn compile_workspace(
                 package,
                 compile_options,
                 expression_width,
+                cached_program,
             )
         })
         .collect();
@@ -164,6 +178,7 @@ pub(crate) fn compile_bin_package(
         package,
         compile_options,
         expression_width,
+        None,
     );
 
     let program = report_errors(
@@ -174,54 +189,6 @@ pub(crate) fn compile_bin_package(
     )?;
 
     Ok(program)
-}
-
-fn compile_program(
-    file_manager: &FileManager,
-    parsed_files: &ParsedFiles,
-    workspace: &Workspace,
-    package: &Package,
-    compile_options: &CompileOptions,
-    expression_width: ExpressionWidth,
-) -> CompilationResult<CompiledProgram> {
-    let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);
-
-    let program_artifact_path = workspace.package_build_path(package);
-    let cached_program: Option<CompiledProgram> = read_program_from_file(program_artifact_path)
-        .ok()
-        .filter(|p| p.noir_version == NOIR_ARTIFACT_VERSION_STRING)
-        .map(|p| p.into());
-
-    let (program, warnings) =
-        noirc_driver::compile_main(&mut context, crate_id, compile_options, cached_program)?;
-
-    // Apply backend specific optimizations.
-    let optimized_program = nargo::ops::optimize_program(program, expression_width);
-    let only_acir = compile_options.only_acir;
-    save_program(optimized_program.clone(), package, &workspace.target_directory_path(), only_acir);
-
-    Ok((optimized_program, warnings))
-}
-
-fn compile_contract(
-    file_manager: &FileManager,
-    parsed_files: &ParsedFiles,
-    package: &Package,
-    compile_options: &CompileOptions,
-    expression_width: ExpressionWidth,
-) -> CompilationResult<CompiledContract> {
-    let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);
-    let (contract, warnings) =
-        match noirc_driver::compile_contract(&mut context, crate_id, compile_options) {
-            Ok(contracts_and_warnings) => contracts_and_warnings,
-            Err(errors) => {
-                return Err(errors);
-            }
-        };
-
-    let optimized_contract = nargo::ops::optimize_contract(contract, expression_width);
-
-    Ok((optimized_contract, warnings))
 }
 
 pub(super) fn save_program(

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -117,7 +117,6 @@ pub(super) fn compile_workspace(
             compile_program(
                 file_manager,
                 parsed_files,
-                workspace,
                 package,
                 compile_options,
                 expression_width,
@@ -162,7 +161,6 @@ pub(super) fn compile_workspace(
 pub(crate) fn compile_bin_package(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,
-    workspace: &Workspace,
     package: &Package,
     compile_options: &CompileOptions,
     expression_width: ExpressionWidth,
@@ -174,7 +172,6 @@ pub(crate) fn compile_bin_package(
     let compilation_result = compile_program(
         file_manager,
         parsed_files,
-        workspace,
         package,
         compile_options,
         expression_width,

--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -75,7 +75,6 @@ fn load_and_compile_project(
     let compiled_program = compile_bin_package(
         &workspace_file_manager,
         &parsed_files,
-        &workspace,
         package,
         &CompileOptions::default(),
         expression_width,

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -69,7 +69,6 @@ pub(crate) fn run(
     let compiled_program = compile_bin_package(
         &workspace_file_manager,
         &parsed_files,
-        &workspace,
         package,
         &args.compile_options,
         expression_width,

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -73,7 +73,6 @@ pub(crate) fn run(
         let compiled_program = compile_bin_package(
             &workspace_file_manager,
             &parsed_files,
-            &workspace,
             package,
             &args.compile_options,
             expression_width,

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -69,22 +69,20 @@ pub(crate) fn run(
     insert_all_files_for_workspace_into_file_manager(&workspace, &mut workspace_file_manager);
     let parsed_files = parse_all(&workspace_file_manager);
 
-    let (binary_packages, contract_packages): (Vec<_>, Vec<_>) = workspace
-        .into_iter()
-        .filter(|package| !package.is_library())
-        .cloned()
-        .partition(|package| package.is_binary());
-
     let expression_width = backend.get_backend_info_or_default();
     let (compiled_programs, compiled_contracts) = compile_workspace(
         &workspace_file_manager,
         &parsed_files,
         &workspace,
-        &binary_packages,
-        &contract_packages,
         expression_width,
         &args.compile_options,
     )?;
+
+    let (binary_packages, contract_packages): (Vec<_>, Vec<_>) = workspace
+        .into_iter()
+        .filter(|package| !package.is_library())
+        .cloned()
+        .partition(|package| package.is_binary());
 
     if args.profile_info {
         for compiled_program in &compiled_programs {

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -100,7 +100,7 @@ pub(crate) fn run(
     let program_info = binary_packages
         .par_bridge()
         .map(|(package, program)| {
-            count_opcodes_and_gates_in_program(backend, program, &package, expression_width)
+            count_opcodes_and_gates_in_program(backend, program, package, expression_width)
         })
         .collect::<Result<_, _>>()?;
 

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -96,7 +96,7 @@ pub(crate) fn run(
     }
 
     let binary_packages =
-        workspace.into_iter().filter(|package| !package.is_binary()).zip(compiled_programs);
+        workspace.into_iter().filter(|package| package.is_binary()).zip(compiled_programs);
     let program_info = binary_packages
         .par_bridge()
         .map(|(package, program)| {

--- a/tooling/nargo_cli/src/cli/prove_cmd.rs
+++ b/tooling/nargo_cli/src/cli/prove_cmd.rs
@@ -73,7 +73,6 @@ pub(crate) fn run(
         let program = compile_bin_package(
             &workspace_file_manager,
             &parsed_files,
-            &workspace,
             package,
             &args.compile_options,
             expression_width,

--- a/tooling/nargo_cli/src/cli/verify_cmd.rs
+++ b/tooling/nargo_cli/src/cli/verify_cmd.rs
@@ -60,7 +60,6 @@ pub(crate) fn run(
         let program = compile_bin_package(
             &workspace_file_manager,
             &parsed_files,
-            &workspace,
             package,
             &args.compile_options,
             expression_width,


### PR DESCRIPTION
# Description

## Problem\*

Resolves partially #3503

## Summary\*

This PR removes some duplication on the compilation methods

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
