### PR TITLE
chore: fix unmutable environment

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -60,6 +60,8 @@ pub enum TypeCheckError {
     TupleIndexOutOfBounds { index: usize, lhs_type: Type, length: usize, span: Span },
     #[error("Variable {name} must be mutable to be assigned to")]
     VariableMustBeMutable { name: String, span: Span },
+    #[error("Variable {name} captured in lambda must be a mutable reference")]
+    MutableCaptureNeedsRef { name: String, span: Span },
     #[error("No method named '{method_name}' found for type '{object_type}'")]
     UnresolvedMethodCall { method_name: String, object_type: Type, span: Span },
     #[error("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?}")]
@@ -240,6 +242,11 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             | TypeCheckError::InvalidShiftSize { span } => {
                 Diagnostic::simple_error(error.to_string(), String::new(), *span)
             }
+            TypeCheckError::MutableCaptureNeedsRef { name, span } => Diagnostic::simple_error(
+                format!("Variable {name} captured in lambda must be a mutable reference"),
+                "Use '&mut' instead of 'mut' to capture a mutable variable.".to_string(),
+                *span,
+            ),
             TypeCheckError::PublicReturnType { typ, span } => Diagnostic::simple_error(
                 "Functions cannot declare a public return type".to_string(),
                 format!("return type is {typ}"),

--- a/compiler/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/stmt.rs
@@ -194,6 +194,9 @@ impl<'interner> TypeChecker<'interner> {
                     typ.follow_bindings()
                 };
 
+                // TODO cleanup
+                dbg!("check_lvalue", typ.clone(), ident.clone(), mutable);
+
                 (typ.clone(), HirLValue::Ident(ident.clone(), typ), mutable)
             }
             HirLValue::MemberAccess { object, field_name, location, .. } => {

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -919,6 +919,13 @@ impl NodeInterner {
         self.definitions.get(id.0)
     }
 
+    /// Tries to retrieve the given id's definition.
+    /// This function should be used during name resolution or type checking when we cannot be sure
+    /// all variables have corresponding definitions (in case of an error in the user's code).
+    pub fn try_definition_mut(&mut self, id: DefinitionId) -> Option<&mut DefinitionInfo> {
+        self.definitions.get_mut(id.0)
+    }
+
     /// Returns the name of the definition
     ///
     /// This is needed as the Environment needs to map variable names to witness indices


### PR DESCRIPTION

# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4795

## Summary\*

This PR simply adds a check on mutable captures: when not `&mut`, a type checking error is thrown.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
