### PR TITLE
feat: Handle `BrilligCall` opcodes in the debugger

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -30,19 +30,6 @@ pub struct BrilligSolver<'b, B: BlackBoxFunctionSolver> {
 }
 
 impl<'b, B: BlackBoxFunctionSolver> BrilligSolver<'b, B> {
-    /// Evaluates if the Brillig block should be skipped entirely
-    pub(super) fn should_skip(
-        witness: &WitnessMap,
-        brillig: &Brillig,
-    ) -> Result<bool, OpcodeResolutionError> {
-        // If the predicate is `None`, the block should never be skipped
-        // If the predicate is `Some` but we cannot find a value, then we return stalled
-        match &brillig.predicate {
-            Some(pred) => Ok(get_value(pred, witness)?.is_zero()),
-            None => Ok(false),
-        }
-    }
-
     /// Assigns the zero value to all outputs of the given [`Brillig`] bytecode.
     pub(super) fn zero_out_brillig_outputs(
         initial_witness: &mut WitnessMap,

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -469,47 +469,10 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
     }
 
     pub fn step_into_brillig(&mut self) -> StepResult<'a, B> {
-        match &self.opcodes[self.instruction_pointer] {
-            Opcode::BrilligCall { .. } => self.step_into_brillig_call_opcode(),
-            _ => StepResult::Status(self.solve_opcode()),
-        }
-    }
-
-    pub fn step_into_brillig_opcode(&mut self) -> StepResult<'a, B> {
-        let Opcode::Brillig(brillig) = &self.opcodes[self.instruction_pointer] else {
-            unreachable!("Not executing a Brillig opcode");
-        };
-
-        let witness = &mut self.witness_map;
-        let should_skip = match BrilligSolver::<B>::should_skip(witness, brillig) {
-            Ok(result) => result,
-            Err(err) => return StepResult::Status(self.handle_opcode_resolution(Err(err))),
-        };
-
-        if should_skip {
-            let resolution =
-                BrilligSolver::<B>::zero_out_brillig_outputs(witness, &brillig.outputs);
-            return StepResult::Status(self.handle_opcode_resolution(resolution));
-        }
-
-        let solver = BrilligSolver::new(
-            witness,
-            &self.block_solvers,
-            brillig,
-            self.backend,
-            self.instruction_pointer,
-        );
-        match solver {
-            Ok(solver) => StepResult::IntoBrillig(solver),
-            Err(..) => StepResult::Status(self.handle_opcode_resolution(solver.map(|_| ()))),
-        }
-    }
-
-    fn step_into_brillig_call_opcode(&mut self) -> StepResult<'a, B> {
         let Opcode::BrilligCall { id, inputs, outputs, predicate } =
             &self.opcodes[self.instruction_pointer]
         else {
-            unreachable!("Not executing a BrilligCall opcode");
+            return StepResult::Status(self.solve_opcode());
         };
 
         let witness = &mut self.witness_map;
