### PR TITLE
chore!: Add `as_array` and remove `_slice` variants of hash functions

### DIFF
--- a/docs/docs/noir/standard_library/cryptographic_primitives/hashes.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/hashes.mdx
@@ -13,7 +13,6 @@ import BlackBoxInfo from '@site/src/components/Notes/_blackbox.mdx';
 ## sha256
 
 Given an array of bytes, returns the resulting sha256 hash.
-See sha256_slice for a version that works directly on slices.
 
 #include_code sha256 noir_stdlib/src/hash.nr rust
 
@@ -28,18 +27,9 @@ fn main() {
 
 <BlackBoxInfo />
 
-## sha256_slice
-
-A version of sha256 specialized to slices:
-
-#include_code sha256_slice noir_stdlib/src/hash.nr rust
-
-<BlackBoxInfo />
-
 ## blake2s
 
 Given an array of bytes, returns an array with the Blake2 hash
-See blake2s_slice for a version that works directly on slices.
 
 #include_code blake2s noir_stdlib/src/hash.nr rust
 
@@ -54,18 +44,9 @@ fn main() {
 
 <BlackBoxInfo />
 
-## blake2s_slice
-
-A version of blake2s specialized to slices:
-
-#include_code blake2s_slice noir_stdlib/src/hash.nr rust
-
-<BlackBoxInfo />
-
 ## blake3
 
 Given an array of bytes, returns an array with the Blake3 hash
-See blake3_slice for a version that works directly on slices.
 
 #include_code blake3 noir_stdlib/src/hash.nr rust
 
@@ -80,18 +61,9 @@ fn main() {
 
 <BlackBoxInfo />
 
-## blake3_slice
-
-A version of blake3 specialized to slices:
-
-#include_code blake3_slice noir_stdlib/src/hash.nr rust
-
-<BlackBoxInfo />
-
 ## pedersen_hash
 
 Given an array of Fields, returns the Pedersen hash.
-See pedersen_hash_slice for a version that works directly on slices.
 
 #include_code pedersen_hash noir_stdlib/src/hash.nr rust
 
@@ -101,18 +73,9 @@ example:
 
 <BlackBoxInfo />
 
-## pedersen_hash_slice
-
-Given a slice of Fields, returns the Pedersen hash.
-
-#include_code pedersen_hash_slice noir_stdlib/src/hash.nr rust
-
-<BlackBoxInfo />
-
 ## pedersen_commitment
 
 Given an array of Fields, returns the Pedersen commitment.
-See pedersen_commitment_slice for a version that works directly on slices.
 
 #include_code pedersen_commitment noir_stdlib/src/hash.nr rust
 
@@ -122,35 +85,17 @@ example:
 
 <BlackBoxInfo />
 
-## pedersen_commitment_slice
-
-Given a slice of Fields, returns the Pedersen commitment.
-
-#include_code pedersen_commitment_slice noir_stdlib/src/hash.nr rust
-
-<BlackBoxInfo />
-
 ## keccak256
 
 Given an array of bytes (`u8`), returns the resulting keccak hash as an array of
 32 bytes (`[u8; 32]`). Specify a message_size to hash only the first
-`message_size` bytes of the input. See keccak256_slice for a version that works
-directly on slices.
+`message_size` bytes of the input.
 
 #include_code keccak256 noir_stdlib/src/hash.nr rust
 
 example:
 
 #include_code keccak256 test_programs/execution_success/keccak256/src/main.nr rust
-
-<BlackBoxInfo />
-
-## keccak256_slice
-
-Given a slice of bytes (`u8`), returns the resulting keccak hash as an array of
-32 bytes (`[u8; 32]`).
-
-#include_code keccak256_slice noir_stdlib/src/hash.nr rust
 
 <BlackBoxInfo />
 

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -12,34 +12,16 @@ pub fn sha256<N>(input: [u8; N]) -> [u8; 32]
 // docs:end:sha256
 {}
 
-#[foreign(sha256)]
-// docs:start:sha256_slice
-pub fn sha256_slice(input: [u8]) -> [u8; 32]
-// docs:end:sha256_slice
-{}
-
 #[foreign(blake2s)]
 // docs:start:blake2s
 pub fn blake2s<N>(input: [u8; N]) -> [u8; 32]
 // docs:end:blake2s
 {}
 
-#[foreign(blake2s)]
-// docs:start:blake2s_slice
-pub fn blake2s_slice(input: [u8]) -> [u8; 32]
-// docs:end:blake2s_slice
-{}
-
 #[foreign(blake3)]
 // docs:start:blake3
 pub fn blake3<N>(input: [u8; N]) -> [u8; 32]
 // docs:end:blake3
-{}
-
-#[foreign(blake3)]
-// docs:start:blake3_slice
-pub fn blake3_slice(input: [u8]) -> [u8; 32]
-// docs:end:blake3_slice
 {}
 
 // docs:start:pedersen_commitment
@@ -53,25 +35,11 @@ pub fn pedersen_commitment<N>(input: [Field; N]) -> PedersenPoint {
     pedersen_commitment_with_separator(input, 0)
 }
 
-// docs:start:pedersen_commitment_slice
-pub fn pedersen_commitment_slice(input: [Field]) -> PedersenPoint {
-    pedersen_commitment_with_separator_slice(input, 0)
-}
-// docs:end:pedersen_commitment_slice
-
 #[foreign(pedersen_commitment)]
 pub fn __pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> [Field; 2] {}
 
-#[foreign(pedersen_commitment)]
-pub fn __pedersen_commitment_with_separator_slice(input: [Field], separator: u32) -> [Field; 2] {}
-
 pub fn pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> PedersenPoint {
     let values = __pedersen_commitment_with_separator(input, separator);
-    PedersenPoint { x: values[0], y: values[1] }
-}
-
-pub fn pedersen_commitment_with_separator_slice(input: [Field], separator: u32) -> PedersenPoint {
-    let values = __pedersen_commitment_with_separator_slice(input, separator);
     PedersenPoint { x: values[0], y: values[1] }
 }
 
@@ -82,43 +50,24 @@ pub fn pedersen_hash<N>(input: [Field; N]) -> Field
     pedersen_hash_with_separator(input, 0)
 }
 
-// docs:start:pedersen_hash_slice
-pub fn pedersen_hash_slice(input: [Field]) -> Field
-// docs:end:pedersen_hash_slice
-{
-    pedersen_hash_with_separator_slice(input, 0)
-}
-
 #[foreign(pedersen_hash)]
 pub fn pedersen_hash_with_separator<N>(input: [Field; N], separator: u32) -> Field {}
 
-#[foreign(pedersen_hash)]
-pub fn pedersen_hash_with_separator_slice(input: [Field], separator: u32) -> Field {}
-
 pub fn hash_to_field(inputs: [Field]) -> Field {
-    let mut inputs_as_bytes = &[];
+    let mut sum = 0;
 
     for input in inputs {
-        let input_bytes = input.to_le_bytes(32);
-        for i in 0..32 {
-            inputs_as_bytes = inputs_as_bytes.push_back(input_bytes[i]);
-        }
+        let input_bytes: [u8; 32] = input.to_le_bytes(32).as_array();
+        sum += crate::field::bytes32_to_field(blake2s(input_bytes));
     }
 
-    let hashed_input = blake2s_slice(inputs_as_bytes);
-    crate::field::bytes32_to_field(hashed_input)
+    sum
 }
 
 #[foreign(keccak256)]
 // docs:start:keccak256
 pub fn keccak256<N>(input: [u8; N], message_size: u32) -> [u8; 32]
 // docs:end:keccak256
-{}
-
-#[foreign(keccak256)]
-// docs:start:keccak256_slice
-pub fn keccak256_slice(input: [u8], message_size: u32) -> [u8; 32]
-// docs:end:keccak256_slice
 {}
 
 #[foreign(poseidon2_permutation)]

--- a/noir_stdlib/src/hash/pedersen.nr
+++ b/noir_stdlib/src/hash/pedersen.nr
@@ -1,4 +1,4 @@
-use crate::hash::{Hasher, pedersen_hash_slice};
+use crate::hash::Hasher;
 use crate::default::Default;
 
 struct PedersenHasher{
@@ -7,7 +7,8 @@ struct PedersenHasher{
 
 impl Hasher for PedersenHasher {
     fn finish(self) -> Field {
-       pedersen_hash_slice(self._state)
+        // Error here! No pedersen_hash_slice anymore
+        pedersen_hash_slice(self._state)
     }
 
     fn write(&mut self, input: [Field]){

--- a/noir_stdlib/src/slice.nr
+++ b/noir_stdlib/src/slice.nr
@@ -43,4 +43,14 @@ impl<T> [T] {
         }
         self
     }
+
+    pub fn as_array<N>(self) -> [T; N] {
+        assert(self.len() == N);
+
+        let mut array = [crate::unsafe::zeroed(); N];
+        for i in 0 .. N {
+            array[i] = self[i];
+        }
+        array
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue raised in a slack thread:

```rs
let slice1 = &[1, 2, 3];
let slice2 = slice1.pop_back().0.push_back(3);

assert(slice1 == slice2); // fails
```

## Summary\*

Removes `_slice` functions from the stdlib and adds `as_array` method to convert a slice to an array.

## Additional Context

Currently failing because the pedersen hasher uses the pedersen_slice variant.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
  - Documentation is removed currently and I'll need to add separate docs for `as_array`
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
