### PR TITLE
chore: use published noir grumpkin package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,8 +588,8 @@ dependencies = [
  "ark-ff",
  "flate2",
  "getrandom 0.2.10",
- "grumpkin",
  "js-sys",
+ "noir_grumpkin",
  "num-bigint",
  "pkg-config",
  "reqwest",
@@ -1933,17 +1933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "grumpkin"
-version = "0.1.0"
-source = "git+https://github.com/noir-lang/grumpkin?rev=56d99799381f79e42148aaef0de2b0cf9a4b9a5d#56d99799381f79e42148aaef0de2b0cf9a4b9a5d"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +2820,18 @@ dependencies = [
  "tempfile",
  "test-binary",
  "thiserror",
+]
+
+[[package]]
+name = "noir_grumpkin"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7d49a4b14b13c0dc730b05780b385828ab88f4148daaad7db080ecdce07350"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]

--- a/acvm-repo/bn254_blackbox_solver/Cargo.toml
+++ b/acvm-repo/bn254_blackbox_solver/Cargo.toml
@@ -23,8 +23,9 @@ rust-embed = { version = "6.6.0", features = [
     "include-exclude",
 ] }
 
-# BN254 fixed base scalar multiplication solver
-grumpkin = { git = "https://github.com/noir-lang/grumpkin", rev = "56d99799381f79e42148aaef0de2b0cf9a4b9a5d", features = ["std"] }
+grumpkin = { package = "noir_grumpkin", features = [
+    "std",
+] } # BN254 fixed base scalar multiplication solver
 ark-ec = { version = "^0.4.0", default-features = false }
 ark-ff = { version = "^0.4.0", default-features = false }
 num-bigint.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -57,7 +57,7 @@ allow = [
     # bitmaps 2.1.0, generational-arena 0.2.9,im 15.1.0
     "MPL-2.0",
     # Boost Software License
-    "BSL-1.0"
+    "BSL-1.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
@@ -93,7 +93,4 @@ unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = [
-    "https://github.com/noir-lang/grumpkin",
-    "https://github.com/jfecher/chumsky"
-]
+allow-git = ["https://github.com/jfecher/chumsky"]


### PR DESCRIPTION
# Description

Related to #4247 @TomAFrench has identified that since we are using git dependencies, we are not able to publish acv to crates.io. This uses a published version of grumpkin instead of the git dependency version.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
