### PR TITLE
fix: correct formatting for databus visibility types

### DIFF
--- a/tooling/nargo_fmt/src/utils.rs
+++ b/tooling/nargo_fmt/src/utils.rs
@@ -143,15 +143,16 @@ impl HasItem for Param {
     fn format(self, visitor: &FmtVisitor, shape: Shape) -> String {
         let pattern = visitor.slice(self.pattern.span());
         let visibility = match self.visibility {
-            Visibility::Public => "pub ",
+            Visibility::Public => "pub",
             Visibility::Private => "",
-            Visibility::DataBus => "call_data ",
+            Visibility::DataBus => "call_data",
         };
 
         if self.pattern.is_synthesized() || self.typ.is_synthesized() {
             pattern.to_string()
         } else {
             let ty = rewrite::typ(visitor, shape, self.typ);
+            let visibility = append_space_if_nonempty(visibility.to_owned());
             format!("{pattern}: {visibility}{ty}")
         }
     }
@@ -181,6 +182,13 @@ pub(crate) fn is_single_line(s: &str) -> bool {
 
 pub(crate) fn last_line_contains_single_line_comment(s: &str) -> bool {
     s.lines().last().map_or(false, |line| line.contains("//"))
+}
+
+pub(crate) fn append_space_if_nonempty(mut string: String) -> String {
+    if !string.is_empty() {
+        string.push(' ');
+    }
+    string
 }
 
 pub(crate) fn last_line_used_width(s: &str, offset: usize) -> usize {

--- a/tooling/nargo_fmt/src/utils.rs
+++ b/tooling/nargo_fmt/src/utils.rs
@@ -145,7 +145,7 @@ impl HasItem for Param {
         let visibility = match self.visibility {
             Visibility::Public => "pub ",
             Visibility::Private => "",
-            Visibility::DataBus => "call_data",
+            Visibility::DataBus => "call_data ",
         };
 
         if self.pattern.is_synthesized() || self.typ.is_synthesized() {

--- a/tooling/nargo_fmt/src/utils.rs
+++ b/tooling/nargo_fmt/src/utils.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::items::HasItem;
 use crate::rewrite;
 use crate::visitor::{FmtVisitor, Shape};
@@ -152,7 +154,7 @@ impl HasItem for Param {
             pattern.to_string()
         } else {
             let ty = rewrite::typ(visitor, shape, self.typ);
-            let visibility = append_space_if_nonempty(visibility.to_owned());
+            let visibility = append_space_if_nonempty(visibility.into());
             format!("{pattern}: {visibility}{ty}")
         }
     }
@@ -184,10 +186,12 @@ pub(crate) fn last_line_contains_single_line_comment(s: &str) -> bool {
     s.lines().last().map_or(false, |line| line.contains("//"))
 }
 
-pub(crate) fn append_space_if_nonempty(mut string: String) -> String {
+pub(crate) fn append_space_if_nonempty(mut string: Cow<str>) -> Cow<str> {
     if !string.is_empty() {
-        string.push(' ');
+        let inner = string.to_mut();
+        inner.push(' ');
     }
+
     string
 }
 

--- a/tooling/nargo_fmt/src/visitor/item.rs
+++ b/tooling/nargo_fmt/src/visitor/item.rs
@@ -7,7 +7,10 @@ use noirc_frontend::{
 
 use crate::{
     rewrite::{self, UseTree},
-    utils::{last_line_contains_single_line_comment, last_line_used_width, FindToken},
+    utils::{
+        append_space_if_nonempty, last_line_contains_single_line_comment, last_line_used_width,
+        FindToken,
+    },
     visitor::expr::{format_seq, NewlineMode},
 };
 
@@ -119,11 +122,12 @@ impl super::FmtVisitor<'_> {
                 result.push_str("distinct ");
             }
 
-            match func.def.return_visibility {
-                Visibility::Public => result.push_str("pub "),
-                Visibility::DataBus => result.push_str("return_data "),
-                Visibility::Private => (),
-            }
+            let visibility = match func.def.return_visibility {
+                Visibility::Public => "pub",
+                Visibility::DataBus => "return_data",
+                Visibility::Private => "",
+            };
+            result.push_str(&append_space_if_nonempty(visibility.to_owned()));
 
             let typ = rewrite::typ(self, self.shape(), func.return_type());
             result.push_str(&typ);

--- a/tooling/nargo_fmt/src/visitor/item.rs
+++ b/tooling/nargo_fmt/src/visitor/item.rs
@@ -127,7 +127,7 @@ impl super::FmtVisitor<'_> {
                 Visibility::DataBus => "return_data",
                 Visibility::Private => "",
             };
-            result.push_str(&append_space_if_nonempty(visibility.to_owned()));
+            result.push_str(&append_space_if_nonempty(visibility.into()));
 
             let typ = rewrite::typ(self, self.shape(), func.return_type());
             result.push_str(&typ);

--- a/tooling/nargo_fmt/src/visitor/item.rs
+++ b/tooling/nargo_fmt/src/visitor/item.rs
@@ -119,8 +119,10 @@ impl super::FmtVisitor<'_> {
                 result.push_str("distinct ");
             }
 
-            if let Visibility::Public = func.def.return_visibility {
-                result.push_str("pub ");
+            match func.def.return_visibility {
+                Visibility::Public => result.push_str("pub "),
+                Visibility::DataBus => result.push_str("return_data "),
+                Visibility::Private => (),
             }
 
             let typ = rewrite::typ(self, self.shape(), func.return_type());

--- a/tooling/nargo_fmt/tests/expected/databus.nr
+++ b/tooling/nargo_fmt/tests/expected/databus.nr
@@ -1,0 +1,2 @@
+fn main(x: pub u8, y: call_data u8) -> return_data u32 {}
+

--- a/tooling/nargo_fmt/tests/input/databus.nr
+++ b/tooling/nargo_fmt/tests/input/databus.nr
@@ -1,0 +1,2 @@
+fn main(x: pub u8, y: call_data u8) -> return_data u32 {}
+


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR fixes an issue uncovered by #4422 where we're not properly formatting databus visibility modifiers. I've fixed this and added a new test case for regressions.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
