### PR TITLE
chore: remove `noir_wasm` dependency on `noirc_abi_wasm`

### DIFF
--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -42,7 +42,6 @@ jobs:
             result/noirc_abi_wasm/web
 
   build-noir_wasm:
-    needs: [build-noirc_abi_wasm]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -58,14 +57,11 @@ jobs:
           key: noir-wasm
           save-if: false
 
-      - name: Download noirc_abi_wasm package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: noirc_abi_wasm
-          path: ./tooling/noirc_abi_wasm
-
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
+
+      - name: Build noir_js_types
+        run: yarn workspace @noir-lang/noir_js_types build
 
       - name: Build noir_wasm
         run: yarn workspace @noir-lang/noir_wasm build

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -61,7 +61,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build noir_js_types
-        run: yarn workspace @noir-lang/noir_js_types build
+        run: yarn workspace @noir-lang/types build
 
       - name: Build noir_wasm
         run: yarn workspace @noir-lang/noir_wasm build

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -47,7 +47,6 @@ jobs:
           retention-days: 3
 
   build-noir-wasm:
-    needs: [build-noirc-abi]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -64,14 +63,11 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.event_name != 'merge_group' }}
 
-      - name: Download noirc_abi_wasm package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: noirc_abi_wasm
-          path: ./tooling/noirc_abi_wasm
-
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
+
+      - name: Build noir_js_types
+        run: yarn workspace @noir-lang/noir_js_types build
 
       - name: Build noir_wasm
         run: yarn workspace @noir-lang/noir_wasm build

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -67,7 +67,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build noir_js_types
-        run: yarn workspace @noir-lang/noir_js_types build
+        run: yarn workspace @noir-lang/types build
 
       - name: Build noir_wasm
         run: yarn workspace @noir-lang/noir_wasm build

--- a/compiler/wasm/package.json
+++ b/compiler/wasm/package.json
@@ -80,6 +80,7 @@
     "webpack-cli": "^4.7.2"
   },
   "dependencies": {
+    "@noir-lang/types": "workspace:*",
     "pako": "^2.1.0"
   }
 }

