### PR TITLE
fix: Clean error when attemping to return a slice from Brillig to ACIR

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -46,7 +46,7 @@ pub enum RuntimeError {
     NestedSlice { call_stack: CallStack },
     #[error("Big Integer modulus do no match")]
     BigIntModulus { call_stack: CallStack },
-    #[error("Slices cannot be return from an unconstrained runtime to a constrained runtime")]
+    #[error("Slices cannot be returned from an unconstrained runtime to a constrained runtime")]
     UnconstrainedSliceReturnToConstrained { call_stack: CallStack },
 }
 

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -46,9 +46,7 @@ pub enum RuntimeError {
     NestedSlice { call_stack: CallStack },
     #[error("Big Integer modulus do no match")]
     BigIntModulus { call_stack: CallStack },
-    #[error(
-        "Slices cannot be return from an unconstrained environment to a constrained environment"
-    )]
+    #[error("Slices cannot be return from an unconstrained runtime to a constrained runtime")]
     UnconstrainedSliceReturnToConstrained { call_stack: CallStack },
 }
 

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -509,6 +509,14 @@ impl Context {
                                 "expected an intrinsic/brillig call, but found {func:?}. All ACIR methods should be inlined"
                             ),
                             RuntimeType::Brillig => {
+                                // Check that we are not attempting to return a slice from 
+                                // an unconstrained runtime to a constrained runtime
+                                for result_id in result_ids {
+                                    if dfg.type_of_value(*result_id).contains_slice_element() {
+                                        return Err(RuntimeError::UnconstrainedSliceReturnToConstrained { call_stack: self.acir_context.get_call_stack() })
+                                    }
+                                }
+
                                 let inputs = vecmap(arguments, |arg| self.convert_value(*arg, dfg));
 
                                 let code = self.gen_brillig_for(func, brillig)?;

--- a/test_programs/compile_failure/brillig_slice_to_acir/Nargo.toml
+++ b/test_programs/compile_failure/brillig_slice_to_acir/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "brillig_slice_to_acir"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.23.0"
+
+[dependencies]

--- a/test_programs/compile_failure/brillig_slice_to_acir/src/main.nr
+++ b/test_programs/compile_failure/brillig_slice_to_acir/src/main.nr
@@ -1,0 +1,14 @@
+global DEPTH: Field = 40000;
+
+fn main(x: [u32; DEPTH], y: u32) {
+    let mut new_x = [];
+    new_x = clear(x, y);
+}
+
+unconstrained fn clear(x: [u32; DEPTH], y: u32) -> [u32] {
+    let mut a = [];
+    for i in 0..y {
+        a = a.push_back(x[i]);
+    }
+    a
+}

--- a/test_programs/compile_failure/brillig_vec_to_acir/Nargo.toml
+++ b/test_programs/compile_failure/brillig_vec_to_acir/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "brillig_vec_to_acir"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.23.0"
+
+[dependencies]

--- a/test_programs/compile_failure/brillig_vec_to_acir/src/main.nr
+++ b/test_programs/compile_failure/brillig_vec_to_acir/src/main.nr
@@ -1,0 +1,14 @@
+global DEPTH: Field = 40000;
+
+fn main(x: [u32; DEPTH], y: u32) {
+    let mut new_x = Vec::new();
+    new_x = clear(x, y);
+}
+
+unconstrained fn clear(x: [u32; DEPTH], y: u32) -> Vec<u32> {
+    let mut a = Vec::new();
+    for i in 0..y {
+        a.push(x[i]);
+    }
+    a
+}


### PR DESCRIPTION

# Description

## Problem\*

Resolves #2535 

## Summary\*

We currently panic when attempting to return a slice from an unconstrained runtime to an ACIR runtime. In some cases such as in the linked issue the panic is not very clear at all. 

New error:
<img width="811" alt="Screenshot 2024-02-06 at 1 33 39 PM" src="https://github.com/noir-lang/noir/assets/43554004/e37e7b3b-13ef-4222-a359-2f14084478da">


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
