### PR TITLE
feat: add option to set max memory for bb.js

### DIFF
--- a/compiler/integration-tests/package.json
+++ b/compiler/integration-tests/package.json
@@ -19,6 +19,7 @@
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
         "@nomicfoundation/hardhat-ethers": "^3.0.0",
         "@web/dev-server-esbuild": "^0.3.6",
+        "@web/dev-server-import-maps": "^0.2.0",
         "@web/test-runner": "^0.15.3",
         "@web/test-runner-playwright": "^0.10.0",
         "eslint": "^8.50.0",

--- a/compiler/integration-tests/test/mocks/os.js
+++ b/compiler/integration-tests/test/mocks/os.js
@@ -1,0 +1,1 @@
+export const os = { cpus: () => new Array(4) };

--- a/compiler/integration-tests/web-test-runner.config.mjs
+++ b/compiler/integration-tests/web-test-runner.config.mjs
@@ -2,7 +2,8 @@ import { defaultReporter } from '@web/test-runner';
 import { summaryReporter } from '@web/test-runner';
 import { fileURLToPath } from 'url';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
-import { playwrightLauncher } from "@web/test-runner-playwright";
+import { playwrightLauncher } from '@web/test-runner-playwright';
+import { importMapsPlugin } from '@web/dev-server-import-maps';
 
 let reporter = summaryReporter();
 const debugPlugins = [];
