### PR TITLE
fix(ssa): Do not use get_value_max_num_bits when we want pure type information

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -171,21 +171,6 @@ impl Binary {
                     return SimplifyResult::SimplifiedTo(one);
                 }
 
-                if operand_type.is_unsigned() {
-                    // If we're comparing a variable against a constant value which lies outside of the range of
-                    // values which the variable's type can take, we can assume that the equality will be false.
-                    let constant = lhs.or(rhs);
-                    let non_constant = if lhs.is_some() { self.rhs } else { self.lhs };
-                    if let Some(constant) = constant {
-                        let max_possible_value =
-                            2u128.pow(dfg.type_of_value(non_constant).bit_size()) - 1;
-                        if constant > max_possible_value.into() {
-                            let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
-                            return SimplifyResult::SimplifiedTo(zero);
-                        }
-                    }
-                }
-
                 if operand_type == Type::bool() {
                     // Simplify forms of `(boolean == true)` into `boolean`
                     if lhs_is_one {

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -178,7 +178,7 @@ impl Binary {
                     let non_constant = if lhs.is_some() { self.rhs } else { self.lhs };
                     if let Some(constant) = constant {
                         let max_possible_value =
-                            2u128.pow(dfg.get_value_max_num_bits(non_constant)) - 1;
+                            2u128.pow(dfg.type_of_value(non_constant).bit_size()) - 1;
                         if constant > max_possible_value.into() {
                             let zero = dfg.make_constant(FieldElement::zero(), Type::bool());
                             return SimplifyResult::SimplifiedTo(zero);


### PR DESCRIPTION
# Description

## Problem\*

No issue as this was found by @jfecher while testing in debug mode where we get overflow errors after https://github.com/noir-lang/noir/pull/4691

Resolves https://github.com/noir-lang/noir/pull/4699#discussion_r1548634192

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
