### PR TITLE
feat: shortcircuit merging two of the same value during flattening

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -65,6 +65,11 @@ impl<'a> ValueMerger<'a> {
         then_value: ValueId,
         else_value: ValueId,
     ) -> ValueId {
+        if self.dfg.resolve(then_value) == self.dfg.resolve(else_value) {
+            // We assume here that `then_condition + else_condition == 1` which is reasonable.
+            return then_value;
+        }
+
         let then_type = self.dfg.type_of_value(then_value);
         let else_type = self.dfg.type_of_value(else_value);
         assert_eq!(


### PR DESCRIPTION
# Description

## Problem\*

Helps with #4688

## Summary\*

This PR short circuits `merge_numeric_values` if it's passed two copies of the same value.

I've also replaced some clones in the flattening pass with references.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
