### PR TITLE
chore(ci): bump node to 18.19.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: actions/setup-node@v4
       id: node
       with:
-        node-version: 18.17.1
+        node-version: 18.19.0
         cache: 'yarn'
         cache-dependency-path: 'yarn.lock'
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.1
+          node-version: 18.19.0
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
       


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Bumps the node version used in CI to the latest v18 version.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