--- a/compiler/wasm/src/types/noir_artifact.ts
+++ b/compiler/wasm/src/types/noir_artifact.ts
@@ -1,4 +1,4 @@
-import { Abi, AbiType } from '@noir-lang/noirc_abi';
+import { Abi, AbiType } from '@noir-lang/types';
 
 /**
  * A named type.

--- a/tooling/noir_js_types/package.json
+++ b/tooling/noir_js_types/package.json
@@ -38,9 +38,6 @@
       "types": "./lib/esm/types.d.ts"
     }
   },
-  "dependencies": {
-    "@noir-lang/noirc_abi": "workspace:*"
-  },
   "devDependencies": {
     "@types/prettier": "^3",
     "eslint": "^8.50.0",

--- a/tooling/noir_js_types/src/types.ts
+++ b/tooling/noir_js_types/src/types.ts
@@ -1,6 +1,33 @@
-import { Abi } from '@noir-lang/noirc_abi';
+export type Field = string | number | boolean;
+export type InputValue = Field | InputMap | (Field | InputMap)[];
+export type InputMap = { [key: string]: InputValue };
 
-export { Abi, WitnessMap } from '@noir-lang/noirc_abi';
+export type Visibility = "public" | "private" | "databus";
+export type Sign = "unsigned" | "signed";
+export type AbiType = 
+    { kind: "field" } |
+    { kind: "boolean" } |
+    { kind: "string", length: number } |
+    { kind: "integer", sign: Sign, width: number } |
+    { kind: "array", length: number, type: AbiType } |
+    { kind: "tuple", fields: AbiType[] } |
+    { kind: "struct", path: string, fields: { name: string, type: AbiType }[] };
+
+export type AbiParameter = {
+    name: string,
+    type: AbiType,
+    visibility: Visibility,
+};
+    
+// Map from witness index to hex string value of witness.
+export type WitnessMap = Map<number, string>;
+
+export type Abi = {
+    parameters: AbiParameter[],
+    param_witnesses: Record<string, {start: number, end: number}[]>,
+    return_type: {abi_type: AbiType, visibility: Visibility} | null,
+    return_witnesses: number[],
+}
 
 export interface Backend {
   /**

--- a/tooling/noir_js_types/src/types.ts
+++ b/tooling/noir_js_types/src/types.ts
@@ -2,32 +2,32 @@ export type Field = string | number | boolean;
 export type InputValue = Field | InputMap | (Field | InputMap)[];
 export type InputMap = { [key: string]: InputValue };
 
-export type Visibility = "public" | "private" | "databus";
-export type Sign = "unsigned" | "signed";
-export type AbiType = 
-    { kind: "field" } |
-    { kind: "boolean" } |
-    { kind: "string", length: number } |
-    { kind: "integer", sign: Sign, width: number } |
-    { kind: "array", length: number, type: AbiType } |
-    { kind: "tuple", fields: AbiType[] } |
-    { kind: "struct", path: string, fields: { name: string, type: AbiType }[] };
+export type Visibility = 'public' | 'private' | 'databus';
+export type Sign = 'unsigned' | 'signed';
+export type AbiType =
+  | { kind: 'field' }
+  | { kind: 'boolean' }
+  | { kind: 'string'; length: number }
+  | { kind: 'integer'; sign: Sign; width: number }
+  | { kind: 'array'; length: number; type: AbiType }
+  | { kind: 'tuple'; fields: AbiType[] }
+  | { kind: 'struct'; path: string; fields: { name: string; type: AbiType }[] };
 
 export type AbiParameter = {
-    name: string,
-    type: AbiType,
-    visibility: Visibility,
+  name: string;
+  type: AbiType;
+  visibility: Visibility;
 };
-    
+
 // Map from witness index to hex string value of witness.
 export type WitnessMap = Map<number, string>;
 
 export type Abi = {
-    parameters: AbiParameter[],
-    param_witnesses: Record<string, {start: number, end: number}[]>,
-    return_type: {abi_type: AbiType, visibility: Visibility} | null,
-    return_witnesses: number[],
-}
+  parameters: AbiParameter[];
+  param_witnesses: Record<string, { start: number; end: number }[]>;
+  return_type: { abi_type: AbiType; visibility: Visibility } | null;
+  return_witnesses: number[];
+};
 
 export interface Backend {
   /**

--- a/tooling/noirc_abi_wasm/package.json
+++ b/tooling/noirc_abi_wasm/package.json
@@ -37,6 +37,9 @@
     "build:nix": "nix build -L .#noirc_abi_wasm",
     "install:from:nix": "yarn clean && yarn build:nix && cp -rL ./result/noirc_abi_wasm/nodejs ./ && cp -rL ./result/noirc_abi_wasm/web ./"
   },
+  "dependencies": {
+    "@noir-lang/types": "workspace:*"
+  },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@web/dev-server-esbuild": "^0.3.6",

--- a/tooling/noirc_abi_wasm/src/js_witness_map.rs
+++ b/tooling/noirc_abi_wasm/src/js_witness_map.rs
@@ -7,12 +7,6 @@ use acvm::{
 use js_sys::{JsString, Map};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
-#[wasm_bindgen(typescript_custom_section)]
-const WITNESS_MAP: &'static str = r#"
-// Map from witness index to hex string value of witness.
-export type WitnessMap = Map<number, string>;
-"#;
-
 // WitnessMap
 #[wasm_bindgen]
 extern "C" {

--- a/tooling/noirc_abi_wasm/src/lib.rs
+++ b/tooling/noirc_abi_wasm/src/lib.rs
@@ -26,9 +26,8 @@ use js_witness_map::JsWitnessMap;
 
 #[wasm_bindgen(typescript_custom_section)]
 const INPUT_MAP: &'static str = r#"
-export type Field = string | number | boolean;
-export type InputValue = Field | InputMap | (Field | InputMap)[];
-export type InputMap = { [key: string]: InputValue };
+import { Field, InputValue, InputMap, Visibility, Sign, AbiType, AbiParameter, Abi, WitnessMap } from "@noir-lang/types";
+export { Field, InputValue, InputMap, Visibility, Sign, AbiType, AbiParameter, Abi, WitnessMap } from "@noir-lang/types";
 "#;
 
 #[wasm_bindgen]
@@ -36,44 +35,11 @@ extern "C" {
     #[wasm_bindgen(extends = js_sys::Object, js_name = "InputMap", typescript_type = "InputMap")]
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type JsInputMap;
-}
 
-#[wasm_bindgen]
-extern "C" {
     #[wasm_bindgen(extends = js_sys::Object, js_name = "InputValue", typescript_type = "InputValue")]
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type JsInputValue;
-}
 
-#[wasm_bindgen(typescript_custom_section)]
-const ABI: &'static str = r#"
-export type Visibility = "public" | "private" | "databus";
-export type Sign = "unsigned" | "signed";
-export type AbiType = 
-    { kind: "field" } |
-    { kind: "boolean" } |
-    { kind: "string", length: number } |
-    { kind: "integer", sign: Sign, width: number } |
-    { kind: "array", length: number, type: AbiType } |
-    { kind: "tuple", fields: AbiType[] } |
-    { kind: "struct", path: string, fields: { name: string, type: AbiType }[] };
-
-export type AbiParameter = {
-    name: string,
-    type: AbiType,
-    visibility: Visibility,
-};
-    
-export type Abi = {
-    parameters: AbiParameter[],
-    param_witnesses: Record<string, {start: number, end: number}[]>,
-    return_type: {abi_type: AbiType, visibility: Visibility} | null,
-    return_witnesses: number[],
-}
-"#;
-
-#[wasm_bindgen]
-extern "C" {
     #[wasm_bindgen(extends = js_sys::Object, js_name = "Abi", typescript_type = "Abi")]
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type JsAbi;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4523,6 +4523,7 @@ __metadata:
     "@esm-bundle/chai": ^4.3.4-fix.0
     "@ltd/j-toml": ^1.38.0
     "@noir-lang/noirc_abi": "workspace:*"
+    "@noir-lang/types": "workspace:*"
     "@types/adm-zip": ^0.5.0
     "@types/chai": ^4
     "@types/mocha": ^10.0.6
@@ -4572,6 +4573,7 @@ __metadata:
   resolution: "@noir-lang/noirc_abi@workspace:tooling/noirc_abi_wasm"
   dependencies:
     "@esm-bundle/chai": ^4.3.4-fix.0
+    "@noir-lang/types": "workspace:*"
     "@web/dev-server-esbuild": ^0.3.6
     "@web/test-runner": ^0.15.3
     "@web/test-runner-playwright": ^0.10.0
@@ -4610,7 +4612,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@noir-lang/types@workspace:tooling/noir_js_types"
   dependencies:
-    "@noir-lang/noirc_abi": "workspace:*"
     "@types/prettier": ^3
     eslint: ^8.50.0
     eslint-plugin-prettier: ^5.0.0


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

`noir_wasm`s dependency on `noirc_abi_wasm` is preventing us from building it in parallel. It only relies on types so I've moved those to `noir_js_types` and both of those packages pull these types in.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
