### PR TITLE
chore: fix unreachable code warning during docs build

### DIFF
--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -122,9 +122,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
             NargoCommand::Verify(args) => verify_cmd::run(&backend, args, config),
             NargoCommand::Test(args) => test_cmd::run(&backend, args, config),
             NargoCommand::Info(args) => info_cmd::run(&backend, args, config),
-            NargoCommand::CodegenVerifier(args) => {
-                codegen_verifier_cmd::run(&backend, args, config)
-            }
+            NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(&backend, args, config),
             NargoCommand::Backend(args) => backend_cmd::run(args),
             NargoCommand::Lsp(args) => lsp_cmd::run(&backend, args, config),
             NargoCommand::Dap(args) => dap_cmd::run(&backend, args, config),

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -85,8 +85,8 @@ enum NargoCommand {
 pub(crate) fn start_cli() -> eyre::Result<()> {
     #[cfg(feature = "codegen-docs")]
     return codegen_docs();
-    
-    #[allow(unreachable_code)]    
+
+    #[allow(unreachable_code)]
     {
         let NargoCli { command, mut config } = NargoCli::parse();
 
@@ -122,7 +122,9 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
             NargoCommand::Verify(args) => verify_cmd::run(&backend, args, config),
             NargoCommand::Test(args) => test_cmd::run(&backend, args, config),
             NargoCommand::Info(args) => info_cmd::run(&backend, args, config),
-            NargoCommand::CodegenVerifier(args) => codegen_verifier_cmd::run(&backend, args, config),
+            NargoCommand::CodegenVerifier(args) => {
+                codegen_verifier_cmd::run(&backend, args, config)
+            }
             NargoCommand::Backend(args) => backend_cmd::run(args),
             NargoCommand::Lsp(args) => lsp_cmd::run(&backend, args, config),
             NargoCommand::Dap(args) => dap_cmd::run(&backend, args, config),
@@ -130,7 +132,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         }?;
 
         Ok(())
-   }
+    }
 }
 
 #[cfg(feature = "codegen-docs")]


### PR DESCRIPTION

**Summary:**

This pull request addresses the warning for unreachable code generated during the build process of documentation with `yarn build`:
```
   Compiling nargo_cli v0.23.0 (/home/paulallensuxs/noir/tooling/nargo_cli)
warning: unreachable statement
  --> tooling/nargo_cli/src/cli/mod.rs:91:9
   |
87 |     return codegen_docs();
   |     --------------------- any code following this expression is unreachable
...
91 |         let NargoCli { command, mut config } = NargoCli::parse();
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
   |
   = note: `#[warn(unreachable_code)]` on by default
```


**Key Changes:**
- Added `#[allow(unreachable_code)]` attribute to suppress the warning in a controlled manner.
- Applied code formatting with `rustfmt`.

These changes remove the previously reported compiler warning about unreachable statements in `tooling/nargo_cli/src/cli/mod.rs`, specifically after the `return codegen_docs();` line in the conditional compilation block.
