### PR TITLE
feat: Allow slices to brillig entry points

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -70,7 +70,7 @@ impl FunctionContext {
         function_id.to_string()
     }
 
-    fn ssa_type_to_parameter(typ: &Type) -> BrilligParameter {
+    pub(crate) fn ssa_type_to_parameter(typ: &Type) -> BrilligParameter {
         match typ {
             Type::Numeric(_) | Type::Reference(_) => {
                 BrilligParameter::SingleAddr(get_bit_size_from_ssa_type(typ))
@@ -81,24 +81,14 @@ impl FunctionContext {
                 }),
                 *size,
             ),
-            Type::Slice(item_type) => {
-                BrilligParameter::Slice(vecmap(item_type.iter(), |item_typ| {
+            Type::Slice(item_type) => BrilligParameter::Slice(
+                vecmap(item_type.iter(), |item_typ| {
                     FunctionContext::ssa_type_to_parameter(item_typ)
-                }))
-            }
+                }),
+                None,
+            ),
             _ => unimplemented!("Unsupported function parameter/return type {typ:?}"),
         }
-    }
-
-    /// Collects the parameters of a given function
-    pub(crate) fn parameters(func: &Function) -> Vec<BrilligParameter> {
-        func.parameters()
-            .iter()
-            .map(|&value_id| {
-                let typ = func.dfg.type_of_value(value_id);
-                FunctionContext::ssa_type_to_parameter(&typ)
-            })
-            .collect()
     }
 
     /// Collects the return values of a given function

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -81,12 +81,9 @@ impl FunctionContext {
                 }),
                 *size,
             ),
-            Type::Slice(item_type) => BrilligParameter::Slice(
-                vecmap(item_type.iter(), |item_typ| {
-                    FunctionContext::ssa_type_to_parameter(item_typ)
-                }),
-                None,
-            ),
+            Type::Slice(_) => {
+                panic!("ICE: Slice parameters cannot be derived from type information")
+            }
             _ => unimplemented!("Unsupported function parameter/return type {typ:?}"),
         }
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::ssa::ir::dfg::CallStack;
 
-/// Represents a parameter or a return value of a function.
+/// Represents a parameter or a return value of an entry point function.
 #[derive(Debug, Clone)]
 pub(crate) enum BrilligParameter {
     /// A single address parameter or return value. Holds the bit size of the parameter.
@@ -11,8 +11,8 @@ pub(crate) enum BrilligParameter {
     /// An array parameter or return value. Holds the type of an array item and its size.
     Array(Vec<BrilligParameter>, usize),
     /// A slice parameter or return value. Holds the type of a slice item.
-    /// It can hold the slice size if known at compile time.
-    Slice(Vec<BrilligParameter>, Option<usize>),
+    /// Only known-length slices can be passed to brillig entry points, so the size is available as well.
+    Slice(Vec<BrilligParameter>, usize),
 }
 
 /// The result of compiling and linking brillig artifacts.

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -11,7 +11,8 @@ pub(crate) enum BrilligParameter {
     /// An array parameter or return value. Holds the type of an array item and its size.
     Array(Vec<BrilligParameter>, usize),
     /// A slice parameter or return value. Holds the type of a slice item.
-    Slice(Vec<BrilligParameter>),
+    /// It can hold the slice size if known at compile time.
+    Slice(Vec<BrilligParameter>, Option<usize>),
 }
 
 /// The result of compiling and linking brillig artifacts.

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -701,7 +701,7 @@ impl Context {
                             .iter()
                             .map(BrilligFunctionContext::ssa_type_to_parameter)
                             .collect(),
-                        Some(len / item_types.len()),
+                        len / item_types.len(),
                     )
                 } else {
                     BrilligFunctionContext::ssa_type_to_parameter(&typ)

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -21,7 +21,7 @@ use super::{
     },
     ssa_gen::Ssa,
 };
-use crate::brillig::brillig_ir::artifact::GeneratedBrillig;
+use crate::brillig::brillig_ir::artifact::{BrilligParameter, GeneratedBrillig};
 use crate::brillig::brillig_ir::BrilligContext;
 use crate::brillig::{brillig_gen::brillig_fn::FunctionContext as BrilligFunctionContext, Brillig};
 use crate::errors::{InternalError, InternalWarning, RuntimeError, SsaReport};
@@ -297,12 +297,14 @@ impl Context {
             let typ = dfg.type_of_value(*param_id);
             self.create_value_from_type(&typ, &mut |this, _| Ok(this.acir_context.add_variable()))
         })?;
+        let arguments = self.gen_brillig_parameters(dfg[main_func.entry_block()].parameters(), dfg);
+
         let witness_inputs = self.acir_context.extract_witness(&inputs);
 
         let outputs: Vec<AcirType> =
             vecmap(main_func.returns(), |result_id| dfg.type_of_value(*result_id).into());
 
-        let code = self.gen_brillig_for(main_func, brillig)?;
+        let code = self.gen_brillig_for(main_func, arguments, brillig)?;
 
         // We specifically do not attempt execution of the brillig code being generated as this can result in it being
         // replaced with constraints on witnesses to the program outputs.
