### PR TITLE
fix: Fix incorrect result when assigning shared arrays in unconstrained code

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -486,10 +486,30 @@ impl FunctionBuilder {
                     self.increment_array_reference_count(value);
                 }
             }
-            Type::Array(..) | Type::Slice(..) => {
-                self.insert_instruction(Instruction::IncrementRc { value }, None);
+            typ @ Type::Array(..) | typ @ Type::Slice(..) => {
                 // If there are nested arrays or slices, we wait until ArrayGet
                 // is issued to increment the count of that array.
+                self.insert_instruction(Instruction::IncrementRc { value }, None);
+
+                // This is a bit odd, but in brillig the inc_rc instruction operates on
+                // a copy of the array's metadata, so we need to re-store a loaded array
+                // even if there have been no other changes to it.
+                match &self.current_function.dfg[value] {
+                    Value::Instruction { instruction, .. } => {
+                        match &self.current_function.dfg[*instruction] {
+                            Instruction::Load { address } => {
+                                // We can't re-use `value` in case the original address was stored
+                                // to again in the meantime. So introduce another load.
+                                let address = *address;
+                                let value = self.insert_load(address, typ);
+                                self.insert_instruction(Instruction::IncrementRc { value }, None);
+                                self.insert_store(address, value);
+                            }
+                            _ => (),
+                        }
+                    }
+                    _ => (),
+                }
             }
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -678,6 +678,11 @@ impl<'a> FunctionContext<'a> {
         let lhs = self.extract_current_value(&assign.lvalue)?;
         let rhs = self.codegen_expression(&assign.expression)?;
 
+        rhs.clone().for_each(|value| {
+            let value = value.eval(self);
+            self.builder.increment_array_reference_count(value)
+        });
+
         self.assign_new_value(lhs, rhs);
         Ok(Self::unit_value())
     }

--- a/test_programs/execution_success/brillig_cow_assign/Nargo.toml
+++ b/test_programs/execution_success/brillig_cow_assign/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "brillig_cow_assign"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.23.0"
+
+[dependencies]

--- a/test_programs/execution_success/brillig_cow_assign/Prover.toml
+++ b/test_programs/execution_success/brillig_cow_assign/Prover.toml
@@ -1,0 +1,2 @@
+items_to_update = 10
+index = 6

--- a/test_programs/execution_success/brillig_cow_assign/src/main.nr
+++ b/test_programs/execution_success/brillig_cow_assign/src/main.nr
@@ -1,0 +1,23 @@
+global N = 10;
+
+unconstrained fn main() {
+    let mut arr = [0; N];
+    let mut mid_change = arr;
+
+    for i in 0..N {
+        if i == N / 2 {
+            mid_change = arr;
+        }
+        arr[i] = 27;
+    }
+
+    // Expect:
+    // arr        = [27, 27, 27, 27, 27, 27, 27, 27, 27, 27]
+    // mid_change = [27, 27, 27, 27, 27, 0, 0, 0, 0, 0]
+
+    let modified_i = N / 2 + 1;
+    assert_eq(arr[modified_i], 27);
+
+    // Fail here!
+    assert(mid_change[modified_i] != 27);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3795

## Summary\*

`Instruction::IncrementRc` in Brillig actually only increments the reference count on a copy of an array's metadata if the array was loaded from a reference (while the loaded array is a reference rather than a copy). This is suboptimal since it was meant to be shared across references to the array. This is what caused the original issue where mutating the reference saw a different reference count and thought it was safe to mutate without copying first.

I've added a somewhat hacky check in the method to increment reference counts to check if the array was loaded from a reference. If so, we load a fresh value, increment rc on that, and re-store it to update the metadata in the original array.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
