### PR TITLE
chore: resolve unreachable code warning when building docs

### DIFF
--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -82,10 +82,8 @@ enum NargoCommand {
     Dap(dap_cmd::DapCommand),
 }
 
+#[cfg(not(feature = "codegen-docs"))]
 pub(crate) fn start_cli() -> eyre::Result<()> {
-    #[cfg(feature = "codegen-docs")]
-    return codegen_docs();
-
     let NargoCli { command, mut config } = NargoCli::parse();
 
     // If the provided `program_dir` is relative, make it absolute by joining it to the current directory.
@@ -131,7 +129,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
 }
 
 #[cfg(feature = "codegen-docs")]
-fn codegen_docs() -> eyre::Result<()> {
+pub(crate) fn start_cli() -> eyre::Result<()> {
     let markdown: String = clap_markdown::help_markdown::<NargoCli>();
     println!("{markdown}");
     Ok(())


### PR DESCRIPTION
# Description

## Problem\*

Supercedes #4325 

## Summary\*

This PR resolves the warning produced when building the version of nargo use to codegen reference docs.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
