### PR TITLE
chore: clippy fix

### DIFF
--- a/acvm-repo/acir_field/src/generic_ark.rs
+++ b/acvm-repo/acir_field/src/generic_ark.rs
@@ -429,63 +429,6 @@ impl<F: PrimeField> SubAssign for FieldElement<F> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn and() {
-        let max = 10_000u32;
-
-        let num_bits = (std::mem::size_of::<u32>() * 8) as u32 - max.leading_zeros();
-
-        for x in 0..max {
-            let x = crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(x as i128);
-            let res = x.and(&x, num_bits);
-            assert_eq!(res.to_be_bytes(), x.to_be_bytes());
-        }
-    }
-
-    #[test]
-    fn serialize_fixed_test_vectors() {
-        // Serialized field elements from of 0, -1, -2, -3
-        let hex_strings = vec![
-            "0000000000000000000000000000000000000000000000000000000000000000",
-            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000",
-            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593efffffff",
-            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593effffffe",
-        ];
-
-        for (i, string) in hex_strings.into_iter().enumerate() {
-            let minus_i_field_element =
-                -crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
-            assert_eq!(minus_i_field_element.to_hex(), string);
-        }
-    }
-
-    #[test]
-    fn deserialize_even_and_odd_length_hex() {
-        // Test cases of (odd, even) length hex strings
-        let hex_strings =
-            vec![("0x0", "0x00"), ("0x1", "0x01"), ("0x002", "0x0002"), ("0x00003", "0x000003")];
-        for (i, case) in hex_strings.into_iter().enumerate() {
-            let i_field_element =
-                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
-            let odd_field_element =
-                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from_hex(case.0).unwrap();
-            let even_field_element =
-                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from_hex(case.1).unwrap();
-
-            assert_eq!(i_field_element, odd_field_element);
-            assert_eq!(odd_field_element, even_field_element);
-        }
-    }
-
-    #[test]
-    fn max_num_bits_smoke() {
-        let max_num_bits_bn254 = crate::generic_ark::FieldElement::<ark_bn254::Fr>::max_num_bits();
-        assert_eq!(max_num_bits_bn254, 254);
-    }
-}
-
 fn mask_vector_le(bytes: &mut [u8], num_bits: usize) {
     // reverse to big endian format
     bytes.reverse();
@@ -541,5 +484,62 @@ fn superscript(n: u64) -> String {
         superscript(n / 10) + &superscript(n % 10)
     } else {
         panic!("{}", n.to_string() + " can't be converted to superscript.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn and() {
+        let max = 10_000u32;
+
+        let num_bits = (std::mem::size_of::<u32>() * 8) as u32 - max.leading_zeros();
+
+        for x in 0..max {
+            let x = crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(x as i128);
+            let res = x.and(&x, num_bits);
+            assert_eq!(res.to_be_bytes(), x.to_be_bytes());
+        }
+    }
+
+    #[test]
+    fn serialize_fixed_test_vectors() {
+        // Serialized field elements from of 0, -1, -2, -3
+        let hex_strings = vec![
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000",
+            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593efffffff",
+            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593effffffe",
+        ];
+
+        for (i, string) in hex_strings.into_iter().enumerate() {
+            let minus_i_field_element =
+                -crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
+            assert_eq!(minus_i_field_element.to_hex(), string);
+        }
+    }
+
+    #[test]
+    fn deserialize_even_and_odd_length_hex() {
+        // Test cases of (odd, even) length hex strings
+        let hex_strings =
+            vec![("0x0", "0x00"), ("0x1", "0x01"), ("0x002", "0x0002"), ("0x00003", "0x000003")];
+        for (i, case) in hex_strings.into_iter().enumerate() {
+            let i_field_element =
+                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
+            let odd_field_element =
+                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from_hex(case.0).unwrap();
+            let even_field_element =
+                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from_hex(case.1).unwrap();
+
+            assert_eq!(i_field_element, odd_field_element);
+            assert_eq!(odd_field_element, even_field_element);
+        }
+    }
+
+    #[test]
+    fn max_num_bits_smoke() {
+        let max_num_bits_bn254 = crate::generic_ark::FieldElement::<ark_bn254::Fr>::max_num_bits();
+        assert_eq!(max_num_bits_bn254, 254);
     }
 }

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -72,12 +72,9 @@ impl RangeOptimizer {
                     }
                 }
 
