### PR TITLE
chore: lock version of grumpkin package

### DIFF
--- a/acvm-repo/bn254_blackbox_solver/Cargo.toml
+++ b/acvm-repo/bn254_blackbox_solver/Cargo.toml
@@ -23,7 +23,7 @@ rust-embed = { version = "6.6.0", features = [
     "include-exclude",
 ] }
 
-grumpkin = { package = "noir_grumpkin", features = [
+grumpkin = { version = "0.1.0", package = "noir_grumpkin", features = [
     "std",
 ] } # BN254 fixed base scalar multiplication solver
 ark-ec = { version = "^0.4.0", default-features = false }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

@kevaundray was very irresponsible and didn't specify a version for the noir-grumpkin dependency. The reviewer in the PR in which he made this mistake is entirely blameless.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
