### PR TITLE
feat: add `NARGO_FOREIGN_CALL_TIMEOUT` environment variable

### DIFF
--- a/docs/docs/noir/concepts/oracles.md
+++ b/docs/docs/noir/concepts/oracles.md
@@ -11,6 +11,12 @@ keywords:
 sidebar_position: 6
 ---
 
+:::note
+
+This is an experimental feature that is not fully documented. If you notice any outdated information or potential improvements to this page, pull request contributions are very welcome: https://github.com/noir-lang/noir
+
+:::
+
 Noir has support for Oracles via RPC calls. This means Noir will make an RPC call and use the return value for proof generation.
 
 Since Oracles are not resolved by Noir, they are [`unconstrained` functions](./unconstrained.md)
@@ -21,3 +27,5 @@ You can declare an Oracle through the `#[oracle(<name>)]` flag. Example:
 #[oracle(get_number_sequence)]
 unconstrained fn get_number_sequence(_size: Field) -> [Field] {}
 ```
+
+The timeout for when using an external RPC oracle resolver can be set with the `NARGO_FOREIGN_CALL_TIMEOUT` environment variable. This timeout is in units of milliseconds.

--- a/tooling/nargo/src/ops/foreign_calls.rs
+++ b/tooling/nargo/src/ops/foreign_calls.rs
@@ -161,8 +161,16 @@ pub struct DefaultForeignCallExecutor {
 impl DefaultForeignCallExecutor {
     pub fn new(show_output: bool, resolver_url: Option<&str>) -> Self {
         let oracle_resolver = resolver_url.map(|resolver_url| {
-            let transport_builder =
+            let mut transport_builder =
                 Builder::new().url(resolver_url).expect("Invalid oracle resolver URL");
+
+            if let Some(Ok(timeout)) = std::env::var("NARGO_FOREIGN_CALL_TIMEOUT")
+                .ok()
+                .map(|timeout| u64::from_str_radix(&timeout, 10))
+            {
+                let timeout_duration = std::time::Duration::from_millis(timeout);
+                transport_builder = transport_builder.timeout(timeout_duration);
+            };
             Client::with_transport(transport_builder.build())
         });
         DefaultForeignCallExecutor {

--- a/tooling/nargo/src/ops/foreign_calls.rs
+++ b/tooling/nargo/src/ops/foreign_calls.rs
@@ -164,9 +164,8 @@ impl DefaultForeignCallExecutor {
             let mut transport_builder =
                 Builder::new().url(resolver_url).expect("Invalid oracle resolver URL");
 
-            if let Some(Ok(timeout)) = std::env::var("NARGO_FOREIGN_CALL_TIMEOUT")
-                .ok()
-                .map(|timeout| timeout.parse())
+            if let Some(Ok(timeout)) =
+                std::env::var("NARGO_FOREIGN_CALL_TIMEOUT").ok().map(|timeout| timeout.parse())
             {
                 let timeout_duration = std::time::Duration::from_millis(timeout);
                 transport_builder = transport_builder.timeout(timeout_duration);

--- a/tooling/nargo/src/ops/foreign_calls.rs
+++ b/tooling/nargo/src/ops/foreign_calls.rs
@@ -166,7 +166,7 @@ impl DefaultForeignCallExecutor {
 
             if let Some(Ok(timeout)) = std::env::var("NARGO_FOREIGN_CALL_TIMEOUT")
                 .ok()
-                .map(|timeout| u64::from_str_radix(&timeout, 10))
+                .map(|timeout| timeout.parse())
             {
                 let timeout_duration = std::time::Duration::from_millis(timeout);
                 transport_builder = transport_builder.timeout(timeout_duration);


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4772

## Summary\*

This PR adds the `NARGO_FOREIGN_CALL_TIMEOUT` environment variable which allows setting the number of milliseconds which external foreign call resolvers can take to return a result.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
