### PR TITLE
fix: Force src impl for == on slices

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -863,7 +863,13 @@ impl<'interner> TypeChecker<'interner> {
                     span: op.location.span,
                 });
 
-                self.comparator_operand_type_rules(x_type, y_type, op, span)
+                self.comparator_operand_type_rules(x_type, y_type, op, span)?;
+
+                // If the size is not constant, we must fall back to a user-provided impl for
+                // equality on slices.
+                let size = x_size.follow_bindings();
+                let use_src_code_impl = size.evaluate_to_u64().is_none();
+                Ok((Bool, use_src_code_impl))
             }
 
             (String(x_size), String(y_size)) => {

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -863,13 +863,13 @@ impl<'interner> TypeChecker<'interner> {
                     span: op.location.span,
                 });
 
-                self.comparator_operand_type_rules(x_type, y_type, op, span)?;
+                let (_, use_impl) = self.comparator_operand_type_rules(x_type, y_type, op, span)?;
 
                 // If the size is not constant, we must fall back to a user-provided impl for
                 // equality on slices.
                 let size = x_size.follow_bindings();
-                let use_src_code_impl = size.evaluate_to_u64().is_none();
-                Ok((Bool, use_src_code_impl))
+                let use_impl = use_impl || size.evaluate_to_u64().is_none();
+                Ok((Bool, use_impl))
             }
 
             (String(x_size), String(y_size)) => {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1206,4 +1206,16 @@ fn lambda$f1(mut env$l1: (Field)) -> Field {
         "#;
         assert_eq!(get_program_errors(src).len(), 1);
     }
+
+    // This is a regression for #4507
+    #[test]
+    fn slice_eq_works() {
+        let src = r#"
+            fn main() {
+                let slice: [Field] = [1, 2, 3];
+                assert(slice == slice);
+            }
+        "#;
+        assert_eq!(get_program_errors(src).len(), 1);
+    }
 }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1206,16 +1206,4 @@ fn lambda$f1(mut env$l1: (Field)) -> Field {
         "#;
         assert_eq!(get_program_errors(src).len(), 1);
     }
-
-    // This is a regression for #4507
-    #[test]
-    fn slice_eq_works() {
-        let src = r#"
-            fn main() {
-                let slice: [Field] = [1, 2, 3];
-                assert(slice == slice);
-            }
-        "#;
-        assert_eq!(get_program_errors(src).len(), 1);
-    }
 }

--- a/test_programs/execution_success/slices/src/main.nr
+++ b/test_programs/execution_success/slices/src/main.nr
@@ -50,6 +50,8 @@ fn main(x: Field, y: pub Field) {
     // The parameters to this function must come from witness values (inputs to main)
     regression_merge_slices(x, y);
     regression_2370();
+
+    regression_4506();
 }
 // Ensure that slices of struct/tuple values work.
 fn regression_2083() {
@@ -296,4 +298,9 @@ fn merge_slices_remove_between_ifs(x: Field, y: Field) -> [Field] {
 fn regression_2370() {
     let mut slice = [];
     slice = [1, 2, 3];
+}
+
+fn regression_4506() {
+    let slice: [Field] = [1, 2, 3];
+    assert(slice == slice);
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4506

## Summary\*

`==` on slices previously tried to use the built-in impl we have but this leads to a panic when evaluating binary operators in SSA. We expect both sides of the binary to be non-tuples but this isn't true for slice values. Instead of making this work for tuples I changed the type checker to force slices to use the stdlib impl we have for `==` rather than the built in one.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
