### PR TITLE
chore: remove `compile_bin_package`

### DIFF
--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -26,7 +26,7 @@ pub enum ContractFunctionType {
     Unconstrained,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CompiledContract {
     pub noir_version: String,
 

--- a/compiler/noirc_driver/tests/contracts.rs
+++ b/compiler/noirc_driver/tests/contracts.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+
+use fm::FileId;
+use noirc_driver::{file_manager_with_stdlib, prepare_crate, CompileOptions, ErrorsAndWarnings};
+use noirc_errors::CustomDiagnostic;
+use noirc_frontend::hir::{def_map::parse_file, Context};
+
+#[test]
+fn reject_crates_containing_multiple_contracts() -> Result<(), ErrorsAndWarnings> {
+    // We use a minimal source file so that if stdlib produces warnings then we can expect these warnings to _always_
+    // be emitted.
+    let source = "
+contract Foo {}
+
+contract Bar {}";
+
+    let root = Path::new("");
+    let file_name = Path::new("main.nr");
+    let mut file_manager = file_manager_with_stdlib(root);
+    file_manager.add_file_with_source(file_name, source.to_owned()).expect(
+        "Adding source buffer to file manager should never fail when file manager is empty",
+    );
+    let parsed_files = file_manager
+        .as_file_map()
+        .all_file_ids()
+        .map(|&file_id| (file_id, parse_file(&file_manager, file_id)))
+        .collect();
+
+    let mut context = Context::new(file_manager, parsed_files);
+    let root_crate_id = prepare_crate(&mut context, file_name);
+
+    let errors =
+        noirc_driver::compile_contract(&mut context, root_crate_id, &CompileOptions::default())
+            .unwrap_err();
+
+    assert_eq!(
+        errors,
+        vec![CustomDiagnostic::from_message("Packages are limited to a single contract")
+            .in_file(FileId::default())],
+        "stdlib is producing warnings"
+    );
+
+    Ok(())
+}

--- a/compiler/noirc_driver/tests/contracts.rs
+++ b/compiler/noirc_driver/tests/contracts.rs
@@ -7,8 +7,6 @@ use noirc_frontend::hir::{def_map::parse_file, Context};
 
 #[test]
 fn reject_crates_containing_multiple_contracts() -> Result<(), ErrorsAndWarnings> {
-    // We use a minimal source file so that if stdlib produces warnings then we can expect these warnings to _always_
-    // be emitted.
     let source = "
 contract Foo {}
 

--- a/test_programs/compile_failure/multiple_contracts/Nargo.toml
+++ b/test_programs/compile_failure/multiple_contracts/Nargo.toml
@@ -1,5 +1,0 @@
-[package]
-name = "multiple_contracts"
-type = "contract"
-authors = [""]
-[dependencies]

--- a/test_programs/compile_failure/multiple_contracts/src/main.nr
+++ b/test_programs/compile_failure/multiple_contracts/src/main.nr
@@ -1,3 +1,0 @@
-contract Foo {}
-
-contract Bar {}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -281,7 +281,7 @@ fn compile_failure_{test_name}() {{
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("compile").arg("--force");
+    cmd.arg("execute").arg("--force");
 
     cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
 }}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -281,7 +281,7 @@ fn compile_failure_{test_name}() {{
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.env("NARGO_BACKEND_PATH", path_to_mock_backend());
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("execute").arg("--force");
+    cmd.arg("compile").arg("--force");
 
     cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
 }}

--- a/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -1,12 +1,11 @@
+use super::fs::{create_named_dir, write_to_file};
 use super::NargoConfig;
-use super::{
-    compile_cmd::compile_bin_package,
-    fs::{create_named_dir, write_to_file},
-};
 use crate::backends::Backend;
+use crate::cli::compile_cmd::report_errors;
 use crate::errors::CliError;
 
 use clap::Args;
+use nargo::ops::compile_program;
 use nargo::{insert_all_files_for_workspace_into_file_manager, parse_all};
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{file_manager_with_stdlib, CompileOptions, NOIR_ARTIFACT_VERSION_STRING};
@@ -47,13 +46,22 @@ pub(crate) fn run(
     let parsed_files = parse_all(&workspace_file_manager);
 
     let expression_width = backend.get_backend_info()?;
-    for package in &workspace {
-        let program = compile_bin_package(
+    let binary_packages = workspace.into_iter().filter(|package| package.is_binary());
+    for package in binary_packages {
+        let compilation_result = compile_program(
             &workspace_file_manager,
             &parsed_files,
             package,
             &args.compile_options,
             expression_width,
+            None,
+        );
+
+        let program = report_errors(
+            compilation_result,
+            &workspace_file_manager,
+            args.compile_options.deny_warnings,
+            args.compile_options.silence_warnings,
         )?;
 
         let smart_contract_string = backend.eth_contract(&program.circuit)?;

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -158,36 +158,6 @@ pub(super) fn compile_workspace(
     Ok((compiled_programs, compiled_contracts))
 }
 
-pub(crate) fn compile_bin_package(
-    file_manager: &FileManager,
-    parsed_files: &ParsedFiles,
-    package: &Package,
-    compile_options: &CompileOptions,
-    expression_width: ExpressionWidth,
-) -> Result<CompiledProgram, CliError> {
-    if package.is_library() {
-        return Err(CompileError::LibraryCrate(package.name.clone()).into());
-    }
-
-    let compilation_result = compile_program(
-        file_manager,
-        parsed_files,
-        package,
-        compile_options,
-        expression_width,
-        None,
-    );
-
-    let program = report_errors(
-        compilation_result,
-        file_manager,
-        compile_options.deny_warnings,
-        compile_options.silence_warnings,
-    )?;
-
-    Ok(program)
-}
-
 pub(super) fn save_program(
     program: CompiledProgram,
     package: &Package,

--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -2,6 +2,7 @@ use acvm::acir::native_types::WitnessMap;
 use backend_interface::Backend;
 use clap::Args;
 use nargo::constants::PROVER_INPUT_FILE;
+use nargo::ops::compile_program;
 use nargo::workspace::Workspace;
 use nargo::{insert_all_files_for_workspace_into_file_manager, parse_all};
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
@@ -21,7 +22,7 @@ use dap::server::Server;
 use dap::types::Capabilities;
 use serde_json::Value;
 
-use super::compile_cmd::compile_bin_package;
+use super::compile_cmd::report_errors;
 use super::fs::inputs::read_inputs_from_file;
 use crate::errors::CliError;
 
@@ -72,12 +73,21 @@ fn load_and_compile_project(
     insert_all_files_for_workspace_into_file_manager(&workspace, &mut workspace_file_manager);
     let parsed_files = parse_all(&workspace_file_manager);
 
-    let compiled_program = compile_bin_package(
+    let compile_options = CompileOptions::default();
+    let compilation_result = compile_program(
         &workspace_file_manager,
         &parsed_files,
         package,
-        &CompileOptions::default(),
+        &compile_options,
         expression_width,
+        None,
+    );
+
+    let compiled_program = report_errors(
+        compilation_result,
+        &workspace_file_manager,
+        compile_options.deny_warnings,
+        compile_options.silence_warnings,
     )
     .map_err(|_| LoadError("Failed to compile project"))?;
 

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use nargo::artifacts::debug::DebugArtifact;
 use nargo::constants::PROVER_INPUT_FILE;
 use nargo::errors::try_to_diagnose_runtime_error;
-use nargo::ops::DefaultForeignCallExecutor;
+use nargo::ops::{compile_program, DefaultForeignCallExecutor};
 use nargo::package::Package;
 use nargo::{insert_all_files_for_workspace_into_file_manager, parse_all};
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
@@ -16,10 +16,10 @@ use noirc_driver::{
 };
 use noirc_frontend::graph::CrateName;
 
-use super::compile_cmd::compile_bin_package;
 use super::fs::{inputs::read_inputs_from_file, witness::save_witness_to_dir};
 use super::NargoConfig;
 use crate::backends::Backend;
+use crate::cli::compile_cmd::report_errors;
 use crate::errors::CliError;
 
 /// Executes a circuit to calculate its return value
@@ -69,13 +69,22 @@ pub(crate) fn run(
     let parsed_files = parse_all(&workspace_file_manager);
 
     let expression_width = backend.get_backend_info_or_default();
-    for package in &workspace {
-        let compiled_program = compile_bin_package(
+    let binary_packages = workspace.into_iter().filter(|package| package.is_binary());
+    for package in binary_packages {
+        let compilation_result = compile_program(
             &workspace_file_manager,
             &parsed_files,
             package,
             &args.compile_options,
             expression_width,
+            None,
+        );
+
+        let compiled_program = report_errors(
+            compilation_result,
+            &workspace_file_manager,
+            args.compile_options.deny_warnings,
+            args.compile_options.silence_warnings,
         )?;
 
         let (return_value, solved_witness) = execute_program_and_decode(

--- a/tooling/nargo_cli/src/cli/verify_cmd.rs
+++ b/tooling/nargo_cli/src/cli/verify_cmd.rs
@@ -1,12 +1,11 @@
+use super::compile_cmd::report_errors;
+use super::fs::{inputs::read_inputs_from_file, load_hex_data};
 use super::NargoConfig;
-use super::{
-    compile_cmd::compile_bin_package,
-    fs::{inputs::read_inputs_from_file, load_hex_data},
-};
 use crate::{backends::Backend, errors::CliError};
 
 use clap::Args;
 use nargo::constants::{PROOF_EXT, VERIFIER_INPUT_FILE};
+use nargo::ops::compile_program;
 use nargo::package::Package;
 use nargo::workspace::Workspace;
 use nargo::{insert_all_files_for_workspace_into_file_manager, parse_all};
@@ -56,16 +55,25 @@ pub(crate) fn run(
     let parsed_files = parse_all(&workspace_file_manager);
 
     let expression_width = backend.get_backend_info()?;
-    for package in &workspace {
-        let program = compile_bin_package(
+    let binary_packages = workspace.into_iter().filter(|package| package.is_binary());
+    for package in binary_packages {
+        let compilation_result = compile_program(
             &workspace_file_manager,
             &parsed_files,
             package,
             &args.compile_options,
             expression_width,
+            None,
+        );
+
+        let compiled_program = report_errors(
+            compilation_result,
+            &workspace_file_manager,
+            args.compile_options.deny_warnings,
+            args.compile_options.silence_warnings,
         )?;
 
-        verify_package(backend, &workspace, package, program, &args.verifier_name)?;
+        verify_package(backend, &workspace, package, compiled_program, &args.verifier_name)?;
     }
 
     Ok(())


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/2608

## Summary\*

This PR removes the `compile_bin_package` function as it's pretty unnecessary. At the same time I've added filters to other commands which only make sense on binary packages to avoid #2608 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