@@ -21,13 +22,23 @@ if (process.env.CI !== 'true' || process.env.RUNNER_DEBUG === '1') {
 
 export default {
   browsers: [
-    playwrightLauncher({ product: "chromium" }),
+    playwrightLauncher({ product: 'chromium' }),
     // playwrightLauncher({ product: "webkit" }),
     // playwrightLauncher({ product: "firefox" }),
   ],
   plugins: [
     esbuildPlugin({
       ts: true,
+    }),
+    importMapsPlugin({
+      inject: {
+        importMap: {
+          imports: {
+            // mock os module
+            os: '/test/mocks/os.js',
+          },
+        },
+      },
     }),
     ...debugPlugins,
   ],

--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -6,6 +6,7 @@ import { deflattenPublicInputs, flattenPublicInputsAsArray } from './public_inpu
 import { type Barretenberg } from '@aztec/bb.js';
 
 export { publicInputsToWitnessMap } from './public_inputs.js';
+import { cpus } from "os";
 
 // This is the number of bytes in a UltraPlonk proof
 // minus the public inputs.
@@ -24,7 +25,7 @@ export class BarretenbergBackend implements Backend {
 
   constructor(
     acirCircuit: CompiledCircuit,
-    private options: BackendOptions = { threads: 1 },
+    private options: BackendOptions = { threads: navigator ? navigator.hardwareConcurrency : cpus().length },
   ) {
     const acirBytecodeBase64 = acirCircuit.bytecode;
     this.acirUncompressedBytecode = acirToUint8Array(acirBytecodeBase64);

--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -6,7 +6,7 @@ import { deflattenPublicInputs, flattenPublicInputsAsArray } from './public_inpu
 import { type Barretenberg } from '@aztec/bb.js';
 
 export { publicInputsToWitnessMap } from './public_inputs.js';
-import { cpus } from "os";
+import { cpus } from 'os';
 
 // This is the number of bytes in a UltraPlonk proof
 // minus the public inputs.

--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -34,7 +34,7 @@ export class BarretenbergBackend implements Backend {
   async instantiate(): Promise<void> {
     if (!this.api) {
       const { Barretenberg, RawBuffer, Crs } = await import('@aztec/bb.js');
-      const api = await Barretenberg.new({ threads: this.options.threads });
+      const api = await Barretenberg.new(this.options);
 
       const [_exact, _total, subgroupSize] = await api.acirGetCircuitSizes(this.acirUncompressedBytecode);
       const crs = await Crs.new(subgroupSize + 1);

--- a/tooling/noir_js_backend_barretenberg/src/index.ts
+++ b/tooling/noir_js_backend_barretenberg/src/index.ts
@@ -25,7 +25,7 @@ export class BarretenbergBackend implements Backend {
 
   constructor(
     acirCircuit: CompiledCircuit,
-    private options: BackendOptions = { threads: navigator ? navigator.hardwareConcurrency : cpus().length },
+    private options: BackendOptions = { threads: typeof navigator !== "undefined" ? navigator.hardwareConcurrency : cpus().length},
   ) {
     const acirBytecodeBase64 = acirCircuit.bytecode;
     this.acirUncompressedBytecode = acirToUint8Array(acirBytecodeBase64);

--- a/tooling/noir_js_backend_barretenberg/src/types.ts
+++ b/tooling/noir_js_backend_barretenberg/src/types.ts
@@ -5,5 +5,5 @@
 export type BackendOptions = {
   /** @description Number of threads */
   threads: number;
-  memory?: { initial?: number; maximum?: number };
+  memory?: { maximum: number };
 };

--- a/tooling/noir_js_backend_barretenberg/src/types.ts
+++ b/tooling/noir_js_backend_barretenberg/src/types.ts
@@ -5,4 +5,5 @@
 export type BackendOptions = {
   /** @description Number of threads */
   threads: number;
+  memory?: { initial?: number; maximum?: number };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3965,6 +3965,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@import-maps/resolve@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@import-maps/resolve@npm:1.0.1"
+  checksum: 17ee033e26a0fd82294de87eae76d32b553a130fdbf0fb8c70d39f2087a3e8a4a5908970a99aa32bd175153efe9b7dfee6b7f99df36f41abed08c1911dbdb19c
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -6756,6 +6763,20 @@ __metadata:
     parse5: ^6.0.1
     ua-parser-js: ^1.0.33
   checksum: ed29357d8a832c695f129de62bd658744b46b1e17a5aab24ad6d7cd09a90f27714d83fc6ece2471c35bff55f4f09435a18af65b37d65709019bfe09c10f4f9eb
+  languageName: node
+  linkType: hard
+
+"@web/dev-server-import-maps@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@web/dev-server-import-maps@npm:0.2.0"
+  dependencies:
+    "@import-maps/resolve": ^1.0.1
+    "@types/parse5": ^6.0.1
+    "@web/dev-server-core": ^0.7.0
+    "@web/parse5-utils": ^2.1.0
+    parse5: ^6.0.1
+    picomatch: ^2.2.2
+  checksum: 15dabfa385f023bab70758b80cc09443455830799793c1a404a7230d90ebf60e40984a10d8a6ceea2afb8f057e90a9f7356a76f867d5e5a2eeacbc397e41535a
   languageName: node
   linkType: hard
 
@@ -13400,6 +13421,7 @@ __metadata:
     "@nomicfoundation/hardhat-chai-matchers": ^2.0.0
     "@nomicfoundation/hardhat-ethers": ^3.0.0
     "@web/dev-server-esbuild": ^0.3.6
+    "@web/dev-server-import-maps": ^0.2.0
     "@web/test-runner": ^0.15.3
     "@web/test-runner-playwright": ^0.10.0
     eslint: ^8.50.0


### PR DESCRIPTION
# Description

Makes `BackendBarretenberg` pass all the options to the `bb.js` instance.

## Summary\*

Makes `BackendBarretenberg` pass all the options to the `bb.js` instance, namely min and max memory. Manually setting max memory makes iOS not immediately kill workers on the browser.

This is already implemented in BB as per [this PR](https://github.com/AztecProtocol/aztec-packages/pull/3265)

Replicates the change I made in a pinch for `progrcrypto` Istanbul. [Example usage here](https://github.com/signorecello/progcrypto23-act/blob/f95f267f2460a423f99865ca30e29f89e8104bc5/packages/user/pages/index.tsx#L31)

