### PR TITLE
fix: ArrayGet and Set are not pure

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -254,7 +254,7 @@ impl Instruction {
                 // In ACIR, a division with a false predicate outputs (0,0), so it cannot replace another instruction unless they have the same predicate
                 bin.operator != BinaryOp::Div
             }
-            Cast(_, _) | Truncate { .. } | Not(_) | ArrayGet { .. } | ArraySet { .. } => true,
+            Cast(_, _) | Truncate { .. } | Not(_) => true,
 
             // These either have side-effects or interact with memory
             Constrain(..)
@@ -265,6 +265,12 @@ impl Instruction {
             | IncrementRc { .. }
             | DecrementRc { .. }
             | RangeCheck { .. } => false,
+
+            // These can have different behavior depending on the EnableSideEffectsIf context.
+            // Enabling constant folding for these potentially enables replacing an enabled
+            // array get with one that was disabled. See
+            // https://github.com/noir-lang/noir/pull/4716#issuecomment-2047846328.
+            ArrayGet { .. } | ArraySet { .. } => false,
 
             Call { func, .. } => match dfg[*func] {
                 Value::Intrinsic(intrinsic) => !intrinsic.has_side_effects(),


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4600

## Summary\*

Array sets and gets are not pure. Listing them as such can cause constant folding to fold away enabled array gets for ones in disabled contexts (enable_side_effects_if u1 0). When used in disabled contexts they will only ever retrieve from index zero.

## Additional Context

No reproduceable test case unfortunately. The ones in #4600 all require aztec as a dependency and the ones in #4717 only trigger with the remove_if_else pass added there.

I'm going to add a SSA unit test instead where two array get instructions should survive constant folding. This PR is a draft until I add that.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
