### PR TITLE
chore: Capitalize containers section in docs

### DIFF
--- a/docs/docs/noir/standard_library/containers/index.md
+++ b/docs/docs/noir/standard_library/containers/index.md
@@ -1,0 +1,5 @@
+---
+title: Containers
+description: Container types provided by Noir's standard library for storing and retrieving data
+keywords: [containers, data types, vec, hashmap]
+---


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

The "containers" section of noir's docs was the only section not capitalized previously

## Additional Context

I checked "Documentation included in this PR." so that docs can be regenerated for this PR and we can see the section is capitalized.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
