### PR TITLE
chore(github): Improve PR template's "document later" checkbox descri…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Resolves <!-- Link to GitHub Issue -->
 Check one:
 - [ ] No documentation needed.
 - [ ] Documentation included in this PR.
-- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.
+- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.
 
 # PR Checklist\*
 


### PR DESCRIPTION
# Description

## Problem\*

Describing the option as "Exceptional Case" wasn't very intuitive. Some PRs that were meant to check that box checked the "No documentation needed." box instead.

## Summary\*

Describe the option as "For Experimental Features" instead, as most if not all such exceptional cases that docs were preferred to be delayed came from features being still experimental (i.e. not intended for public use yet).

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[Exceptional Case]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.