### PR TITLE
chore: pull in `Default` trait definition through a snippet

### DIFF
--- a/docs/docs/noir/standard_library/traits.md
+++ b/docs/docs/noir/standard_library/traits.md
@@ -8,11 +8,7 @@ keywords: [traits, trait, interface, protocol, default, add, eq]
 
 ### `std::default::Default`
 
-```rust
-trait Default {
-    fn default() -> Self;
-}
-```
+#include_code default-trait noir_stdlib/src/default.nr rust
 
 Constructs a default value of a type.
 

--- a/noir_stdlib/src/default.nr
+++ b/noir_stdlib/src/default.nr
@@ -1,6 +1,8 @@
+// docs:start:default-trait
 trait Default {
     fn default() -> Self;
 }
+// docs:end:default-trait
 
 impl Default for Field { fn default() -> Field { 0 } }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4180

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
