### PR TITLE
chore(ci): run clippy on benchmarks

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -44,7 +44,7 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: Run `cargo clippy`
-        run: cargo clippy --workspace --locked --release
+        run: cargo clippy --all-targets --workspace --locked --release
 
       - name: Run `cargo fmt`
         run: cargo fmt --all --check

--- a/acvm-repo/acir/benches/serialization.rs
+++ b/acvm-repo/acir/benches/serialization.rs
@@ -40,6 +40,7 @@ fn sample_program(num_opcodes: usize) -> Program {
             assert_messages: Vec::new(),
             recursive: false,
         }],
+        unconstrained_functions: Vec::new(),
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're not currently checking the benchmarks in CI which has resulted in them no longer compiling. This PR adds them to the clippy checks which will enforce that they compile properly.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
