### PR TITLE
chore: split node and browser integration tests to run in parallel

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -9,7 +9,7 @@ runs:
       run: echo "PLAYWRIGHT_VERSION=$(yarn workspace @noir-lang/noirc_abi info @web/test-runner-playwright --json | jq .children.Version | tr -d '"')" >> $GITHUB_ENV
 
     - name: Cache playwright binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: playwright-cache
       with:
         path: |

--- a/.github/scripts/integration-test-browser.sh
+++ b/.github/scripts/integration-test-browser.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eu
 
-apt-get install libc++-dev -y
 npx playwright install && npx playwright install-deps
 yarn workspace integration-tests test

--- a/.github/scripts/integration-test-node.sh
+++ b/.github/scripts/integration-test-node.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+
+apt-get install libc++-dev -y
+yarn workspace integration-tests test

--- a/.github/workflows/docker-test-flow.yml
+++ b/.github/workflows/docker-test-flow.yml
@@ -720,7 +720,63 @@ jobs:
       - name: Test
         working-directory: /usr/src/noir
         run: |
-          ./.github/scripts/integration-test.sh
+          ./.github/scripts/integration-test-node.sh
+
+  test-integration-browser:
+    name: Integration test browser
+    runs-on: ubuntu-latest
+    needs: [
+      build-base-js,
+      build-noir-wasm,
+      build-noirc-abi,
+      build-acvm_js,
+      build-noir-js-types,
+      build-noir_js,
+      build-barretenberg-backend
+    ]
+    container:
+      image: ghcr.io/noir-lang/noir:${{ github.sha }}-js
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    steps:
+      - name: Download noir wasm
+        uses: actions/download-artifact@v4
+        with:
+          name: noir_wasm
+          path: /usr/src/noir/compiler/wasm
+      - name: Download noirc abi
+        uses: actions/download-artifact@v4
+        with:
+          name: noirc_abi_wasm
+          path: /usr/src/noir/tooling/noirc_abi_wasm
+      - name: Download acvm js
+        uses: actions/download-artifact@v4
+        with:
+          name: acvm_js
+          path: /usr/src/noir/acvm-repo/acvm_js
+      - name: Download noir js types
+        uses: actions/download-artifact@v4
+        with:
+          name: noir-js-types
+          path: |
+            /usr/src/noir/tooling/noir_js_types/lib
+      - name: Download noir js
+        uses: actions/download-artifact@v4
+        with:
+          name: noir_js
+          path:
+            /usr/src/noir/tooling/noir_js/lib
+      - name: Download Barretenberg backend
+        uses: actions/download-artifact@v4
+        with:
+          name: barretenberg-backend
+          path:
+            /usr/src/noir/tooling/noir_js_backend_barretenberg/lib
+      - name: Test
+        working-directory: /usr/src/noir
+        run: |
+          ./.github/scripts/integration-test-browser.sh
 
   tests-end:
     name: End
@@ -733,6 +789,7 @@ jobs:
       - test-noir-wasm
       - test-noir-wasm-browser
       - test-integration
+      - test-integration-browser
       - test-noir_codegen
       - test-acvm_js
       - test-acvm_js-browser

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -88,7 +88,7 @@ jobs:
           yarn workspaces foreach -Rpt --from docs run build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: ./docs/build/

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@v4
     
       - name: Download built docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs
           path: ./docs/build

--- a/.github/workflows/gates_report.yml
+++ b/.github/workflows/gates_report.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nargo
           path: ./nargo

