### PR TITLE
feat: Separate compilation and expression narrowing in `nargo` interface

### DIFF
--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -26,7 +26,7 @@ pub enum ContractFunctionType {
     Unconstrained,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompiledContract {
     pub noir_version: String,
 
@@ -51,7 +51,7 @@ pub struct CompiledContract {
 /// A contract function unlike a regular Noir program
 /// however can have additional properties.
 /// One of these being a function type.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContractFunction {
     pub name: String,
 

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -190,7 +190,8 @@ pub fn compile(
             })?
             .0;
 
-        let optimized_contract = nargo::ops::optimize_contract(compiled_contract, expression_width);
+        let optimized_contract =
+            nargo::ops::transform_contract(compiled_contract, expression_width);
 
         let compile_output = generate_contract_artifact(optimized_contract);
         Ok(JsCompileResult::new(compile_output))
@@ -205,7 +206,7 @@ pub fn compile(
             })?
             .0;
 
-        let optimized_program = nargo::ops::optimize_program(compiled_program, expression_width);
+        let optimized_program = nargo::ops::transform_program(compiled_program, expression_width);
 
         let compile_output = generate_program_artifact(optimized_program);
         Ok(JsCompileResult::new(compile_output))

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -109,7 +109,7 @@ impl CompilerContext {
                 })?
                 .0;
 
-        let optimized_program = nargo::ops::optimize_program(compiled_program, np_language);
+        let optimized_program = nargo::ops::transform_program(compiled_program, np_language);
 
         let compile_output = generate_program_artifact(optimized_program);
         Ok(JsCompileResult::new(compile_output))
@@ -134,7 +134,7 @@ impl CompilerContext {
                 })?
                 .0;
 
-        let optimized_contract = nargo::ops::optimize_contract(compiled_contract, np_language);
+        let optimized_contract = nargo::ops::transform_contract(compiled_contract, np_language);
 
         let compile_output = generate_contract_artifact(optimized_contract);
         Ok(JsCompileResult::new(compile_output))

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -126,18 +126,18 @@ impl From<CompiledProgram> for DebugArtifact {
     }
 }
 
