### PR TITLE
fix(experimental): Skip over comptime functions in scan pass

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/scan.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/scan.rs
@@ -34,6 +34,12 @@ impl<'interner> Interpreter<'interner> {
     /// These nodes will be modified in place, replaced with the
     /// result of their evaluation.
     pub fn scan_function(&mut self, function: FuncId) -> IResult<()> {
+        // Don't scan through functions that are already comptime. They may use comptime-only
+        // features (most likely HirExpression::Quote) that we'd otherwise error for.
+        if self.interner.function_modifiers(&function).is_comptime {
+            return Ok(());
+        }
+
         let function = self.interner.function(&function);
 
         let state = self.enter_function();


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4892

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