--- a/.github/workflows/gates_report.yml
+++ b/.github/workflows/gates_report.yml
@@ -36,7 +36,7 @@ jobs:
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-x86_64-unknown-linux-gnu.tar.gz
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nargo
           path: ./dist/*

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           nix build -L .#noirc_abi_wasm
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: noirc_abi_wasm
           path: |
@@ -71,7 +71,7 @@ jobs:
         run: yarn workspace @noir-lang/noir_wasm build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: noir_wasm
           path: |
@@ -98,7 +98,7 @@ jobs:
         run: |
           nix build -L .#acvm_js
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: acvm_js
           path: |

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -59,7 +59,7 @@ jobs:
           save-if: false
 
       - name: Download noirc_abi_wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
@@ -114,17 +114,17 @@ jobs:
         with:
           ref: ${{ inputs.noir-ref }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: acvm_js
           path: acvm-repo/acvm_js
       
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: noir_wasm
           path: compiler/wasm
       
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: tooling/noirc_abi_wasm

--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -67,7 +67,7 @@ jobs:
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nargo-${{ matrix.target }}
           path: ./dist/*
@@ -145,7 +145,7 @@ jobs:
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nargo-${{ matrix.target }}
           path: ./dist/*

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -388,8 +388,8 @@ jobs:
       - name: Run noir_codegen tests
         run: yarn workspace @noir-lang/noir_codegen test
 
-  test-integration:
-    name: Integration Tests
+  test-integration-node:
+    name: Integration Tests (Node)
     runs-on: ubuntu-latest
     needs: [build-acvm-js, build-noir-wasm, build-nargo, build-noirc-abi]
     timeout-minutes: 30
@@ -433,6 +433,48 @@ jobs:
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
 
+      - name: Setup `integration-tests`
+        run: |
+          # Note the lack of spaces between package names.
+          PACKAGES_TO_BUILD="@noir-lang/types,@noir-lang/backend_barretenberg,@noir-lang/noir_js"
+          yarn workspaces foreach -vtp --from "{$PACKAGES_TO_BUILD}" run build
+
+      - name: Run `integration-tests`
+        working-directory: ./compiler/integration-tests
+        run: |
+          yarn test:node
+
+  test-integration-browser:
+    name: Integration Tests (Browser)
+    runs-on: ubuntu-latest
+    needs: [build-acvm-js, build-noir-wasm, build-nargo, build-noirc-abi]
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download acvm_js package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: acvm-js
+          path: ./acvm-repo/acvm_js
+
+      - name: Download noir_wasm package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: noir_wasm
+          path: ./compiler/wasm
+
+      - name: Download noirc_abi package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: noirc_abi_wasm
+          path: ./tooling/noirc_abi_wasm
+
+      - name: Install Yarn dependencies
+        uses: ./.github/actions/setup
+
       - name: Install Playwright
         uses: ./.github/actions/install-playwright
 
@@ -443,8 +485,9 @@ jobs:
           yarn workspaces foreach -vtp --from "{$PACKAGES_TO_BUILD}" run build
 
       - name: Run `integration-tests`
+        working-directory: ./compiler/integration-tests
         run: |
-          yarn test:integration
+          yarn test:browser
   
   # This is a job which depends on all test jobs and reports the overall status.
   # This allows us to add/remove test jobs without having to update the required workflows.
@@ -461,7 +504,8 @@ jobs:
       - test-noir-js
       - test-noir-wasm
       - test-noir-codegen
-      - test-integration
+      - test-integration-node
+      - test-integration-browser
     
     steps:
         - name: Report overall success

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -65,7 +65,7 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: Download noirc_abi_wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Nix
         uses: ./.github/actions/nix
@@ -154,7 +154,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acvm-js
           path: ./acvm-repo/acvm_js
@@ -176,7 +176,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acvm-js
           path: ./acvm-repo/acvm_js
@@ -200,10 +200,10 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
@@ -257,19 +257,19 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Download nargo binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nargo
           path: ./nargo
       
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acvm-js
           path: ./acvm-repo/acvm_js
 
       - name: Download wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
@@ -307,7 +307,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noir_wasm
           path: ./compiler/wasm
@@ -316,7 +316,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nargo
           path: ./nargo
@@ -351,19 +351,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nargo
           path: ./nargo
 
       - name: Download acvm_js package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acvm-js
           path: ./acvm-repo/acvm_js
       
       - name: Download noirc_abi package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
@@ -399,25 +399,25 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nargo
           path: ./nargo
 
       - name: Download acvm_js package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acvm-js
           path: ./acvm-repo/acvm_js
 
       - name: Download noir_wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noir_wasm
           path: ./compiler/wasm
 
       - name: Download noirc_abi package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
@@ -455,19 +455,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download acvm_js package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acvm-js
           path: ./acvm-repo/acvm_js
 
       - name: Download noir_wasm package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noir_wasm
           path: ./compiler/wasm
 
       - name: Download noirc_abi package artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -40,7 +40,7 @@ jobs:
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-x86_64-unknown-linux-gnu.tar.gz
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nargo
           path: ./dist/*
@@ -77,7 +77,7 @@ jobs:
         run: yarn workspace @noir-lang/noir_wasm build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: noir_wasm
           path: |
@@ -108,7 +108,7 @@ jobs:
         run: echo "UPLOAD_PATH=$(readlink -f result/acvm_js)" >> $GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: acvm-js
           path: ${{ env.UPLOAD_PATH }}
@@ -137,7 +137,7 @@ jobs:
         run: echo "UPLOAD_PATH=$(readlink -f ./result/noirc_abi_wasm)" >> $GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: noirc_abi_wasm
           path: ${{ env.UPLOAD_PATH }}

--- a/compiler/integration-tests/package.json
+++ b/compiler/integration-tests/package.json
@@ -5,8 +5,8 @@
     "private": true,
     "scripts": {
         "build": "echo Integration Test build step",
-        "test": "bash ./scripts/codegen-verifiers.sh && yarn test:browser && yarn test:node",
-        "test:node": "hardhat test test/node/**/*",
+        "test": "yarn test:browser && yarn test:node",
+        "test:node": "bash ./scripts/codegen-verifiers.sh && hardhat test test/node/**/*",
         "test:browser": "web-test-runner",
         "test:integration:browser": "web-test-runner test/browser/**/*.test.ts",
         "test:integration:browser:watch": "web-test-runner test/browser/**/*.test.ts --watch",


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This should help cut CI times to remove the new bottleneck after #4305 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