@@ -537,10 +500,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
     }
 
     pub fn finish_brillig_with_solver(&mut self, solver: BrilligSolver<'a, B>) -> ACVMStatus {
-        if !matches!(
-            self.opcodes[self.instruction_pointer],
-            Opcode::BrilligCall { .. }
-        ) {
+        if !matches!(self.opcodes[self.instruction_pointer], Opcode::BrilligCall { .. }) {
             unreachable!("Not executing a Brillig/BrilligCall opcode");
         }
         self.brillig_solver = Some(solver);

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -470,7 +470,6 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
 
     pub fn step_into_brillig(&mut self) -> StepResult<'a, B> {
         match &self.opcodes[self.instruction_pointer] {
-            Opcode::Brillig(_) => self.step_into_brillig_opcode(),
             Opcode::BrilligCall { .. } => self.step_into_brillig_call_opcode(),
             _ => StepResult::Status(self.solve_opcode()),
         }
@@ -540,7 +539,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
     pub fn finish_brillig_with_solver(&mut self, solver: BrilligSolver<'a, B>) -> ACVMStatus {
         if !matches!(
             self.opcodes[self.instruction_pointer],
-            Opcode::Brillig(..) | Opcode::BrilligCall { .. }
+            Opcode::BrilligCall { .. }
         ) {
             unreachable!("Not executing a Brillig/BrilligCall opcode");
         }

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -217,7 +217,6 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
         self.get_opcodes()
             .iter()
             .map(|opcode| match opcode {
-                Opcode::Brillig(brillig_block) => brillig_block.bytecode.len(),
                 Opcode::BrilligCall { id, .. } => {
                     self.unconstrained_functions[*id as usize].bytecode.len()
                 }
@@ -302,10 +301,6 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
             Some(OpcodeLocation::Acir(acir_index)) => {
                 let opcode = &opcodes[*acir_index];
                 match opcode {
-                    Opcode::Brillig(brillig) => {
-                        let first_opcode = &brillig.bytecode[0];
-                        format!("BRILLIG {first_opcode:?}")
-                    }
                     Opcode::BrilligCall { id, .. } => {
                         let first_opcode = &self.unconstrained_functions[*id as usize].bytecode[0];
                         format!("BRILLIG CALL {first_opcode:?}")
@@ -315,10 +310,6 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
             }
             Some(OpcodeLocation::Brillig { acir_index, brillig_index }) => {
                 match &opcodes[*acir_index] {
-                    Opcode::Brillig(brillig) => {
-                        let opcode = &brillig.bytecode[*brillig_index];
-                        format!("      | {opcode:?}")
-                    }
                     Opcode::BrilligCall { id, .. } => {
                         let bytecode = &self.unconstrained_functions[*id as usize].bytecode;
                         let opcode = &bytecode[*brillig_index];
@@ -458,7 +449,7 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
             Some(OpcodeLocation::Acir(acir_index)) => {
                 matches!(
                     self.get_opcodes()[acir_index],
-                    Opcode::Brillig(_) | Opcode::BrilligCall { .. }
+                    Opcode::BrilligCall { .. }
                 )
             }
             _ => false,
@@ -567,7 +558,6 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
             OpcodeLocation::Brillig { acir_index, brillig_index } => {
                 if acir_index < opcodes.len() {
                     match &opcodes[acir_index] {
-                        Opcode::Brillig(brillig) => brillig_index < brillig.bytecode.len(),
                         Opcode::BrilligCall { id, .. } => {
                             let bytecode = &self.unconstrained_functions[*id as usize].bytecode;
                             brillig_index < bytecode.len()

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -400,7 +400,7 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
             return self.step_brillig_opcode();
         }
 
-        match self.acvm.step_into_brillig_opcode() {
+        match self.acvm.step_into_brillig() {
             StepResult::IntoBrillig(solver) => {
                 self.brillig_solver = Some(solver);
                 self.step_brillig_opcode()

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -447,10 +447,7 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
         match self.get_current_opcode_location() {
             Some(OpcodeLocation::Brillig { .. }) => true,
             Some(OpcodeLocation::Acir(acir_index)) => {
-                matches!(
-                    self.get_opcodes()[acir_index],
-                    Opcode::BrilligCall { .. }
-                )
+                matches!(self.get_opcodes()[acir_index], Opcode::BrilligCall { .. })
             }
             _ => false,
         }

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -69,23 +69,15 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
             Some(location) => {
                 match location {
                     OpcodeLocation::Acir(ip) => {
-                        // Default Brillig display is too bloated for this context,
-                        // so we limit it to denoting it's the start of a Brillig
-                        // block. The user can still use the `opcodes` command to
-                        // take a look at the whole block.
-                        let opcode_summary = match opcodes[ip] {
-                            Opcode::Brillig(..) => "BRILLIG: ...".into(),
-                            _ => format!("{}", opcodes[ip]),
-                        };
-                        println!("At opcode {}: {}", ip, opcode_summary);
+                        println!("At opcode {}: {}", ip, opcodes[ip]);
                     }
                     OpcodeLocation::Brillig { acir_index, brillig_index } => {
-                        let brillig_bytecode = match opcodes[acir_index] {
-                            Opcode::BrilligCall { id, .. } => {
+                        let brillig_bytecode =
+                            if let Opcode::BrilligCall { id, .. } = opcodes[acir_index] {
                                 &self.unconstrained_functions[id as usize].bytecode
-                            }
-                            _ => unreachable!("Brillig location does not contain a Brillig block"),
-                        };
+                            } else {
+                                unreachable!("Brillig location does not contain Brillig opcodes");
+                            };
                         println!(
                             "At opcode {}.{}: {:?}",
                             acir_index, brillig_index, brillig_bytecode[brillig_index]
@@ -108,11 +100,11 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                 )
             }
             OpcodeLocation::Brillig { acir_index, brillig_index } => {
-                let brillig_bytecode = match opcodes[*acir_index] {
-                    Opcode::BrilligCall { id, .. } => {
-                        &self.unconstrained_functions[id as usize].bytecode
-                    }
-                    _ => unreachable!("Brillig location does not contain a Brillig block"),
+                let brillig_bytecode = if let Opcode::BrilligCall { id, .. } = opcodes[*acir_index]
+                {
+                    &self.unconstrained_functions[id as usize].bytecode
+                } else {
+                    unreachable!("Brillig location does not contain Brillig opcodes");
                 };
                 println!(
                     "Frame #{index}, opcode {}.{}: {:?}",

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -81,7 +81,6 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                     }
                     OpcodeLocation::Brillig { acir_index, brillig_index } => {
                         let brillig_bytecode = match opcodes[acir_index] {
-                            Opcode::Brillig(ref brillig) => &brillig.bytecode,
                             Opcode::BrilligCall { id, .. } => {
                                 &self.unconstrained_functions[id as usize].bytecode
                             }
@@ -110,7 +109,6 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
             }
             OpcodeLocation::Brillig { acir_index, brillig_index } => {
                 let brillig_bytecode = match opcodes[*acir_index] {
-                    Opcode::Brillig(ref brillig) => &brillig.bytecode,
                     Opcode::BrilligCall { id, .. } => {
                         &self.unconstrained_functions[id as usize].bytecode
                     }
@@ -185,11 +183,6 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
         for (acir_index, opcode) in opcodes.iter().enumerate() {
             let marker = outer_marker(acir_index);
             match &opcode {
-                Opcode::Brillig(brillig) => {
-                    println!("{:>3} {:2} BRILLIG inputs={:?}", acir_index, marker, brillig.inputs);
-                    println!("       |       outputs={:?}", brillig.outputs);
-                    print_brillig_bytecode(acir_index, &brillig.bytecode);
-                }
                 Opcode::BrilligCall { id, inputs, outputs, .. } => {
                     println!(
                         "{:>3} {:2} BRILLIG CALL id={} inputs={:?}",

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -79,12 +79,16 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                         println!("At opcode {}: {}", ip, opcode_summary);
                     }
                     OpcodeLocation::Brillig { acir_index, brillig_index } => {
-                        let Opcode::Brillig(ref brillig) = opcodes[acir_index] else {
-                            unreachable!("Brillig location does not contain a Brillig block");
+                        let brillig_bytecode = match opcodes[acir_index] {
+                            Opcode::Brillig(ref brillig) => &brillig.bytecode,
+                            Opcode::BrilligCall { id, .. } => {
+                                &self.unconstrained_functions[id as usize].bytecode
+                            }
+                            _ => unreachable!("Brillig location does not contain a Brillig block"),
                         };
                         println!(
                             "At opcode {}.{}: {:?}",
-                            acir_index, brillig_index, brillig.bytecode[brillig_index]
+                            acir_index, brillig_index, brillig_bytecode[brillig_index]
                         );
                     }
                 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4823 

With the introduction of the `BrilligCall` opcode to deduplicate the Brillig bytecode instead of inlining it into `Brillig` opcodes, the debugger was not being able to correctly step into the execution of unconstrained functions.

## Summary\*

This PR adds support to the Noir debugger to handle the new `BrilligCall` opcodes and allows stepping into unconstrained functions by retrieving the opcodes from the deduplicated Brillig functions. The changes impact both the REPL and the DAP debuggers.

## Additional Context

In DAP mode, the disassembly request is still not working properly. It seems that we are not responding to the command in an appropriate manner. We will tackle that problem separately.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
