### PR TITLE
chore: remove initialisation of logger in `acvm_js` tests

### DIFF
--- a/acvm-repo/acvm_js/test/browser/black_box_solvers.test.ts
+++ b/acvm-repo/acvm_js/test/browser/black_box_solvers.test.ts
@@ -4,7 +4,6 @@ import initACVM, {
   blake2s256,
   ecdsa_secp256k1_verify,
   ecdsa_secp256r1_verify,
-  initLogLevel,
   keccak256,
   sha256,
   xor,
@@ -12,8 +11,6 @@ import initACVM, {
 
 beforeEach(async () => {
   await initACVM();
-
-  initLogLevel('INFO');
 });
 
 it('successfully calculates the bitwise AND of two fields', async () => {


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

We're intermittently failing in CI due to #4849 however this initialisation is not strictly necessary. I'm then disabling it until a permanent fix is in place.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
