### PR TITLE
feat: Add HashMap to the stdlib

### DIFF
--- a/noir_stdlib/src/collections.nr
+++ b/noir_stdlib/src/collections.nr
@@ -1,2 +1,3 @@
 mod vec;
 mod bounded_vec;
+mod map;

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -1,0 +1,245 @@
+use crate::cmp::Eq;
+use crate::collections::vec::Vec;
+use crate::option::Option;
+use crate::default::Default;
+use crate::hash::{Hash, Hasher, BuildHasher};
+
+// Generic trait for one-directional key -> value data structure.
+// May be implemented by either hash tables or graphs for instance.
+trait Map<K, V> {
+    fn len(self) -> u64;
+    fn get(self, key: K) -> Option<V>;
+    fn insert(&mut self, key: K, value: V);
+    fn remove(&mut self, key: K);
+}
+
+// Hash table with open addressing and quadratic probing.
+// Size of the underlying table must be known at compile time.
+// It is advised to select capacity N as a power of two, or a prime number 
+// because utilized probing scheme is best tailored for it.
+struct HashMap<K, V, N, B> {
+    _table: [Slot<K, V>; N],
+
+    // Amount of valid elements in the map.
+    _len: u64,
+
+    _build_hasher: B
+}
+
+// Data unit in the HashMap table.
+// In case Noir would support enums in future, this  
+// better to be refactored to use it with three states:
+// 1. (key, value)
+// 2. (empty)
+// 3. (deleted)
+struct Slot<K, V> {
+    _key_value: Option<(K, V)>,
+    _is_deleted: bool,
+}
+
+impl<K, V> Default for Slot<K, V>{
+    fn default() -> Self{
+        Slot{
+            _key_value: Option::none(),
+            _is_deleted: false
+        }
+    }
+}
+
+impl<K, V> Slot<K, V>{
+    fn is_valid(self) -> bool{
+        !self._is_deleted & self._key_value.is_some()
+    }
+
+    fn is_available(self) -> bool{
+        self._is_deleted | self._key_value.is_none()
+    }
+
+    fn key_value_unchecked(self) -> (K, V){
+        self._key_value.unwrap_unchecked()
+    }
+
+    fn set(&mut self, key: K, value: V){
+        self._key_value = Option::some((key, value));
+        self._is_deleted = false;
+    }
+
+    // Shall not override `_key_value` with Option::none(),
+    // because we must we able to differentiate empty 
+    // and deleted slots for lookup.
+    fn mark_deleted(&mut self){
+        self._is_deleted = true;
+    }
+}
+
+impl<K, V, N, B, H> HashMap<K, V, N, B> {   
+    // Creates a new instance of HashMap with specified BuildHasher.
+    pub fn with_hasher(_build_hasher: B) -> Self
+    where
+        B: BuildHasher<H>
+    {
+        let _table = [Slot::default(); N];
+        let _len = 0;
+        Self{_table, _len, _build_hasher}
+    }
+
+    fn hash(self, key: K) -> u64
+    where
+        K: Hash,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
+        let mut hasher = self._build_hasher.build_wrapper();
+        key.hash(&mut hasher);
+        hasher.finish() as u64
+    }
+
+    // Probing scheme: quadratic function.
+    // We use 0.5 constant near variadic attempt and attempt^2 monomials.
+    // This ensures good uniformity of distribution for table sizes
+    // equal to prime numbers or powers of two. 
+    fn quadratic_probe(self, hash: u64, attempt: u64) -> u64 {
+        (hash + (attempt + attempt * attempt) / 2 ) % N
+    }
+}
+
+// While conducting lookup, we iterate attempt from 0 to N - 1 due to heuristic,
+// that if we have went that far without finding desired, 
+// it is very unlikely to be after - performance in that case would be drastical.
+impl<K, V, N, B, H> Map<K, V> for HashMap<K, V, N, B>
+where
+    K: Eq + Hash,
+    B: BuildHasher<H>,
+    H: Hasher
+{
+    fn len(self) -> u64{
+        self._len
+    }
+
+    fn get(self, key: K) -> Option<V>{
+        let mut result = Option::none();
+
+        let hash = self.hash(key);
+        let mut break = false;
+
+        for attempt in 0..N{
+            if !break{
+                let index = self.quadratic_probe(hash, attempt as u64);
+                let slot = self._table[index];
+
+                // Not marked as deleted and has key-value.
+                if slot.is_valid(){ 
+                    let (current_key, value) = slot.key_value_unchecked();
+                    if current_key == key{
+                        result = Option::some(value);
+                        break = true;
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    fn insert(&mut self, key: K, value: V){
+        let hash = self.hash(key);
+        let mut break = false;
+
+        for attempt in 0..N{
+            if !break{
+                let index = self.quadratic_probe(hash, attempt as u64);
+                let mut slot = self._table[index];
+                let mut insert = false;
+
+                // Either marked as deleted or has unset key-value.
+                if slot.is_available(){ 
+                    insert = true;
+                    self._len += 1;
+                }else{
+                    let (current_key, _) = slot.key_value_unchecked();
+                    if current_key == key{
+                        insert = true;
+                    }
+                }
+
+                if insert{
+                    slot.set(key, value);
+                    self._table[index] = slot;
+                    break = true;
+                }
+            }
+        }
+    }
+
+    fn remove(&mut self, key: K){
+        let hash = self.hash(key);
+        let mut break = false;
+
+        for attempt in 0..N{
+            if !break{
+                let index = self.quadratic_probe(hash, attempt as u64);
+                let mut slot = self._table[index];
+
+                // Not marked as deleted and has key-value.
+                if slot.is_valid(){ 
+                    let (current_key, _) = slot.key_value_unchecked();
+                    if current_key == key{
+                        slot.mark_deleted();
+                        self._table[index] = slot;
+                        self._len -= 1;
+                        break = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Equality class on HashMap has to test that they have 
+// equal sets of key-value pairs, 
+// thus one is a subset of the other and vice versa.
+impl<K, V, N, B, H> Eq for HashMap<K, V, N, B>
+where
+    K: Eq + Hash,
+    V: Eq,
+    B: BuildHasher<H>,
+    H: Hasher
+{
+    fn eq(self, other: HashMap<K, V, N, B>) -> bool{
+        let mut equal = false;
+
+        if self.len() == other.len(){
+            equal = true;
+            for slot in self._table{
+                // Not marked as deleted and has key-value.
+                if equal & slot.is_valid(){
+                    let (key, value) = slot.key_value_unchecked();
+                    let other_value = other.get(key);
+
+                    if other_value.is_none(){
+                        equal = false;
+                    }else{
+                        let other_value = other_value.unwrap_unchecked();
+                        if value != other_value{
+                            equal = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        equal
+    }
+}
+
+impl<K, V, N, B, H> Default for HashMap<K, V, N, B>
+where
+    B: BuildHasher<H> + Default,
+    H: Hasher + Default
+{
+    fn default() -> Self{
+        let _build_hasher = B::default();
+        let map: HashMap<K, V, N, B> = HashMap::with_hasher(_build_hasher);
+        map
+    }
+}

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -44,20 +44,24 @@ impl<K, V> Default for Slot<K, V>{
     }
 }
 
-impl<K, V> Slot<K, V>{
-    fn is_valid(self) -> bool{
+impl<K, V> Slot<K, V> {
+    fn is_valid(self) -> bool {
         !self._is_deleted & self._key_value.is_some()
     }
 
-    fn is_available(self) -> bool{
+    fn is_available(self) -> bool {
         self._is_deleted | self._key_value.is_none()
     }
 
-    fn key_value_unchecked(self) -> (K, V){
+    fn key_value(self) -> Option<(K, V)> {
+        self._key_value
+    }
+
+    fn key_value_unchecked(self) -> (K, V) {
         self._key_value.unwrap_unchecked()
     }
 
-    fn set(&mut self, key: K, value: V){
+    fn set(&mut self, key: K, value: V) {
         self._key_value = Option::some((key, value));
         self._is_deleted = false;
     }
@@ -65,7 +69,7 @@ impl<K, V> Slot<K, V>{
     // Shall not override `_key_value` with Option::none(),
     // because we must be able to differentiate empty 
     // and deleted slots for lookup.
-    fn mark_deleted(&mut self){
+    fn mark_deleted(&mut self) {
         self._is_deleted = true;
     }
 }
@@ -73,132 +77,129 @@ impl<K, V> Slot<K, V>{
 // While conducting lookup, we iterate attempt from 0 to N - 1 due to heuristic,
 // that if we have went that far without finding desired, 
 // it is very unlikely to be after - performance will be heavily degraded.
-impl<K, V, N, B, H> HashMap<K, V, N, B> {   
+impl<K, V, N, B, H> HashMap<K, V, N, B> {
     // Creates a new instance of HashMap with specified BuildHasher.
     pub fn with_hasher(_build_hasher: B) -> Self
     where
-        B: BuildHasher<H>
-    {
+        B: BuildHasher<H> {
         let _table = [Slot::default(); N];
         let _len = 0;
-        Self{_table, _len, _build_hasher}
+        Self { _table, _len, _build_hasher }
     }
 
-    // Clears the map, removing all key-value pairs.
-    pub fn clear(&mut self){
+    // Clears the map, removing all key-value entries.
+    pub fn clear(&mut self) {
         self._table = [Slot::default(); N];
         self._len = 0;
     }
 
     // Returns true if the map contains a value for the specified key.
-    pub fn contains_key(self, key: K) -> bool
+    pub fn contains_key(
+        self,
+        key: K
+    ) -> bool
     where
         K: Hash + Eq,
         B: BuildHasher<H>,
-        H: Hasher
-    {
+        H: Hasher {
         self.get(key).is_some()
     }
 
     // Returns true if the map contains no elements.
-    pub fn is_empty(self) -> bool{
+    pub fn is_empty(self) -> bool {
         self._len == 0
     }
 
-    // Returns array of all active key-value pairs.
-    // Array size is restricted to N because of 
-    // compile time limitations and nested slices temporary ban, 
-    // hovewer first len() positioned with pairs 
-    // and afterwards all elements are zeroed().
-    pub fn iter(self) -> [(K, V); N]{
-        let mut pairs = [zeroed(); N];
-        let mut i = 0;
+    // Get the Option<(K, V) array of valid entries 
+    // with a length of map capacity. First len() elements 
+    // are safe to unwrap_unchecked(), whilst remaining 
+    // are guaranteed to be Option::none().
+    //
+    // This design is reasoned by compile-time limitations and
+    // temporary nested slices ban. 
+    pub fn entries(self) -> [Option<(K, V)>; N] {
+        let mut entries = [Option::none(); N];
+        let mut valid_amount = 0;
 
-        for slot in self._table{
-            if slot.is_valid(){
-                pairs[i] = slot.key_value_unchecked();
-                i += 1;
+        for slot in self._table {
+            if slot.is_valid() {
+                entries[valid_amount] = slot.key_value();
+                valid_amount += 1;
             }
         }
-        
-        assert(
-            i == self._len, 
-            f"Must have iterated {self._len} times, instead did {i}."
-        );
 
-        pairs
-    } 
+        let msg = f"Amount of valid elements should have been {self._len} times, but got {valid_amount}.";
+        assert(valid_amount == self._len, msg);
 
-    // Returns array of all active keys.
-    // Array size is restricted to N because of 
-    // compile time limitations and nested slices temporary ban, 
-    // hovewer first len() positioned with keys 
-    // and afterwards all elements are zeroed().
-    pub fn keys(self) -> [K; N]{
-        let mut keys = [zeroed(); N];
-        let mut i = 0;
+        entries
+    }
 
-        for slot in self._table{
-            if slot.is_valid(){
+    // Get the Option<K> array of valid keys 
+    // with a length of map capacity. First len() elements 
+    // are safe to unwrap_unchecked(), whilst remaining 
+    // are guaranteed to be Option::none().
+    //
+    // This design is reasoned by compile-time limitations and
+    // temporary nested slices ban. 
+    pub fn keys(self) -> [Option<K>; N] {
+        let mut keys = [Option::none(); N];
+        let mut valid_amount = 0;
+
+        for slot in self._table {
+            if slot.is_valid() {
                 let (key, _) = slot.key_value_unchecked();
-                keys[i] = key;
-                i += 1;
+                keys[valid_amount] = Option::some(key);
+                valid_amount += 1;
             }
         }
-        
-        assert(
-            i == self._len, 
-            f"Must have iterated {self._len} times, instead did {i}."
-        );
+
+        let msg = f"Amount of valid elements should have been {self._len} times, but got {valid_amount}.";
+        assert(valid_amount == self._len, msg);
 
         keys
-    } 
+    }
 
-    // Returns array of all active values.
-    // Array size is restricted to N because of 
-    // compile time limitations and nested slices temporary ban, 
-    // hovewer first len() positioned with values 
-    // and afterwards all elements are zeroed().
-    pub fn values(self) -> [V; N]{
-        let mut values = [zeroed(); N];
-        let mut i = 0;
+    // Get the Option<V> array of valid values 
+    // with a length of map capacity. First len() elements 
+    // are safe to unwrap_unchecked(), whilst remaining 
+    // are guaranteed to be Option::none().
+    //
+    // This design is reasoned by compile-time limitations and
+    // temporary nested slices ban. 
+    pub fn values(self) -> [Option<V>; N] {
+        let mut values = [Option::none(); N];
+        let mut valid_amount = 0;
 
-        for slot in self._table{
-            if slot.is_valid(){
+        for slot in self._table {
+            if slot.is_valid() {
                 let (_, value) = slot.key_value_unchecked();
-                values[i] = value;
-                i += 1;
+                values[valid_amount] = Option::some(value);
+                valid_amount += 1;
             }
         }
-        
-        assert(
-            i == self._len, 
-            f"Must have iterated {self._len} times, instead did {i}."
-        );
+
+        let msg = f"Amount of valid elements should have been {self._len} times, but got {valid_amount}.";
+        assert(valid_amount == self._len, msg);
 
         values
-    } 
+    }
 
-    // For each key-value pair applies mutator function.
-    pub fn iter_mut(&mut self, f: fn(K, V) -> (K, V))
+    // For each key-value entry applies mutator function.
+    pub fn iter_mut(
+        &mut self,
+        f: fn(K, V) -> (K, V)
+    )
     where
         K: Eq + Hash,
         B: BuildHasher<H>,
-        H: Hasher
-    {
-        let mut pairs = self.iter();
-        for i in 0..N{
-            if i < self._len{
-                let (key, value) = pairs[i];
-                pairs[i] = f(key, value);
-            }
-        }
-
+        H: Hasher {
+        let mut entries = self.entries();
         let mut new_map = HashMap::with_hasher(self._build_hasher);
 
-        for i in 0..N{
-            if i < self._len{
-                let (key, value) = pairs[i];
+        for i in 0..N {
+            if i < self._len {
+                let entry = entries[i].unwrap_unchecked();
+                let (key, value) = f(entry.0, entry.1);
                 new_map.insert(key, value);
             }
         }
@@ -207,25 +208,21 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
     }
 
     // For each key applies mutator function.
-    pub fn mut_keys(&mut self, f: fn(K) -> K) 
+    pub fn iter_keys_mut(
+        &mut self,
+        f: fn(K) -> K
+    ) 
     where
         K: Eq + Hash,
         B: BuildHasher<H>,
-        H: Hasher
-    {
-        let mut pairs = self.iter();
-        for i in 0..N{
-            if i < self._len{
-                let (key, value) = pairs[i];
-                pairs[i] = (f(key), value);
-            }
-        }
-
+        H: Hasher {
+        let mut entries = self.entries();
         let mut new_map = HashMap::with_hasher(self._build_hasher);
 
-        for i in 0..N{
-            if i < self._len{
-                let (key, value) = pairs[i];
+        for i in 0..N {
+            if i < self._len {
+                let entry = entries[i].unwrap_unchecked();
+                let (key, value) = (f(entry.0), entry.1);
                 new_map.insert(key, value);
             }
         }
@@ -234,24 +231,24 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
     }
 
     // For each value applies mutator function.
-    pub fn mut_values(&mut self, f: fn(V) -> V) {
-        for i in 0..N{
+    pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
+        for i in 0..N {
             let mut slot = self._table[i];
-            if slot.is_valid(){
+            if slot.is_valid() {
                 let (key, value) = slot.key_value_unchecked();
                 slot.set(key, f(value));
                 self._table[i] = slot;
             }
         }
     }
-    
+
     // Retains only the elements specified by the predicate.
-    pub fn retain(&mut self, f: fn(K, V) -> bool){
-        for index in 0..N{
+    pub fn retain(&mut self, f: fn(K, V) -> bool) {
+        for index in 0..N {
             let mut slot = self._table[index];
-            if slot.is_valid(){
+            if slot.is_valid() {
                 let (key, value) = slot.key_value_unchecked();
-                if !f(key, value){
+                if !f(key, value) {
                     slot.mark_deleted();
                     self._len -= 1;
                     self._table[index] = slot;
@@ -260,32 +257,39 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
         }
     }
 
-    // Amount of active key-value pairs.
-    pub fn len(self) -> u64{
+    // Amount of active key-value entries.
+    pub fn len(self) -> u64 {
         self._len
     }
 
+    // Get the compile-time map capacity.
+    pub fn capacity(self) -> u64 {
+        N
+    }
+
     // Get the value by key. If it does not exist, returns none().
-    pub fn get(self, key: K) -> Option<V>
+    pub fn get(
+        self,
+        key: K
+    ) -> Option<V>
     where
         K: Eq + Hash,
         B: BuildHasher<H>,
-        H: Hasher
-    {
+        H: Hasher {
         let mut result = Option::none();
 
         let hash = self.hash(key);
         let mut break = false;
 
-        for attempt in 0..N{
-            if !break{
+        for attempt in 0..N {
+            if !break {
                 let index = self.quadratic_probe(hash, attempt as u64);
                 let slot = self._table[index];
 
                 // Not marked as deleted and has key-value.
-                if slot.is_valid(){ 
+                if slot.is_valid() {
                     let (current_key, value) = slot.key_value_unchecked();
-                    if current_key == key{
+                    if current_key == key {
                         result = Option::some(value);
                         break = true;
                     }
@@ -296,36 +300,39 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
         result
     }
 
-    // Insert key-value pair. In case key was already present, value is overridden. 
-    pub fn insert(&mut self, key: K, value: V)
+    // Insert key-value entry. In case key was already present, value is overridden. 
+    pub fn insert(
+        &mut self,
+        key: K,
+        value: V
+    )
     where
         K: Eq + Hash,
         B: BuildHasher<H>,
-        H: Hasher
-    {
+        H: Hasher {
         self.assert_load_factor();
 
         let hash = self.hash(key);
         let mut break = false;
 
-        for attempt in 0..N{
-            if !break{
+        for attempt in 0..N {
+            if !break {
                 let index = self.quadratic_probe(hash, attempt as u64);
                 let mut slot = self._table[index];
                 let mut insert = false;
 
                 // Either marked as deleted or has unset key-value.
-                if slot.is_available(){ 
+                if slot.is_available() {
                     insert = true;
                     self._len += 1;
-                }else{
+                } else {
                     let (current_key, _) = slot.key_value_unchecked();
-                    if current_key == key{
+                    if current_key == key {
                         insert = true;
                     }
                 }
 
-                if insert{
+                if insert {
                     slot.set(key, value);
                     self._table[index] = slot;
                     break = true;
@@ -335,24 +342,26 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
     }
 
     // Remove key-value entry. If key is not present, HashMap remains unchanged.
-    pub fn remove(&mut self, key: K)
+    pub fn remove(
+        &mut self,
+        key: K
+    )
     where
         K: Eq + Hash,
         B: BuildHasher<H>,
-        H: Hasher
-    {
+        H: Hasher {
         let hash = self.hash(key);
         let mut break = false;
 
-        for attempt in 0..N{
-            if !break{
+        for attempt in 0..N {
+            if !break {
                 let index = self.quadratic_probe(hash, attempt as u64);
                 let mut slot = self._table[index];
 
                 // Not marked as deleted and has key-value.
-                if slot.is_valid(){ 
+                if slot.is_valid() {
                     let (current_key, _) = slot.key_value_unchecked();
-                    if current_key == key{
+                    if current_key == key {
                         slot.mark_deleted();
                         self._table[index] = slot;
                         self._len -= 1;
@@ -364,12 +373,14 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
     }
 
     // Apply HashMap's hasher onto key to obtain pre-hash for probing.
-    fn hash(self, key: K) -> u64
+    fn hash(
+        self,
+        key: K
+    ) -> u64
     where
         K: Hash,
         B: BuildHasher<H>,
-        H: Hasher
-    {
+        H: Hasher {
         let mut hasher = self._build_hasher.build_hasher();
         key.hash(&mut hasher);
         hasher.finish() as u64
@@ -380,15 +391,15 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
     // This ensures good uniformity of distribution for table sizes
     // equal to prime numbers or powers of two. 
     fn quadratic_probe(self, hash: u64, attempt: u64) -> u64 {
-        (hash + (attempt + attempt * attempt) / 2 ) % N
+        (hash + (attempt + attempt * attempt) / 2) % N
     }
 
     // Amount of elements in the table in relation to available slots exceeds α_max. 
-    // To avoid division with potential incorrectness due to floating point values,
-    // we conduct cross-multiplication.
+    // To avoid a comparatively more expensive division operation 
+    // we conduct cross-multiplication instead.
     // n / m >= MAX_LOAD_FACTOR_NUMERATOR / MAX_LOAD_FACTOR_DEN0MINATOR 
-    // n * MAX_LOAD_FACTOR_NUMERATOR >= m * MAX_LOAD_FACTOR_DEN0MINATOR
-    fn assert_load_factor(self){
+    // n * MAX_LOAD_FACTOR_DEN0MINATOR >= m * MAX_LOAD_FACTOR_NUMERATOR
+    fn assert_load_factor(self) {
         let lhs = self._len * MAX_LOAD_FACTOR_DEN0MINATOR;
         let rhs = self._table.len() as u64 * MAX_LOAD_FACTOR_NUMERATOR;
         let exceeded = lhs >= rhs;
@@ -397,7 +408,7 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
 }
 
 // Equality class on HashMap has to test that they have 
-// equal sets of key-value pairs, 
+// equal sets of key-value entries, 
 // thus one is a subset of the other and vice versa.
 impl<K, V, N, B, H> Eq for HashMap<K, V, N, B>
 where

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -149,7 +149,7 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
         B: BuildHasher<H>,
         H: Hasher
     {
-        let mut hasher = self._build_hasher.build_wrapper();
+        let mut hasher = self._build_hasher.build_hasher();
         key.hash(&mut hasher);
         hasher.finish() as u64
     }

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -262,7 +262,7 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
     }
 
     // Get the compile-time map capacity.
-    pub fn capacity(self) -> u64 {
+    pub fn capacity(_self: Self) -> u64 {
         N
     }
 
@@ -389,7 +389,7 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
     // We use 0.5 constant near variadic attempt and attempt^2 monomials.
     // This ensures good uniformity of distribution for table sizes
     // equal to prime numbers or powers of two. 
-    fn quadratic_probe(self, hash: u64, attempt: u64) -> u64 {
+    fn quadratic_probe(_self: Self, hash: u64, attempt: u64) -> u64 {
         (hash + (attempt + attempt * attempt) / 2) % N
     }
 

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -2,16 +2,14 @@ use crate::cmp::Eq;
 use crate::collections::vec::Vec;
 use crate::option::Option;
 use crate::default::Default;
+use crate::unsafe::zeroed;
 use crate::hash::{Hash, Hasher, BuildHasher};
 
-// Generic trait for one-directional key -> value data structure.
-// May be implemented by either hash tables or graphs for instance.
-trait Map<K, V> {
-    fn len(self) -> u64;
-    fn get(self, key: K) -> Option<V>;
-    fn insert(&mut self, key: K, value: V);
-    fn remove(&mut self, key: K);
-}
+// We use load factor α_max = 0.75. 
+// Upon exceeding it, assert will fail in order to inform the user 
+// about performance degradation, so that he can adjust the capacity.
+global MAX_LOAD_FACTOR_NUMERATOR = 3;
+global MAX_LOAD_FACTOR_DEN0MINATOR = 4;
 
 // Hash table with open addressing and quadratic probing.
 // Size of the underlying table must be known at compile time.
@@ -27,8 +25,8 @@ struct HashMap<K, V, N, B> {
 }
 
 // Data unit in the HashMap table.
-// In case Noir would support enums in future, this  
-// better to be refactored to use it with three states:
+// In case Noir adds support for enums in the future, this  
+// should be refactored to have three states:
 // 1. (key, value)
 // 2. (empty)
 // 3. (deleted)
@@ -65,13 +63,16 @@ impl<K, V> Slot<K, V>{
     }
 
     // Shall not override `_key_value` with Option::none(),
-    // because we must we able to differentiate empty 
+    // because we must be able to differentiate empty 
     // and deleted slots for lookup.
     fn mark_deleted(&mut self){
         self._is_deleted = true;
     }
 }
 
+// While conducting lookup, we iterate attempt from 0 to N - 1 due to heuristic,
+// that if we have went that far without finding desired, 
+// it is very unlikely to be after - performance will be heavily degraded.
 impl<K, V, N, B, H> HashMap<K, V, N, B> {   
     // Creates a new instance of HashMap with specified BuildHasher.
     pub fn with_hasher(_build_hasher: B) -> Self
@@ -104,30 +105,146 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
         self._len == 0
     }
 
-    // Returns a vector of all active keys.
-    pub fn keys(self) -> Vec<K>{
-        let mut keys = Vec::new();
+    // Returns array of all active key-value pairs.
+    // Array size is restricted to N because of 
+    // compile time limitations and nested slices temporary ban, 
+    // hovewer first len() positioned with pairs 
+    // and afterwards all elements are zeroed().
+    pub fn iter(self) -> [(K, V); N]{
+        let mut pairs = [zeroed(); N];
+        let mut i = 0;
+
+        for slot in self._table{
+            if slot.is_valid(){
+                pairs[i] = slot.key_value_unchecked();
+                i += 1;
+            }
+        }
+        
+        assert(
+            i == self._len, 
+            f"Must have iterated {self._len} times, instead did {i}."
+        );
+
+        pairs
+    } 
+
+    // Returns array of all active keys.
+    // Array size is restricted to N because of 
+    // compile time limitations and nested slices temporary ban, 
+    // hovewer first len() positioned with keys 
+    // and afterwards all elements are zeroed().
+    pub fn keys(self) -> [K; N]{
+        let mut keys = [zeroed(); N];
+        let mut i = 0;
+
         for slot in self._table{
             if slot.is_valid(){
                 let (key, _) = slot.key_value_unchecked();
-                keys.push(key);
+                keys[i] = key;
+                i += 1;
             }
         }
-        keys
-    }
+        
+        assert(
+            i == self._len, 
+            f"Must have iterated {self._len} times, instead did {i}."
+        );
 
-    // Returns a vector of all active values. Not necessarily unique.
-    pub fn values(self) -> Vec<V>{
-        let mut values = Vec::new();
+        keys
+    } 
+
+    // Returns array of all active values.
+    // Array size is restricted to N because of 
+    // compile time limitations and nested slices temporary ban, 
+    // hovewer first len() positioned with values 
+    // and afterwards all elements are zeroed().
+    pub fn values(self) -> [V; N]{
+        let mut values = [zeroed(); N];
+        let mut i = 0;
+
         for slot in self._table{
             if slot.is_valid(){
                 let (_, value) = slot.key_value_unchecked();
-                values.push(value);
+                values[i] = value;
+                i += 1;
             }
         }
+        
+        assert(
+            i == self._len, 
+            f"Must have iterated {self._len} times, instead did {i}."
+        );
+
         values
+    } 
+
+    // For each key-value pair applies mutator function.
+    pub fn iter_mut(&mut self, f: fn(K, V) -> (K, V))
+    where
+        K: Eq + Hash,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
+        let mut pairs = self.iter();
+        for i in 0..N{
+            if i < self._len{
+                let (key, value) = pairs[i];
+                pairs[i] = f(key, value);
+            }
+        }
+
+        let mut new_map = HashMap::with_hasher(self._build_hasher);
+
+        for i in 0..N{
+            if i < self._len{
+                let (key, value) = pairs[i];
+                new_map.insert(key, value);
+            }
+        }
+
+        self._table = new_map._table;
     }
 
+    // For each key applies mutator function.
+    pub fn mut_keys(&mut self, f: fn(K) -> K) 
+    where
+        K: Eq + Hash,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
+        let mut pairs = self.iter();
+        for i in 0..N{
+            if i < self._len{
+                let (key, value) = pairs[i];
+                pairs[i] = (f(key), value);
+            }
+        }
+
+        let mut new_map = HashMap::with_hasher(self._build_hasher);
+
+        for i in 0..N{
+            if i < self._len{
+                let (key, value) = pairs[i];
+                new_map.insert(key, value);
+            }
+        }
+
+        self._table = new_map._table;
+    }
+
+    // For each value applies mutator function.
+    pub fn mut_values(&mut self, f: fn(V) -> V) {
+        for i in 0..N{
+            let mut slot = self._table[i];
+            if slot.is_valid(){
+                let (key, value) = slot.key_value_unchecked();
+                slot.set(key, f(value));
+                self._table[i] = slot;
+            }
+        }
+    }
+    
     // Retains only the elements specified by the predicate.
     pub fn retain(&mut self, f: fn(K, V) -> bool){
         for index in 0..N{
@@ -143,40 +260,18 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
         }
     }
 
-    fn hash(self, key: K) -> u64
-    where
-        K: Hash,
-        B: BuildHasher<H>,
-        H: Hasher
-    {
-        let mut hasher = self._build_hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish() as u64
-    }
-
-    // Probing scheme: quadratic function.
-    // We use 0.5 constant near variadic attempt and attempt^2 monomials.
-    // This ensures good uniformity of distribution for table sizes
-    // equal to prime numbers or powers of two. 
-    fn quadratic_probe(self, hash: u64, attempt: u64) -> u64 {
-        (hash + (attempt + attempt * attempt) / 2 ) % N
-    }
-}
-
-// While conducting lookup, we iterate attempt from 0 to N - 1 due to heuristic,
-// that if we have went that far without finding desired, 
-// it is very unlikely to be after - performance in that case would be drastical.
-impl<K, V, N, B, H> Map<K, V> for HashMap<K, V, N, B>
-where
-    K: Eq + Hash,
-    B: BuildHasher<H>,
-    H: Hasher
-{
-    fn len(self) -> u64{
+    // Amount of active key-value pairs.
+    pub fn len(self) -> u64{
         self._len
     }
 
-    fn get(self, key: K) -> Option<V>{
+    // Get the value by key. If it does not exist, returns none().
+    pub fn get(self, key: K) -> Option<V>
+    where
+        K: Eq + Hash,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
         let mut result = Option::none();
 
         let hash = self.hash(key);
@@ -201,7 +296,15 @@ where
         result
     }
 
-    fn insert(&mut self, key: K, value: V){
+    // Insert key-value pair. In case key was already present, value is overridden. 
+    pub fn insert(&mut self, key: K, value: V)
+    where
+        K: Eq + Hash,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
+        self.assert_load_factor();
+
         let hash = self.hash(key);
         let mut break = false;
 
@@ -231,7 +334,13 @@ where
         }
     }
 
-    fn remove(&mut self, key: K){
+    // Remove key-value entry. If key is not present, HashMap remains unchanged.
+    pub fn remove(&mut self, key: K)
+    where
+        K: Eq + Hash,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
         let hash = self.hash(key);
         let mut break = false;
 
@@ -252,6 +361,38 @@ where
                 }
             }
         }
+    }
+
+    // Apply HashMap's hasher onto key to obtain pre-hash for probing.
+    fn hash(self, key: K) -> u64
+    where
+        K: Hash,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
+        let mut hasher = self._build_hasher.build_hasher();
+        key.hash(&mut hasher);
+        hasher.finish() as u64
+    }
+
+    // Probing scheme: quadratic function.
+    // We use 0.5 constant near variadic attempt and attempt^2 monomials.
+    // This ensures good uniformity of distribution for table sizes
+    // equal to prime numbers or powers of two. 
+    fn quadratic_probe(self, hash: u64, attempt: u64) -> u64 {
+        (hash + (attempt + attempt * attempt) / 2 ) % N
+    }
+
+    // Amount of elements in the table in relation to available slots exceeds α_max. 
+    // To avoid division with potential incorrectness due to floating point values,
+    // we conduct cross-multiplication.
+    // n / m >= MAX_LOAD_FACTOR_NUMERATOR / MAX_LOAD_FACTOR_DEN0MINATOR 
+    // n * MAX_LOAD_FACTOR_NUMERATOR >= m * MAX_LOAD_FACTOR_DEN0MINATOR
+    fn assert_load_factor(self){
+        let lhs = self._len * MAX_LOAD_FACTOR_DEN0MINATOR;
+        let rhs = self._table.len() as u64 * MAX_LOAD_FACTOR_NUMERATOR;
+        let exceeded = lhs >= rhs;
+        assert(!exceeded, "Load factor is exceeded, consider increasing the capacity.");
     }
 }
 

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -83,6 +83,66 @@ impl<K, V, N, B, H> HashMap<K, V, N, B> {
         Self{_table, _len, _build_hasher}
     }
 
+    // Clears the map, removing all key-value pairs.
+    pub fn clear(&mut self){
+        self._table = [Slot::default(); N];
+        self._len = 0;
+    }
+
+    // Returns true if the map contains a value for the specified key.
+    pub fn contains_key(self, key: K) -> bool
+    where
+        K: Hash + Eq,
+        B: BuildHasher<H>,
+        H: Hasher
+    {
+        self.get(key).is_some()
+    }
+
+    // Returns true if the map contains no elements.
+    pub fn is_empty(self) -> bool{
+        self._len == 0
+    }
+
+    // Returns a vector of all active keys.
+    pub fn keys(self) -> Vec<K>{
+        let mut keys = Vec::new();
+        for slot in self._table{
+            if slot.is_valid(){
+                let (key, _) = slot.key_value_unchecked();
+                keys.push(key);
+            }
+        }
+        keys
+    }
+
+    // Returns a vector of all active values. Not necessarily unique.
+    pub fn values(self) -> Vec<V>{
+        let mut values = Vec::new();
+        for slot in self._table{
+            if slot.is_valid(){
+                let (_, value) = slot.key_value_unchecked();
+                values.push(value);
+            }
+        }
+        values
+    }
+
+    // Retains only the elements specified by the predicate.
+    pub fn retain(&mut self, f: fn(K, V) -> bool){
+        for index in 0..N{
+            let mut slot = self._table[index];
+            if slot.is_valid(){
+                let (key, value) = slot.key_value_unchecked();
+                if !f(key, value){
+                    slot.mark_deleted();
+                    self._len -= 1;
+                    self._table[index] = slot;
+                }
+            }
+        }
+    }
+
     fn hash(self, key: K) -> u64
     where
         K: Hash,

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -2,7 +2,6 @@ use crate::cmp::Eq;
 use crate::collections::vec::Vec;
 use crate::option::Option;
 use crate::default::Default;
-use crate::unsafe::zeroed;
 use crate::hash::{Hash, Hasher, BuildHasher};
 
 // We use load factor α_max = 0.75. 

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -105,7 +105,7 @@ impl<H> BuildHasher<H> for BuildHasherDefault<H>
 where 
     H: Hasher + Default
 {
-    fn build_hasher(self) -> H{
+    fn build_hasher(_self: Self) -> H{
         H::default()
     }
 }

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -78,17 +78,14 @@ pub fn poseidon2_permutation<N>(_input: [u8; N], _state_length: u32) -> [u8; N] 
 #[foreign(sha256_compression)]
 pub fn sha256_compression(_input: [u32; 16], _state: [u32; 8]) -> [u32; 8] {}
 
-// Generic hashing support.
+// Generic hashing support. 
 // Partially ported and impacted by rust.
 
 // Hash trait shall be implemented per type.
-// We use HasherWrapper since we desire to have `&mut Hasher` in `Hash` trait functions prototype,
-// but Noir can not correctly infer generic into pointer receiver, ergo such a hack is utilized
-// and shall be removed upon generics improvement.
 trait Hash{
-    fn hash<H>(self, state: &mut HasherWrapper<H>) where H: Hasher;
+    fn hash<H>(self, state: &mut H) where H: Hasher;
 
-    fn hash_slice<H>(data: [Self], state: &mut HasherWrapper<H>) where H: Hasher{
+    fn hash_slice<H>(data: [Self], state: &mut H) where H: Hasher{
         for piece in data{
             piece.hash(state);
         }
@@ -98,88 +95,38 @@ trait Hash{
 // Hasher trait shall be implemented by algorithms to provide hash-agnostic means.
 trait Hasher{
     fn finish(self) -> Field;
-
-    fn write(self, input: [Field]) -> Self;
+    
+    fn write(&mut self, input: [Field]);
 }
 
 // BuildHasher is a factory trait, responsible for production of specific Hasher.
 trait BuildHasher<H> where H: Hasher{
     fn build_hasher(self) -> H;
-
-    fn build_wrapper(self) -> HasherWrapper<H>{
-        let hasher = self.build_hasher();
-        HasherWrapper::new(hasher)
-    }
-}
-
-struct HasherWrapper<H>{
-    _inner: H
-}
-
-impl<H> HasherWrapper<H>
-{
-    pub fn new(_inner: H) -> Self{
-        HasherWrapper{_inner}
-    }
-
-    pub fn unwrap(self) -> H{
-        self._inner
-    }
-
-    pub fn finish(self) -> Field
-    where
-        H: Hasher
-    {
-        self._inner.finish()
-    }
-
-    pub fn write(&mut self, input: [Field])
-    where
-        H: Hasher
-    {
-        self._inner = self._inner.write(input);
-    }
-}
-
-impl<H> Default for HasherWrapper<H>
-where
-    H: Hasher + Default
-{
-    fn default() -> Self{
-        HasherWrapper{
-            _inner: H::default()
-        }
-    }
 }
 
 struct BuildHasherDefault<H>;
 
 impl<H> BuildHasher<H> for BuildHasherDefault<H>
-where
+where 
     H: Hasher + Default
 {
     fn build_hasher(self) -> H{
         H::default()
     }
-
-    fn build_wrapper(self) -> HasherWrapper<H>{
-        let wrapper: HasherWrapper<H> = HasherWrapper::default();
-        wrapper
-    }
 }
 
 impl<H> Default for BuildHasherDefault<H>
-where
+where 
     H: Hasher + Default
 {
     fn default() -> Self{
         BuildHasherDefault{}
-    }
+    }    
 }
 
 impl Hash for Field{
-    fn hash<H>(self, state: &mut HasherWrapper<H>) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher{
         let input: [Field] = [self];
-        state.write(input);
+        H::write(state, input);
     }
 }

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -1,5 +1,8 @@
 mod poseidon;
 mod mimc;
+mod pedersen;
+
+use crate::default::Default;
 
 #[foreign(sha256)]
 // docs:start:sha256
@@ -74,3 +77,109 @@ pub fn poseidon2_permutation<N>(_input: [u8; N], _state_length: u32) -> [u8; N] 
 
 #[foreign(sha256_compression)]
 pub fn sha256_compression(_input: [u32; 16], _state: [u32; 8]) -> [u32; 8] {}
+
+// Generic hashing support.
+// Partially ported and impacted by rust.
+
+// Hash trait shall be implemented per type.
+// We use HasherWrapper since we desire to have `&mut Hasher` in `Hash` trait functions prototype,
+// but Noir can not correctly infer generic into pointer receiver, ergo such a hack is utilized
+// and shall be removed upon generics improvement.
+trait Hash{
+    fn hash<H>(self, state: &mut HasherWrapper<H>) where H: Hasher;
+
+    fn hash_slice<H>(data: [Self], state: &mut HasherWrapper<H>) where H: Hasher{
+        for piece in data{
+            piece.hash(state);
+        }
+    }
+}
+
+// Hasher trait shall be implemented by algorithms to provide hash-agnostic means.
+trait Hasher{
+    fn finish(self) -> Field;
+
+    fn write(self, input: [Field]) -> Self;
+}
+
+// BuildHasher is a factory trait, responsible for production of specific Hasher.
+trait BuildHasher<H> where H: Hasher{
+    fn build_hasher(self) -> H;
+
+    fn build_wrapper(self) -> HasherWrapper<H>{
+        let hasher = self.build_hasher();
+        HasherWrapper::new(hasher)
+    }
+}
+
+struct HasherWrapper<H>{
+    _inner: H
+}
+
+impl<H> HasherWrapper<H>
+{
+    pub fn new(_inner: H) -> Self{
+        HasherWrapper{_inner}
+    }
+
+    pub fn unwrap(self) -> H{
+        self._inner
+    }
+
+    pub fn finish(self) -> Field
+    where
+        H: Hasher
+    {
+        self._inner.finish()
+    }
+
+    pub fn write(&mut self, input: [Field])
+    where
+        H: Hasher
+    {
+        self._inner = self._inner.write(input);
+    }
+}
+
+impl<H> Default for HasherWrapper<H>
+where
+    H: Hasher + Default
+{
+    fn default() -> Self{
+        HasherWrapper{
+            _inner: H::default()
+        }
+    }
+}
+
+struct BuildHasherDefault<H>;
+
+impl<H> BuildHasher<H> for BuildHasherDefault<H>
+where
+    H: Hasher + Default
+{
+    fn build_hasher(self) -> H{
+        H::default()
+    }
+
+    fn build_wrapper(self) -> HasherWrapper<H>{
+        let wrapper: HasherWrapper<H> = HasherWrapper::default();
+        wrapper
+    }
+}
+
+impl<H> Default for BuildHasherDefault<H>
+where
+    H: Hasher + Default
+{
+    fn default() -> Self{
+        BuildHasherDefault{}
+    }
+}
+
+impl Hash for Field{
+    fn hash<H>(self, state: &mut HasherWrapper<H>) where H: Hasher{
+        let input: [Field] = [self];
+        state.write(input);
+    }
+}

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -84,15 +84,10 @@ pub fn sha256_compression(_input: [u32; 16], _state: [u32; 8]) -> [u32; 8] {}
 // Hash trait shall be implemented per type.
 trait Hash{
     fn hash<H>(self, state: &mut H) where H: Hasher;
-
-    fn hash_slice<H>(data: [Self], state: &mut H) where H: Hasher{
-        for piece in data{
-            piece.hash(state);
-        }
-    }
 }
 
 // Hasher trait shall be implemented by algorithms to provide hash-agnostic means.
+// TODO: consider making the types generic here ([u8], [Field], etc.)
 trait Hasher{
     fn finish(self) -> Field;
     
@@ -124,6 +119,7 @@ where
     }    
 }
 
+// TODO: add implementations for the remainder of primitive types.
 impl Hash for Field{
     fn hash<H>(self, state: &mut H) where H: Hasher{
         let input: [Field] = [self];

--- a/noir_stdlib/src/hash/pedersen.nr
+++ b/noir_stdlib/src/hash/pedersen.nr
@@ -10,9 +10,8 @@ impl Hasher for PedersenHasher {
        pedersen_hash(self._state)
     }
 
-    fn write(self, input: [Field]) -> Self{
-        let _state = self._state.append(input);
-        PedersenHasher{_state}
+    fn write(&mut self, input: [Field]){
+        self._state = self._state.append(input);
     }
 }
 

--- a/noir_stdlib/src/hash/pedersen.nr
+++ b/noir_stdlib/src/hash/pedersen.nr
@@ -1,0 +1,25 @@
+use crate::hash::{Hasher, pedersen_hash};
+use crate::default::Default;
+
+struct PedersenHasher{
+    _state: [Field]
+}
+
+impl Hasher for PedersenHasher {
+    fn finish(self) -> Field {
+       pedersen_hash(self._state)
+    }
+
+    fn write(self, input: [Field]) -> Self{
+        let _state = self._state.append(input);
+        PedersenHasher{_state}
+    }
+}
+
+impl Default for PedersenHasher{
+    fn default() -> Self{
+        PedersenHasher{
+            _state: []
+        }
+    }
+}

--- a/test_programs/compile_failure/hashmap_load_factor/Nargo.toml
+++ b/test_programs/compile_failure/hashmap_load_factor/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "hashmap_load_factor"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/hashmap_load_factor/Prover.toml
+++ b/test_programs/compile_failure/hashmap_load_factor/Prover.toml
@@ -1,0 +1,26 @@
+# Expected 6 key-value entries for hashmap capacity of 8.
+# These must be distinct (both key-to-key, and value-to-value) for correct testing.
+
+[[input]]
+key = 2
+value = 17
+
+[[input]]
+key = 3
+value = 19
+
+[[input]]
+key = 5
+value = 23
+
+[[input]]
+key = 7
+value = 29
+
+[[input]]
+key = 11
+value = 31
+
+[[input]]
+key = 41
+value = 43

--- a/test_programs/compile_failure/hashmap_load_factor/src/main.nr
+++ b/test_programs/compile_failure/hashmap_load_factor/src/main.nr
@@ -1,0 +1,35 @@
+use dep::std::collections::map::HashMap;
+use dep::std::hash::BuildHasherDefault;
+use dep::std::hash::pedersen::PedersenHasher;
+
+struct Entry{
+    key: Field,
+    value: Field
+}
+
+global HASHMAP_CAP = 8;
+global HASHMAP_LEN = 6;
+
+fn allocate_hashmap() -> HashMap<Field, Field, HASHMAP_CAP, BuildHasherDefault<PedersenHasher>> {
+    HashMap::default()
+}
+
+fn main(input: [Entry; HASHMAP_LEN]) {
+    test_load_factor(input);
+}
+
+// In this test we exceed load factor:
+// α_max = 0.75, thus for capacity of 8 and lenght of 6
+// insertion of new unique key (7-th) should throw assertion error.
+fn test_load_factor(input: [Entry; HASHMAP_LEN]) {
+    let mut hashmap = allocate_hashmap();
+
+    for entry in input {
+        hashmap.insert(entry.key, entry.value);
+    }
+
+    // We use prime numbers for testing, 
+    // therefore it is guaranteed that doubling key we get unique value.
+    let key = input[0].key * 2;
+    hashmap.insert(key, input[0].value);
+}

--- a/test_programs/execution_success/hashmap/Nargo.toml
+++ b/test_programs/execution_success/hashmap/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "hashmap"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/hashmap/Prover.toml
+++ b/test_programs/execution_success/hashmap/Prover.toml
@@ -1,0 +1,26 @@
+# Input: 6 key-value entries for hashmap capacity of 8.
+# These must be distinct (both key-to-key, and value-to-value) for correct testing.
+
+[[input]]
+key = 2
+value = 17
+
+[[input]]
+key = 3
+value = 19
+
+[[input]]
+key = 5
+value = 23
+
+[[input]]
+key = 7
+value = 29
+
+[[input]]
+key = 11
+value = 31
+
+[[input]]
+key = 41
+value = 43

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -1,6 +1,10 @@
+mod utils;
+
 use dep::std::collections::map::HashMap;
 use dep::std::hash::BuildHasherDefault;
 use dep::std::hash::pedersen::PedersenHasher;
+
+use utils::cut;
 
 struct Entry{
     key: Field,
@@ -9,6 +13,9 @@ struct Entry{
 
 global HASHMAP_CAP = 8;
 global HASHMAP_LEN = 6;
+
+global FIELD_CMP = |a: Field, b: Field| a.lt(b);
+global PAIR_CMP = |a: (Field, Field), b: (Field, Field)| a.0.lt(b.0);
 
 fn allocate_hashmap() -> HashMap<Field, Field, HASHMAP_CAP, BuildHasherDefault<PedersenHasher>> {
     HashMap::default()
@@ -21,6 +28,8 @@ fn main(input: [Entry; HASHMAP_LEN]) {
     test_insert_and_methods(input);
     test_hashmaps_equality(input);
     test_retain();
+    test_iterators();
+    test_mut_iterators();
 }
 
 // Insert, get, remove.
@@ -128,4 +137,49 @@ fn test_hashmaps_equality(input: [Entry; HASHMAP_LEN]) {
     hashmap_2.remove(input[0].key);
 
     assert(hashmap_1 != hashmap_2, "HashMaps should not be equal.");
+}
+
+// Test Iter, Keys, Values.
+fn test_iterators() {
+    let mut hashmap = allocate_hashmap();
+
+    hashmap.insert(2, 3);
+    hashmap.insert(5, 7);
+    hashmap.insert(11, 13);
+
+    let keys: [Field; 3] = cut(hashmap.keys()).sort_via(FIELD_CMP);
+    let values: [Field; 3] = cut(hashmap.values()).sort_via(FIELD_CMP);
+    let entries: [(Field, Field); 3] = cut(hashmap.iter()).sort_via(PAIR_CMP);
+
+    assert(keys == [2, 5, 11], "Got incorrect iteration of keys.");
+    assert(values == [3, 7, 13], "Got incorrect iteration of values.");
+    assert(entries == [(2, 3), (5, 7), (11, 13)], "Got incorrect iteration of entries.");
+}
+
+// Test mutable Iter, Keys, Values.
+fn test_mut_iterators() {
+    let mut hashmap = allocate_hashmap();
+
+    hashmap.insert(2, 3);
+    hashmap.insert(5, 7);
+    hashmap.insert(11, 13);
+
+    let f = |k: Field| -> Field{ k * 3};
+    hashmap.mut_keys(f);
+
+    let f = |v: Field| -> Field{ v * 5};
+    hashmap.mut_values(f);
+
+    let keys: [Field; 3] = cut(hashmap.keys()).sort_via(FIELD_CMP);
+    let values: [Field; 3] = cut(hashmap.values()).sort_via(FIELD_CMP);
+
+    assert(keys == [6, 15, 33], f"Got incorrect iteration of keys: {keys}");
+    assert(values == [15, 35, 65], "Got incorrect iteration of values.");
+
+    let f = |k: Field, v: Field| -> (Field, Field){(k * 2, v * 2)};
+    hashmap.iter_mut(f);
+
+    let entries: [(Field, Field); 3] = cut(hashmap.iter()).sort_via(PAIR_CMP);
+
+    assert(entries == [(12, 30), (30, 70), (66, 130)], "Got incorrect iteration of entries.");
 }

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -12,8 +12,8 @@ type V = Field;
 
 // It is more convenient and readable to use structs as input.
 struct Entry{
-    key: K,
-    value: V
+    key: Field,
+    value: Field
 }
 
 global HASHMAP_CAP = 8;

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -146,7 +146,7 @@ fn test_hashmaps_equality(input: [Entry; HASHMAP_LEN]) {
     assert(hashmap_1 != hashmap_2, "HashMaps should not be equal.");
 }
 
-// Test Iter, Keys, Values.
+// Test entries, keys, values.
 fn test_iterators() {
     let mut hashmap = ALLOCATE_HASHMAP();
 
@@ -163,7 +163,7 @@ fn test_iterators() {
     assert(entries == [(2, 3), (5, 7), (11, 13)], "Got incorrect iteration of entries.");
 }
 
-// Test mutable Iter, Keys, Values.
+// Test mutable iteration over keys, values and entries.
 fn test_mut_iterators() {
     let mut hashmap = ALLOCATE_HASHMAP();
 

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -3,23 +3,30 @@ mod utils;
 use dep::std::collections::map::HashMap;
 use dep::std::hash::BuildHasherDefault;
 use dep::std::hash::pedersen::PedersenHasher;
+use dep::std::cmp::Eq;
 
 use utils::cut;
 
+type K = Field;
+type V = Field;
+
+// It is more convenient and readable to use structs as input.
 struct Entry{
-    key: Field,
-    value: Field
+    key: K,
+    value: V
 }
 
 global HASHMAP_CAP = 8;
 global HASHMAP_LEN = 6;
 
 global FIELD_CMP = |a: Field, b: Field| a.lt(b);
-global PAIR_CMP = |a: (Field, Field), b: (Field, Field)| a.0.lt(b.0);
 
-fn allocate_hashmap() -> HashMap<Field, Field, HASHMAP_CAP, BuildHasherDefault<PedersenHasher>> {
-    HashMap::default()
-}
+global K_CMP = FIELD_CMP;
+global V_CMP = FIELD_CMP;
+global KV_CMP = |a: (K, V), b: (K, V)| a.0.lt(b.0);
+
+global ALLOCATE_HASHMAP = || -> HashMap<K, V, HASHMAP_CAP, BuildHasherDefault<PedersenHasher>> 
+    HashMap::default();
 
 fn main(input: [Entry; HASHMAP_LEN]) {
     test_sequential(input[0].key, input[0].value);
@@ -33,8 +40,8 @@ fn main(input: [Entry; HASHMAP_LEN]) {
 }
 
 // Insert, get, remove.
-fn test_sequential(key: Field, value: Field) {
-    let mut hashmap = allocate_hashmap();
+fn test_sequential(key: K, value: V) {
+    let mut hashmap = ALLOCATE_HASHMAP();
     assert(hashmap.is_empty(), "New HashMap should be empty.");
 
     hashmap.insert(key, value);
@@ -52,8 +59,8 @@ fn test_sequential(key: Field, value: Field) {
 }
 
 // Insert same pair several times.
-fn test_multiple_equal_insert(key: Field, value: Field) {
-    let mut hashmap = allocate_hashmap();
+fn test_multiple_equal_insert(key: K, value: V) {
+    let mut hashmap = ALLOCATE_HASHMAP();
     assert(hashmap.is_empty(), "New HashMap should be empty.");
 
     for _ in 0..HASHMAP_LEN {
@@ -70,8 +77,8 @@ fn test_multiple_equal_insert(key: Field, value: Field) {
 }
 
 // Override value for existing pair.
-fn test_value_override(key: Field, value: Field, new_value: Field) {
-    let mut hashmap = allocate_hashmap();
+fn test_value_override(key: K, value: V, new_value: V) {
+    let mut hashmap = ALLOCATE_HASHMAP();
     assert(hashmap.is_empty(), "New hashmap should be empty.");
 
     hashmap.insert(key, value);
@@ -86,7 +93,7 @@ fn test_value_override(key: Field, value: Field, new_value: Field) {
 
 // Insert several distinct pairs and test auxiliary methods.
 fn test_insert_and_methods(input: [Entry; HASHMAP_LEN]) {
-    let mut hashmap = allocate_hashmap();
+    let mut hashmap = ALLOCATE_HASHMAP();
     assert(hashmap.is_empty(), "New HashMap should be empty.");
 
     for entry in input {
@@ -105,7 +112,7 @@ fn test_insert_and_methods(input: [Entry; HASHMAP_LEN]) {
 
 // Insert several pairs and test retaining.
 fn test_retain() {
-    let mut hashmap = allocate_hashmap();
+    let mut hashmap = ALLOCATE_HASHMAP();
     assert(hashmap.is_empty(), "New HashMap should be empty.");
 
     let (key, value) = (5, 11);
@@ -115,7 +122,7 @@ fn test_retain() {
     let (key, value) = (11, 5);
     hashmap.insert(key, value);
 
-    let predicate = |key: Field, value: Field| -> bool {key * value == 55};
+    let predicate = |key: K, value: V| -> bool {key * value == 55};
     hashmap.retain(predicate);
 
     assert(hashmap.len() == 2, "HashMap should have retained 2 elements.");
@@ -124,8 +131,8 @@ fn test_retain() {
 
 // Equality trait check.
 fn test_hashmaps_equality(input: [Entry; HASHMAP_LEN]) {
-    let mut hashmap_1 = allocate_hashmap();
-    let mut hashmap_2 = allocate_hashmap();
+    let mut hashmap_1 = ALLOCATE_HASHMAP();
+    let mut hashmap_2 = ALLOCATE_HASHMAP();
 
     for entry in input {
         hashmap_1.insert(entry.key, entry.value);
@@ -141,15 +148,15 @@ fn test_hashmaps_equality(input: [Entry; HASHMAP_LEN]) {
 
 // Test Iter, Keys, Values.
 fn test_iterators() {
-    let mut hashmap = allocate_hashmap();
+    let mut hashmap = ALLOCATE_HASHMAP();
 
     hashmap.insert(2, 3);
     hashmap.insert(5, 7);
     hashmap.insert(11, 13);
 
-    let keys: [Field; 3] = cut(hashmap.keys()).sort_via(FIELD_CMP);
-    let values: [Field; 3] = cut(hashmap.values()).sort_via(FIELD_CMP);
-    let entries: [(Field, Field); 3] = cut(hashmap.iter()).sort_via(PAIR_CMP);
+    let keys: [K; 3] = cut(hashmap.keys()).map(|k: Option<K>| k.unwrap_unchecked()).sort_via(K_CMP);
+    let values: [V; 3] = cut(hashmap.values()).map(|v: Option<V>| v.unwrap_unchecked()).sort_via(V_CMP);
+    let entries: [(K, V); 3] = cut(hashmap.entries()).map(|e: Option<(K, V)>| e.unwrap_unchecked()).sort_via(KV_CMP);
 
     assert(keys == [2, 5, 11], "Got incorrect iteration of keys.");
     assert(values == [3, 7, 13], "Got incorrect iteration of values.");
@@ -158,28 +165,28 @@ fn test_iterators() {
 
 // Test mutable Iter, Keys, Values.
 fn test_mut_iterators() {
-    let mut hashmap = allocate_hashmap();
+    let mut hashmap = ALLOCATE_HASHMAP();
 
     hashmap.insert(2, 3);
     hashmap.insert(5, 7);
     hashmap.insert(11, 13);
 
-    let f = |k: Field| -> Field{ k * 3};
-    hashmap.mut_keys(f);
+    let f = |k: K| -> K{ k * 3};
+    hashmap.iter_keys_mut(f);
 
-    let f = |v: Field| -> Field{ v * 5};
-    hashmap.mut_values(f);
+    let f = |v: V| -> V{ v * 5};
+    hashmap.iter_values_mut(f);
 
-    let keys: [Field; 3] = cut(hashmap.keys()).sort_via(FIELD_CMP);
-    let values: [Field; 3] = cut(hashmap.values()).sort_via(FIELD_CMP);
+    let keys: [K; 3] = cut(hashmap.keys()).map(|k: Option<K>| k.unwrap_unchecked()).sort_via(K_CMP);
+    let values: [V; 3] = cut(hashmap.values()).map(|v: Option<V>| v.unwrap_unchecked()).sort_via(V_CMP);
 
     assert(keys == [6, 15, 33], f"Got incorrect iteration of keys: {keys}");
     assert(values == [15, 35, 65], "Got incorrect iteration of values.");
 
-    let f = |k: Field, v: Field| -> (Field, Field){(k * 2, v * 2)};
+    let f = |k: K, v: V| -> (K, V){(k * 2, v * 2)};
     hashmap.iter_mut(f);
 
-    let entries: [(Field, Field); 3] = cut(hashmap.iter()).sort_via(PAIR_CMP);
+    let entries: [(K, V); 3] = cut(hashmap.entries()).map(|e: Option<(K, V)>| e.unwrap_unchecked()).sort_via(KV_CMP);
 
     assert(entries == [(12, 30), (30, 70), (66, 130)], "Got incorrect iteration of entries.");
 }

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -21,9 +21,6 @@ fn main(input: [Entry; HASHMAP_LEN]) {
     test_insert_and_methods(input);
     test_hashmaps_equality(input);
     test_retain();
-
-    // FAIL
-    test_load_factor(input);
 }
 
 // Insert, get, remove.

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -4,39 +4,35 @@ use dep::std::hash::pedersen::PedersenHasher;
 
 fn main() {
     test_sequential();
-    test_multiple_same_insert();
+    test_multiple_equal_insert();
     test_value_override();
+    test_insert_and_methods();
+    test_retain();
 }
 
 // Insert, get, remove.
 fn test_sequential() {
     let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.len() == 0, "new hashmap should be empty");
+    assert(hashmap.is_empty(), "new hashmap should be empty");
 
     let (key, value): (Field, Field) = (1, 2);
 
     hashmap.insert(key, value);
     assert(hashmap.len() == 1, "hashmap after one insert should have a length of 1 element");
-
     let retrieved_value = hashmap.get(key);
     assert(retrieved_value.is_some(), "retrived value is none");
-
     let retrieved_value = retrieved_value.unwrap_unchecked();
     assert(value == retrieved_value, "retrieved value does not match inserted");
-
     hashmap.remove(key);
-    assert(
-        hashmap.len() == 0, "hashmap after one insert and corresponding removal should have a lenght of 1 element"
-    );
-
+    assert(hashmap.is_empty(), "hashmap after one insert and corresponding removal should be empty");
     let retrieved_value = hashmap.get(key);
     assert(retrieved_value.is_none(), "value has been removed, but is still available");
 }
 
 // Insert same pair several times.
-fn test_multiple_same_insert() {
+fn test_multiple_equal_insert() {
     let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.len() == 0, "new hashmap should be empty");
+    assert(hashmap.is_empty(), "new hashmap should be empty");
 
     let (key, value): (Field, Field) = (1, 2);
     hashmap.insert(key, value);
@@ -53,7 +49,7 @@ fn test_multiple_same_insert() {
 // Override value for existing pair.
 fn test_value_override() {
     let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.len() == 0, "new hashmap should be empty");
+    assert(hashmap.is_empty(), "new hashmap should be empty");
 
     let (key, value): (Field, Field) = (1, 2);
     hashmap.insert(key, value);
@@ -65,4 +61,63 @@ fn test_value_override() {
     assert(retrieved_value.is_some(), "retrieved value is none");
     let retrieved_value = retrieved_value.unwrap_unchecked();
     assert(retrieved_value == 3, "retrieved value is not correct");
+}
+
+// Insert several distinct pairs and test auxiliary methods.
+fn test_insert_and_methods() {
+    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+    assert(hashmap.is_empty(), "new hashmap should be empty");
+
+    let (key, value) = (5, 11);
+    hashmap.insert(key, value);
+    let (key, value) = (2, 13);
+    hashmap.insert(key, value);
+    let (key, value) = (3, 7);
+    hashmap.insert(key, value);
+
+    assert(hashmap.len() == 3, "hashmap length should be 3");
+
+    assert(hashmap.contains_key(5), "hashmap does not contain key 5");
+    assert(hashmap.contains_key(2), "hashmap does not contain key 2");
+    assert(hashmap.contains_key(3), "hashmap does not contain key 3");
+
+    let mut keys = hashmap.keys();
+    let mut accumulator = 1;
+    for _ in 0..3 {
+        let key = keys.pop();
+        assert((key == 5) | (key == 2) | (key == 3), "found unexpected key");
+        accumulator *= key;
+    }
+    assert(accumulator == 30, "got invalid set of keys");
+
+    let mut values = hashmap.values();
+    let mut accumulator = 1;
+    for _ in 0..3 {
+        let value = values.pop();
+        assert((value == 11) | (value == 13) | (value == 7), "found unexpected value");
+        accumulator *= value;
+    }
+    assert(accumulator == 1001, "got invalid set of values");
+
+    hashmap.clear();
+    assert(hashmap.is_empty(), "hashmap after clear should be empty");
+}
+
+// Insert several pairs and test retaining.
+fn test_retain() {
+    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+    assert(hashmap.is_empty(), "new hashmap should be empty");
+
+    let (key, value) = (5, 11);
+    hashmap.insert(key, value);
+    let (key, value) = (2, 13);
+    hashmap.insert(key, value);
+    let (key, value) = (11, 5);
+    hashmap.insert(key, value);
+
+    let predicate = |key: Field, value: Field| -> bool {key * value == 55};
+    hashmap.retain(predicate);
+
+    assert(hashmap.len() == 2, "HashMap should have retained 2 elements");
+    assert(hashmap.get(2).is_none(), "pair should have been removed, since it does not match predicate");
 }

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -2,112 +2,105 @@ use dep::std::collections::map::HashMap;
 use dep::std::hash::BuildHasherDefault;
 use dep::std::hash::pedersen::PedersenHasher;
 
-fn main() {
-    test_sequential();
-    test_multiple_equal_insert();
-    test_value_override();
-    test_insert_and_methods();
+struct Entry{
+    key: Field,
+    value: Field
+}
+
+global HASHMAP_CAP = 8;
+global HASHMAP_LEN = 6;
+
+fn allocate_hashmap() -> HashMap<Field, Field, HASHMAP_CAP, BuildHasherDefault<PedersenHasher>> {
+    HashMap::default()
+}
+
+fn main(input: [Entry; HASHMAP_LEN]) {
+    test_sequential(input[0].key, input[0].value);
+    test_multiple_equal_insert(input[1].key, input[1].value);
+    test_value_override(input[2].key, input[2].value, input[3].value);
+    test_insert_and_methods(input);
+    test_hashmaps_equality(input);
     test_retain();
-    test_hashmaps_equality();
+
+    // FAIL
+    test_load_factor(input);
 }
 
 // Insert, get, remove.
-fn test_sequential() {
-    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.is_empty(), "new hashmap should be empty");
-
-    let (key, value): (Field, Field) = (1, 2);
+fn test_sequential(key: Field, value: Field) {
+    let mut hashmap = allocate_hashmap();
+    assert(hashmap.is_empty(), "New HashMap should be empty.");
 
     hashmap.insert(key, value);
-    assert(hashmap.len() == 1, "hashmap after one insert should have a length of 1 element");
-    let retrieved_value = hashmap.get(key);
-    assert(retrieved_value.is_some(), "retrived value is none");
-    let retrieved_value = retrieved_value.unwrap_unchecked();
-    assert(value == retrieved_value, "retrieved value does not match inserted");
+    assert(hashmap.len() == 1, "HashMap after one insert should have a length of 1 element.");
+
+    let got = hashmap.get(key);
+    assert(got.is_some(), "Got none value.");
+    let got = got.unwrap_unchecked();
+    assert(value == got, f"Inserted {value} but got {got} for the same key.");
+
     hashmap.remove(key);
-    assert(hashmap.is_empty(), "hashmap after one insert and corresponding removal should be empty");
-    let retrieved_value = hashmap.get(key);
-    assert(retrieved_value.is_none(), "value has been removed, but is still available");
+    assert(hashmap.is_empty(), "HashMap after one insert and corresponding removal should be empty.");
+    let got = hashmap.get(key);
+    assert(got.is_none(), "Value has been removed, but is still available (not none).");
 }
 
 // Insert same pair several times.
-fn test_multiple_equal_insert() {
-    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.is_empty(), "new hashmap should be empty");
+fn test_multiple_equal_insert(key: Field, value: Field) {
+    let mut hashmap = allocate_hashmap();
+    assert(hashmap.is_empty(), "New HashMap should be empty.");
 
-    let (key, value): (Field, Field) = (1, 2);
-    hashmap.insert(key, value);
-    hashmap.insert(key, value);
-    hashmap.insert(key, value);
-    assert(hashmap.len() == 1, "hashmap length is invalid");
+    for _ in 0..HASHMAP_LEN {
+        hashmap.insert(key, value);
+    }
 
-    let retrieved_value = hashmap.get(key);
-    assert(retrieved_value.is_some(), "retrieved value is none");
-    let retrieved_value = retrieved_value.unwrap_unchecked();
-    assert(retrieved_value == value, "retrieved value is not correct");
+    let len = hashmap.len();
+    assert(len == 1, f"HashMap length must be 1, got {len}.");
+
+    let got = hashmap.get(key);
+    assert(got.is_some(), "Got none value.");
+    let got = got.unwrap_unchecked();
+    assert(value == got, f"Inserted {value} but got {got} for the same key.");
 }
 
 // Override value for existing pair.
-fn test_value_override() {
-    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.is_empty(), "new hashmap should be empty");
+fn test_value_override(key: Field, value: Field, new_value: Field) {
+    let mut hashmap = allocate_hashmap();
+    assert(hashmap.is_empty(), "New hashmap should be empty.");
 
-    let (key, value): (Field, Field) = (1, 2);
     hashmap.insert(key, value);
-    let value = 3;
-    hashmap.insert(key, value);
-    assert(hashmap.len() == 1, "hashmap length is invalid");
+    hashmap.insert(key, new_value);
+    assert(hashmap.len() == 1, "HashMap length is invalid.");
 
-    let retrieved_value = hashmap.get(key);
-    assert(retrieved_value.is_some(), "retrieved value is none");
-    let retrieved_value = retrieved_value.unwrap_unchecked();
-    assert(retrieved_value == 3, "retrieved value is not correct");
+    let got = hashmap.get(key);
+    assert(got.is_some(), "Got none value.");
+    let got = got.unwrap_unchecked();
+    assert(got == new_value, f"Expected {new_value}, but got {got}.");
 }
 
 // Insert several distinct pairs and test auxiliary methods.
-fn test_insert_and_methods() {
-    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.is_empty(), "new hashmap should be empty");
+fn test_insert_and_methods(input: [Entry; HASHMAP_LEN]) {
+    let mut hashmap = allocate_hashmap();
+    assert(hashmap.is_empty(), "New HashMap should be empty.");
 
-    let (key, value) = (5, 11);
-    hashmap.insert(key, value);
-    let (key, value) = (2, 13);
-    hashmap.insert(key, value);
-    let (key, value) = (3, 7);
-    hashmap.insert(key, value);
-
-    assert(hashmap.len() == 3, "hashmap length should be 3");
-
-    assert(hashmap.contains_key(5), "hashmap does not contain key 5");
-    assert(hashmap.contains_key(2), "hashmap does not contain key 2");
-    assert(hashmap.contains_key(3), "hashmap does not contain key 3");
-
-    let mut keys = hashmap.keys();
-    let mut accumulator = 1;
-    for _ in 0..3 {
-        let key = keys.pop();
-        assert((key == 5) | (key == 2) | (key == 3), "found unexpected key");
-        accumulator *= key;
+    for entry in input {
+        hashmap.insert(entry.key, entry.value);
     }
-    assert(accumulator == 30, "got invalid set of keys");
 
-    let mut values = hashmap.values();
-    let mut accumulator = 1;
-    for _ in 0..3 {
-        let value = values.pop();
-        assert((value == 11) | (value == 13) | (value == 7), "found unexpected value");
-        accumulator *= value;
+    assert(hashmap.len() == HASHMAP_LEN, "hashmap.len() does not match input lenght.");
+
+    for entry in input {
+        assert(hashmap.contains_key(entry.key), f"Not found inserted key {entry.key}.");
     }
-    assert(accumulator == 1001, "got invalid set of values");
 
     hashmap.clear();
-    assert(hashmap.is_empty(), "hashmap after clear should be empty");
+    assert(hashmap.is_empty(), "HashMap after clear() should be empty.");
 }
 
 // Insert several pairs and test retaining.
 fn test_retain() {
-    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    assert(hashmap.is_empty(), "new hashmap should be empty");
+    let mut hashmap = allocate_hashmap();
+    assert(hashmap.is_empty(), "New HashMap should be empty.");
 
     let (key, value) = (5, 11);
     hashmap.insert(key, value);
@@ -119,32 +112,23 @@ fn test_retain() {
     let predicate = |key: Field, value: Field| -> bool {key * value == 55};
     hashmap.retain(predicate);
 
-    assert(hashmap.len() == 2, "HashMap should have retained 2 elements");
-    assert(hashmap.get(2).is_none(), "pair should have been removed, since it does not match predicate");
+    assert(hashmap.len() == 2, "HashMap should have retained 2 elements.");
+    assert(hashmap.get(2).is_none(), "Pair should have been removed, since it does not match predicate.");
 }
 
 // Equality trait check.
-fn test_hashmaps_equality() {
-    let mut hashmap_1: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
-    let mut hashmap_2: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+fn test_hashmaps_equality(input: [Entry; HASHMAP_LEN]) {
+    let mut hashmap_1 = allocate_hashmap();
+    let mut hashmap_2 = allocate_hashmap();
 
-    let (key, value) = (5, 11);
-    hashmap_1.insert(key, value);
-    let (key, value) = (2, 13);
-    hashmap_1.insert(key, value);
-    let (key, value) = (11, 5);
-    hashmap_1.insert(key, value);
+    for entry in input {
+        hashmap_1.insert(entry.key, entry.value);
+        hashmap_2.insert(entry.key, entry.value);
+    }
 
-    let (key, value) = (5, 11);
-    hashmap_2.insert(key, value);
-    let (key, value) = (2, 13);
-    hashmap_2.insert(key, value);
-    let (key, value) = (11, 5);
-    hashmap_2.insert(key, value);
+    assert(hashmap_1 == hashmap_2, "HashMaps should be equal.");
 
-    assert(hashmap_1 == hashmap_2, "HashMaps should be equal");
+    hashmap_2.remove(input[0].key);
 
-    hashmap_2.remove(11);
-
-    assert(hashmap_1 != hashmap_2, "HashMaps should not be equal");
+    assert(hashmap_1 != hashmap_2, "HashMaps should not be equal.");
 }

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -8,6 +8,7 @@ fn main() {
     test_value_override();
     test_insert_and_methods();
     test_retain();
+    test_hashmaps_equality();
 }
 
 // Insert, get, remove.
@@ -120,4 +121,30 @@ fn test_retain() {
 
     assert(hashmap.len() == 2, "HashMap should have retained 2 elements");
     assert(hashmap.get(2).is_none(), "pair should have been removed, since it does not match predicate");
+}
+
+// Equality trait check.
+fn test_hashmaps_equality() {
+    let mut hashmap_1: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+    let mut hashmap_2: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+
+    let (key, value) = (5, 11);
+    hashmap_1.insert(key, value);
+    let (key, value) = (2, 13);
+    hashmap_1.insert(key, value);
+    let (key, value) = (11, 5);
+    hashmap_1.insert(key, value);
+
+    let (key, value) = (5, 11);
+    hashmap_2.insert(key, value);
+    let (key, value) = (2, 13);
+    hashmap_2.insert(key, value);
+    let (key, value) = (11, 5);
+    hashmap_2.insert(key, value);
+
+    assert(hashmap_1 == hashmap_2, "HashMaps should be equal");
+
+    hashmap_2.remove(11);
+
+    assert(hashmap_1 != hashmap_2, "HashMaps should not be equal");
 }

--- a/test_programs/execution_success/hashmap/src/main.nr
+++ b/test_programs/execution_success/hashmap/src/main.nr
@@ -1,0 +1,68 @@
+use dep::std::collections::map::HashMap;
+use dep::std::hash::BuildHasherDefault;
+use dep::std::hash::pedersen::PedersenHasher;
+
+fn main() {
+    test_sequential();
+    test_multiple_same_insert();
+    test_value_override();
+}
+
+// Insert, get, remove.
+fn test_sequential() {
+    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+    assert(hashmap.len() == 0, "new hashmap should be empty");
+
+    let (key, value): (Field, Field) = (1, 2);
+
+    hashmap.insert(key, value);
+    assert(hashmap.len() == 1, "hashmap after one insert should have a length of 1 element");
+
+    let retrieved_value = hashmap.get(key);
+    assert(retrieved_value.is_some(), "retrived value is none");
+
+    let retrieved_value = retrieved_value.unwrap_unchecked();
+    assert(value == retrieved_value, "retrieved value does not match inserted");
+
+    hashmap.remove(key);
+    assert(
+        hashmap.len() == 0, "hashmap after one insert and corresponding removal should have a lenght of 1 element"
+    );
+
+    let retrieved_value = hashmap.get(key);
+    assert(retrieved_value.is_none(), "value has been removed, but is still available");
+}
+
+// Insert same pair several times.
+fn test_multiple_same_insert() {
+    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+    assert(hashmap.len() == 0, "new hashmap should be empty");
+
+    let (key, value): (Field, Field) = (1, 2);
+    hashmap.insert(key, value);
+    hashmap.insert(key, value);
+    hashmap.insert(key, value);
+    assert(hashmap.len() == 1, "hashmap length is invalid");
+
+    let retrieved_value = hashmap.get(key);
+    assert(retrieved_value.is_some(), "retrieved value is none");
+    let retrieved_value = retrieved_value.unwrap_unchecked();
+    assert(retrieved_value == value, "retrieved value is not correct");
+}
+
+// Override value for existing pair.
+fn test_value_override() {
+    let mut hashmap: HashMap<Field, Field, 4, BuildHasherDefault<PedersenHasher>> = HashMap::default();
+    assert(hashmap.len() == 0, "new hashmap should be empty");
+
+    let (key, value): (Field, Field) = (1, 2);
+    hashmap.insert(key, value);
+    let value = 3;
+    hashmap.insert(key, value);
+    assert(hashmap.len() == 1, "hashmap length is invalid");
+
+    let retrieved_value = hashmap.get(key);
+    assert(retrieved_value.is_some(), "retrieved value is none");
+    let retrieved_value = retrieved_value.unwrap_unchecked();
+    assert(retrieved_value == 3, "retrieved value is not correct");
+}

--- a/test_programs/execution_success/hashmap/src/utils.nr
+++ b/test_programs/execution_success/hashmap/src/utils.nr
@@ -1,0 +1,10 @@
+// Compile-time: cuts the M first elements from the [T; N] array.
+pub(crate) fn cut<T, N, M>(input: [T; N]) -> [T; M] {
+    assert(M as u64 < N as u64, "M should be less than N.");
+
+    let mut new = [dep::std::unsafe::zeroed(); M];
+    for i in 0..M {
+        new[i] = input[i];
+    }
+    new
+}


### PR DESCRIPTION
# Description

This PR shall bring HashMap into the `stdlib` of Noir.

## Problem\*

Resolves #4241

## Summary\*

Implementation of `HashMap` with open addressing and quadratic probing scheme. Since Noir requires knowing loop bounds (and recursive calls) at compile time, `HashMap` is of fixed capacity and **no** dynamic resize is accomplished with regard to load factor. 

Furthermore, contribution includes implementation of `PedersenHasher` to be used for now. One can examine potentially better and less heavy prehash functions. 

I tried to conform with best practices of engineering, however since Noir is in rapid development, there are certain things which may be optimized in future, both from the code style and performance point of view.


## Additional Context

I put the `PedersenHasher` among the `poseidon.nr` and `mimc.nr`, so one can consider moving declaration of other pedersen-related functionality there, however that would be a breaking change.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
