### PR TITLE
fix: handling of gh deps in noir_wasm

### DIFF
--- a/compiler/wasm/src/noir/package.ts
+++ b/compiler/wasm/src/noir/package.ts
@@ -105,7 +105,12 @@ export class Package {
       handles
         .filter((handle) => SOURCE_EXTENSIONS.find((ext) => handle.endsWith(ext)))
         .map(async (file) => {
-          const suffix = file.replace(this.#srcPath, '');
+          // Github deps are directly added to the file manager, which causes them to be missing the absolute path to the source file
+          // and only include the extraction directory relative to the fm root directory
+          // This regexp ensures we remove the "real" source path for all dependencies, providing the compiler with what it expects for each source file:
+          // <absoluteSourcePath> -> <sourceAsString> for bin/contract packages
+          // <depAlias/relativePathToSource> -> <sourceAsString> for libs
+          const suffix = file.replace(new RegExp(`.*${this.#srcPath}`), '');
           return {
             path: this.getType() === 'lib' ? `${alias ? alias : this.#config.package.name}${suffix}` : file,
             source: (await fm.readFile(file, 'utf-8')).toString(),


### PR DESCRIPTION
# Description

Github deps are directly added to the file manager, which causes them to be missing the absolute path to the source file and only include the extraction directory relative to the fm root directory. This caused the path to the file to be formatted in an unexpected way and the compiler to panic.

Resolves: https://github.com/noir-lang/noir/issues/4355

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
