### PR TITLE
chore(docs): fix external contributor force push workflow

### DIFF
--- a/.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
+++ b/.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
@@ -1,5 +1,0 @@
-Thank you for your contribution to the Noir language.
-
-Please **do not force push to this branch** after the Noir team have reviewed this PR. Doing so will only delay us merging your PR as we will need to start the review process from scratch.
-
-Thanks for your understanding.

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Post comment on force pushes
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          path: ./.github/EXTERNAL_CONTRIBUTOR_PR_COMMENT.md
+          message: |
+            Thank you for your contribution to the Noir language.
 
+            Please **do not force push to this branch** after the Noir team have started review of this PR. Doing so will only delay us merging your PR as we will need to start the review process from scratch.
+
+            Thanks for your understanding.
           


### PR DESCRIPTION
# Description

## Problem\*

Resolves #

## Summary\*

This workflow was failing due to the fact that we're storing the message in a file but not checking out the repository.

While checking out would be safe in this case, I've just moved the comment into the workflow for paranoia reasons.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
