### PR TITLE
chore!: Remove empty value from bounded vec

### DIFF
--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -1,12 +1,12 @@
 struct BoundedVec<T, MaxLen> {
     storage: [T; MaxLen],
     len: u64,
-    empty_value: T,
 }
 
 impl<T, MaxLen> BoundedVec<T, MaxLen> {
-    pub fn new(initial_value: T) -> Self {
-        BoundedVec { storage: [initial_value; MaxLen], len: 0, empty_value: initial_value }
+    pub fn new() -> Self {
+        let zeroed = crate::unsafe::zeroed();
+        BoundedVec { storage: [zeroed; MaxLen], len: 0 }
     }
 
     pub fn get(mut self: Self, index: u64) -> T {
@@ -68,7 +68,7 @@ impl<T, MaxLen> BoundedVec<T, MaxLen> {
         self.len -= 1;
 
         let elem = self.storage[self.len];
-        self.storage[self.len] = self.empty_value;
+        self.storage[self.len] = crate::unsafe::zeroed();
         elem
     }
 
@@ -77,7 +77,7 @@ impl<T, MaxLen> BoundedVec<T, MaxLen> {
         let mut exceeded_len = false;
         for i in 0..MaxLen {
             exceeded_len |= i == self.len;
-            if (!exceeded_len) {
+            if !exceeded_len {
                 ret |= predicate(self.storage[i]);
             }
         }

--- a/noir_stdlib/src/hash/poseidon2.nr
+++ b/noir_stdlib/src/hash/poseidon2.nr
@@ -18,12 +18,7 @@ impl Poseidon2 {
     }
 
     fn new(iv: Field) -> Poseidon2 {
-        let mut result = Poseidon2 {
-            cache: [0;3],
-            state: [0;4],
-            cache_size: 0,
-            squeeze_mode: false,
-        };
+        let mut result = Poseidon2 { cache: [0; 3], state: [0; 4], cache_size: 0, squeeze_mode: false };
         result.state[rate] = iv;
         result
     }
@@ -67,8 +62,7 @@ impl Poseidon2 {
         }
     }
 
-    fn squeeze(&mut self) -> Field
-    {
+    fn squeeze(&mut self) -> Field {
         if self.squeeze_mode & (self.cache_size == 0) {
             // If we're in squeze mode and the cache is empty, there is nothing left to squeeze out of the sponge!
             // Switch to absorb mode.
@@ -98,9 +92,8 @@ impl Poseidon2 {
         result
     }
 
-    fn hash_internal<N>(input:[Field;N], in_len:u32, is_variable_length: bool) -> Field
-    {
-        let iv : Field = (in_len as Field)*18446744073709551616;
+    fn hash_internal<N>(input: [Field; N], in_len: u32, is_variable_length: bool) -> Field {
+        let iv : Field = (in_len as Field) * 18446744073709551616;
         let mut sponge = Poseidon2::new(iv);
         for i in 0..input.len() {
             if i as u32 < in_len {

--- a/test_programs/noir_test_success/bounded_vec/src/main.nr
+++ b/test_programs/noir_test_success/bounded_vec/src/main.nr
@@ -1,6 +1,6 @@
 #[test]
 fn test_vec_push_pop() {
-    let mut vec: BoundedVec<Field, 3> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     assert(vec.len == 0);
     vec.push(2);
     assert(vec.len == 1);
@@ -17,7 +17,7 @@ fn test_vec_push_pop() {
 
 #[test]
 fn test_vec_extend_from_array() {
-    let mut vec: BoundedVec<Field, 3> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     vec.extend_from_array([2, 4]);
     assert(vec.len == 2);
     assert(vec.get(0) == 2);
@@ -26,13 +26,13 @@ fn test_vec_extend_from_array() {
 
 #[test(should_fail_with="extend_from_array out of bounds")]
 fn test_vec_extend_from_array_out_of_bound() {
-    let mut vec: BoundedVec<Field, 2> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 2> = BoundedVec::new();
     vec.extend_from_array([2, 4, 6]);
 }
 
 #[test(should_fail_with="extend_from_array out of bounds")]
 fn test_vec_extend_from_array_twice_out_of_bound() {
-    let mut vec: BoundedVec<Field, 2> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 2> = BoundedVec::new();
     vec.extend_from_array([2]);
     assert(vec.len == 1);
     vec.extend_from_array([4, 6]);
@@ -40,36 +40,36 @@ fn test_vec_extend_from_array_twice_out_of_bound() {
 
 #[test(should_fail)]
 fn test_vec_get_out_of_bound() {
-    let mut vec: BoundedVec<Field, 2> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 2> = BoundedVec::new();
     vec.extend_from_array([2, 4]);
     let _x = vec.get(2);
 }
 
 #[test(should_fail)]
 fn test_vec_get_not_declared() {
-    let mut vec: BoundedVec<Field, 2> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 2> = BoundedVec::new();
     vec.extend_from_array([2]);
     let _x = vec.get(1);
 }
 
 #[test(should_fail)]
 fn test_vec_get_uninitialized() {
-    let mut vec: BoundedVec<Field, 2> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 2> = BoundedVec::new();
     let _x = vec.get(0);
 }
 
 #[test(should_fail_with="push out of bounds")]
 fn test_vec_push_out_of_bound() {
-    let mut vec: BoundedVec<Field, 1> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 1> = BoundedVec::new();
     vec.push(1);
     vec.push(2);
 }
 
 #[test(should_fail_with="extend_from_bounded_vec out of bounds")]
 fn test_vec_extend_from_bounded_vec_out_of_bound() {
-    let mut vec: BoundedVec<Field, 2> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 2> = BoundedVec::new();
 
-    let mut another_vec: BoundedVec<Field, 3> = BoundedVec::new(0);
+    let mut another_vec: BoundedVec<Field, 3> = BoundedVec::new();
     another_vec.extend_from_array([1, 2, 3]);
 
     vec.extend_from_bounded_vec(another_vec);
@@ -77,10 +77,10 @@ fn test_vec_extend_from_bounded_vec_out_of_bound() {
 
 #[test(should_fail_with="extend_from_bounded_vec out of bounds")]
 fn test_vec_extend_from_bounded_vec_twice_out_of_bound() {
-    let mut vec: BoundedVec<Field, 2> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 2> = BoundedVec::new();
     vec.extend_from_array([1, 2]);
 
-    let mut another_vec: BoundedVec<Field, 1> = BoundedVec::new(0);
+    let mut another_vec: BoundedVec<Field, 1> = BoundedVec::new();
     another_vec.push(3);
 
     vec.extend_from_bounded_vec(another_vec);
@@ -88,7 +88,7 @@ fn test_vec_extend_from_bounded_vec_twice_out_of_bound() {
 
 #[test]
 fn test_vec_any() {
-    let mut vec: BoundedVec<Field, 3> = BoundedVec::new(0);
+    let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     vec.extend_from_array([2, 4, 6]);
     assert(vec.any(|v| v == 2) == true);
     assert(vec.any(|v| v == 4) == true);

--- a/test_programs/noir_test_success/bounded_vec/src/main.nr
+++ b/test_programs/noir_test_success/bounded_vec/src/main.nr
@@ -98,8 +98,8 @@ fn test_vec_any() {
 
 #[test]
 fn test_vec_any_not_default() {
-    let default_value = 1;
-    let mut vec: BoundedVec<Field, 3> = BoundedVec::new(default_value);
+    let default_value = 0;
+    let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     vec.extend_from_array([2, 4]);
     assert(vec.any(|v| v == default_value) == false);
 }


### PR DESCRIPTION
# Description

## Problem\*
## Summary\*

Removes the `empty_value` field from the bounded vec. This muddies the API and shouldn't be needed since we have `crate::unsafe::zeroed()` instead.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[Exceptional Case]** Documentation to be submitted in a separate PR.
  - Included in https://github.com/noir-lang/noir/pull/4430

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
