### PR TITLE
feat: add specific error for attempting `string[x] = ".."`

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -140,6 +140,8 @@ pub enum TypeCheckError {
         method_name: String,
         span: Span,
     },
+    #[error("Strings do not support indexed assignment")]
+    StringIndexAssign { span: Span },
 }
 
 impl TypeCheckError {
@@ -237,7 +239,8 @@ impl From<TypeCheckError> for Diagnostic {
             | TypeCheckError::ConstrainedReferenceToUnconstrained { span }
             | TypeCheckError::UnconstrainedReferenceToConstrained { span }
             | TypeCheckError::UnconstrainedSliceReturnToConstrained { span }
-            | TypeCheckError::NonConstantSliceLength { span } => {
+            | TypeCheckError::NonConstantSliceLength { span }
+            | TypeCheckError::StringIndexAssign { span } => {
                 Diagnostic::simple_error(error.to_string(), String::new(), span)
             }
             TypeCheckError::PublicReturnType { typ, span } => Diagnostic::simple_error(

--- a/compiler/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/stmt.rs
@@ -260,9 +260,7 @@ impl<'interner> TypeChecker<'interner> {
                     Type::Error => Type::Error,
                     Type::String(_) => {
                         let (_lvalue_name, lvalue_span) = self.get_lvalue_name_and_span(&lvalue);
-                        self.errors.push(TypeCheckError::StringIndexAssign {
-                            span: lvalue_span,
-                        });
+                        self.errors.push(TypeCheckError::StringIndexAssign { span: lvalue_span });
                         Type::Error
                     }
                     other => {

--- a/compiler/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/stmt.rs
@@ -258,6 +258,13 @@ impl<'interner> TypeChecker<'interner> {
                     Type::Array(_, elem_type) => *elem_type,
                     Type::Slice(elem_type) => *elem_type,
                     Type::Error => Type::Error,
+                    Type::String(_) => {
+                        let (_lvalue_name, lvalue_span) = self.get_lvalue_name_and_span(&lvalue);
+                        self.errors.push(TypeCheckError::StringIndexAssign {
+                            span: lvalue_span,
+                        });
+                        Type::Error
+                    }
                     other => {
                         // TODO: Need a better span here
                         self.errors.push(TypeCheckError::TypeMismatch {


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4267

## Summary\*

New error:

```bash
error: Strings do not support indexed assignment
  ┌─ /Users/michaelklein/Coding/rust/noir/test_programs/compile_failure/mutable_str_index/src/main.nr:3:5
  │
3 │     example[0] = "?";
  │     -------
  │

Aborting due to 1 previous error
```

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
