### PR TITLE
fix: Consistent bit size for truncate

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
@@ -61,7 +61,7 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 let mut message_vector = convert_array_or_vector(brillig_context, message, bb_func);
-                message_vector.size = *array_size;
+                message_vector.size = array_size.address;
 
                 brillig_context.black_box_op_instruction(BlackBoxOp::Keccak256 {
                     message: message_vector.to_heap_vector(),
@@ -98,7 +98,7 @@ pub(crate) fn convert_black_box_call(
                     public_key_x: public_key_x.to_heap_array(),
                     public_key_y: public_key_y.to_heap_array(),
                     signature: signature.to_heap_array(),
-                    result: *result_register,
+                    result: result_register.address,
                 });
             } else {
                 unreachable!(
@@ -119,7 +119,7 @@ pub(crate) fn convert_black_box_call(
                     public_key_x: public_key_x.to_heap_array(),
                     public_key_y: public_key_y.to_heap_array(),
                     signature: signature.to_heap_array(),
-                    result: *result_register,
+                    result: result_register.address,
                 });
             } else {
                 unreachable!(
@@ -137,7 +137,7 @@ pub(crate) fn convert_black_box_call(
                 let message_vector = convert_array_or_vector(brillig_context, message, bb_func);
                 brillig_context.black_box_op_instruction(BlackBoxOp::PedersenCommitment {
                     inputs: message_vector.to_heap_vector(),
-                    domain_separator: *domain_separator,
+                    domain_separator: domain_separator.address,
                     output: result_array.to_heap_array(),
                 });
             } else {
@@ -153,8 +153,8 @@ pub(crate) fn convert_black_box_call(
                 let message_vector = convert_array_or_vector(brillig_context, message, bb_func);
                 brillig_context.black_box_op_instruction(BlackBoxOp::PedersenHash {
                     inputs: message_vector.to_heap_vector(),
-                    domain_separator: *domain_separator,
-                    output: *result,
+                    domain_separator: domain_separator.address,
+                    output: result.address,
                 });
             } else {
                 unreachable!("ICE: Pedersen hash expects one array argument, a register for the domain separator, and one register result")
@@ -169,11 +169,11 @@ pub(crate) fn convert_black_box_call(
                 let message_hash = convert_array_or_vector(brillig_context, message, bb_func);
                 let signature = brillig_context.array_to_vector(signature);
                 brillig_context.black_box_op_instruction(BlackBoxOp::SchnorrVerify {
-                    public_key_x: *public_key_x,
-                    public_key_y: *public_key_y,
+                    public_key_x: public_key_x.address,
+                    public_key_y: public_key_y.address,
                     message: message_hash.to_heap_vector(),
                     signature: signature.to_heap_vector(),
-                    result: *result_register,
+                    result: result_register.address,
                 });
             } else {
                 unreachable!("ICE: Schnorr verify expects two registers for the public key, an array for signature, an array for the message hash and one result register")
@@ -186,8 +186,8 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::FixedBaseScalarMul {
-                    low: *low,
-                    high: *high,
+                    low: low.address,
+                    high: high.address,
                     result: result_array.to_heap_array(),
                 });
             } else {
@@ -203,10 +203,10 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::EmbeddedCurveAdd {
-                    input1_x: *input1_x,
-                    input1_y: *input1_y,
-                    input2_x: *input2_x,
-                    input2_y: *input2_y,
+                    input1_x: input1_x.address,
+                    input1_y: input1_y.address,
+                    input2_x: input2_x.address,
+                    input2_y: input2_y.address,
                     result: result_array.to_heap_array(),
                 });
             } else {
@@ -234,9 +234,9 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntAdd {
-                    lhs: *lhs,
-                    rhs: *rhs,
-                    output: *output,
+                    lhs: lhs.address,
+                    rhs: rhs.address,
+                    output: output.address,
                 });
             } else {
                 unreachable!(
@@ -251,9 +251,9 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntSub {
-                    lhs: *lhs,
-                    rhs: *rhs,
-                    output: *output,
+                    lhs: lhs.address,
+                    rhs: rhs.address,
+                    output: output.address,
                 });
             } else {
                 unreachable!(
@@ -268,9 +268,9 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntMul {
-                    lhs: *lhs,
-                    rhs: *rhs,
-                    output: *output,
+                    lhs: lhs.address,
+                    rhs: rhs.address,
+                    output: output.address,
                 });
             } else {
                 unreachable!(
@@ -285,9 +285,9 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntDiv {
-                    lhs: *lhs,
-                    rhs: *rhs,
-                    output: *output,
+                    lhs: lhs.address,
+                    rhs: rhs.address,
+                    output: output.address,
                 });
             } else {
                 unreachable!(
@@ -304,7 +304,7 @@ pub(crate) fn convert_black_box_call(
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntFromLeBytes {
                     inputs: inputs_vector.to_heap_vector(),
                     modulus: modulus_vector.to_heap_vector(),
-                    output: *output,
+                    output: output.address,
                 });
             } else {
                 unreachable!(
@@ -319,7 +319,7 @@ pub(crate) fn convert_black_box_call(
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntToLeBytes {
-                    input: *input,
+                    input: input.address,
                     output: result_vector.to_heap_vector(),
                 });
             } else {
@@ -338,7 +338,7 @@ pub(crate) fn convert_black_box_call(
                 brillig_context.black_box_op_instruction(BlackBoxOp::Poseidon2Permutation {
                     message: message_vector.to_heap_vector(),
                     output: result_array.to_heap_array(),
-                    len: *state_len,
+                    len: state_len.address,
                 });
             } else {
                 unreachable!("ICE: Poseidon2Permutation expects one array argument, a length and one array result")

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
@@ -56,7 +56,7 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::Keccak256 => {
             if let (
-                [message, BrilligVariable::Simple(array_size)],
+                [message, BrilligVariable::SingleAddr(array_size)],
                 [BrilligVariable::BrilligArray(result_array)],
             ) = (function_arguments, function_results)
             {
@@ -88,7 +88,7 @@ pub(crate) fn convert_black_box_call(
         BlackBoxFunc::EcdsaSecp256k1 => {
             if let (
                 [BrilligVariable::BrilligArray(public_key_x), BrilligVariable::BrilligArray(public_key_y), BrilligVariable::BrilligArray(signature), message],
-                [BrilligVariable::Simple(result_register)],
+                [BrilligVariable::SingleAddr(result_register)],
             ) = (function_arguments, function_results)
             {
                 let message_hash_vector =
@@ -109,7 +109,7 @@ pub(crate) fn convert_black_box_call(
         BlackBoxFunc::EcdsaSecp256r1 => {
             if let (
                 [BrilligVariable::BrilligArray(public_key_x), BrilligVariable::BrilligArray(public_key_y), BrilligVariable::BrilligArray(signature), message],
-                [BrilligVariable::Simple(result_register)],
+                [BrilligVariable::SingleAddr(result_register)],
             ) = (function_arguments, function_results)
             {
                 let message_hash_vector =
@@ -130,7 +130,7 @@ pub(crate) fn convert_black_box_call(
 
         BlackBoxFunc::PedersenCommitment => {
             if let (
-                [message, BrilligVariable::Simple(domain_separator)],
+                [message, BrilligVariable::SingleAddr(domain_separator)],
                 [BrilligVariable::BrilligArray(result_array)],
             ) = (function_arguments, function_results)
             {
@@ -146,8 +146,8 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::PedersenHash => {
             if let (
-                [message, BrilligVariable::Simple(domain_separator)],
-                [BrilligVariable::Simple(result)],
+                [message, BrilligVariable::SingleAddr(domain_separator)],
+                [BrilligVariable::SingleAddr(result)],
             ) = (function_arguments, function_results)
             {
                 let message_vector = convert_array_or_vector(brillig_context, message, bb_func);
@@ -162,8 +162,8 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::SchnorrVerify => {
             if let (
-                [BrilligVariable::Simple(public_key_x), BrilligVariable::Simple(public_key_y), BrilligVariable::BrilligArray(signature), message],
-                [BrilligVariable::Simple(result_register)],
+                [BrilligVariable::SingleAddr(public_key_x), BrilligVariable::SingleAddr(public_key_y), BrilligVariable::BrilligArray(signature), message],
+                [BrilligVariable::SingleAddr(result_register)],
             ) = (function_arguments, function_results)
             {
                 let message_hash = convert_array_or_vector(brillig_context, message, bb_func);
@@ -181,7 +181,7 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::FixedBaseScalarMul => {
             if let (
-                [BrilligVariable::Simple(low), BrilligVariable::Simple(high)],
+                [BrilligVariable::SingleAddr(low), BrilligVariable::SingleAddr(high)],
                 [BrilligVariable::BrilligArray(result_array)],
             ) = (function_arguments, function_results)
             {
@@ -198,7 +198,7 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::EmbeddedCurveAdd => {
             if let (
-                [BrilligVariable::Simple(input1_x), BrilligVariable::Simple(input1_y), BrilligVariable::Simple(input2_x), BrilligVariable::Simple(input2_y)],
+                [BrilligVariable::SingleAddr(input1_x), BrilligVariable::SingleAddr(input1_y), BrilligVariable::SingleAddr(input2_x), BrilligVariable::SingleAddr(input2_y)],
                 [BrilligVariable::BrilligArray(result_array)],
             ) = (function_arguments, function_results)
             {
@@ -229,8 +229,8 @@ pub(crate) fn convert_black_box_call(
         ),
         BlackBoxFunc::BigIntAdd => {
             if let (
-                [BrilligVariable::Simple(lhs), BrilligVariable::Simple(rhs)],
-                [BrilligVariable::Simple(output)],
+                [BrilligVariable::SingleAddr(lhs), BrilligVariable::SingleAddr(rhs)],
+                [BrilligVariable::SingleAddr(output)],
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntAdd {
@@ -246,8 +246,8 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::BigIntSub => {
             if let (
-                [BrilligVariable::Simple(lhs), BrilligVariable::Simple(rhs)],
-                [BrilligVariable::Simple(output)],
+                [BrilligVariable::SingleAddr(lhs), BrilligVariable::SingleAddr(rhs)],
+                [BrilligVariable::SingleAddr(output)],
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntSub {
@@ -263,8 +263,8 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::BigIntMul => {
             if let (
-                [BrilligVariable::Simple(lhs), BrilligVariable::Simple(rhs)],
-                [BrilligVariable::Simple(output)],
+                [BrilligVariable::SingleAddr(lhs), BrilligVariable::SingleAddr(rhs)],
+                [BrilligVariable::SingleAddr(output)],
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntMul {
@@ -280,8 +280,8 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::BigIntDiv => {
             if let (
-                [BrilligVariable::Simple(lhs), BrilligVariable::Simple(rhs)],
-                [BrilligVariable::Simple(output)],
+                [BrilligVariable::SingleAddr(lhs), BrilligVariable::SingleAddr(rhs)],
+                [BrilligVariable::SingleAddr(output)],
             ) = (function_arguments, function_results)
             {
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntDiv {
@@ -296,7 +296,7 @@ pub(crate) fn convert_black_box_call(
             }
         }
         BlackBoxFunc::BigIntFromLeBytes => {
-            if let ([inputs, modulus], [BrilligVariable::Simple(output)]) =
+            if let ([inputs, modulus], [BrilligVariable::SingleAddr(output)]) =
                 (function_arguments, function_results)
             {
                 let inputs_vector = convert_array_or_vector(brillig_context, inputs, bb_func);
@@ -314,7 +314,7 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::BigIntToLeBytes => {
             if let (
-                [BrilligVariable::Simple(input)],
+                [BrilligVariable::SingleAddr(input)],
                 [BrilligVariable::BrilligVector(result_vector)],
             ) = (function_arguments, function_results)
             {
@@ -330,7 +330,7 @@ pub(crate) fn convert_black_box_call(
         }
         BlackBoxFunc::Poseidon2Permutation => {
             if let (
-                [message, BrilligVariable::Simple(state_len)],
+                [message, BrilligVariable::SingleAddr(state_len)],
                 [BrilligVariable::BrilligArray(result_array)],
             ) = (function_arguments, function_results)
             {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -1,5 +1,5 @@
 use crate::brillig::brillig_ir::brillig_variable::{
-    type_to_heap_value_type, BrilligArray, BrilligVariable, BrilligVector,
+    type_to_heap_value_type, BrilligArray, BrilligVariable, BrilligVector, SimpleVariable,
 };
 use crate::brillig::brillig_ir::{
     BrilligBinaryOp, BrilligContext, BRILLIG_INTEGER_ARITHMETIC_BIT_SIZE,
@@ -117,9 +117,9 @@ impl<'block> BrilligBlock<'block> {
     ) {
         match terminator_instruction {
             TerminatorInstruction::JmpIf { condition, then_destination, else_destination } => {
-                let condition = self.convert_ssa_register_value(*condition, dfg);
+                let condition = self.convert_ssa_simple_value(*condition, dfg);
                 self.brillig_context.jump_if_instruction(
-                    condition,
+                    condition.address,
                     self.create_block_label_for_current_function(*then_destination),
                 );
                 self.brillig_context.jump_instruction(
@@ -163,11 +163,8 @@ impl<'block> BrilligBlock<'block> {
     /// Passes an arbitrary variable from the registers of the source to the registers of the destination
     fn pass_variable(&mut self, source: BrilligVariable, destination: BrilligVariable) {
         match (source, destination) {
-            (
-                BrilligVariable::Simple(source_register),
-                BrilligVariable::Simple(destination_register),
-            ) => {
-                self.brillig_context.mov_instruction(destination_register, source_register);
+            (BrilligVariable::Simple(source_var), BrilligVariable::Simple(destination_var)) => {
+                self.brillig_context.mov_instruction(destination_var.address, source_var.address);
             }
             (
                 BrilligVariable::BrilligArray(BrilligArray {
@@ -241,16 +238,19 @@ impl<'block> BrilligBlock<'block> {
 
         match instruction {
             Instruction::Binary(binary) => {
-                let result_register = self.variables.define_register_variable(
+                let result_var = self.variables.define_simple_variable(
                     self.function_context,
                     self.brillig_context,
                     dfg.instruction_results(instruction_id)[0],
                     dfg,
                 );
-                self.convert_ssa_binary(binary, dfg, result_register);
+                self.convert_ssa_binary(binary, dfg, result_var);
             }
             Instruction::Constrain(lhs, rhs, assert_message) => {
-                let condition = self.brillig_context.allocate_register();
+                let condition = SimpleVariable {
+                    address: self.brillig_context.allocate_register(),
+                    bit_size: 1,
+                };
 
                 self.convert_ssa_binary(
                     &Binary { lhs: *lhs, rhs: *rhs, operator: BinaryOp::Eq },
@@ -281,12 +281,12 @@ impl<'block> BrilligBlock<'block> {
                     None
                 };
 
-                self.brillig_context.constrain_instruction(condition, assert_message);
-                self.brillig_context.deallocate_register(condition);
+                self.brillig_context.constrain_instruction(condition.address, assert_message);
+                self.brillig_context.deallocate_register(condition.address);
             }
             Instruction::Allocate => {
                 let result_value = dfg.instruction_results(instruction_id)[0];
-                let address_register = self.variables.define_register_variable(
+                let address_register = self.variables.define_simple_variable(
                     self.function_context,
                     self.brillig_context,
                     result_value,
@@ -296,15 +296,15 @@ impl<'block> BrilligBlock<'block> {
                     Type::Reference(element) => match *element {
                         Type::Array(..) => {
                             self.brillig_context
-                                .allocate_array_reference_instruction(address_register);
+                                .allocate_array_reference_instruction(address_register.address);
                         }
                         Type::Slice(..) => {
                             self.brillig_context
-                                .allocate_vector_reference_instruction(address_register);
+                                .allocate_vector_reference_instruction(address_register.address);
                         }
                         _ => {
                             self.brillig_context
-                                .allocate_simple_reference_instruction(address_register);
+                                .allocate_simple_reference_instruction(address_register.address);
                         }
                     },
                     _ => {
@@ -313,10 +313,11 @@ impl<'block> BrilligBlock<'block> {
                 }
             }
             Instruction::Store { address, value } => {
-                let address_register = self.convert_ssa_register_value(*address, dfg);
+                let address_var = self.convert_ssa_simple_value(*address, dfg);
                 let source_variable = self.convert_ssa_value(*value, dfg);
 
-                self.brillig_context.store_variable_instruction(address_register, source_variable);
+                self.brillig_context
+                    .store_variable_instruction(address_var.address, source_variable);
             }
             Instruction::Load { address } => {
                 let target_variable = self.variables.define_variable(
@@ -326,20 +327,25 @@ impl<'block> BrilligBlock<'block> {
                     dfg,
                 );
 
-                let address_register = self.convert_ssa_register_value(*address, dfg);
+                let address_variable = self.convert_ssa_simple_value(*address, dfg);
 
-                self.brillig_context.load_variable_instruction(target_variable, address_register);
+                self.brillig_context
+                    .load_variable_instruction(target_variable, address_variable.address);
             }
             Instruction::Not(value) => {
-                let condition_register = self.convert_ssa_register_value(*value, dfg);
-                let result_register = self.variables.define_register_variable(
+                let condition_register = self.convert_ssa_simple_value(*value, dfg);
+                let result_register = self.variables.define_simple_variable(
                     self.function_context,
                     self.brillig_context,
                     dfg.instruction_results(instruction_id)[0],
                     dfg,
                 );
                 let bit_size = get_bit_size_from_ssa_type(&dfg.type_of_value(*value));
-                self.brillig_context.not_instruction(condition_register, bit_size, result_register);
+                self.brillig_context.not_instruction(
+                    condition_register.address,
+                    bit_size,
+                    result_register.address,
+                );
             }
             Instruction::Call { func, arguments } => match &dfg[*func] {
                 Value::ForeignFunction(func_name) => {
@@ -431,7 +437,7 @@ impl<'block> BrilligBlock<'block> {
                     );
                 }
                 Value::Intrinsic(Intrinsic::ArrayLen) => {
-                    let result_register = self.variables.define_register_variable(
+                    let result_variable = self.variables.define_simple_variable(
                         self.function_context,
                         self.brillig_context,
                         dfg.instruction_results(instruction_id)[0],
@@ -443,10 +449,11 @@ impl<'block> BrilligBlock<'block> {
                     // or an array in the case of an array.
                     if let Type::Numeric(_) = dfg.type_of_value(param_id) {
                         let len_variable = self.convert_ssa_value(arguments[0], dfg);
-                        let len_register_index = len_variable.extract_register();
-                        self.brillig_context.mov_instruction(result_register, len_register_index);
+                        let length = len_variable.extract_simple();
+                        self.brillig_context
+                            .mov_instruction(result_variable.address, length.address);
                     } else {
-                        self.convert_ssa_array_len(arguments[0], result_register, dfg);
+                        self.convert_ssa_array_len(arguments[0], result_variable.address, dfg);
                     }
                 }
                 Value::Intrinsic(
@@ -465,13 +472,13 @@ impl<'block> BrilligBlock<'block> {
                     );
                 }
                 Value::Intrinsic(Intrinsic::ToRadix(endianness)) => {
-                    let source = self.convert_ssa_register_value(arguments[0], dfg);
-                    let radix = self.convert_ssa_register_value(arguments[1], dfg);
-                    let limb_count = self.convert_ssa_register_value(arguments[2], dfg);
+                    let source = self.convert_ssa_simple_value(arguments[0], dfg);
+                    let radix = self.convert_ssa_simple_value(arguments[1], dfg);
+                    let limb_count = self.convert_ssa_simple_value(arguments[2], dfg);
 
                     let results = dfg.instruction_results(instruction_id);
 
-                    let target_len = self.variables.define_register_variable(
+                    let target_len = self.variables.define_simple_variable(
                         self.function_context,
                         self.brillig_context,
                         results[0],
@@ -489,19 +496,19 @@ impl<'block> BrilligBlock<'block> {
                         .extract_vector();
 
                     // Update the user-facing slice length
-                    self.brillig_context.mov_instruction(target_len, limb_count);
+                    self.brillig_context.mov_instruction(target_len.address, limb_count.address);
 
                     self.brillig_context.radix_instruction(
-                        source,
+                        source.address,
                         target_vector,
-                        radix,
-                        limb_count,
+                        radix.address,
+                        limb_count.address,
                         matches!(endianness, Endian::Big),
                     );
                 }
                 Value::Intrinsic(Intrinsic::ToBits(endianness)) => {
-                    let source = self.convert_ssa_register_value(arguments[0], dfg);
-                    let limb_count = self.convert_ssa_register_value(arguments[1], dfg);
+                    let source = self.convert_ssa_simple_value(arguments[0], dfg);
+                    let limb_count = self.convert_ssa_simple_value(arguments[1], dfg);
 
                     let results = dfg.instruction_results(instruction_id);
 
@@ -511,7 +518,7 @@ impl<'block> BrilligBlock<'block> {
                         results[0],
                         dfg,
                     );
-                    let target_len = target_len_variable.extract_register();
+                    let target_len = target_len_variable.extract_simple();
 
                     let target_vector = match self.variables.define_variable(
                         self.function_context,
@@ -531,13 +538,13 @@ impl<'block> BrilligBlock<'block> {
                         .make_constant(2_usize.into(), FieldElement::max_num_bits());
 
                     // Update the user-facing slice length
-                    self.brillig_context.mov_instruction(target_len, limb_count);
+                    self.brillig_context.mov_instruction(target_len.address, limb_count.address);
 
                     self.brillig_context.radix_instruction(
-                        source,
+                        source.address,
                         target_vector,
                         radix,
-                        limb_count,
+                        limb_count.address,
                         matches!(endianness, Endian::Big),
                     );
 
@@ -549,13 +556,13 @@ impl<'block> BrilligBlock<'block> {
             },
             Instruction::Truncate { value, bit_size, .. } => {
                 let result_ids = dfg.instruction_results(instruction_id);
-                let destination_register = self.variables.define_register_variable(
+                let destination_register = self.variables.define_simple_variable(
                     self.function_context,
                     self.brillig_context,
                     result_ids[0],
                     dfg,
                 );
-                let source_register = self.convert_ssa_register_value(*value, dfg);
+                let source_register = self.convert_ssa_simple_value(*value, dfg);
                 self.brillig_context.truncate_instruction(
                     destination_register,
                     source_register,
@@ -564,14 +571,14 @@ impl<'block> BrilligBlock<'block> {
             }
             Instruction::Cast(value, typ) => {
                 let result_ids = dfg.instruction_results(instruction_id);
-                let destination_register = self.variables.define_register_variable(
+                let destination_register = self.variables.define_simple_variable(
                     self.function_context,
                     self.brillig_context,
                     result_ids[0],
                     dfg,
                 );
-                let source_register = self.convert_ssa_register_value(*value, dfg);
-                self.convert_cast(destination_register, source_register, typ);
+                let source_register = self.convert_ssa_simple_value(*value, dfg);
+                self.convert_cast(destination_register.address, source_register.address, typ);
             }
             Instruction::ArrayGet { array, index } => {
                 let result_ids = dfg.instruction_results(instruction_id);
@@ -589,17 +596,17 @@ impl<'block> BrilligBlock<'block> {
                     _ => unreachable!("ICE: array get on non-array"),
                 };
 
-                let index_register = self.convert_ssa_register_value(*index, dfg);
-                self.validate_array_index(array_variable, index_register);
+                let index_variable = self.convert_ssa_simple_value(*index, dfg);
+                self.validate_array_index(array_variable, index_variable);
                 self.retrieve_variable_from_array(
                     array_pointer,
-                    index_register,
+                    index_variable.address,
                     destination_variable,
                 );
             }
             Instruction::ArraySet { array, index, value, .. } => {
                 let source_variable = self.convert_ssa_value(*array, dfg);
-                let index_register = self.convert_ssa_register_value(*index, dfg);
+                let index_register = self.convert_ssa_simple_value(*index, dfg);
                 let value_variable = self.convert_ssa_value(*value, dfg);
 
                 let result_ids = dfg.instruction_results(instruction_id);
@@ -614,15 +621,15 @@ impl<'block> BrilligBlock<'block> {
                 self.convert_ssa_array_set(
                     source_variable,
                     destination_variable,
-                    index_register,
+                    index_register.address,
                     value_variable,
                 );
             }
             Instruction::RangeCheck { value, max_bit_size, assert_message } => {
-                let value = self.convert_ssa_register_value(*value, dfg);
+                let value = self.convert_ssa_simple_value(*value, dfg);
                 // Cast original value to field
                 let left = self.brillig_context.allocate_register();
-                self.convert_cast(left, value, &Type::field());
+                self.convert_cast(left, value.address, &Type::field());
 
                 // Create a field constant with the max
                 let max = BigUint::from(2_u128).pow(*max_bit_size) - BigUint::from(1_u128);
@@ -730,7 +737,7 @@ impl<'block> BrilligBlock<'block> {
     fn validate_array_index(
         &mut self,
         array_variable: BrilligVariable,
-        index_register: MemoryAddress,
+        index_register: SimpleVariable,
     ) {
         let (size_as_register, should_deallocate_size) = match array_variable {
             BrilligVariable::BrilligArray(BrilligArray { size, .. }) => {
@@ -743,7 +750,7 @@ impl<'block> BrilligBlock<'block> {
         let condition = self.brillig_context.allocate_register();
 
         self.brillig_context.memory_op(
-            index_register,
+            index_register.address,
             size_as_register,
             condition,
             BinaryIntOp::LessThan,
@@ -766,7 +773,11 @@ impl<'block> BrilligBlock<'block> {
     ) {
         match destination_variable {
             BrilligVariable::Simple(destination_register) => {
-                self.brillig_context.array_get(array_pointer, index_register, destination_register);
+                self.brillig_context.array_get(
+                    array_pointer,
+                    index_register,
+                    destination_register.address,
+                );
             }
             BrilligVariable::BrilligArray(..) | BrilligVariable::BrilligVector(..) => {
                 let reference = self.brillig_context.allocate_register();
@@ -868,8 +879,8 @@ impl<'block> BrilligBlock<'block> {
         value_variable: BrilligVariable,
     ) {
         match value_variable {
-            BrilligVariable::Simple(value_register) => {
-                ctx.array_set(destination_pointer, index_register, value_register);
+            BrilligVariable::Simple(value_variable) => {
+                ctx.array_set(destination_pointer, index_register, value_variable.address);
             }
             BrilligVariable::BrilligArray(_) => {
                 let reference: MemoryAddress = ctx.allocate_register();
@@ -940,7 +951,7 @@ impl<'block> BrilligBlock<'block> {
                     self.convert_ssa_value(*arg, dfg)
                 });
 
-                self.update_slice_length(target_len, arguments[0], dfg, BinaryIntOp::Add);
+                self.update_slice_length(target_len.address, arguments[0], dfg, BinaryIntOp::Add);
 
                 self.slice_push_back_operation(target_vector, source_vector, &item_values);
             }
@@ -966,7 +977,7 @@ impl<'block> BrilligBlock<'block> {
                     self.convert_ssa_value(*arg, dfg)
                 });
 
-                self.update_slice_length(target_len, arguments[0], dfg, BinaryIntOp::Add);
+                self.update_slice_length(target_len.address, arguments[0], dfg, BinaryIntOp::Add);
 
                 self.slice_push_front_operation(target_vector, source_vector, &item_values);
             }
@@ -999,7 +1010,7 @@ impl<'block> BrilligBlock<'block> {
                     )
                 });
 
-                self.update_slice_length(target_len, arguments[0], dfg, BinaryIntOp::Sub);
+                self.update_slice_length(target_len.address, arguments[0], dfg, BinaryIntOp::Sub);
 
                 self.slice_pop_back_operation(target_vector, source_vector, &pop_variables);
             }
@@ -1031,7 +1042,7 @@ impl<'block> BrilligBlock<'block> {
                 );
                 let target_vector = target_variable.extract_vector();
 
-                self.update_slice_length(target_len, arguments[0], dfg, BinaryIntOp::Sub);
+                self.update_slice_length(target_len.address, arguments[0], dfg, BinaryIntOp::Sub);
 
                 self.slice_pop_front_operation(target_vector, source_vector, &pop_variables);
             }
@@ -1058,13 +1069,13 @@ impl<'block> BrilligBlock<'block> {
 
                 // Remove if indexing in insert is changed to flattened indexing
                 // https://github.com/noir-lang/noir/issues/1889#issuecomment-1668048587
-                let user_index = self.convert_ssa_register_value(arguments[2], dfg);
+                let user_index = self.convert_ssa_simple_value(arguments[2], dfg);
 
                 let converted_index = self.brillig_context.make_usize_constant(element_size.into());
 
                 self.brillig_context.memory_op(
                     converted_index,
-                    user_index,
+                    user_index.address,
                     converted_index,
                     BinaryIntOp::Mul,
                 );
@@ -1073,7 +1084,7 @@ impl<'block> BrilligBlock<'block> {
                     self.convert_ssa_value(*arg, dfg)
                 });
 
-                self.update_slice_length(target_len, arguments[0], dfg, BinaryIntOp::Add);
+                self.update_slice_length(target_len.address, arguments[0], dfg, BinaryIntOp::Add);
 
                 self.slice_insert_operation(target_vector, source_vector, converted_index, &items);
                 self.brillig_context.deallocate_register(converted_index);
@@ -1101,12 +1112,12 @@ impl<'block> BrilligBlock<'block> {
 
                 // Remove if indexing in remove is changed to flattened indexing
                 // https://github.com/noir-lang/noir/issues/1889#issuecomment-1668048587
-                let user_index = self.convert_ssa_register_value(arguments[2], dfg);
+                let user_index = self.convert_ssa_simple_value(arguments[2], dfg);
 
                 let converted_index = self.brillig_context.make_usize_constant(element_size.into());
                 self.brillig_context.memory_op(
                     converted_index,
-                    user_index,
+                    user_index.address,
                     converted_index,
                     BinaryIntOp::Mul,
                 );
@@ -1120,7 +1131,7 @@ impl<'block> BrilligBlock<'block> {
                     )
                 });
 
-                self.update_slice_length(target_len, arguments[0], dfg, BinaryIntOp::Sub);
+                self.update_slice_length(target_len.address, arguments[0], dfg, BinaryIntOp::Sub);
 
                 self.slice_remove_operation(
                     target_vector,
@@ -1152,9 +1163,9 @@ impl<'block> BrilligBlock<'block> {
         binary_op: BinaryIntOp,
     ) {
         let source_len_variable = self.convert_ssa_value(source_value, dfg);
-        let source_len = source_len_variable.extract_register();
+        let source_len = source_len_variable.extract_simple();
 
-        self.brillig_context.usize_op(source_len, target_len, binary_op, 1);
+        self.brillig_context.usize_op(source_len.address, target_len, binary_op, 1);
     }
 
     /// Converts an SSA cast to a sequence of Brillig opcodes.
@@ -1171,18 +1182,23 @@ impl<'block> BrilligBlock<'block> {
         &mut self,
         binary: &Binary,
         dfg: &DataFlowGraph,
-        result_register: MemoryAddress,
+        result_variable: SimpleVariable,
     ) {
         let binary_type =
             type_of_binary_operation(dfg[binary.lhs].get_type(), dfg[binary.rhs].get_type());
 
-        let left = self.convert_ssa_register_value(binary.lhs, dfg);
-        let right = self.convert_ssa_register_value(binary.rhs, dfg);
+        let left = self.convert_ssa_simple_value(binary.lhs, dfg);
+        let right = self.convert_ssa_simple_value(binary.rhs, dfg);
 
         let brillig_binary_op =
             convert_ssa_binary_op_to_brillig_binary_op(binary.operator, &binary_type);
 
-        self.brillig_context.binary_instruction(left, right, result_register, brillig_binary_op);
+        self.brillig_context.binary_instruction(
+            left.address,
+            right.address,
+            result_variable.address,
+            brillig_binary_op,
+        );
     }
 
     /// Converts an SSA `ValueId` into a `RegisterOrMemory`. Initializes if necessary.
@@ -1204,10 +1220,10 @@ impl<'block> BrilligBlock<'block> {
                 } else {
                     let new_variable =
                         self.variables.allocate_constant(self.brillig_context, value_id, dfg);
-                    let register_index = new_variable.extract_register();
+                    let register_index = new_variable.extract_simple();
 
                     self.brillig_context.const_instruction(
-                        register_index,
+                        register_index.address,
                         (*constant).into(),
                         get_bit_size_from_ssa_type(typ),
                     );
@@ -1273,10 +1289,10 @@ impl<'block> BrilligBlock<'block> {
                 // value.
                 let new_variable =
                     self.variables.allocate_constant(self.brillig_context, value_id, dfg);
-                let register_index = new_variable.extract_register();
+                let register_index = new_variable.extract_simple();
 
                 self.brillig_context.const_instruction(
-                    register_index,
+                    register_index.address,
                     value_id.to_usize().into(),
                     32,
                 );
@@ -1289,13 +1305,13 @@ impl<'block> BrilligBlock<'block> {
     }
 
     /// Converts an SSA `ValueId` into a `MemoryAddress`. Initializes if necessary.
-    fn convert_ssa_register_value(
+    fn convert_ssa_simple_value(
         &mut self,
         value_id: ValueId,
         dfg: &DataFlowGraph,
-    ) -> MemoryAddress {
+    ) -> SimpleVariable {
         let variable = self.convert_ssa_value(value_id, dfg);
-        variable.extract_register()
+        variable.extract_simple()
     }
 
     fn allocate_external_call_result(

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -351,14 +351,14 @@ impl<'block> BrilligBlock<'block> {
                     let result_ids = dfg.instruction_results(instruction_id);
 
                     let input_registers = vecmap(arguments, |value_id| {
-                        self.convert_ssa_value(*value_id, dfg).to_register_or_memory()
+                        self.convert_ssa_value(*value_id, dfg).to_value_or_array()
                     });
                     let input_value_types = vecmap(arguments, |value_id| {
                         let value_type = dfg.type_of_value(*value_id);
                         type_to_heap_value_type(&value_type)
                     });
                     let output_registers = vecmap(result_ids, |value_id| {
-                        self.allocate_external_call_result(*value_id, dfg).to_register_or_memory()
+                        self.allocate_external_call_result(*value_id, dfg).to_value_or_array()
                     });
                     let output_value_types = vecmap(result_ids, |value_id| {
                         let value_type = dfg.type_of_value(*value_id);

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -1,5 +1,5 @@
 use crate::brillig::brillig_ir::brillig_variable::{
-    type_to_heap_value_type, BrilligArray, BrilligVariable, BrilligVector, SimpleVariable,
+    type_to_heap_value_type, BrilligArray, BrilligVariable, BrilligVector, SingleAddrVariable,
 };
 use crate::brillig::brillig_ir::{
     BrilligBinaryOp, BrilligContext, BRILLIG_INTEGER_ARITHMETIC_BIT_SIZE,
@@ -117,7 +117,7 @@ impl<'block> BrilligBlock<'block> {
     ) {
         match terminator_instruction {
             TerminatorInstruction::JmpIf { condition, then_destination, else_destination } => {
-                let condition = self.convert_ssa_simple_value(*condition, dfg);
+                let condition = self.convert_ssa_single_addr_value(*condition, dfg);
                 self.brillig_context.jump_if_instruction(
                     condition.address,
                     self.create_block_label_for_current_function(*then_destination),
@@ -163,7 +163,10 @@ impl<'block> BrilligBlock<'block> {
     /// Passes an arbitrary variable from the registers of the source to the registers of the destination
     fn pass_variable(&mut self, source: BrilligVariable, destination: BrilligVariable) {
         match (source, destination) {
-            (BrilligVariable::Simple(source_var), BrilligVariable::Simple(destination_var)) => {
+            (
+                BrilligVariable::SingleAddr(source_var),
+                BrilligVariable::SingleAddr(destination_var),
+            ) => {
                 self.brillig_context.mov_instruction(destination_var.address, source_var.address);
             }
             (
@@ -238,7 +241,7 @@ impl<'block> BrilligBlock<'block> {
 
         match instruction {
             Instruction::Binary(binary) => {
-                let result_var = self.variables.define_simple_variable(
+                let result_var = self.variables.define_single_addr_variable(
                     self.function_context,
                     self.brillig_context,
                     dfg.instruction_results(instruction_id)[0],
@@ -247,7 +250,7 @@ impl<'block> BrilligBlock<'block> {
                 self.convert_ssa_binary(binary, dfg, result_var);
             }
             Instruction::Constrain(lhs, rhs, assert_message) => {
-                let condition = SimpleVariable {
+                let condition = SingleAddrVariable {
                     address: self.brillig_context.allocate_register(),
                     bit_size: 1,
                 };
@@ -286,7 +289,7 @@ impl<'block> BrilligBlock<'block> {
             }
             Instruction::Allocate => {
                 let result_value = dfg.instruction_results(instruction_id)[0];
-                let address_register = self.variables.define_simple_variable(
+                let address_register = self.variables.define_single_addr_variable(
                     self.function_context,
                     self.brillig_context,
                     result_value,
@@ -303,8 +306,9 @@ impl<'block> BrilligBlock<'block> {
                                 .allocate_vector_reference_instruction(address_register.address);
                         }
                         _ => {
-                            self.brillig_context
-                                .allocate_simple_reference_instruction(address_register.address);
+                            self.brillig_context.allocate_single_addr_reference_instruction(
+                                address_register.address,
+                            );
                         }
                     },
                     _ => {
@@ -313,7 +317,7 @@ impl<'block> BrilligBlock<'block> {
                 }
             }
             Instruction::Store { address, value } => {
-                let address_var = self.convert_ssa_simple_value(*address, dfg);
+                let address_var = self.convert_ssa_single_addr_value(*address, dfg);
                 let source_variable = self.convert_ssa_value(*value, dfg);
 
                 self.brillig_context
@@ -327,14 +331,14 @@ impl<'block> BrilligBlock<'block> {
                     dfg,
                 );
 
-                let address_variable = self.convert_ssa_simple_value(*address, dfg);
+                let address_variable = self.convert_ssa_single_addr_value(*address, dfg);
 
                 self.brillig_context
                     .load_variable_instruction(target_variable, address_variable.address);
             }
             Instruction::Not(value) => {
-                let condition_register = self.convert_ssa_simple_value(*value, dfg);
-                let result_register = self.variables.define_simple_variable(
+                let condition_register = self.convert_ssa_single_addr_value(*value, dfg);
+                let result_register = self.variables.define_single_addr_variable(
                     self.function_context,
                     self.brillig_context,
                     dfg.instruction_results(instruction_id)[0],
@@ -432,7 +436,7 @@ impl<'block> BrilligBlock<'block> {
                     );
                 }
                 Value::Intrinsic(Intrinsic::ArrayLen) => {
-                    let result_variable = self.variables.define_simple_variable(
+                    let result_variable = self.variables.define_single_addr_variable(
                         self.function_context,
                         self.brillig_context,
                         dfg.instruction_results(instruction_id)[0],
@@ -444,7 +448,7 @@ impl<'block> BrilligBlock<'block> {
                     // or an array in the case of an array.
                     if let Type::Numeric(_) = dfg.type_of_value(param_id) {
                         let len_variable = self.convert_ssa_value(arguments[0], dfg);
-                        let length = len_variable.extract_simple();
+                        let length = len_variable.extract_single_addr();
                         self.brillig_context
                             .mov_instruction(result_variable.address, length.address);
                     } else {
@@ -467,13 +471,13 @@ impl<'block> BrilligBlock<'block> {
                     );
                 }
                 Value::Intrinsic(Intrinsic::ToRadix(endianness)) => {
-                    let source = self.convert_ssa_simple_value(arguments[0], dfg);
-                    let radix = self.convert_ssa_simple_value(arguments[1], dfg);
-                    let limb_count = self.convert_ssa_simple_value(arguments[2], dfg);
+                    let source = self.convert_ssa_single_addr_value(arguments[0], dfg);
+                    let radix = self.convert_ssa_single_addr_value(arguments[1], dfg);
+                    let limb_count = self.convert_ssa_single_addr_value(arguments[2], dfg);
 
                     let results = dfg.instruction_results(instruction_id);
 
-                    let target_len = self.variables.define_simple_variable(
+                    let target_len = self.variables.define_single_addr_variable(
                         self.function_context,
                         self.brillig_context,
                         results[0],
@@ -502,8 +506,8 @@ impl<'block> BrilligBlock<'block> {
                     );
                 }
                 Value::Intrinsic(Intrinsic::ToBits(endianness)) => {
-                    let source = self.convert_ssa_simple_value(arguments[0], dfg);
-                    let limb_count = self.convert_ssa_simple_value(arguments[1], dfg);
+                    let source = self.convert_ssa_single_addr_value(arguments[0], dfg);
+                    let limb_count = self.convert_ssa_single_addr_value(arguments[1], dfg);
 
                     let results = dfg.instruction_results(instruction_id);
 
@@ -513,7 +517,7 @@ impl<'block> BrilligBlock<'block> {
                         results[0],
                         dfg,
                     );
-                    let target_len = target_len_variable.extract_simple();
+                    let target_len = target_len_variable.extract_single_addr();
 
                     let target_vector = match self.variables.define_variable(
                         self.function_context,
@@ -525,7 +529,7 @@ impl<'block> BrilligBlock<'block> {
                             self.brillig_context.array_to_vector(&array)
                         }
                         BrilligVariable::BrilligVector(vector) => vector,
-                        BrilligVariable::Simple(..) => unreachable!("ICE: ToBits on non-array"),
+                        BrilligVariable::SingleAddr(..) => unreachable!("ICE: ToBits on non-array"),
                     };
 
                     let radix = self
@@ -551,13 +555,13 @@ impl<'block> BrilligBlock<'block> {
             },
             Instruction::Truncate { value, bit_size, .. } => {
                 let result_ids = dfg.instruction_results(instruction_id);
-                let destination_register = self.variables.define_simple_variable(
+                let destination_register = self.variables.define_single_addr_variable(
                     self.function_context,
                     self.brillig_context,
                     result_ids[0],
                     dfg,
                 );
-                let source_register = self.convert_ssa_simple_value(*value, dfg);
+                let source_register = self.convert_ssa_single_addr_value(*value, dfg);
                 self.brillig_context.truncate_instruction(
                     destination_register,
                     source_register,
@@ -566,13 +570,13 @@ impl<'block> BrilligBlock<'block> {
             }
             Instruction::Cast(value, _) => {
                 let result_ids = dfg.instruction_results(instruction_id);
-                let destination_variable = self.variables.define_simple_variable(
+                let destination_variable = self.variables.define_single_addr_variable(
                     self.function_context,
                     self.brillig_context,
                     result_ids[0],
                     dfg,
                 );
-                let source_variable = self.convert_ssa_simple_value(*value, dfg);
+                let source_variable = self.convert_ssa_single_addr_value(*value, dfg);
                 self.convert_cast(destination_variable, source_variable);
             }
             Instruction::ArrayGet { array, index } => {
@@ -591,7 +595,7 @@ impl<'block> BrilligBlock<'block> {
                     _ => unreachable!("ICE: array get on non-array"),
                 };
 
-                let index_variable = self.convert_ssa_simple_value(*index, dfg);
+                let index_variable = self.convert_ssa_single_addr_value(*index, dfg);
                 self.validate_array_index(array_variable, index_variable);
                 self.retrieve_variable_from_array(
                     array_pointer,
@@ -601,7 +605,7 @@ impl<'block> BrilligBlock<'block> {
             }
             Instruction::ArraySet { array, index, value, .. } => {
                 let source_variable = self.convert_ssa_value(*array, dfg);
-                let index_register = self.convert_ssa_simple_value(*index, dfg);
+                let index_register = self.convert_ssa_single_addr_value(*index, dfg);
                 let value_variable = self.convert_ssa_value(*value, dfg);
 
                 let result_ids = dfg.instruction_results(instruction_id);
@@ -621,9 +625,9 @@ impl<'block> BrilligBlock<'block> {
                 );
             }
             Instruction::RangeCheck { value, max_bit_size, assert_message } => {
-                let value = self.convert_ssa_simple_value(*value, dfg);
+                let value = self.convert_ssa_single_addr_value(*value, dfg);
                 // Cast original value to field
-                let left = SimpleVariable {
+                let left = SingleAddrVariable {
                     address: self.brillig_context.allocate_register(),
                     bit_size: FieldElement::max_num_bits(),
                 };
@@ -740,7 +744,7 @@ impl<'block> BrilligBlock<'block> {
     fn validate_array_index(
         &mut self,
         array_variable: BrilligVariable,
-        index_register: SimpleVariable,
+        index_register: SingleAddrVariable,
     ) {
         let (size_as_register, should_deallocate_size) = match array_variable {
             BrilligVariable::BrilligArray(BrilligArray { size, .. }) => {
@@ -775,7 +779,7 @@ impl<'block> BrilligBlock<'block> {
         destination_variable: BrilligVariable,
     ) {
         match destination_variable {
-            BrilligVariable::Simple(destination_register) => {
+            BrilligVariable::SingleAddr(destination_register) => {
                 self.brillig_context.array_get(
                     array_pointer,
                     index_register,
@@ -882,7 +886,7 @@ impl<'block> BrilligBlock<'block> {
         value_variable: BrilligVariable,
     ) {
         match value_variable {
-            BrilligVariable::Simple(value_variable) => {
+            BrilligVariable::SingleAddr(value_variable) => {
                 ctx.array_set(destination_pointer, index_register, value_variable.address);
             }
             BrilligVariable::BrilligArray(_) => {
@@ -938,7 +942,7 @@ impl<'block> BrilligBlock<'block> {
                     results[0],
                     dfg,
                 ) {
-                    BrilligVariable::Simple(register_index) => register_index,
+                    BrilligVariable::SingleAddr(register_index) => register_index,
                     _ => unreachable!("ICE: first value of a slice must be a register index"),
                 };
 
@@ -965,7 +969,7 @@ impl<'block> BrilligBlock<'block> {
                     results[0],
                     dfg,
                 ) {
-                    BrilligVariable::Simple(register_index) => register_index,
+                    BrilligVariable::SingleAddr(register_index) => register_index,
                     _ => unreachable!("ICE: first value of a slice must be a register index"),
                 };
 
@@ -991,7 +995,7 @@ impl<'block> BrilligBlock<'block> {
                     results[0],
                     dfg,
                 ) {
-                    BrilligVariable::Simple(register_index) => register_index,
+                    BrilligVariable::SingleAddr(register_index) => register_index,
                     _ => unreachable!("ICE: first value of a slice must be a register index"),
                 };
 
@@ -1024,7 +1028,7 @@ impl<'block> BrilligBlock<'block> {
                     results[element_size],
                     dfg,
                 ) {
-                    BrilligVariable::Simple(register_index) => register_index,
+                    BrilligVariable::SingleAddr(register_index) => register_index,
                     _ => unreachable!("ICE: first value of a slice must be a register index"),
                 };
 
@@ -1056,7 +1060,7 @@ impl<'block> BrilligBlock<'block> {
                     results[0],
                     dfg,
                 ) {
-                    BrilligVariable::Simple(register_index) => register_index,
+                    BrilligVariable::SingleAddr(register_index) => register_index,
                     _ => unreachable!("ICE: first value of a slice must be a register index"),
                 };
 
@@ -1072,7 +1076,7 @@ impl<'block> BrilligBlock<'block> {
 
                 // Remove if indexing in insert is changed to flattened indexing
                 // https://github.com/noir-lang/noir/issues/1889#issuecomment-1668048587
-                let user_index = self.convert_ssa_simple_value(arguments[2], dfg);
+                let user_index = self.convert_ssa_single_addr_value(arguments[2], dfg);
 
                 let converted_index = self.brillig_context.make_usize_constant(element_size.into());
 
@@ -1099,7 +1103,7 @@ impl<'block> BrilligBlock<'block> {
                     results[0],
                     dfg,
                 ) {
-                    BrilligVariable::Simple(register_index) => register_index,
+                    BrilligVariable::SingleAddr(register_index) => register_index,
                     _ => unreachable!("ICE: first value of a slice must be a register index"),
                 };
 
@@ -1115,7 +1119,7 @@ impl<'block> BrilligBlock<'block> {
 
                 // Remove if indexing in remove is changed to flattened indexing
                 // https://github.com/noir-lang/noir/issues/1889#issuecomment-1668048587
-                let user_index = self.convert_ssa_simple_value(arguments[2], dfg);
+                let user_index = self.convert_ssa_single_addr_value(arguments[2], dfg);
 
                 let converted_index = self.brillig_context.make_usize_constant(element_size.into());
                 self.brillig_context.memory_op(
@@ -1166,14 +1170,14 @@ impl<'block> BrilligBlock<'block> {
         binary_op: BinaryIntOp,
     ) {
         let source_len_variable = self.convert_ssa_value(source_value, dfg);
-        let source_len = source_len_variable.extract_simple();
+        let source_len = source_len_variable.extract_single_addr();
 
         self.brillig_context.usize_op(source_len.address, target_len, binary_op, 1);
     }
 
     /// Converts an SSA cast to a sequence of Brillig opcodes.
     /// Casting is only necessary when shrinking the bit size of a numeric value.
-    fn convert_cast(&mut self, destination: SimpleVariable, source: SimpleVariable) {
+    fn convert_cast(&mut self, destination: SingleAddrVariable, source: SingleAddrVariable) {
         // We assume that `source` is a valid `target_type` as it's expected that a truncate instruction was emitted
         // to ensure this is the case.
 
@@ -1185,13 +1189,13 @@ impl<'block> BrilligBlock<'block> {
         &mut self,
         binary: &Binary,
         dfg: &DataFlowGraph,
-        result_variable: SimpleVariable,
+        result_variable: SingleAddrVariable,
     ) {
         let binary_type =
             type_of_binary_operation(dfg[binary.lhs].get_type(), dfg[binary.rhs].get_type());
 
-        let left = self.convert_ssa_simple_value(binary.lhs, dfg);
-        let right = self.convert_ssa_simple_value(binary.rhs, dfg);
+        let left = self.convert_ssa_single_addr_value(binary.lhs, dfg);
+        let right = self.convert_ssa_single_addr_value(binary.rhs, dfg);
 
         let brillig_binary_op =
             convert_ssa_binary_op_to_brillig_binary_op(binary.operator, &binary_type);
@@ -1223,7 +1227,7 @@ impl<'block> BrilligBlock<'block> {
                 } else {
                     let new_variable =
                         self.variables.allocate_constant(self.brillig_context, value_id, dfg);
-                    let register_index = new_variable.extract_simple();
+                    let register_index = new_variable.extract_single_addr();
 
                     self.brillig_context.const_instruction(
                         register_index.address,
@@ -1292,7 +1296,7 @@ impl<'block> BrilligBlock<'block> {
                 // value.
                 let new_variable =
                     self.variables.allocate_constant(self.brillig_context, value_id, dfg);
-                let register_index = new_variable.extract_simple();
+                let register_index = new_variable.extract_single_addr();
 
                 self.brillig_context.const_instruction(
                     register_index.address,
@@ -1308,13 +1312,13 @@ impl<'block> BrilligBlock<'block> {
     }
 
     /// Converts an SSA `ValueId` into a `MemoryAddress`. Initializes if necessary.
-    fn convert_ssa_simple_value(
+    fn convert_ssa_single_addr_value(
         &mut self,
         value_id: ValueId,
         dfg: &DataFlowGraph,
-    ) -> SimpleVariable {
+    ) -> SingleAddrVariable {
         let variable = self.convert_ssa_value(value_id, dfg);
-        variable.extract_simple()
+        variable.extract_single_addr()
     }
 
     fn allocate_external_call_result(

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
@@ -1,10 +1,9 @@
-use acvm::brillig_vm::brillig::MemoryAddress;
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::{
     brillig::brillig_ir::{
-        brillig_variable::{BrilligArray, BrilligVariable, BrilligVector},
-        BrilligContext,
+        brillig_variable::{BrilligArray, BrilligVariable, BrilligVector, SimpleVariable},
+        BrilligContext, BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
     },
     ssa::ir::{
         basic_block::BasicBlockId,
@@ -71,15 +70,15 @@ impl BlockVariables {
     }
 
     /// Defines a variable that fits in a single register and returns the allocated register.
-    pub(crate) fn define_register_variable(
+    pub(crate) fn define_simple_variable(
         &mut self,
         function_context: &mut FunctionContext,
         brillig_context: &mut BrilligContext,
         value: ValueId,
         dfg: &DataFlowGraph,
-    ) -> MemoryAddress {
+    ) -> SimpleVariable {
         let variable = self.define_variable(function_context, brillig_context, value, dfg);
-        variable.extract_register()
+        variable.extract_simple()
     }
 
     /// Removes a variable so it's not used anymore within this block.
@@ -190,12 +189,22 @@ pub(crate) fn allocate_value(
     let typ = dfg.type_of_value(value_id);
 
     match typ {
-        Type::Numeric(_) | Type::Reference(_) | Type::Function => {
+        Type::Numeric(numeric_type) => BrilligVariable::Simple(SimpleVariable {
+            address: brillig_context.allocate_register(),
+            bit_size: numeric_type.bit_size(),
+        }),
+        Type::Reference(_) => BrilligVariable::Simple(SimpleVariable {
+            address: brillig_context.allocate_register(),
+            bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
+        }),
+        Type::Function => {
             // NB. function references are converted to a constant when
             // translating from SSA to Brillig (to allow for debugger
             // instrumentation to work properly)
-            let register = brillig_context.allocate_register();
-            BrilligVariable::Simple(register)
+            BrilligVariable::Simple(SimpleVariable {
+                address: brillig_context.allocate_register(),
+                bit_size: 32,
+            })
         }
         Type::Array(item_typ, elem_count) => {
             let pointer_register = brillig_context.allocate_register();

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
@@ -2,7 +2,7 @@ use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::{
     brillig::brillig_ir::{
-        brillig_variable::{BrilligArray, BrilligVariable, BrilligVector, SimpleVariable},
+        brillig_variable::{BrilligArray, BrilligVariable, BrilligVector, SingleAddrVariable},
         BrilligContext, BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
     },
     ssa::ir::{
@@ -70,15 +70,15 @@ impl BlockVariables {
     }
 
     /// Defines a variable that fits in a single register and returns the allocated register.
-    pub(crate) fn define_simple_variable(
+    pub(crate) fn define_single_addr_variable(
         &mut self,
         function_context: &mut FunctionContext,
         brillig_context: &mut BrilligContext,
         value: ValueId,
         dfg: &DataFlowGraph,
-    ) -> SimpleVariable {
+    ) -> SingleAddrVariable {
         let variable = self.define_variable(function_context, brillig_context, value, dfg);
-        variable.extract_simple()
+        variable.extract_single_addr()
     }
 
     /// Removes a variable so it's not used anymore within this block.
@@ -189,11 +189,11 @@ pub(crate) fn allocate_value(
     let typ = dfg.type_of_value(value_id);
 
     match typ {
-        Type::Numeric(numeric_type) => BrilligVariable::Simple(SimpleVariable {
+        Type::Numeric(numeric_type) => BrilligVariable::SingleAddr(SingleAddrVariable {
             address: brillig_context.allocate_register(),
             bit_size: numeric_type.bit_size(),
         }),
-        Type::Reference(_) => BrilligVariable::Simple(SimpleVariable {
+        Type::Reference(_) => BrilligVariable::SingleAddr(SingleAddrVariable {
             address: brillig_context.allocate_register(),
             bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
         }),
@@ -201,7 +201,7 @@ pub(crate) fn allocate_value(
             // NB. function references are converted to a constant when
             // translating from SSA to Brillig (to allow for debugger
             // instrumentation to work properly)
-            BrilligVariable::Simple(SimpleVariable {
+            BrilligVariable::SingleAddr(SingleAddrVariable {
                 address: brillig_context.allocate_register(),
                 bit_size: 32,
             })

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -74,7 +74,7 @@ impl FunctionContext {
     fn ssa_type_to_parameter(typ: &Type) -> BrilligParameter {
         match typ {
             Type::Numeric(_) | Type::Reference(_) => {
-                BrilligParameter::Simple(get_bit_size_from_ssa_type(typ))
+                BrilligParameter::SingleAddr(get_bit_size_from_ssa_type(typ))
             }
             Type::Array(item_type, size) => BrilligParameter::Array(
                 vecmap(item_type.iter(), |item_typ| {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
@@ -334,7 +334,7 @@ mod tests {
     use crate::brillig::brillig_gen::brillig_fn::FunctionContext;
     use crate::brillig::brillig_ir::artifact::BrilligParameter;
     use crate::brillig::brillig_ir::brillig_variable::{
-        BrilligArray, BrilligVariable, BrilligVector,
+        BrilligArray, BrilligVariable, BrilligVector, SimpleVariable,
     };
     use crate::brillig::brillig_ir::tests::{
         create_and_run_vm, create_context, create_entry_point_bytecode,
@@ -397,7 +397,10 @@ mod tests {
                 size: array.len(),
                 rc: context.allocate_register(),
             };
-            let item_to_insert = context.allocate_register();
+            let item_to_insert = SimpleVariable {
+                address: context.allocate_register(),
+                bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
+            };
 
             // Cast the source array to a vector
             let source_vector = context.array_to_vector(&array_variable);
@@ -501,7 +504,10 @@ mod tests {
                 size: context.allocate_register(),
                 rc: context.allocate_register(),
             };
-            let removed_item = context.allocate_register();
+            let removed_item = SimpleVariable {
+                address: context.allocate_register(),
+                bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
+            };
 
             let mut block = create_brillig_block(&mut function_context, &mut context);
 
@@ -519,7 +525,11 @@ mod tests {
                 );
             }
 
-            context.return_instruction(&[target_vector.pointer, target_vector.rc, removed_item]);
+            context.return_instruction(&[
+                target_vector.pointer,
+                target_vector.rc,
+                removed_item.address,
+            ]);
 
             let bytecode = create_entry_point_bytecode(context, arguments, returns).byte_code;
             let expected_return: Vec<_> =
@@ -578,7 +588,10 @@ mod tests {
                 size: array.len(),
                 rc: context.allocate_register(),
             };
-            let item_to_insert = context.allocate_register();
+            let item_to_insert = SimpleVariable {
+                address: context.allocate_register(),
+                bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
+            };
             let index_to_insert = context.allocate_register();
 
             // Cast the source array to a vector
@@ -708,7 +721,10 @@ mod tests {
                 size: context.allocate_register(),
                 rc: context.allocate_register(),
             };
-            let removed_item = context.allocate_register();
+            let removed_item = SimpleVariable {
+                address: context.allocate_register(),
+                bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
+            };
 
             let mut block = create_brillig_block(&mut function_context, &mut context);
 
@@ -719,7 +735,11 @@ mod tests {
                 &[BrilligVariable::Simple(removed_item)],
             );
 
-            context.return_instruction(&[target_vector.pointer, target_vector.size, removed_item]);
+            context.return_instruction(&[
+                target_vector.pointer,
+                target_vector.size,
+                removed_item.address,
+            ]);
 
             let calldata: Vec<_> = array.into_iter().chain(vec![index]).collect();
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
@@ -334,7 +334,7 @@ mod tests {
     use crate::brillig::brillig_gen::brillig_fn::FunctionContext;
     use crate::brillig::brillig_ir::artifact::BrilligParameter;
     use crate::brillig::brillig_ir::brillig_variable::{
-        BrilligArray, BrilligVariable, BrilligVector, SimpleVariable,
+        BrilligArray, BrilligVariable, BrilligVector, SingleAddrVariable,
     };
     use crate::brillig::brillig_ir::tests::{
         create_and_run_vm, create_context, create_entry_point_bytecode,
@@ -379,13 +379,13 @@ mod tests {
         ) {
             let arguments = vec![
                 BrilligParameter::Array(
-                    vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                    vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                     array.len(),
                 ),
-                BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
             let returns = vec![BrilligParameter::Array(
-                vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                 array.len() + 1,
             )];
 
@@ -397,7 +397,7 @@ mod tests {
                 size: array.len(),
                 rc: context.allocate_register(),
             };
-            let item_to_insert = SimpleVariable {
+            let item_to_insert = SingleAddrVariable {
                 address: context.allocate_register(),
                 bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
             };
@@ -418,13 +418,13 @@ mod tests {
                 block.slice_push_back_operation(
                     target_vector,
                     source_vector,
-                    &[BrilligVariable::Simple(item_to_insert)],
+                    &[BrilligVariable::SingleAddr(item_to_insert)],
                 );
             } else {
                 block.slice_push_front_operation(
                     target_vector,
                     source_vector,
-                    &[BrilligVariable::Simple(item_to_insert)],
+                    &[BrilligVariable::SingleAddr(item_to_insert)],
                 );
             }
 
@@ -475,15 +475,15 @@ mod tests {
             expected_return_item: Value,
         ) {
             let arguments = vec![BrilligParameter::Array(
-                vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                 array.len(),
             )];
             let returns = vec![
                 BrilligParameter::Array(
-                    vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                    vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                     array.len() - 1,
                 ),
-                BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
 
             let (_, mut function_context, mut context) = create_test_environment();
@@ -504,7 +504,7 @@ mod tests {
                 size: context.allocate_register(),
                 rc: context.allocate_register(),
             };
-            let removed_item = SimpleVariable {
+            let removed_item = SingleAddrVariable {
                 address: context.allocate_register(),
                 bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
             };
@@ -515,13 +515,13 @@ mod tests {
                 block.slice_pop_back_operation(
                     target_vector,
                     source_vector,
-                    &[BrilligVariable::Simple(removed_item)],
+                    &[BrilligVariable::SingleAddr(removed_item)],
                 );
             } else {
                 block.slice_pop_front_operation(
                     target_vector,
                     source_vector,
-                    &[BrilligVariable::Simple(removed_item)],
+                    &[BrilligVariable::SingleAddr(removed_item)],
                 );
             }
 
@@ -569,14 +569,14 @@ mod tests {
         ) {
             let arguments = vec![
                 BrilligParameter::Array(
-                    vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                    vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                     array.len(),
                 ),
-                BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
-                BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
             let returns = vec![BrilligParameter::Array(
-                vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                 array.len() + 1,
             )];
 
@@ -588,7 +588,7 @@ mod tests {
                 size: array.len(),
                 rc: context.allocate_register(),
             };
-            let item_to_insert = SimpleVariable {
+            let item_to_insert = SingleAddrVariable {
                 address: context.allocate_register(),
                 bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
             };
@@ -610,7 +610,7 @@ mod tests {
                 target_vector,
                 source_vector,
                 index_to_insert,
-                &[BrilligVariable::Simple(item_to_insert)],
+                &[BrilligVariable::SingleAddr(item_to_insert)],
             );
 
             context.return_instruction(&[target_vector.pointer, target_vector.rc]);
@@ -689,17 +689,17 @@ mod tests {
         ) {
             let arguments = vec![
                 BrilligParameter::Array(
-                    vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                    vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                     array.len(),
                 ),
-                BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
             let returns = vec![
                 BrilligParameter::Array(
-                    vec![BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
+                    vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
                     array.len() - 1,
                 ),
-                BrilligParameter::Simple(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
 
             let (_, mut function_context, mut context) = create_test_environment();
@@ -721,7 +721,7 @@ mod tests {
                 size: context.allocate_register(),
                 rc: context.allocate_register(),
             };
-            let removed_item = SimpleVariable {
+            let removed_item = SingleAddrVariable {
                 address: context.allocate_register(),
                 bit_size: BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
             };
@@ -732,7 +732,7 @@ mod tests {
                 target_vector,
                 source_vector,
                 index_to_insert,
-                &[BrilligVariable::Simple(removed_item)],
+                &[BrilligVariable::SingleAddr(removed_item)],
             );
 
             context.return_instruction(&[

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -6,8 +6,8 @@ use crate::ssa::ir::dfg::CallStack;
 /// Represents a parameter or a return value of a function.
 #[derive(Debug, Clone)]
 pub(crate) enum BrilligParameter {
-    /// A simple parameter or return value. Holds the bit size of the parameter.
-    Simple(u32),
+    /// A single address parameter or return value. Holds the bit size of the parameter.
+    SingleAddr(u32),
     /// An array parameter or return value. Holds the type of an array item and its size.
     Array(Vec<BrilligParameter>, usize),
     /// A slice parameter or return value. Holds the type of a slice item.

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
@@ -5,6 +5,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::ssa::ir::types::Type;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
+pub(crate) struct SimpleVariable {
+    pub(crate) address: MemoryAddress,
+    pub(crate) bit_size: u32,
+}
+
 /// The representation of a noir array in the Brillig IR
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
 pub(crate) struct BrilligArray {
@@ -52,15 +58,15 @@ impl BrilligVector {
 /// The representation of a noir value in the Brillig IR
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
 pub(crate) enum BrilligVariable {
-    Simple(MemoryAddress),
+    Simple(SimpleVariable),
     BrilligArray(BrilligArray),
     BrilligVector(BrilligVector),
 }
 
 impl BrilligVariable {
-    pub(crate) fn extract_register(self) -> MemoryAddress {
+    pub(crate) fn extract_simple(self) -> SimpleVariable {
         match self {
-            BrilligVariable::Simple(register_index) => register_index,
+            BrilligVariable::Simple(simple) => simple,
             _ => unreachable!("ICE: Expected register, got {self:?}"),
         }
     }
@@ -81,7 +87,7 @@ impl BrilligVariable {
 
     pub(crate) fn extract_registers(self) -> Vec<MemoryAddress> {
         match self {
-            BrilligVariable::Simple(register_index) => vec![register_index],
+            BrilligVariable::Simple(simple) => vec![simple.address],
             BrilligVariable::BrilligArray(array) => array.extract_registers(),
             BrilligVariable::BrilligVector(vector) => vector.extract_registers(),
         }
@@ -89,7 +95,7 @@ impl BrilligVariable {
 
     pub(crate) fn to_register_or_memory(self) -> ValueOrArray {
         match self {
-            BrilligVariable::Simple(register_index) => ValueOrArray::MemoryAddress(register_index),
+            BrilligVariable::Simple(simple) => ValueOrArray::MemoryAddress(simple.address),
             BrilligVariable::BrilligArray(array) => ValueOrArray::HeapArray(array.to_heap_array()),
             BrilligVariable::BrilligVector(vector) => {
                 ValueOrArray::HeapVector(vector.to_heap_vector())

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
@@ -93,7 +93,7 @@ impl BrilligVariable {
         }
     }
 
-    pub(crate) fn to_register_or_memory(self) -> ValueOrArray {
+    pub(crate) fn to_value_or_array(self) -> ValueOrArray {
         match self {
             BrilligVariable::SingleAddr(single_addr) => {
                 ValueOrArray::MemoryAddress(single_addr.address)

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::ssa::ir::types::Type;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
-pub(crate) struct SimpleVariable {
+pub(crate) struct SingleAddrVariable {
     pub(crate) address: MemoryAddress,
     pub(crate) bit_size: u32,
 }
@@ -58,15 +58,15 @@ impl BrilligVector {
 /// The representation of a noir value in the Brillig IR
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
 pub(crate) enum BrilligVariable {
-    Simple(SimpleVariable),
+    SingleAddr(SingleAddrVariable),
     BrilligArray(BrilligArray),
     BrilligVector(BrilligVector),
 }
 
 impl BrilligVariable {
-    pub(crate) fn extract_simple(self) -> SimpleVariable {
+    pub(crate) fn extract_single_addr(self) -> SingleAddrVariable {
         match self {
-            BrilligVariable::Simple(simple) => simple,
+            BrilligVariable::SingleAddr(single_addr) => single_addr,
             _ => unreachable!("ICE: Expected register, got {self:?}"),
         }
     }
@@ -87,7 +87,7 @@ impl BrilligVariable {
 
     pub(crate) fn extract_registers(self) -> Vec<MemoryAddress> {
         match self {
-            BrilligVariable::Simple(simple) => vec![simple.address],
+            BrilligVariable::SingleAddr(single_addr) => vec![single_addr.address],
             BrilligVariable::BrilligArray(array) => array.extract_registers(),
             BrilligVariable::BrilligVector(vector) => vector.extract_registers(),
         }
@@ -95,7 +95,9 @@ impl BrilligVariable {
 
     pub(crate) fn to_register_or_memory(self) -> ValueOrArray {
         match self {
-            BrilligVariable::Simple(simple) => ValueOrArray::MemoryAddress(simple.address),
+            BrilligVariable::SingleAddr(single_addr) => {
+                ValueOrArray::MemoryAddress(single_addr.address)
+            }
             BrilligVariable::BrilligArray(array) => ValueOrArray::HeapArray(array.to_heap_array()),
             BrilligVariable::BrilligVector(vector) => {
                 ValueOrArray::HeapVector(vector.to_heap_vector())

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -1,6 +1,6 @@
 use super::{
     artifact::{BrilligArtifact, BrilligParameter},
-    brillig_variable::{BrilligArray, BrilligVariable, SimpleVariable},
+    brillig_variable::{BrilligArray, BrilligVariable, SingleAddrVariable},
     debug_show::DebugShow,
     registers::BrilligRegistersContext,
     BrilligContext, ReservedRegisters, BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
@@ -63,13 +63,13 @@ impl BrilligContext {
         let mut argument_variables: Vec<_> = arguments
             .iter()
             .map(|argument| match argument {
-                BrilligParameter::Simple(bit_size) => {
-                    let simple_address = self.allocate_register();
-                    let var = BrilligVariable::Simple(SimpleVariable {
-                        address: simple_address,
+                BrilligParameter::SingleAddr(bit_size) => {
+                    let single_address = self.allocate_register();
+                    let var = BrilligVariable::SingleAddr(SingleAddrVariable {
+                        address: single_address,
                         bit_size: *bit_size,
                     });
-                    self.mov_instruction(simple_address, MemoryAddress(current_calldata_pointer));
+                    self.mov_instruction(single_address, MemoryAddress(current_calldata_pointer));
                     current_calldata_pointer += 1;
                     var
                 }
@@ -119,7 +119,7 @@ impl BrilligContext {
 
         fn flat_bit_sizes(param: &BrilligParameter) -> Box<dyn Iterator<Item = u32> + '_> {
             match param {
-                BrilligParameter::Simple(bit_size) => Box::new(std::iter::once(*bit_size)),
+                BrilligParameter::SingleAddr(bit_size) => Box::new(std::iter::once(*bit_size)),
                 BrilligParameter::Array(item_types, item_count) => Box::new(
                     (0..*item_count).flat_map(move |_| item_types.iter().flat_map(flat_bit_sizes)),
                 ),
@@ -142,7 +142,7 @@ impl BrilligContext {
     /// Computes the size of a parameter if it was flattened
     fn flattened_size(param: &BrilligParameter) -> usize {
         match param {
-            BrilligParameter::Simple(_) => 1,
+            BrilligParameter::SingleAddr(_) => 1,
             BrilligParameter::Array(item_types, item_count) => {
                 let item_size: usize = item_types.iter().map(BrilligContext::flattened_size).sum();
                 item_count * item_size
@@ -160,7 +160,7 @@ impl BrilligContext {
 
     /// Computes the size of a parameter if it was flattened
     fn has_nested_arrays(tuple: &[BrilligParameter]) -> bool {
-        tuple.iter().any(|param| !matches!(param, BrilligParameter::Simple(_)))
+        tuple.iter().any(|param| !matches!(param, BrilligParameter::SingleAddr(_)))
     }
 
     /// Deflatten an array by recursively allocating nested arrays and copying the plain values.
@@ -197,7 +197,7 @@ impl BrilligContext {
                         self.make_usize_constant((target_item_base_index + subitem_index).into());
 
                     match subitem {
-                        BrilligParameter::Simple(_) => {
+                        BrilligParameter::SingleAddr(_) => {
                             self.array_get(
                                 flattened_array_pointer,
                                 source_index,
@@ -282,10 +282,12 @@ impl BrilligContext {
         let returned_variables: Vec<_> = return_parameters
             .iter()
             .map(|return_parameter| match return_parameter {
-                BrilligParameter::Simple(bit_size) => BrilligVariable::Simple(SimpleVariable {
-                    address: self.allocate_register(),
-                    bit_size: *bit_size,
-                }),
+                BrilligParameter::SingleAddr(bit_size) => {
+                    BrilligVariable::SingleAddr(SingleAddrVariable {
+                        address: self.allocate_register(),
+                        bit_size: *bit_size,
+                    })
+                }
                 BrilligParameter::Array(item_types, item_count) => {
                     BrilligVariable::BrilligArray(BrilligArray {
                         pointer: self.allocate_register(),
@@ -307,10 +309,10 @@ impl BrilligContext {
 
         for (return_param, returned_variable) in return_parameters.iter().zip(&returned_variables) {
             match return_param {
-                BrilligParameter::Simple(_) => {
+                BrilligParameter::SingleAddr(_) => {
                     self.mov_instruction(
                         MemoryAddress(return_data_index),
-                        returned_variable.extract_simple().address,
+                        returned_variable.extract_single_addr().address,
                     );
                     return_data_index += 1;
                 }
@@ -365,7 +367,7 @@ impl BrilligContext {
                         self.make_usize_constant((target_item_base_index + target_offset).into());
 
                     match subitem {
-                        BrilligParameter::Simple(_) => {
+                        BrilligParameter::SingleAddr(_) => {
                             self.array_get(
                                 deflattened_array_pointer,
                                 source_index,
@@ -474,12 +476,12 @@ mod tests {
         ];
         let arguments = vec![BrilligParameter::Array(
             vec![
-                BrilligParameter::Array(vec![BrilligParameter::Simple(8)], 2),
-                BrilligParameter::Simple(8),
+                BrilligParameter::Array(vec![BrilligParameter::SingleAddr(8)], 2),
+                BrilligParameter::SingleAddr(8),
             ],
             2,
         )];
-        let returns = vec![BrilligParameter::Simple(8)];
+        let returns = vec![BrilligParameter::SingleAddr(8)];
 
         let mut context = create_context();
 
@@ -512,8 +514,8 @@ mod tests {
         ];
         let array_param = BrilligParameter::Array(
             vec![
-                BrilligParameter::Array(vec![BrilligParameter::Simple(8)], 2),
-                BrilligParameter::Simple(8),
+                BrilligParameter::Array(vec![BrilligParameter::SingleAddr(8)], 2),
+                BrilligParameter::SingleAddr(8),
             ],
             2,
         );


### PR DESCRIPTION
# Description

## Problem\*

Work towards #4369

## Summary\*

Uses consistent bit sizes for truncate and starts a refactor where we start to track bit sizes for values in brillig IR

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
