### PR TITLE
fix(flake): stop flake.nix removing ignored-tests.txt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
           # Custom filter with various file extensions that we rely upon to build packages
           # Currently: `.nr`, `.sol`, `.sh`, `.json`, `.md` and `.wasm`
           filter = path: type:
-            (builtins.match ".*\.(nr|sol|sh|json|md|wasm)$" path != null) || (craneLib.filterCargoSources path type);
+            (builtins.match ".*\.(nr|sol|sh|json|md|wasm|txt)$" path != null) || (craneLib.filterCargoSources path type);
         };
 
         # TODO(#1198): It'd be nice to include these flags when running `cargo clippy` in a devShell.


### PR DESCRIPTION
# Description

Fixes a problem with `flake.nix` that prevented building packages via said flake.

## Problem\*

Currently `flake.nix` does not keep files ending with `.txt` when building packages, this means https://github.com/noir-lang/noir/blob/master/tooling/debugger/build.rs#L44 fails and so does the build.

<details>
<summary>Expand for full error trace.</summary>

```txt
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/s9q28qnr32r9cd62pm3vapvq87ipdpyq-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
Executing configureCargoCommonVars
copying cargo artifacts from /nix/store/21iwpq5w9854ga1mmb8g4r4r2p20202b-nargo-deps-0.24.0/target to target
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
will append /private/tmp/nix-build-nargo-0.24.0.drv-0/source/.cargo-home/config.toml with contents of /nix/store/rl1r6p506a4hk57049rsql0cnd9f6236-vendor-cargo-deps/config.toml
default configurePhase, nothing to do
@nix { "action": "setPhase", "phase": "buildPhase" }
building
++ command cargo --version
cargo 1.73.0 (9c4383fb5 2023-08-26)
++ command cargo build --release --message-format json-render-diagnostics
   Compiling acir_field v0.40.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/acvm-repo/acir_field)
   Compiling iter-extended v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/compiler/utils/iter-extended)
   Compiling fm v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/compiler/fm)
   Compiling arena v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/compiler/utils/arena)
   Compiling noirc_driver v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/compiler/noirc_driver)
   Compiling nargo v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/tooling/nargo)
   Compiling bb_abstraction_leaks v0.11.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/tooling/bb_abstraction_leaks)
   Compiling nargo_fmt v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/tooling/nargo_fmt)
   Compiling bn254_blackbox_solver v0.39.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/acvm-repo/bn254_blackbox_solver)
   Compiling noir_debugger v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/tooling/debugger)
   Compiling nargo_cli v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/tooling/nargo_cli)
   Compiling brillig v0.40.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/acvm-repo/brillig)
error: failed to run custom build command for `noir_debugger v0.24.0 (/private/tmp/nix-build-nargo-0.24.0.drv-0/source/tooling/debugger)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/private/tmp/nix-build-nargo-0.24.0.drv-0/source/target/release/build/noir_debugger-64219c61a62b2d11/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=tests
  cargo:rerun-if-changed=ignored-tests.txt
  cargo:rerun-if-changed=/private/tmp/nix-build-nargo-0.24.0.drv-0/source/test_programs

  --- stderr
  thread 'main' panicked at tooling/debugger/build.rs:44:74:
  called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/panicking.rs:595:5
     1: core::panicking::panic_fmt
               at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:67:14
     2: core::result::unwrap_failed
               at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/result.rs:1652:5
     3: core::result::Result<T,E>::unwrap
     4: build_script_build::generate_debugger_tests
     5: build_script_build::main
     6: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
warning: build failed, waiting for other jobs to finish..
```
</details>

<details>
<summary>Expand for the (probably poorly written) _consuming_ `flake.nix`</summary>

If you use the patched version `noir.url` (this PR) the build now works.

```nix
{
    description = "Tikan -- Fog of War Chess";

    inputs = {
        nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
        flake-parts.url = "github:hercules-ci/flake-parts";
        devshell.url = "github:numtide/devshell";
        noir.url = "github:noir-lang/noir/db9ea8481197286e38b89269aa6e8f14acf1ce93";
        # noir.url = "github:tsujp/noir/0cf043d81e2da7c4b23c4b18e0c3a944dd7ea017";
    };

    outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
        flake-parts.lib.mkFlake { inherit inputs; } {
            imports = [
                inputs.devshell.flakeModule
            ];

            systems = [
                "aarch64-linux"
                "aarch64-darwin"
                "x86_64-linux"
                "x86_64-darwin"
            ];

            perSystem = { pkgs, ... }: rec {
                packages.noir = inputs.noir.packages;

                devshells.default = {
                    packages = with pkgs; [
                        bun
                    ] ++ [ packages.noir.${system}.nargo ];
                };
            };
        };
}
```
</details>

## Documentation\*

Check one:
- [x] No documentation needed.
- ~[ ] Documentation included in this PR.~
- ~[ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.~

# PR Checklist\*

- [x] I have tested the changes locally.
- ~[ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.~