### PR TITLE
fix: Compute the correct slice length when coercing from a literal array of complex types

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1787,7 +1787,7 @@ impl From<&Type> for PrintableType {
         match value {
             Type::FieldElement => PrintableType::Field,
             Type::Array(size, typ) => {
-                let length = size.evaluate_to_u64();
+                let length = size.evaluate_to_u64().expect("Cannot print variable sized arrays");
                 let typ = typ.as_ref();
                 PrintableType::Array { length, typ: Box::new(typ.into()) }
             }

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -186,7 +186,8 @@ fn to_string(value: &PrintableValue, typ: &PrintableType) -> Option<String> {
         (_, PrintableType::MutableReference { .. }) => {
             output.push_str("<<mutable ref>>");
         }
-        (PrintableValue::Vec { array_elements, is_slice }, PrintableType::Array { typ, .. }) => {
+        (PrintableValue::Vec { array_elements, is_slice }, PrintableType::Array { typ, .. })
+        | (PrintableValue::Vec { array_elements, is_slice }, PrintableType::Slice { typ }) => {
             if *is_slice {
                 output.push('&')
             }

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 pub enum PrintableType {
     Field,
     Array {
-        length: Option<u64>,
+        length: u64,
         #[serde(rename = "type")]
         typ: Box<PrintableType>,
     },
@@ -317,19 +317,7 @@ pub fn decode_value(
 
             PrintableValue::Field(field_element)
         }
-        PrintableType::Array { length: None, typ } => {
-            let length = field_iterator
-                .next()
-                .expect("not enough data to decode variable array length")
-                .to_u128() as usize;
-            let mut array_elements = Vec::with_capacity(length);
-            for _ in 0..length {
-                array_elements.push(decode_value(field_iterator, typ));
-            }
-
-            PrintableValue::Vec { array_elements, is_slice: false }
-        }
-        PrintableType::Array { length: Some(length), typ } => {
+        PrintableType::Array { length, typ } => {
             let length = *length as usize;
             let mut array_elements = Vec::with_capacity(length);
             for _ in 0..length {

--- a/test_programs/execution_success/debug_logs/src/main.nr
+++ b/test_programs/execution_success/debug_logs/src/main.nr
@@ -71,6 +71,8 @@ fn main(x: Field, y: pub Field) {
     let closured_lambda = |x| x + one;
     println(f"closured_lambda: {closured_lambda}, sentinel: {sentinel}");
     println(closured_lambda);
+
+    regression_4967();
 }
 
 fn string_identity(string: fmtstr<14, (Field, Field)>) -> fmtstr<14, (Field, Field)> {
@@ -122,3 +124,14 @@ fn regression_2906() {
     println(f"array_five_vals: {array_five_vals}, label_five_vals: {label_five_vals}");
 }
 
+fn regression_4967() {
+    let sentinel: u32 = 8888;
+
+    let slice_of_tuples: [(i32, u8)] = &[(11, 22), (33, 44)];
+    println(f"slice_of_tuples: {slice_of_tuples}, sentinel: {sentinel}");
+    println(slice_of_tuples);
+
+    let slice_of_tuples_coerced: [(i32, u8)] = [(11, 22), (33, 44)];
+    println(f"slice_of_tuples: {slice_of_tuples_coerced}, sentinel: {sentinel}");
+    println(slice_of_tuples_coerced);
+}

--- a/test_programs/execution_success/slice_coercion/src/main.nr
+++ b/test_programs/execution_success/slice_coercion/src/main.nr
@@ -21,7 +21,7 @@ fn main(expected: pub Field, first: Field) {
 }
 
 fn regression_4967() {
-   let var1: [(i32, u8)] = [(1, 2)];
-   assert(var1.len() == 1);
-   dep::std::println(var1);
+    let var1: [(i32, u8)] = [(1, 2)];
+    assert(var1.len() == 1);
+    dep::std::println(var1);
 }

--- a/test_programs/execution_success/slice_coercion/src/main.nr
+++ b/test_programs/execution_success/slice_coercion/src/main.nr
@@ -16,4 +16,12 @@ fn main(expected: pub Field, first: Field) {
     let mut hasher = Hasher::new();
     hasher.add(first);
     assert(hasher.fields[0] == expected);
+
+    regression_4967();
+}
+
+fn regression_4967() {
+   let var1: [(i32, u8)] = [(1, 2)];
+   assert(var1.len() == 1);
+   dep::std::println(var1);
 }

--- a/tooling/nargo/src/artifacts/debug_vars.rs
+++ b/tooling/nargo/src/artifacts/debug_vars.rs
@@ -96,13 +96,11 @@ impl DebugVars {
                     PrintableType::Array { length, typ },
                 ) => {
                     assert!(!*is_slice, "slice has array type");
-                    if let Some(len) = length {
-                        if *index as u64 >= *len {
-                            panic!("unexpected field index past array length")
-                        }
-                        if *len != array_elements.len() as u64 {
-                            panic!("type/array length mismatch")
-                        }
+                    if *index as u64 >= *length {
+                        panic!("unexpected field index past array length")
+                    }
+                    if *length != array_elements.len() as u64 {
+                        panic!("type/array length mismatch")
                     }
                     (array_elements.get_mut(*index as usize).unwrap(), &*Box::leak(typ.clone()))
                 }

--- a/tooling/nargo/src/artifacts/debug_vars.rs
+++ b/tooling/nargo/src/artifacts/debug_vars.rs
@@ -108,7 +108,7 @@ impl DebugVars {
                     PrintableValue::Vec { array_elements, is_slice },
                     PrintableType::Slice { typ },
                 ) => {
-                    assert!(*is_slice, "array has slice type");
+                    assert!(*is_slice, "slice doesn't have slice type");
                     (array_elements.get_mut(*index as usize).unwrap(), &*Box::leak(typ.clone()))
                 }
                 (


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4967

## Summary\*

There is a problem in the [array to slice coercion](https://github.com/noir-lang/noir/blob/07930d4373a393146210efae69e6ec40171f047b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs#L87) code. When evaluating the coercion, it does not take into account that for SSA, complex types such as tuples and structs are flattened, resulting in an array representation with length of elements times the size of the complex type (as a result of the flattening). This results in the replacement slice having an incorrect size.

Then, because the slice has an inflated size, the code which decodes the elements of the slice for printing or tracking (in the debugger) crashes when it attempts to decode beyond the values that it has available.

## Additional Context

There are two additional minor changes introduced in this PR:

1. Removed the `Optional<>` for `PrintableType::Array`'s length. This was introduced to be able to print slices (setting the length to `None`), but those are now represented properly with `PrintableType::Slice`.
2. Added support for printing slices.

Both are pretty small changes which I made while investigating the issue, but I'm willing to send separate PRs for those if required.

I also expanded the existing test cases to verify both the coerced slice length and printing of slices.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
