### PR TITLE
chore(ci): fix long debugger test times

### DIFF
--- a/tooling/debugger/tests/debug.rs
+++ b/tooling/debugger/tests/debug.rs
@@ -12,7 +12,7 @@ mod tests {
         let nargo_bin =
             cargo_bin("nargo").into_os_string().into_string().expect("Cannot parse nargo path");
 
-        let timeout_seconds = 120;
+        let timeout_seconds = 10;
         let mut dbg_session =
             spawn_bash(Some(timeout_seconds * 1000)).expect("Could not start bash session");
 
@@ -51,5 +51,8 @@ mod tests {
         dbg_session
             .exp_regex(".*Circuit witness successfully solved.*")
             .expect("Expected circuit witness to be successfully solved.");
+
+        // Exit the bash session.
+        dbg_session.send_line("exit").expect("Failed to quit debugger");
     }
 }

--- a/tooling/debugger/tests/debug.rs
+++ b/tooling/debugger/tests/debug.rs
@@ -53,6 +53,6 @@ mod tests {
             .expect("Expected circuit witness to be successfully solved.");
 
         // Exit the bash session.
-        dbg_session.send_line("exit").expect("Failed to quit debugger");
+        dbg_session.send_line("exit").expect("Failed to quit bash session");
     }
 }

--- a/tooling/debugger/tests/debug.rs
+++ b/tooling/debugger/tests/debug.rs
@@ -12,7 +12,7 @@ mod tests {
         let nargo_bin =
             cargo_bin("nargo").into_os_string().into_string().expect("Cannot parse nargo path");
 
-        let timeout_seconds = 10;
+        let timeout_seconds = 20;
         let mut dbg_session =
             spawn_bash(Some(timeout_seconds * 1000)).expect("Could not start bash session");
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently not closing the spawned bash process so we have to wait for the full timeout duration before the test registers as successful. This PR then adds an explicit call to `exit` to finish the test early.

I've also shortened the timeout as 2 minutes seems excessive.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
