### PR TITLE
chore: add `ModuleDeclaration` struct

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -241,6 +241,17 @@ pub trait Recoverable {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ModuleDeclaration {
+    pub ident: Ident,
+}
+
+impl std::fmt::Display for ModuleDeclaration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "mod {}", self.ident)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ImportStatement {
     pub path: Path,
     pub alias: Option<Ident>,

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -40,9 +40,9 @@ use crate::parser::{force, ignore_then_commit, statement_recovery};
 use crate::token::{Keyword, Token, TokenKind};
 use crate::{
     BinaryOp, BinaryOpKind, BlockExpression, Distinctness, ForLoopStatement, ForRange,
-    FunctionReturnType, Ident, IfExpression, InfixExpression, LValue, Literal, NoirTypeAlias,
-    Param, Path, Pattern, Recoverable, Statement, TraitBound, TypeImpl, UnresolvedTraitConstraint,
-    UnresolvedTypeExpression, UseTree, UseTreeKind, Visibility,
+    FunctionReturnType, Ident, IfExpression, InfixExpression, LValue, Literal, ModuleDeclaration,
+    NoirTypeAlias, Param, Path, Pattern, Recoverable, Statement, TraitBound, TypeImpl,
+    UnresolvedTraitConstraint, UnresolvedTypeExpression, UseTree, UseTreeKind, Visibility,
 };
 
 use chumsky::prelude::*;
@@ -370,7 +370,9 @@ fn optional_type_annotation<'a>() -> impl NoirParser<UnresolvedType> + 'a {
 }
 
 fn module_declaration() -> impl NoirParser<TopLevelStatement> {
-    keyword(Keyword::Mod).ignore_then(ident()).map(TopLevelStatement::Module)
+    keyword(Keyword::Mod)
+        .ignore_then(ident())
+        .map(|ident| TopLevelStatement::Module(ModuleDeclaration { ident }))
 }
 
 fn use_statement() -> impl NoirParser<TopLevelStatement> {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is some groundwork pulled out from https://github.com/noir-lang/noir/pull/4491

We're going to want to apply visibility modifiers to module declarations so this PR creates a proper struct for these so it's easier for us to add an extra field to hold the visibility.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
