### PR TITLE
feat: improve SSA type-awareness in EQ and MUL instructions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -174,28 +174,15 @@ impl Binary {
                 if operand_type.is_unsigned() {
                     // If we're comparing a variable against a constant value which lies outside of the range of
                     // values which the variable's type can take, we can assume that the equality will be false.
-                    match (lhs, rhs) {
-                        (Some(lhs), None) => {
-                            let max_possible_value =
-                                2u128.pow(dfg.get_value_max_num_bits(self.rhs)) - 1;
-                            if lhs > max_possible_value.into() {
-                                let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
-                                return SimplifyResult::SimplifiedTo(zero);
-                            }
-                        }
-
-                        (None, Some(rhs)) => {
-                            let max_possible_value =
-                                2u128.pow(dfg.get_value_max_num_bits(self.lhs)) - 1;
-                            if rhs > max_possible_value.into() {
-                                let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
-                                return SimplifyResult::SimplifiedTo(zero);
-                            }
-                        }
-
-                        (None, None) => (),
-                        (Some(_), Some(_)) => {
-                            unreachable!("Constant binary instructions should be handled above")
+                    let constant = lhs.or(rhs);
+                    let non_constant = if lhs.is_some() { self.rhs } else { self.lhs };
+                    
+                    if let Some(constant) = constant {
+                        let max_possible_value =
+                            2u128.pow(dfg.get_value_max_num_bits(non_constant)) - 1;
+                        if constant > max_possible_value.into() {
+                            let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
+                            return SimplifyResult::SimplifiedTo(zero);
                         }
                     }
                 }

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -176,7 +176,6 @@ impl Binary {
                     // values which the variable's type can take, we can assume that the equality will be false.
                     let constant = lhs.or(rhs);
                     let non_constant = if lhs.is_some() { self.rhs } else { self.lhs };
-                    
                     if let Some(constant) = constant {
                         let max_possible_value =
                             2u128.pow(dfg.get_value_max_num_bits(non_constant)) - 1;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -133,6 +133,7 @@ impl Binary {
                 if dfg.resolve(self.lhs) == dfg.resolve(self.rhs)
                     && dfg.get_value_max_num_bits(self.lhs) == 1
                 {
+                    // Squaring a boolean value is a noop.
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }
             }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds some improvements for SSA generation for programs such as in #4688 where we now make more use of information on casted values.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
