### PR TITLE
chore: fix acvm crates reporting errors as JS packages

### DIFF
--- a/.github/ACVM_PUBLISH_FAILED.md
+++ b/.github/ACVM_PUBLISH_FAILED.md
@@ -1,0 +1,10 @@
+---
+title: "ACVM crates failed to publish"
+assignees: TomAFrench, Savio-Sou
+---
+
+The {{env.CRATE_VERSION}} release of the ACVM crates failed.
+
+Check the [Publish ACVM crates]({{env.WORKFLOW_URL}}) workflow for details.
+
+This issue was raised by the workflow `{{env.WORKFLOW_NAME}}`

--- a/.github/workflows/publish-acvm.yml
+++ b/.github/workflows/publish-acvm.yml
@@ -74,4 +74,4 @@ jobs:
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           update_existing: true
-          filename: .github/JS_PUBLISH_FAILED.md
+          filename: .github/ACVM_PUBLISH_FAILED.md


### PR DESCRIPTION
# Description

## Problem\*

Addresses incorrect content of #4634

## Summary\*

We were raising an alert for a bad publish of the ACVM crates as if they were the JS packages so this PR updates the alert to be consistent.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
