### PR TITLE
fix: simplify constant assert messages into `ConstrainError::Static`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -8,7 +8,7 @@ use context::SharedContext;
 use iter_extended::{try_vecmap, vecmap};
 use noirc_errors::Location;
 use noirc_frontend::{
-    monomorphization::ast::{self, Expression, Literal, Program},
+    monomorphization::ast::{self, Expression, Program},
     Visibility,
 };
 
@@ -700,7 +700,7 @@ impl<'a> FunctionContext<'a> {
             return Ok(None)
         };
 
-        if let ast::Expression::Literal(Literal::Str(assert_message)) = assert_message_expr.as_ref()
+        if let ast::Expression::Literal(ast::Literal::Str(assert_message)) = assert_message_expr.as_ref()
         {
             return Ok(Some(Box::new(ConstrainError::Static(assert_message.to_string()))));
         }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -700,7 +700,8 @@ impl<'a> FunctionContext<'a> {
             return Ok(None)
         };
 
-        if let ast::Expression::Literal(ast::Literal::Str(assert_message)) = assert_message_expr.as_ref()
+        if let ast::Expression::Literal(ast::Literal::Str(assert_message)) =
+            assert_message_expr.as_ref()
         {
             return Ok(Some(Box::new(ConstrainError::Static(assert_message.to_string()))));
         }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -8,7 +8,7 @@ use context::SharedContext;
 use iter_extended::{try_vecmap, vecmap};
 use noirc_errors::Location;
 use noirc_frontend::{
-    monomorphization::ast::{self, Expression, Program},
+    monomorphization::ast::{self, Expression, Literal, Program},
     Visibility,
 };
 
@@ -699,6 +699,11 @@ impl<'a> FunctionContext<'a> {
         let Some(assert_message_expr) = assert_message else {
             return Ok(None)
         };
+
+        if let ast::Expression::Literal(Literal::Str(assert_message)) = assert_message_expr.as_ref()
+        {
+            return Ok(Some(Box::new(ConstrainError::Static(assert_message.to_string()))));
+        }
 
         let ast::Expression::Call(call) = assert_message_expr.as_ref() else {
             return Err(InternalError::Unexpected {

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1211,9 +1211,7 @@ impl<'a> Resolver<'a> {
         span: Span,
         condition: Expression,
     ) -> Option<ExprId> {
-        let Some(assert_message_expr) = assert_message_expr else {
-            return None;
-        };
+        let assert_message_expr = assert_message_expr?;
 
         if matches!(assert_message_expr,  Expression {kind: ExpressionKind::Literal(Literal::Str(..)), ..}){
             return Some(self.resolve_expression(assert_message_expr));

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1211,6 +1211,15 @@ impl<'a> Resolver<'a> {
         span: Span,
         condition: Expression,
     ) -> Option<ExprId> {
+        if let Some(
+            assert_message_expr @ Expression {
+                kind: ExpressionKind::Literal(Literal::Str(..)), ..
+            },
+        ) = assert_message_expr
+        {
+            return Some(self.resolve_expression(assert_message_expr));
+        }
+
         let mut assert_msg_call_args = if let Some(assert_message_expr) = assert_message_expr {
             vec![assert_message_expr.clone()]
         } else {

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1213,7 +1213,10 @@ impl<'a> Resolver<'a> {
     ) -> Option<ExprId> {
         let assert_message_expr = assert_message_expr?;
 
-        if matches!(assert_message_expr,  Expression {kind: ExpressionKind::Literal(Literal::Str(..)), ..}){
+        if matches!(
+            assert_message_expr,
+            Expression { kind: ExpressionKind::Literal(Literal::Str(..)), .. }
+        ) {
             return Some(self.resolve_expression(assert_message_expr));
         }
 

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1211,21 +1211,13 @@ impl<'a> Resolver<'a> {
         span: Span,
         condition: Expression,
     ) -> Option<ExprId> {
-        if let Some(
-            assert_message_expr @ Expression {
-                kind: ExpressionKind::Literal(Literal::Str(..)), ..
-            },
-        ) = assert_message_expr
-        {
-            return Some(self.resolve_expression(assert_message_expr));
-        }
-
-        let mut assert_msg_call_args = if let Some(assert_message_expr) = assert_message_expr {
-            vec![assert_message_expr.clone()]
-        } else {
+        let Some(assert_message_expr) = assert_message_expr else {
             return None;
         };
-        assert_msg_call_args.push(condition);
+
+        if matches!(assert_message_expr,  Expression {kind: ExpressionKind::Literal(Literal::Str(..)), ..}){
+            return Some(self.resolve_expression(assert_message_expr));
+        }
 
         let is_in_stdlib = self.path_resolver.module_id().krate.is_stdlib();
         let assert_msg_call_path = if is_in_stdlib {
@@ -1241,6 +1233,7 @@ impl<'a> Resolver<'a> {
                 span,
             })
         };
+        let assert_msg_call_args = vec![assert_message_expr.clone(), condition];
         let assert_msg_call_expr = Expression::call(
             Expression { kind: assert_msg_call_path, span },
             assert_msg_call_args,

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -530,7 +530,7 @@ mod tests {
         let initial_witness = BTreeMap::from([(Witness(1), fe_1)]).into();
 
         let foreign_call_executor =
-            Box::new(DefaultDebugForeignCallExecutor::from_artifact(true, &debug_artifact));
+            Box::new(DefaultDebugForeignCallExecutor::from_artifact(true, debug_artifact));
         let mut context = DebugContext::new(
             &StubbedBlackBoxSolver,
             circuit,
@@ -624,7 +624,7 @@ mod tests {
         let initial_witness = BTreeMap::from([(Witness(1), fe_1), (Witness(2), fe_1)]).into();
 
         let foreign_call_executor =
-            Box::new(DefaultDebugForeignCallExecutor::from_artifact(true, &debug_artifact));
+            Box::new(DefaultDebugForeignCallExecutor::from_artifact(true, debug_artifact));
         let mut context = DebugContext::new(
             &StubbedBlackBoxSolver,
             circuit,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes the unnecessary foreign call we're performing for static error messages.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
