### PR TITLE
fix: only add `.nr` files to file manager

### DIFF
--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -16,7 +16,7 @@ pub mod workspace;
 
 use std::collections::BTreeMap;
 
-use fm::FileManager;
+use fm::{FileManager, FILE_EXTENSION};
 use noirc_driver::{add_dep, prepare_crate, prepare_dependency};
 use noirc_frontend::{
     graph::{CrateId, CrateName},
@@ -69,8 +69,7 @@ fn insert_all_files_for_package_into_file_manager(
         .clone();
 
     // Get all files in the package and add them to the file manager
-    let paths =
-        get_all_paths_in_dir(entry_path_parent).expect("could not get all paths in the package");
+    let paths = get_all_noir_source_in_dir(entry_path_parent).expect("could not get all paths in the package");
     for path in paths {
         let source = std::fs::read_to_string(path.as_path())
             .unwrap_or_else(|_| panic!("could not read file {:?} into string", path));
@@ -125,6 +124,13 @@ pub fn prepare_package<'file_manager, 'parsed_files>(
     (context, crate_id)
 }
 
+// Get all Noir source files in the directory and subdirectories.
+//
+// Panics: If the path is not a path to a directory.
+fn get_all_noir_source_in_dir(dir: &std::path::Path) -> std::io::Result<Vec<std::path::PathBuf>> {
+    get_all_paths_in_dir(dir, |path| path.extension().map_or(false, |extension| extension == FILE_EXTENSION))
+}
+
 // Get all paths in the directory and subdirectories.
 //
 // Panics: If the path is not a path to a directory.
@@ -132,7 +138,7 @@ pub fn prepare_package<'file_manager, 'parsed_files>(
 // TODO: Along with prepare_package, this function is an abstraction leak
 // TODO: given that this crate should not know about the file manager.
 // TODO: We can clean this up in a future refactor
-fn get_all_paths_in_dir(dir: &std::path::Path) -> std::io::Result<Vec<std::path::PathBuf>> {
+fn get_all_paths_in_dir(dir: &std::path::Path, predicate: fn(&std::path::Path) -> bool) -> std::io::Result<Vec<std::path::PathBuf>> {
     assert!(dir.is_dir(), "directory {dir:?} is not a path to a directory");
 
     let mut paths = Vec::new();
@@ -142,9 +148,9 @@ fn get_all_paths_in_dir(dir: &std::path::Path) -> std::io::Result<Vec<std::path:
             let entry = entry?;
             let path = entry.path();
             if path.is_dir() {
-                let mut sub_paths = get_all_paths_in_dir(&path)?;
+                let mut sub_paths = get_all_paths_in_dir(&path, predicate)?;
                 paths.append(&mut sub_paths);
-            } else {
+            } else if predicate(&path) {
                 paths.push(path);
             }
         }
@@ -177,7 +183,7 @@ mod tests {
         create_test_dir_structure(temp_dir.path())
             .expect("could not create test directory structure");
 
-        let paths = get_all_paths_in_dir(temp_dir.path())
+        let paths = get_all_paths_in_dir(temp_dir.path(), |_| true)
             .expect("could not get all paths in the test directory");
 
         // This should be the paths to all of the files in the directory and the subdirectory

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -69,7 +69,8 @@ fn insert_all_files_for_package_into_file_manager(
         .clone();
 
     // Get all files in the package and add them to the file manager
-    let paths = get_all_noir_source_in_dir(entry_path_parent).expect("could not get all paths in the package");
+    let paths = get_all_noir_source_in_dir(entry_path_parent)
+        .expect("could not get all paths in the package");
     for path in paths {
         let source = std::fs::read_to_string(path.as_path())
             .unwrap_or_else(|_| panic!("could not read file {:?} into string", path));
@@ -128,7 +129,9 @@ pub fn prepare_package<'file_manager, 'parsed_files>(
 //
 // Panics: If the path is not a path to a directory.
 fn get_all_noir_source_in_dir(dir: &std::path::Path) -> std::io::Result<Vec<std::path::PathBuf>> {
-    get_all_paths_in_dir(dir, |path| path.extension().map_or(false, |extension| extension == FILE_EXTENSION))
+    get_all_paths_in_dir(dir, |path| {
+        path.extension().map_or(false, |extension| extension == FILE_EXTENSION)
+    })
 }
 
 // Get all paths in the directory and subdirectories.
@@ -138,7 +141,10 @@ fn get_all_noir_source_in_dir(dir: &std::path::Path) -> std::io::Result<Vec<std:
 // TODO: Along with prepare_package, this function is an abstraction leak
 // TODO: given that this crate should not know about the file manager.
 // TODO: We can clean this up in a future refactor
-fn get_all_paths_in_dir(dir: &std::path::Path, predicate: fn(&std::path::Path) -> bool) -> std::io::Result<Vec<std::path::PathBuf>> {
+fn get_all_paths_in_dir(
+    dir: &std::path::Path,
+    predicate: fn(&std::path::Path) -> bool,
+) -> std::io::Result<Vec<std::path::PathBuf>> {
     assert!(dir.is_dir(), "directory {dir:?} is not a path to a directory");
 
     let mut paths = Vec::new();


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4379

## Summary\*

This PR adds a filter so we only add files with a `.nr` extension to the file manager.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
