### PR TITLE
fix: Make `nargo` the default binary for cargo run

### DIFF
--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "nargo_cli"
 description = "Noir's package manager"
+default-run = "nargo"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

## Problem\*

The acvm binary was added recently which prevents developers from using `cargo run` without an additional `--bin nargo` to specify the nargo binary

## Summary\*

Sets the default binary to run to `nargo` for `cargo run`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
