### PR TITLE
feat: add `--skip-prelude` hidden CLI option

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -260,7 +260,8 @@ pub fn check_crate(
         if disable_macros { &[] } else { &[&aztec_macros::AztecMacro as &dyn MacroProcessor] };
 
     let mut errors = vec![];
-    let diagnostics = CrateDefMap::collect_defs(crate_id, context, use_elaborator, skip_prelude, macros);
+    let diagnostics =
+        CrateDefMap::collect_defs(crate_id, context, use_elaborator, skip_prelude, macros);
     errors.extend(diagnostics.into_iter().map(|(error, file_id)| {
         let diagnostic = CustomDiagnostic::from(&error);
         diagnostic.in_file(file_id)

--- a/compiler/noirc_driver/tests/stdlib_warnings.rs
+++ b/compiler/noirc_driver/tests/stdlib_warnings.rs
@@ -25,7 +25,7 @@ fn stdlib_does_not_produce_constant_warnings() -> Result<(), ErrorsAndWarnings> 
     let root_crate_id = prepare_crate(&mut context, file_name);
 
     let ((), warnings) =
-        noirc_driver::check_crate(&mut context, root_crate_id, false, false, false)?;
+        noirc_driver::check_crate(&mut context, root_crate_id, false, false, false, false)?;
 
     assert_eq!(warnings, Vec::new(), "stdlib is producing warnings");
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -293,7 +293,12 @@ impl DefCollector {
         if !skip_prelude {
             inject_prelude(crate_id, context, crate_root, &mut def_collector.imports);
             for submodule in submodules {
-                inject_prelude(crate_id, context, LocalModuleId(submodule), &mut def_collector.imports);
+                inject_prelude(
+                    crate_id,
+                    context,
+                    LocalModuleId(submodule),
+                    &mut def_collector.imports,
+                );
             }
         }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -237,6 +237,7 @@ impl DefCollector {
         ast: SortedModule,
         root_file_id: FileId,
         use_elaborator: bool,
+        skip_prelude: bool,
         macro_processors: &[&dyn MacroProcessor],
     ) -> Vec<(CompilationError, FileId)> {
         let mut errors: Vec<(CompilationError, FileId)> = vec![];
@@ -254,6 +255,7 @@ impl DefCollector {
                 dep.crate_id,
                 context,
                 use_elaborator,
+                skip_prelude,
                 macro_processors,
             ));
 
@@ -288,9 +290,11 @@ impl DefCollector {
         // Add the current crate to the collection of DefMaps
         context.def_maps.insert(crate_id, def_collector.def_map);
 
-        inject_prelude(crate_id, context, crate_root, &mut def_collector.imports);
-        for submodule in submodules {
-            inject_prelude(crate_id, context, LocalModuleId(submodule), &mut def_collector.imports);
+        if !skip_prelude {
+            inject_prelude(crate_id, context, crate_root, &mut def_collector.imports);
+            for submodule in submodules {
+                inject_prelude(crate_id, context, LocalModuleId(submodule), &mut def_collector.imports);
+            }
         }
 
         // Resolve unresolved imports collected from the crate, one by one.

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -74,6 +74,7 @@ impl CrateDefMap {
         crate_id: CrateId,
         context: &mut Context,
         use_elaborator: bool,
+        skip_prelude: bool,
         macro_processors: &[&dyn MacroProcessor],
     ) -> Vec<(CompilationError, FileId)> {
         // Check if this Crate has already been compiled
@@ -123,6 +124,7 @@ impl CrateDefMap {
             ast,
             root_file_id,
             use_elaborator,
+            skip_prelude,
             macro_processors,
         ));
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -82,6 +82,7 @@ pub(crate) fn get_program(src: &str) -> (ParsedModule, Context, Vec<(Compilation
             program.clone().into_sorted(),
             root_file_id,
             false,
+            false,
             &[], // No macro processors
         ));
     }

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -345,7 +345,7 @@ fn prepare_package_from_source_string() {
     let mut state = LspState::new(&client, acvm::blackbox_solver::StubbedBlackBoxSolver);
 
     let (mut context, crate_id) = crate::prepare_source(source.to_string(), &mut state);
-    let _check_result = noirc_driver::check_crate(&mut context, crate_id, false, false, false);
+    let _check_result = noirc_driver::check_crate(&mut context, crate_id, false, false, false, false);
     let main_func_id = context.get_main_function(&crate_id);
     assert!(main_func_id.is_some());
 }

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -345,7 +345,8 @@ fn prepare_package_from_source_string() {
     let mut state = LspState::new(&client, acvm::blackbox_solver::StubbedBlackBoxSolver);
 
     let (mut context, crate_id) = crate::prepare_source(source.to_string(), &mut state);
-    let _check_result = noirc_driver::check_crate(&mut context, crate_id, false, false, false, false);
+    let _check_result =
+        noirc_driver::check_crate(&mut context, crate_id, false, false, false, false);
     let main_func_id = context.get_main_function(&crate_id);
     assert!(main_func_id.is_some());
 }

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -139,10 +139,11 @@ fn process_noir_document(
             let (mut context, crate_id) =
                 prepare_package(&workspace_file_manager, &parsed_files, package);
 
-            let file_diagnostics = match check_crate(&mut context, crate_id, false, false, false, false) {
-                Ok(((), warnings)) => warnings,
-                Err(errors_and_warnings) => errors_and_warnings,
-            };
+            let file_diagnostics =
+                match check_crate(&mut context, crate_id, false, false, false, false) {
+                    Ok(((), warnings)) => warnings,
+                    Err(errors_and_warnings) => errors_and_warnings,
+                };
 
             let package_root_dir: String = package.root_dir.as_os_str().to_string_lossy().into();
 

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -56,7 +56,7 @@ pub(super) fn on_did_change_text_document(
     state.input_files.insert(params.text_document.uri.to_string(), text.clone());
 
     let (mut context, crate_id) = prepare_source(text, state);
-    let _ = check_crate(&mut context, crate_id, false, false, false);
+    let _ = check_crate(&mut context, crate_id, false, false, false, false);
 
     let workspace = match resolve_workspace_for_source_path(
         params.text_document.uri.to_file_path().unwrap().as_path(),
@@ -139,7 +139,7 @@ fn process_noir_document(
             let (mut context, crate_id) =
                 prepare_package(&workspace_file_manager, &parsed_files, package);
 
-            let file_diagnostics = match check_crate(&mut context, crate_id, false, false, false) {
+            let file_diagnostics = match check_crate(&mut context, crate_id, false, false, false, false) {
                 Ok(((), warnings)) => warnings,
                 Err(errors_and_warnings) => errors_and_warnings,
             };

--- a/tooling/lsp/src/requests/code_lens_request.rs
+++ b/tooling/lsp/src/requests/code_lens_request.rs
@@ -67,7 +67,7 @@ fn on_code_lens_request_inner(
     let (mut context, crate_id) = prepare_source(source_string, state);
     // We ignore the warnings and errors produced by compilation for producing code lenses
     // because we can still get the test functions even if compilation fails
-    let _ = check_crate(&mut context, crate_id, false, false, false);
+    let _ = check_crate(&mut context, crate_id, false, false, false, false);
 
     let collected_lenses =
         collect_lenses_for_package(&context, crate_id, &workspace, package, None);

--- a/tooling/lsp/src/requests/goto_declaration.rs
+++ b/tooling/lsp/src/requests/goto_declaration.rs
@@ -46,7 +46,7 @@ fn on_goto_definition_inner(
         interner = def_interner;
     } else {
         // We ignore the warnings and errors produced by compilation while resolving the definition
-        let _ = noirc_driver::check_crate(&mut context, crate_id, false, false, false);
+        let _ = noirc_driver::check_crate(&mut context, crate_id, false, false, false, false);
         interner = &context.def_interner;
     }
 

--- a/tooling/lsp/src/requests/goto_definition.rs
+++ b/tooling/lsp/src/requests/goto_definition.rs
@@ -54,7 +54,7 @@ fn on_goto_definition_inner(
         interner = def_interner;
     } else {
         // We ignore the warnings and errors produced by compilation while resolving the definition
-        let _ = noirc_driver::check_crate(&mut context, crate_id, false, false, false);
+        let _ = noirc_driver::check_crate(&mut context, crate_id, false, false, false, false);
         interner = &context.def_interner;
     }
 

--- a/tooling/lsp/src/requests/test_run.rs
+++ b/tooling/lsp/src/requests/test_run.rs
@@ -60,7 +60,7 @@ fn on_test_run_request_inner(
         Some(package) => {
             let (mut context, crate_id) =
                 prepare_package(&workspace_file_manager, &parsed_files, package);
-            if check_crate(&mut context, crate_id, false, false, false).is_err() {
+            if check_crate(&mut context, crate_id, false, false, false, false).is_err() {
                 let result = NargoTestRunResult {
                     id: params.id.clone(),
                     result: "error".to_string(),

--- a/tooling/lsp/src/requests/tests.rs
+++ b/tooling/lsp/src/requests/tests.rs
@@ -61,7 +61,7 @@ fn on_tests_request_inner(
                 prepare_package(&workspace_file_manager, &parsed_files, package);
             // We ignore the warnings and errors produced by compilation for producing tests
             // because we can still get the test functions even if compilation fails
-            let _ = check_crate(&mut context, crate_id, false, false, false);
+            let _ = check_crate(&mut context, crate_id, false, false, false, false);
 
             // We don't add test headings for a package if it contains no `#[test]` functions
             get_package_tests_in_crate(&context, &crate_id, &package.name)

--- a/tooling/nargo_cli/src/cli/check_cmd.rs
+++ b/tooling/nargo_cli/src/cli/check_cmd.rs
@@ -178,7 +178,8 @@ pub(crate) fn check_crate_and_report_errors(
     use_elaborator: bool,
     skip_prelude: bool,
 ) -> Result<(), CompileError> {
-    let result = check_crate(context, crate_id, deny_warnings, disable_macros, use_elaborator, skip_prelude);
+    let result =
+        check_crate(context, crate_id, deny_warnings, disable_macros, use_elaborator, skip_prelude);
     report_errors(result, &context.file_manager, deny_warnings, silence_warnings)
 }
 

--- a/tooling/nargo_cli/src/cli/check_cmd.rs
+++ b/tooling/nargo_cli/src/cli/check_cmd.rs
@@ -88,6 +88,7 @@ fn check_package(
         compile_options.disable_macros,
         compile_options.silence_warnings,
         compile_options.use_elaborator,
+        compile_options.skip_prelude,
     )?;
 
     if package.is_library() || package.is_contract() {
@@ -175,8 +176,9 @@ pub(crate) fn check_crate_and_report_errors(
     disable_macros: bool,
     silence_warnings: bool,
     use_elaborator: bool,
+    skip_prelude: bool,
 ) -> Result<(), CompileError> {
-    let result = check_crate(context, crate_id, deny_warnings, disable_macros, use_elaborator);
+    let result = check_crate(context, crate_id, deny_warnings, disable_macros, use_elaborator, skip_prelude);
     report_errors(result, &context.file_manager, deny_warnings, silence_warnings)
 }
 

--- a/tooling/nargo_cli/src/cli/export_cmd.rs
+++ b/tooling/nargo_cli/src/cli/export_cmd.rs
@@ -90,6 +90,7 @@ fn compile_exported_functions(
         compile_options.disable_macros,
         compile_options.silence_warnings,
         compile_options.use_elaborator,
+        compile_options.skip_prelude,
     )?;
 
     let exported_functions = context.get_all_exported_functions_in_crate(&crate_id);

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -176,6 +176,7 @@ fn run_test<S: BlackBoxFunctionSolver + Default>(
         compile_options.deny_warnings,
         compile_options.disable_macros,
         compile_options.use_elaborator,
+        compile_options.skip_prelude,
     )
     .expect("Any errors should have occurred when collecting test functions");
 
@@ -210,6 +211,7 @@ fn get_tests_in_package(
         compile_options.disable_macros,
         compile_options.silence_warnings,
         compile_options.use_elaborator,
+        compile_options.skip_prelude,
     )?;
 
     Ok(context

--- a/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -29,7 +29,7 @@ fn run_stdlib_tests(use_elaborator: bool) {
     let (mut context, dummy_crate_id) =
         prepare_package(&file_manager, &parsed_files, &dummy_package);
 
-    let result = check_crate(&mut context, dummy_crate_id, true, false, use_elaborator);
+    let result = check_crate(&mut context, dummy_crate_id, true, false, use_elaborator, false);
     report_errors(result, &context.file_manager, true, false)
         .expect("Error encountered while compiling standard library");
 


### PR DESCRIPTION
# Description

## Problem\*

Usually, when debugging programs, they can be converted to a `noirc_frontend/tests.rs` test with or without including the stdlib/prelude.

However, workspace and multi-file-specific cases can be tedious to debug when the failing file has ~10 LOC and most of the context / parsing / type checking / etc. is all stdlib.

## Summary\*

Adds `--skip-prelude` flag to skip calling `inject_prelude` when collecting definitions.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
