### PR TITLE
chore(ci): stop updating version list before cutting new docs version

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -75,9 +75,11 @@ jobs:
         run: |
           npm i wasm-opt -g
 
+      - name: Query active docs versions
+        run: yarn workspace docs version::stables
+
       - name: Build docs
-        run: 
-          yarn workspaces foreach -Rpt --from docs run build
+        run: yarn workspaces foreach -Rpt --from docs run build
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,10 +28,11 @@ jobs:
         run: |
           npm i wasm-opt -g
       
+      - name: Query active docs versions
+        run: yarn workspace docs version::stables
+
       - name: Build docs for deploying
-        working-directory: docs
-        run: 
-          yarn workspaces foreach -Rt run build
+        run: yarn workspaces foreach -Rpt --from docs run build
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v2.1

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "preprocess": "yarn workspace @noir-lang/acvm_js build && ./scripts/codegen_nargo_reference.sh && yarn node ./scripts/preprocess/index.js",
     "start": "yarn preprocess && docusaurus start",
-    "build": "yarn preprocess && yarn version::stables && docusaurus build",
+    "build": "yarn preprocess && docusaurus build",
     "version::stables": "ts-node ./scripts/setStable.ts",
     "serve": "serve build",
-    "version": "yarn preprocess && docusaurus build && docusaurus docs:version"
+    "version": "yarn build && docusaurus docs:version"
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "preprocess": "yarn workspace @noir-lang/acvm_js build && ./scripts/codegen_nargo_reference.sh && yarn node ./scripts/preprocess/index.js",
     "start": "yarn preprocess && docusaurus start",
     "build": "yarn preprocess && docusaurus build",
+    "clean": "rm -rf ./processed-docs ./processed-docs ./build",
     "version::stables": "ts-node ./scripts/setStable.ts",
     "serve": "serve build",
     "version": "yarn build && docusaurus docs:version"


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

When cutting a new version of the docs in release PRs we're querying the list of released noir versions from github and updating `versions.json` before we cut the new version. This results in docusaurus thinking that it should already have content for that version.

We can then no longer build the docs site in order to do all of the necessary preprocessing before creating the new versioned docs folder.

This PR stops the automated polling of github on every build to prevent this issue.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
