### PR TITLE
chore: Optimize mutating arrays in if statements

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -354,7 +354,8 @@ fn simplify_slice_push_back(
     slice_sizes.insert(set_last_slice_value, slice_size / element_size);
     slice_sizes.insert(new_slice, slice_size / element_size);
 
-    let mut value_merger = ValueMerger::new(dfg, block, &mut slice_sizes);
+    let modified_indices = HashMap::default();
+    let mut value_merger = ValueMerger::new(dfg, block, &mut slice_sizes, &modified_indices);
     let new_slice = value_merger.merge_values(
         len_not_equals_capacity,
         len_equals_capacity,

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -130,6 +130,14 @@ impl Type {
         }
     }
 
+    /// Returns the length of this array type - if it is one
+    pub(crate) fn array_length(&self) -> Option<usize> {
+        match self {
+            Type::Array(_, length) => Some(*length),
+            _ => None,
+        }
+    }
+
     /// Returns the flattened size of a Type
     pub(crate) fn flattened_size(&self) -> usize {
         match self {

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -277,9 +277,16 @@ impl<'a> ValueMerger<'a> {
         // to start with the then or else value is arbitrary.
         let mut new_array = then_value;
 
+        eprintln!("array set opt triggered! Modified indices are:");
+
         for (index, element_type) in modified_indices {
             let index = *index;
             let typevars = Some(vec![element_type.clone()]);
+
+            if let Some(c) = self.dfg.get_numeric_constant(index) {
+                let i = c.try_to_u64().unwrap();
+                eprintln!("  index {}", i);
+            }
 
             let mut get_element = |array, typevars| {
                 let get = Instruction::ArrayGet { array, index };

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -414,7 +414,6 @@ mod tests {
         ir::{
             basic_block::BasicBlockId,
             dfg::DataFlowGraph,
-            function::{InlineType, RuntimeType},
             instruction::{BinaryOp, Instruction, Intrinsic, TerminatorInstruction},
             map::Id,
             types::Type,


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4692

## Summary\*

Tries to make merging of array values during flattening smarter by keeping track of only which indices may change.

Note that pinning which indices actually change is much more difficult since these arrays are in references which are loaded from and stored to. This'd require mem2reg and alias analysis to do. So I instead opted for an approximation: we track which indices are changed for each array type within an if branch instead.

If the indices that may be stored to are known, and this list is less than the array's length, then we store to only these indices instead.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
