### PR TITLE
fix: Allow non-integer globals to reference struct methods

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -331,11 +331,6 @@ impl DefCollector {
         // Must resolve structs before we resolve globals.
         errors.extend(resolve_structs(context, def_collector.collected_types, crate_id));
 
-        // We must wait to resolve non-integer globals until after we resolve structs since struct
-        // globals will need to reference the struct type they're initialized to to ensure they are valid.
-        resolved_globals.extend(resolve_globals(context, other_globals, crate_id));
-        errors.extend(resolved_globals.errors);
-
         // Bind trait impls to their trait. Collect trait functions, that have a
         // default implementation, which hasn't been overridden.
         errors.extend(collect_trait_impls(
@@ -352,6 +347,11 @@ impl DefCollector {
         // These are resolved after trait impls so that struct methods are chosen
         // over trait methods if there are name conflicts.
         errors.extend(collect_impls(context, crate_id, &def_collector.collected_impls));
+
+        // We must wait to resolve non-integer globals until after we resolve structs since struct
+        // globals will need to reference the struct type they're initialized to to ensure they are valid.
+        resolved_globals.extend(resolve_globals(context, other_globals, crate_id));
+        errors.extend(resolved_globals.errors);
 
         // Resolve each function in the crate. This is now possible since imports have been resolved
         let mut functions = Vec::new();

--- a/test_programs/execution_success/global_consts/src/main.nr
+++ b/test_programs/execution_success/global_consts/src/main.nr
@@ -115,12 +115,12 @@ struct Foo {
 struct Bar {}
 
 impl Bar {
-  fn get_a() -> Field {
-    1
-  }
+    fn get_a() -> Field {
+        1
+    }
 }
 
 // Regression for #1440
 global foo = Foo {
-  a: Bar::get_a(),
+    a: Bar::get_a(),
 };

--- a/test_programs/execution_success/global_consts/src/main.nr
+++ b/test_programs/execution_success/global_consts/src/main.nr
@@ -107,3 +107,20 @@ mod my_submodule {
         x
     }
 }
+
+struct Foo {
+  a: Field,
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get_a() -> Field {
+    1
+  }
+}
+
+// Regression for #1440
+global foo = Foo {
+  a: Bar::get_a(),
+};


### PR DESCRIPTION
# Description

## Problem\*

Resolves #1440

## Summary\*

This was a fairly simple change - non-integer globals used to be resolved before struct methods were even collected. I've moved this to after methods are collected. Now global resolution is the first step of resolving in general.

Integer globals are still resolved early since structs may refer to them in numeric generics.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
