### PR TITLE
fix: Substitute generics when checking the field count of a type

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -127,11 +127,7 @@ impl Type {
                 let fields = struct_type.get_fields(args);
                 fields.iter().fold(0, |acc, (_, field_type)| acc + field_type.field_count())
             }
-            Type::Alias(def, _) => {
-                // It is safe to access `typ` without instantiating generics here since generics
-                // cannot change the number of fields in `typ`.
-                def.borrow().typ.field_count()
-            }
+            Type::Alias(def, generics) => def.borrow().get_type(generics).field_count(),
             Type::Tuple(fields) => {
                 fields.iter().fold(0, |acc, field_typ| acc + field_typ.field_count())
             }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1213,4 +1213,14 @@ fn lambda$f1(mut env$l1: (Field)) -> Field {
         "#;
         assert_eq!(get_program_errors(src).len(), 0);
     }
+
+    // Regression for #4545
+    #[test]
+    fn type_aliases_in_main() {
+        let src = r#"
+            type Outer<N> = [u8; N];
+            fn main(arg: Outer<1>) {}
+        "#;
+        assert_eq!(get_program_errors(src).len(), 0);
+    }
 }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1219,7 +1219,7 @@ fn lambda$f1(mut env$l1: (Field)) -> Field {
     fn type_aliases_in_main() {
         let src = r#"
             type Outer<N> = [u8; N];
-            fn main(arg: Outer<1>) {}
+            fn main(_arg: Outer<1>) {}
         "#;
         assert_eq!(get_program_errors(src).len(), 0);
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4545

## Summary\*

A prior assumption we had where we didn't need to bind generics just to check how many fields a type can have turned out not to be true. Binding generics is important for cases such as the new test case where generic lengths are used.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
