### PR TITLE
chore: Optimize HashMap: unconstrained approach

### DIFF
--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -45,6 +45,7 @@ impl<Size> HashMap<Size> {
             {
                 found_index = i as Field;
                 found = true;
+                break;
             }
         }
         (found_index, found)
@@ -74,6 +75,7 @@ impl<Size> HashMap<Size> {
             {
                 found_index = previous_index as Field;
                 insert_between_two_entries = true;
+                break;
             }
         }
         (found_index, insert_between_two_entries, insert_at_start, insert_at_end)
@@ -174,6 +176,7 @@ impl<Size> HashMap<Size> {
             if (key == self.entries[i].key) {
                 index = i;
                 found = true;
+                break;
             }
         }
         assert(found == true);

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -1,474 +1,233 @@
-use crate::cmp::Eq;
-use crate::collections::vec::Vec;
-use crate::option::Option;
-use crate::default::Default;
-use crate::hash::{Hash, Hasher, BuildHasher};
-use crate::collections::bounded_vec::BoundedVec;
+use crate::field::bn254::assert_gt;
 
-// We use load factor α_max = 0.75. 
-// Upon exceeding it, assert will fail in order to inform the user 
-// about performance degradation, so that he can adjust the capacity.
-global MAX_LOAD_FACTOR_NUMERATOR = 3;
-global MAX_LOAD_FACTOR_DEN0MINATOR = 4;
-
-// Hash table with open addressing and quadratic probing.
-// Size of the underlying table must be known at compile time.
-// It is advised to select capacity N as a power of two, or a prime number 
-// because utilized probing scheme is best tailored for it.
-struct HashMap<K, V, N, B> {
-    _table: [Slot<K, V>; N],
-
-    // Amount of valid elements in the map.
-    _len: u64,
-
-    _build_hasher: B
+struct ListItem {
+    key: Field,
+    value: Field,
+    previous: Field,
+    next: Field,
 }
 
-// Data unit in the HashMap table.
-// In case Noir adds support for enums in the future, this  
-// should be refactored to have three states:
-// 1. (key, value)
-// 2. (empty)
-// 3. (deleted)
-struct Slot<K, V> {
-    _key_value: Option<(K, V)>,
-    _is_deleted: bool,
-}
-
-impl<K, V> Default for Slot<K, V>{
-    fn default() -> Self{
-        Slot{
-            _key_value: Option::none(),
-            _is_deleted: false
+impl ListItem {
+    fn default() -> ListItem {
+        ListItem {
+            key: 0,
+            value: 0,
+            previous: 0,
+            next: 0,
         }
     }
 }
 
-impl<K, V> Slot<K, V> {
-    fn is_valid(self) -> bool {
-        !self._is_deleted & self._key_value.is_some()
+struct HashMap<Size> {
+    entries: [ListItem; Size],
+    size: Field,
+    is_empty: bool,
+    first_index: Field,
+    last_index: Field,
+}
+
+impl<Size> HashMap<Size> {
+    pub fn default() -> HashMap<Size> {
+        HashMap{
+            entries: [ListItem::default(); Size], // todo fix
+            size: 0,
+            is_empty: true,
+            first_index: 0,
+            last_index: 0,
+        }
     }
 
-    fn is_available(self) -> bool {
-        self._is_deleted | self._key_value.is_none()
+    unconstrained fn check_for_collision(self, key: Field) -> (Field, bool) {
+        let mut found_index: Field = 0;
+        let mut found: bool = false;
+        for i in 0 .. self.size as u64 {
+            if (self.entries[i].key == key)
+            {
+                found_index = i as Field;
+                found = true;
+            }
+        }
+        (found_index, found)
     }
 
-    fn key_value(self) -> Option<(K, V)> {
-        self._key_value
+    unconstrained fn find_previous_key_location(self, key: Field) -> (Field, bool, bool, bool) {
+        let mut found_index: Field = 0;
+        let mut insert_between_two_entries: bool = false;
+        let mut insert_at_start: bool = false;
+        let mut insert_at_end: bool = false;
+
+        if (key.lt(self.entries[self.first_index].key) & !self.is_empty)
+        {
+            found_index = self.first_index;
+            insert_at_start = true;
+        }
+        else if (self.entries[self.last_index].key.lt(key) & !self.is_empty)
+        {
+            found_index = self.last_index;
+            insert_at_end = true;
+        }
+
+        for i in 0 .. self.size as u64 {
+            let previous_index = self.entries[i].previous;
+            let previous_item = self.entries[previous_index].key;
+            if (key.lt(self.entries[i].key) & previous_item.lt(key))
+            {
+                found_index = previous_index as Field;
+                insert_between_two_entries = true;
+            }
+        }
+        (found_index, insert_between_two_entries, insert_at_start, insert_at_end)
     }
 
-    fn key_value_unchecked(self) -> (K, V) {
-        self._key_value.unwrap_unchecked()
+    pub fn insert(&mut self, key: Field, value: Field) {
+        // TODO: make the check that Size < 2^16 an unconstrained compile-time check
+        (Size - self.size).assert_max_bit_size(16);
+        let (previous_index, insert_between_two_entries, insert_at_start, insert_at_end) = self.find_previous_key_location(key);
+        let (collision_index, found_collision) = self.check_for_collision(key);
+        let is_first_entry = self.is_empty;
+
+        // Assert that one (and only one) of is_first_entry, insert_at_start, insert_at_end, insert_between_two_entries, found_collision is true
+        let path_check = is_first_entry as Field + insert_at_start as Field + insert_at_end as Field + insert_between_two_entries as Field + found_collision as Field;
+        assert_eq(path_check, 1, f"path_check is not 1, is_first_entry = {is_first_entry}, insert_at_start = {insert_at_start}, insert_at_end = {insert_at_end}, insert_between_two_entries = {insert_between_two_entries}, found_collision = {found_collision}");
+
+  
+        let next_index = self.entries[previous_index].next;
+        let previous = self.entries[previous_index].key;
+        let next = self.entries[next_index].key;
+
+        // We apply two greater-than checks.
+        // Case 1: We insert in between two existing entries
+        // key > previous
+        // next > key
+        // Case 2: We insert at start of list
+        // next > key
+        // Case 3: We insert at end of list
+        // key > previous
+        // Case 4: Collision!
+        // key == next
+        // Case 5: List is empty
+
+        // key > previous check
+        let apply_key_gt_previous_check: bool = insert_between_two_entries | insert_at_end;
+        let apply_next_gt_key_check: bool = insert_between_two_entries | insert_at_start;
+
+        let key_lhs = if apply_key_gt_previous_check { key } else { 1 };
+        let previous_rhs = if apply_key_gt_previous_check { previous } else { 0 };
+        assert_gt(key_lhs, previous_rhs);
+
+        let next_lhs = if apply_next_gt_key_check { next } else { 1 };
+        let key_rhs = if apply_next_gt_key_check { key } else { 0 };
+        assert_gt(next_lhs, key_rhs);
+
+
+        // If we have collided, validate previous == key
+        if (found_collision)
+        {
+            assert_eq(previous, key);
+        }
+
+        // If insert_at_start, validate self.entries[previous_index].previous = invalid index
+        if (insert_at_start)
+        {
+            assert_eq(previous_index, self.first_index);
+            self.first_index = self.size;
+        }
+
+        // If insert_at_end, validate self.entries[previous_index].next = invalid index
+        if (insert_at_end)
+        {
+            assert_eq(previous_index, self.last_index);
+            self.last_index = self.size;
+        }
+    
+        if (self.is_empty)
+        {
+            self.first_index = self.size;
+            self.last_index = self.size;
+        }
+
+        // New entry.
+        // If insert_at_end OR first entry, next = -1, else next = next_index
+        let new_item_next = if (insert_at_end | is_first_entry) { Size - 1 } else { next_index };
+        // If insert_at_start OR first entry, previous = -1, else previous = previous_index
+        let new_item_previous = if (insert_at_start | is_first_entry) { Size -1 } else { previous_index };
+
+        // we DONT update previous index if: first entry OR collision OR insert at start
+        let update_previous_index = insert_at_end | insert_between_two_entries;
+        self.entries[previous_index].next = if update_previous_index { self.size } else { self.entries[previous_index].next};
+
+        // we DONT update next index if: first entry OR collision OR insert at end
+        let update_next_index = insert_at_start | insert_between_two_entries;
+        self.entries[next_index].previous = if update_next_index { self.size } else { self.entries[next_index].previous };
+
+        let new_entry_index = if found_collision { collision_index } else { self.size };
+        self.entries[new_entry_index] = ListItem{ key: key, value: value, previous: new_item_previous, next: new_item_next };
+
+        self.size += 1 - found_collision as Field;
+        self.is_empty = false;
     }
 
-    fn set(&mut self, key: K, value: V) {
-        self._key_value = Option::some((key, value));
-        self._is_deleted = false;
+    unconstrained fn find_key_location(self, key: Field) -> u8 {
+        let mut found: bool = false;
+        let mut index: u8 = 0;
+        for i in 0..Size {
+            if (key == self.entries[i].key) {
+                index = i;
+                found = true;
+            }
+        }
+        assert(found == true);
+        index
     }
 
-    // Shall not override `_key_value` with Option::none(),
-    // because we must be able to differentiate empty 
-    // and deleted slots for lookup.
-    fn mark_deleted(&mut self) {
-        self._is_deleted = true;
+
+    pub fn at(self, key: Field) -> Field {
+        let index: u8 = self.find_key_location(key);
+        assert(self.entries[index].key == key);
+        self.entries[index].value
+    }
+
+
+    pub fn get(self, key: Field) -> ListItem {
+        let index: u8 = self.find_key_location(key);
+        assert(self.entries[index].key == key);
+        self.entries[index]
     }
 }
 
-// While conducting lookup, we iterate attempt from 0 to N - 1 due to heuristic,
-// that if we have went that far without finding desired, 
-// it is very unlikely to be after - performance will be heavily degraded.
-impl<K, V, N, B, H> HashMap<K, V, N, B> {
-    // Creates a new instance of HashMap with specified BuildHasher.
-    // docs:start:with_hasher
-    pub fn with_hasher(_build_hasher: B) -> Self
-    where
-        B: BuildHasher<H> {
-        // docs:end:with_hasher
-        let _table = [Slot::default(); N];
-        let _len = 0;
-        Self { _table, _len, _build_hasher }
-    }
+#[test]
+fn test_insert() {
+    let mut test_list: HashMap<5> = HashMap::default();
+    test_list.insert(123, 456);
+    assert(test_list.size == 1);
+    let mut result = test_list.at(123);
+    assert(result == 456);
 
-    // Clears the map, removing all key-value entries.
-    // docs:start:clear
-    pub fn clear(&mut self) {
-        // docs:end:clear
-        self._table = [Slot::default(); N];
-        self._len = 0;
-    }
+    test_list.insert(128, 999);
+    assert(test_list.size == 2);
+    result = test_list.at(128);
+    assert(result == 999);
 
-    // Returns true if the map contains a value for the specified key.
-    // docs:start:contains_key
-    pub fn contains_key(
-        self,
-        key: K
-    ) -> bool
-    where
-        K: Hash + Eq,
-        B: BuildHasher<H>,
-        H: Hasher {
-        // docs:end:contains_key
-        self.get(key).is_some()
-    }
+    let first = test_list.get(123);
+    let second = test_list.get(128);
+    assert(test_list.entries[first.next].key == second.key);
+    assert(test_list.entries[second.previous].key == first.key);
+    assert(first.next == 1);
+    assert(second.previous == 0);
+    assert(first.previous == 4);
+    assert(second.next == 4);
 
-    // Returns true if the map contains no elements.
-    // docs:start:is_empty
-    pub fn is_empty(self) -> bool {
-        // docs:end:is_empty
-        self._len == 0
-    }
+    test_list.insert(127, 333);
+    assert(test_list.size == 3);
+    result = test_list.at(127);
+    assert(result == 333);
+    test_list.insert(123, 457);
+    assert(test_list.size == 3);
+    result = test_list.at(123);
+    assert(result == 457);
 
-    // Returns a BoundedVec of all valid entries in this HashMap.
-    // The length of the returned vector will always match the length of this HashMap.
-    // docs:start:entries
-    pub fn entries(self) -> BoundedVec<(K, V), N> {
-        // docs:end:entries
-        let mut entries = BoundedVec::new();
-
-        for slot in self._table {
-            if slot.is_valid() {
-                // SAFETY: slot.is_valid() should ensure there is a valid key-value pairing here
-                let key_value = slot.key_value().unwrap_unchecked();
-                entries.push(key_value);
-            }
-        }
-
-        let msg = f"Amount of valid elements should have been {self._len} times, but got {entries.len()}.";
-        assert(entries.len() == self._len, msg);
-
-        entries
-    }
-
-    // Returns a BoundedVec containing all the keys within this HashMap.
-    // The length of the returned vector will always match the length of this HashMap.
-    // docs:start:keys
-    pub fn keys(self) -> BoundedVec<K, N> {
-        // docs:end:keys
-        let mut keys = BoundedVec::new();
-
-        for slot in self._table {
-            if slot.is_valid() {
-                let (key, _) = slot.key_value_unchecked();
-                keys.push(key);
-            }
-        }
-
-        let msg = f"Amount of valid elements should have been {self._len} times, but got {keys.len()}.";
-        assert(keys.len() == self._len, msg);
-
-        keys
-    }
-
-    // Returns a BoundedVec containing all the values within this HashMap.
-    // The length of the returned vector will always match the length of this HashMap.
-    // docs:start:values
-    pub fn values(self) -> BoundedVec<V, N> {
-        // docs:end:values
-        let mut values = BoundedVec::new();
-
-        for slot in self._table {
-            if slot.is_valid() {
-                let (_, value) = slot.key_value_unchecked();
-                values.push(value);
-            }
-        }
-
-        let msg = f"Amount of valid elements should have been {self._len} times, but got {values.len()}.";
-        assert(values.len() == self._len, msg);
-
-        values
-    }
-
-    // For each key-value entry applies mutator function.
-    // docs:start:iter_mut
-    pub fn iter_mut(
-        &mut self,
-        f: fn(K, V) -> (K, V)
-    )
-    where
-        K: Eq + Hash,
-        B: BuildHasher<H>,
-        H: Hasher {
-        // docs:end:iter_mut
-        let mut entries = self.entries();
-        let mut new_map = HashMap::with_hasher(self._build_hasher);
-
-        for i in 0..N {
-            if i < self._len {
-                let entry = entries.get_unchecked(i);
-                let (key, value) = f(entry.0, entry.1);
-                new_map.insert(key, value);
-            }
-        }
-
-        self._table = new_map._table;
-    }
-
-    // For each key applies mutator function.
-    // docs:start:iter_keys_mut
-    pub fn iter_keys_mut(
-        &mut self,
-        f: fn(K) -> K
-    ) 
-    where
-        K: Eq + Hash,
-        B: BuildHasher<H>,
-        H: Hasher {
-        // docs:end:iter_keys_mut
-        let mut entries = self.entries();
-        let mut new_map = HashMap::with_hasher(self._build_hasher);
-
-        for i in 0..N {
-            if i < self._len {
-                let entry = entries.get_unchecked(i);
-                let (key, value) = (f(entry.0), entry.1);
-                new_map.insert(key, value);
-            }
-        }
-
-        self._table = new_map._table;
-    }
-
-    // For each value applies mutator function.
-    // docs:start:iter_values_mut
-    pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
-        // docs:end:iter_values_mut
-        for i in 0..N {
-            let mut slot = self._table[i];
-            if slot.is_valid() {
-                let (key, value) = slot.key_value_unchecked();
-                slot.set(key, f(value));
-                self._table[i] = slot;
-            }
-        }
-    }
-
-    // Retains only the elements specified by the predicate.
-    // docs:start:retain
-    pub fn retain(&mut self, f: fn(K, V) -> bool) {
-        // docs:end:retain
-        for index in 0..N {
-            let mut slot = self._table[index];
-            if slot.is_valid() {
-                let (key, value) = slot.key_value_unchecked();
-                if !f(key, value) {
-                    slot.mark_deleted();
-                    self._len -= 1;
-                    self._table[index] = slot;
-                }
-            }
-        }
-    }
-
-    // Amount of active key-value entries.
-    // docs:start:len
-    pub fn len(self) -> u64 {
-        // docs:end:len
-        self._len
-    }
-
-    // Get the compile-time map capacity.
-    // docs:start:capacity
-    pub fn capacity(_self: Self) -> u64 {
-        // docs:end:capacity
-        N
-    }
-
-    // Get the value by key. If it does not exist, returns none().
-    // docs:start:get
-    pub fn get(
-        self,
-        key: K
-    ) -> Option<V>
-    where
-        K: Eq + Hash,
-        B: BuildHasher<H>,
-        H: Hasher {
-        // docs:end:get
-        let mut result = Option::none();
-
-        let hash = self.hash(key);
-        let mut should_break = false;
-
-        for attempt in 0..N {
-            if !should_break {
-                let index = self.quadratic_probe(hash, attempt as u64);
-                let slot = self._table[index];
-
-                // Not marked as deleted and has key-value.
-                if slot.is_valid() {
-                    let (current_key, value) = slot.key_value_unchecked();
-                    if current_key == key {
-                        result = Option::some(value);
-                        should_break = true;
-                    }
-                }
-            }
-        }
-
-        result
-    }
-
-    // Insert key-value entry. In case key was already present, value is overridden. 
-    // docs:start:insert
-    pub fn insert(
-        &mut self,
-        key: K,
-        value: V
-    )
-    where
-        K: Eq + Hash,
-        B: BuildHasher<H>,
-        H: Hasher {
-        // docs:end:insert
-        self.assert_load_factor();
-
-        let hash = self.hash(key);
-        let mut should_break = false;
-
-        for attempt in 0..N {
-            if !should_break {
-                let index = self.quadratic_probe(hash, attempt as u64);
-                let mut slot = self._table[index];
-                let mut insert = false;
-
-                // Either marked as deleted or has unset key-value.
-                if slot.is_available() {
-                    insert = true;
-                    self._len += 1;
-                } else {
-                    let (current_key, _) = slot.key_value_unchecked();
-                    if current_key == key {
-                        insert = true;
-                    }
-                }
-
-                if insert {
-                    slot.set(key, value);
-                    self._table[index] = slot;
-                    should_break = true;
-                }
-            }
-        }
-    }
-
-    // Removes a key-value entry. If key is not present, HashMap remains unchanged.
-    // docs:start:remove
-    pub fn remove(
-        &mut self,
-        key: K
-    )
-    where
-        K: Eq + Hash,
-        B: BuildHasher<H>,
-        H: Hasher {
-        // docs:end:remove
-        let hash = self.hash(key);
-        let mut should_break = false;
-
-        for attempt in 0..N {
-            if !should_break {
-                let index = self.quadratic_probe(hash, attempt as u64);
-                let mut slot = self._table[index];
-
-                // Not marked as deleted and has key-value.
-                if slot.is_valid() {
-                    let (current_key, _) = slot.key_value_unchecked();
-                    if current_key == key {
-                        slot.mark_deleted();
-                        self._table[index] = slot;
-                        self._len -= 1;
-                        should_break = true;
-                    }
-                }
-            }
-        }
-    }
-
-    // Apply HashMap's hasher onto key to obtain pre-hash for probing.
-    fn hash(
-        self,
-        key: K
-    ) -> u64
-    where
-        K: Hash,
-        B: BuildHasher<H>,
-        H: Hasher {
-        let mut hasher = self._build_hasher.build_hasher();
-        key.hash(&mut hasher);
-        hasher.finish() as u64
-    }
-
-    // Probing scheme: quadratic function.
-    // We use 0.5 constant near variadic attempt and attempt^2 monomials.
-    // This ensures good uniformity of distribution for table sizes
-    // equal to prime numbers or powers of two. 
-    fn quadratic_probe(_self: Self, hash: u64, attempt: u64) -> u64 {
-        (hash + (attempt + attempt * attempt) / 2) % N
-    }
-
-    // Amount of elements in the table in relation to available slots exceeds α_max. 
-    // To avoid a comparatively more expensive division operation 
-    // we conduct cross-multiplication instead.
-    // n / m >= MAX_LOAD_FACTOR_NUMERATOR / MAX_LOAD_FACTOR_DEN0MINATOR 
-    // n * MAX_LOAD_FACTOR_DEN0MINATOR >= m * MAX_LOAD_FACTOR_NUMERATOR
-    fn assert_load_factor(self) {
-        let lhs = self._len * MAX_LOAD_FACTOR_DEN0MINATOR;
-        let rhs = self._table.len() * MAX_LOAD_FACTOR_NUMERATOR;
-        let exceeded = lhs >= rhs;
-        assert(!exceeded, "Load factor is exceeded, consider increasing the capacity.");
-    }
-}
-
-// Equality class on HashMap has to test that they have 
-// equal sets of key-value entries, 
-// thus one is a subset of the other and vice versa.
-// docs:start:eq
-impl<K, V, N, B, H> Eq for HashMap<K, V, N, B>
-where
-    K: Eq + Hash,
-    V: Eq,
-    B: BuildHasher<H>,
-    H: Hasher
-{
-    fn eq(self, other: HashMap<K, V, N, B>) -> bool {
-// docs:end:eq
-        let mut equal = false;
-
-        if self.len() == other.len(){
-            equal = true;
-            for slot in self._table{
-                // Not marked as deleted and has key-value.
-                if equal & slot.is_valid(){
-                    let (key, value) = slot.key_value_unchecked();
-                    let other_value = other.get(key);
-
-                    if other_value.is_none(){
-                        equal = false;
-                    }else{
-                        let other_value = other_value.unwrap_unchecked();
-                        if value != other_value{
-                            equal = false;
-                        }
-                    }
-                }
-            }
-        }
-
-        equal
-    }
-}
-
-// docs:start:default
-impl<K, V, N, B, H> Default for HashMap<K, V, N, B>
-where
-    B: BuildHasher<H> + Default,
-    H: Hasher + Default
-{
-    fn default() -> Self {
-// docs:end:default
-        let _build_hasher = B::default();
-        let map: HashMap<K, V, N, B> = HashMap::with_hasher(_build_hasher);
-        map
-    }
+    test_list.insert(1, 3);
+    assert(test_list.size == 4);
+    result = test_list.at(1);
+    assert(result == 3);
 }


### PR DESCRIPTION
…of concept

# Description

## Problem\*

Resolves #4584

## Summary\*

This branch optimizes `HashMap` using an unconstrained approach suggested by @zac-williamson. This PR is here to show the differences of this approach, but the timings and benchmark information are on the PR with the bucketed approach here: https://github.com/noir-lang/noir/pull/4603

## Additional Information

The current approach in this PR is not yet abstracted to any key or value type. When this is done it should be noted that this approach also requires `Ord` on the key type.

It's also unclear if the unconstrained approach would be as efficient for an API returning an optional value in `get`. I think in the `None` case we would need to iterate through the entire hashmap to assert that they key isn't present to prevent under constraining the result value.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