-impl From<&CompiledContract> for DebugArtifact {
-    fn from(compiled_artifact: &CompiledContract) -> Self {
+impl From<CompiledContract> for DebugArtifact {
+    fn from(compiled_artifact: CompiledContract) -> Self {
         let all_functions_debug: Vec<DebugInfo> = compiled_artifact
             .functions
-            .iter()
-            .map(|contract_function| contract_function.debug.clone())
+            .into_iter()
+            .map(|contract_function| contract_function.debug)
             .collect();
 
         DebugArtifact {
             debug_symbols: all_functions_debug,
-            file_map: compiled_artifact.file_map.clone(),
-            warnings: compiled_artifact.warnings.clone(),
+            file_map: compiled_artifact.file_map,
+            warnings: compiled_artifact.warnings,
         }
     }
 }

--- a/tooling/nargo/src/ops/compile.rs
+++ b/tooling/nargo/src/ops/compile.rs
@@ -9,6 +9,8 @@ use crate::{package::Package, workspace::Workspace};
 
 use rayon::prelude::*;
 
+use super::{transform_contract, transform_program};
+
 /// Compiles workspace.
 ///
 /// # Errors
@@ -89,7 +91,7 @@ pub fn compile_program(
         noirc_driver::compile_main(&mut context, crate_id, compile_options, cached_program)?;
 
     // Apply backend specific optimizations.
-    let optimized_program = crate::ops::optimize_program(program, expression_width);
+    let optimized_program = transform_program(program, expression_width);
 
     Ok((optimized_program, warnings))
 }
@@ -105,7 +107,7 @@ pub fn compile_contract(
     let (contract, warnings) =
         noirc_driver::compile_contract(&mut context, crate_id, compile_options)?;
 
-    let optimized_contract = crate::ops::optimize_contract(contract, expression_width);
+    let optimized_contract = transform_contract(contract, expression_width);
 
     Ok((optimized_contract, warnings))
 }

--- a/tooling/nargo/src/ops/mod.rs
+++ b/tooling/nargo/src/ops/mod.rs
@@ -2,6 +2,8 @@ pub use self::compile::{compile_contract, compile_program, compile_workspace};
 pub use self::execute::execute_circuit;
 pub use self::foreign_calls::{DefaultForeignCallExecutor, ForeignCallExecutor};
 pub use self::optimize::{optimize_contract, optimize_program};
+pub use self::transform::{transform_contract, transform_program};
+
 pub use self::test::{run_test, TestStatus};
 
 mod compile;
@@ -9,3 +11,4 @@ mod execute;
 mod foreign_calls;
 mod optimize;
 mod test;
+mod transform;

--- a/tooling/nargo/src/ops/optimize.rs
+++ b/tooling/nargo/src/ops/optimize.rs
@@ -1,26 +1,16 @@
-use acvm::ExpressionWidth;
 use iter_extended::vecmap;
 use noirc_driver::{CompiledContract, CompiledProgram};
 
-pub fn optimize_program(
-    mut program: CompiledProgram,
-    expression_width: ExpressionWidth,
-) -> CompiledProgram {
-    let (optimized_circuit, location_map) =
-        acvm::compiler::compile(program.circuit, expression_width);
-
+pub fn optimize_program(mut program: CompiledProgram) -> CompiledProgram {
+    let (optimized_circuit, location_map) = acvm::compiler::optimize(program.circuit);
     program.circuit = optimized_circuit;
     program.debug.update_acir(location_map);
     program
 }
 
-pub fn optimize_contract(
-    contract: CompiledContract,
-    expression_width: ExpressionWidth,
-) -> CompiledContract {
+pub fn optimize_contract(contract: CompiledContract) -> CompiledContract {
     let functions = vecmap(contract.functions, |mut func| {
-        let (optimized_bytecode, location_map) =
-            acvm::compiler::compile(func.bytecode, expression_width);
+        let (optimized_bytecode, location_map) = acvm::compiler::optimize(func.bytecode);
         func.bytecode = optimized_bytecode;
         func.debug.update_acir(location_map);
         func

--- a/tooling/nargo/src/ops/transform.rs
+++ b/tooling/nargo/src/ops/transform.rs
@@ -1,0 +1,30 @@
+use acvm::ExpressionWidth;
+use iter_extended::vecmap;
+use noirc_driver::{CompiledContract, CompiledProgram};
+
+pub fn transform_program(
+    mut program: CompiledProgram,
+    expression_width: ExpressionWidth,
+) -> CompiledProgram {
+    let (optimized_circuit, location_map) =
+        acvm::compiler::compile(program.circuit, expression_width);
+
+    program.circuit = optimized_circuit;
+    program.debug.update_acir(location_map);
+    program
+}
+
+pub fn transform_contract(
+    contract: CompiledContract,
+    expression_width: ExpressionWidth,
+) -> CompiledContract {
+    let functions = vecmap(contract.functions, |mut func| {
+        let (optimized_bytecode, location_map) =
+            acvm::compiler::compile(func.bytecode, expression_width);
+        func.bytecode = optimized_bytecode;
+        func.debug.update_acir(location_map);
+        func
+    });
+
+    CompiledContract { functions, ..contract }
+}

--- a/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
+++ b/tooling/nargo_cli/src/cli/codegen_verifier_cmd.rs
@@ -53,7 +53,6 @@ pub(crate) fn run(
             &parsed_files,
             package,
             &args.compile_options,
-            expression_width,
             None,
         );
 
@@ -63,6 +62,8 @@ pub(crate) fn run(
             args.compile_options.deny_warnings,
             args.compile_options.silence_warnings,
         )?;
+
+        let program = nargo::ops::transform_program(program, expression_width);
 
         let smart_contract_string = backend.eth_contract(&program.circuit)?;
 

--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -74,14 +74,8 @@ fn load_and_compile_project(
     let parsed_files = parse_all(&workspace_file_manager);
 
     let compile_options = CompileOptions::default();
-    let compilation_result = compile_program(
-        &workspace_file_manager,
-        &parsed_files,
-        package,
-        &compile_options,
-        expression_width,
-        None,
-    );
+    let compilation_result =
+        compile_program(&workspace_file_manager, &parsed_files, package, &compile_options, None);
 
     let compiled_program = report_errors(
         compilation_result,
@@ -90,6 +84,8 @@ fn load_and_compile_project(
         compile_options.silence_warnings,
     )
     .map_err(|_| LoadError("Failed to compile project"))?;
+
+    let compiled_program = nargo::ops::transform_program(compiled_program, expression_width);
 
     let (inputs_map, _) =
         read_inputs_from_file(&package.root_dir, prover_name, Format::Toml, &compiled_program.abi)

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -72,7 +72,6 @@ pub(crate) fn run(
         &parsed_files,
         package,
         &args.compile_options,
-        expression_width,
         None,
     );
 
@@ -82,6 +81,8 @@ pub(crate) fn run(
         args.compile_options.deny_warnings,
         args.compile_options.silence_warnings,
     )?;
+
+    let compiled_program = nargo::ops::transform_program(compiled_program, expression_width);
 
     run_async(package, compiled_program, &args.prover_name, &args.witness_name, target_dir)
 }

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -76,7 +76,6 @@ pub(crate) fn run(
             &parsed_files,
             package,
             &args.compile_options,
-            expression_width,
             None,
         );
 
@@ -86,6 +85,8 @@ pub(crate) fn run(
             args.compile_options.deny_warnings,
             args.compile_options.silence_warnings,
         )?;
+
+        let compiled_program = nargo::ops::transform_program(compiled_program, expression_width);
 
         let (return_value, solved_witness) = execute_program_and_decode(
             compiled_program,

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -74,19 +74,25 @@ pub(crate) fn run(
         &workspace_file_manager,
         &parsed_files,
         &workspace,
-        expression_width,
         &args.compile_options,
     )?;
+
+    let compiled_programs = vecmap(compiled_programs, |program| {
+        nargo::ops::transform_program(program, expression_width)
+    });
+    let compiled_contracts = vecmap(compiled_contracts, |contract| {
+        nargo::ops::transform_contract(contract, expression_width)
+    });
 
     if args.profile_info {
         for compiled_program in &compiled_programs {
             let span_opcodes = compiled_program.debug.count_span_opcodes();
-            let debug_artifact: DebugArtifact = compiled_program.clone().into();
+            let debug_artifact = DebugArtifact::from(compiled_program.clone());
             print_span_opcodes(span_opcodes, &debug_artifact);
         }
 
         for compiled_contract in &compiled_contracts {
-            let debug_artifact: DebugArtifact = compiled_contract.clone().into();
+            let debug_artifact = DebugArtifact::from(compiled_contract.clone());
             let functions = &compiled_contract.functions;
             for contract_function in functions {
                 let span_opcodes = contract_function.debug.count_span_opcodes();

--- a/tooling/nargo_cli/src/cli/prove_cmd.rs
+++ b/tooling/nargo_cli/src/cli/prove_cmd.rs
@@ -77,7 +77,6 @@ pub(crate) fn run(
             &parsed_files,
             package,
             &args.compile_options,
-            expression_width,
             None,
         );
 
@@ -87,6 +86,8 @@ pub(crate) fn run(
             args.compile_options.deny_warnings,
             args.compile_options.silence_warnings,
         )?;
+
+        let compiled_program = nargo::ops::transform_program(compiled_program, expression_width);
 
         prove_package(
             backend,

--- a/tooling/nargo_cli/src/cli/verify_cmd.rs
+++ b/tooling/nargo_cli/src/cli/verify_cmd.rs
@@ -62,7 +62,6 @@ pub(crate) fn run(
             &parsed_files,
             package,
             &args.compile_options,
-            expression_width,
             None,
         );
 
@@ -72,6 +71,8 @@ pub(crate) fn run(
             args.compile_options.deny_warnings,
             args.compile_options.silence_warnings,
         )?;
+
+        let compiled_program = nargo::ops::transform_program(compiled_program, expression_width);
 
         verify_package(backend, &workspace, package, compiled_program, &args.verifier_name)?;
     }

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -512,7 +512,7 @@ fn decode_string_value(field_elements: &[FieldElement]) -> String {
     final_string.to_owned()
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContractEvent {
     /// Event name
     name: String,


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

This PR moves the responsibility for transforming a circuit into a certain expression width into `nargo_cli`. This gives us better separation of concerns where we no longer need to know the target backend before we compile a circuit (i.e. we can save a generic artifact and then target multiple backends using this)

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
