### PR TITLE
chore(ci): fix cutting new versions of the docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf ./processed-docs ./processed-docs ./build",
     "version::stables": "ts-node ./scripts/setStable.ts",
     "serve": "serve build",
-    "version": "yarn build && docusaurus docs:version"
+    "version": "yarn version::stables && ./scripts/cut_version.sh"
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.1",

--- a/docs/scripts/cut_version.sh
+++ b/docs/scripts/cut_version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eu
+
+cd $(dirname "$0")/..
+
+VERSION=$1
+
+# We assume that the new release tag has been made on github, so setStable.ts will add this to `versions.json`.
+# We don't have a version of the docs for this release however (that's what we're doing right now!) so we need to remove it.
+jq 'map(select(. != "'"$VERSION"'"))' versions.json > tmp.json && mv tmp.json versions.json
+
+# We need to build the docs in order to perform all necessary preprocessing.
+yarn build
+
+# Finally cut the actual new docs version.
+yarn docusaurus docs:version $VERSION


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Followup to https://github.com/noir-lang/noir/pull/4726. The previous PR was slightly too blunt, we still need to generate `versions.json` but we need to filter out the new version before we build the docs as we're trying to build a new version of the docs before we've fully generated the dev version of the docs from which it is to be made.

We now generate `versions.json` as before but filter out the version of the docs which we are making before we build so that the build can complete.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
