### PR TITLE
feat: Optimize merging numeric values

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -72,6 +72,11 @@ impl<'a> ValueMerger<'a> {
             "Expected values merged to be of the same type but found {then_type} and {else_type}"
         );
 
+        // Don't merge two values if they're already equal. That can make them non-constant
+        if then_value == else_value {
+            return then_value;
+        }
+
         let then_call_stack = self.dfg.get_value_call_stack(then_value);
         let else_call_stack = self.dfg.get_value_call_stack(else_value);
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves 

## Summary\*

Found while working on https://github.com/noir-lang/noir/pull/4716

~~This reduces the size of the circuit in #4688 to just 19725 constraints (2314 acir opcodes).~~ Forgot my local version of the test program was modified.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
