### PR TITLE
fix: correct invalid brillig codegen for `EmbeddedCurvePoint.add`

### DIFF
--- a/noir_stdlib/src/scalar_mul.nr
+++ b/noir_stdlib/src/scalar_mul.nr
@@ -32,5 +32,14 @@ pub fn fixed_base_embedded_curve(
 // docs:end:fixed_base_embedded_curve
 {}
 
+// This is a hack as returning an `EmbeddedCurvePoint` from a foreign function in brillig returns a [BrilligVariable::SingleAddr; 2] rather than BrilligVariable::BrilligArray
+// as is defined in the brillig bytecode format. This is a workaround which allows us to fix this without modifying the serialization format.
+fn embedded_curve_add(point1: EmbeddedCurvePoint, point2: EmbeddedCurvePoint) -> EmbeddedCurvePoint {
+    let point_array = embedded_curve_add_array_return(point1, point2);
+    let x = point_array[0];
+    let y = point_array[1];
+    EmbeddedCurvePoint { x, y }
+}
+
 #[foreign(embedded_curve_add)]
-fn embedded_curve_add(_point1: EmbeddedCurvePoint, _point2: EmbeddedCurvePoint) -> EmbeddedCurvePoint {}
+fn embedded_curve_add_array_return(_point1: EmbeddedCurvePoint, _point2: EmbeddedCurvePoint) -> [Field; 2] {}

--- a/test_programs/execution_success/brillig_scalar_mul/src/main.nr
+++ b/test_programs/execution_success/brillig_scalar_mul/src/main.nr
@@ -20,4 +20,13 @@ unconstrained fn main(
     let res = std::scalar_mul::fixed_base_embedded_curve(priv_key, 0);
     assert(res[0] == pub_x);
     assert(res[1] == pub_y);
+
+    let pub_point= std::scalar_mul::EmbeddedCurvePoint { x: pub_x, y: pub_y };
+    let g1_y = 17631683881184975370165255887551781615748388533673675138860;
+    let g1= std::scalar_mul::EmbeddedCurvePoint { x: 1, y: g1_y };
+
+    let res = pub_point.double();
+    let double = g1.add(g1);
+
+    assert(double.x == res.x);
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves  https://github.com/noir-lang/noir/issues/4260

## Summary\*

The error is explained in the comment I've added to the stdlib. This is a quick fix and we can clean it up once we're making serialisation changes in `aztec-packages` again.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
