### PR TITLE
feat: run tests in parallel in `nargo test` 

### DIFF
--- a/tooling/lsp/src/requests/test_run.rs
+++ b/tooling/lsp/src/requests/test_run.rs
@@ -84,7 +84,7 @@ fn on_test_run_request_inner(
             let test_result = run_test(
                 &state.solver,
                 &mut context,
-                test_function,
+                &test_function,
                 false,
                 None,
                 &CompileOptions::default(),

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -23,7 +23,7 @@ impl TestStatus {
 pub fn run_test<B: BlackBoxFunctionSolver>(
     blackbox_solver: &B,
     context: &mut Context,
-    test_function: TestFunction,
+    test_function: &TestFunction,
     show_output: bool,
     foreign_call_resolver_url: Option<&str>,
     config: &CompileOptions,
@@ -51,7 +51,7 @@ pub fn run_test<B: BlackBoxFunctionSolver>(
 /// that a constraint was never satisfiable.
 /// An example of this is the program `assert(false)`
 /// In that case, we check if the test function should fail, and if so, we return `TestStatus::Pass`.
-fn test_status_program_compile_fail(err: CompileError, test_function: TestFunction) -> TestStatus {
+fn test_status_program_compile_fail(err: CompileError, test_function: &TestFunction) -> TestStatus {
     // The test has failed compilation, but it should never fail. Report error.
     if !test_function.should_fail() {
         return TestStatus::CompileError(err.into());
@@ -76,7 +76,7 @@ fn test_status_program_compile_fail(err: CompileError, test_function: TestFuncti
 /// We now check whether execution passed/failed and whether it should have
 /// passed/failed to determine the test status.
 fn test_status_program_compile_pass(
-    test_function: TestFunction,
+    test_function: &TestFunction,
     debug: DebugInfo,
     circuit_execution: Result<WitnessMap, NargoError>,
 ) -> TestStatus {
@@ -115,7 +115,7 @@ fn test_status_program_compile_pass(
 }
 
 fn check_expected_failure_message(
-    test_function: TestFunction,
+    test_function: &TestFunction,
     failed_assertion: Option<String>,
     error_diagnostic: Option<FileDiagnostic>,
 ) -> TestStatus {

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -14,6 +14,12 @@ pub enum TestStatus {
     CompileError(FileDiagnostic),
 }
 
+impl TestStatus {
+    pub fn failed(&self) -> bool {
+        !matches!(self, TestStatus::Pass)
+    }
+}
+
 pub fn run_test<B: BlackBoxFunctionSolver>(
     blackbox_solver: &B,
     context: &mut Context,

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -123,7 +123,6 @@ pub(crate) fn run(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn run_tests<S: BlackBoxFunctionSolver + Default>(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -4,7 +4,6 @@ use acvm::BlackBoxFunctionSolver;
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use clap::Args;
 use fm::FileManager;
-use iter_extended::vecmap;
 use nargo::{
     insert_all_files_for_workspace_into_file_manager,
     ops::{run_test, TestStatus},
@@ -12,11 +11,14 @@ use nargo::{
     parse_all, prepare_package,
 };
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
-use noirc_driver::{file_manager_with_stdlib, CompileOptions, NOIR_ARTIFACT_VERSION_STRING};
+use noirc_driver::{
+    check_crate, file_manager_with_stdlib, CompileOptions, NOIR_ARTIFACT_VERSION_STRING,
+};
 use noirc_frontend::{
     graph::CrateName,
     hir::{FunctionNameMatch, ParsedFiles},
 };
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use crate::{backends::Backend, cli::check_cmd::check_crate_and_report_errors, errors::CliError};
@@ -83,15 +85,12 @@ pub(crate) fn run(
         None => FunctionNameMatch::Anything,
     };
 
-    let blackbox_solver = Bn254BlackBoxSolver::new();
-
     let test_reports: Vec<Vec<(String, TestStatus)>> = workspace
         .into_iter()
         .map(|package| {
-            run_tests(
+            run_tests::<Bn254BlackBoxSolver>(
                 &workspace_file_manager,
                 &parsed_files,
-                &blackbox_solver,
                 package,
                 pattern,
                 args.show_output,
@@ -125,16 +124,71 @@ pub(crate) fn run(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn run_tests<S: BlackBoxFunctionSolver>(
+fn run_tests<S: BlackBoxFunctionSolver + Default>(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,
-    blackbox_solver: &S,
     package: &Package,
     fn_name: FunctionNameMatch,
     show_output: bool,
     foreign_call_resolver_url: Option<&str>,
     compile_options: &CompileOptions,
 ) -> Result<Vec<(String, TestStatus)>, CliError> {
+    let test_functions =
+        get_tests_in_package(file_manager, parsed_files, package, fn_name, compile_options)?;
+
+    let count_all = test_functions.len();
+
+    let plural = if count_all == 1 { "" } else { "s" };
+    println!("[{}] Running {count_all} test function{plural}", package.name);
+
+    let test_report: Vec<(String, TestStatus)> = test_functions
+        .into_par_iter()
+        .map(|test_name| {
+            // This is really hacky but we can't share `Context` or `S` across threads.
+            // We then need to construct a separate copy for each test.
+
+            let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);
+            check_crate(
+                &mut context,
+                crate_id,
+                compile_options.deny_warnings,
+                compile_options.disable_macros,
+            )
+            .expect("Any errors should have occurred when collecting test functions");
+
+            let test_functions = context.get_all_test_functions_in_crate_matching(
+                &crate_id,
+                FunctionNameMatch::Exact(&test_name),
+            );
+            let (_, test_function) = test_functions.first().expect("Test function should exist");
+
+            let blackbox_solver = S::default();
+
+            let test_output = run_test(
+                &blackbox_solver,
+                &mut context,
+                test_function,
+                show_output,
+                foreign_call_resolver_url,
+                compile_options,
+            );
+
+            (test_name, test_output)
+        })
+        .collect();
+
+    display_test_report(file_manager, package, compile_options, &test_report)?;
+    Ok(test_report)
+}
+
+fn get_tests_in_package(
+    file_manager: &FileManager,
+    parsed_files: &ParsedFiles,
+    package: &Package,
+    fn_name: FunctionNameMatch,
+
+    compile_options: &CompileOptions,
+) -> Result<Vec<String>, CliError> {
     let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);
     check_crate_and_report_errors(
         &mut context,
@@ -144,28 +198,11 @@ fn run_tests<S: BlackBoxFunctionSolver>(
         compile_options.silence_warnings,
     )?;
 
-    let test_functions = context.get_all_test_functions_in_crate_matching(&crate_id, fn_name);
-    let count_all = test_functions.len();
-
-    let plural = if count_all == 1 { "" } else { "s" };
-    println!("[{}] Running {count_all} test function{plural}", package.name);
-
-    let test_report = vecmap(test_functions, |(test_name, test_function)| {
-        (
-            test_name,
-            run_test(
-                blackbox_solver,
-                &mut context,
-                test_function,
-                show_output,
-                foreign_call_resolver_url,
-                compile_options,
-            ),
-        )
-    });
-
-    display_test_report(&context.file_manager, package, compile_options, &test_report)?;
-    Ok(test_report)
+    Ok(context
+        .get_all_test_functions_in_crate_matching(&crate_id, fn_name)
+        .into_iter()
+        .map(|(test_name, _)| test_name)
+        .collect())
 }
 
 fn display_test_report(

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -255,8 +255,7 @@ fn display_test_report(
     write!(writer, "[{}] ", package.name).expect("Failed to write to stderr");
 
     let count_all = test_report.len();
-    let count_failed =
-        test_report.iter().filter(|(_, status)| !matches!(status, TestStatus::Pass)).count();
+    let count_failed = test_report.iter().filter(|(_, status)| status.failed()).count();
     let plural = if count_all == 1 { "" } else { "s" };
     if count_failed == 0 {
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Green))).expect("Failed to set color");

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -116,7 +116,7 @@ pub(crate) fn run(
         };
     }
 
-    if test_report.iter().any(|(_, status)| matches!(status, TestStatus::Fail { .. })) {
+    if test_report.iter().any(|(_, status)| status.failed()) {
         Err(CliError::Generic(String::new()))
     } else {
         Ok(())

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -185,7 +185,6 @@ fn get_tests_in_package(
     parsed_files: &ParsedFiles,
     package: &Package,
     fn_name: FunctionNameMatch,
-
     compile_options: &CompileOptions,
 ) -> Result<Vec<String>, CliError> {
     let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is a dirty hack to get tests running in parallel. To do this, we've given up printing the test results in a stream as they're run but we instead wait for all tests in a package to be run before we print them out in one go.

This takes the noir-protocol-circuits test suite from taking 1:46s to 27s.

## Additional Context

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
