### PR TITLE
feat: Add brillig array index check

### DIFF
--- a/test_programs/noir_test_success/out_of_bounds_alignment/Nargo.toml
+++ b/test_programs/noir_test_success/out_of_bounds_alignment/Nargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "out_of_bounds_alignment"
+type = "bin"
+authors = [""]
+[dependencies]

--- a/test_programs/noir_test_success/out_of_bounds_alignment/src/main.nr
+++ b/test_programs/noir_test_success/out_of_bounds_alignment/src/main.nr
@@ -1,0 +1,17 @@
+fn out_of_bounds(arr_1: [Field; 50]) -> Field {
+    arr_1[50 + 1]
+}
+
+unconstrained fn out_of_bounds_unconstrained_wrapper(arr_1: [Field; 50], arr_2: [Field; 50]) -> Field {
+    out_of_bounds(arr_1)
+}
+
+#[test(should_fail)]
+fn test_acir() {
+    assert_eq(out_of_bounds([0; 50]), 0);
+}
+
+#[test(should_fail)]
+fn test_brillig() {
+    assert_eq(out_of_bounds_unconstrained_wrapper([0; 50], [0; 50]), 0);
+}


### PR DESCRIPTION
# Description

## Problem\*

Adds a runtime length check to avoid out of bounds accesses, to emulate the behavior with ACIR dynamic array accesses.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
