### PR TITLE
fix: Fix panic when returning a zeroed unit value

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -241,6 +241,7 @@ impl<'a> FunctionContext<'a> {
 
                 Ok(Tree::Branch(vec![string, field_count.into(), fields]))
             }
+            ast::Literal::Unit => Ok(Self::unit_value()),
         }
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -92,6 +92,7 @@ pub enum Literal {
     Slice(ArrayLiteral),
     Integer(FieldElement, Type, Location),
     Bool(bool),
+    Unit,
     Str(String),
     FmtStr(String, u64, Box<Expression>),
 }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1553,9 +1553,7 @@ impl<'interner> Monomorphizer<'interner> {
                 ast::Expression::Literal(ast::Literal::Integer(0_u128.into(), typ, location))
             }
             ast::Type::Bool => ast::Expression::Literal(ast::Literal::Bool(false)),
-            // There is no unit literal currently. Replace it with 'false' since it should be ignored
-            // anyway.
-            ast::Type::Unit => ast::Expression::Literal(ast::Literal::Bool(false)),
+            ast::Type::Unit => ast::Expression::Literal(ast::Literal::Unit),
             ast::Type::Array(length, element_type) => {
                 let element = self.zeroed_value_of_type(element_type.as_ref(), location);
                 ast::Expression::Literal(ast::Literal::Array(ast::ArrayLiteral {

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -110,6 +110,9 @@ impl AstPrinter {
                 s.fmt(f)?;
                 write!(f, "\"")
             }
+            super::ast::Literal::Unit => {
+                write!(f, "()")
+            }
         }
     }
 

--- a/test_programs/execution_success/unit_value/Nargo.toml
+++ b/test_programs/execution_success/unit_value/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "short"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.23.0"
+
+[dependencies]

--- a/test_programs/execution_success/unit_value/src/main.nr
+++ b/test_programs/execution_success/unit_value/src/main.nr
@@ -1,0 +1,7 @@
+fn get_transaction() {
+    dep::std::unsafe::zeroed()
+}
+
+fn main() {
+    get_transaction();
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4791

## Summary\*

Zeroed used boolean values since we didn't have true unit values before. These were meant to be filtered out by the type but as shown in the issue, they'd still be used if they were directly returned.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
