### PR TITLE
fix(ssa): Handle mergers of slices returned from calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/capacity_tracker.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/capacity_tracker.rs
@@ -5,6 +5,7 @@ use crate::ssa::ir::{
     value::{Value, ValueId},
 };
 
+use acvm::FieldElement;
 use fxhash::FxHashMap as HashMap;
 
 pub(crate) struct SliceCapacityTracker<'a> {
@@ -62,21 +63,26 @@ impl<'a> SliceCapacityTracker<'a> {
                         | Intrinsic::SlicePushFront
                         | Intrinsic::SlicePopBack
                         | Intrinsic::SliceInsert
-                        | Intrinsic::SliceRemove => (1, 1),
+                        | Intrinsic::SliceRemove => (Some(1), 1),
                         // `pop_front` returns the popped element, and then the respective slice.
                         // This means in the case of a slice with structs, the result index of the popped slice
                         // will change depending on the number of elements in the struct.
                         // For example, a slice with four elements will look as such in SSA:
                         // v3, v4, v5, v6, v7, v8 = call slice_pop_front(v1, v2)
                         // where v7 is the slice length and v8 is the popped slice itself.
-                        Intrinsic::SlicePopFront => (1, results.len() - 1),
+                        Intrinsic::SlicePopFront => (Some(1), results.len() - 1),
+                        // The slice capacity of these intrinsics is not determined by the arguments of the function.
+                        Intrinsic::ToBits(_) | Intrinsic::ToRadix(_) => (None, 1),
                         _ => return,
                     };
