### PR TITLE
chore: Move turbofish changes to the elaborator

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -345,7 +345,8 @@ impl<'context> Elaborator<'context> {
                     self.interner,
                 );
 
-                let func_type = self.type_check_variable(function_name, function_id, turbofish_generics);
+                let func_type =
+                    self.type_check_variable(function_name, function_id, turbofish_generics);
 
                 // Type check the new call now that it has been changed from a method call
                 // to a function call. This way we avoid duplicating code.

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -194,7 +194,7 @@ impl<'context> Elaborator<'context> {
                 let expr_id = self.interner.push_expr(ident);
                 self.interner.push_expr_location(expr_id, call_expr_span, self.file);
                 let ident = old_value.ident.clone();
-                let typ = self.type_check_variable(ident, expr_id);
+                let typ = self.type_check_variable(ident, expr_id, None);
                 self.interner.push_expr_type(expr_id, typ.clone());
                 capture_types.push(typ);
                 fmt_str_idents.push(expr_id);
@@ -291,16 +291,25 @@ impl<'context> Elaborator<'context> {
             Some(method_ref) => {
                 // Automatically add `&mut` if the method expects a mutable reference and
                 // the object is not already one.
-                if let HirMethodReference::FuncId(func_id) = &method_ref {
-                    if *func_id != FuncId::dummy_id() {
-                        let function_type = self.interner.function_meta(func_id).typ.clone();
-
-                        self.try_add_mutable_reference_to_object(
-                            &function_type,
-                            &mut object_type,
-                            &mut object,
-                        );
+                let func_id = match &method_ref {
+                    HirMethodReference::FuncId(func_id) => *func_id,
+                    HirMethodReference::TraitMethodId(method_id, _) => {
+                        let id = self.interner.trait_method_id(*method_id);
+                        let definition = self.interner.definition(id);
+                        let DefinitionKind::Function(func_id) = definition.kind else {
+                            unreachable!("Expected trait function to be a DefinitionKind::Function")
+                        };
+                        func_id
                     }
+                };
+
+                if *func_id != FuncId::dummy_id() {
+                    let function_type = self.interner.function_meta(&func_id).typ.clone();
+                    self.try_add_mutable_reference_to_object(
+                        &function_type,
+                        &mut object_type,
+                        &mut object,
+                    );
                 }
 
                 // These arguments will be given to the desugared function call.
@@ -335,7 +344,7 @@ impl<'context> Elaborator<'context> {
                     self.interner,
                 );
 
-                let func_type = self.type_check_variable(function_name, function_id);
+                let func_type = self.type_check_variable(function_name, function_id, method_call.generics);
 
                 // Type check the new call now that it has been changed from a method call
                 // to a function call. This way we avoid duplicating code.

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -331,13 +331,9 @@ impl<'context> Elaborator<'context> {
                 let generics = method_call.generics.map(|option_inner| {
                     option_inner.into_iter().map(|generic| self.resolve_type(generic)).collect()
                 });
-                let method_call = HirMethodCallExpression {
-                    method,
-                    object,
-                    arguments,
-                    location,
-                    generics: generics.clone(),
-                };
+                let turbofish_generics = generics.clone();
+                let method_call =
+                    HirMethodCallExpression { method, object, arguments, location, generics };
 
                 // Desugar the method call into a normal, resolved function call
                 // so that the backend doesn't need to worry about methods

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -303,7 +303,7 @@ impl<'context> Elaborator<'context> {
                     }
                 };
 
-                if *func_id != FuncId::dummy_id() {
+                if func_id != FuncId::dummy_id() {
                     let function_type = self.interner.function_meta(&func_id).typ.clone();
                     self.try_add_mutable_reference_to_object(
                         &function_type,
@@ -331,8 +331,13 @@ impl<'context> Elaborator<'context> {
                 let generics = method_call.generics.map(|option_inner| {
                     option_inner.into_iter().map(|generic| self.resolve_type(generic)).collect()
                 });
-                let method_call =
-                    HirMethodCallExpression { method, object, arguments, location, generics };
+                let method_call = HirMethodCallExpression {
+                    method,
+                    object,
+                    arguments,
+                    location,
+                    generics: generics.clone(),
+                };
 
                 // Desugar the method call into a normal, resolved function call
                 // so that the backend doesn't need to worry about methods
@@ -344,7 +349,7 @@ impl<'context> Elaborator<'context> {
                     self.interner,
                 );
 
-                let func_type = self.type_check_variable(function_name, function_id, method_call.generics);
+                let func_type = self.type_check_variable(function_name, function_id, generics);
 
                 // Type check the new call now that it has been changed from a method call
                 // to a function call. This way we avoid duplicating code.

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -345,7 +345,7 @@ impl<'context> Elaborator<'context> {
                     self.interner,
                 );
 
-                let func_type = self.type_check_variable(function_name, function_id, generics);
+                let func_type = self.type_check_variable(function_name, function_id, turbofish_generics);
 
                 // Type check the new call now that it has been changed from a method call
                 // to a function call. This way we avoid duplicating code.

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -486,16 +486,12 @@ impl<'context> Elaborator<'context> {
         match turbofish_generics {
             Some(turbofish_generics) => {
                 if turbofish_generics.len() != function_generic_count {
-                    self.errors.push((
-                        CompilationError::TypeError(
-                            TypeCheckError::IncorrectTurbofishGenericCount {
-                                expected_count: function_generic_count,
-                                actual_count: turbofish_generics.len(),
-                                span,
-                            },
-                        ),
-                        location.file,
-                    ));
+                    let type_check_err = TypeCheckError::IncorrectTurbofishGenericCount {
+                        expected_count: function_generic_count,
+                        actual_count: turbofish_generics.len(),
+                        span,
+                    };
+                    self.errors.push((CompilationError::TypeError(type_check_err), location.file));
                     typ.instantiate_with_bindings(bindings, self.interner)
                 } else {
                     // Fetch the count of any implicit generics on the function, such as

--- a/compiler/noirc_frontend/src/hir/type_check/expr.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/expr.rs
@@ -399,8 +399,6 @@ impl<'interner> TypeChecker<'interner> {
         // variable to handle generic functions.
         let t = self.interner.id_type_substitute_trait_as_type(ident.id);
 
-        let span = self.interner.expr_span(expr_id);
-
         let definition = self.interner.try_definition(ident.id);
         let function_generic_count = definition.map_or(0, |definition| match &definition.kind {
             DefinitionKind::Function(function) => {
@@ -409,6 +407,7 @@ impl<'interner> TypeChecker<'interner> {
             _ => 0,
         });
 
+        let span = self.interner.expr_span(expr_id);
         // This instantiates a trait's generics as well which need to be set
         // when the constraint below is later solved for when the function is
         // finished. How to link the two?


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Moving https://github.com/noir-lang/noir/pull/3542, https://github.com/noir-lang/noir/pull/5041, and https://github.com/noir-lang/noir/pull/5087 to the elaborator 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
