### PR TITLE
chore: pass release PR number to sticky comment action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
     if: ${{ always() }}
     
     needs:
+      - release-please
       - update-acvm-workspace-package-versions
       - update-docs
 
@@ -127,6 +128,8 @@ jobs:
       - name: Add warning to sticky comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          # We need to specify the PR on which to make the comment as workflow is triggered by push.
+          number: ${{ fromJSON(needs.release-please.outputs.release-pr).number }}
           # delete the comment in case failures have been fixed
           delete: ${{ !env.FAIL }}
           message: "The release workflow has not completed successfully. Releasing now will result in a broken release"


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

See comment

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
