### PR TITLE
fix: Remove hack in increment_array_reference_count

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -486,25 +486,10 @@ impl FunctionBuilder {
                     self.increment_array_reference_count(value);
                 }
             }
-            typ @ Type::Array(..) | typ @ Type::Slice(..) => {
+            Type::Array(..) | Type::Slice(..) => {
                 // If there are nested arrays or slices, we wait until ArrayGet
                 // is issued to increment the count of that array.
                 self.insert_instruction(Instruction::IncrementRc { value }, None);
-
-                // This is a bit odd, but in brillig the inc_rc instruction operates on
-                // a copy of the array's metadata, so we need to re-store a loaded array
-                // even if there have been no other changes to it.
-                if let Value::Instruction { instruction, .. } = &self.current_function.dfg[value] {
-                    let instruction = &self.current_function.dfg[*instruction];
-                    if let Instruction::Load { address } = instruction {
-                        // We can't re-use `value` in case the original address was stored
-                        // to again in the meantime. So introduce another load.
-                        let address = *address;
-                        let value = self.insert_load(address, typ);
-                        self.insert_instruction(Instruction::IncrementRc { value }, None);
-                        self.insert_store(address, value);
-                    }
-                }
             }
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -997,6 +997,7 @@ impl<'a> FunctionContext<'a> {
         new_value.for_each(|value| {
             let value = value.eval(self);
             array = self.builder.insert_array_set(array, index, value);
+            self.builder.increment_array_reference_count(array);
             index = self.builder.insert_binary(index, BinaryOp::Add, one);
         });
         array


### PR DESCRIPTION
# Description

## Problem\*

A followup to https://github.com/noir-lang/noir/pull/4210

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
