### PR TITLE
chore: more explicit `self` parameter in `Into` trait

### DIFF
--- a/noir_stdlib/src/convert.nr
+++ b/noir_stdlib/src/convert.nr
@@ -12,12 +12,12 @@ impl<T> From<T> for T {
 
 // docs:start:into-trait
 trait Into<T> {
-    fn into(input: Self) -> T;
+    fn into(self) -> T;
 }
 
 impl<T, U> Into<T> for U where T: From<U> {
-  fn into(input: U) -> T {
-      T::from(input)
+  fn into(self) -> T {
+      T::from(self)
   }
 }
 // docs:end:into-trait


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR just updates the `Into` trait definition to use a more explicit `self` parameter.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
