### PR TITLE
chore(ci): add alerts for failed publishes

### DIFF
--- a/.github/CRATES_IO_PUBLISH_FAILED.md
+++ b/.github/CRATES_IO_PUBLISH_FAILED.md
@@ -1,0 +1,10 @@
+---
+title: "ACVM crates failed to publish"
+assignees: TomAFrench kevaundray savio-sou
+---
+
+The {{env.CRATE_VERSION}} release of the ACVM crates failed.
+
+Check the [Publish ACVM]({{env.WORKFLOW_URL}}) workflow for details.
+
+This issue was raised by the workflow `{{env.WORKFLOW_NAME}}`

--- a/.github/JS_PUBLISH_FAILED.md
+++ b/.github/JS_PUBLISH_FAILED.md
@@ -1,0 +1,11 @@
+---
+title: "JS packages failed to publish"
+assignees: TomAFrench kevaundray savio-sou
+labels: js
+---
+
+The {{env.NPM_TAG}} release of the JS packages failed.
+
+Check the [Publish JS packages]({{env.WORKFLOW_URL}}) workflow for details.
+
+This issue was raised by the workflow `{{env.WORKFLOW_NAME}}`

--- a/.github/workflows/publish-acvm.yml
+++ b/.github/workflows/publish-acvm.yml
@@ -62,3 +62,16 @@ jobs:
           cargo publish --package acvm
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
+
+      # Raise an issue if any package failed to publish
+      - name: Alert on failed publish
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CRATE_VERSION: ${{ inputs.noir-ref }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/JS_PUBLISH_FAILED.md

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -143,3 +143,16 @@ jobs:
 
       - name: Publish ES Packages
         run: yarn publish:all --access public --tag ${{ inputs.npm-tag }}
+
+      # Raise an issue if any package failed to publish
+      - name: Alert on failed publish
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TAG: ${{ inputs.npm-tag }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/JS_PUBLISH_FAILED.md


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds an action to open an issue if either the ACVM crates or JS packages fail to publish.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
