### PR TITLE
chore: add test for formatting assertions

### DIFF
--- a/tooling/nargo_fmt/src/visitor/stmt.rs
+++ b/tooling/nargo_fmt/src/visitor/stmt.rs
@@ -41,7 +41,7 @@ impl super::FmtVisitor<'_> {
                     let message = message.map_or(String::new(), |message| format!(", {message}"));
 
                     let (callee, args) = match kind {
-                        ConstrainKind::Assert => {
+                        ConstrainKind::Assert | ConstrainKind::Constrain => {
                             let assertion = rewrite::sub_expr(self, nested_shape, expr);
                             let args = format!("{assertion}{message}");
 
@@ -58,12 +58,6 @@ impl super::FmtVisitor<'_> {
                             } else {
                                 unreachable!()
                             }
-                        }
-                        ConstrainKind::Constrain => {
-                            let expr = rewrite::sub_expr(self, self.shape(), expr);
-                            let constrain = format!("constrain {expr};");
-                            self.push_rewrite(constrain, span);
-                            return;
                         }
                     };
 

--- a/tooling/nargo_fmt/tests/expected/assert.nr
+++ b/tooling/nargo_fmt/tests/expected/assert.nr
@@ -1,0 +1,4 @@
+fn main(x: Field) {
+    assert(x == 0, "with a message");
+    assert_eq(x, 1);
+}

--- a/tooling/nargo_fmt/tests/input/assert.nr
+++ b/tooling/nargo_fmt/tests/input/assert.nr
@@ -1,0 +1,7 @@
+fn main(x: Field) {
+    assert(x == 0,   "with a message");
+    assert_eq(
+        x,
+        1
+    );
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a test for how as format `assert` calls along with removal of handling for the `constrain` keyword. We'll now rewrite them to be `assert` although in reality we error out of the formatter before we reach this.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
