### PR TITLE
chore: improve warning message for returning a constant value

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -68,7 +68,7 @@ impl From<SsaReport> for FileDiagnostic {
                 let message = warning.to_string();
                 let (secondary_message, call_stack) = match warning {
                     InternalWarning::ReturnConstant { call_stack } => {
-                        ("constant value".to_string(), call_stack)
+                        ("This variable contains a value which is constrained to be a constant. Consider removing this value as additional return values increase proving/verification time".to_string(), call_stack)
                     },
                     InternalWarning::VerifyProof { call_stack } => {
                         ("verify_proof(...) aggregates data for the verifier, the actual verification will be done when the full proof is verified using nargo verify. nargo prove may generate an invalid proof if bad data is used as input to verify_proof".to_string(), call_stack)
@@ -87,7 +87,7 @@ impl From<SsaReport> for FileDiagnostic {
 
 #[derive(Debug, PartialEq, Eq, Clone, Error, Serialize, Deserialize)]
 pub enum InternalWarning {
-    #[error("Returning a constant value is not allowed")]
+    #[error("Return variable contains a constant value")]
     ReturnConstant { call_stack: CallStack },
     #[error("Calling std::verify_proof(...) does not verify a proof")]
     VerifyProof { call_stack: CallStack },


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This message is a bit strong for a warning (constant return values are technically allowed, there's just generally not much reason for them). It also doesn't give much information on why they may not be a good idea.

I've updated the warning to something which I think is more useful. Happy to take feedback on this however.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
