### PR TITLE
chore(debugger): Limit printed BRILLIG opcode info while stepping in REPL debugger

### DIFF
--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -53,7 +53,15 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
             Some(location) => {
                 match location {
                     OpcodeLocation::Acir(ip) => {
-                        println!("At opcode {}: {}", ip, opcodes[ip])
+                        // Default Brillig display is too bloated for this context,
+                        // so we limit it to denoting it's the start of a Brillig
+                        // block. The user can still use the `opcodes` command to
+                        // take a look at the whole block.
+                        let opcode_summary = match opcodes[ip] {
+                            Opcode::Brillig(..) => "BRILLIG: ...".into(),
+                            _ => format!("{}", opcodes[ip]),
+                        };
+                        println!("At opcode {}: {}", ip, opcode_summary);
                     }
                     OpcodeLocation::Brillig { acir_index, brillig_index } => {
                         let Opcode::Brillig(ref brillig) = opcodes[acir_index] else {


### PR DESCRIPTION
# Description

Reduces the amount of information printed to the console after each step, when execution pauses at an ACIR BRILLIG opcode.

## Problem

Part of #3015. 

## Summary

Before this change:

```
[1327_concrete_in_generic] Starting debugger
At opcode 0: BRILLIG: inputs: [Single(Expression { mul_terms: [], linear_combinations: [], q_c: 0 }), Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })]
outputs: []
[Mov { destination: RegisterIndex(2), source: RegisterIndex(0) }, Mov { destination: RegisterIndex(3), source: RegisterIndex(1) }, Const { destination: RegisterIndex(0), value: Value { inner: 0 } }, Const { destination: RegisterIndex(1), value: Value { inner: 0 } }, Mov { destination: RegisterIndex(2), source: RegisterIndex(2) }, Mov { destination: RegisterIndex(3), source: RegisterIndex(3) }, Call { location: 8 }, Stop, ForeignCall { function: "__debug_var_assign", destinations: [], inputs: [RegisterIndex(RegisterIndex(2)), RegisterIndex(RegisterIndex(3))] }, Return]

At ~/noir/test_programs/execution_success/1327_concrete_in_generic/src/main.nr:56:9
 51    ...
 52    fn get_d_method_interface() -> MethodInterface<D> {
 53        MethodInterface { some_method_on_t_d: d_method }
 54    }
 55    // ---
 56 -> fn main(input: Field) -> pub Field {
 57        let b: B<C<D>> = B::new(new_concrete_c_over_d);
 58        let c: C<D> = b.get_t_c(); // Singleton<Note>
 59        let d: D = D { d: input }; // Note
 60        let output = c.call_method_of_t_d(d);
```

After this change:

```
[1327_concrete_in_generic] Starting debugger
At opcode 0: BRILLIG: ...
At ~/noir/test_programs/execution_success/1327_concrete_in_generic/src/main.nr:56:9
 51    ...
 52    fn get_d_method_interface() -> MethodInterface<D> {
 53        MethodInterface { some_method_on_t_d: d_method }
 54    }
 55    // ---
 56 -> fn main(input: Field) -> pub Field {
 57        let b: B<C<D>> = B::new(new_concrete_c_over_d);
 58        let c: C<D> = b.get_t_c(); // Singleton<Note>
 59        let d: D = D { d: input }; // Note
 60        let output = c.call_method_of_t_d(d);
 61    ...
>
```

Note: the user can still inspect the full contents of opcode 0 by using the `opcodes` command.


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
