### PR TITLE
feat: do not return databus returndata, keep it private.

### DIFF
--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -429,7 +429,15 @@ impl Abi {
                         .copied()
                 })
             {
-                Some(decode_value(&mut return_witness_values.into_iter(), &return_type.abi_type)?)
+                // We do not return value for the data bus.
+                if return_type.visibility == AbiVisibility::DataBus {
+                    None
+                } else {
+                    Some(decode_value(
+                        &mut return_witness_values.into_iter(),
+                        &return_type.abi_type,
+                    )?)
+                }
             } else {
                 // Unlike for the circuit inputs, we tolerate not being able to find the witness values for the return value.
                 // This is because the user may be decoding a partial witness map for which is hasn't been calculated yet.


### PR DESCRIPTION
# Description

## Problem\*

Related to  #4974

## Summary\*
Very small PR which avoids returning databus objects, because they need to be handled as private inputs.
This is incremental work, so it cannot be tested yet. The PR only impact databus use case.



## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
