### PR TITLE
chore: remove duplicate `parse_all` function in wasm compiler

### DIFF
--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -1,9 +1,12 @@
 use fm::FileManager;
 use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{JsString, Object};
-use nargo::artifacts::{
-    contract::{ContractArtifact, ContractFunctionArtifact},
-    program::ProgramArtifact,
+use nargo::{
+    artifacts::{
+        contract::{ContractArtifact, ContractFunctionArtifact},
+        program::ProgramArtifact,
+    },
+    parse_all,
 };
 use noirc_driver::{
     add_dep, compile_contract, compile_main, file_manager_with_stdlib, prepare_crate,
@@ -13,7 +16,7 @@ use noirc_driver::{
 use noirc_evaluator::errors::SsaReport;
 use noirc_frontend::{
     graph::{CrateId, CrateName},
-    hir::{def_map::parse_file, Context, ParsedFiles},
+    hir::Context,
 };
 use serde::Deserialize;
 use std::{collections::HashMap, path::Path};
@@ -138,10 +141,6 @@ impl PathToFileSourceMap {
         let old_value = self.0.insert(path_buf, source_code);
         old_value.is_some()
     }
-}
-
-pub(crate) fn parse_all(fm: &FileManager) -> ParsedFiles {
-    fm.as_file_map().all_file_ids().map(|&file_id| (file_id, parse_file(fm, file_id))).collect()
 }
 
 pub enum CompileResult {
@@ -291,14 +290,13 @@ pub(crate) fn generate_contract_artifact(contract: CompiledContract) -> CompileR
 
 #[cfg(test)]
 mod test {
+    use nargo::parse_all;
     use noirc_driver::prepare_crate;
     use noirc_frontend::{graph::CrateName, hir::Context};
 
     use crate::compile::PathToFileSourceMap;
 
-    use super::{
-        file_manager_with_source_map, parse_all, process_dependency_graph, DependencyGraph,
-    };
+    use super::{file_manager_with_source_map, process_dependency_graph, DependencyGraph};
     use std::{collections::HashMap, path::Path};
 
     fn setup_test_context(source_map: PathToFileSourceMap) -> Context<'static, 'static> {

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -1,8 +1,9 @@
 use crate::compile::{
-    file_manager_with_source_map, generate_contract_artifact, generate_program_artifact, parse_all,
+    file_manager_with_source_map, generate_contract_artifact, generate_program_artifact,
     JsCompileResult, PathToFileSourceMap,
 };
 use crate::errors::{CompileError, JsCompileError};
+use nargo::parse_all;
 use noirc_driver::{
     add_dep, compile_contract, compile_main, prepare_crate, prepare_dependency, CompileOptions,
 };
@@ -230,10 +231,11 @@ pub fn compile_(
 
 #[cfg(test)]
 mod test {
+    use nargo::parse_all;
     use noirc_driver::prepare_crate;
     use noirc_frontend::hir::Context;
 
-    use crate::compile::{file_manager_with_source_map, parse_all, PathToFileSourceMap};
+    use crate::compile::{file_manager_with_source_map, PathToFileSourceMap};
 
     use std::path::Path;
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This removes a function which exists in `nargo` from being defined again in `noir_wasm`

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
