### PR TITLE
chore: use `bbup` to install `bb`

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -402,8 +402,7 @@ jobs:
       - name: Install `bb`
         run: |
           ./scripts/install_bb.sh
-          echo "$HOME/.barretenberg/" >> $GITHUB_PATH
-          export PATH="$PATH:$HOME/.barretenberg/"
+          echo "$HOME/.bb/" >> $GITHUB_PATH
 
       - name: Download nargo binary
         uses: actions/download-artifact@v4
@@ -512,8 +511,7 @@ jobs:
       - name: Install `bb`
         run: |
           ./scripts/install_bb.sh
-          echo "$HOME/.barretenberg/" >> $GITHUB_PATH
-          export PATH="$PATH:$HOME/.barretenberg/"
+          echo "$HOME/.bb/" >> $GITHUB_PATH
 
       - name: Download nargo binary
         uses: actions/download-artifact@v4

--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,7 @@
         "barebones",
         "barretenberg",
         "barustenberg",
+        "bbup",
         "bincode",
         "bindgen",
         "bitand",

--- a/docs/docs/getting_started/barretenberg/index.md
+++ b/docs/docs/getting_started/barretenberg/index.md
@@ -23,31 +23,25 @@ Open a terminal on your machine, and write:
 ##### macOS (Apple Silicon)
 
 ```bash
-mkdir -p $HOME/.barretenberg && \
-curl -o ./barretenberg-aarch64-apple-darwin.tar.gz -L https://github.com/AztecProtocol/aztec-packages/releases/download/aztec-packages-v0.38.0/barretenberg-aarch64-apple-darwin.tar.gz && \
-tar -xvf ./barretenberg-aarch64-apple-darwin.tar.gz -C $HOME/.barretenberg/ && \
-echo 'export PATH=$PATH:$HOME/.barretenberg/' >> ~/.zshrc && \
+curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/master/barretenberg/cpp/installation/install | bash
 source ~/.zshrc
+bbup -v 0.41.0
 ```
 
 ##### macOS (Intel)
 
 ```bash
-mkdir -p $HOME/.barretenberg && \
-curl -o ./barretenberg-x86_64-apple-darwin.tar.gz -L https://github.com/AztecProtocol/aztec-packages/releases/download/aztec-packages-v0.38.0/barretenberg-x86_64-apple-darwin.tar.gz && \
-tar -xvf ./barretenberg-x86_64-apple-darwin.tar.gz -C $HOME/.barretenberg/ && \
-echo 'export PATH=$PATH:$HOME/.barretenberg/' >> ~/.zshrc && \
+curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/master/barretenberg/cpp/installation/install | bash
 source ~/.zshrc
+bbup -v 0.41.0
 ```
 
 ##### Linux (Bash)
 
 ```bash
-mkdir -p $HOME/.barretenberg && \
-curl -o ./barretenberg-x86_64-linux-gnu.tar.gz -L https://github.com/AztecProtocol/aztec-packages/releases/download/aztec-packages-v0.38.0/barretenberg-x86_64-linux-gnu.tar.gz && \
-tar -xvf ./barretenberg-x86_64-linux-gnu.tar.gz -C $HOME/.barretenberg/ && \
-echo -e 'export PATH=$PATH:$HOME/.barretenberg/' >> ~/.bashrc && \
+curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/master/barretenberg/cpp/installation/install | bash
 source ~/.bashrc
+bbup -v 0.41.0
 ```
 
 Now we're ready to start working on [our first Noir program!](../hello_noir/index.md)

--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# We use this script just for CI so we assume we're running on x86 linux
+VERSION="0.41.0"
 
-mkdir -p $HOME/.barretenberg
-curl -o ./barretenberg-x86_64-linux-gnu.tar.gz -L https://github.com/AztecProtocol/aztec-packages/releases/download/aztec-packages-v0.41.0/barretenberg-x86_64-linux-gnu.tar.gz
-tar -xvf ./barretenberg-x86_64-linux-gnu.tar.gz -C $HOME/.barretenberg/
-echo 'export PATH=$PATH:$HOME/.barretenberg/' >> ~/.bashrc
-source ~/.bashrc
+BBUP_PATH=~/.bb/bbup
+
+if ! [ -f $BBUP_PATH ]; then 
+    curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/master/barretenberg/cpp/installation/install | bash
+fi
+
+$BBUP_PATH -v $VERSION


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

`bbup` is now in master so we can use it to install `bb`

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
