### PR TITLE
chore!: bump msrv to 1.73.0

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           targets: ${{ matrix.target }}
           components: clippy, rustfmt

--- a/.github/workflows/gates_report.yml
+++ b/.github/workflows/gates_report.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/publish-acvm.yml
+++ b/.github/workflows/publish-acvm.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ inputs.noir-ref }}
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       # These steps are in a specific order so crate dependencies are updated first
       - name: Publish acir_field

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ inputs.noir-ref }}
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -46,7 +46,7 @@ jobs:
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx$(sw_vers -productVersion) --show-sdk-platform-version)" >> $GITHUB_ENV
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           targets: ${{ matrix.target }}
 
@@ -120,7 +120,7 @@ jobs:
           ref: ${{ inputs.tag || env.GITHUB_REF }}
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           targets: x86_64-unknown-linux-gnu
 
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           targets: x86_64-unknown-linux-gnu
 

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           targets: x86_64-unknown-linux-gnu
 
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup toolchain
-        uses: dtolnay/rust-toolchain@1.71.1
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           targets: x86_64-unknown-linux-gnu
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ version = "0.24.0"
 # x-release-please-end
 authors = ["The Noir Team <team@noir-lang.org>"]
 edition = "2021"
-rust-version = "1.71.1"
+rust-version = "1.73.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/noir-lang/noir/"
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM rust:1.71.1-slim-bookworm as base
+FROM rust:1.73.0-slim-bookworm as base
 RUN apt-get update && apt-get upgrade -y && apt-get install build-essential git -y
 WORKDIR /usr/src/noir
 ENV PATH="${PATH}:/usr/src/noir/target/release"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Concretely the following items are on the road map:
 
 ## Minimum Rust version
 
-This crate's minimum supported rustc version is 1.71.1.
+This crate's minimum supported rustc version is 1.73.0.
 
 ## Working on this project
 

--- a/docs/docs/getting_started/installation/other_install_methods.md
+++ b/docs/docs/getting_started/installation/other_install_methods.md
@@ -212,7 +212,7 @@ code .
 #### Building and testing
 
 Assuming you are using `direnv` to populate your environment, building and testing the project can be done
-with the typical `cargo build`, `cargo test`, and `cargo clippy` commands. You'll notice that the `cargo` version matches the version we specify in `rust-toolchain.toml`, which is 1.71.1 at the time of this writing.
+with the typical `cargo build`, `cargo test`, and `cargo clippy` commands. You'll notice that the `cargo` version matches the version we specify in `rust-toolchain.toml`, which is 1.73.0 at the time of this writing.
 
 If you want to build the entire project in an isolated sandbox, you can use Nix commands:
 

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
 
       rustToolchain = fenix.packages.${system}.fromToolchainFile {
         file = ./rust-toolchain.toml;
-        sha256 = "sha256-dxE7lmCFWlq0nl/wKcmYvpP9zqQbBitAQgZ1zx9Ooik=";
+        sha256 = "sha256-rLP8+fTxnPHoR96ZJiCa/5Ans1OojI7MLsmSqR2ip8o=";
       };
 
       craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.72.1"
+channel = "1.73.0"
 components = [ "rust-src" ]
 targets = [ "wasm32-unknown-unknown", "wasm32-wasi", "aarch64-apple-darwin" ]
 profile = "default"

--- a/tooling/nargo/build.rs
+++ b/tooling/nargo/build.rs
@@ -2,8 +2,8 @@ use rustc_version::{version, Version};
 
 fn check_rustc_version() {
     assert!(
-        version().unwrap() >= Version::parse("1.71.1").unwrap(),
-        "The minimal supported rustc version is 1.71.1."
+        version().unwrap() >= Version::parse("1.73.0").unwrap(),
+        "The minimal supported rustc version is 1.73.0."
     );
 }
 

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -6,8 +6,8 @@ use std::{env, fs};
 
 fn check_rustc_version() {
     assert!(
-        version().unwrap() >= Version::parse("1.71.1").unwrap(),
-        "The minimal supported rustc version is 1.71.1."
+        version().unwrap() >= Version::parse("1.73.0").unwrap(),
+        "The minimal supported rustc version is 1.73.0."
     );
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Bumpalo bumped their MSRV in a [patch/minor release](https://github.com/fitzgen/bumpalo/commit/f8597ceb3600807a902fa9692fb43c49e7b63b27) and wasmer is using an unlocked dependency so we need to bump to match.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
