### PR TITLE
feat: add `Neg` trait to stdlib

### DIFF
--- a/docs/docs/noir/standard_library/traits.md
+++ b/docs/docs/noir/standard_library/traits.md
@@ -232,6 +232,15 @@ impl Rem for i32 { fn rem(self, other: i32) -> i32 { self % other } }
 impl Rem for i64 { fn rem(self, other: i64) -> i64 { self % other } }
 ```
 
+### `std::ops::Neg`
+
+#include_code neg-trait noir_stdlib/src/ops.nr rust
+
+`Neg::neg` is equivalent to the unary negation operator `-`.
+
+Implementations:
+#include_code neg-trait-impls noir_stdlib/src/ops.nr rust
+
 ### `std::ops::{ BitOr, BitAnd, BitXor }`
 
 #include_code bitor-trait noir_stdlib/src/ops.nr rust

--- a/noir_stdlib/src/ops.nr
+++ b/noir_stdlib/src/ops.nr
@@ -76,6 +76,20 @@ impl Rem for i8 { fn rem(self, other: i8) -> i8 { self % other } }
 impl Rem for i32 { fn rem(self, other: i32) -> i32 { self % other } }
 impl Rem for i64 { fn rem(self, other: i64) -> i64 { self % other } }
 
+// docs:start:neg-trait
+trait Neg {
+    fn neg(self) -> Self;
+}
+// docs:end:neg-trait
+
+// docs:start:neg-trait-impls
+impl Neg for Field { fn neg(self) -> Field { -self } }
+
+impl Neg for i8 { fn neg(self) -> i8 { -self } }
+impl Neg for i32 { fn neg(self) -> i32 { -self } }
+impl Neg for i64 { fn neg(self) -> i64 { -self } }
+// docs:end:neg-trait-impls
+
 // docs:start:bitor-trait
 trait BitOr {
     fn bitor(self, other: Self) -> Self;
@@ -153,3 +167,4 @@ impl Shr for u1 { fn shr(self, other: u8) -> u1 { self >> other } }
 impl Shr for i8 { fn shr(self, other: u8) -> i8 { self >> other } }
 impl Shr for i32 { fn shr(self, other: u8) -> i32 { self >> other } }
 impl Shr for i64 { fn shr(self, other: u8) -> i64 { self >> other } }
+

--- a/noir_stdlib/src/scalar_mul.nr
+++ b/noir_stdlib/src/scalar_mul.nr
@@ -1,4 +1,4 @@
-use crate::ops::Add;
+use crate::ops::{Add, Sub, Neg};
 
 struct EmbeddedCurvePoint {
     x: Field,
@@ -17,6 +17,21 @@ impl Add for EmbeddedCurvePoint {
     }
 }
 
+impl Sub for EmbeddedCurvePoint {
+    fn sub(self, other: EmbeddedCurvePoint) -> EmbeddedCurvePoint { 
+        self + other.neg()
+    }
+}
+
+impl Neg for EmbeddedCurvePoint {
+    fn neg(self) -> EmbeddedCurvePoint { 
+        EmbeddedCurvePoint {
+            x: self.x,
+            y: -self.y
+        }
+    }
+}
+
 // Computes a fixed base scalar multiplication over the embedded curve.
 // For bn254, We have Grumpkin and Baby JubJub.
 // For bls12-381, we have JubJub and Bandersnatch.
@@ -25,10 +40,7 @@ impl Add for EmbeddedCurvePoint {
 // underlying proof system.
 #[foreign(fixed_base_scalar_mul)]
 // docs:start:fixed_base_embedded_curve
-pub fn fixed_base_embedded_curve(
-    low: Field,
-    high: Field
-) -> [Field; 2]
+pub fn fixed_base_embedded_curve(low: Field, high: Field) -> [Field; 2]
 // docs:end:fixed_base_embedded_curve
 {}
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR implements the `std::op::Neg` trait so that we can implement `Sub` on `EmbeddedCurvePoint`

## Additional Context

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

BEGIN_COMMIT_OVERRIDE
feat: add `std::ops::Neg` trait to stdlib
feat: implement `std::ops::Sub` on `EmbeddedCurvePoint`
END_COMMIT_OVERRIDE