### PR TITLE
feat(ci): Use wasm-opt when compiling wasm packages

### DIFF
--- a/.github/scripts/wasm-opt-install.sh
+++ b/.github/scripts/wasm-opt-install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+
+cd $(dirname "$0")
+
+./cargo-binstall-install.sh
+
+cargo-binstall wasm-opt --version 0.116.0 -y

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
 
+      - name: Install wasm-opt
+        run: ./.github/scripts/wasm-opt-install.sh
+
       - name: Build noirc_abi
         run: ./.github/scripts/noirc-abi-build.sh
 
@@ -60,6 +63,9 @@ jobs:
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
+
+      - name: Install wasm-opt
+        run: ./.github/scripts/wasm-opt-install.sh
 
       - name: Build noir_js_types
         run: yarn workspace @noir-lang/types build
@@ -92,6 +98,9 @@ jobs:
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
+
+      - name: Install wasm-opt
+        run: ./.github/scripts/wasm-opt-install.sh
 
       - name: Build acvm_js
         run: ./.github/scripts/acvm_js-build.sh

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
 
+      - name: Install wasm-opt
+        run: ./.github/scripts/wasm-opt-install.sh
+
       - name: Build noirc_abi
         run: ./.github/scripts/noirc-abi-build.sh
 
@@ -96,6 +99,9 @@ jobs:
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
+
+      - name: Install wasm-opt
+        run: ./.github/scripts/wasm-opt-install.sh
 
       - name: Build noir_js_types
         run: yarn workspace @noir-lang/types build
@@ -131,6 +137,9 @@ jobs:
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
+
+      - name: Install wasm-opt
+        run: ./.github/scripts/wasm-opt-install.sh
 
       - name: Build acvm_js
         run: ./.github/scripts/acvm_js-build.sh


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently building unoptimised wasm binaries in CI as wasm-opt isn't installed. This PR installs wasm-opt to perform these optimisations.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
