### PR TITLE
chore: fix docker test workflows

### DIFF
--- a/.github/scripts/noir-wasm-build.sh
+++ b/.github/scripts/noir-wasm-build.sh
@@ -2,4 +2,5 @@
 set -eu
 
 .github/scripts/wasm-pack-install.sh
+yarn workspace @noir-lang/types build
 yarn workspace @noir-lang/noir_wasm build


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Docker tests have been broken for a while. This PR builds the types package so that the `noir_wasm` package can build.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
