### PR TITLE
chore: fix docs builds on master

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "preprocess": "./scripts/codegen_nargo_reference.sh && yarn node ./scripts/preprocess/index.js",
+    "preprocess": "yarn workspace @noir-lang/acvm_js build && ./scripts/codegen_nargo_reference.sh && yarn node ./scripts/preprocess/index.js",
     "start": "yarn preprocess && docusaurus start",
     "build": "yarn preprocess && yarn version::stables && docusaurus build",
     "version::stables": "ts-node ./scripts/setStable.ts",


### PR DESCRIPTION
# Description

## Problem\*

Followup to https://github.com/noir-lang/noir/pull/4568
Fixes https://github.com/noir-lang/noir/actions/runs/8347752784/job/22848198145#step:5:1324

## Summary\*

Looks like the typedoc plugin doesn't build transitive dependencies if they're reexported so we need to ensure that the ACVM crate is built and available.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
