### PR TITLE
chore(docs): Add manual trigger for publishing docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths: [docs/**]
+  workflow_dispatch:
 
 jobs:
   publish-docs:


### PR DESCRIPTION
# Description

## Problem\*

Our docs are currently published when and only when there is a doc change merged to master.

We at times might need more flexibility for publishing docs though (e.g. when a release is flipped stable).

## Summary\*

This PR adds a manual trigger for publishing docs.

## Additional Context

We attempted automated triggers by release status change (e.g. when a release is flipped from pre-release to stable) some while ago, but that approach would only build and publish docs from the release commit instead of from master (that contains post-release doc patches).

We used to have a manual trigger, which was removed in https://github.com/noir-lang/noir/pull/3877.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

YOLO