### PR TITLE
chore: automatically clear any unwanted directories in `test_programs`

### DIFF
--- a/test_programs/rebuild.sh
+++ b/test_programs/rebuild.sh
@@ -8,6 +8,14 @@ process_dir() {
     local current_dir=$2
     local dir_name=$(basename "$dir")
 
+    if [[ ! -f "$dir/Nargo.toml" ]]; then
+      # This directory isn't a proper test but just hold some stale build artifacts
+      # We then delete it and carry on.
+      rm -rf $dir
+      return 0
+    fi
+
+
     if [[ ! -d "$current_dir/acir_artifacts/$dir_name" ]]; then
       mkdir -p $current_dir/acir_artifacts/$dir_name
     fi

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -102,7 +102,8 @@ pub(crate) fn run(args: InfoCommand, config: NargoConfig) -> Result<(), CliError
     } else {
         // Otherwise print human-readable table.
         if !info_report.programs.is_empty() {
-            let mut program_table = table!([Fm->"Package", Fm->"Function", Fm->"Expression Width", Fm->"ACIR Opcodes"]);
+            let mut program_table =
+                table!([Fm->"Package", Fm->"Function", Fm->"Expression Width", Fm->"ACIR Opcodes"]);
 
             for program_info in info_report.programs {
                 let program_rows: Vec<Row> = program_info.into();


### PR DESCRIPTION
# Description

## Problem\*

Closes #5035

## Summary\*

Alternative to #5035 which just deletes any test programs which don't have a Nargo.toml file.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
