### PR TITLE
chore(ci): replace `yarn build:js:only` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "yarn workspaces foreach --verbose run lint",
     "spellcheck": "cspell '**/*.{md,rs}' -c ./cspell.json",
     "prepare:publish": "yarn clean && yarn build",
+    "build:js:only": "yarn workspaces foreach -vtp --exclude \"{@noir-lang/acvm_js,@noir-lang/noirc_abi,@noir-lang/noir_wasm,docs,@noir-lang/root}\" run build",
     "nightly:version": "yarn workspaces foreach run nightly:version",
     "publish:all": "yarn install && yarn workspaces foreach run publish"
   },


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This was removed in #4681 however it is required by the publish workflow for js packages. I've modified it to exclude the wasm based packages rather than being an explicit whitelist to avoid it missing off any new JS packages in future.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
