### PR TITLE
feat: remove predicate from `sort` intrinsic function

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -1649,7 +1649,6 @@ impl AcirContext {
         &mut self,
         inputs: Vec<AcirVar>,
         bit_size: u32,
-        predicate: AcirVar,
     ) -> Result<Vec<AcirVar>, RuntimeError> {
         let len = inputs.len();
         // Convert the inputs into expressions
@@ -1666,23 +1665,14 @@ impl AcirContext {
         self.acir_ir.permutation(&inputs_expr, &output_expr)?;
 
         // Enforce the outputs to be sorted
+        let true_var = self.add_constant(true);
         for i in 0..(outputs_var.len() - 1) {
-            self.less_than_constrain(outputs_var[i], outputs_var[i + 1], bit_size, predicate)?;
+            let less_than_next_element =
+                self.more_than_eq_var(outputs_var[i + 1], outputs_var[i], bit_size)?;
+            self.assert_eq_var(less_than_next_element, true_var, None)?;
         }
 
         Ok(outputs_var)
-    }
-
-    /// Constrain lhs to be less than rhs
-    fn less_than_constrain(
-        &mut self,
-        lhs: AcirVar,
-        rhs: AcirVar,
-        bit_size: u32,
-        predicate: AcirVar,
-    ) -> Result<(), RuntimeError> {
-        let lhs_less_than_rhs = self.more_than_eq_var(rhs, lhs, bit_size)?;
-        self.maybe_eq_predicate(lhs_less_than_rhs, predicate)
     }
 
     /// Returns a Variable that is constrained to be the result of reading

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -1623,8 +1623,7 @@ impl Context {
                     }
                 }
                 // Generate the sorted output variables
-                let out_vars =
-                    self.acir_context.sort(input_vars, bit_size).expect("Could not sort");
+                let out_vars = self.acir_context.sort(input_vars, bit_size)?;
 
                 Ok(self.convert_vars_to_values(out_vars, dfg, result_ids))
             }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -1623,10 +1623,8 @@ impl Context {
                     }
                 }
                 // Generate the sorted output variables
-                let out_vars = self
-                    .acir_context
-                    .sort(input_vars, bit_size, self.current_side_effects_enabled_var)
-                    .expect("Could not sort");
+                let out_vars =
+                    self.acir_context.sort(input_vars, bit_size).expect("Could not sort");
 
                 Ok(self.convert_vars_to_values(out_vars, dfg, result_ids))
             }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes the predicate from `AcirContext.sort()`. I'm not sure why this exists as we should always be able to perform a sorting on an array of values. We also list `Intrinsic::Sort` as having no side effects so it doesn't make sense for us to be using the side effects predicate here.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
