### PR TITLE
fix(experimental elaborator): Avoid defining globals twice

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -154,9 +154,6 @@ impl<'context> Elaborator<'context> {
         let old_generic_count = self.generics.len();
         self.scopes.start_function();
 
-        // Check whether the function has globals in the local module and add them to the scope
-        self.resolve_local_globals();
-
         self.trait_bounds = where_clause.to_vec();
 
         let kind = FunctionKind::Normal;


### PR DESCRIPTION
# Description

## Problem\*

Fixes the "Duplicate definitions of <global> found" error by removing `resolve_local_globals`.

## Summary\*



## Additional Context

We don't need to re-add globals to scope anymore via `resolve_local_globals` since we're not creating a new Elaborator for each function like we do for NameResolvers. The flip side of this is that I think we'll need to change how globals are stored eventually so that they're not all always visible. I think how it is now may violate imports but I'll leave that for a later fix to keep these PRs small. (and wait until I have a test case that shows it).

Down to 61 errors after this PR. The errors are:
- "Duplicate definitions of \<generic> found" - looks to be only one case where there is a generic directly on a trait method. `fn hash<H>(self, state: &mut H) where H: Hasher;`
- "Expression type is ambiguous" - from the two turbofish cases that haven't been merged in this branch yet
- "Expected type &mut _, found type H" - issues with auto-deref and trait methods possibly
- "No matching impl found for ..." - trait solver issues

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
