### PR TITLE
feat: expose separate functions to compile programs vs contracts in `noir_wasm`

### DIFF
--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -1,10 +1,12 @@
 use crate::compile::{
-    file_manager_with_source_map, generate_contract_artifact, generate_program_artifact, parse_all,
-    JsCompileResult, PathToFileSourceMap,
+    file_manager_with_source_map, parse_all, JsCompileContractResult, JsCompileProgramResult,
+    PathToFileSourceMap,
 };
 use crate::errors::{CompileError, JsCompileError};
+use nargo::artifacts::contract::{ContractArtifact, ContractFunctionArtifact};
 use noirc_driver::{
     add_dep, compile_contract, compile_main, prepare_crate, prepare_dependency, CompileOptions,
+    NOIR_ARTIFACT_VERSION_STRING,
 };
 use noirc_frontend::{
     graph::{CrateId, CrateName},
@@ -92,7 +94,7 @@ impl CompilerContext {
     pub fn compile_program(
         mut self,
         program_width: usize,
-    ) -> Result<JsCompileResult, JsCompileError> {
+    ) -> Result<JsCompileProgramResult, JsCompileError> {
         let compile_options = CompileOptions::default();
         let np_language = acvm::acir::circuit::ExpressionWidth::Bounded { width: program_width };
 
@@ -110,15 +112,15 @@ impl CompilerContext {
                 .0;
 
         let optimized_program = nargo::ops::transform_program(compiled_program, np_language);
+        let warnings = optimized_program.warnings.clone();
 
-        let compile_output = generate_program_artifact(optimized_program);
-        Ok(JsCompileResult::new(compile_output))
+        Ok(JsCompileProgramResult::new(optimized_program.into(), warnings))
     }
 
     pub fn compile_contract(
         mut self,
         program_width: usize,
-    ) -> Result<JsCompileResult, JsCompileError> {
+    ) -> Result<JsCompileContractResult, JsCompileError> {
         let compile_options = CompileOptions::default();
         let np_language = acvm::acir::circuit::ExpressionWidth::Bounded { width: program_width };
         let root_crate_id = *self.context.root_crate_id();
@@ -136,23 +138,63 @@ impl CompilerContext {
 
         let optimized_contract = nargo::ops::transform_contract(compiled_contract, np_language);
 
-        let compile_output = generate_contract_artifact(optimized_contract);
-        Ok(JsCompileResult::new(compile_output))
+        let functions =
+            optimized_contract.functions.into_iter().map(ContractFunctionArtifact::from).collect();
+
+        let contract_artifact = ContractArtifact {
+            noir_version: String::from(NOIR_ARTIFACT_VERSION_STRING),
+            name: optimized_contract.name,
+            functions,
+            events: optimized_contract.events,
+            file_map: optimized_contract.file_map,
+        };
+
+        Ok(JsCompileContractResult::new(contract_artifact, optimized_contract.warnings))
     }
 }
 
 /// This is a method that exposes the same API as `compile`
 /// But uses the Context based APi internally
 #[wasm_bindgen]
-pub fn compile_(
+pub fn compile_program_(
     entry_point: String,
-    contracts: Option<bool>,
     dependency_graph: Option<crate::compile::JsDependencyGraph>,
     file_source_map: PathToFileSourceMap,
-) -> Result<JsCompileResult, JsCompileError> {
-    use std::collections::HashMap;
-
+) -> Result<JsCompileProgramResult, JsCompileError> {
     console_error_panic_hook::set_once();
+
+    let compiler_context =
+        prepare_compiler_context(entry_point, dependency_graph, file_source_map)?;
+    let program_width = 3;
+
+    compiler_context.compile_program(program_width)
+}
+
+/// This is a method that exposes the same API as `compile`
+/// But uses the Context based APi internally
+#[wasm_bindgen]
+pub fn compile_contract_(
+    entry_point: String,
+    dependency_graph: Option<crate::compile::JsDependencyGraph>,
+    file_source_map: PathToFileSourceMap,
+) -> Result<JsCompileContractResult, JsCompileError> {
+    console_error_panic_hook::set_once();
+
+    let compiler_context =
+        prepare_compiler_context(entry_point, dependency_graph, file_source_map)?;
+    let program_width = 3;
+
+    compiler_context.compile_contract(program_width)
+}
+
+/// This is a method that exposes the same API as `prepare_context`
+/// But uses the Context based API internally
+fn prepare_compiler_context(
+    entry_point: String,
+    dependency_graph: Option<crate::compile::JsDependencyGraph>,
+    file_source_map: PathToFileSourceMap,
+) -> Result<CompilerContext, JsCompileError> {
+    use std::collections::HashMap;
 
     let dependency_graph: crate::compile::DependencyGraph =
         if let Some(dependency_graph) = dependency_graph {
@@ -218,14 +260,7 @@ pub fn compile_(
         }
     }
 
-    let is_contract = contracts.unwrap_or(false);
-    let program_width = 3;
-
-    if is_contract {
-        compiler_context.compile_contract(program_width)
-    } else {
-        compiler_context.compile_program(program_width)
-    }
+    Ok(compiler_context)
 }
 
 #[cfg(test)]

--- a/compiler/wasm/src/index.cts
+++ b/compiler/wasm/src/index.cts
@@ -2,7 +2,7 @@ import { FileManager } from './noir/file-manager/file-manager';
 import { createNodejsFileManager } from './noir/file-manager/nodejs-file-manager';
 import { NoirWasmCompiler } from './noir/noir-wasm-compiler';
 import { LogData, LogFn } from './utils';
-import { CompilationResult } from './types/noir_artifact';
+import { ContractCompilationArtifacts, ProgramCompilationArtifacts } from './types/noir_artifact';
 import { inflateDebugSymbols } from './noir/debug';
 
 /**
@@ -17,36 +17,86 @@ import { inflateDebugSymbols } from './noir/debug';
  * ```typescript
  * // Node.js
  *
- * import { compile, createFileManager } from '@noir-lang/noir_wasm';
+ * import { compile_program, createFileManager } from '@noir-lang/noir_wasm';
  *
  * const fm = createFileManager(myProjectPath);
- * const myCompiledCode = await compile(fm);
+ * const myCompiledCode = await compile_program(fm);
  * ```
  *
  * ```typescript
  * // Browser
  *
- * import { compile, createFileManager } from '@noir-lang/noir_wasm';
+ * import { compile_program, createFileManager } from '@noir-lang/noir_wasm';
  *
  * const fm = createFileManager('/');
  * for (const path of files) {
  *   await fm.writeFile(path, await getFileAsStream(path));
  * }
- * const myCompiledCode = await compile(fm);
+ * const myCompiledCode = await compile_program(fm);
  * ```
  */
-async function compile(
+async function compile_program(
   fileManager: FileManager,
   projectPath?: string,
   logFn?: LogFn,
   debugLogFn?: LogFn,
-): Promise<CompilationResult> {
+): Promise<ProgramCompilationArtifacts> {
+  const compiler = await setup_compiler(fileManager, projectPath, logFn, debugLogFn);
+  return await compiler.compile_program();
+}
+
+/**
+ * Compiles a Noir project
+ *
+ * @param fileManager - The file manager to use
+ * @param projectPath - The path to the project inside the file manager. Defaults to the root of the file manager
+ * @param logFn - A logging function. If not provided, console.log will be used
+ * @param debugLogFn - A debug logging function. If not provided, logFn will be used
+ *
+ * @example
+ * ```typescript
+ * // Node.js
+ *
+ * import { compile_contract, createFileManager } from '@noir-lang/noir_wasm';
+ *
+ * const fm = createFileManager(myProjectPath);
+ * const myCompiledCode = await compile_contract(fm);
+ * ```
+ *
+ * ```typescript
+ * // Browser
+ *
+ * import { compile_contract, createFileManager } from '@noir-lang/noir_wasm';
+ *
+ * const fm = createFileManager('/');
+ * for (const path of files) {
+ *   await fm.writeFile(path, await getFileAsStream(path));
+ * }
+ * const myCompiledCode = await compile_contract(fm);
+ * ```
+ */
+async function compile_contract(
+  fileManager: FileManager,
+  projectPath?: string,
+  logFn?: LogFn,
+  debugLogFn?: LogFn,
+): Promise<ContractCompilationArtifacts> {
+  const compiler = await setup_compiler(fileManager, projectPath, logFn, debugLogFn);
+  return await compiler.compile_contract();
+}
+
+async function setup_compiler(
+  fileManager: FileManager,
+  projectPath?: string,
+  logFn?: LogFn,
+  debugLogFn?: LogFn,
+): Promise<NoirWasmCompiler> {
   if (logFn && !debugLogFn) {
     debugLogFn = logFn;
   }
 
   const cjs = await require('../build/cjs');
-  const compiler = await NoirWasmCompiler.new(
+  return await NoirWasmCompiler.new(
     fileManager,
     projectPath ?? fileManager.getDataDir(),
     cjs,
@@ -72,9 +122,16 @@ async function compile(
         },
     },
   );
-  return await compiler.compile();
 }
 
 const createFileManager = createNodejsFileManager;
 
-export { compile, createFileManager, inflateDebugSymbols, CompilationResult };
+export {
+  compile_program as compile,
+  compile_program,
+  compile_contract,
+  createFileManager,
+  inflateDebugSymbols,
+  ProgramCompilationArtifacts,
+  ContractCompilationArtifacts,
+};

--- a/compiler/wasm/src/index.mts
+++ b/compiler/wasm/src/index.mts
@@ -2,7 +2,7 @@ import { FileManager } from './noir/file-manager/file-manager';
 import { createNodejsFileManager } from './noir/file-manager/nodejs-file-manager';
 import { NoirWasmCompiler } from './noir/noir-wasm-compiler';
 import { LogData, LogFn } from './utils';
-import { CompilationResult } from './types/noir_artifact';
+import { ContractCompilationArtifacts, ProgramCompilationArtifacts } from './types/noir_artifact';
 import { inflateDebugSymbols } from './noir/debug';
 
 /**
@@ -17,30 +17,80 @@ import { inflateDebugSymbols } from './noir/debug';
  * ```typescript
  * // Node.js
  *
- * import { compile, createFileManager } from '@noir-lang/noir_wasm';
+ * import { compile_program, createFileManager } from '@noir-lang/noir_wasm';
  *
  * const fm = createFileManager(myProjectPath);
- * const myCompiledCode = await compile(fm);
+ * const myCompiledCode = await compile_program(fm);
  * ```
  *
  * ```typescript
  * // Browser
  *
- * import { compile, createFileManager } from '@noir-lang/noir_wasm';
+ * import { compile_program, createFileManager } from '@noir-lang/noir_wasm';
  *
  * const fm = createFileManager('/');
  * for (const path of files) {
  *   await fm.writeFile(path, await getFileAsStream(path));
  * }
- * const myCompiledCode = await compile(fm);
+ * const myCompiledCode = await compile_program(fm);
  * ```
  */
-async function compile(
+async function compile_program(
   fileManager: FileManager,
   projectPath?: string,
   logFn?: LogFn,
   debugLogFn?: LogFn,
-): Promise<CompilationResult> {
+): Promise<ProgramCompilationArtifacts> {
+  const compiler = await setup_compiler(fileManager, projectPath, logFn, debugLogFn);
+  return await compiler.compile_program();
+}
+
+/**
+ * Compiles a Noir project
+ *
+ * @param fileManager - The file manager to use
+ * @param projectPath - The path to the project inside the file manager. Defaults to the root of the file manager
+ * @param logFn - A logging function. If not provided, console.log will be used
+ * @param debugLogFn - A debug logging function. If not provided, logFn will be used
+ *
+ * @example
+ * ```typescript
+ * // Node.js
+ *
+ * import { compile_contract, createFileManager } from '@noir-lang/noir_wasm';
+ *
+ * const fm = createFileManager(myProjectPath);
+ * const myCompiledCode = await compile_contract(fm);
+ * ```
+ *
+ * ```typescript
+ * // Browser
+ *
+ * import { compile_contract, createFileManager } from '@noir-lang/noir_wasm';
+ *
+ * const fm = createFileManager('/');
+ * for (const path of files) {
+ *   await fm.writeFile(path, await getFileAsStream(path));
+ * }
+ * const myCompiledCode = await compile_contract(fm);
+ * ```
+ */
+async function compile_contract(
+  fileManager: FileManager,
+  projectPath?: string,
+  logFn?: LogFn,
+  debugLogFn?: LogFn,
+): Promise<ContractCompilationArtifacts> {
+  const compiler = await setup_compiler(fileManager, projectPath, logFn, debugLogFn);
+  return await compiler.compile_contract();
+}
+
+async function setup_compiler(
+  fileManager: FileManager,
+  projectPath?: string,
+  logFn?: LogFn,
+  debugLogFn?: LogFn,
+): Promise<NoirWasmCompiler> {
   if (logFn && !debugLogFn) {
     debugLogFn = logFn;
   }
@@ -48,7 +98,7 @@ async function compile(
   const esm = await import(/* webpackMode: "eager" */ '../build/esm');
   await esm.default();
 
-  const compiler = await NoirWasmCompiler.new(
+  return await NoirWasmCompiler.new(
     fileManager,
     projectPath ?? fileManager.getDataDir(),
     esm,
@@ -74,9 +124,16 @@ async function compile(
         },
     },
   );
-  return await compiler.compile();
 }
 
 const createFileManager = createNodejsFileManager;
 
-export { compile, createFileManager, inflateDebugSymbols, CompilationResult };
+export {
+  compile_program as compile,
+  compile_program,
+  compile_contract,
+  createFileManager,
+  inflateDebugSymbols,
+  ProgramCompilationArtifacts,
+  ContractCompilationArtifacts,
+};

--- a/compiler/wasm/src/lib.rs
+++ b/compiler/wasm/src/lib.rs
@@ -18,10 +18,10 @@ mod compile;
 mod compile_new;
 mod errors;
 
-pub use compile::compile;
+pub use compile::{compile_contract, compile_program};
 
 // Expose the new Context-Centric API
-pub use compile_new::{compile_, CompilerContext, CrateIDWrapper};
+pub use compile_new::{compile_contract_, compile_program_, CompilerContext, CrateIDWrapper};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 #[derive(Serialize, Deserialize)]

--- a/compiler/wasm/src/types/noir_artifact.ts
+++ b/compiler/wasm/src/types/noir_artifact.ts
@@ -180,22 +180,3 @@ export interface ProgramCompilationArtifacts {
   /** Compilation warnings. */
   warnings: Warning[];
 }
-
-/**
- * output of Noir Wasm compilation, can be for a contract or lib/binary
- */
-export type CompilationResult = ContractCompilationArtifacts | ProgramCompilationArtifacts;
-
-/**
- * Check if it has Contract unique property
- */
-export function isContractCompilationArtifacts(artifact: CompilationResult): artifact is ContractCompilationArtifacts {
-  return (artifact as ContractCompilationArtifacts).contract !== undefined;
-}
-
-/**
- * Check if it has Contract unique property
- */
-export function isProgramCompilationArtifacts(artifact: CompilationResult): artifact is ProgramCompilationArtifacts {
-  return (artifact as ProgramCompilationArtifacts).program !== undefined;
-}

--- a/compiler/wasm/test/compiler/browser/compile.test.ts
+++ b/compiler/wasm/test/compiler/browser/compile.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { getPaths } from '../../shared';
 import { expect } from '@esm-bundle/chai';
-import { compile, createFileManager } from '@noir-lang/noir_wasm';
+import { compile_program, compile_contract, createFileManager } from '@noir-lang/noir_wasm';
 import { ContractArtifact, ProgramArtifact } from '../../../src/types/noir_artifact';
 import { shouldCompileContractIdentically, shouldCompileProgramIdentically } from '../shared/compile.test';
 
@@ -33,7 +33,7 @@ describe('noir-compiler/browser', () => {
         await fm.writeFile(path, (await getFile(path)).body as ReadableStream<Uint8Array>);
       }
       const nargoArtifact = (await getPrecompiledSource(simpleScriptExpectedArtifact)) as ProgramArtifact;
-      const noirWasmArtifact = await compile(fm, '/fixtures/simple');
+      const noirWasmArtifact = await compile_program(fm, '/fixtures/simple');
 
       return { nargoArtifact, noirWasmArtifact };
     },
@@ -51,7 +51,7 @@ describe('noir-compiler/browser', () => {
         await fm.writeFile(path, (await getFile(path)).body as ReadableStream<Uint8Array>);
       }
       const nargoArtifact = (await getPrecompiledSource(depsScriptExpectedArtifact)) as ProgramArtifact;
-      const noirWasmArtifact = await compile(fm, '/fixtures/with-deps');
+      const noirWasmArtifact = await compile_program(fm, '/fixtures/with-deps');
 
       return { nargoArtifact, noirWasmArtifact };
     },
@@ -69,7 +69,7 @@ describe('noir-compiler/browser', () => {
         await fm.writeFile(path, (await getFile(path)).body as ReadableStream<Uint8Array>);
       }
       const nargoArtifact = (await getPrecompiledSource(contractExpectedArtifact)) as ContractArtifact;
-      const noirWasmArtifact = await compile(fm, '/fixtures/noir-contract');
+      const noirWasmArtifact = await compile_contract(fm, '/fixtures/noir-contract');
 
       return { nargoArtifact, noirWasmArtifact };
     },

--- a/compiler/wasm/test/compiler/node/compile.test.ts
+++ b/compiler/wasm/test/compiler/node/compile.test.ts
@@ -2,7 +2,7 @@ import { join, resolve } from 'path';
 import { getPaths } from '../../shared';
 
 import { expect } from 'chai';
-import { compile, compile_contract, createFileManager } from '@noir-lang/noir_wasm';
+import { compile_program, compile_contract, createFileManager } from '@noir-lang/noir_wasm';
 import { readFile } from 'fs/promises';
 import { ContractArtifact, ProgramArtifact } from '../../../src/types/noir_artifact';
 import { shouldCompileContractIdentically, shouldCompileProgramIdentically } from '../shared/compile.test';
@@ -15,7 +15,7 @@ describe('noir-compiler/node', () => {
 
     const fm = createFileManager(simpleScriptProjectPath);
     const nargoArtifact = JSON.parse((await readFile(simpleScriptExpectedArtifact)).toString()) as ProgramArtifact;
-    const noirWasmArtifact = await compile(fm);
+    const noirWasmArtifact = await compile_program(fm);
     return { nargoArtifact, noirWasmArtifact };
   }, expect);
 
@@ -24,7 +24,7 @@ describe('noir-compiler/node', () => {
 
     const fm = createFileManager(depsScriptProjectPath);
     const nargoArtifact = JSON.parse((await readFile(depsScriptExpectedArtifact)).toString()) as ProgramArtifact;
-    const noirWasmArtifact = await compile(fm);
+    const noirWasmArtifact = await compile_program(fm);
     return { nargoArtifact, noirWasmArtifact };
   }, expect);
 

--- a/compiler/wasm/test/compiler/node/compile.test.ts
+++ b/compiler/wasm/test/compiler/node/compile.test.ts
@@ -2,7 +2,7 @@ import { join, resolve } from 'path';
 import { getPaths } from '../../shared';
 
 import { expect } from 'chai';
-import { compile, createFileManager } from '@noir-lang/noir_wasm';
+import { compile, compile_contract, createFileManager } from '@noir-lang/noir_wasm';
 import { readFile } from 'fs/promises';
 import { ContractArtifact, ProgramArtifact } from '../../../src/types/noir_artifact';
 import { shouldCompileContractIdentically, shouldCompileProgramIdentically } from '../shared/compile.test';
@@ -33,7 +33,7 @@ describe('noir-compiler/node', () => {
 
     const fm = createFileManager(contractProjectPath);
     const nargoArtifact = JSON.parse((await readFile(contractExpectedArtifact)).toString()) as ContractArtifact;
-    const noirWasmArtifact = await compile(fm);
+    const noirWasmArtifact = await compile_contract(fm);
     return { nargoArtifact, noirWasmArtifact };
   }, expect);
 });

--- a/compiler/wasm/test/compiler/shared/compile.test.ts
+++ b/compiler/wasm/test/compiler/shared/compile.test.ts
@@ -1,4 +1,4 @@
-import { CompilationResult, inflateDebugSymbols } from '@noir-lang/noir_wasm';
+import { inflateDebugSymbols } from '@noir-lang/noir_wasm';
 import { type expect as Expect } from 'chai';
 import {
   ContractArtifact,
@@ -11,7 +11,7 @@ import {
 } from '../../../src/types/noir_artifact';
 
 export function shouldCompileProgramIdentically(
-  compileFn: () => Promise<{ nargoArtifact: ProgramArtifact; noirWasmArtifact: CompilationResult }>,
+  compileFn: () => Promise<{ nargoArtifact: ProgramArtifact; noirWasmArtifact: ProgramCompilationArtifacts }>,
   expect: typeof Expect,
   timeout = 5000,
 ) {
@@ -24,7 +24,7 @@ export function shouldCompileProgramIdentically(
     normalizeVersion(nargoArtifact);
 
     // Prepare noir-wasm artifact
-    const noirWasmProgram = (noirWasmArtifact as unknown as ProgramCompilationArtifacts).program;
+    const noirWasmProgram = noirWasmArtifact.program;
     expect(noirWasmProgram).not.to.be.undefined;
     const [_noirWasmDebugInfos, norWasmFileMap] = deleteProgramDebugMetadata(noirWasmProgram);
     normalizeVersion(noirWasmProgram);
@@ -47,7 +47,7 @@ export function shouldCompileProgramIdentically(
 }
 
 export function shouldCompileContractIdentically(
-  compileFn: () => Promise<{ nargoArtifact: ContractArtifact; noirWasmArtifact: CompilationResult }>,
+  compileFn: () => Promise<{ nargoArtifact: ContractArtifact; noirWasmArtifact: ContractCompilationArtifacts }>,
   expect: typeof Expect,
   timeout = 5000,
 ) {
@@ -60,7 +60,7 @@ export function shouldCompileContractIdentically(
     normalizeVersion(nargoArtifact);
 
     // Prepare noir-wasm artifact
-    const noirWasmContract = (noirWasmArtifact as unknown as ContractCompilationArtifacts).contract;
+    const noirWasmContract = noirWasmArtifact.contract;
     expect(noirWasmContract).not.to.be.undefined;
     const [noirWasmDebugInfos, norWasmFileMap] = deleteContractDebugMetadata(noirWasmContract);
     normalizeVersion(noirWasmContract);

--- a/compiler/wasm/test/wasm/browser/index.test.ts
+++ b/compiler/wasm/test/wasm/browser/index.test.ts
@@ -2,7 +2,7 @@
 import { getPaths } from '../../shared';
 import { expect } from '@esm-bundle/chai';
 
-import init, { compile, PathToFileSourceMap, compile_, CompilerContext } from '../../../build/esm';
+import init, { compile_program, PathToFileSourceMap, compile_program_, CompilerContext } from '../../../build/esm';
 
 // @ts-ignore
 await init();
@@ -35,7 +35,7 @@ describe('noir wasm compilation', () => {
     it('matching nargos compilation', async () => {
       const sourceMap = new PathToFileSourceMap();
       sourceMap.add_source_code('script/main.nr', await getFileAsString(simpleScriptSourcePath));
-      const wasmCircuit = compile('script/main.nr', undefined, undefined, sourceMap);
+      const wasmCircuit = compile_program('script/main.nr', undefined, sourceMap);
       const cliCircuit = await getPrecompiledSource(simpleScriptExpectedArtifact);
 
       if (!('program' in wasmCircuit)) {
@@ -58,9 +58,8 @@ describe('noir wasm compilation', () => {
     });
 
     it('matching nargos compilation', async () => {
-      const wasmCircuit = compile(
+      const wasmCircuit = compile_program(
         'script/main.nr',
-        false,
         {
           root_dependencies: ['lib_a'],
           library_dependencies: {
@@ -132,9 +131,8 @@ describe('noir wasm compilation', () => {
     }).timeout(60 * 20e3);
 
     it('matching nargos compilation - context-implementation-compile-api', async () => {
-      const wasmCircuit = await compile_(
+      const wasmCircuit = await compile_program_(
         'script/main.nr',
-        false,
         {
           root_dependencies: ['lib_a'],
           library_dependencies: {

--- a/compiler/wasm/test/wasm/node/index.test.ts
+++ b/compiler/wasm/test/wasm/node/index.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { expect } from 'chai';
 
-import { compile, PathToFileSourceMap, compile_, CompilerContext } from '../../../build/cjs';
+import { compile_program, PathToFileSourceMap, compile_program_, CompilerContext } from '../../../build/cjs';
 
 const basePath = resolve(join(__dirname, '../../'));
 const {
@@ -26,7 +26,7 @@ describe('noir wasm compilation', () => {
     it('matching nargos compilation', async () => {
       const sourceMap = new PathToFileSourceMap();
       sourceMap.add_source_code(simpleScriptSourcePath, readFileSync(simpleScriptSourcePath, 'utf-8'));
-      const wasmCircuit = compile(simpleScriptSourcePath, undefined, undefined, sourceMap);
+      const wasmCircuit = compile_program(simpleScriptSourcePath, undefined, sourceMap);
       const cliCircuit = await getPrecompiledSource(simpleScriptExpectedArtifact);
 
       if (!('program' in wasmCircuit)) {
@@ -49,9 +49,8 @@ describe('noir wasm compilation', () => {
     });
 
     it('matching nargos compilation', async () => {
-      const wasmCircuit = compile(
+      const wasmCircuit = compile_program(
         'script/main.nr',
-        false,
         {
           root_dependencies: ['lib_a'],
           library_dependencies: {
@@ -123,9 +122,8 @@ describe('noir wasm compilation', () => {
     }).timeout(60 * 20e3);
 
     it('matching nargos compilation - context-implementation-compile-api', async () => {
-      const wasmCircuit = await compile_(
+      const wasmCircuit = await compile_program_(
         'script/main.nr',
-        false,
         {
           root_dependencies: ['lib_a'],
           library_dependencies: {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR exposes separate functions to compile contracts vs programs in the wasm compiler. This allows us to simplify various code paths as we don't need to deal with the potential for the two artifact types as this just leads to us asserting types and breaking type safety.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
