### PR TITLE
chore(ci): prevent msrv checks from blocking PRs

### DIFF
--- a/.github/ACVM_NOT_PUBLISHABLE.md
+++ b/.github/ACVM_NOT_PUBLISHABLE.md
@@ -1,0 +1,13 @@
+---
+title: "ACVM crates are not publishable"
+assignees: TomAFrench kevaundray savio-sou
+---
+
+
+The ACVM crates are currently unpublishable, making a release will NOT push our crates to crates.io.
+
+This is likely due to a crate we depend on bumping its MSRV above our own. Our lockfile is not taken into account when publishing to crates.io (as people downloading our crate don't use it) so we need to be able to use the most up to date versions of our dependencies (including transient dependencies) specified. 
+
+Check the [MSRV check]({{env.WORKFLOW_URL}}) workflow for details.
+
+This issue was raised by the workflow `{{env.WORKFLOW_NAME}}`

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -6,8 +6,9 @@ name: Test (MSRV check)
 # We must then always be able to build the workspace using the latest versions of all of our dependencies, so we explicitly update them and build in this workflow. 
 
 on:
-  pull_request:
-  merge_group:
+  schedule:
+    # Run a nightly check at 2 AM UTC
+    - cron: "0 2 * * *"
   push:
     branches:
       - master
@@ -100,13 +101,25 @@ jobs:
       - run-tests
     
     steps:
-        - name: Report overall success
-          run: |
-            if [[ $FAIL == true ]]; then
-                exit 1
-            else
-                exit 0
-            fi
-          env:
-            # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
-            FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+      - name: Report overall success
+        run: |
+          if [[ $FAIL == true ]]; then
+              exit 1
+          else
+              exit 0
+          fi
+        env:
+          # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
+          FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+    
+      # Raise an issue if the tests failed
+      - name: Alert on failed publish
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/JS_PUBLISH_FAILED.md

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -88,13 +88,13 @@ jobs:
       - run-tests
     
     steps:
-        - name: Report overall success
-          run: |
-            if [[ $FAIL == true ]]; then
-                exit 1
-            else
-                exit 0
-            fi
-          env:
-            # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
-            FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+      - name: Report overall success
+        run: |
+          if [[ $FAIL == true ]]; then
+              exit 1
+          else
+              exit 0
+          fi
+        env:
+          # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
+          FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}

--- a/cspell.json
+++ b/cspell.json
@@ -118,6 +118,7 @@
         "monomorphizes",
         "monomorphizing",
         "montcurve",
+        "MSRV",
         "nand",
         "nargo",
         "neovim",


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Current the MSRV check CI runs on every PR so if one of our dependencies breaks us, all merges halt until we fix this. This is unnecessary as we only need to stop publishing releases and normal development work can continue.

This PR switches this workflow to instead run only on master and on a nightly schedule. If the workflow fails then an issue will be raised.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
