### PR TITLE
fix: Ensure that destination register is allocated when moving between registers in brillig gen

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -916,8 +916,11 @@ impl BrilligContext {
         //
         // This means that the arguments will be in the first `n` registers after
         // the number of reserved registers.
-        let (sources, destinations) =
+        let (sources, destinations): (Vec<_>, Vec<_>) =
             arguments.iter().enumerate().map(|(i, argument)| (*argument, self.register(i))).unzip();
+        destinations
+            .iter()
+            .for_each(|destination| self.registers.ensure_register_is_allocated(*destination));
         self.mov_registers_to_registers_instruction(sources, destinations);
         saved_registers
     }

--- a/tooling/debugger/ignored-tests.txt
+++ b/tooling/debugger/ignored-tests.txt
@@ -17,4 +17,3 @@ signed_comparison
 simple_2d_array
 to_bytes_integration
 bigint
-brillig_slices


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/AztecProtocol/aztec-packages/issues/4513

## Summary\*

Move registers to registers wasn't ensuring that the destinations were allocated so it was possible to codegen a case where move registers to registers was squashing values

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
