### PR TITLE
feat: Add eddsa_poseidon_to_pub function to stdlib with test + docs

### DIFF
--- a/docs/docs/noir/standard_library/cryptographic_primitives/eddsa.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/eddsa.mdx
@@ -19,7 +19,7 @@ fn eddsa_poseidon_verify(public_key_x : Field, public_key_y : Field, signature_s
 
 ## eddsa::eddsa_to_pub
 
-Private to public key conversion for EdDSA signatures.
+Private to public key conversion.
 
 Returns `(pub_key_x, pub_key_y)`
 

--- a/docs/docs/noir/standard_library/cryptographic_primitives/eddsa.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/eddsa.mdx
@@ -17,13 +17,13 @@ fn eddsa_poseidon_verify(public_key_x : Field, public_key_y : Field, signature_s
 
 <BlackBoxInfo />
 
-## eddsa::eddsa_poseidon_to_pub
+## eddsa::eddsa_to_pub
 
 Private to public key conversion for EdDSA signatures.
 
 Returns `(pub_key_x, pub_key_y)`
 
 ```rust
-fn eddsa_poseidon_to_pub(secret : Field) -> (Field, Field)
+fn eddsa_to_pub(secret : Field) -> (Field, Field)
 ```
 

--- a/docs/docs/noir/standard_library/cryptographic_primitives/eddsa.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/eddsa.mdx
@@ -16,3 +16,14 @@ fn eddsa_poseidon_verify(public_key_x : Field, public_key_y : Field, signature_s
 ```
 
 <BlackBoxInfo />
+
+## eddsa::eddsa_poseidon_to_pub
+
+Private to public key conversion for EdDSA signatures.
+
+Returns `(pub_key_x, pub_key_y)`
+
+```rust
+fn eddsa_poseidon_to_pub(secret : Field) -> (Field, Field)
+```
+

--- a/noir_stdlib/src/eddsa.nr
+++ b/noir_stdlib/src/eddsa.nr
@@ -40,9 +40,7 @@ pub fn eddsa_poseidon_verify(
 }
 
 // Returns the public key of the given secret key as (pub_key_x, pub_key_y)
-pub fn eddsa_to_pub(
-    secret: Field,
-) -> (Field, Field) {
+pub fn eddsa_to_pub(secret: Field) -> (Field, Field) {
     let bjj = baby_jubjub();
     let pub_key = bjj.curve.mul(secret, bjj.curve.gen);
     (pub_key.x, pub_key.y)

--- a/noir_stdlib/src/eddsa.nr
+++ b/noir_stdlib/src/eddsa.nr
@@ -40,7 +40,7 @@ pub fn eddsa_poseidon_verify(
 }
 
 // Returns the public key of the given secret key as (pub_key_x, pub_key_y)
-pub fn eddsa_poseidon_to_pub(
+pub fn eddsa_to_pub(
     secret: Field,
 ) -> (Field, Field) {
     let bjj = baby_jubjub();

--- a/noir_stdlib/src/eddsa.nr
+++ b/noir_stdlib/src/eddsa.nr
@@ -38,3 +38,12 @@ pub fn eddsa_poseidon_verify(
 
     left.eq(right)
 }
+
+// Returns the public key of the given secret key as (pub_key_x, pub_key_y)
+pub fn eddsa_poseidon_to_pub(
+    secret: Field,
+) -> (Field, Field) {
+    let bjj = baby_jubjub();
+    let pub_key = bjj.curve.mul(secret, bjj.curve.gen);
+    (pub_key.x, pub_key.y)
+}

--- a/test_programs/execution_success/eddsa/src/main.nr
+++ b/test_programs/execution_success/eddsa/src/main.nr
@@ -2,7 +2,7 @@ use dep::std::compat;
 use dep::std::ec::consts::te::baby_jubjub;
 use dep::std::ec::tecurve::affine::Point as TEPoint;
 use dep::std::hash;
-use dep::std::eddsa::{eddsa_poseidon_to_pub, eddsa_poseidon_verify};
+use dep::std::eddsa::{eddsa_to_pub, eddsa_poseidon_verify};
 
 fn main(msg: pub Field, _priv_key_a: Field, _priv_key_b: Field) {
     // Skip this test for non-bn254 backends
@@ -11,8 +11,8 @@ fn main(msg: pub Field, _priv_key_a: Field, _priv_key_b: Field) {
 
         let pub_key_a = bjj.curve.mul(_priv_key_a, bjj.curve.gen);
         let pub_key_b = bjj.curve.mul(_priv_key_b, bjj.curve.gen);
-        let (pub_key_a_x, pub_key_a_y) = eddsa_poseidon_to_pub(_priv_key_a);
-        let (pub_key_b_x, pub_key_b_y) = eddsa_poseidon_to_pub(_priv_key_b);
+        let (pub_key_a_x, pub_key_a_y) = eddsa_to_pub(_priv_key_a);
+        let (pub_key_b_x, pub_key_b_y) = eddsa_to_pub(_priv_key_b);
         assert(TEPoint::new(pub_key_a_x, pub_key_a_y) == pub_key_a);
         assert(TEPoint::new(pub_key_b_x, pub_key_b_y) == pub_key_b);
         // Manually computed as fields can't use modulo. Importantantly the commitment is within

--- a/test_programs/execution_success/eddsa/src/main.nr
+++ b/test_programs/execution_success/eddsa/src/main.nr
@@ -1,14 +1,20 @@
 use dep::std::compat;
 use dep::std::ec::consts::te::baby_jubjub;
+use dep::std::ec::tecurve::affine::Point as TEPoint;
 use dep::std::hash;
-use dep::std::eddsa::eddsa_poseidon_verify;
+use dep::std::eddsa::{eddsa_poseidon_to_pub, eddsa_poseidon_verify};
+
 fn main(msg: pub Field, _priv_key_a: Field, _priv_key_b: Field) {
     // Skip this test for non-bn254 backends
     if compat::is_bn254() {
         let bjj = baby_jubjub();
 
         let pub_key_a = bjj.curve.mul(_priv_key_a, bjj.curve.gen);
-        // let pub_key_b = bjj.curve.mul(_priv_key_b, bjj.curve.gen);
+        let pub_key_b = bjj.curve.mul(_priv_key_b, bjj.curve.gen);
+        let (pub_key_a_x, pub_key_a_y) = eddsa_poseidon_to_pub(_priv_key_a);
+        let (pub_key_b_x, pub_key_b_y) = eddsa_poseidon_to_pub(_priv_key_b);
+        assert(TEPoint::new(pub_key_a_x, pub_key_a_y) == pub_key_a);
+        assert(TEPoint::new(pub_key_b_x, pub_key_b_y) == pub_key_b);
         // Manually computed as fields can't use modulo. Importantantly the commitment is within
         // the subgroup order. Note that choice of hash is flexible for this step.
         // let r_a = hash::pedersen_commitment([_priv_key_a, msg])[0] % bjj.suborder; // modulus computed manually


### PR DESCRIPTION
# Description

## Problem\*

Gives a source of truth for deriving public keys for EdDSA signatures, e.g. for testing.

## Summary\*

Adds this function:
```rust
fn eddsa_poseidon_to_pub(secret: Field) -> (Field, Field)
```

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
