### PR TITLE
fix: proper field inversion for bigints

### DIFF
--- a/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
@@ -105,7 +105,7 @@ impl BigIntSolver {
             }
             BlackBoxFunc::BigIntMul => lhs * rhs,
             BlackBoxFunc::BigIntDiv => {
-                lhs * rhs.modpow(&(&modulus - BigUint::from(1_u32)), &modulus)
+                lhs * rhs.modpow(&(&modulus - BigUint::from(2_u32)), &modulus)
             } //TODO ensure that modulus is prime
             _ => unreachable!("ICE - bigint_op must be called for an operation"),
         };

--- a/test_programs/execution_success/bigint/src/main.nr
+++ b/test_programs/execution_success/bigint/src/main.nr
@@ -10,11 +10,11 @@ fn main(mut x: [u8; 5], y: [u8; 5]) {
         assert(a_bytes[i] == x[i]);
         assert(b_bytes[i] == y[i]);
     }
+    //Regression for issue #4578
+    let d = a * b;
+    assert(d / b == a);
 
-    let d = a * b - b;
-    let d1 = bigint::Secpk1Fq::from_le_bytes(597243850900842442924.to_le_bytes(10));
-    assert(d1 == d);
-    // big_int_example(x[0], x[1]);
+    big_int_example(x[0], x[1]);
 }
 
 // docs:start:big_int_example


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4578. The fix for issue #4530 has also being merged back so I also activate the related test case.

## Summary\*

Field inversion for bigints had a typo.

## Additional Context

I did not consider biguint256 since it was decided not to merge the PR.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
