### PR TITLE
feat: perform constraints on uncasted values if they are the same type

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
@@ -120,6 +120,20 @@ pub(super) fn decompose_constrain(
                 }
             }
 
+
+            (Value::Instruction { instruction: instruction_lhs, .. }, Value::Instruction { instruction: instruction_rhs, .. }) =>
+            {
+                match (&dfg[*instruction_lhs], &dfg[*instruction_rhs]) {
+                    // Here's we're casting two values just to enforce an equality on them.
+                    //
+                    // This is equivalent to enforcing equality on the original values.
+                    (Instruction::Cast(original_lhs, _), Instruction::Cast(original_rhs, _)) if dfg.type_of_value(*original_lhs) == dfg.type_of_value(*original_rhs) => {
+                        vec![Instruction::Constrain(*original_lhs, *original_rhs, msg.clone())]
+                    }
+
+                    _ => vec![Instruction::Constrain(lhs, rhs, msg.clone())],
+                }
+            }
             _ => vec![Instruction::Constrain(lhs, rhs, msg.clone())],
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Followup to #4302.

## Summary\*

This PR unwraps `constrain cast(v0, typ) == cast(v1, typ)` into `constrain v0 == v1`. This will potentially improve #4060 effectiveness as we're moving this constraint information up the DFG.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
