### PR TITLE
chore: fix versioning of `bn254_blackbox_solver` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "bn254_blackbox_solver"
-version = "0.39.0"
+version = "0.42.0"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ acvm = { version = "0.42.0", path = "acvm-repo/acvm" }
 brillig = { version = "0.42.0", path = "acvm-repo/brillig", default-features = false }
 brillig_vm = { version = "0.42.0", path = "acvm-repo/brillig_vm", default-features = false }
 acvm_blackbox_solver = { version = "0.42.0", path = "acvm-repo/blackbox_solver", default-features = false }
-bn254_blackbox_solver = { version = "0.39.0", path = "acvm-repo/bn254_blackbox_solver", default-features = false }
+bn254_blackbox_solver = { version = "0.42.0", path = "acvm-repo/bn254_blackbox_solver", default-features = false }
 
 # Noir compiler workspace dependencies
 arena = { path = "compiler/utils/arena" }

--- a/acvm-repo/bn254_blackbox_solver/Cargo.toml
+++ b/acvm-repo/bn254_blackbox_solver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bn254_blackbox_solver"
 description = "Solvers for black box functions which are specific for the bn254 curve"
 # x-release-please-start-version
-version = "0.39.0"
+version = "0.42.0"
 # x-release-please-end
 authors.workspace = true
 edition.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -61,8 +61,8 @@
         "acir_field/Cargo.toml",
         "acvm/Cargo.toml",
         "acvm_js/Cargo.toml",
-        "barretenberg_blackbox_solver/Cargo.toml",
         "blackbox_solver/Cargo.toml",
+        "bn254_blackbox_solver/Cargo.toml",
         "brillig/Cargo.toml",
         "brillig_vm/Cargo.toml",
         {


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4634 

## Summary\*

The ACVM crate publishing steps are failing because when `barretenberg_blackbox_solver` was renamed to `bn254_blackbox_solver` the release please config wasn't updated to match, resulting in the version not being incremented on releases.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
