### PR TITLE
chore: do not panic when dividing by zero

### DIFF
--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -36,18 +36,20 @@ pub(crate) fn evaluate_binary_bigint_op(
         BinaryIntOp::UnsignedDiv => {
             let b_mod = b % bit_modulo;
             if b_mod.is_zero() {
-                return Err("Division by zero".to_owned());
+                BigUint::zero()
+            } else {
+                (a % bit_modulo) / b_mod
             }
-            (a % bit_modulo) / b_mod
         }
         // Perform signed division by first converting a and b to signed integers and then back to unsigned after the operation.
         BinaryIntOp::SignedDiv => {
             let b_signed = to_big_signed(b, bit_size);
             if b_signed.is_zero() {
-                return Err("Division by zero".to_owned());
+                BigUint::zero()
+            } else {
+                let signed_div = to_big_signed(a, bit_size) / b_signed;
+                to_big_unsigned(signed_div, bit_size)
             }
-            let signed_div = to_big_signed(a, bit_size) / b_signed;
-            to_big_unsigned(signed_div, bit_size)
         }
         // Perform a == operation, returning 0 or 1
         BinaryIntOp::Equals => {


### PR DESCRIPTION
# Description

## Problem\*

Resolves #2480

## Summary\*
In BrilligVM, we have now the same behaviour regarding division by 0. Whether it is a field or integer division, we return 0 when dividing by zero. Since we have a constraint which checks that the inverse times itself is 1, this constraint will always fail if we divide by zero (instead of panic or returning an error).


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
