### PR TITLE
fix(ec): Add check for EC operations that argument is indeed on the curve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ examples/**/target/
 examples/9
 node_modules
 pkg/
+.gitpod.yml
 
 # Yarn
 .pnp.*

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -109,17 +109,21 @@ mod affine {
 
         // Point addition
         pub fn add(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.into_tecurve().add(p1.into_tecurve(), p2.into_tecurve()).into_montcurve()
         }
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
         fn bit_mul<N>(self, bits: [u1; N], p: Point) -> Point {
+            assert(self.contains(p));
             self.into_tecurve().bit_mul(bits, p.into_tecurve()).into_montcurve()
         }
 
         // Scalar multiplication (p + ... + p n times)
         fn mul(self, n: Field, p: Point) -> Point {
+            assert(self.contains(p));
             self.into_tecurve().mul(n, p.into_tecurve()).into_montcurve()
         }
         
@@ -128,6 +132,8 @@ mod affine {
             let mut out = Point::zero();
 
             for i in 0..N {
+                assert(self.contains(p[i]));
+
                 out = self.add(out, self.mul(n[i], p[i]));
             }
 
@@ -136,6 +142,8 @@ mod affine {
 
         // Point subtraction
         fn subtract(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.add(p1, p2.negate())
         }
 
@@ -157,11 +165,14 @@ mod affine {
 
         // Point mapping into equivalent Short Weierstraß curve
         pub fn map_into_swcurve(self, p: Point) -> SWPoint {
+            assert(self.contains(p));
             if p.is_zero() {
                 SWPoint::zero()
             } else {
-                SWPoint::new((3*p.x + self.j)/(3*self.k),
-                             p.y/self.k)
+                SWPoint::new(
+                    (3*p.x + self.j)/(3*self.k),
+                    p.y/self.k
+                )
             }
         }
 
@@ -171,7 +182,9 @@ mod affine {
             let j = self.j;
             let k = self.k;
             
-            Point {x: (3*k*x - j)/3, y: y*k, infty}
+            let result = Point {x: (3*k*x - j)/3, y: y*k, infty}
+            assert(self.contains(result));
+            result
         }
 
         // Elligator 2 map-to-curve method; see <https://datatracker.ietf.org/doc/id/draft-irtf-cfrg-hash-to-curve-06.html#name-elligator-2-method>.
@@ -312,17 +325,21 @@ mod curvegroup {
 
         // Point addition
         pub fn add(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.into_affine().add(p1.into_affine(), p2.into_affine()).into_group()
         }
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
         fn bit_mul<N>(self, bits: [u1; N], p: Point) -> Point {
+            assert(self.contains(p));
             self.into_tecurve().bit_mul(bits, p.into_tecurve()).into_montcurve()
         }
         
         // Scalar multiplication (p + ... + p n times)
         pub fn mul(self, n: Field, p: Point) -> Point {
+            assert(self.contains(p));
             self.into_tecurve().mul(n, p.into_tecurve()).into_montcurve()
         }
         
@@ -331,6 +348,8 @@ mod curvegroup {
             let mut out = Point::zero();
 
             for i in 0..N {
+                assert(self.contains(p));
+
                 out = self.add(out, self.mul(n[i], p[i]));
             }
 
@@ -339,6 +358,8 @@ mod curvegroup {
 
         // Point subtraction
         pub fn subtract(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.add(p1, p2.negate())
         }
 

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -97,11 +97,15 @@ mod affine {
         
         // Point addition, implemented in terms of mixed addition for reasons of efficiency
         pub fn add(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.mixed_add(p1, p2.into_group()).into_affine()
         }
 
         // Mixed point addition, i.e. first argument in affine, second in CurveGroup coordinates.
         fn mixed_add(self, p1: Point, p2: curvegroup::Point) -> curvegroup::Point {
+            assert(self.contains(p1));
+            assert(self.into_group().contains(p2));
             if p1.is_zero() {
                 p2
             } else if p2.is_zero() {
@@ -136,11 +140,13 @@ mod affine {
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
         fn bit_mul<N>(self, bits: [u1; N], p: Point) -> Point {
+            assert(self.contains(p));
             self.into_group().bit_mul(bits, p.into_group()).into_affine()
         }
         
         // Scalar multiplication (p + ... + p n times)
         pub fn mul(self, n: Field, p: Point) -> Point {
+            assert(self.contains(p));
             self.into_group().mul(n, p.into_group()).into_affine()
         }
 
@@ -149,6 +155,8 @@ mod affine {
             let mut out = Point::zero();
 
             for i in 0..N {
+                assert(self.contains(p[i]));
+
                 out = self.add(out, self.mul(n[i], p[i]));
             }
 
@@ -157,6 +165,8 @@ mod affine {
 
         // Point subtraction
         pub fn subtract(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.add(p1, p2.negate())
         }
 
@@ -279,6 +289,8 @@ mod curvegroup {
         
         // Addition
         pub fn add(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
 
             if p1.is_zero() {
                 p2
@@ -312,6 +324,7 @@ mod curvegroup {
 
         // Point doubling
         pub fn double(self, p: Point) -> Point {
+            assert(self.contains(p));
             let Point {x, y, z} = p;
             
             if p.is_zero() {
@@ -332,6 +345,7 @@ mod curvegroup {
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
         fn bit_mul<N>(self, bits: [u1; N], p: Point) -> Point {
+            assert(self.contains(p));
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -345,6 +359,7 @@ mod curvegroup {
 
         // Scalar multiplication (p + ... + p n times)
         pub fn mul(self, n: Field, p: Point) -> Point {
+            assert(self.contains(p));
             let N_BITS = crate::field::modulus_num_bits();
 
             // TODO: temporary workaround until issue 1354 is solved
@@ -362,6 +377,8 @@ mod curvegroup {
             let mut out = Point::zero();
 
             for i in 0..N {
+                assert(self.contains(p[i]));
+
                 out = self.add(out, self.mul(n[i], p[i]));
             }
 

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -106,11 +106,15 @@ mod affine {
         
         // Point addition, implemented in terms of mixed addition for reasons of efficiency
         pub fn add(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.mixed_add(p1, p2.into_group()).into_affine()
         }
 
         // Mixed point addition, i.e. first argument in affine, second in CurveGroup coordinates.
         fn mixed_add(self, p1: Point, p2: curvegroup::Point) -> curvegroup::Point {
+            assert(self.contains(p1));
+            assert(self.into_group().contains(p2));
             let Point{x: x1, y: y1} = p1;
             let curvegroup::Point{x: x2, y: y2, t: t2, z: z2} = p2;
 
@@ -133,11 +137,13 @@ mod affine {
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
         fn bit_mul<N>(self, bits: [u1; N], p: Point) -> Point {
+            assert(self.contains(p));
             self.into_group().bit_mul(bits, p.into_group()).into_affine()
         }
         
         // Scalar multiplication (p + ... + p n times)
         fn mul(self, n: Field, p: Point) -> Point {
+            assert(self.contains(1));
             self.into_group().mul(n, p.into_group()).into_affine()
         }
 
@@ -146,6 +152,8 @@ mod affine {
             let mut out = Point::zero();
 
             for i in 0..N {
+                assert(self.contains(p[i]));
+                
                 out = self.add(out, self.mul(n[i], p[i]));
             }
 
@@ -154,6 +162,8 @@ mod affine {
 
         // Point subtraction
         fn subtract(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.add(p1, p2.negate())
         }
 
@@ -173,12 +183,15 @@ mod affine {
 
         // Point mapping into equivalent Short Weierstraß curve
         pub fn map_into_swcurve(self, p: Point) -> SWPoint {
+            assert(self.contains(p));
             self.into_montcurve().map_into_swcurve(p.into_montcurve())
         }
 
         // Point mapping from equivalent Short Weierstraß curve
         fn map_from_swcurve(self, p: SWPoint) -> Point {
-            self.into_montcurve().map_from_swcurve(p).into_tecurve()
+            let result = self.into_montcurve().map_from_swcurve(p).into_tecurve()
+            assert(self.contains(result));
+            result
         }
 
         // Elligator 2 map-to-curve method (via rational map)
@@ -295,6 +308,8 @@ mod curvegroup {
 
         // Point addition
         pub fn add(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             let Point{x: x1, y: y1, t: t1, z: z1} = p1;
             let Point{x: x2, y: y2, t: t2, z: z2} = p2;
 
@@ -317,6 +332,7 @@ mod curvegroup {
 
         // Point doubling, cf. §3.3
         pub fn double(self, p: Point) -> Point {
+            assert(self.contains(p));
             let Point{x, y, t: _t, z} = p;
 
             let a = x*x;
@@ -339,6 +355,7 @@ mod curvegroup {
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
         fn bit_mul<N>(self, bits: [u1; N], p: Point) -> Point {
+            assert(self.contains(p));
             let mut out = Point::zero();
             
             for i in 0..N {
@@ -352,6 +369,7 @@ mod curvegroup {
         
         // Scalar multiplication (p + ... + p n times)
         pub fn mul(self, n: Field, p: Point) -> Point {
+            assert(self.contains(p));
             let N_BITS = crate::field::modulus_num_bits();
 
             // TODO: temporary workaround until issue 1354 is solved
@@ -369,6 +387,8 @@ mod curvegroup {
             let mut out = Point::zero();
 
             for i in 0..N {
+                assert(self.contains(p[i]));
+
                 out = self.add(out, self.mul(n[i], p[i]));
             }
 
@@ -377,6 +397,8 @@ mod curvegroup {
 
         // Point subtraction
         fn subtract(self, p1: Point, p2: Point) -> Point {
+            assert(self.contains(p1));
+            assert(self.contains(p2));
             self.add(p1, p2.negate())
         }
 
@@ -392,12 +414,15 @@ mod curvegroup {
 
         // Point mapping into equivalent short Weierstraß curve
         pub fn map_into_swcurve(self, p: Point) -> SWPoint {
+            assert(self.contains(p));
             self.into_montcurve().map_into_swcurve(p.into_montcurve())
         }
 
         // Point mapping from equivalent short Weierstraß curve
         fn map_from_swcurve(self, p: SWPoint) -> Point {
-            self.into_montcurve().map_from_swcurve(p).into_tecurve()
+            let result = self.into_montcurve().map_from_swcurve(p).into_tecurve()
+            assert(self.contains(result));
+            result
         }
 
         // Elligator 2 map-to-curve method (via rational maps)


### PR DESCRIPTION
# Description

## Problem\*

`std` user isn't expected to sanitize every input to `ec`, so these constraints should be added by the lib.

## Summary\*

Add check for EC operations that argument is indeed on the curve

## Additional Context

none

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
