### PR TITLE
fix(docs): codegen docs before cutting a new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Cut a new version
         working-directory: ./docs
-        run: yarn docusaurus docs:version ${{ steps.noir-version.outputs.semver }}
+        run: yarn version ${{ steps.noir-version.outputs.semver }}
 
       - name: Configure git
         run: |

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,8 @@
     "start": "yarn preprocess && docusaurus start",
     "build": "yarn preprocess && yarn version::stables && docusaurus build",
     "version::stables": "ts-node ./scripts/setStable.ts",
-    "serve": "serve build"
+    "serve": "serve build",
+    "version": "yarn preprocess && docusaurus docs:version"
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.1",


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Currently when cutting a release in CI, docusaurus is looking for `processed-docs` however this hasn't been generated.

This PR then ensures this is up to date when generating a release by running `preprocess` before doing so.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
