### PR TITLE
chore: fix trigger for force-push sticky comment

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -31,7 +31,7 @@ jobs:
   force-push-comment:
     name: Warn external contributors about force-pushing
     runs-on: ubuntu-latest
-    if: github.repository != 'noir-lang/noir' && github.event_name == 'pull_request_target'
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != 'noir-lang/noir' }} 
     permissions:
       pull-requests: write
     


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

#4373 isn't being triggered properly currently.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
