### PR TITLE
fix(acir_gen): More granular element sizes array check

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -2268,8 +2268,9 @@ impl Context {
 
 // We can omit the element size array for arrays which don't contain arrays or slices.
 fn can_omit_element_sizes_array(array_typ: &Type) -> bool {
-    let (Type::Array(types, _) | Type::Slice(types)) = array_typ else {
-        panic!("ICE: expected array type");
+    let types = match array_typ {
+        Type::Array(types, _) | Type::Slice(types) => types,
+        _ => panic!("ICE: expected array or slice type"),
     };
 
     !types.iter().any(|typ| typ.contains_an_array())

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -2268,10 +2268,7 @@ impl Context {
 
 // We can omit the element size array for arrays which don't contain arrays or slices.
 fn can_omit_element_sizes_array(array_typ: &Type) -> bool {
-    if array_typ.contains_slice_element() {
-        return false;
-    }
-    let Type::Array(types, _) = array_typ else {
+    let (Type::Array(types, _) | Type::Slice(types)) = array_typ else {
         panic!("ICE: expected array type");
     };
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The `array_typ.contains_slice_element()` check in `can_omit_element_sizes_array` is incorrect.

This should have been `is_nested_slice()` but we already banned nested slices so I just removed it. This leads to improvements for slices in general so I have made it a separate PR.

This was also a blocker for https://github.com/noir-lang/noir/pull/4523. When working with `AsSlice` we would omit the element sizes array. When it came time to access a slice created with `as_slice()` we would attempt to use the element sizes array which was never initialized correctly and we would go out of bounds.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