-
                 Opcode::BlackBoxFuncCall(BlackBoxFuncCall::RANGE {
                     input: FunctionInput { witness, num_bits },
-                }) => {
-                    Some((*witness, *num_bits))
-                }
+                }) => Some((*witness, *num_bits)),
 
                 _ => None,
             }) else {

--- a/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
@@ -69,7 +69,7 @@ impl BigIntSolver {
     pub(crate) fn bigint_to_bytes(
         &self,
         input: u32,
-        outputs: &Vec<Witness>,
+        outputs: &[Witness],
         initial_witness: &mut WitnessMap,
     ) -> Result<(), OpcodeResolutionError> {
         let bigint = self.get_bigint(input, BlackBoxFunc::BigIntToLeBytes)?;

--- a/aztec_macros/src/lib.rs
+++ b/aztec_macros/src/lib.rs
@@ -809,7 +809,7 @@ fn get_serialized_length(
 ) -> Result<u64, AztecMacroError> {
     let (struct_name, maybe_stored_in_state) = match typ {
         Type::Struct(struct_type, generics) => {
-            Ok((struct_type.borrow().name.0.contents.clone(), generics.get(0)))
+            Ok((struct_type.borrow().name.0.contents.clone(), generics.first()))
         }
         _ => Err(AztecMacroError::CouldNotAssignStorageSlots {
             secondary_message: Some("State storage variable must be a struct".to_string()),
@@ -859,7 +859,7 @@ fn get_serialized_length(
     let serialized_trait_impl_shared = interner.get_trait_implementation(*serialized_trait_impl_id);
     let serialized_trait_impl = serialized_trait_impl_shared.borrow();
 
-    match serialized_trait_impl.trait_generics.get(0).unwrap() {
+    match serialized_trait_impl.trait_generics.first().unwrap() {
         Type::Constant(value) => Ok(*value),
         _ => Err(AztecMacroError::CouldNotAssignStorageSlots { secondary_message: None }),
     }
@@ -947,7 +947,7 @@ fn assign_storage_slots(
 
                 let current_storage_slot = match slot_arg_expression {
                     HirExpression::Literal(HirLiteral::Integer(slot, _)) => {
-                        Ok(slot.borrow().to_u128())
+                        Ok(slot.to_u128())
                     }
                     _ => Err((
                         AztecMacroError::CouldNotAssignStorageSlots {

--- a/aztec_macros/src/lib.rs
+++ b/aztec_macros/src/lib.rs
@@ -946,9 +946,7 @@ fn assign_storage_slots(
                 let slot_arg_expression = interner.expression(&new_call_expression.arguments[1]);
 
                 let current_storage_slot = match slot_arg_expression {
-                    HirExpression::Literal(HirLiteral::Integer(slot, _)) => {
-                        Ok(slot.to_u128())
-                    }
+                    HirExpression::Literal(HirLiteral::Integer(slot, _)) => Ok(slot.to_u128()),
                     _ => Err((
                         AztecMacroError::CouldNotAssignStorageSlots {
                             secondary_message: Some(

--- a/compiler/noirc_errors/src/debug_info.rs
+++ b/compiler/noirc_errors/src/debug_info.rs
@@ -90,7 +90,7 @@ impl DebugInfo {
 
         for (opcode_location, locations) in self.locations.iter() {
             for location in locations.iter() {
-                let opcodes = accumulator.entry(*location).or_insert(Vec::new());
+                let opcodes = accumulator.entry(*location).or_default();
                 opcodes.push(opcode_location);
             }
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -269,7 +269,7 @@ impl<'block> BrilligBlock<'block> {
                                 unreachable!("expected a call instruction")
                             };
 
-                            let Value::Function(func_id) =  &dfg[*func]  else {
+                            let Value::Function(func_id) = &dfg[*func] else {
                                 unreachable!("expected a function value")
                             };
 

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -684,9 +684,7 @@ impl<'a> FunctionContext<'a> {
         &mut self,
         assert_message: &Option<Box<Expression>>,
     ) -> Result<Option<Box<ConstrainError>>, RuntimeError> {
-        let Some(assert_message_expr) = assert_message else {
-            return Ok(None)
-        };
+        let Some(assert_message_expr) = assert_message else { return Ok(None) };
 
         if let ast::Expression::Literal(ast::Literal::Str(assert_message)) =
             assert_message_expr.as_ref()

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -96,7 +96,7 @@ impl DebugInstrumenter {
         self.walk_scope(&mut func.body.0, func.span);
 
         // prepend fn params:
-        func.body.0 = vec![set_fn_params, func.body.0.clone()].concat();
+        func.body.0 = [set_fn_params, func.body.0.clone()].concat();
     }
 
     // Modify a vector of statements in-place, adding instrumentation for sets and drops.
@@ -130,7 +130,7 @@ impl DebugInstrumenter {
         let span = Span::empty(span.end());
 
         // drop scope variables
-        let scope_vars = self.scope.pop().unwrap_or(HashMap::default());
+        let scope_vars = self.scope.pop().unwrap_or_default();
         let drop_vars_stmts = scope_vars.values().map(|var_id| build_drop_var_stmt(*var_id, span));
         statements.extend(drop_vars_stmts);
 

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -64,7 +64,8 @@ impl<'interner> TypeChecker<'interner> {
                     HirLiteral::Array(HirArrayLiteral::Standard(arr)) => {
                         let elem_types = vecmap(&arr, |arg| self.check_expression(arg));
 
-                        let first_elem_type = elem_types.first()
+                        let first_elem_type = elem_types
+                            .first()
                             .cloned()
                             .unwrap_or_else(|| self.interner.next_type_variable());
 

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -64,8 +64,7 @@ impl<'interner> TypeChecker<'interner> {
                     HirLiteral::Array(HirArrayLiteral::Standard(arr)) => {
                         let elem_types = vecmap(&arr, |arg| self.check_expression(arg));
 
-                        let first_elem_type = elem_types
-                            .get(0)
+                        let first_elem_type = elem_types.first()
                             .cloned()
                             .unwrap_or_else(|| self.interner.next_type_variable());
 

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -774,6 +774,27 @@ impl Keyword {
     }
 }
 
+pub struct Tokens(pub Vec<SpannedToken>);
+
+type TokenMapIter = Map<IntoIter<SpannedToken>, fn(SpannedToken) -> (Token, Span)>;
+
+impl<'a> From<Tokens> for chumsky::Stream<'a, Token, Span, TokenMapIter> {
+    fn from(tokens: Tokens) -> Self {
+        let end_of_input = match tokens.0.last() {
+            Some(spanned_token) => spanned_token.to_span(),
+            None => Span::single_char(0),
+        };
+
+        fn get_span(token: SpannedToken) -> (Token, Span) {
+            let span = token.to_span();
+            (token.into_token(), span)
+        }
+
+        let iter = tokens.0.into_iter().map(get_span as fn(_) -> _);
+        chumsky::Stream::from_iter(end_of_input, iter)
+    }
+}
+
 #[cfg(test)]
 mod keywords {
     use strum::IntoEnumIterator;
@@ -794,26 +815,5 @@ mod keywords {
                 "Keyword::lookup_keyword returns unexpected Keyword"
             );
         }
-    }
-}
-
-pub struct Tokens(pub Vec<SpannedToken>);
-
-type TokenMapIter = Map<IntoIter<SpannedToken>, fn(SpannedToken) -> (Token, Span)>;
-
-impl<'a> From<Tokens> for chumsky::Stream<'a, Token, Span, TokenMapIter> {
-    fn from(tokens: Tokens) -> Self {
-        let end_of_input = match tokens.0.last() {
-            Some(spanned_token) => spanned_token.to_span(),
-            None => Span::single_char(0),
-        };
-
-        fn get_span(token: SpannedToken) -> (Token, Span) {
-            let span = token.to_span();
-            (token.into_token(), span)
-        }
-
-        let iter = tokens.0.into_iter().map(get_span as fn(_) -> _);
-        chumsky::Stream::from_iter(end_of_input, iter)
     }
 }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -733,7 +733,9 @@ impl<'interner> Monomorphizer<'interner> {
             }
             DefinitionKind::Global(global_id) => {
                 let Some(let_) = self.interner.get_global_let_statement(*global_id) else {
-                    unreachable!("Globals should have a corresponding let statement by monomorphization")
+                    unreachable!(
+                        "Globals should have a corresponding let statement by monomorphization"
+                    )
                 };
                 self.expr(let_.expression)
             }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1147,7 +1147,7 @@ impl NodeInterner {
                     })
                     .collect()
             })
-            .unwrap_or(vec![])
+            .unwrap_or_default()
     }
 
     /// Similar to `lookup_trait_implementation` but does not apply any type bindings on success.
@@ -1670,7 +1670,7 @@ impl Methods {
         for method in self.iter() {
             match interner.function_meta(&method).typ.instantiate(interner).0 {
                 Type::Function(args, _, _) => {
-                    if let Some(object) = args.get(0) {
+                    if let Some(object) = args.first() {
                         let mut bindings = TypeBindings::new();
 
                         if object.try_unify(typ, &mut bindings).is_ok() {

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -833,7 +833,7 @@ where
     ignore_then_commit(keyword(Keyword::Assert), parenthesized(argument_parser))
         .labelled(ParsingRuleLabel::Statement)
         .validate(|expressions, span, _| {
-            let condition = expressions.get(0).unwrap_or(&Expression::error(span)).clone();
+            let condition = expressions.first().unwrap_or(&Expression::error(span)).clone();
             let message = expressions.get(1).cloned();
             StatementKind::Constrain(ConstrainStatement(condition, message, ConstrainKind::Assert))
         })
@@ -851,7 +851,7 @@ where
         .validate(|exprs: Vec<Expression>, span, _| {
             let predicate = Expression::new(
                 ExpressionKind::Infix(Box::new(InfixExpression {
-                    lhs: exprs.get(0).unwrap_or(&Expression::error(span)).clone(),
+                    lhs: exprs.first().unwrap_or(&Expression::error(span)).clone(),
                     rhs: exprs.get(1).unwrap_or(&Expression::error(span)).clone(),
                     operator: Spanned::from(span, BinaryOpKind::Equal),
                 })),
@@ -2483,8 +2483,7 @@ mod test {
 
     #[test]
     fn return_validation() {
-        let cases = vec![
-            Case {
+        let cases = [Case {
                 source: "{ return 42; }",
                 expect: concat!("{\n", "    Error\n", "}",),
                 errors: 1,
@@ -2504,16 +2503,14 @@ mod test {
                 expect: concat!("{\n", "    Error\n", "}",),
                 errors: 2,
             },
-            Case { source: "{ return; }", expect: concat!("{\n", "    Error\n", "}",), errors: 1 },
-        ];
+            Case { source: "{ return; }", expect: concat!("{\n", "    Error\n", "}",), errors: 1 }];
 
         check_cases_with_errors(&cases[..], block(fresh_statement()));
     }
 
     #[test]
     fn expr_no_constructors() {
-        let cases = vec![
-            Case {
+        let cases = [Case {
                 source: "{ if structure { a: 1 } {} }",
                 expect: concat!(
                     "{\n",
@@ -2558,8 +2555,7 @@ mod test {
                     "}",
                 ),
                 errors: 0,
-            },
-        ];
+            }];
 
         check_cases_with_errors(&cases[..], block(fresh_statement()));
     }
@@ -2567,10 +2563,10 @@ mod test {
     #[test]
     fn parse_raw_string_expr() {
         let cases = vec![
-            Case { source: r##" r"foo" "##, expect: r##"r"foo""##, errors: 0 },
+            Case { source: r#" r"foo" "#, expect: r#"r"foo""#, errors: 0 },
             Case { source: r##" r#"foo"# "##, expect: r##"r#"foo"#"##, errors: 0 },
             // backslash
-            Case { source: r##" r"\\" "##, expect: r##"r"\\""##, errors: 0 },
+            Case { source: r#" r"\\" "#, expect: r#"r"\\""#, errors: 0 },
             Case { source: r##" r#"\"# "##, expect: r##"r#"\"#"##, errors: 0 },
             Case { source: r##" r#"\\"# "##, expect: r##"r#"\\"#"##, errors: 0 },
             Case { source: r##" r#"\\\"# "##, expect: r##"r#"\\\"#"##, errors: 0 },
@@ -2582,27 +2578,27 @@ mod test {
             },
             Case { source: r##" r#"\\\\\\\\"# "##, expect: r##"r#"\\\\\\\\"#"##, errors: 0 },
             // mismatch - errors:
-            Case { source: r###" r#"foo"## "###, expect: r###"r#"foo"#"###, errors: 1 },
-            Case { source: r###" r##"foo"# "###, expect: "(none)", errors: 2 },
+            Case { source: r###" r#"foo"## "###, expect: r##"r#"foo"#"##, errors: 1 },
+            Case { source: r##" r##"foo"# "##, expect: "(none)", errors: 2 },
             // mismatch: short:
-            Case { source: r###" r"foo"# "###, expect: r###"r"foo""###, errors: 1 },
-            Case { source: r###" r#"foo" "###, expect: "(none)", errors: 2 },
+            Case { source: r##" r"foo"# "##, expect: r#"r"foo""#, errors: 1 },
+            Case { source: r#" r#"foo" "#, expect: "(none)", errors: 2 },
             // empty string
-            Case { source: r####"r"""####, expect: r####"r"""####, errors: 0 },
+            Case { source: r#"r"""#, expect: r#"r"""#, errors: 0 },
             Case { source: r####"r###""###"####, expect: r####"r###""###"####, errors: 0 },
             // miscellaneous
-            Case { source: r###" r#\"foo\"# "###, expect: "plain::r", errors: 2 },
-            Case { source: r###" r\"foo\" "###, expect: "plain::r", errors: 1 },
-            Case { source: r###" r##"foo"# "###, expect: "(none)", errors: 2 },
+            Case { source: r##" r#\"foo\"# "##, expect: "plain::r", errors: 2 },
+            Case { source: r#" r\"foo\" "#, expect: "plain::r", errors: 1 },
+            Case { source: r##" r##"foo"# "##, expect: "(none)", errors: 2 },
             // missing 'r' letter
-            Case { source: r###" ##"foo"# "###, expect: r#""foo""#, errors: 2 },
-            Case { source: r###" #"foo" "###, expect: "plain::foo", errors: 2 },
+            Case { source: r##" ##"foo"# "##, expect: r#""foo""#, errors: 2 },
+            Case { source: r#" #"foo" "#, expect: "plain::foo", errors: 2 },
             // whitespace
-            Case { source: r###" r #"foo"# "###, expect: "plain::r", errors: 2 },
-            Case { source: r###" r# "foo"# "###, expect: "plain::r", errors: 3 },
-            Case { source: r###" r#"foo" # "###, expect: "(none)", errors: 2 },
+            Case { source: r##" r #"foo"# "##, expect: "plain::r", errors: 2 },
+            Case { source: r##" r# "foo"# "##, expect: "plain::r", errors: 3 },
+            Case { source: r#" r#"foo" # "#, expect: "(none)", errors: 2 },
             // after identifier
-            Case { source: r###" bar#"foo"# "###, expect: "plain::bar", errors: 2 },
+            Case { source: r##" bar#"foo"# "##, expect: "plain::bar", errors: 2 },
             // nested
             Case {
                 source: r###"r##"foo r#"bar"# r"baz" ### bye"##"###,
@@ -2617,10 +2613,10 @@ mod test {
     #[test]
     fn parse_raw_string_lit() {
         let lit_cases = vec![
-            Case { source: r##" r"foo" "##, expect: r##"r"foo""##, errors: 0 },
+            Case { source: r#" r"foo" "#, expect: r#"r"foo""#, errors: 0 },
             Case { source: r##" r#"foo"# "##, expect: r##"r#"foo"#"##, errors: 0 },
             // backslash
-            Case { source: r##" r"\\" "##, expect: r##"r"\\""##, errors: 0 },
+            Case { source: r#" r"\\" "#, expect: r#"r"\\""#, errors: 0 },
             Case { source: r##" r#"\"# "##, expect: r##"r#"\"#"##, errors: 0 },
             Case { source: r##" r#"\\"# "##, expect: r##"r#"\\"#"##, errors: 0 },
             Case { source: r##" r#"\\\"# "##, expect: r##"r#"\\\"#"##, errors: 0 },
@@ -2632,8 +2628,8 @@ mod test {
             },
             Case { source: r##" r#"\\\\\\\\"# "##, expect: r##"r#"\\\\\\\\"#"##, errors: 0 },
             // mismatch - errors:
-            Case { source: r###" r#"foo"## "###, expect: r###"r#"foo"#"###, errors: 1 },
-            Case { source: r###" r##"foo"# "###, expect: "(none)", errors: 2 },
+            Case { source: r###" r#"foo"## "###, expect: r##"r#"foo"#"##, errors: 1 },
+            Case { source: r##" r##"foo"# "##, expect: "(none)", errors: 2 },
         ];
 
         check_cases_with_errors(&lit_cases[..], literal());

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -2483,7 +2483,8 @@ mod test {
 
     #[test]
     fn return_validation() {
-        let cases = [Case {
+        let cases = [
+            Case {
                 source: "{ return 42; }",
                 expect: concat!("{\n", "    Error\n", "}",),
                 errors: 1,
@@ -2503,14 +2504,16 @@ mod test {
                 expect: concat!("{\n", "    Error\n", "}",),
                 errors: 2,
             },
-            Case { source: "{ return; }", expect: concat!("{\n", "    Error\n", "}",), errors: 1 }];
+            Case { source: "{ return; }", expect: concat!("{\n", "    Error\n", "}",), errors: 1 },
+        ];
 
         check_cases_with_errors(&cases[..], block(fresh_statement()));
     }
 
     #[test]
     fn expr_no_constructors() {
-        let cases = [Case {
+        let cases = [
+            Case {
                 source: "{ if structure { a: 1 } {} }",
                 expect: concat!(
                     "{\n",
@@ -2555,7 +2558,8 @@ mod test {
                     "}",
                 ),
                 errors: 0,
-            }];
+            },
+        ];
 
         check_cases_with_errors(&cases[..], block(fresh_statement()));
     }

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -138,7 +138,7 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
                     })
                     .collect()
             })
-            .unwrap_or(vec![])
+            .unwrap_or_default()
     }
 
     /// Returns the current call stack with expanded source locations. In

--- a/tooling/debugger/src/dap.rs
+++ b/tooling/debugger/src/dap.rs
@@ -115,7 +115,8 @@ impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> DapSession<'a, R, W, B> {
             let source_location = source_locations[0];
             let span = source_location.span;
             let file_id = source_location.file;
-            let Ok(line_index) = &simple_files[&file_id].line_index((), span.start() as usize) else {
+            let Ok(line_index) = &simple_files[&file_id].line_index((), span.start() as usize)
+            else {
                 return;
             };
             let line_number = line_index + 1;
@@ -446,29 +447,31 @@ impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> DapSession<'a, R, W, B> {
 
         // compute breakpoints to set and return
         let mut breakpoints_to_set: Vec<(OpcodeLocation, i64)> = vec![];
-        let breakpoints: Vec<Breakpoint> = args.breakpoints.iter().map(|breakpoint| {
-            let Ok(location) = OpcodeLocation::from_str(breakpoint.instruction_reference.as_str()) else {
-                return Breakpoint {
-                    verified: false,
-                    message: Some(String::from("Missing instruction reference")),
-                    ..Breakpoint::default()
+        let breakpoints: Vec<Breakpoint> = args
+            .breakpoints
+            .iter()
+            .map(|breakpoint| {
+                let Ok(location) =
+                    OpcodeLocation::from_str(breakpoint.instruction_reference.as_str())
+                else {
+                    return Breakpoint {
+                        verified: false,
+                        message: Some(String::from("Missing instruction reference")),
+                        ..Breakpoint::default()
+                    };
                 };
-            };
-            if !self.context.is_valid_opcode_location(&location) {
-                return Breakpoint {
-                    verified: false,
-                    message: Some(String::from("Invalid opcode location")),
-                    ..Breakpoint::default()
-                };
-            }
-            let id = self.get_next_breakpoint_id();
-            breakpoints_to_set.push((location, id));
-            Breakpoint {
-                id: Some(id),
-                verified: true,
-                ..Breakpoint::default()
-            }
-        }).collect();
+                if !self.context.is_valid_opcode_location(&location) {
+                    return Breakpoint {
+                        verified: false,
+                        message: Some(String::from("Invalid opcode location")),
+                        ..Breakpoint::default()
+                    };
+                }
+                let id = self.get_next_breakpoint_id();
+                breakpoints_to_set.push((location, id));
+                Breakpoint { id: Some(id), verified: true, ..Breakpoint::default() }
+            })
+            .collect();
 
         // actually set the computed breakpoints
         self.instruction_breakpoints = breakpoints_to_set;
@@ -539,7 +542,9 @@ impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> DapSession<'a, R, W, B> {
                 let Some(location) = self.find_opcode_for_source_location(&file_id, line) else {
                     return Breakpoint {
                         verified: false,
-                        message: Some(String::from("Source location cannot be matched to opcode location")),
+                        message: Some(String::from(
+                            "Source location cannot be matched to opcode location",
+                        )),
                         ..Breakpoint::default()
                     };
                 };

--- a/tooling/debugger/src/dap.rs
+++ b/tooling/debugger/src/dap.rs
@@ -143,7 +143,7 @@ impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> DapSession<'a, R, W, B> {
     pub fn run_loop(&mut self) -> Result<(), ServerError> {
         self.running = self.context.get_current_opcode_location().is_some();
 
-        if self.running && matches!(self.context.get_current_source_location(), None) {
+        if self.running && self.context.get_current_source_location().is_none() {
             // TODO: remove this? This is to ensure that the tool has a proper
             // source location to show when first starting the debugger, but
             // maybe the default behavior should be to start executing until the
@@ -297,7 +297,7 @@ impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> DapSession<'a, R, W, B> {
             }
         }
         // the actual opcodes
-        while count > 0 && !matches!(opcode_location, None) {
+        while count > 0 && opcode_location.is_some() {
             instructions.push(DisassembledInstruction {
                 address: format!("{}", opcode_location.unwrap()),
                 instruction: self.context.render_opcode_at_location(&opcode_location),

--- a/tooling/debugger/src/foreign_calls.rs
+++ b/tooling/debugger/src/foreign_calls.rs
@@ -100,7 +100,7 @@ impl ForeignCallExecutor for DefaultDebugForeignCallExecutor {
                 Ok(ForeignCallResult::default().into())
             }
             Some(DebugForeignCall::MemberAssign(arity)) => {
-                if let Some(ForeignCallParam::Single(var_id_value)) = foreign_call.inputs.get(0) {
+                if let Some(ForeignCallParam::Single(var_id_value)) = foreign_call.inputs.first() {
                     let arity = arity as usize;
                     let var_id = debug_var_id(var_id_value);
                     let n = foreign_call.inputs.len();
@@ -116,7 +116,7 @@ impl ForeignCallExecutor for DefaultDebugForeignCallExecutor {
                         .collect();
                     let values: Vec<Value> = (0..n - 1 - arity)
                         .flat_map(|i| {
-                            foreign_call.inputs.get(1 + i).map(|fci| fci.values()).unwrap_or(vec![])
+                            foreign_call.inputs.get(1 + i).map(|fci| fci.values()).unwrap_or_default()
                         })
                         .collect();
                     self.debug_vars.assign_field(var_id, indexes, &values);

--- a/tooling/debugger/src/foreign_calls.rs
+++ b/tooling/debugger/src/foreign_calls.rs
@@ -116,7 +116,11 @@ impl ForeignCallExecutor for DefaultDebugForeignCallExecutor {
                         .collect();
                     let values: Vec<Value> = (0..n - 1 - arity)
                         .flat_map(|i| {
-                            foreign_call.inputs.get(1 + i).map(|fci| fci.values()).unwrap_or_default()
+                            foreign_call
+                                .inputs
+                                .get(1 + i)
+                                .map(|fci| fci.values())
+                                .unwrap_or_default()
                         })
                         .collect();
                     self.debug_vars.assign_field(var_id, indexes, &values);

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -320,7 +320,7 @@ fn parse_diff(file_manager: &FileManager, state: &mut LspState) -> ParsedFiles {
         cache_misses
             .into_iter()
             .map(|(id, _, _, parse_results)| (id, parse_results))
-            .chain(cache_hits.into_iter())
+            .chain(cache_hits)
             .collect()
     } else {
         parse_all(file_manager)

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -222,11 +222,15 @@ pub(crate) fn resolve_workspace_for_source_path(file_path: &Path) -> Result<Work
         )
         .map_err(|err| LspError::WorkspaceResolutionError(err.to_string()))
     } else {
-        let Some(parent_folder) = file_path.parent().and_then(|f| f.file_name()).and_then(|file_name_os_str| file_name_os_str.to_str()) else {
+        let Some(parent_folder) = file_path
+            .parent()
+            .and_then(|f| f.file_name())
+            .and_then(|file_name_os_str| file_name_os_str.to_str())
+        else {
             return Err(LspError::WorkspaceResolutionError(format!(
                 "Could not resolve parent folder for file: {:?}",
                 file_path
-            )))
+            )));
         };
         let assumed_package = Package {
             version: None,

--- a/tooling/nargo/src/artifacts/debug_vars.rs
+++ b/tooling/nargo/src/artifacts/debug_vars.rs
@@ -30,11 +30,11 @@ impl DebugVars {
     }
 
     pub fn insert_variables(&mut self, vars: &DebugVariables) {
-        self.variables.extend(vars.clone().into_iter());
+        self.variables.extend(vars.clone());
     }
 
     pub fn insert_types(&mut self, types: &DebugTypes) {
-        self.types.extend(types.clone().into_iter());
+        self.types.extend(types.clone());
     }
 
     pub fn assign_var(&mut self, var_id: DebugVarId, values: &[Value]) {

--- a/tooling/nargo/src/artifacts/debug_vars.rs
+++ b/tooling/nargo/src/artifacts/debug_vars.rs
@@ -18,13 +18,15 @@ impl DebugVars {
         self.active
             .iter()
             .filter_map(|var_id| {
-                self.variables
-                    .get(var_id)
-                    .and_then(|debug_var| {
-                        let Some(value) = self.values.get(var_id) else { return None; };
-                        let Some(ptype) = self.types.get(&debug_var.debug_type_id) else { return None; };
-                        Some((debug_var.name.as_str(), value, ptype))
-                    })
+                self.variables.get(var_id).and_then(|debug_var| {
+                    let Some(value) = self.values.get(var_id) else {
+                        return None;
+                    };
+                    let Some(ptype) = self.types.get(&debug_var.debug_type_id) else {
+                        return None;
+                    };
+                    Some((debug_var.name.as_str(), value, ptype))
+                })
             })
             .collect()
     }

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -65,8 +65,7 @@ fn insert_all_files_for_package_into_file_manager(
     let entry_path_parent = package
         .entry_path
         .parent()
-        .unwrap_or_else(|| panic!("The entry path is expected to be a single file within a directory and so should have a parent {:?}", package.entry_path))
-        .clone();
+        .unwrap_or_else(|| panic!("The entry path is expected to be a single file within a directory and so should have a parent {:?}", package.entry_path));
 
     // Get all files in the package and add them to the file manager
     let paths = get_all_noir_source_in_dir(entry_path_parent)

--- a/tooling/nargo_cli/src/cli/check_cmd.rs
+++ b/tooling/nargo_cli/src/cli/check_cmd.rs
@@ -142,6 +142,24 @@ fn create_input_toml_template(
     toml::to_string(&map).unwrap()
 }
 
+/// Run the lexing, parsing, name resolution, and type checking passes and report any warnings
+/// and errors found.
+pub(crate) fn check_crate_and_report_errors(
+    context: &mut Context,
+    crate_id: CrateId,
+    deny_warnings: bool,
+    disable_macros: bool,
+    silence_warnings: bool,
+) -> Result<(), CompileError> {
+    let result = check_crate(context, crate_id, deny_warnings, disable_macros);
+    super::compile_cmd::report_errors(
+        result,
+        &context.file_manager,
+        deny_warnings,
+        silence_warnings,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use noirc_abi::{AbiParameter, AbiType, AbiVisibility, Sign};
@@ -188,22 +206,4 @@ d2 = ["", "", ""]
 "#;
         assert_eq!(toml_str, expected_toml_str);
     }
-}
-
-/// Run the lexing, parsing, name resolution, and type checking passes and report any warnings
-/// and errors found.
-pub(crate) fn check_crate_and_report_errors(
-    context: &mut Context,
-    crate_id: CrateId,
-    deny_warnings: bool,
-    disable_macros: bool,
-    silence_warnings: bool,
-) -> Result<(), CompileError> {
-    let result = check_crate(context, crate_id, deny_warnings, disable_macros);
-    super::compile_cmd::report_errors(
-        result,
-        &context.file_manager,
-        deny_warnings,
-        silence_warnings,
-    )
 }

--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -159,7 +159,8 @@ fn loop_uninitialized_dap<R: Read, W: Write>(
                     server.respond(req.error("Missing launch arguments"))?;
                     continue;
                 };
-                let Some(Value::String(ref project_folder)) = additional_data.get("projectFolder") else {
+                let Some(Value::String(ref project_folder)) = additional_data.get("projectFolder")
+                else {
                     server.respond(req.error("Missing project folder argument"))?;
                     continue;
                 };

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -147,8 +147,7 @@ fn instrument_package_files(
     let entry_path_parent = package
         .entry_path
         .parent()
-        .unwrap_or_else(|| panic!("The entry path is expected to be a single file within a directory and so should have a parent {:?}", package.entry_path))
-        .clone();
+        .unwrap_or_else(|| panic!("The entry path is expected to be a single file within a directory and so should have a parent {:?}", package.entry_path));
 
     let mut debug_instrumenter = DebugInstrumenter::default();
 

--- a/tooling/nargo_fmt/src/rewrite/infix.rs
+++ b/tooling/nargo_fmt/src/rewrite/infix.rs
@@ -96,7 +96,9 @@ pub(crate) fn flatten(
 
                 result.push(rewrite);
 
-                let Some(pop) = stack.pop() else { break; };
+                let Some(pop) = stack.pop() else {
+                    break;
+                };
 
                 match &pop.kind {
                     ExpressionKind::Infix(infix) => {

--- a/tooling/nargo_fmt/src/visitor/expr.rs
+++ b/tooling/nargo_fmt/src/visitor/expr.rs
@@ -202,7 +202,6 @@ pub(crate) fn format_seq<T: HasItem>(
     reduce: bool,
 ) -> String {
     let mut nested_indent = shape;
-    let shape = shape;
 
     nested_indent.indent.block_indent(visitor.config);
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

As we're bumping the MSRV in #4385, we're getting a whole new version of clippy which is picking up more stuff. This PR applies clippy + cargo fmt changes from rustc 1.76.0 to reduce the diff on #4385


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
