### PR TITLE
chore: install wasm-bindgen using binstall

### DIFF
--- a/.github/scripts/wasm-bindgen-install.sh
+++ b/.github/scripts/wasm-bindgen-install.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eu
 
-curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-cargo binstall wasm-bindgen-cli@0.2.86 --force --no-confirm
-
+# TODO call this script directly
+./scripts/install_wasm-bindgen.sh

--- a/.github/scripts/wasm-bindgen-install.sh
+++ b/.github/scripts/wasm-bindgen-install.sh
@@ -2,4 +2,5 @@
 set -eu
 
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-cargo-binstall wasm-bindgen-cli --version 0.2.86 -y
+cargo binstall wasm-bindgen-cli@0.2.86 --force --no-confirm
+

--- a/scripts/install_wasm-bindgen.sh
+++ b/scripts/install_wasm-bindgen.sh
@@ -3,8 +3,12 @@ set -eu
 
 cd $(dirname "$0")/..
 
+# Install binstall
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
 # Install wasm-bindgen-cli.
 if [ "$(wasm-bindgen --version | cut -d' ' -f2)" != "0.2.86" ]; then
   echo "Building wasm-bindgen..."
-  RUSTFLAGS="-Ctarget-feature=-crt-static" cargo install -f wasm-bindgen-cli --version 0.2.86
+  cargo binstall wasm-bindgen-cli@0.2.86 --force --no-confirm
 fi
+


### PR DESCRIPTION
# Description

This uses a preinstalled version of wasmbindgen-cli install of recompiling each time

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
