### PR TITLE
fix: Dynamic assert messages in brillig

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -248,17 +248,6 @@ impl<'block> BrilligBlock<'block> {
                 self.convert_ssa_binary(binary, dfg, result_var);
             }
             Instruction::Constrain(lhs, rhs, assert_message) => {
-                let condition = SingleAddrVariable {
-                    address: self.brillig_context.allocate_register(),
-                    bit_size: 1,
-                };
-
-                self.convert_ssa_binary(
-                    &Binary { lhs: *lhs, rhs: *rhs, operator: BinaryOp::Eq },
-                    dfg,
-                    condition,
-                );
-
                 let assert_message = if let Some(error) = assert_message {
                     match error.as_ref() {
                         ConstrainError::Static(string) => Some(string.clone()),
@@ -281,6 +270,17 @@ impl<'block> BrilligBlock<'block> {
                 } else {
                     None
                 };
+
+                let condition = SingleAddrVariable {
+                    address: self.brillig_context.allocate_register(),
+                    bit_size: 1,
+                };
+
+                self.convert_ssa_binary(
+                    &Binary { lhs: *lhs, rhs: *rhs, operator: BinaryOp::Eq },
+                    dfg,
+                    condition,
+                );
 
                 self.brillig_context.constrain_instruction(condition.address, assert_message);
                 self.brillig_context.deallocate_register(condition.address);


### PR DESCRIPTION
# Description

## Problem\*

Temporary regisers are not conserved when calling and returning from another function, only alive variables are conserved. The condition in an assert was computed before the call to the dynamic message handler so it could be overwritten by the callee. I just compute the condition after the potential call.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
