### PR TITLE
chore: pass `import_directive` by reference

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -278,7 +278,7 @@ impl DefCollector {
 
         // Resolve unresolved imports collected from the crate, one by one.
         for collected_import in def_collector.collected_imports {
-            match resolve_import(crate_id, collected_import, &context.def_maps) {
+            match resolve_import(crate_id, &collected_import, &context.def_maps) {
                 Ok(resolved_import) => {
                     // Populate module namespaces according to the imports used
                     let current_def_map = context.def_maps.get_mut(&crate_id).unwrap();

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -52,7 +52,7 @@ impl From<PathResolutionError> for CustomDiagnostic {
 
 pub fn resolve_import(
     crate_id: CrateId,
-    import_directive: ImportDirective,
+    import_directive: &ImportDirective,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
 ) -> Result<ResolvedImport, (PathResolutionError, LocalModuleId)> {
     let def_map = &def_maps[&crate_id];
@@ -62,10 +62,10 @@ pub fn resolve_import(
 
     let module_scope = import_directive.module_id;
     let resolved_namespace =
-        resolve_path_to_ns(&import_directive, def_map, def_maps, allow_contracts)
+        resolve_path_to_ns(import_directive, def_map, def_maps, allow_contracts)
             .map_err(|error| (error, module_scope))?;
 
-    let name = resolve_path_name(&import_directive);
+    let name = resolve_path_name(import_directive);
     Ok(ResolvedImport {
         name,
         resolved_namespace,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We don't need to pass by value here so we can just pass by reference instead.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
