### PR TITLE
chore(ci): force the install of wasm-pack when building noir_wasm

### DIFF
--- a/compiler/wasm/scripts/install_wasm-pack.sh
+++ b/compiler/wasm/scripts/install_wasm-pack.sh
@@ -9,4 +9,4 @@ if [ $CARGO_BINSTALL_CHECK != "true" ]; then
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
-cargo-binstall wasm-pack@0.12.1 -y
+cargo-binstall wasm-pack@0.12.1 -y --force


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
