### PR TITLE
fix: broken url replaced with a working url

### DIFF
--- a/docs/versioned_docs/version-v0.22.0/tutorials/noirjs_app.md
+++ b/docs/versioned_docs/version-v0.22.0/tutorials/noirjs_app.md
@@ -256,6 +256,6 @@ You can find the complete app code for this guide [here](https://github.com/noir
 
 ## Further Reading
 
-You can see how noirjs is used in a full stack Next.js hardhat application in the [noir-starter repo here](https://github.com/noir-lang/noir-starter/tree/main/next-hardhat). The example shows how to calculate a proof in the browser and verify it with a deployed Solidity verifier contract from noirjs.
+You can see how noirjs is used in a full stack Next.js hardhat application in the [noir-starter repo here](https://github.com/noir-lang/noir-starter/blob/main/vite-hardhat). The example shows how to calculate a proof in the browser and verify it with a deployed Solidity verifier contract from noirjs.
 
 You should also check out the more advanced examples in the [noir-examples repo](https://github.com/noir-lang/noir-examples), where you'll find reference usage for some cool apps.


### PR DESCRIPTION
The URL for noir-starter example redirected to a broken URL. I've replaced it with the latest and working URL which redirects to the noir-starter/vite-hardhat example.

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
