### PR TITLE
chore: Use is_entry_point helper on RuntimeType

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -174,8 +174,6 @@ fn convert_generated_acir_into_circuit(
         ..
     } = generated_acir;
 
-    let locations = locations.clone();
-
     let (public_parameter_witnesses, private_parameters) =
         split_public_and_private_inputs(&func_sig, &input_witnesses);
 
@@ -189,7 +187,7 @@ fn convert_generated_acir_into_circuit(
         private_parameters,
         public_parameters,
         return_values,
-        assert_messages: assert_messages.clone().into_iter().collect(),
+        assert_messages: assert_messages.into_iter().collect(),
         recursive,
     };
 

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -11,7 +11,7 @@ use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
         dfg::{CallStack, InsertInstructionResult},
-        function::{Function, FunctionId, InlineType, RuntimeType},
+        function::{Function, FunctionId},
         instruction::{Instruction, InstructionId, TerminatorInstruction},
         value::{Value, ValueId},
     },
@@ -351,14 +351,13 @@ impl<'function> PerFunctionContext<'function> {
         for id in block.instructions() {
             match &self.source_function.dfg[*id] {
                 Instruction::Call { func, arguments } => match self.get_function(*func) {
-                    Some(function) => match ssa.functions[&function].runtime() {
-                        RuntimeType::Acir(InlineType::Inline) => {
+                    Some(function) => {
+                        if ssa.functions[&function].runtime().is_entry_point() {
+                            self.push_instruction(*id);
+                        } else {
                             self.inline_function(ssa, *id, function, arguments);
                         }
-                        RuntimeType::Acir(InlineType::Fold) | RuntimeType::Brillig => {
-                            self.push_instruction(*id);
-                        }
-                    },
+                    }
                     None => self.push_instruction(*id),
                 },
                 _ => self.push_instruction(*id),


### PR DESCRIPTION
…y clones

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I just noticed a spot that was missed in inlining where `RuntimeType::is_entry_point` could be used rather than matching on `RuntimeType`. This is also better cause it stays in line with the filter for `get_entry_point_functions`. 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
