### PR TITLE
chore(ci): add warning sticky comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,36 @@ jobs:
           git commit -m "chore(docs): cut new docs version for tag ${{ steps.noir-version.outputs.semver }}"
           git push
 
+  release-end:
+    name: Release End
+    runs-on: ubuntu-latest
+    # We want this job to always run (even if the dependant jobs fail) as we need apply changes to the sticky comment.
+    if: ${{ always() }}
+    
+    needs:
+      - update-acvm-workspace-package-versions
+      - update-docs
+
+    env:
+      # We treat any skipped or failing jobs as a failure for the workflow as a whole.
+      FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }
+
+    steps:  
+      - name: Add warning to sticky comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # delete the comment in case failures have been fixed
+          delete: ${{ !env.FAIL }}
+          message: "The release workflow has not completed successfully. Releasing now will result in a broken release"
+
+      - name: Report overall success
+        run: |
+          if [[ $FAIL == true ]]; then
+              exit 1
+          else
+              exit 0
+          fi
+
   build-binaries:
     name: Build binaries
     needs: [release-please]


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently don't have any feedback for when the release workflow doesn't fully complete to signal that releases shouldn't be made. I've updated the workflow so that we post a sticky comment in this situation.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
