### PR TITLE
feat: add option to print monomorphized program

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -398,7 +398,6 @@ pub fn compile_no_check(
     if options.show_monomorphized {
         println!("Monomorphized AST for program with hash: {}", hash);
         println!("{program}");
-        println!();
     }
 
     // If user has specified that they want to see intermediate steps printed then we should

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -75,6 +75,10 @@ pub struct CompileOptions {
     /// Disables the builtin macros being used in the compiler
     #[arg(long, hide = true)]
     pub disable_macros: bool,
+
+    /// Disables the builtin macros being used in the compiler
+    #[arg(long, hide = true)]
+    pub show_monomorphized: bool,
 }
 
 /// Helper type used to signify where only warnings are expected in file diagnostics
@@ -391,6 +395,11 @@ pub fn compile_no_check(
 
     let hash = fxhash::hash64(&program);
     let hashes_match = cached_program.as_ref().map_or(false, |program| program.hash == hash);
+    if options.show_monomorphized {
+        println!("Monomorphized AST for program with hash: {}", hash);
+        println!("{program}");
+        println!();
+    }
 
     // If user has specified that they want to see intermediate steps printed then we should
     // force compilation even if the program hasn't changed.

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -76,7 +76,7 @@ pub struct CompileOptions {
     #[arg(long, hide = true)]
     pub disable_macros: bool,
 
-    /// Disables the builtin macros being used in the compiler
+    /// Outputs the monomorphized IR to stdout for debugging
     #[arg(long, hide = true)]
     pub show_monomorphized: bool,
 }

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -396,7 +396,6 @@ pub fn compile_no_check(
     let hash = fxhash::hash64(&program);
     let hashes_match = cached_program.as_ref().map_or(false, |program| program.hash == hash);
     if options.show_monomorphized {
-        println!("Monomorphized AST for program with hash: {}", hash);
         println!("{program}");
     }
 


### PR DESCRIPTION

# Description

Debugging optimizations often requires inspecting the monomorphized program. This adds an option to enable this.

## Problem\*

https://github.com/noir-lang/noir/issues/4067

## Summary\*

Example usage:

```bash
❯ (cd test_programs/compile_success_contract/simple_contract && cargo run compile --show-monomorphized)
   Compiling nargo_cli v0.23.0 (/Users/michaelklein/Coding/rust/noir/tooling/nargo_cli)
    Finished dev [optimized + debuginfo] target(s) in 1.79s
     Running `/Users/michaelklein/Coding/rust/noir/target/debug/nargo compile --show-monomorphized`
Monomorphized AST for program with hash: 18020856208726922572
fn triple$f0(x$l0: Field) -> Field {
    (x$l0 * 3)
}

Monomorphized AST for program with hash: 9305131916264092540
fn skibbidy$f0(x$l0: Field) -> Field {
    (x$l0 * 5)
}

Monomorphized AST for program with hash: 17799031513160233728
fn double$f0(x$l0: Field) -> Field {
    (x$l0 * 2)
}

Monomorphized AST for program with hash: 16417890415031598568
fn quadruple$f0(x$l0: Field) -> Field {
    (x$l0 * 4)
}
```

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed. (hidden option)
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
