### PR TITLE
fix: build noir_codegen when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:types": "yarn workspace @noir-lang/types run build",
     "build:backend_barretenberg": "yarn workspace @noir-lang/backend_barretenberg run build",
     "build:noir_js": "yarn workspace @noir-lang/noir_js run build",
-    "build:js:only": "yarn build:types && yarn build:backend_barretenberg && yarn build:noir_js",
+    "build:js:only": "yarn workspaces foreach -vtp --from \"{@noir-lang/types,@noir-lang/backend_barretenberg,@noir-lang/noir_js,@noir-lang/noir_codegen}\" run build",
     "prepare:publish": "yarn clean && yarn install:from:nix && yarn build:js:only",
     "nightly:version": "yarn workspaces foreach run nightly:version",
     "publish:all": "yarn install && yarn workspaces foreach run publish"


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4446 

## Summary\*

We're currently not building `noir_codegen` before we publish so I've updated the build script.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
