### PR TITLE
chore(docs): remove link to play.noir-lang.org

### DIFF
--- a/docs/versioned_docs/version-v0.22.0/getting_started/tooling/index.md
+++ b/docs/versioned_docs/version-v0.22.0/getting_started/tooling/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tooling
-Description: This section provides information about the various tools and utilities available for Noir development. It covers the Noir playground, IDE tools, Codespaces, and community projects.
+Description: This section provides information about the various tools and utilities available for Noir development. It covers IDE tools, Codespaces, and community projects.
 Keywords: [Noir, Development, Playground, IDE Tools, Language Service Provider, VS Code Extension, Codespaces, noir-starter, Community Projects, Awesome Noir Repository, Developer Tooling]
 ---
 

--- a/docs/versioned_docs/version-v0.23.0/getting_started/tooling/index.mdx
+++ b/docs/versioned_docs/version-v0.23.0/getting_started/tooling/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tooling
-Description: This section provides information about the various tools and utilities available for Noir development. It covers the Noir playground, IDE tools, Codespaces, and community projects.
+Description: This section provides information about the various tools and utilities available for Noir development. It covers IDE tools, Codespaces, and community projects.
 Keywords: [Noir, Development, Playground, IDE Tools, Language Service Provider, VS Code Extension, Codespaces, noir-starter, Community Projects, Awesome Noir Repository, Developer Tooling]
 ---
 

--- a/docs/versioned_docs/version-v0.24.0/getting_started/tooling/index.mdx
+++ b/docs/versioned_docs/version-v0.24.0/getting_started/tooling/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tooling
-Description: This section provides information about the various tools and utilities available for Noir development. It covers the Noir playground, IDE tools, Codespaces, and community projects.
+Description: This section provides information about the various tools and utilities available for Noir development. It covers IDE tools, Codespaces, and community projects.
 Keywords: [Noir, Development, Playground, IDE Tools, Language Service Provider, VS Code Extension, Codespaces, noir-starter, Community Projects, Awesome Noir Repository, Developer Tooling]
 ---
 

--- a/docs/versioned_docs/version-v0.25.0/getting_started/tooling/index.mdx
+++ b/docs/versioned_docs/version-v0.25.0/getting_started/tooling/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tooling
-Description: This section provides information about the various tools and utilities available for Noir development. It covers the Noir playground, IDE tools, Codespaces, and community projects.
+Description: This section provides information about the various tools and utilities available for Noir development. It covers IDE tools, Codespaces, and community projects.
 Keywords: [Noir, Development, Playground, IDE Tools, Language Service Provider, VS Code Extension, Codespaces, noir-starter, Community Projects, Awesome Noir Repository, Developer Tooling]
 ---
 

--- a/docs/versioned_docs/version-v0.26.0/getting_started/tooling/index.mdx
+++ b/docs/versioned_docs/version-v0.26.0/getting_started/tooling/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tooling
-Description: This section provides information about the various tools and utilities available for Noir development. It covers the Noir playground, IDE tools, Codespaces, and community projects.
+Description: This section provides information about the various tools and utilities available for Noir development. It covers IDE tools, Codespaces, and community projects.
 Keywords: [Noir, Development, Playground, IDE Tools, Language Service Provider, VS Code Extension, Codespaces, noir-starter, Community Projects, Awesome Noir Repository, Developer Tooling]
 ---
 

--- a/docs/versioned_docs/version-v0.27.0/getting_started/tooling/index.mdx
+++ b/docs/versioned_docs/version-v0.27.0/getting_started/tooling/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tooling
-Description: This section provides information about the various tools and utilities available for Noir development. It covers the Noir playground, IDE tools, Codespaces, and community projects.
+Description: This section provides information about the various tools and utilities available for Noir development. It covers IDE tools, Codespaces, and community projects.
 Keywords: [Noir, Development, Playground, IDE Tools, Language Service Provider, VS Code Extension, Codespaces, noir-starter, Community Projects, Awesome Noir Repository, Developer Tooling]
 ---
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4770 

## Summary\*

This PR removes the dead link to the noir playground.

cc @signorecello 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
