### PR TITLE
chore: update cargo deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,11 +2,13 @@
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
-unsound = "warn"
+version = 2
 yanked = "warn"
-notice = "warn"
+
+ignore = [
+    "RUSTSEC-2020-0168", # mach unmaintained
+    "RUSTSEC-2020-0016"  # net2 unmaintained
+]
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
@@ -32,9 +34,8 @@ skip = []
 skip-tree = []
 
 [licenses]
-unlicensed = "deny"
+version = 2
 confidence-threshold = 0.9
-# copyleft = "deny"
 
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

cargo deny is deprecating a bunch of its config file so this PR updates to the new format.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
