### PR TITLE
chore(ssa): Remove mem2reg run before flattening

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -54,11 +54,6 @@ pub(crate) fn optimize_into_acir(
         .try_run_pass(Ssa::evaluate_assert_constant, "After Assert Constant:")?
         .try_run_pass(Ssa::unroll_loops, "After Unrolling:")?
         .run_pass(Ssa::simplify_cfg, "After Simplifying:")
-        // Run mem2reg before flattening to handle any promotion
-        // of values that can be accessed after loop unrolling.
-        // If there are slice mergers uncovered by loop unrolling
-        // and this pass is missed, slice merging will fail inside of flattening.
-        .run_pass(Ssa::mem2reg, "After Mem2Reg:")
         .run_pass(Ssa::flatten_cfg, "After Flattening:")
         .run_pass(Ssa::remove_bit_shifts, "After Removing Bit Shifts:")
         // Run mem2reg once more with the flattened CFG to catch any remaining loads/stores


### PR DESCRIPTION
# Description

## Problem\*

Before https://github.com/noir-lang/noir/pull/4240 we needed mem2reg to be run as to not panic when fetching slice lengths.

## Summary\*

After the linked PR we have an improved startegy for tracking slice capacities by generating a slice capacities map before merging of values. This should enable us to remove a mem2reg pass that is run before flattening. 

## Additional Context


## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
