### PR TITLE
chore!: Remove unused Shl and Shr from Brillig IR

### DIFF
--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -164,8 +164,4 @@ pub enum BinaryIntOp {
     Or,
     /// (^) Bitwise XOR
     Xor,
-    /// (<<) Shift left
-    Shl,
-    /// (>>) Shift right
-    Shr,
 }

--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -1,7 +1,7 @@
 use acir::brillig::{BinaryFieldOp, BinaryIntOp};
 use acir::FieldElement;
 use num_bigint::{BigInt, BigUint};
-use num_traits::{One, ToPrimitive, Zero};
+use num_traits::{One, Zero};
 
 /// Evaluate a binary operation on two FieldElements and return the result as a FieldElement.
 pub(crate) fn evaluate_binary_field_op(
@@ -77,16 +77,6 @@ pub(crate) fn evaluate_binary_bigint_op(
         BinaryIntOp::And => (a & b) % bit_modulo,
         BinaryIntOp::Or => (a | b) % bit_modulo,
         BinaryIntOp::Xor => (a ^ b) % bit_modulo,
-        BinaryIntOp::Shl => {
-            assert!(bit_size <= 128, "unsupported bit size for right shift");
-            let b = b.to_u128().unwrap();
-            (a << b) % bit_modulo
-        }
-        BinaryIntOp::Shr => {
-            assert!(bit_size <= 128, "unsupported bit size for right shift");
-            let b = b.to_u128().unwrap();
-            (a >> b) % bit_modulo
-        }
     };
 
     Ok(result)
@@ -112,6 +102,7 @@ fn to_big_unsigned(a: BigInt, bit_size: u32) -> BigUint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use num_traits::ToPrimitive;
 
     struct TestParams {
         a: u128,


### PR DESCRIPTION
# Description

This was spotted by Facundo.

These are not being used in the IR and so have been removed, if you need this, one should instead use Multiplication or Signed/UnsignedDiv

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
