### PR TITLE
chore: Add secondary message for UnknownLoopBound error

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -160,6 +160,17 @@ impl RuntimeError {
                     noirc_errors::Span::inclusive(0, 0)
                 )
             }
+            RuntimeError::UnknownLoopBound { .. } => {
+                let primary_message = self.to_string();
+                let location =
+                    self.call_stack().back().expect("Expected RuntimeError to have a location");
+
+                Diagnostic::simple_error(
+                    primary_message,
+                    "If attempting to fetch the length of a slice, try converting to an array. Slices only use dynamic lengths.".to_string(),
+                    location.span,
+                )
+            }
             _ => {
                 let message = self.to_string();
                 let location =


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3687 

## Summary\*

This simply adds a secondary message to clarify that using a slice length will lead to the `Could not determine loop bound at compile-time` error. 

I was thinking of disabling this earlier during type check but we don't necessarily know that we will have a slice until codegen as arrays and slices are polymorphic with one another. I also thought about making a separate runtime error to check during loop unrolling but we are not necessarily going to still have the `ArrayLen` call codegen'd in SSA and will instead have the call's results for the loop condition, so this isn't a basic check and some more logic would be needed.

The best option for a specific error check seems to be during `codegen_for` before we codegen the end range. We can check whether we are making a slice ArrayLen call for the end range. These changes all felt a bit much as the error is quite clear except for this one error case and thus a secondary message felt sufficient.

If we would like the error to be more specific for the failure case then I can look at adding logic that triggers an error for a slice length loop bound. 

An example of the error now:
<img width="1013" alt="Screenshot 2024-02-05 at 5 10 39 PM" src="https://github.com/noir-lang/noir/assets/43554004/45bc240b-90a7-47b0-974d-d60e7c9a2079">



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
