### PR TITLE
chore(docs): Update v0.23.0 docs with retroactive doc updates

### DIFF
--- a/docs/docs/noir/standard_library/black_box_fns.md
+++ b/docs/docs/noir/standard_library/black_box_fns.md
@@ -15,7 +15,7 @@ Here is a list of the current black box functions:
 - [SHA256](./cryptographic_primitives/hashes#sha256)
 - [Schnorr signature verification](./cryptographic_primitives/schnorr)
 - [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Blake3](./cryptographic_primitives/hashes#blake2s)
+- [Blake3](./cryptographic_primitives/hashes#blake3)
 - [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
 - [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
 - [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)

--- a/docs/docs/tutorials/noirjs_app.md
+++ b/docs/docs/tutorials/noirjs_app.md
@@ -101,7 +101,7 @@ At this point in the tutorial, your folder structure should look like this:
 
 `npx create vite` is amazing but it creates a bunch of files we don't really need for our simple example. Actually, let's just delete everything except for `index.html`, `main.js` and `package.json`. I feel lighter already.
 
-![my heart is ready for you, noir.js](../../static/img/memes/titanic.jpeg)
+![my heart is ready for you, noir.js](@site/static/img/memes/titanic.jpeg)
 
 ## HTML
 
@@ -270,7 +270,7 @@ if (verification) display('logs', 'Verifying proof... ✅');
 
 You have successfully generated a client-side Noir web app!
 
-![coded app without math knowledge](../../static/img/memes/flextape.jpeg)
+![coded app without math knowledge](@site/static/img/memes/flextape.jpeg)
 
 ## Further Reading
 

--- a/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/fields.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/fields.md
@@ -157,10 +157,36 @@ fn main() {
 }
 ```
 
+### assert_max_bit_size
+
+Adds a constraint to specify that the field can be represented with `bit_size` number of bits
+
+```rust
+fn assert_max_bit_size(self, bit_size: u32)
+```
+
+example:
+
+```rust
+fn main() {
+    let field = 2
+    field.assert_max_bit_size(32);
+}
+```
+
 ### sgn0
 
 Parity of (prime) Field element, i.e. sgn0(x mod p) = 0 if x ∈ \{0, ..., p-1\} is even, otherwise sgn0(x mod p) = 1.
 
 ```rust
 fn sgn0(self) -> u1
+```
+
+
+### lt
+
+Returns true if the field is less than the other field
+
+```rust
+pub fn lt(self, another: Field) -> bool
 ```

--- a/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/integers.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/integers.md
@@ -51,6 +51,55 @@ If you are using the default proving backend with Noir, both even (e.g. _u2_, _i
 
 :::
 
+
+## 128 bits Unsigned Integers
+
+The built-in structure `U128` allows you to use 128-bit unsigned integers almost like a native integer type. However, there are some differences to keep in mind:
+- You cannot cast between a native integer and `U128`
+- There is a higher performance cost when using `U128`, compared to a native type.
+
+Conversion between unsigned integer types and U128 are done through the use of `from_integer` and `to_integer` functions.
+
+```rust
+fn main() {
+    let x = U128::from_integer(23);
+    let y = U128::from_hex("0x7");
+    let z = x + y;
+    assert(z.to_integer() == 30);
+}
+```
+
+`U128` is implemented with two 64 bits limbs, representing the low and high bits, which explains the performance cost. You should expect `U128` to be twice more costly for addition and four times more costly for multiplication.
+You can construct a U128 from its limbs:
+```rust
+fn main(x: u64, y: u64) {
+    let x = U128::from_u64s_be(x,y);
+    assert(z.hi == x as Field);
+    assert(z.lo == y as Field);
+}
+```
+
+Note that the limbs are stored as Field elements in order to avoid unnecessary conversions.
+Apart from this, most operations will work as usual:
+
+```rust
+fn main(x: U128, y: U128) {
+    // multiplication
+    let c = x * y;
+    // addition and subtraction
+    let c = c - x + y;
+    // division
+    let c = x / y;
+    // bit operation;
+    let c = x & y | y;
+    // bit shift
+    let c = x << y;
+    // comparisons;
+    let c = x < y;
+    let c = x == y;
+}
+```
+
 ## Overflows
 
 Computations that exceed the type boundaries will result in overflow errors. This happens with both signed and unsigned integers. For example, attempting to prove:
@@ -108,6 +157,6 @@ Example of how it is used:
 use dep::std;
 
 fn main(x: u8, y: u8) -> pub u8 {
-    std::wrapping_add(x + y)
+    std::wrapping_add(x, y)
 }
 ```

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/black_box_fns.md
@@ -6,40 +6,26 @@ keywords: [noir, black box functions]
 
 Black box functions are functions in Noir that rely on backends implementing support for specialized constraints. This makes certain zk-snark unfriendly computations cheaper than if they were implemented in Noir.
 
-:::warning
-
-It is likely that not all backends will support a particular black box function.
-
-:::
-
-Because it is not guaranteed that all backends will support black box functions, it is possible that certain Noir programs won't compile against a particular backend if they use an unsupported black box function. It is possible to fallback to less efficient implementations written in Noir/ACIR in some cases.
-
-Black box functions are specified with the `#[foreign(black_box_fn)]` attribute. For example, the SHA256 function in the Noir [source code](https://github.com/noir-lang/noir/blob/v0.5.1/noir_stdlib/src/hash.nr) looks like:
-
-```rust
-#[foreign(sha256)]
-fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
-```
+The ACVM spec defines a set of blackbox functions which backends will be expected to implement. This allows backends to use optimized implementations of these constraints if they have them, however they may also fallback to less efficient naive implementations if not.
 
 ## Function list
 
-Here is a list of the current black box functions that are supported by UltraPlonk:
+Here is a list of the current black box functions:
 
-- AES
 - [SHA256](./cryptographic_primitives/hashes#sha256)
 - [Schnorr signature verification](./cryptographic_primitives/schnorr)
 - [Blake2s](./cryptographic_primitives/hashes#blake2s)
+- [Blake3](./cryptographic_primitives/hashes#blake3)
 - [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
 - [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
 - [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
 - [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
 - AND
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes#keccak256)
 - [Recursive proof verification](./recursion)
 
-Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
+Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 
 You can view the black box functions defined in the ACVM code [here](https://github.com/noir-lang/noir/blob/master/acvm-repo/acir/src/circuit/black_box_functions.rs).

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/bn254.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/bn254.md
@@ -1,0 +1,46 @@
+---
+title: Bn254 Field Library
+---
+
+Noir provides a module in standard library with some optimized functions for bn254 Fr in `std::field::bn254`.
+
+## decompose
+
+```rust
+fn decompose(x: Field) -> (Field, Field) {}
+```
+
+Decomposes a single field into two fields, low and high. The low field contains the lower 16 bytes of the input field and the high field contains the upper 16 bytes of the input field. Both field results are range checked to 128 bits.
+
+
+## assert_gt
+
+```rust
+fn assert_gt(a: Field, b: Field) {}
+```
+
+Asserts that a > b. This will generate less constraints than using `assert(gt(a, b))`.
+
+## assert_lt
+
+```rust
+fn assert_lt(a: Field, b: Field) {}
+```
+
+Asserts that a < b. This will generate less constraints than using `assert(lt(a, b))`.
+
+## gt
+
+```rust
+fn gt(a: Field, b: Field) -> bool  {}
+```
+
+Returns true if a > b.
+
+## lt
+
+```rust
+fn lt(a: Field, b: Field) -> bool  {}
+```
+
+Returns true if a < b.

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
@@ -13,9 +13,16 @@ Noir supports ECDSA signatures verification over the secp256k1 and secp256r1 cur
 
 Verifier for ECDSA Secp256k1 signatures
 
-```rust
-fn verify_signature(_public_key_x : [u8; 32], _public_key_y : [u8; 32], _signature: [u8; 64], _message: [u8]) -> bool
+```rust title="ecdsa_secp256k1" showLineNumbers 
+pub fn verify_signature<N>(
+    public_key_x: [u8; 32],
+    public_key_y: [u8; 32],
+    signature: [u8; 64],
+    message_hash: [u8; N]
+) -> bool
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256k1.nr#L2-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256k1.nr#L2-L9</a></sub></sup>
+
 
 example:
 
@@ -30,9 +37,16 @@ fn main(hashed_message : [u8;32], pub_key_x : [u8;32], pub_key_y : [u8;32], sign
 
 Verifier for ECDSA Secp256r1 signatures
 
-```rust
-fn verify_signature(_public_key_x : [u8; 32], _public_key_y : [u8; 32], _signature: [u8; 64], _message: [u8]) -> bool
+```rust title="ecdsa_secp256r1" showLineNumbers 
+pub fn verify_signature<N>(
+    public_key_x: [u8; 32],
+    public_key_y: [u8; 32],
+    signature: [u8; 64],
+    message_hash: [u8; N]
+) -> bool
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256r1.nr#L2-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256r1.nr#L2-L9</a></sub></sup>
+
 
 example:
 

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/hashes.mdx
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/hashes.mdx
@@ -14,9 +14,11 @@ import BlackBoxInfo from '@site/src/components/Notes/_blackbox.mdx';
 
 Given an array of bytes, returns the resulting sha256 hash.
 
-```rust
-fn sha256(_input : [u8]) -> [u8; 32]
+```rust title="sha256" showLineNumbers 
+pub fn sha256<N>(input: [u8; N]) -> [u8; 32]
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash.nr#L5-L7</a></sub></sup>
+
 
 example:
 
@@ -33,9 +35,11 @@ fn main() {
 
 Given an array of bytes, returns an array with the Blake2 hash
 
-```rust
-fn blake2s(_input : [u8]) -> [u8; 32]
+```rust title="blake2s" showLineNumbers 
+pub fn blake2s<N>(input: [u8; N]) -> [u8; 32]
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash.nr#L11-L13</a></sub></sup>
+
 
 example:
 
@@ -48,43 +52,81 @@ fn main() {
 
 <BlackBoxInfo />
 
-## pedersen_hash
+## blake3
 
-Given an array of Fields, returns the Pedersen hash.
+Given an array of bytes, returns an array with the Blake3 hash
 
-```rust
-fn pedersen_hash(_input : [Field]) -> Field
+```rust title="blake3" showLineNumbers 
+pub fn blake3<N>(input: [u8; N]) -> [u8; 32]
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash.nr#L17-L19" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash.nr#L17-L19</a></sub></sup>
+
 
 example:
 
 ```rust
 fn main() {
     let x = [163, 117, 178, 149]; // some random bytes
-    let hash = std::hash::pedersen_hash(x);
+    let hash = std::hash::blake3(x);
 }
 ```
 
 <BlackBoxInfo />
 
+## pedersen_hash
+
+Given an array of Fields, returns the Pedersen hash.
+
+```rust title="pedersen_hash" showLineNumbers 
+pub fn pedersen_hash<N>(input: [Field; N]) -> Field
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash.nr#L42-L44" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash.nr#L42-L44</a></sub></sup>
+
+
+example:
+
+```rust title="pedersen-hash" showLineNumbers 
+use dep::std;
+
+fn main(x: Field, y: Field, expected_hash: Field) {
+    let hash = std::hash::pedersen_hash([x, y]);
+    assert_eq(hash, expected_hash);
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_hash/src/main.nr#L1-L8" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_hash/src/main.nr#L1-L8</a></sub></sup>
+
+
 <BlackBoxInfo />
+
 
 ## pedersen_commitment
 
 Given an array of Fields, returns the Pedersen commitment.
 
-```rust
-fn pedersen_commitment(_input : [Field]) -> [Field; 2]
+```rust title="pedersen_commitment" showLineNumbers 
+struct PedersenPoint {
+   x : Field,
+   y : Field,
+}
+
+pub fn pedersen_commitment<N>(input: [Field; N]) -> PedersenPoint
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash.nr#L22-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash.nr#L22-L29</a></sub></sup>
+
 
 example:
 
-```rust
-fn main() {
-    let x = [163, 117, 178, 149]; // some random bytes
-    let commitment = std::hash::pedersen_commitment(x);
+```rust title="pedersen-commitment" showLineNumbers 
+use dep::std;
+
+fn main(x: Field, y: Field, expected_commitment: std::hash::PedersenPoint) {
+    let commitment = std::hash::pedersen_commitment([x, y]);
+    assert_eq(commitment.x, expected_commitment.x);
+    assert_eq(commitment.y, expected_commitment.y);
 }
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L9" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L9</a></sub></sup>
+
 
 <BlackBoxInfo />
 
@@ -94,19 +136,38 @@ Given an array of bytes (`u8`), returns the resulting keccak hash as an array of
 (`[u8; 32]`). Specify a message_size to hash only the first `message_size` bytes
 of the input.
 
-```rust
-fn keccak256<N>(_input : [u8; N], _message_size: u32) -> [u8; 32]
+```rust title="keccak256" showLineNumbers 
+pub fn keccak256<N>(input: [u8; N], message_size: u32) -> [u8; 32]
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash.nr#L67-L69" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash.nr#L67-L69</a></sub></sup>
+
 
 example:
 
-```rust
-fn main() {
-    let x = [163, 117, 178, 149]; // some random bytes
+```rust title="keccak256" showLineNumbers 
+use dep::std;
+
+fn main(x: Field, result: [u8; 32]) {
+    // We use the `as` keyword here to denote the fact that we want to take just the first byte from the x Field
+    // The padding is taken care of by the program
+    let digest = std::hash::keccak256([x as u8], 1);
+    assert(digest == result);
+
+    //#1399: variable message size
     let message_size = 4;
-    let hash = std::hash::keccak256(x, message_size);
+    let hash_a = std::hash::keccak256([1, 2, 3, 4], message_size);
+    let hash_b = std::hash::keccak256([1, 2, 3, 4, 0, 0, 0, 0], message_size);
+
+    assert(hash_a == hash_b);
+
+    let message_size_big = 8;
+    let hash_c = std::hash::keccak256([1, 2, 3, 4, 0, 0, 0, 0], message_size_big);
+
+    assert(hash_a != hash_c);
 }
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/keccak256/src/main.nr#L1-L22" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/keccak256/src/main.nr#L1-L22</a></sub></sup>
+
 
 <BlackBoxInfo />
 
@@ -122,13 +183,19 @@ fn hash_1(input: [Field; 1]) -> Field
 
 example:
 
-```rust
-fn main()
-{
-  let hash_2 = std::hash::poseidon::bn254::hash_2([1, 2]);
-  assert(hash2 == 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a);
+```rust title="poseidon" showLineNumbers 
+use dep::std::hash::poseidon;
+
+fn main(x1: [Field; 2], y1: pub Field, x2: [Field; 4], y2: pub Field) {
+    let hash1 = poseidon::bn254::hash_2(x1);
+    assert(hash1 == y1);
+
+    let hash2 = poseidon::bn254::hash_4(x2);
+    assert(hash2 == y2);
 }
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/poseidon_bn254_hash/src/main.nr#L1-L11" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/poseidon_bn254_hash/src/main.nr#L1-L11</a></sub></sup>
+
 
 ## mimc_bn254 and mimc
 

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/scalar.mdx
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/scalar.mdx
@@ -12,9 +12,14 @@ import BlackBoxInfo from '@site/src/components/Notes/_blackbox.mdx';
 Performs scalar multiplication over the embedded curve whose coordinates are defined by the
 configured noir field. For the BN254 scalar field, this is BabyJubJub or Grumpkin.
 
-```rust
-fn fixed_base_embedded_curve(_input : Field) -> [Field; 2]
+```rust title="fixed_base_embedded_curve" showLineNumbers 
+pub fn fixed_base_embedded_curve(
+    low: Field,
+    high: Field
+) -> [Field; 2]
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/scalar_mul.nr#L27-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/scalar_mul.nr#L27-L32</a></sub></sup>
+
 
 example
 

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/schnorr.mdx
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/cryptographic_primitives/schnorr.mdx
@@ -11,9 +11,16 @@ import BlackBoxInfo from '@site/src/components/Notes/_blackbox.mdx';
 
 Verifier for Schnorr signatures over the embedded curve (for BN254 it is Grumpkin).
 
-```rust
-fn verify_signature(_public_key_x: Field, _public_key_y: Field, _signature: [u8; 64], _message: [u8]) -> bool
+```rust title="schnorr_verify" showLineNumbers 
+pub fn verify_signature<N>(
+    public_key_x: Field,
+    public_key_y: Field,
+    signature: [u8; 64],
+    message: [u8; N]
+) -> bool
 ```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/schnorr.nr#L2-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/schnorr.nr#L2-L9</a></sub></sup>
+
 
 where `_signature` can be generated like so using the npm package
 [@noir-lang/barretenberg](https://www.npmjs.com/package/@noir-lang/barretenberg)

--- a/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/.nojekyll
+++ b/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/functions/compile.md
+++ b/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/functions/compile.md
@@ -1,0 +1,51 @@
+# compile()
+
+```ts
+compile(
+   fileManager, 
+   projectPath?, 
+   logFn?, 
+debugLogFn?): Promise<CompilationResult>
+```
+
+Compiles a Noir project
+
+## Parameters
+
+| Parameter | Type | Description |
+| :------ | :------ | :------ |
+| `fileManager` | `FileManager` | The file manager to use |
+| `projectPath`? | `string` | The path to the project inside the file manager. Defaults to the root of the file manager |
+| `logFn`? | `LogFn` | A logging function. If not provided, console.log will be used |
+| `debugLogFn`? | `LogFn` | A debug logging function. If not provided, logFn will be used |
+
+## Returns
+
+`Promise`\<[`CompilationResult`](../type-aliases/CompilationResult.md)\>
+
+## Example
+
+```typescript
+// Node.js
+
+import { compile, createFileManager } from '@noir-lang/noir_wasm';
+
+const fm = createFileManager(myProjectPath);
+const myCompiledCode = await compile(fm);
+```
+
+```typescript
+// Browser
+
+import { compile, createFileManager } from '@noir-lang/noir_wasm';
+
+const fm = createFileManager('/');
+for (const path of files) {
+  await fm.writeFile(path, await getFileAsStream(path));
+}
+const myCompiledCode = await compile(fm);
+```
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/functions/createFileManager.md
+++ b/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/functions/createFileManager.md
@@ -1,0 +1,21 @@
+# createFileManager()
+
+```ts
+createFileManager(dataDir): FileManager
+```
+
+Creates a new FileManager instance based on fs in node and memfs in the browser (via webpack alias)
+
+## Parameters
+
+| Parameter | Type | Description |
+| :------ | :------ | :------ |
+| `dataDir` | `string` | root of the file system |
+
+## Returns
+
+`FileManager`
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/functions/inflateDebugSymbols.md
+++ b/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/functions/inflateDebugSymbols.md
@@ -1,0 +1,21 @@
+# inflateDebugSymbols()
+
+```ts
+inflateDebugSymbols(debugSymbols): any
+```
+
+Decompresses and decodes the debug symbols
+
+## Parameters
+
+| Parameter | Type | Description |
+| :------ | :------ | :------ |
+| `debugSymbols` | `string` | The base64 encoded debug symbols |
+
+## Returns
+
+`any`
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/index.md
+++ b/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/index.md
@@ -1,0 +1,21 @@
+# noir_wasm
+
+## Exports
+
+### Type Aliases
+
+| Type alias | Description |
+| :------ | :------ |
+| [CompilationResult](type-aliases/CompilationResult.md) | output of Noir Wasm compilation, can be for a contract or lib/binary |
+
+### Functions
+
+| Function | Description |
+| :------ | :------ |
+| [compile](functions/compile.md) | Compiles a Noir project |
+| [createFileManager](functions/createFileManager.md) | Creates a new FileManager instance based on fs in node and memfs in the browser (via webpack alias) |
+| [inflateDebugSymbols](functions/inflateDebugSymbols.md) | Decompresses and decodes the debug symbols |
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/type-aliases/CompilationResult.md
+++ b/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/type-aliases/CompilationResult.md
@@ -1,0 +1,11 @@
+# CompilationResult
+
+```ts
+type CompilationResult: ContractCompilationArtifacts | ProgramCompilationArtifacts;
+```
+
+output of Noir Wasm compilation, can be for a contract or lib/binary
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/typedoc-sidebar.cjs
+++ b/docs/versioned_docs/version-v0.23.0/reference/NoirJS/noir_wasm/typedoc-sidebar.cjs
@@ -1,0 +1,4 @@
+// @ts-check
+/** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
+const typedocSidebar = { items: [{"type":"doc","id":"reference/NoirJS/noir_wasm/index","label":"API"},{"type":"category","label":"Type Aliases","items":[{"type":"doc","id":"reference/NoirJS/noir_wasm/type-aliases/CompilationResult","label":"CompilationResult"}]},{"type":"category","label":"Functions","items":[{"type":"doc","id":"reference/NoirJS/noir_wasm/functions/compile","label":"compile"},{"type":"doc","id":"reference/NoirJS/noir_wasm/functions/createFileManager","label":"createFileManager"},{"type":"doc","id":"reference/NoirJS/noir_wasm/functions/inflateDebugSymbols","label":"inflateDebugSymbols"}]}]};
+module.exports = typedocSidebar.items;

--- a/docs/versioned_docs/version-v0.23.0/tutorials/noirjs_app.md
+++ b/docs/versioned_docs/version-v0.23.0/tutorials/noirjs_app.md
@@ -101,7 +101,7 @@ At this point in the tutorial, your folder structure should look like this:
 
 `npx create vite` is amazing but it creates a bunch of files we don't really need for our simple example. Actually, let's just delete everything except for `index.html`, `main.js` and `package.json`. I feel lighter already.
 
-![my heart is ready for you, noir.js](../../static/img/memes/titanic.jpeg)
+![my heart is ready for you, noir.js](@site/static/img/memes/titanic.jpeg)
 
 ## HTML
 
@@ -270,7 +270,7 @@ if (verification) display('logs', 'Verifying proof... ✅');
 
 You have successfully generated a client-side Noir web app!
 
-![coded app without math knowledge](../../static/img/memes/flextape.jpeg)
+![coded app without math knowledge](@site/static/img/memes/flextape.jpeg)
 
 ## Further Reading
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4200.

## Summary\*

Copy updates introduced by the PRs listed in the Issue linked into the versioned v0.23.0 doc folder.

Majority of the changes in this PR are merely direct copy-paste of updates from the individual PRs. Exception being minor path fixes.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
