### PR TITLE
fix: Fix no predicates for brillig with intermediate functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -393,10 +393,11 @@ impl<'function> PerFunctionContext<'function> {
                         let function = &ssa.functions[&func_id];
                         // If we have not already finished the flattening pass, functions marked
                         // to not have predicates should be marked as entry points unless we are inlining into brillig.
+                        let entry_point = &ssa.functions[&self.context.entry_point];
                         let no_predicates_is_entry_point =
                             self.context.no_predicates_is_entry_point
                                 && function.is_no_predicates()
-                                && !matches!(self.source_function.runtime(), RuntimeType::Brillig);
+                                && !matches!(entry_point.runtime(), RuntimeType::Brillig);
                         if function.runtime().is_entry_point() || no_predicates_is_entry_point {
                             self.push_instruction(*id);
                         } else {

--- a/test_programs/execution_success/no_predicates_brillig/src/main.nr
+++ b/test_programs/execution_success/no_predicates_brillig/src/main.nr
@@ -1,4 +1,8 @@
 unconstrained fn main(x: u32, y: pub u32) {
+    intermediate_function(x, y);
+}
+
+fn intermediate_function(x: u32, y: u32) {
     basic_checks(x, y);
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Fixes https://github.com/noir-lang/noir/pull/5012 using the entry point instead of the source function, to consider intermediate functions.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
