### PR TITLE
feat: Activate return_data in ACIR opcodes

### DIFF
--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -18,6 +18,12 @@ pub enum BlockType {
     ReturnData,
 }
 
+impl BlockType {
+    pub fn is_databus(&self) -> bool {
+        matches!(self, BlockType::CallData | BlockType::ReturnData)
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Opcode {

--- a/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
@@ -44,8 +44,9 @@ impl UnusedMemoryOptimizer {
         let mut optimized_opcodes = Vec::with_capacity(self.circuit.opcodes.len());
         for (idx, opcode) in self.circuit.opcodes.into_iter().enumerate() {
             match opcode {
-                Opcode::MemoryInit { block_id, .. }
-                    if self.unused_memory_initializations.contains(&block_id) =>
+                Opcode::MemoryInit { block_id, block_type, .. }
+                    if !block_type.is_databus()
+                        && self.unused_memory_initializations.contains(&block_id) =>
                 {
                     // Drop opcode
                 }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -1728,7 +1728,7 @@ impl<'a> Context<'a> {
         &mut self,
         terminator: &TerminatorInstruction,
         dfg: &DataFlowGraph,
-    ) -> Result<Vec<SsaReport>, InternalError> {
+    ) -> Result<Vec<SsaReport>, RuntimeError> {
         let (return_values, call_stack) = match terminator {
             TerminatorInstruction::Return { return_values, call_stack } => {
                 (return_values, call_stack)
@@ -1750,6 +1750,8 @@ impl<'a> Context<'a> {
             if !is_databus {
                 // We do not return value for the data bus.
                 self.acir_context.return_var(acir_var)?;
+            } else {
+                self.check_array_is_initialized(self.data_bus.return_data.unwrap(), dfg)?;
             }
         }
         Ok(warnings)


### PR DESCRIPTION
# Description

## Problem\*

Related to #4974

## Summary\*
This PR mark return data array with return_data block type, and disable the unused arrays optimisation for databus.
This is required because the return_data is not returned from main although similar constraints will be generated on the backend side.


## Additional Context
This should be the last piece for this databus iteration from issue #4974, and it will allow to generate an end-to-end test with the databus to check if we get what is expected.


## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [X] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
