### PR TITLE
chore: add `memfs` to cspell

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -106,6 +106,7 @@
         "lvalue",
         "Maddiaa",
         "mathbb",
+        "memfs",
         "merkle",
         "metas",
         "minreq",


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This fixes an issue where some codegened docs has an unrecognised word in it.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
