### PR TITLE
chore(ci): add warning for external contributors force pushing

### DIFF
--- a/.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
+++ b/.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
@@ -1,5 +1,5 @@
 Thank you for your contribution to the Noir language.
 
-Please **DO NOT FORCE PUSH TO THIS BRANCH** after the Noir team have reviewed this PR. Doing so will only delay us merging your PR as we will need to start the review process from scratch.
+Please **do not force push to this branch** after the Noir team have reviewed this PR. Doing so will only delay us merging your PR as we will need to start the review process from scratch.
 
 Thanks for your understanding.

--- a/.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
+++ b/.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
@@ -1,0 +1,5 @@
+Thank you for your contribution to the Noir language.
+
+Please **DO NOT FORCE PUSH TO THIS BRANCH** after the Noir team have reviewed this PR. Doing so will only delay us merging your PR as we will need to start the review process from scratch.
+
+Thanks for your understanding.

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -27,3 +27,18 @@ jobs:
             fix
             feat
             chore
+
+  force-push-comment:
+    name: Warn external contributors about force-pushing
+    runs-on: ubuntu-latest
+    if: github.repository != 'noir-lang/noir' && github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: write
+    
+    steps:
+      - name: Post comment on force pushes
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: ./.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
+
+          


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a sticky comment to any PRs which are opened from another repository which warns against force pushing once we've started reviewing the PR.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
