### PR TITLE
chore: Fix Incorrect `wrapping_add` Usage in Integers Tutorial

### DIFF
--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -157,6 +157,6 @@ Example of how it is used:
 use dep::std;
 
 fn main(x: u8, y: u8) -> pub u8 {
-    std::wrapping_add(x + y)
+    std::wrapping_add(x, y)
 }
 ```


### PR DESCRIPTION
This pull request addresses an issue identified in the [integers tutorial](https://noir-lang.org/docs/noir/syntax/data_types/integers/), where the `wrapping_add` function was incorrectly called with a single argument `(x + y)` instead of the correct form with two separate arguments `(x, y)`.

### Changes Made
The documentation has been updated to reflect the correct usage:
```diff
- std::wrapping_add(x + y)
+ std::wrapping_add(x, y)
```

### Acknowledgements
Special thanks to @Complexlity for identifying this issue and bringing it to attention through issue #4272. 