### PR TITLE
fix: Add `follow_bindings` to follow `Type::Alias` links

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1691,23 +1691,15 @@ impl<'interner> Monomorphizer<'interner> {
 }
 
 fn unwrap_tuple_type(typ: &HirType) -> Vec<HirType> {
-    match typ {
+    match typ.follow_bindings() {
         HirType::Tuple(fields) => fields.clone(),
-        HirType::TypeVariable(binding, TypeVariableKind::Normal) => match &*binding.borrow() {
-            TypeBinding::Bound(binding) => unwrap_tuple_type(binding),
-            TypeBinding::Unbound(_) => unreachable!(),
-        },
         other => unreachable!("unwrap_tuple_type: expected tuple, found {:?}", other),
     }
 }
 
 fn unwrap_struct_type(typ: &HirType) -> Vec<(String, HirType)> {
-    match typ {
-        HirType::Struct(def, args) => def.borrow().get_fields(args),
-        HirType::TypeVariable(binding, TypeVariableKind::Normal) => match &*binding.borrow() {
-            TypeBinding::Bound(binding) => unwrap_struct_type(binding),
-            TypeBinding::Unbound(_) => unreachable!(),
-        },
+    match typ.follow_bindings() {
+        HirType::Struct(def, args) => def.borrow().get_fields(&args),
         other => unreachable!("unwrap_struct_type: expected struct, found {:?}", other),
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4518

## Summary\*



## Additional Context

A match case for `Type::Alias` was forgotten when that was initially added.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
