### PR TITLE
chore: fix JS package publishing

### DIFF
--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: acvm_js
+          name: acvm-js
           path: acvm-repo/acvm_js
       
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Publishing of Noir packages is currently failing due to a `_` being used in place of a `-`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
