### PR TITLE
feat: simplify all unsigned constant NOT instructions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -440,9 +440,10 @@ impl Instruction {
                     // Limit optimizing ! on constants to only booleans. If we tried it on fields,
                     // there is no Not on FieldElement, so we'd need to convert between u128. This
                     // would be incorrect however since the extra bits on the field would not be flipped.
-                    Value::NumericConstant { constant, typ } if *typ == Type::bool() => {
-                        let value = constant.is_zero() as u128;
-                        SimplifiedTo(dfg.make_constant(value.into(), Type::bool()))
+                    Value::NumericConstant { constant, typ } if typ.is_unsigned() => {
+                        // As we're casting to a `u128`, we need to clear out any upper bits that the NOT fills.
+                        let value = !constant.to_u128() % (1 << typ.bit_size());
+                        SimplifiedTo(dfg.make_constant(value.into(), typ.clone()))
                     }
                     Value::Instruction { instruction, .. } => {
                         // !!v => v

--- a/test_programs/compile_success_empty/literal_not_simplification/Nargo.toml
+++ b/test_programs/compile_success_empty/literal_not_simplification/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "literal_not_simplification"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.23.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/literal_not_simplification/src/main.nr
+++ b/test_programs/compile_success_empty/literal_not_simplification/src/main.nr
@@ -1,4 +1,4 @@
-fn main(x: u8) {
+fn main() {
     let four: u8 = 4;
     let not_four: u8 = !four;
 

--- a/test_programs/compile_success_empty/literal_not_simplification/src/main.nr
+++ b/test_programs/compile_success_empty/literal_not_simplification/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: u8) {
+    let four: u8 = 4;
+    let not_four: u8 = !four;
+
+    let five: u8 = 5;
+    let not_five: u8 = !five;
+    assert(not_four != not_five);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR expands the existing simplification of constant NOT instructions to cover all unsigned integers.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
