### PR TITLE
chore(docs): correct 'Edit this page' URL for dev docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -38,7 +38,7 @@ export default {
             },
           },
           editUrl: ({ versionDocsDirPath, docPath }) =>
-            `https://github.com/noir-lang/noir/edit/master/docs/${versionDocsDirPath}/${docPath}`,
+            `https://github.com/noir-lang/noir/edit/master/docs/${versionDocsDirPath.replace('processed-docs', 'docs')}/${docPath}`,
         },
         blog: false,
         theme: {


### PR DESCRIPTION
# Description

## Problem*

The "Edit this page" button in the generated documentation for the `noir-lang` project leads to a 404 - Page Not Found error for documents in the development version. This issue is due to the button's link containing `/processed-docs` in the path instead of `/docs`. The problem affects the development version of the documentation, whereas versioned documentation (e.g., v0.23.0) correctly links to editable markdown files on GitHub.

| Before                                                                                             | After                                                                                              |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| ![Before](https://github.com/noir-lang/noir/assets/150683513/260f8eb5-4ef9-46db-ba39-ae836d2bb7de) | ![After](https://github.com/noir-lang/noir/assets/150683513/087e2c8c-b9dc-4c35-b824-2b95742872f6) |

## Summary*

This pull request fixes the incorrect URL generated for the "Edit this page" button in the docusaurus configuration. By modifying the `editUrl` function within `docusaurus.config.ts`, the path now correctly replaces `processed-docs` with `docs` for the development version of the documentation. This change guarantees that contributors are directed to the correct GitHub page to edit the documentation, thus eliminating the 404 error previously encountered.

## Additional Context

The issue was identified when attempting to edit pages from the development version of the docs. The button's link incorrectly pointed to a non-existent path due to the inclusion of `processed-docs` in the URL.

## Documentation*

- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
