### PR TITLE
chore(ci): fix JS publishing workflow checking out inconsistent commits

### DIFF
--- a/.github/JS_PUBLISH_FAILED.md
+++ b/.github/JS_PUBLISH_FAILED.md
@@ -1,6 +1,6 @@
 ---
 title: "JS packages failed to publish"
-assignees: TomAFrench kevaundray savio-sou
+assignees: TomAFrench kevaundray Savio-Sou
 labels: js
 ---
 

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - name: Checkout Noir repo
         uses: actions/checkout@v4
-
+        with:
+          ref: ${{ inputs.noir-ref }}
+      
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.73.0
 
@@ -87,6 +89,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.noir-ref }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1.73.0


### PR DESCRIPTION
# Description

## Problem\*

Resolves #

## Summary\*

The 0.24.0 publish failed and was rerun after some more commits were merged into master. This caused an issue as some of the jobs weren't properly pulling the historical commit to build from and instead built from master. This caused inconsistent serialisation formats as there was likely a serialisation between those two commits.

This PR ensures that all packages are built from the same commit and also fixes a broken reporting mechanism.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
