### PR TITLE
chore(ci): fix alerts on msrv issues

### DIFF
--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -112,6 +112,9 @@ jobs:
           # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
           FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
     
+      - name: Checkout
+        uses: actions/checkout@v4
+
       # Raise an issue if the tests failed
       - name: Alert on failed publish
         uses: JasonEtco/create-an-issue@v2
@@ -122,4 +125,4 @@ jobs:
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           update_existing: true
-          filename: .github/JS_PUBLISH_FAILED.md
+          filename: .github/ACVM_NOT_PUBLISHABLE.md


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We weren't checking out the repo and had the wrong filename so the github action couldn't open an issue properly when the CI started failing.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