-                    let slice_contents = arguments[argument_index];
+                    let result_slice = results[result_index];
                     match intrinsic {
                         Intrinsic::SlicePushBack
                         | Intrinsic::SlicePushFront
                         | Intrinsic::SliceInsert => {
+                            let argument_index = argument_index.expect("ICE: Should have an argument index for slice intrinsics");
+                            let slice_contents = arguments[argument_index];
+
                             for arg in &arguments[(argument_index + 1)..] {
                                 let element_typ = self.dfg.type_of_value(*arg);
                                 if element_typ.contains_slice_element() {
@@ -85,23 +91,36 @@ impl<'a> SliceCapacityTracker<'a> {
                             }
                             if let Some(contents_capacity) = slice_sizes.get(&slice_contents) {
                                 let new_capacity = *contents_capacity + 1;
-                                slice_sizes.insert(results[result_index], new_capacity);
+                                slice_sizes.insert(result_slice, new_capacity);
                             }
                         }
                         Intrinsic::SlicePopBack
                         | Intrinsic::SliceRemove
                         | Intrinsic::SlicePopFront => {
+                            let argument_index = argument_index.expect("ICE: Should have an argument index for slice intrinsics");
+                            let slice_contents = arguments[argument_index];
+
                             // We do not decrement the size on intrinsics that could remove values from a slice.
                             // This is because we could potentially go back to the smaller slice and not fill in dummies.
                             // This pass should be tracking the potential max that a slice ***could be***
                             if let Some(contents_capacity) = slice_sizes.get(&slice_contents) {
                                 let new_capacity = *contents_capacity - 1;
-                                slice_sizes.insert(results[result_index], new_capacity);
+                                slice_sizes.insert(result_slice, new_capacity);
                             }
+                        }
+                        Intrinsic::ToBits(_) => {
+                            // Compiler sanity check
+                            assert!(matches!(self.dfg.type_of_value(result_slice), Type::Slice(_)));
+                            slice_sizes.insert(result_slice, FieldElement::max_num_bits() as usize);
+                        }
+                        Intrinsic::ToRadix(_) => {
+                            // Compiler sanity check
+                            assert!(matches!(self.dfg.type_of_value(result_slice), Type::Slice(_)));
+                            slice_sizes.insert(result_slice, FieldElement::max_num_bytes() as usize);
                         }
                         _ => {}
                     }
-                }
+                } 
             }
             Instruction::Store { address, value } => {
                 let value_typ = self.dfg.type_of_value(*value);

--- a/test_programs/execution_success/slices/src/main.nr
+++ b/test_programs/execution_success/slices/src/main.nr
@@ -2,54 +2,55 @@ use dep::std::slice;
 use dep::std;
 
 fn main(x: Field, y: pub Field) {
-    let mut slice = [0; 2];
-    assert(slice[0] == 0);
-    assert(slice[0] != 1);
-    slice[0] = x;
-    assert(slice[0] == x);
+    // let mut slice = [0; 2];
+    // assert(slice[0] == 0);
+    // assert(slice[0] != 1);
+    // slice[0] = x;
+    // assert(slice[0] == x);
 
-    let slice_plus_10 = slice.push_back(y);
-    assert(slice_plus_10[2] == 10);
-    assert(slice_plus_10[2] != 8);
-    assert(slice_plus_10.len() == 3);
+    // let slice_plus_10 = slice.push_back(y);
+    // assert(slice_plus_10[2] == 10);
+    // assert(slice_plus_10[2] != 8);
+    // assert(slice_plus_10.len() == 3);
 
-    let mut new_slice = [];
-    for i in 0..5 {
-        new_slice = new_slice.push_back(i);
-    }
-    assert(new_slice.len() == 5);
+    // let mut new_slice = [];
+    // for i in 0..5 {
+    //     new_slice = new_slice.push_back(i);
+    // }
+    // assert(new_slice.len() == 5);
 
-    new_slice = new_slice.push_front(20);
-    assert(new_slice[0] == 20);
-    assert(new_slice.len() == 6);
+    // new_slice = new_slice.push_front(20);
+    // assert(new_slice[0] == 20);
+    // assert(new_slice.len() == 6);
 
-    let (popped_slice, last_elem) = new_slice.pop_back();
-    assert(last_elem == 4);
-    assert(popped_slice.len() == 5);
+    // let (popped_slice, last_elem) = new_slice.pop_back();
+    // assert(last_elem == 4);
+    // assert(popped_slice.len() == 5);
 
-    let (first_elem, rest_of_slice) = popped_slice.pop_front();
-    assert(first_elem == 20);
-    assert(rest_of_slice.len() == 4);
+    // let (first_elem, rest_of_slice) = popped_slice.pop_front();
+    // assert(first_elem == 20);
+    // assert(rest_of_slice.len() == 4);
 
-    new_slice = rest_of_slice.insert(2, 100);
-    assert(new_slice[2] == 100);
-    assert(new_slice[4] == 3);
-    assert(new_slice.len() == 5);
+    // new_slice = rest_of_slice.insert(2, 100);
+    // assert(new_slice[2] == 100);
+    // assert(new_slice[4] == 3);
+    // assert(new_slice.len() == 5);
 
-    let (remove_slice, removed_elem) = new_slice.remove(3);
-    assert(removed_elem == 2);
-    assert(remove_slice[3] == 3);
-    assert(remove_slice.len() == 4);
+    // let (remove_slice, removed_elem) = new_slice.remove(3);
+    // assert(removed_elem == 2);
+    // assert(remove_slice[3] == 3);
+    // assert(remove_slice.len() == 4);
 
-    let append = [1, 2].append([3, 4, 5]);
-    assert(append.len() == 5);
-    assert(append[0] == 1);
-    assert(append[4] == 5);
+    // let append = [1, 2].append([3, 4, 5]);
+    // assert(append.len() == 5);
+    // assert(append[0] == 1);
+    // assert(append[4] == 5);
 
-    regression_2083();
-    // The parameters to this function must come from witness values (inputs to main)
-    regression_merge_slices(x, y);
-    regression_2370();
+    // regression_2083();
+    // // The parameters to this function must come from witness values (inputs to main)
+    // regression_merge_slices(x, y);
+    // regression_2370();
+    regression_4418(x);
 }
 // Ensure that slices of struct/tuple values work.
 fn regression_2083() {
@@ -296,4 +297,10 @@ fn merge_slices_remove_between_ifs(x: Field, y: Field) -> [Field] {
 fn regression_2370() {
     let mut slice = [];
     slice = [1, 2, 3];
+}
+
+fn regression_4418(x: Field) {
+    let mut crash = x.to_be_bytes(32);
+
+    if (x != 0) {}
 }

--- a/test_programs/execution_success/slices/src/main.nr
+++ b/test_programs/execution_success/slices/src/main.nr
@@ -2,55 +2,57 @@ use dep::std::slice;
 use dep::std;
 
 fn main(x: Field, y: pub Field) {
-    // let mut slice = [0; 2];
-    // assert(slice[0] == 0);
-    // assert(slice[0] != 1);
-    // slice[0] = x;
-    // assert(slice[0] == x);
+    let mut slice = [0; 2];
+    assert(slice[0] == 0);
+    assert(slice[0] != 1);
+    slice[0] = x;
+    assert(slice[0] == x);
 
-    // let slice_plus_10 = slice.push_back(y);
-    // assert(slice_plus_10[2] == 10);
-    // assert(slice_plus_10[2] != 8);
-    // assert(slice_plus_10.len() == 3);
+    let slice_plus_10 = slice.push_back(y);
+    assert(slice_plus_10[2] == 10);
+    assert(slice_plus_10[2] != 8);
+    assert(slice_plus_10.len() == 3);
 
-    // let mut new_slice = [];
-    // for i in 0..5 {
-    //     new_slice = new_slice.push_back(i);
-    // }
-    // assert(new_slice.len() == 5);
+    let mut new_slice = [];
+    for i in 0..5 {
+        new_slice = new_slice.push_back(i);
+    }
+    assert(new_slice.len() == 5);
 
-    // new_slice = new_slice.push_front(20);
-    // assert(new_slice[0] == 20);
-    // assert(new_slice.len() == 6);
+    new_slice = new_slice.push_front(20);
+    assert(new_slice[0] == 20);
+    assert(new_slice.len() == 6);
 
-    // let (popped_slice, last_elem) = new_slice.pop_back();
-    // assert(last_elem == 4);
-    // assert(popped_slice.len() == 5);
+    let (popped_slice, last_elem) = new_slice.pop_back();
+    assert(last_elem == 4);
+    assert(popped_slice.len() == 5);
 
-    // let (first_elem, rest_of_slice) = popped_slice.pop_front();
-    // assert(first_elem == 20);
-    // assert(rest_of_slice.len() == 4);
+    let (first_elem, rest_of_slice) = popped_slice.pop_front();
+    assert(first_elem == 20);
+    assert(rest_of_slice.len() == 4);
 
-    // new_slice = rest_of_slice.insert(2, 100);
-    // assert(new_slice[2] == 100);
-    // assert(new_slice[4] == 3);
-    // assert(new_slice.len() == 5);
+    new_slice = rest_of_slice.insert(2, 100);
+    assert(new_slice[2] == 100);
+    assert(new_slice[4] == 3);
+    assert(new_slice.len() == 5);
 
-    // let (remove_slice, removed_elem) = new_slice.remove(3);
-    // assert(removed_elem == 2);
-    // assert(remove_slice[3] == 3);
-    // assert(remove_slice.len() == 4);
+    let (remove_slice, removed_elem) = new_slice.remove(3);
+    assert(removed_elem == 2);
+    assert(remove_slice[3] == 3);
+    assert(remove_slice.len() == 4);
 
-    // let append = [1, 2].append([3, 4, 5]);
-    // assert(append.len() == 5);
-    // assert(append[0] == 1);
-    // assert(append[4] == 5);
+    let append = [1, 2].append([3, 4, 5]);
+    assert(append.len() == 5);
+    assert(append[0] == 1);
+    assert(append[4] == 5);
 
-    // regression_2083();
-    // // The parameters to this function must come from witness values (inputs to main)
-    // regression_merge_slices(x, y);
-    // regression_2370();
+    regression_2083();
+    // The parameters to this function must come from witness values (inputs to main)
+    regression_merge_slices(x, y);
+    regression_2370();
+
     regression_4418(x);
+    regression_slice_call_result(x, y);
 }
 // Ensure that slices of struct/tuple values work.
 fn regression_2083() {
@@ -302,5 +304,23 @@ fn regression_2370() {
 fn regression_4418(x: Field) {
     let mut crash = x.to_be_bytes(32);
 
-    if (x != 0) {}
+    if x != 0 { 
+        crash[0] = 10;
+    }
+}
+
+fn regression_slice_call_result(x: Field, y: Field) {
+    let mut slice = merge_slices_return(x, y);
+    if x != 0 {
+        slice = slice.push_back(5);
+        slice = slice.push_back(10);
+    } else {
+        slice = slice.push_back(5);
+    }
+    assert(slice.len() == 5);
+    assert(slice[0] == 0);
+    assert(slice[1] == 0);
+    assert(slice[2] == 10);
+    assert(slice[3] == 5);
+    assert(slice[4] == 10);
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4418 

## Summary\*

This PR does two fixes. For one, we were not accurately tracking slice capacities when they are the parameters of blocks. We also need to add handling for slices returned from `ToRadix` and `ToBits`. 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
