### PR TITLE
fix(experimental elaborator): Don't check return type for trait methods

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -184,7 +184,7 @@ impl<'context> Elaborator<'context> {
         };
 
         let mut function = NoirFunction { kind, def };
-        self.define_function_meta(&mut function, func_id);
+        self.define_function_meta(&mut function, func_id, true);
         self.elaborate_function(function, func_id);
         let _ = self.scopes.end_function();
         // Don't check the scope tree for unused variables, they can't be used in a declaration anyway.

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -1107,6 +1107,7 @@ impl<'a> Resolver<'a> {
 
             // This is only used by the elaborator
             all_generics: Vec::new(),
+            is_trait_function: false,
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -49,7 +49,7 @@ pub struct TypeChecker<'interner> {
 pub fn type_check_func(interner: &mut NodeInterner, func_id: FuncId) -> Vec<TypeCheckError> {
     let meta = interner.function_meta(&func_id);
     let declared_return_type = meta.return_type().clone();
-    let can_ignore_ret = meta.can_ignore_return_type();
+    let can_ignore_ret = meta.is_stub();
 
     let function_body_id = &interner.function(&func_id).as_expr();
 
@@ -549,6 +549,7 @@ pub mod test {
             trait_constraints: Vec::new(),
             direct_generics: Vec::new(),
             is_entry_point: true,
+            is_trait_function: false,
             has_inline_attribute: false,
             all_generics: Vec::new(),
         };

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -129,6 +129,11 @@ pub struct FuncMeta {
     /// For non-contracts, this means the function is `main`.
     pub is_entry_point: bool,
 
+    /// True if this function was defined within a trait (not a trait impl!).
+    /// Trait functions are just stubs and shouldn't have their return type checked
+    /// against their body type, nor should unused variables be checked.
+    pub is_trait_function: bool,
+
     /// True if this function is marked with an attribute
     /// that indicates it should be inlined differently than the default (inline everything).
     /// For example, such as `fold` (never inlined) or `no_predicates` (inlined after flattening)
@@ -136,12 +141,13 @@ pub struct FuncMeta {
 }
 
 impl FuncMeta {
-    /// Builtin, LowLevel and Oracle functions usually have the return type
-    /// declared, however their function bodies will be empty
-    /// So this method tells the type checker to ignore the return
-    /// of the empty function, which is unit
-    pub fn can_ignore_return_type(&self) -> bool {
-        self.kind.can_ignore_return_type()
+    /// A stub function does not have a body. This includes Builtin, LowLevel,
+    /// and Oracle functions in addition to method declarations within a trait.
+    ///
+    /// We don't check the return type of these functions since it will always have
+    /// an empty body, and we don't check for unused parameters.
+    pub fn is_stub(&self) -> bool {
+        self.kind.can_ignore_return_type() || self.is_trait_function
     }
 
     pub fn function_signature(&self) -> FunctionSignature {


### PR DESCRIPTION
# Description

## Problem\*

Resolves some errors in the elaborator from checking a trait method's empty body against the expected type that was declared.

## Summary\*

Adds whether or not a function is a trait method (not a trait impl method) to the `is_stub` method which is just a renamed `can_ignore_return_type`.

## Additional Context

Down to 203 errors in the stdlib.

This also fixes unused variable warnings that were present before but not shown in the error count.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
