### PR TITLE
fix: message formatting for assert statement

### DIFF
--- a/tooling/nargo_fmt/src/visitor/stmt.rs
+++ b/tooling/nargo_fmt/src/visitor/stmt.rs
@@ -38,7 +38,10 @@ impl super::FmtVisitor<'_> {
 
                     nested_shape.indent.block_indent(self.config);
 
-                    let message = message.map_or(String::new(), |message| format!(", {message}"));
+                    let message = message.map_or(String::new(), |message| {
+                        let message = rewrite::sub_expr(self, nested_shape, message);
+                        format!(", {message}")
+                    });
 
                     let (callee, args) = match kind {
                         ConstrainKind::Assert | ConstrainKind::Constrain => {

--- a/tooling/nargo_fmt/tests/expected/assert.nr
+++ b/tooling/nargo_fmt/tests/expected/assert.nr
@@ -1,5 +1,5 @@
 fn main(x: Field) {
     assert(x == 0, "with a message");
     assert_eq(x, 1);
-    assert_eq(x, message);
+    assert(x, message);
 }

--- a/tooling/nargo_fmt/tests/expected/assert.nr
+++ b/tooling/nargo_fmt/tests/expected/assert.nr
@@ -1,4 +1,5 @@
 fn main(x: Field) {
     assert(x == 0, "with a message");
     assert_eq(x, 1);
+    assert_eq(x, message);
 }

--- a/tooling/nargo_fmt/tests/input/assert.nr
+++ b/tooling/nargo_fmt/tests/input/assert.nr
@@ -4,5 +4,5 @@ fn main(x: Field) {
         x,
         1
     );
-    assert_eq( x, message );
+    assert( x, message );
 }

--- a/tooling/nargo_fmt/tests/input/assert.nr
+++ b/tooling/nargo_fmt/tests/input/assert.nr
@@ -4,4 +4,5 @@ fn main(x: Field) {
         x,
         1
     );
+    assert_eq( x, message );
 }


### PR DESCRIPTION
# Description

Due to our use of Display for message formatting, we were generating invalid code.

Output before the PR:
```rust
assert(x, plain::message);
```
Output after the PR:
```rust
assert(x, message);
```

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