@@ -594,8 +596,9 @@ impl Context {
                                 }
 
                                 let inputs = vecmap(arguments, |arg| self.convert_value(*arg, dfg));
+                                let arguments = self.gen_brillig_parameters(arguments, dfg);
 
-                                let code = self.gen_brillig_for(func, brillig)?;
+                                let code = self.gen_brillig_for(func, arguments, brillig)?;
 
                                 let outputs: Vec<AcirType> = vecmap(result_ids, |result_id| {
                                     dfg.type_of_value(*result_id).into()
@@ -673,14 +676,49 @@ impl Context {
         Ok(())
     }
 
+    fn gen_brillig_parameters(
+        &self,
+        values: &[ValueId],
+        dfg: &DataFlowGraph,
+    ) -> Vec<BrilligParameter> {
+        values
+            .iter()
+            .map(|&value_id| {
+                let typ = dfg.type_of_value(value_id);
+                if let Type::Slice(item_types) = typ {
+                    let len = match self
+                        .ssa_values
+                        .get(&value_id)
+                        .expect("ICE: Unknown slice input to brillig")
+                    {
+                        AcirValue::DynamicArray(AcirDynamicArray { len, .. }) => *len,
+                        AcirValue::Array(array) => array.len(),
+                        _ => unreachable!("ICE: Slice value is not a dynamic array"),
+                    };
+
+                    BrilligParameter::Slice(
+                        item_types
+                            .iter()
+                            .map(BrilligFunctionContext::ssa_type_to_parameter)
+                            .collect(),
+                        Some(len / item_types.len()),
+                    )
+                } else {
+                    BrilligFunctionContext::ssa_type_to_parameter(&typ)
+                }
+            })
+            .collect()
+    }
+
     fn gen_brillig_for(
         &self,
         func: &Function,
+        arguments: Vec<BrilligParameter>,
         brillig: &Brillig,
     ) -> Result<GeneratedBrillig, InternalError> {
         // Create the entry point artifact
         let mut entry_point = BrilligContext::new_entry_point_artifact(
-            BrilligFunctionContext::parameters(func),
+            arguments,
             BrilligFunctionContext::return_values(func),
             BrilligFunctionContext::function_id_to_function_label(func.id()),
         );

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -693,7 +693,7 @@ impl Context {
                     {
                         AcirValue::DynamicArray(AcirDynamicArray { len, .. }) => *len,
                         AcirValue::Array(array) => array.len(),
-                        _ => unreachable!("ICE: Slice value is not a dynamic array"),
+                        _ => unreachable!("ICE: Slice value is not an array"),
                     };
 
                     BrilligParameter::Slice(

--- a/test_programs/execution_success/brillig_slice_input/Nargo.toml
+++ b/test_programs/execution_success/brillig_slice_input/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "brillig_slice_input"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/brillig_slice_input/src/main.nr
+++ b/test_programs/execution_success/brillig_slice_input/src/main.nr
@@ -3,24 +3,38 @@ struct Point {
     y: Field,
 }
 
-unconstrained fn sum_slice(slice: [Point]) -> Field {
+unconstrained fn sum_slice(slice: [[Point; 2]]) -> Field {
     let mut sum = 0;
     for i in 0..slice.len() {
-        sum += slice[i].x + slice[i].y;
+        for j in 0..slice[i].len() {
+            sum += slice[i][j].x + slice[i][j].y;
+        }
     }
     sum
 }
 
 fn main() {
     let mut slice = &[];
-    slice = slice.push_back(Point {
-        x: 13,
-        y: 14,
-    });
-    slice = slice.push_front(Point {
-        x: 20,
-        y: 8,
-    });
+    slice = slice.push_back([
+        Point {
+            x: 13,
+            y: 14,
+        },
+        Point {
+            x: 20,
+            y: 8,
+        }
+    ]);
+    slice = slice.push_back([
+        Point {
+            x: 15,
+            y: 5,
+        },
+        Point {
+            x: 12,
+            y: 13,
+        }
+    ]);
     let brillig_sum = sum_slice(slice);
-    assert_eq(brillig_sum, 55);
+    assert_eq(brillig_sum, 100);
 }

--- a/test_programs/execution_success/brillig_slice_input/src/main.nr
+++ b/test_programs/execution_success/brillig_slice_input/src/main.nr
@@ -1,0 +1,26 @@
+struct Point {
+    x: Field,
+    y: Field,
+}
+
+unconstrained fn sum_slice(slice: [Point]) -> Field {
+    let mut sum = 0;
+    for i in 0..slice.len() {
+        sum += slice[i].x + slice[i].y;
+    }
+    sum
+}
+
+fn main() {
+    let mut slice = &[];
+    slice = slice.push_back(Point {
+        x: 13,
+        y: 14,
+    });
+    slice = slice.push_front(Point {
+        x: 20,
+        y: 8,
+    });
+    let brillig_sum = sum_slice(slice);
+    assert_eq(brillig_sum, 55);
+}


### PR DESCRIPTION
# Description

## Problem\*

Allows passing slices to brillig entry points, since ACIR knows the initial length of the slice and is fixed at compile time.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
