### PR TITLE
chore: remove unnecessary dev dependency from `noir_wasm`

### DIFF
--- a/compiler/wasm/package.json
+++ b/compiler/wasm/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@ltd/j-toml": "^1.38.0",
-    "@noir-lang/noirc_abi": "workspace:*",
     "@types/adm-zip": "^0.5.0",
     "@types/chai": "^4",
     "@types/mocha": "^10.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4448,7 +4448,6 @@ __metadata:
   dependencies:
     "@esm-bundle/chai": ^4.3.4-fix.0
     "@ltd/j-toml": ^1.38.0
-    "@noir-lang/noirc_abi": "workspace:*"
     "@noir-lang/types": "workspace:*"
     "@types/adm-zip": ^0.5.0
     "@types/chai": ^4


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

`noir_wasm` doesn't use `noirc_abi` so we can remove this dependency.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
