### PR TITLE
chore(docs): fix wrong Nargo.toml workspace examples

### DIFF
--- a/docs/docs/noir/modules_packages_crates/workspaces.md
+++ b/docs/docs/noir/modules_packages_crates/workspaces.md
@@ -11,16 +11,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.17.0/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.17.0/modules_packages_crates/workspaces.md
@@ -10,16 +10,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.19.0/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.19.0/modules_packages_crates/workspaces.md
@@ -10,16 +10,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.19.1/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.19.1/modules_packages_crates/workspaces.md
@@ -10,16 +10,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.19.2/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.19.2/modules_packages_crates/workspaces.md
@@ -10,16 +10,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.19.3/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.19.3/modules_packages_crates/workspaces.md
@@ -10,16 +10,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.19.4/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.19.4/modules_packages_crates/workspaces.md
@@ -10,16 +10,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.22.0/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.22.0/noir/modules_packages_crates/workspaces.md
@@ -11,16 +11,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.23.0/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/modules_packages_crates/workspaces.md
@@ -11,16 +11,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.24.0/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/modules_packages_crates/workspaces.md
@@ -11,16 +11,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.25.0/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/modules_packages_crates/workspaces.md
@@ -11,16 +11,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.26.0/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/modules_packages_crates/workspaces.md
@@ -11,16 +11,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:

--- a/docs/versioned_docs/version-v0.27.0/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/modules_packages_crates/workspaces.md
@@ -11,16 +11,18 @@ For a project with the following structure:
 
 ```tree
 ├── crates
-│   ├── a
-│   │   ├── Nargo.toml
-│   │   └── src
-│   │       └── main.nr
-│   └── b
-│       ├── Nargo.toml
-│       └── src
-│           └── main.nr
-├── Nargo.toml
-└── Prover.toml
+│   ├── a
+│   │   ├── Nargo.toml
+│   │   └── Prover.toml
+│   │   └── src
+│   │       └── main.nr
+│   └── b
+│       ├── Nargo.toml
+│       └── Prover.toml
+│       └── src
+│           └── main.nr
+│
+└── Nargo.toml
 ```
 
 You can define a workspace in Nargo.toml like so:


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4805

## Summary\*

This PR fixes the issue found by @iAmMichaelConnor in #4805, where the example Nargo.toml content for [workspace] has 
 members with wrong paths. 

Since the structure has Nargo.toml inside the `crates` folder, then `members` should direct to folders inside `crates`.
``` file structure
├── crates
│   ├── a
│   │   ├── Nargo.toml
│   │   └── src
│   │       └── main.nr
│   └── b
│       ├── Nargo.toml
│       └── src
│           └── main.nr
├── Nargo.toml
└── Prover.toml
```

## Additional Context

All nargo versions I've tested with, from v0.19.0 to v0.27.0, return `Cannot read file /home/sihanouk/crates/crates/a/Nargo.toml - does it exist?` without the fix.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
