### PR TITLE
chore: add warning for adding new git dependencies in `deny.toml`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -93,6 +93,11 @@ unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
+
+# DON'T YOU DARE ADD ANYTHING TO THIS IF YOU WANT TO PUBLISH ANYTHING NOIR RELATED TO CRATES.IO
+#
+# crates.io rejects git dependencies so anything depending on these is unpublishable and you'll ruin my day
+# when I find out.
 allow-git = [
     "https://github.com/noir-lang/grumpkin",
     "https://github.com/jfecher/chumsky"


### PR DESCRIPTION
# Description

## Problem\*

Related to https://github.com/noir-lang/noir/issues/4247

## Summary\*

This PR adds a big nasty warning for adding new git dependencies as part of avoiding #4247 happening again.

## Additional Context

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
