### PR TITLE
feat: Add `break <line-number>` command

### DIFF
--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -178,6 +178,17 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
             .filter(|v: &Vec<Location>| !v.is_empty())
     }
 
+    /// Returns the `FileId` of the file associated with the innermost function on the call stack.
+    pub(super) fn get_current_file(&mut self) -> Option<FileId> {
+        match self.get_current_source_location() {
+            Some(locations) => match locations.last() {
+                Some(location) => Some(location.file),
+                None => None,
+            },
+            None => None,
+        }
+    }
+
     /// Returns the (possible) stack of source locations corresponding to the
     /// given opcode location. Due to compiler inlining it's possible for this
     /// function to return multiple source locations. An empty vector means that


### PR DESCRIPTION
This makes it much easier to find the correct place to add a break point while debugging a program.

For example, now one can do the following:

```
$ cd test_programs/execution_success/merkle_insert/
$ nargo debug
[merkle_insert] Starting debugger
At opcode 0: BRILLIG CALL func 0: PREDICATE = %EXPR [ 1 ]%
inputs: [Single(Expression { mul_terms: [], linear_combina [...]
> next
At opcode 0.17: Const { destination: MemoryAddress(21), bi [...]
At [...]/test_programs/execution_success/merkle_insert/src/main.nr:12:3
  7    ...
  8        new_root: pub Field,
  9        leaf: Field,
 10        index: Field,
 11        mimc_input: [Field; 4]
 12 -> ) {
 13        assert(old_root == std::merkle::compute_merkle_ [...]
 14
 15        let calculated_root = std::merkle::compute_merk [...]
 16        assert(new_root == calculated_root);
 17
 18        let h = mimc::mimc_bn254(mimc_input);
 19        // Regression test for PR #891
 20        std::println(h);
 21        assert(h == 18226366069841799622585958305961373 [...]
 22    }
> break 18     # ** <- this is the new command **
Added breakpoint at opcode 0.1274
> continue
(Continuing execution...)
Stopped at breakpoint in opcode 0.1274
At opcode 0.1274: Const { destination: MemoryAddress(36),  [...]
At /home/stan/code/repos/noir/test_programs/execution_succ [...]
 13    ...
 14
 15        let calculated_root = std::merkle::compute_merk [...]
 16        assert(new_root == calculated_root);
 17
 18 ->     let h = mimc::mimc_bn254(mimc_input);
 19        // Regression test for PR #891
 20        std::println(h);
 21        assert(h == 18226366069841799622585958305961373 [...]
 22    }
>
```

# Description

This PR is in the spirit of "submit your feature request as a PR".

## Problem\*

At the moment, one can only do `break <opcode>` and not `break <line-number>` in `nargo debug`.

## Summary\*

This PR adds the necessary functionality and implements the `break <line-number>` command.

## Additional Context

I am exploring the current capabilities of `nargo debug` and found it would be very useful to add this command.

## Documentation\*

The new command automatically appears in the help command of `nargo debug`.

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
