### PR TITLE
feat: update error message when trying to load workspace as dependency

### DIFF
--- a/tooling/nargo_toml/src/errors.rs
+++ b/tooling/nargo_toml/src/errors.rs
@@ -28,7 +28,7 @@ pub enum ManifestError {
     #[error("Nargo.toml is badly formed, could not parse.\n\n {0}")]
     MalformedFile(#[from] toml::de::Error),
 
-    #[error("Unexpected workspace definition found in {0}")]
+    #[error("Unexpected workspace definition found in {0}. If you're attempting to load this as a dependency, you may need to add a `directory` field to your `Nargo.toml` to show which package within the workspace to use")]
     UnexpectedWorkspace(PathBuf),
 
     #[error("Cannot find file {entry} which was specified as the `entry` field in {toml}")]


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This addresses an issue that a user in the discord is running into where they're trying to load a workspace as a dependency and can't figure out how to fix their Nargo.toml.

## Additional Context

We should probably be embedding links to the docs but that would require some setup so that we point to the correct version, etc.


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
