### PR TITLE
fix(ssa): Check cast bit size when fetching the max num bits for a value 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -342,12 +342,19 @@ impl DataFlowGraph {
     /// Should `value` be a numeric constant then this function will return the exact number of bits required,
     /// otherwise it will return the minimum number of bits based on type information.
     pub(crate) fn get_value_max_num_bits(&self, value: ValueId) -> u32 {
+        dbg!(self[value].clone());
         match self[value] {
             Value::Instruction { instruction, .. } => {
+                let bit_size = self.type_of_value(value).bit_size();
                 if let Instruction::Cast(original_value, _) = self[instruction] {
-                    self.type_of_value(original_value).bit_size()
+                    let original_bit_size = self.type_of_value(original_value).bit_size();
+                    if original_bit_size < bit_size {
+                        original_bit_size
+                    } else {
+                        bit_size
+                    }
                 } else {
-                    self.type_of_value(value).bit_size()
+                    bit_size
                 }
             }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -342,7 +342,6 @@ impl DataFlowGraph {
     /// Should `value` be a numeric constant then this function will return the exact number of bits required,
     /// otherwise it will return the minimum number of bits based on type information.
     pub(crate) fn get_value_max_num_bits(&self, value: ValueId) -> u32 {
-        dbg!(self[value].clone());
         match self[value] {
             Value::Instruction { instruction, .. } => {
                 let bit_size = self.type_of_value(value).bit_size();

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -174,11 +174,13 @@ impl Binary {
                 if operand_type.is_unsigned() {
                     // If we're comparing a variable against a constant value which lies outside of the range of
                     // values which the variable's type can take, we can assume that the equality will be false.
+                    // When checking the variable's max range we want to make sure to include type information
+                    // from previous casts which tell us whether the variable was cast up from a smaller type.
                     let constant = lhs.or(rhs);
                     let non_constant = if lhs.is_some() { self.rhs } else { self.lhs };
                     if let Some(constant) = constant {
                         let max_possible_value =
-                            2u128.pow(dfg.type_of_value(non_constant).bit_size()) - 1;
+                            2u128.pow(dfg.get_value_max_num_bits(non_constant)) - 1;
                         if constant > max_possible_value.into() {
                             let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                             return SimplifyResult::SimplifiedTo(zero);

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -178,7 +178,7 @@ impl Binary {
                     let non_constant = if lhs.is_some() { self.rhs } else { self.lhs };
                     if let Some(constant) = constant {
                         let max_possible_value =
-                            2u128.pow(dfg.get_value_max_num_bits(non_constant)) - 1;
+                            2u128.pow(dfg.type_of_value(non_constant).bit_size()) - 1;
                         if constant > max_possible_value.into() {
                             let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                             return SimplifyResult::SimplifiedTo(zero);


### PR DESCRIPTION
# Description

## Problem\*

No issue as this was found by @jfecher while testing in debug mode so pushed a quick fix

## Summary\*

We check for `Cast` instructions in `get_value_max_num_bits` as per this PR (https://github.com/noir-lang/noir/pull/4039) in order to determine a more restrictive upper bound on values. However, if we cast from a larger data type we are returning the larger bit size.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
