### PR TITLE
feat: implement `ops` traits on `u16`/`i16`

### DIFF
--- a/noir_stdlib/src/ops/arith.nr
+++ b/noir_stdlib/src/ops/arith.nr
@@ -66,7 +66,7 @@ impl Div for u16 { fn div(self, other: u16) -> u16 { self / other } }
 impl Div for u8 { fn div(self, other: u8) -> u8 { self / other } }
 
 impl Div for i8 { fn div(self, other: i8) -> i8 { self / other } }
-impl Mul for i16 { fn div(self, other: i16) -> i16 { self / other } }
+impl Div for i16 { fn div(self, other: i16) -> i16 { self / other } }
 impl Div for i32 { fn div(self, other: i32) -> i32 { self / other } }
 impl Div for i64 { fn div(self, other: i64) -> i64 { self / other } }
 
@@ -96,7 +96,7 @@ trait Neg {
 impl Neg for Field { fn neg(self) -> Field { -self } }
 
 impl Neg for i8 { fn neg(self) -> i8 { -self } }
-impl Mul for i16 { fn neg(self) -> i16 { -self } }
+impl Neg for i16 { fn neg(self) -> i16 { -self } }
 impl Neg for i32 { fn neg(self) -> i32 { -self } }
 impl Neg for i64 { fn neg(self) -> i64 { -self } }
 // docs:end:neg-trait-impls

--- a/noir_stdlib/src/ops/arith.nr
+++ b/noir_stdlib/src/ops/arith.nr
@@ -8,9 +8,11 @@ impl Add for Field { fn add(self, other: Field) -> Field { self + other } }
 
 impl Add for u64 { fn add(self, other: u64) -> u64 { self + other } }
 impl Add for u32 { fn add(self, other: u32) -> u32 { self + other } }
+impl Add for u16 { fn add(self, other: u16) -> u16 { self + other } }
 impl Add for u8 { fn add(self, other: u8) -> u8 { self + other } }
 
 impl Add for i8 { fn add(self, other: i8) -> i8 { self + other } }
+impl Add for i16 { fn add(self, other: i16) -> i16 { self + other } }
 impl Add for i32 { fn add(self, other: i32) -> i32 { self + other } }
 impl Add for i64 { fn add(self, other: i64) -> i64 { self + other } }
 
@@ -24,9 +26,11 @@ impl Sub for Field { fn sub(self, other: Field) -> Field { self - other } }
 
 impl Sub for u64 { fn sub(self, other: u64) -> u64 { self - other } }
 impl Sub for u32 { fn sub(self, other: u32) -> u32 { self - other } }
+impl Sub for u16 { fn sub(self, other: u16) -> u16 { self - other } }
 impl Sub for u8 { fn sub(self, other: u8) -> u8 { self - other } }
 
 impl Sub for i8 { fn sub(self, other: i8) -> i8 { self - other } }
+impl Sub for i16 { fn sub(self, other: i16) -> i16 { self - other } }
 impl Sub for i32 { fn sub(self, other: i32) -> i32 { self - other } }
 impl Sub for i64 { fn sub(self, other: i64) -> i64 { self - other } }
 
@@ -40,9 +44,11 @@ impl Mul for Field { fn mul(self, other: Field) -> Field { self * other } }
 
 impl Mul for u64 { fn mul(self, other: u64) -> u64 { self * other } }
 impl Mul for u32 { fn mul(self, other: u32) -> u32 { self * other } }
+impl Mul for u16 { fn mul(self, other: u16) -> u16 { self * other } }
 impl Mul for u8 { fn mul(self, other: u8) -> u8 { self * other } }
 
 impl Mul for i8 { fn mul(self, other: i8) -> i8 { self * other } }
+impl Mul for i16 { fn mul(self, other: i16) -> i16 { self * other } }
 impl Mul for i32 { fn mul(self, other: i32) -> i32 { self * other } }
 impl Mul for i64 { fn mul(self, other: i64) -> i64 { self * other } }
 
@@ -56,9 +62,11 @@ impl Div for Field { fn div(self, other: Field) -> Field { self / other } }
 
 impl Div for u64 { fn div(self, other: u64) -> u64 { self / other } }
 impl Div for u32 { fn div(self, other: u32) -> u32 { self / other } }
+impl Div for u16 { fn div(self, other: u16) -> u16 { self / other } }
 impl Div for u8 { fn div(self, other: u8) -> u8 { self / other } }
 
 impl Div for i8 { fn div(self, other: i8) -> i8 { self / other } }
+impl Mul for i16 { fn div(self, other: i16) -> i16 { self / other } }
 impl Div for i32 { fn div(self, other: i32) -> i32 { self / other } }
 impl Div for i64 { fn div(self, other: i64) -> i64 { self / other } }
 
@@ -70,9 +78,11 @@ trait Rem{
 
 impl Rem for u64 { fn rem(self, other: u64) -> u64 { self % other } }
 impl Rem for u32 { fn rem(self, other: u32) -> u32 { self % other } }
+impl Rem for u16 { fn rem(self, other: u16) -> u16 { self % other } }
 impl Rem for u8 { fn rem(self, other: u8) -> u8 { self % other } }
 
 impl Rem for i8 { fn rem(self, other: i8) -> i8 { self % other } }
+impl Rem for i16 { fn rem(self, other: i16) -> i16 { self % other } }
 impl Rem for i32 { fn rem(self, other: i32) -> i32 { self % other } }
 impl Rem for i64 { fn rem(self, other: i64) -> i64 { self % other } }
 
@@ -86,6 +96,7 @@ trait Neg {
 impl Neg for Field { fn neg(self) -> Field { -self } }
 
 impl Neg for i8 { fn neg(self) -> i8 { -self } }
+impl Mul for i16 { fn neg(self) -> i16 { -self } }
 impl Neg for i32 { fn neg(self) -> i32 { -self } }
 impl Neg for i64 { fn neg(self) -> i64 { -self } }
 // docs:end:neg-trait-impls

--- a/noir_stdlib/src/ops/bit.nr
+++ b/noir_stdlib/src/ops/bit.nr
@@ -8,9 +8,11 @@ impl BitOr for bool { fn bitor(self, other: bool) -> bool { self | other } }
 
 impl BitOr for u64 { fn bitor(self, other: u64) -> u64 { self | other } }
 impl BitOr for u32 { fn bitor(self, other: u32) -> u32 { self | other } }
+impl BitOr for u16 { fn bitor(self, other: u16) -> u16 { self | other } }
 impl BitOr for u8 { fn bitor(self, other: u8) -> u8 { self | other } }
 
 impl BitOr for i8 { fn bitor(self, other: i8) -> i8 { self | other } }
+impl BitOr for i16 { fn bitor(self, other: i16) -> i16 { self | other } }
 impl BitOr for i32 { fn bitor(self, other: i32) -> i32 { self | other } }
 impl BitOr for i64 { fn bitor(self, other: i64) -> i64 { self | other } }
 
@@ -24,9 +26,11 @@ impl BitAnd for bool { fn bitand(self, other: bool) -> bool { self & other } }
 
 impl BitAnd for u64 { fn bitand(self, other: u64) -> u64 { self & other } }
 impl BitAnd for u32 { fn bitand(self, other: u32) -> u32 { self & other } }
+impl BitAnd for u16 { fn bitand(self, other: u16) -> u16 { self & other } }
 impl BitAnd for u8 { fn bitand(self, other: u8) -> u8 { self & other } }
 
 impl BitAnd for i8 { fn bitand(self, other: i8) -> i8 { self & other } }
+impl BitAnd for i16 { fn bitand(self, other: i16) -> i16 { self & other } }
 impl BitAnd for i32 { fn bitand(self, other: i32) -> i32 { self & other } }
 impl BitAnd for i64 { fn bitand(self, other: i64) -> i64 { self & other } }
 
@@ -40,9 +44,11 @@ impl BitXor for bool { fn bitxor(self, other: bool) -> bool { self ^ other } }
 
 impl BitXor for u64 { fn bitxor(self, other: u64) -> u64 { self ^ other } }
 impl BitXor for u32 { fn bitxor(self, other: u32) -> u32 { self ^ other } }
+impl BitXor for u16 { fn bitxor(self, other: u16) -> u16 { self ^ other } }
 impl BitXor for u8 { fn bitxor(self, other: u8) -> u8 { self ^ other } }
 
 impl BitXor for i8 { fn bitxor(self, other: i8) -> i8 { self ^ other } }
+impl BitXor for i16 { fn bitxor(self, other: i16) -> i16 { self ^ other } }
 impl BitXor for i32 { fn bitxor(self, other: i32) -> i32 { self ^ other } }
 impl BitXor for i64 { fn bitxor(self, other: i64) -> i64 { self ^ other } }
 
@@ -54,10 +60,12 @@ trait Shl {
 
 impl Shl for u32 { fn shl(self, other: u8) -> u32 { self << other } }
 impl Shl for u64 { fn shl(self, other: u8) -> u64 { self << other } }
+impl Shl for u16 { fn shl(self, other: u8) -> u16 { self << other } }
 impl Shl for u8 { fn shl(self, other: u8) -> u8 { self << other } }
 impl Shl for u1 { fn shl(self, other: u8) -> u1 { self << other } }
 
 impl Shl for i8 { fn shl(self, other: u8) -> i8 { self << other } }
+impl Shl for i16 { fn shl(self, other: u8) -> i16 { self << other } }
 impl Shl for i32 { fn shl(self, other: u8) -> i32 { self << other } }
 impl Shl for i64 { fn shl(self, other: u8) -> i64 { self << other } }
 
@@ -69,10 +77,12 @@ trait Shr {
 
 impl Shr for u64 { fn shr(self, other: u8) -> u64 { self >> other } }
 impl Shr for u32 { fn shr(self, other: u8) -> u32 { self >> other } }
+impl Shr for u16 { fn shr(self, other: u8) -> u16 { self >> other } }
 impl Shr for u8 { fn shr(self, other: u8) -> u8 { self >> other } }
 impl Shr for u1 { fn shr(self, other: u8) -> u1 { self >> other } }
 
 impl Shr for i8 { fn shr(self, other: u8) -> i8 { self >> other } }
+impl Shr for i16 { fn shr(self, other: u8) -> i16 { self >> other } }
 impl Shr for i32 { fn shr(self, other: u8) -> i32 { self >> other } }
 impl Shr for i64 { fn shr(self, other: u8) -> i64 { self >> other } }
 


### PR DESCRIPTION
# Description

## Problem\*

Followup to #4985 

## Summary\*

This PR adds implementations for the `std::ops` traits for the new 16 bit traits.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
