### PR TITLE
chore: convert vec references to slices

### DIFF
--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -168,7 +168,7 @@ impl<'a, B: BlackBoxFunctionSolver> VM<'a, B> {
         self.registers.set(register_index, value);
     }
 
-    pub fn get_memory(&self) -> &Vec<Value> {
+    pub fn get_memory(&self) -> &[Value] {
         self.memory.values()
     }
 

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -748,7 +748,7 @@ mod tests {
 
             let opcodes = [&start[..], &loop_body[..]].concat();
             let vm = brillig_execute_and_get_vm(memory, &opcodes);
-            vm.get_memory().clone()
+            vm.get_memory().to_vec()
         }
 
         let memory = brillig_write_memory(vec![Value::from(0u128); 5]);
@@ -904,7 +904,7 @@ mod tests {
 
             let opcodes = [&start[..], &recursive_fn[..]].concat();
             let vm = brillig_execute_and_get_vm(memory, &opcodes);
-            vm.get_memory().clone()
+            vm.get_memory().to_vec()
         }
 
         let memory = brillig_recursive_write_memory(vec![Value::from(0u128); 5]);

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -39,7 +39,7 @@ impl Memory {
     }
 
     /// Returns the values of the memory
-    pub fn values(&self) -> &Vec<Value> {
+    pub fn values(&self) -> &[Value] {
         &self.inner
     }
 }

--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -63,7 +63,7 @@ fn into_abi_params(context: &Context, params: Vec<Param>) -> Vec<AbiParameter> {
 // Takes each abi parameter and shallowly maps to the expected witness range in which the
 // parameter's constituent values live.
 fn param_witnesses_from_abi_param(
-    abi_params: &Vec<AbiParameter>,
+    abi_params: &[AbiParameter],
     input_witnesses: Vec<Witness>,
 ) -> BTreeMap<String, Vec<Range<Witness>>> {
     let mut idx = 0_usize;

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -1751,7 +1751,7 @@ fn execute_brillig(
     // It may be finished, in-progress, failed, or may be waiting for results of a foreign call.
     // If it's finished then we can omit the opcode and just write in the return values.
     match vm_status {
-        VMStatus::Finished => Some((vm.get_registers().clone(), vm.get_memory().clone())),
+        VMStatus::Finished => Some((vm.get_registers().clone(), vm.get_memory().to_vec())),
         VMStatus::InProgress => unreachable!("Brillig VM has not completed execution"),
         VMStatus::Failure { .. } => {
             // TODO: Return an error stating that the brillig function failed.

--- a/compiler/noirc_frontend/src/ast/function.rs
+++ b/compiler/noirc_frontend/src/ast/function.rs
@@ -72,7 +72,7 @@ impl NoirFunction {
     pub fn function_attribute(&self) -> Option<&FunctionAttribute> {
         self.def.attributes.function.as_ref()
     }
-    pub fn secondary_attributes(&self) -> &Vec<SecondaryAttribute> {
+    pub fn secondary_attributes(&self) -> &[SecondaryAttribute] {
         self.def.attributes.secondary.as_ref()
     }
     pub fn def(&self) -> &FunctionDefinition {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -460,7 +460,7 @@ fn type_check_functions(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn check_methods_signatures(
     resolver: &mut Resolver,
-    impl_methods: &Vec<(FileId, FuncId)>,
+    impl_methods: &[(FileId, FuncId)],
     trait_id: TraitId,
     trait_name_span: Span,
     // These are the generics on the trait itself from the impl.

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -1028,9 +1028,9 @@ impl<'interner> TypeChecker<'interner> {
 
     fn bind_function_type_impl(
         &mut self,
-        fn_params: &Vec<Type>,
+        fn_params: &[Type],
         fn_ret: &Type,
-        callsite_args: &Vec<(Type, ExprId, Span)>,
+        callsite_args: &[(Type, ExprId, Span)],
         span: Span,
     ) -> Type {
         if fn_params.len() != callsite_args.len() {

--- a/tooling/nargo/src/ops/foreign_calls.rs
+++ b/tooling/nargo/src/ops/foreign_calls.rs
@@ -82,8 +82,8 @@ impl MockedCall {
 }
 
 impl MockedCall {
-    fn matches(&self, name: &str, params: &Vec<ForeignCallParam>) -> bool {
-        self.name == name && (self.params.is_none() || self.params.as_ref() == Some(params))
+    fn matches(&self, name: &str, params: &[ForeignCallParam]) -> bool {
+        self.name == name && (self.params.is_none() || self.params.as_deref() == Some(params))
     }
 }
 


### PR DESCRIPTION
# Description

Converts usages of `&Vec<T>` to `&[T]`

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/679 

## Summary\*

`&Vec` can be dereferenced into `&[T]` whereas `&[T]` is more general.

In all but the following two cases, the type can simply be changed:

1. Both `clone` and `to_vec` perform a copy:
```rust
        VMStatus::Finished => Some((vm.get_registers().clone(), vm.get_memory().clone())),
        VMStatus::Finished => Some((vm.get_registers().clone(), vm.get_memory().to_vec())),
```

2. Both perform a match on the `Option`:
```rust
        self.name == name && (self.params.is_none() || self.params.as_ref() == Some(params))
        self.name == name && (self.params.is_none() || self.params.as_deref() == Some(params))
```

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
