### PR TITLE
chore: include durations of tracing spans in log output

### DIFF
--- a/tooling/nargo_cli/src/main.rs
+++ b/tooling/nargo_cli/src/main.rs
@@ -25,14 +25,14 @@ fn main() {
     if let Ok(log_dir) = env::var("NARGO_LOG_DIR") {
         let debug_file = rolling::daily(log_dir, "nargo-log");
         tracing_subscriber::fmt()
-            .with_span_events(FmtSpan::ACTIVE)
+            .with_span_events(FmtSpan::ENTER | FmtSpan::CLOSE)
             .with_writer(debug_file)
             .with_ansi(false)
             .with_env_filter(EnvFilter::from_default_env())
             .init();
     } else {
         tracing_subscriber::fmt()
-            .with_span_events(FmtSpan::ACTIVE)
+            .with_span_events(FmtSpan::ENTER | FmtSpan::CLOSE)
             .with_ansi(true)
             .with_env_filter(EnvFilter::from_env("NOIR_LOG"))
             .init();


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the filter on span events so that we get the duration of the span being printed.


Example output:
```
2024-03-27T17:18:17.207634Z TRACE check_crate{crate_id=Root(1) deny_warnings=false disable_macros=false}: noirc_driver: new
2024-03-27T17:18:17.238046Z TRACE check_crate{crate_id=Root(1) deny_warnings=false disable_macros=false}: noirc_driver: close time.busy=30.4ms time.idle=39.3µs
2024-03-27T17:18:17.238075Z TRACE compile_no_check{function_name="main"}: noirc_driver: new
2024-03-27T17:18:17.238081Z TRACE compile_no_check{function_name="main"}:monomorphize: noirc_frontend::monomorphization: new
2024-03-27T17:18:17.238180Z TRACE compile_no_check{function_name="main"}:monomorphize: noirc_frontend::monomorphization: close time.busy=95.5µs time.idle=3.56µs
2024-03-27T17:18:17.238217Z TRACE compile_no_check{function_name="main"}:create_circuit: noirc_evaluator::ssa: new
2024-03-27T17:18:17.238234Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation: noirc_evaluator::ssa: new
2024-03-27T17:18:17.238458Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:defunctionalize: noirc_evaluator::ssa::opt::defunctionalize: new
2024-03-27T17:18:17.238476Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:defunctionalize: noirc_evaluator::ssa::opt::defunctionalize: close time.busy=12.5µs time.idle=6.24µs
2024-03-27T17:18:17.238482Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:remove_paired_rc: noirc_evaluator::ssa::opt::rc: new
2024-03-27T17:18:17.238499Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:remove_paired_rc: noirc_evaluator::ssa::opt::rc: close time.busy=7.51µs time.idle=9.60µs
2024-03-27T17:18:17.238504Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:inline_functions: noirc_evaluator::ssa::opt::inlining: new
2024-03-27T17:18:17.238572Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:inline_functions: noirc_evaluator::ssa::opt::inlining: close time.busy=64.0µs time.idle=3.42µs
2024-03-27T17:18:17.238578Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:mem2reg: noirc_evaluator::ssa::opt::mem2reg: new
2024-03-27T17:18:17.238668Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:mem2reg: noirc_evaluator::ssa::opt::mem2reg: close time.busy=83.6µs time.idle=5.48µs
2024-03-27T17:18:17.238675Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:evaluate_assert_constant: noirc_evaluator::ssa::opt::assert_constant: new
2024-03-27T17:18:17.238682Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:evaluate_assert_constant: noirc_evaluator::ssa::opt::assert_constant: close time.busy=3.01µs time.idle=4.07µs
2024-03-27T17:18:17.238688Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:unroll_loops: noirc_evaluator::ssa::opt::unrolling: new
2024-03-27T17:18:17.387314Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:unroll_loops: noirc_evaluator::ssa::opt::unrolling: close time.busy=149ms time.idle=5.25µs
2024-03-27T17:18:17.387343Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:simplify_cfg: noirc_evaluator::ssa::opt::simplify_cfg: new
2024-03-27T17:18:17.393664Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:simplify_cfg: noirc_evaluator::ssa::opt::simplify_cfg: close time.busy=6.31ms time.idle=6.11µs
2024-03-27T17:18:17.393681Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:flatten_cfg: noirc_evaluator::ssa::opt::flatten_cfg: new
2024-03-27T17:18:22.881528Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:flatten_cfg: noirc_evaluator::ssa::opt::flatten_cfg: close time.busy=5.49s time.idle=9.78µs
2024-03-27T17:18:22.881558Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:remove_bit_shifts: noirc_evaluator::ssa::opt::remove_bit_shifts: new
2024-03-27T17:18:22.939961Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:remove_bit_shifts: noirc_evaluator::ssa::opt::remove_bit_shifts: close time.busy=58.4ms time.idle=7.86µs
2024-03-27T17:18:22.939994Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:mem2reg: noirc_evaluator::ssa::opt::mem2reg: new
2024-03-27T17:18:39.127772Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:mem2reg: noirc_evaluator::ssa::opt::mem2reg: close time.busy=16.2s time.idle=7.82µs
2024-03-27T17:18:39.127802Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:fold_constants: noirc_evaluator::ssa::opt::constant_folding: new
2024-03-27T17:18:42.247447Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:fold_constants: noirc_evaluator::ssa::opt::constant_folding: close time.busy=3.12s time.idle=6.51µs
2024-03-27T17:18:42.247480Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:fold_constants_using_constraints: noirc_evaluator::ssa::opt::constant_folding: new
2024-03-27T17:18:46.333707Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:fold_constants_using_constraints: noirc_evaluator::ssa::opt::constant_folding: close time.busy=4.09s time.idle=10.1µs
2024-03-27T17:18:46.333739Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:dead_instruction_elimination: noirc_evaluator::ssa::opt::die: new
2024-03-27T17:18:47.352043Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation:dead_instruction_elimination: noirc_evaluator::ssa::opt::die: close time.busy=1.02s time.idle=8.20µs
2024-03-27T17:18:47.366309Z TRACE compile_no_check{function_name="main"}:create_circuit:find_last_array_uses: noirc_evaluator::ssa::opt::array_use: new
2024-03-27T17:18:47.371971Z TRACE compile_no_check{function_name="main"}:create_circuit:find_last_array_uses: noirc_evaluator::ssa::opt::array_use: close time.busy=5.64ms time.idle=18.0µs
2024-03-27T17:18:47.371988Z TRACE compile_no_check{function_name="main"}:create_circuit:into_acir: noirc_evaluator::ssa::acir_gen: new
2024-03-27T17:18:54.310129Z TRACE compile_no_check{function_name="main"}:create_circuit:into_acir: noirc_evaluator::ssa::acir_gen: close time.busy=6.94s time.idle=8.21µs
2024-03-27T17:18:54.310156Z TRACE compile_no_check{function_name="main"}:create_circuit:ssa_generation: noirc_evaluator::ssa: close time.busy=30.1s time.idle=6.94s
2024-03-27T17:18:54.311567Z TRACE compile_no_check{function_name="main"}:create_circuit:optimize_acir: acvm::compiler::optimizers: new
2024-03-27T17:18:54.311580Z  INFO compile_no_check{function_name="main"}:create_circuit:optimize_acir: acvm::compiler::optimizers: Number of opcodes before: 8323
2024-03-27T17:18:54.312564Z  INFO compile_no_check{function_name="main"}:create_circuit:optimize_acir: acvm::compiler::optimizers: Number of opcodes after: 8323
2024-03-27T17:18:54.312571Z TRACE compile_no_check{function_name="main"}:create_circuit:optimize_acir: acvm::compiler::optimizers: close time.busy=995µs time.idle=9.56µs
2024-03-27T17:18:54.313322Z TRACE compile_no_check{function_name="main"}:create_circuit:update_acir: noirc_errors::debug_info: new
2024-03-27T17:18:54.314192Z TRACE compile_no_check{function_name="main"}:create_circuit:update_acir: noirc_errors::debug_info: close time.busy=863µs time.idle=6.04µs
2024-03-27T17:18:54.314446Z TRACE compile_no_check{function_name="main"}:create_circuit: noirc_evaluator::ssa: close time.busy=37.1s time.idle=4.23µs
2024-03-27T17:18:54.315015Z TRACE compile_no_check{function_name="main"}: noirc_driver: close time.busy=37.1s time.idle=4.54µs
2024-03-27T17:18:54.320236Z TRACE optimize_acir: acvm::compiler::optimizers: new
2024-03-27T17:18:54.320252Z  INFO optimize_acir: acvm::compiler::optimizers: Number of opcodes before: 8323
2024-03-27T17:18:54.321141Z  INFO optimize_acir: acvm::compiler::optimizers: Number of opcodes after: 8323
2024-03-27T17:18:54.321147Z TRACE optimize_acir: acvm::compiler::optimizers: close time.busy=902µs time.idle=9.38µs
2024-03-27T17:18:54.321156Z TRACE transform_acir{expression_width=Bounded { width: 3 }}: acvm::compiler::transformers: new
2024-03-27T17:18:54.322544Z TRACE transform_acir{expression_width=Bounded { width: 3 }}: acvm::compiler::transformers: close time.busy=1.38ms time.idle=4.58µs
2024-03-27T17:18:54.323134Z TRACE update_acir: noirc_errors::debug_info: new
2024-03-27T17:18:54.323928Z TRACE update_acir: noirc_errors::debug_info: close time.busy=789µs time.idle=5.42µs
```

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
