### PR TITLE
fix: Use correct type for numeric generics

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -714,7 +714,6 @@ impl<'interner> Monomorphizer<'interner> {
                 let mutable = definition.mutable;
                 let location = Some(ident.location);
                 let name = definition.name.clone();
-                let typ = self.interner.id_type(expr_id);
                 let definition = self.lookup_function(*func_id, expr_id, &typ, None);
                 let typ = self.convert_type(&typ);
                 let ident = ast::Ident { location, mutable, definition, name, typ: typ.clone() };
@@ -753,7 +752,8 @@ impl<'interner> Monomorphizer<'interner> {
 
                 let value = FieldElement::from(value as u128);
                 let location = self.interner.id_location(expr_id);
-                ast::Expression::Literal(ast::Literal::Integer(value, ast::Type::Field, location))
+                let typ = self.convert_type(&typ);
+                ast::Expression::Literal(ast::Literal::Integer(value, typ, location))
             }
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4290 

## Summary\*

Previously, the monomorphizer would assume all numeric generics were Fields, but this was not necessarily true.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
