### PR TITLE
chore(experimental): Add Ast Functor

### DIFF
--- a/compiler/noirc_frontend/src/composer/functor.rs
+++ b/compiler/noirc_frontend/src/composer/functor.rs
@@ -1,0 +1,221 @@
+//! This module defines a Functor version of the Ast where
+//! each recursive Ast field is replaced by a generic result value.
+//! This is given to name resolution, type checking, and the comptime
+//! interpreter to prevent them from recursing on ast nodes themselves
+//! and falling out of lock-step with each other.
+use acvm::FieldElement;
+use noirc_errors::Span;
+
+use crate::{macros_api::{Path, UnaryOp, Ident, UnresolvedType, ItemVisibility, Visibility, Pattern, SecondaryAttribute}, ast::{BinaryOp, UnresolvedGenerics, UnresolvedTraitConstraint, ConstrainKind}, token::Attributes};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Expression<T> {
+    Literal(Literal<T>),
+    Block(BlockExpression<T>),
+    Prefix(PrefixExpression<T>),
+    Index(IndexExpression<T>),
+    Call(CallExpression<T>),
+    MethodCall(MethodCallExpression<T>),
+    Constructor(ConstructorExpression<T>),
+    MemberAccess(MemberAccessExpression<T>),
+    Cast(CastExpression<T>),
+    Infix(InfixExpression<T>),
+    If(IfExpression<T>),
+    Variable(Path),
+    Tuple(Vec<T>),
+    Lambda(Lambda<T>),
+    Quote(BlockExpression<T>),
+    Comptime(BlockExpression<T>),
+    Error,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Literal<T> {
+    Array(ArrayLiteral<T>),
+    Slice(ArrayLiteral<T>),
+    Bool(bool),
+    Integer(FieldElement, /*sign*/ bool), // false for positive integer and true for negative
+    Str(String),
+    RawStr(String, u8),
+    FmtStr(String),
+    Unit,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PrefixExpression<T> {
+    pub operator: UnaryOp,
+    pub rhs: T,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct InfixExpression<T> {
+    pub lhs: T,
+    pub operator: BinaryOp,
+    pub rhs: T,
+}
+
+// This is an infix expression with 'as' as the binary operator
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct CastExpression<T> {
+    pub lhs: T,
+    pub r#type: UnresolvedType,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct IfExpression<T> {
+    pub condition: T,
+    pub consequence: T,
+    pub alternative: Option<T>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Lambda<T> {
+    pub parameters: Vec<(Pattern, UnresolvedType)>,
+    pub return_type: UnresolvedType,
+    pub body: T,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FunctionDefinition<T> {
+    pub name: Ident,
+
+    // The `Attributes` container holds both `primary` (ones that change the function kind)
+    // and `secondary` attributes (ones that do not change the function kind)
+    pub attributes: Attributes,
+
+    /// True if this function was defined with the 'unconstrained' keyword
+    pub is_unconstrained: bool,
+
+    /// True if this function was defined with the 'comptime' keyword
+    pub is_comptime: bool,
+
+    /// Indicate if this function was defined with the 'pub' keyword
+    pub visibility: ItemVisibility,
+
+    pub generics: UnresolvedGenerics,
+    pub parameters: Vec<Param>,
+    pub body: BlockExpression<T>,
+    pub span: Span,
+    pub where_clause: Vec<UnresolvedTraitConstraint>,
+    pub return_type: FunctionReturnType,
+    pub return_visibility: Visibility,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Param {
+    pub visibility: Visibility,
+    pub pattern: Pattern,
+    pub typ: UnresolvedType,
+    pub span: Span,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FunctionReturnType {
+    /// Returns type is not specified.
+    Default(Span),
+    /// Everything else.
+    Ty(UnresolvedType),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ArrayLiteral<T> {
+    Standard(Vec<T>),
+    Repeated { repeated_element: T, length: T },
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct CallExpression<T> {
+    pub func: T,
+    pub arguments: Vec<T>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MethodCallExpression<T> {
+    pub object: T,
+    pub method_name: Ident,
+    pub arguments: Vec<T>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ConstructorExpression<T> {
+    pub type_name: Path,
+    pub fields: Vec<(Ident, T)>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MemberAccessExpression<T> {
+    pub lhs: T,
+    pub rhs: Ident,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct IndexExpression<T> {
+    pub collection: T,
+    pub index: T,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BlockExpression<T> {
+    pub statements: Vec<T>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Statement<T> {
+    Let(LetStatement<T>),
+    Constrain(ConstrainStatement<T>),
+    Expression(T),
+    Assign(AssignStatement<T>),
+    For(ForLoopStatement<T>),
+    Break,
+    Continue,
+    Comptime(T),
+    Semi(T),
+    Error,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct LetStatement<T> {
+    pub pattern: Pattern,
+    pub r#type: UnresolvedType,
+    pub expression: T,
+    pub attributes: Vec<SecondaryAttribute>,
+
+    // True if this should only be run during compile-time
+    pub comptime: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct AssignStatement<T> {
+    pub lvalue: LValue<T>,
+    pub expression: T,
+}
+
+/// Represents an Ast form that can be assigned to
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LValue<T> {
+    Ident(Ident),
+    MemberAccess { object: Box<LValue<T>>, field_name: Ident, span: Span },
+    Index { array: Box<LValue<T>>, index: T, span: Span },
+    Dereference(Box<LValue<T>>, Span),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ConstrainStatement<T> {
+    pub condition: T,
+    pub message: Option<T>,
+    pub kind: ConstrainKind,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ForRange<T> {
+    Range { start: T, end: T },
+    Array(T),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ForLoopStatement<T> {
+    pub identifier: Ident,
+    pub range: ForRange<T>,
+    pub block: T,
+    pub span: Span,
+}

--- a/compiler/noirc_frontend/src/composer/functor.rs
+++ b/compiler/noirc_frontend/src/composer/functor.rs
@@ -6,7 +6,14 @@
 use acvm::FieldElement;
 use noirc_errors::Span;
 
-use crate::{macros_api::{Path, UnaryOp, Ident, UnresolvedType, ItemVisibility, Visibility, Pattern, SecondaryAttribute}, ast::{BinaryOp, UnresolvedGenerics, UnresolvedTraitConstraint, ConstrainKind}, token::Attributes};
+use crate::{
+    ast::{BinaryOp, ConstrainKind, UnresolvedGenerics, UnresolvedTraitConstraint},
+    macros_api::{
+        Ident, ItemVisibility, Path, Pattern, SecondaryAttribute, UnaryOp, UnresolvedType,
+        Visibility,
+    },
+    token::Attributes,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Expression<T> {

--- a/compiler/noirc_frontend/src/composer/mod.rs
+++ b/compiler/noirc_frontend/src/composer/mod.rs
@@ -1,0 +1,8 @@
+//! The Composer's job is to recur on the Ast, calling name resolution,
+//! type checking, and the comptime interpreter in lock-step one node at a time.
+//! It accomplishes this with the `functor::Ast` which does not have sub-nodes
+//! that these passes can recur upon. Instead, it has generic slots for result values.
+//!
+//! The Composer's job then is to just recur on the raw Ast, create a `functor::Ast`
+//! for that node holding results from any recursive calls, and hand that off to each pass.
+mod functor;

--- a/compiler/noirc_frontend/src/composer/mod.rs
+++ b/compiler/noirc_frontend/src/composer/mod.rs
@@ -5,4 +5,4 @@
 //!
 //! The Composer's job then is to just recur on the raw Ast, create a `functor::Ast`
 //! for that node holding results from any recursive calls, and hand that off to each pass.
-mod functor;
+pub mod functor;

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -11,7 +11,7 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 
 pub mod ast;
-mod composer;
+pub mod composer;
 pub mod debug;
 pub mod graph;
 pub mod lexer;

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -11,6 +11,7 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 
 pub mod ast;
+mod composer;
 pub mod debug;
 pub mod graph;
 pub mod lexer;


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4954

## Summary\*

Adds a functor (mappable) version of our Ast enum.

## Additional Context

This is needed for interleaving three compiler passes for the metaprogramming work. See the linked issue and the issue linked from it as well.

The actual Ast isn't used at all yet but will eventually be used by the future composer struct.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
