### PR TITLE
feat: increase default expression width to 4

### DIFF
--- a/acvm-repo/acir/benches/serialization.rs
+++ b/acvm-repo/acir/benches/serialization.rs
@@ -33,7 +33,7 @@ fn sample_program(num_opcodes: usize) -> Program {
         functions: vec![Circuit {
             current_witness_index: 4000,
             opcodes: assert_zero_opcodes.to_vec(),
-            expression_width: ExpressionWidth::Bounded { width: 3 },
+            expression_width: ExpressionWidth::Bounded { width: 4 },
             private_parameters: BTreeSet::from([Witness(1), Witness(2), Witness(3), Witness(4)]),
             public_parameters: PublicInputs(BTreeSet::from([Witness(5)])),
             return_values: PublicInputs(BTreeSet::from([Witness(6)])),

--- a/acvm-repo/acvm/src/compiler/optimizers/constant_backpropagation.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/constant_backpropagation.rs
@@ -282,7 +282,7 @@ mod tests {
     fn test_circuit(opcodes: Vec<Opcode>) -> Circuit {
         Circuit {
             current_witness_index: 1,
-            expression_width: ExpressionWidth::Bounded { width: 3 },
+            expression_width: ExpressionWidth::Bounded { width: 4 },
             opcodes,
             private_parameters: BTreeSet::new(),
             public_parameters: PublicInputs::default(),

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -164,7 +164,7 @@ mod tests {
 
         Circuit {
             current_witness_index: 1,
-            expression_width: ExpressionWidth::Bounded { width: 3 },
+            expression_width: ExpressionWidth::Bounded { width: 4 },
             opcodes,
             private_parameters: BTreeSet::new(),
             public_parameters: PublicInputs::default(),

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -54,7 +54,7 @@ pub const NOIR_ARTIFACT_VERSION_STRING: &str =
 #[derive(Args, Clone, Debug, Default)]
 pub struct CompileOptions {
     /// Override the expression width requested by the backend.
-    #[arg(long, value_parser = parse_expression_width, default_value = "3")]
+    #[arg(long, value_parser = parse_expression_width, default_value = "4")]
     pub expression_width: ExpressionWidth,
 
     /// Force a full recompilation.

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -170,8 +170,8 @@ pub fn compile_program(
     let (crate_id, mut context) = prepare_context(entry_point, dependency_graph, file_source_map)?;
 
     let compile_options = CompileOptions::default();
-    // For now we default to a bounded width of 3, though we can add it as a parameter
-    let expression_width = acvm::acir::circuit::ExpressionWidth::Bounded { width: 3 };
+    // For now we default to a bounded width of 4, though we can add it as a parameter
+    let expression_width = acvm::acir::circuit::ExpressionWidth::Bounded { width: 4 };
 
     let compiled_program =
         noirc_driver::compile_main(&mut context, crate_id, &compile_options, None)
@@ -200,8 +200,8 @@ pub fn compile_contract(
     let (crate_id, mut context) = prepare_context(entry_point, dependency_graph, file_source_map)?;
 
     let compile_options = CompileOptions::default();
-    // For now we default to a bounded width of 3, though we can add it as a parameter
-    let expression_width = acvm::acir::circuit::ExpressionWidth::Bounded { width: 3 };
+    // For now we default to a bounded width of 4, though we can add it as a parameter
+    let expression_width = acvm::acir::circuit::ExpressionWidth::Bounded { width: 4 };
 
     let compiled_contract =
         noirc_driver::compile_contract(&mut context, crate_id, &compile_options)

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -1,3 +1,4 @@
+use acvm::acir::circuit::ExpressionWidth;
 use fm::FileManager;
 use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{JsString, Object};
@@ -169,7 +170,10 @@ pub fn compile_program(
     console_error_panic_hook::set_once();
     let (crate_id, mut context) = prepare_context(entry_point, dependency_graph, file_source_map)?;
 
-    let compile_options = CompileOptions::default();
+    let compile_options = CompileOptions {
+        expression_width: ExpressionWidth::Bounded { width: 4 },
+        ..CompileOptions::default()
+    };
 
     let compiled_program =
         noirc_driver::compile_main(&mut context, crate_id, &compile_options, None)
@@ -198,7 +202,10 @@ pub fn compile_contract(
     console_error_panic_hook::set_once();
     let (crate_id, mut context) = prepare_context(entry_point, dependency_graph, file_source_map)?;
 
-    let compile_options = CompileOptions::default();
+    let compile_options = CompileOptions {
+        expression_width: ExpressionWidth::Bounded { width: 4 },
+        ..CompileOptions::default()
+    };
 
     let compiled_contract =
         noirc_driver::compile_contract(&mut context, crate_id, &compile_options)

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -170,8 +170,6 @@ pub fn compile_program(
     let (crate_id, mut context) = prepare_context(entry_point, dependency_graph, file_source_map)?;
 
     let compile_options = CompileOptions::default();
-    // For now we default to a bounded width of 4, though we can add it as a parameter
-    let expression_width = acvm::acir::circuit::ExpressionWidth::Bounded { width: 4 };
 
     let compiled_program =
         noirc_driver::compile_main(&mut context, crate_id, &compile_options, None)
@@ -184,7 +182,8 @@ pub fn compile_program(
             })?
             .0;
 
-    let optimized_program = nargo::ops::transform_program(compiled_program, expression_width);
+    let optimized_program =
+        nargo::ops::transform_program(compiled_program, compile_options.expression_width);
     let warnings = optimized_program.warnings.clone();
 
     Ok(JsCompileProgramResult::new(optimized_program.into(), warnings))
@@ -200,8 +199,6 @@ pub fn compile_contract(
     let (crate_id, mut context) = prepare_context(entry_point, dependency_graph, file_source_map)?;
 
     let compile_options = CompileOptions::default();
-    // For now we default to a bounded width of 4, though we can add it as a parameter
-    let expression_width = acvm::acir::circuit::ExpressionWidth::Bounded { width: 4 };
 
     let compiled_contract =
         noirc_driver::compile_contract(&mut context, crate_id, &compile_options)
@@ -214,7 +211,8 @@ pub fn compile_contract(
             })?
             .0;
 
-    let optimized_contract = nargo::ops::transform_contract(compiled_contract, expression_width);
+    let optimized_contract =
+        nargo::ops::transform_contract(compiled_contract, compile_options.expression_width);
 
     let functions =
         optimized_contract.functions.into_iter().map(ContractFunctionArtifact::from).collect();

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -3,6 +3,7 @@ use crate::compile::{
     PathToFileSourceMap,
 };
 use crate::errors::{CompileError, JsCompileError};
+use acvm::acir::circuit::ExpressionWidth;
 use nargo::artifacts::contract::{ContractArtifact, ContractFunctionArtifact};
 use nargo::parse_all;
 use noirc_driver::{
@@ -96,11 +97,14 @@ impl CompilerContext {
         mut self,
         program_width: usize,
     ) -> Result<JsCompileProgramResult, JsCompileError> {
-        let compile_options = CompileOptions::default();
-        let np_language = acvm::acir::circuit::ExpressionWidth::Bounded { width: program_width };
+        let expression_width = if program_width == 0 {
+            ExpressionWidth::Unbounded
+        } else {
+            ExpressionWidth::Bounded { width: 4 }
+        };
+        let compile_options = CompileOptions { expression_width, ..CompileOptions::default() };
 
         let root_crate_id = *self.context.root_crate_id();
-
         let compiled_program =
             compile_main(&mut self.context, root_crate_id, &compile_options, None)
                 .map_err(|errs| {
@@ -112,7 +116,8 @@ impl CompilerContext {
                 })?
                 .0;
 
-        let optimized_program = nargo::ops::transform_program(compiled_program, np_language);
+        let optimized_program =
+            nargo::ops::transform_program(compiled_program, compile_options.expression_width);
         let warnings = optimized_program.warnings.clone();
 
         Ok(JsCompileProgramResult::new(optimized_program.into(), warnings))
@@ -122,10 +127,14 @@ impl CompilerContext {
         mut self,
         program_width: usize,
     ) -> Result<JsCompileContractResult, JsCompileError> {
-        let compile_options = CompileOptions::default();
-        let np_language = acvm::acir::circuit::ExpressionWidth::Bounded { width: program_width };
-        let root_crate_id = *self.context.root_crate_id();
+        let expression_width = if program_width == 0 {
+            ExpressionWidth::Unbounded
+        } else {
+            ExpressionWidth::Bounded { width: 4 }
+        };
+        let compile_options = CompileOptions { expression_width, ..CompileOptions::default() };
 
+        let root_crate_id = *self.context.root_crate_id();
         let compiled_contract =
             compile_contract(&mut self.context, root_crate_id, &compile_options)
                 .map_err(|errs| {
@@ -137,7 +146,8 @@ impl CompilerContext {
                 })?
                 .0;
 
-        let optimized_contract = nargo::ops::transform_contract(compiled_contract, np_language);
+        let optimized_contract =
+            nargo::ops::transform_contract(compiled_contract, compile_options.expression_width);
 
         let functions =
             optimized_contract.functions.into_iter().map(ContractFunctionArtifact::from).collect();

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -166,7 +166,7 @@ pub fn compile_program_(
 
     let compiler_context =
         prepare_compiler_context(entry_point, dependency_graph, file_source_map)?;
-    let program_width = 3;
+    let program_width = 4;
 
     compiler_context.compile_program(program_width)
 }
@@ -183,7 +183,7 @@ pub fn compile_contract_(
 
     let compiler_context =
         prepare_compiler_context(entry_point, dependency_graph, file_source_map)?;
-    let program_width = 3;
+    let program_width = 4;
 
     compiler_context.compile_contract(program_width)
 }

--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -28,7 +28,7 @@ use noir_debugger::errors::{DapError, LoadError};
 #[derive(Debug, Clone, Args)]
 pub(crate) struct DapCommand {
     /// Override the expression width requested by the backend.
-    #[arg(long, value_parser = parse_expression_width, default_value = "3")]
+    #[arg(long, value_parser = parse_expression_width, default_value = "4")]
     expression_width: ExpressionWidth,
 
     #[clap(long)]


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The new version of `bb` can use an expression width of 4 so we update to make use of this.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
