### PR TITLE
chore: Avoid creating witness for simple multiplications

### DIFF
--- a/acvm-repo/acvm/src/compiler/transformers/csat.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/csat.rs
@@ -210,16 +210,16 @@ impl CSatTransformer {
                             }
                         } else {
                             // No more usable elements left in the old opcode
-                            opcode.linear_combinations = remaining_linear_terms;
                             break;
                         }
                     }
+                    opcode.linear_combinations.extend(remaining_linear_terms);
+
                     // Constraint this intermediate_opcode to be equal to the temp variable by adding it into the IndexMap
                     // We need a unique name for our intermediate variable
                     // XXX: Another optimization, which could be applied in another algorithm
                     // If two opcodes have a large fan-in/out and they share a few common terms, then we should create intermediate variables for them
                     // Do some sort of subset matching algorithm for this on the terms of the polynomial
-
                     let inter_var = Self::get_or_create_intermediate_vars(
                         intermediate_variables,
                         intermediate_opcode,


### PR DESCRIPTION
# Description

## Problem\*

Related to  #4629

## Summary\*
Do not create a witness when multiplying a witness (or an affine transformation of a witness) with an expression of degree 1.


## Additional Context
This PR does NOT fix the issue #4629, but it should help reducing the overall gates number.
The arithmetic expressions resulting from the multiplication should not explode in width since I only consider multiplication with a witness (or 'affine witness').

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
