### PR TITLE
feat: make ACVM generic across fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ version = "0.46.0"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
+ "ark-bls12-381",
  "brillig_vm",
  "indexmap 1.9.3",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "aztec_macros"
 version = "0.30.0"
 dependencies = [
+ "acvm",
  "convert_case 0.6.0",
  "iter-extended",
  "noirc_errors",

--- a/acvm-repo/acir/Cargo.toml
+++ b/acvm-repo/acir/Cargo.toml
@@ -33,9 +33,8 @@ criterion.workspace = true
 pprof.workspace = true
 
 [features]
-default = ["bn254"]
-bn254 = ["acir_field/bn254", "brillig/bn254"]
-bls12_381 = ["acir_field/bls12_381", "brillig/bls12_381"]
+bn254 = ["acir_field/bn254"]
+bls12_381 = ["acir_field/bls12_381"]
 
 [[bench]]
 name = "serialization"

--- a/acvm-repo/acir/benches/serialization.rs
+++ b/acvm-repo/acir/benches/serialization.rs
@@ -11,8 +11,8 @@ use pprof::criterion::{Output, PProfProfiler};
 
 const SIZES: [usize; 9] = [10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000];
 
-fn sample_program(num_opcodes: usize) -> Program {
-    let assert_zero_opcodes: Vec<Opcode> = (0..num_opcodes)
+fn sample_program(num_opcodes: usize) -> Program<FieldElement> {
+    let assert_zero_opcodes: Vec<Opcode<_>> = (0..num_opcodes)
         .map(|i| {
             Opcode::AssertZero(Expression {
                 mul_terms: vec![(
@@ -83,7 +83,7 @@ fn bench_deserialization(c: &mut Criterion) {
             BenchmarkId::from_parameter(size),
             &serialized_program,
             |b, program| {
-                b.iter(|| Program::deserialize_program(program));
+                b.iter(|| Program::<FieldElement>::deserialize_program(program));
             },
         );
     }
@@ -107,7 +107,7 @@ fn bench_deserialization(c: &mut Criterion) {
             |b, program| {
                 b.iter(|| {
                     let mut deserializer = serde_json::Deserializer::from_slice(program);
-                    Program::deserialize_program_base64(&mut deserializer)
+                    Program::<FieldElement>::deserialize_program_base64(&mut deserializer)
                 });
             },
         );

--- a/acvm-repo/acir/src/circuit/brillig.rs
+++ b/acvm-repo/acir/src/circuit/brillig.rs
@@ -24,6 +24,6 @@ pub enum BrilligOutputs {
 /// a full Brillig function to be executed by the Brillig VM.
 /// This is stored separately on a program and accessed through a [BrilligPointer].
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default, Debug)]
-pub struct BrilligBytecode {
-    pub bytecode: Vec<BrilligOpcode>,
+pub struct BrilligBytecode<F> {
+    pub bytecode: Vec<BrilligOpcode<F>>,
 }

--- a/acvm-repo/acir/src/circuit/brillig.rs
+++ b/acvm-repo/acir/src/circuit/brillig.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 /// Inputs for the Brillig VM. These are the initial inputs
 /// that the Brillig VM will use to start.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-pub enum BrilligInputs {
-    Single(Expression),
-    Array(Vec<Expression>),
+pub enum BrilligInputs<F> {
+    Single(Expression<F>),
+    Array(Vec<Expression<F>>),
     MemoryArray(BlockId),
 }
 

--- a/acvm-repo/acir/src/circuit/directives.rs
+++ b/acvm-repo/acir/src/circuit/directives.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Directives do not apply any constraints.
 /// You can think of them as opcodes that allow one to use non-determinism
 /// In the future, this can be replaced with asm non-determinism blocks
-pub enum Directive {
+pub enum Directive<F> {
     //decomposition of a: a=\sum b[i]*radix^i where b is an array of witnesses < radix in little endian form
-    ToLeRadix { a: Expression, b: Vec<Witness>, radix: u32 },
+    ToLeRadix { a: Expression<F>, b: Vec<Witness>, radix: u32 },
 }

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -365,7 +365,7 @@ mod tests {
         circuit::{ExpressionWidth, Program},
         native_types::Witness,
     };
-    use acir_field::FieldElement;
+    use acir_field::{AcirField, FieldElement};
 
     fn and_opcode() -> Opcode {
         Opcode::BlackBoxFuncCall(BlackBoxFuncCall::AND {

--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -3,6 +3,7 @@ use super::{
     directives::Directive,
 };
 use crate::native_types::{Expression, Witness};
+use acir_field::AcirField;
 use serde::{Deserialize, Serialize};
 
 mod black_box_function_call;
@@ -26,19 +27,19 @@ impl BlockType {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Opcode {
-    AssertZero(Expression),
+pub enum Opcode<F> {
+    AssertZero(Expression<F>),
     /// Calls to "gadgets" which rely on backends implementing support for specialized constraints.
     ///
     /// Often used for exposing more efficient implementations of SNARK-unfriendly computations.  
     BlackBoxFuncCall(BlackBoxFuncCall),
-    Directive(Directive),
+    Directive(Directive<F>),
     /// Atomic operation on a block of memory
     MemoryOp {
         block_id: BlockId,
-        op: MemOp,
+        op: MemOp<F>,
         /// Predicate of the memory operation - indicates if it should be skipped
-        predicate: Option<Expression>,
+        predicate: Option<Expression<F>>,
     },
     MemoryInit {
         block_id: BlockId,
@@ -51,11 +52,11 @@ pub enum Opcode {
         /// to fetch the appropriate Brillig bytecode from this id.
         id: u32,
         /// Inputs to the function call
-        inputs: Vec<BrilligInputs>,
+        inputs: Vec<BrilligInputs<F>>,
         /// Outputs to the function call
         outputs: Vec<BrilligOutputs>,
         /// Predicate of the Brillig execution - indicates if it should be skipped
-        predicate: Option<Expression>,
+        predicate: Option<Expression<F>>,
     },
     /// Calls to functions represented as a separate circuit. A call opcode allows us
     /// to build a call stack when executing the outer-most circuit.
@@ -68,11 +69,11 @@ pub enum Opcode {
         /// Outputs of the function call
         outputs: Vec<Witness>,
         /// Predicate of the circuit execution - indicates if it should be skipped
-        predicate: Option<Expression>,
+        predicate: Option<Expression<F>>,
     },
 }
 
-impl std::fmt::Display for Opcode {
+impl<F: AcirField> std::fmt::Display for Opcode<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Opcode::AssertZero(expr) => {
@@ -147,7 +148,7 @@ impl std::fmt::Display for Opcode {
     }
 }
 
-impl std::fmt::Debug for Opcode {
+impl<F: AcirField> std::fmt::Debug for Opcode<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
     }

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -481,7 +481,7 @@ where
 mod tests {
 
     use crate::{circuit::Opcode, native_types::Witness};
-    use acir_field::FieldElement;
+    use acir_field::{AcirField, FieldElement};
 
     use super::{BlackBoxFuncCall, FunctionInput};
 

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -485,7 +485,7 @@ mod tests {
 
     use super::{BlackBoxFuncCall, FunctionInput};
 
-    fn keccakf1600_opcode() -> Opcode {
+    fn keccakf1600_opcode<F: AcirField>() -> Opcode<F> {
         let inputs: Box<[FunctionInput; 25]> = Box::new(std::array::from_fn(|i| FunctionInput {
             witness: Witness(i as u32 + 1),
             num_bits: 8,
@@ -494,7 +494,7 @@ mod tests {
 
         Opcode::BlackBoxFuncCall(BlackBoxFuncCall::Keccakf1600 { inputs, outputs })
     }
-    fn schnorr_verify_opcode() -> Opcode {
+    fn schnorr_verify_opcode<F: AcirField>() -> Opcode<F> {
         let public_key_x =
             FunctionInput { witness: Witness(1), num_bits: FieldElement::max_num_bits() };
         let public_key_y =
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn keccakf1600_serialization_roundtrip() {
-        let opcode = keccakf1600_opcode();
+        let opcode = keccakf1600_opcode::<FieldElement>();
         let buf = bincode::serialize(&opcode).unwrap();
         let recovered_opcode = bincode::deserialize(&buf).unwrap();
         assert_eq!(opcode, recovered_opcode);
@@ -524,7 +524,7 @@ mod tests {
 
     #[test]
     fn schnorr_serialization_roundtrip() {
-        let opcode = schnorr_verify_opcode();
+        let opcode = schnorr_verify_opcode::<FieldElement>();
         let buf = bincode::serialize(&opcode).unwrap();
         let recovered_opcode = bincode::deserialize(&buf).unwrap();
         assert_eq!(opcode, recovered_opcode);

--- a/acvm-repo/acir/src/circuit/opcodes/memory_operation.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/memory_operation.rs
@@ -1,4 +1,5 @@
 use crate::native_types::{Expression, Witness};
+use acir_field::AcirField;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash, Copy, Default)]
@@ -7,22 +8,22 @@ pub struct BlockId(pub u32);
 /// Operation on a block of memory
 /// We can either write or read at an index in memory
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-pub struct MemOp {
+pub struct MemOp<F> {
     /// Can be 0 (read) or 1 (write)
-    pub operation: Expression,
-    pub index: Expression,
-    pub value: Expression,
+    pub operation: Expression<F>,
+    pub index: Expression<F>,
+    pub value: Expression<F>,
 }
 
-impl MemOp {
+impl<F: AcirField> MemOp<F> {
     /// Creates a `MemOp` which reads from memory at `index` and inserts the read value
     /// into the [`WitnessMap`][crate::native_types::WitnessMap] at `witness`
-    pub fn read_at_mem_index(index: Expression, witness: Witness) -> Self {
+    pub fn read_at_mem_index(index: Expression<F>, witness: Witness) -> Self {
         MemOp { operation: Expression::zero(), index, value: witness.into() }
     }
 
     /// Creates a `MemOp` which writes the [`Expression`] `value` into memory at `index`.
-    pub fn write_to_mem_index(index: Expression, value: Expression) -> Self {
+    pub fn write_to_mem_index(index: Expression<F>, value: Expression<F>) -> Self {
         MemOp { operation: Expression::one(), index, value }
     }
 }

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -31,6 +31,7 @@ mod reflection {
         path::{Path, PathBuf},
     };
 
+    use acir_field::FieldElement;
     use brillig::{
         BinaryFieldOp, BinaryIntOp, BlackBoxOp, HeapValueType, Opcode as BrilligOpcode,
         ValueOrArray,
@@ -61,23 +62,23 @@ mod reflection {
 
         let mut tracer = Tracer::new(TracerConfig::default());
         tracer.trace_simple_type::<BlockType>().unwrap();
-        tracer.trace_simple_type::<Program>().unwrap();
-        tracer.trace_simple_type::<Circuit>().unwrap();
+        tracer.trace_simple_type::<Program<FieldElement>>().unwrap();
+        tracer.trace_simple_type::<Circuit<FieldElement>>().unwrap();
         tracer.trace_simple_type::<ExpressionWidth>().unwrap();
-        tracer.trace_simple_type::<Opcode>().unwrap();
+        tracer.trace_simple_type::<Opcode<FieldElement>>().unwrap();
         tracer.trace_simple_type::<OpcodeLocation>().unwrap();
         tracer.trace_simple_type::<BinaryFieldOp>().unwrap();
         tracer.trace_simple_type::<BlackBoxFuncCall>().unwrap();
-        tracer.trace_simple_type::<BrilligInputs>().unwrap();
+        tracer.trace_simple_type::<BrilligInputs<FieldElement>>().unwrap();
         tracer.trace_simple_type::<BrilligOutputs>().unwrap();
         tracer.trace_simple_type::<BrilligOpcode>().unwrap();
         tracer.trace_simple_type::<BinaryIntOp>().unwrap();
         tracer.trace_simple_type::<BlackBoxOp>().unwrap();
-        tracer.trace_simple_type::<Directive>().unwrap();
+        tracer.trace_simple_type::<Directive<FieldElement>>().unwrap();
         tracer.trace_simple_type::<ValueOrArray>().unwrap();
         tracer.trace_simple_type::<HeapValueType>().unwrap();
-        tracer.trace_simple_type::<AssertionPayload>().unwrap();
-        tracer.trace_simple_type::<ExpressionOrMemory>().unwrap();
+        tracer.trace_simple_type::<AssertionPayload<FieldElement>>().unwrap();
+        tracer.trace_simple_type::<ExpressionOrMemory<FieldElement>>().unwrap();
 
         let registry = tracer.registry().unwrap();
 

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -71,7 +71,7 @@ mod reflection {
         tracer.trace_simple_type::<BlackBoxFuncCall>().unwrap();
         tracer.trace_simple_type::<BrilligInputs<FieldElement>>().unwrap();
         tracer.trace_simple_type::<BrilligOutputs>().unwrap();
-        tracer.trace_simple_type::<BrilligOpcode>().unwrap();
+        tracer.trace_simple_type::<BrilligOpcode<FieldElement>>().unwrap();
         tracer.trace_simple_type::<BinaryIntOp>().unwrap();
         tracer.trace_simple_type::<BlackBoxOp>().unwrap();
         tracer.trace_simple_type::<Directive<FieldElement>>().unwrap();
@@ -111,8 +111,8 @@ mod reflection {
 
         let mut tracer = Tracer::new(TracerConfig::default());
         tracer.trace_simple_type::<Witness>().unwrap();
-        tracer.trace_simple_type::<WitnessMap>().unwrap();
-        tracer.trace_simple_type::<WitnessStack>().unwrap();
+        tracer.trace_simple_type::<WitnessMap<FieldElement>>().unwrap();
+        tracer.trace_simple_type::<WitnessStack<FieldElement>>().unwrap();
 
         let registry = tracer.registry().unwrap();
 

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -9,7 +9,7 @@ pub mod circuit;
 pub mod native_types;
 
 pub use acir_field;
-pub use acir_field::FieldElement;
+pub use acir_field::{AcirField, FieldElement};
 pub use brillig;
 pub use circuit::black_box_functions::BlackBoxFunc;
 

--- a/acvm-repo/acir/src/native_types/expression/mod.rs
+++ b/acvm-repo/acir/src/native_types/expression/mod.rs
@@ -1,8 +1,7 @@
 use crate::native_types::Witness;
-use acir_field::FieldElement;
+use acir_field::{AcirField, FieldElement};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-
 mod operators;
 mod ordering;
 

--- a/acvm-repo/acir/src/native_types/expression/mod.rs
+++ b/acvm-repo/acir/src/native_types/expression/mod.rs
@@ -1,5 +1,5 @@
 use crate::native_types::Witness;
-use acir_field::{AcirField, FieldElement};
+use acir_field::AcirField;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 mod operators;
@@ -360,36 +360,42 @@ impl<F: AcirField> From<Witness> for Expression<F> {
     }
 }
 
-#[test]
-fn add_mul_smoketest() {
-    let a = Expression {
-        mul_terms: vec![(FieldElement::from(2u128), Witness(1), Witness(2))],
-        ..Default::default()
-    };
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acir_field::{AcirField, FieldElement};
 
-    let k = FieldElement::from(10u128);
+    #[test]
+    fn add_mul_smoketest() {
+        let a = Expression {
+            mul_terms: vec![(FieldElement::from(2u128), Witness(1), Witness(2))],
+            ..Default::default()
+        };
 
-    let b = Expression {
-        mul_terms: vec![
-            (FieldElement::from(3u128), Witness(0), Witness(2)),
-            (FieldElement::from(3u128), Witness(1), Witness(2)),
-            (FieldElement::from(4u128), Witness(4), Witness(5)),
-        ],
-        linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
-        q_c: FieldElement::one(),
-    };
+        let k = FieldElement::from(10u128);
 
-    let result = a.add_mul(k, &b);
-    assert_eq!(
-        result,
-        Expression {
+        let b = Expression {
             mul_terms: vec![
-                (FieldElement::from(30u128), Witness(0), Witness(2)),
-                (FieldElement::from(32u128), Witness(1), Witness(2)),
-                (FieldElement::from(40u128), Witness(4), Witness(5)),
+                (FieldElement::from(3u128), Witness(0), Witness(2)),
+                (FieldElement::from(3u128), Witness(1), Witness(2)),
+                (FieldElement::from(4u128), Witness(4), Witness(5)),
             ],
-            linear_combinations: vec![(FieldElement::from(40u128), Witness(4))],
-            q_c: FieldElement::from(10u128)
-        }
-    );
+            linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
+            q_c: FieldElement::one(),
+        };
+
+        let result = a.add_mul(k, &b);
+        assert_eq!(
+            result,
+            Expression {
+                mul_terms: vec![
+                    (FieldElement::from(30u128), Witness(0), Witness(2)),
+                    (FieldElement::from(32u128), Witness(1), Witness(2)),
+                    (FieldElement::from(40u128), Witness(4), Witness(5)),
+                ],
+                linear_combinations: vec![(FieldElement::from(40u128), Witness(4))],
+                q_c: FieldElement::from(10u128)
+            }
+        );
+    }
 }

--- a/acvm-repo/acir/src/native_types/expression/operators.rs
+++ b/acvm-repo/acir/src/native_types/expression/operators.rs
@@ -1,5 +1,5 @@
 use crate::native_types::Witness;
-use acir_field::{AcirField, FieldElement};
+use acir_field::AcirField;
 use std::{
     cmp::Ordering,
     ops::{Add, Mul, Neg, Sub},
@@ -205,62 +205,68 @@ fn single_mul<F: AcirField>(w: Witness, b: &Expression<F>) -> Expression<F> {
     }
 }
 
-#[test]
-fn add_smoke_test() {
-    let a = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![(FieldElement::from(2u128), Witness(2))],
-        q_c: FieldElement::from(2u128),
-    };
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acir_field::{AcirField, FieldElement};
 
-    let b = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
-        q_c: FieldElement::one(),
-    };
-
-    assert_eq!(
-        &a + &b,
-        Expression {
+    #[test]
+    fn add_smoke_test() {
+        let a = Expression {
             mul_terms: vec![],
-            linear_combinations: vec![
-                (FieldElement::from(2u128), Witness(2)),
-                (FieldElement::from(4u128), Witness(4))
-            ],
-            q_c: FieldElement::from(3u128)
-        }
-    );
+            linear_combinations: vec![(FieldElement::from(2u128), Witness(2))],
+            q_c: FieldElement::from(2u128),
+        };
 
-    // Enforce commutativity
-    assert_eq!(&a + &b, &b + &a);
-}
+        let b = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
+            q_c: FieldElement::one(),
+        };
 
-#[test]
-fn mul_smoke_test() {
-    let a = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![(FieldElement::from(2u128), Witness(2))],
-        q_c: FieldElement::from(2u128),
-    };
+        assert_eq!(
+            &a + &b,
+            Expression {
+                mul_terms: vec![],
+                linear_combinations: vec![
+                    (FieldElement::from(2u128), Witness(2)),
+                    (FieldElement::from(4u128), Witness(4))
+                ],
+                q_c: FieldElement::from(3u128)
+            }
+        );
 
-    let b = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
-        q_c: FieldElement::one(),
-    };
+        // Enforce commutativity
+        assert_eq!(&a + &b, &b + &a);
+    }
 
-    assert_eq!(
-        (&a * &b).unwrap(),
-        Expression {
-            mul_terms: vec![(FieldElement::from(8u128), Witness(2), Witness(4)),],
-            linear_combinations: vec![
-                (FieldElement::from(2u128), Witness(2)),
-                (FieldElement::from(8u128), Witness(4))
-            ],
-            q_c: FieldElement::from(2u128)
-        }
-    );
+    #[test]
+    fn mul_smoke_test() {
+        let a = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![(FieldElement::from(2u128), Witness(2))],
+            q_c: FieldElement::from(2u128),
+        };
 
-    // Enforce commutativity
-    assert_eq!(&a * &b, &b * &a);
+        let b = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
+            q_c: FieldElement::one(),
+        };
+
+        assert_eq!(
+            (&a * &b).unwrap(),
+            Expression {
+                mul_terms: vec![(FieldElement::from(8u128), Witness(2), Witness(4)),],
+                linear_combinations: vec![
+                    (FieldElement::from(2u128), Witness(2)),
+                    (FieldElement::from(8u128), Witness(4))
+                ],
+                q_c: FieldElement::from(2u128)
+            }
+        );
+
+        // Enforce commutativity
+        assert_eq!(&a * &b, &b * &a);
+    }
 }

--- a/acvm-repo/acir/src/native_types/expression/operators.rs
+++ b/acvm-repo/acir/src/native_types/expression/operators.rs
@@ -1,5 +1,5 @@
 use crate::native_types::Witness;
-use acir_field::FieldElement;
+use acir_field::{AcirField, FieldElement};
 use std::{
     cmp::Ordering,
     ops::{Add, Mul, Neg, Sub},

--- a/acvm-repo/acir/src/native_types/expression/ordering.rs
+++ b/acvm-repo/acir/src/native_types/expression/ordering.rs
@@ -1,3 +1,5 @@
+use acir_field::AcirField;
+
 use crate::native_types::Witness;
 use std::cmp::Ordering;
 
@@ -6,7 +8,7 @@ use super::Expression;
 // TODO: It's undecided whether `Expression` should implement `Ord/PartialOrd`.
 // This is currently used in ACVM in the compiler.
 
-impl Ord for Expression {
+impl<F: AcirField> Ord for Expression<F> {
     fn cmp(&self, other: &Self) -> Ordering {
         let mut i1 = self.get_max_idx();
         let mut i2 = other.get_max_idx();
@@ -17,13 +19,13 @@ impl Ord for Expression {
             if m1.is_none() && m2.is_none() {
                 return Ordering::Equal;
             }
-            result = Expression::cmp_max(m1, m2);
+            result = Expression::<F>::cmp_max(m1, m2);
         }
         result
     }
 }
 
-impl PartialOrd for Expression {
+impl<F: AcirField> PartialOrd for Expression<F> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -35,7 +37,7 @@ struct WitnessIdx {
     second_term: bool,
 }
 
-impl Expression {
+impl<F: AcirField> Expression<F> {
     fn get_max_idx(&self) -> WitnessIdx {
         WitnessIdx {
             linear: self.linear_combinations.len(),

--- a/acvm-repo/acir/src/native_types/witness.rs
+++ b/acvm-repo/acir/src/native_types/witness.rs
@@ -1,6 +1,6 @@
 use std::ops::Add;
 
-use acir_field::FieldElement;
+use acir_field::{AcirField, FieldElement};
 use serde::{Deserialize, Serialize};
 
 use super::Expression;

--- a/acvm-repo/acir/src/native_types/witness.rs
+++ b/acvm-repo/acir/src/native_types/witness.rs
@@ -33,11 +33,3 @@ impl From<u32> for Witness {
         Self(value)
     }
 }
-
-impl Add<Witness> for Witness {
-    type Output = Expression;
-
-    fn add(self, rhs: Witness) -> Self::Output {
-        Expression::from(self).add_mul(FieldElement::one(), &Expression::from(rhs))
-    }
-}

--- a/acvm-repo/acir/src/native_types/witness.rs
+++ b/acvm-repo/acir/src/native_types/witness.rs
@@ -1,9 +1,4 @@
-use std::ops::Add;
-
-use acir_field::{AcirField, FieldElement};
 use serde::{Deserialize, Serialize};
-
-use super::Expression;
 
 // Witness might be a misnomer. This is an index that represents the position a witness will take
 #[derive(

--- a/acvm-repo/acir/tests/test_program_serialization.rs
+++ b/acvm-repo/acir/tests/test_program_serialization.rs
@@ -34,12 +34,12 @@ fn addition_circuit() {
         q_c: FieldElement::zero(),
     });
 
-    let circuit = Circuit {
+    let circuit: Circuit<FieldElement> = Circuit {
         current_witness_index: 4,
         opcodes: vec![addition],
         private_parameters: BTreeSet::from([Witness(1), Witness(2)]),
         return_values: PublicInputs([Witness(3)].into()),
-        ..Circuit::default()
+        ..Circuit::<FieldElement>::default()
     };
     let program = Program { functions: vec![circuit], unconstrained_functions: vec![] };
 
@@ -59,18 +59,19 @@ fn addition_circuit() {
 
 #[test]
 fn multi_scalar_mul_circuit() {
-    let multi_scalar_mul = Opcode::BlackBoxFuncCall(BlackBoxFuncCall::MultiScalarMul {
-        points: vec![
-            FunctionInput { witness: Witness(1), num_bits: 128 },
-            FunctionInput { witness: Witness(2), num_bits: 128 },
-            FunctionInput { witness: Witness(3), num_bits: 1 },
-        ],
-        scalars: vec![
-            FunctionInput { witness: Witness(4), num_bits: 128 },
-            FunctionInput { witness: Witness(5), num_bits: 128 },
-        ],
-        outputs: (Witness(6), Witness(7), Witness(8)),
-    });
+    let multi_scalar_mul: Opcode<FieldElement> =
+        Opcode::BlackBoxFuncCall(BlackBoxFuncCall::MultiScalarMul {
+            points: vec![
+                FunctionInput { witness: Witness(1), num_bits: 128 },
+                FunctionInput { witness: Witness(2), num_bits: 128 },
+                FunctionInput { witness: Witness(3), num_bits: 1 },
+            ],
+            scalars: vec![
+                FunctionInput { witness: Witness(4), num_bits: 128 },
+                FunctionInput { witness: Witness(5), num_bits: 128 },
+            ],
+            outputs: (Witness(6), Witness(7), Witness(8)),
+        });
 
     let circuit = Circuit {
         current_witness_index: 9,
@@ -107,7 +108,7 @@ fn pedersen_circuit() {
         domain_separator: 0,
     });
 
-    let circuit = Circuit {
+    let circuit: Circuit<FieldElement> = Circuit {
         current_witness_index: 4,
         opcodes: vec![pedersen],
         private_parameters: BTreeSet::from([Witness(1)]),
@@ -151,7 +152,7 @@ fn schnorr_verify_circuit() {
         output,
     });
 
-    let circuit = Circuit {
+    let circuit: Circuit<FieldElement> = Circuit {
         current_witness_index: 100,
         opcodes: vec![schnorr],
         private_parameters: BTreeSet::from_iter((1..=last_input).map(Witness)),
@@ -219,7 +220,7 @@ fn simple_brillig_foreign_call() {
         predicate: None,
     }];
 
-    let circuit = Circuit {
+    let circuit: Circuit<FieldElement> = Circuit {
         current_witness_index: 8,
         opcodes,
         private_parameters: BTreeSet::from([Witness(1), Witness(2)]),

--- a/acvm-repo/acir/tests/test_program_serialization.rs
+++ b/acvm-repo/acir/tests/test_program_serialization.rs
@@ -19,7 +19,7 @@ use acir::{
     },
     native_types::{Expression, Witness},
 };
-use acir_field::FieldElement;
+use acir_field::{AcirField, FieldElement};
 use brillig::{HeapArray, HeapValueType, MemoryAddress, ValueOrArray};
 
 #[test]

--- a/acvm-repo/acir_field/Cargo.toml
+++ b/acvm-repo/acir_field/Cargo.toml
@@ -24,11 +24,10 @@ ark-bn254 = { version = "^0.4.0", optional = true, default-features = false, fea
 ark-bls12-381 = { version = "^0.4.0", optional = true, default-features = false, features = [
     "curve",
 ] }
-ark-ff = { version = "^0.4.0", optional = true, default-features = false }
+ark-ff = { version = "^0.4.0", default-features = false }
 
 cfg-if = "1.0.0"
 
 [features]
-default = ["bn254"]
-bn254 = ["dep:ark-bn254", "dep:ark-ff"]
-bls12_381 = ["dep:ark-bls12-381", "dep:ark-ff"]
+bn254 = ["dep:ark-bn254"]
+bls12_381 = ["dep:ark-bls12-381"]

--- a/acvm-repo/acir_field/Cargo.toml
+++ b/acvm-repo/acir_field/Cargo.toml
@@ -18,16 +18,12 @@ num-bigint.workspace = true
 serde.workspace = true
 num-traits.workspace = true
 
-ark-bn254 = { version = "^0.4.0", optional = true, default-features = false, features = [
-    "curve",
-] }
-ark-bls12-381 = { version = "^0.4.0", optional = true, default-features = false, features = [
-    "curve",
-] }
+ark-bn254 = { version = "^0.4.0", default-features = false, features = ["curve"] }
+ark-bls12-381 = { version = "^0.4.0", optional = true, default-features = false, features = ["curve"] }
 ark-ff = { version = "^0.4.0", default-features = false }
 
 cfg-if = "1.0.0"
 
 [features]
-bn254 = ["dep:ark-bn254"]
+bn254 = []
 bls12_381 = ["dep:ark-bls12-381"]

--- a/acvm-repo/acir_field/src/generic_ark.rs
+++ b/acvm-repo/acir_field/src/generic_ark.rs
@@ -4,7 +4,24 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
-pub trait AcirField: std::marker::Sized {
+pub trait AcirField:
+    std::marker::Sized
+    + Display
+    + Debug
+    + Default
+    + Clone
+    + Copy
+    + Neg<Output = Self>
+    + Add<Self, Output = Self>
+    + Sub<Self, Output = Self>
+    + Mul<Self, Output = Self>
+    + Div<Self, Output = Self>
+    + AddAssign<Self>
+    + SubAssign<Self>
+    + std::cmp::Eq
+    + Serialize
+    + for<'a> Deserialize<'a>
+{
     fn one() -> Self;
     fn zero() -> Self;
 
@@ -68,7 +85,7 @@ pub trait AcirField: std::marker::Sized {
 
 // XXX: Switch out for a trait and proper implementations
 // This implementation is in-efficient, can definitely remove hex usage and Iterator instances for trivial functionality
-#[derive(Clone, Copy, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, Copy, Eq, PartialOrd, Ord)]
 pub struct FieldElement<F: PrimeField>(F);
 
 impl<F: PrimeField> std::fmt::Display for FieldElement<F> {
@@ -445,6 +462,8 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
     }
 }
 
+use std::fmt::Debug;
+use std::fmt::Display;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 impl<F: PrimeField> Neg for FieldElement<F> {

--- a/acvm-repo/acir_field/src/generic_ark.rs
+++ b/acvm-repo/acir_field/src/generic_ark.rs
@@ -4,6 +4,68 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
+pub trait AcirField: std::marker::Sized {
+    fn one() -> Self;
+    fn zero() -> Self;
+
+    fn is_zero(&self) -> bool;
+    fn is_one(&self) -> bool;
+
+    fn pow(&self, exponent: &Self) -> Self;
+
+    /// Maximum number of bits needed to represent a field element
+    /// This is not the amount of bits being used to represent a field element
+    /// Example, you only need 254 bits to represent a field element in BN256
+    /// But the representation uses 256 bits, so the top two bits are always zero
+    /// This method would return 254
+    fn max_num_bits() -> u32;
+
+    /// Maximum numbers of bytes needed to represent a field element
+    /// We are not guaranteed that the number of bits being used to represent a field element
+    /// will always be divisible by 8. If the case that it is not, we add one to the max number of bytes
+    /// For example, a max bit size of 254 would give a max byte size of 32.
+    fn max_num_bytes() -> u32;
+
+    fn modulus() -> BigUint;
+
+    /// This is the number of bits required to represent this specific field element
+    fn num_bits(&self) -> u32;
+
+    fn fits_in_u128(&self) -> bool;
+
+    fn to_u128(self) -> u128;
+
+    fn try_into_u128(self) -> Option<u128>;
+
+    fn to_i128(self) -> i128;
+
+    fn try_to_u64(&self) -> Option<u64>;
+
+    /// Computes the inverse or returns zero if the inverse does not exist
+    /// Before using this FieldElement, please ensure that this behavior is necessary
+    fn inverse(&self) -> Self;
+
+    fn try_inverse(self) -> Option<Self>;
+
+    fn to_hex(self) -> String;
+
+    fn from_hex(hex_str: &str) -> Option<Self>;
+
+    fn to_be_bytes(self) -> Vec<u8>;
+
+    /// Converts bytes into a FieldElement and applies a reduction if needed.
+    fn from_be_bytes_reduce(bytes: &[u8]) -> Self;
+
+    fn bits(&self) -> Vec<bool>;
+
+    /// Returns the closest number of bytes to the bits specified
+    /// This method truncates
+    fn fetch_nearest_bytes(&self, num_bits: usize) -> Vec<u8>;
+
+    fn and(&self, rhs: &Self, num_bits: u32) -> Self;
+    fn xor(&self, rhs: &Self, num_bits: u32) -> Self;
+}
+
 // XXX: Switch out for a trait and proper implementations
 // This implementation is in-efficient, can definitely remove hex usage and Iterator instances for trivial functionality
 #[derive(Clone, Copy, Eq, PartialOrd, Ord)]
@@ -161,53 +223,20 @@ impl<F: PrimeField> From<bool> for FieldElement<F> {
 }
 
 impl<F: PrimeField> FieldElement<F> {
-    pub fn one() -> FieldElement<F> {
-        FieldElement(F::one())
-    }
-    pub fn zero() -> FieldElement<F> {
-        FieldElement(F::zero())
+    pub fn from_repr(field: F) -> Self {
+        Self(field)
     }
 
-    pub fn is_zero(&self) -> bool {
-        self == &Self::zero()
-    }
-    pub fn is_one(&self) -> bool {
-        self == &Self::one()
+    // XXX: This method is used while this field element
+    // implementation is not generic.
+    pub fn into_repr(self) -> F {
+        self.0
     }
 
-    pub fn is_negative(&self) -> bool {
+    fn is_negative(&self) -> bool {
         self.neg().num_bits() < self.num_bits()
     }
 
-    pub fn pow(&self, exponent: &Self) -> Self {
-        FieldElement(self.0.pow(exponent.0.into_bigint()))
-    }
-
-    /// Maximum number of bits needed to represent a field element
-    /// This is not the amount of bits being used to represent a field element
-    /// Example, you only need 254 bits to represent a field element in BN256
-    /// But the representation uses 256 bits, so the top two bits are always zero
-    /// This method would return 254
-    pub const fn max_num_bits() -> u32 {
-        F::MODULUS_BIT_SIZE
-    }
-
-    /// Maximum numbers of bytes needed to represent a field element
-    /// We are not guaranteed that the number of bits being used to represent a field element
-    /// will always be divisible by 8. If the case that it is not, we add one to the max number of bytes
-    /// For example, a max bit size of 254 would give a max byte size of 32.
-    pub const fn max_num_bytes() -> u32 {
-        let num_bytes = Self::max_num_bits() / 8;
-        if Self::max_num_bits() % 8 == 0 {
-            num_bytes
-        } else {
-            num_bytes + 1
-        }
-    }
-
-    pub fn modulus() -> BigUint {
-        F::MODULUS.into()
-    }
     /// Returns None, if the string is not a canonical
     /// representation of a field element; less than the order
     /// or if the hex string is invalid.
@@ -219,125 +248,6 @@ impl<F: PrimeField> FieldElement<F> {
 
         let fr = F::from_str(input).ok()?;
         Some(FieldElement(fr))
-    }
-
-    /// This is the number of bits required to represent this specific field element
-    pub fn num_bits(&self) -> u32 {
-        let bits = self.bits();
-        // Iterate the number of bits and pop off all leading zeroes
-        let iter = bits.iter().skip_while(|x| !(**x));
-        // Note: count will panic if it goes over usize::MAX.
-        // This may not be suitable for devices whose usize < u16
-        iter.count() as u32
-    }
-
-    pub fn fits_in_u128(&self) -> bool {
-        self.num_bits() <= 128
-    }
-
-    pub fn to_u128(self) -> u128 {
-        let bytes = self.to_be_bytes();
-        u128::from_be_bytes(bytes[16..32].try_into().unwrap())
-    }
-
-    pub fn try_into_u128(self) -> Option<u128> {
-        self.fits_in_u128().then(|| self.to_u128())
-    }
-
-    pub fn to_i128(self) -> i128 {
-        let is_negative = self.is_negative();
-        let bytes = if is_negative { self.neg() } else { self }.to_be_bytes();
-        i128::from_be_bytes(bytes[16..32].try_into().unwrap()) * if is_negative { -1 } else { 1 }
-    }
-
-    pub fn try_to_u64(&self) -> Option<u64> {
-        (self.num_bits() <= 64).then(|| self.to_u128() as u64)
-    }
-
-    /// Computes the inverse or returns zero if the inverse does not exist
-    /// Before using this FieldElement, please ensure that this behavior is necessary
-    pub fn inverse(&self) -> FieldElement<F> {
-        let inv = self.0.inverse().unwrap_or_else(F::zero);
-        FieldElement(inv)
-    }
-
-    pub fn try_inverse(mut self) -> Option<Self> {
-        self.0.inverse_in_place().map(|f| FieldElement(*f))
-    }
-
-    pub fn from_repr(field: F) -> Self {
-        Self(field)
-    }
-
-    // XXX: This method is used while this field element
-    // implementation is not generic.
-    pub fn into_repr(self) -> F {
-        self.0
-    }
-
-    pub fn to_hex(self) -> String {
-        let mut bytes = Vec::new();
-        self.0.serialize_uncompressed(&mut bytes).unwrap();
-        bytes.reverse();
-        hex::encode(bytes)
-    }
-    pub fn from_hex(hex_str: &str) -> Option<FieldElement<F>> {
-        let value = hex_str.strip_prefix("0x").unwrap_or(hex_str);
-        // Values of odd length require an additional "0" prefix
-        let sanitized_value =
-            if value.len() % 2 == 0 { value.to_string() } else { format!("0{}", value) };
-        let hex_as_bytes = hex::decode(sanitized_value).ok()?;
-        Some(FieldElement::from_be_bytes_reduce(&hex_as_bytes))
-    }
-
-    pub fn to_be_bytes(self) -> Vec<u8> {
-        // to_be_bytes! uses little endian which is why we reverse the output
-        // TODO: Add a little endian equivalent, so the caller can use whichever one
-        // TODO they desire
-        let mut bytes = Vec::new();
-        self.0.serialize_uncompressed(&mut bytes).unwrap();
-        bytes.reverse();
-        bytes
-    }
-
-    /// Converts bytes into a FieldElement and applies a
-    /// reduction if needed.
-    pub fn from_be_bytes_reduce(bytes: &[u8]) -> FieldElement<F> {
-        FieldElement(F::from_be_bytes_mod_order(bytes))
-    }
-
-    pub fn bits(&self) -> Vec<bool> {
-        let bytes = self.to_be_bytes();
-        let mut bits = Vec::with_capacity(bytes.len() * 8);
-        for byte in bytes {
-            let _bits = FieldElement::<F>::byte_to_bit(byte);
-            bits.extend(_bits);
-        }
-        bits
-    }
-
-    fn byte_to_bit(byte: u8) -> Vec<bool> {
-        let mut bits = Vec::with_capacity(8);
-        for index in (0..=7).rev() {
-            bits.push((byte & (1 << index)) >> index == 1);
-        }
-        bits
-    }
-
-    /// Returns the closest number of bytes to the bits specified
-    /// This method truncates
-    pub fn fetch_nearest_bytes(&self, num_bits: usize) -> Vec<u8> {
-        fn nearest_bytes(num_bits: usize) -> usize {
-            ((num_bits + 7) / 8) * 8
-        }
-
-        let num_bytes = nearest_bytes(num_bits);
-        let num_elements = num_bytes / 8;
-
-        let mut bytes = self.to_be_bytes();
-        bytes.reverse(); // put it in big endian format. XXX(next refactor): we should be explicit about endianness.
-
-        bytes[0..num_elements].to_vec()
     }
 
     // mask_to methods will not remove any bytes from the field
@@ -371,10 +281,166 @@ impl<F: PrimeField> FieldElement<F> {
 
         FieldElement::from_be_bytes_reduce(&and_byte_arr)
     }
-    pub fn and(&self, rhs: &FieldElement<F>, num_bits: u32) -> FieldElement<F> {
+}
+
+impl<F: PrimeField> AcirField for FieldElement<F> {
+    fn one() -> FieldElement<F> {
+        FieldElement(F::one())
+    }
+    fn zero() -> FieldElement<F> {
+        FieldElement(F::zero())
+    }
+
+    fn is_zero(&self) -> bool {
+        self == &Self::zero()
+    }
+    fn is_one(&self) -> bool {
+        self == &Self::one()
+    }
+
+    fn pow(&self, exponent: &Self) -> Self {
+        FieldElement(self.0.pow(exponent.0.into_bigint()))
+    }
+
+    /// Maximum number of bits needed to represent a field element
+    /// This is not the amount of bits being used to represent a field element
+    /// Example, you only need 254 bits to represent a field element in BN256
+    /// But the representation uses 256 bits, so the top two bits are always zero
+    /// This method would return 254
+    fn max_num_bits() -> u32 {
+        F::MODULUS_BIT_SIZE
+    }
+
+    /// Maximum numbers of bytes needed to represent a field element
+    /// We are not guaranteed that the number of bits being used to represent a field element
+    /// will always be divisible by 8. If the case that it is not, we add one to the max number of bytes
+    /// For example, a max bit size of 254 would give a max byte size of 32.
+    fn max_num_bytes() -> u32 {
+        let num_bytes = Self::max_num_bits() / 8;
+        if Self::max_num_bits() % 8 == 0 {
+            num_bytes
+        } else {
+            num_bytes + 1
+        }
+    }
+
+    fn modulus() -> BigUint {
+        F::MODULUS.into()
+    }
+
+    /// This is the number of bits required to represent this specific field element
+    fn num_bits(&self) -> u32 {
+        let bits = self.bits();
+        // Iterate the number of bits and pop off all leading zeroes
+        let iter = bits.iter().skip_while(|x| !(**x));
+        // Note: count will panic if it goes over usize::MAX.
+        // This may not be suitable for devices whose usize < u16
+        iter.count() as u32
+    }
+
+    fn fits_in_u128(&self) -> bool {
+        self.num_bits() <= 128
+    }
+
+    fn to_u128(self) -> u128 {
+        let bytes = self.to_be_bytes();
+        u128::from_be_bytes(bytes[16..32].try_into().unwrap())
+    }
+
+    fn try_into_u128(self) -> Option<u128> {
+        self.fits_in_u128().then(|| self.to_u128())
+    }
+
+    fn to_i128(self) -> i128 {
+        let is_negative = self.is_negative();
+        let bytes = if is_negative { self.neg() } else { self }.to_be_bytes();
+        i128::from_be_bytes(bytes[16..32].try_into().unwrap()) * if is_negative { -1 } else { 1 }
+    }
+
+    fn try_to_u64(&self) -> Option<u64> {
+        (self.num_bits() <= 64).then(|| self.to_u128() as u64)
+    }
+
+    /// Computes the inverse or returns zero if the inverse does not exist
+    /// Before using this FieldElement, please ensure that this behavior is necessary
+    fn inverse(&self) -> FieldElement<F> {
+        let inv = self.0.inverse().unwrap_or_else(F::zero);
+        FieldElement(inv)
+    }
+
+    fn try_inverse(mut self) -> Option<Self> {
+        self.0.inverse_in_place().map(|f| FieldElement(*f))
+    }
+
+    fn to_hex(self) -> String {
+        let mut bytes = Vec::new();
+        self.0.serialize_uncompressed(&mut bytes).unwrap();
+        bytes.reverse();
+        hex::encode(bytes)
+    }
+    fn from_hex(hex_str: &str) -> Option<FieldElement<F>> {
+        let value = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+        // Values of odd length require an additional "0" prefix
+        let sanitized_value =
+            if value.len() % 2 == 0 { value.to_string() } else { format!("0{}", value) };
+        let hex_as_bytes = hex::decode(sanitized_value).ok()?;
+        Some(FieldElement::from_be_bytes_reduce(&hex_as_bytes))
+    }
+
+    fn to_be_bytes(self) -> Vec<u8> {
+        // to_be_bytes! uses little endian which is why we reverse the output
+        // TODO: Add a little endian equivalent, so the caller can use whichever one
+        // TODO they desire
+        let mut bytes = Vec::new();
+        self.0.serialize_uncompressed(&mut bytes).unwrap();
+        bytes.reverse();
+        bytes
+    }
+
+    /// Converts bytes into a FieldElement and applies a
+    /// reduction if needed.
+    fn from_be_bytes_reduce(bytes: &[u8]) -> FieldElement<F> {
+        FieldElement(F::from_be_bytes_mod_order(bytes))
+    }
+
+    fn bits(&self) -> Vec<bool> {
+        fn byte_to_bit(byte: u8) -> Vec<bool> {
+            let mut bits = Vec::with_capacity(8);
+            for index in (0..=7).rev() {
+                bits.push((byte & (1 << index)) >> index == 1);
+            }
+            bits
+        }
+
+        let bytes = self.to_be_bytes();
+        let mut bits = Vec::with_capacity(bytes.len() * 8);
+        for byte in bytes {
+            let _bits = byte_to_bit(byte);
+            bits.extend(_bits);
+        }
+        bits
+    }
+
+    /// Returns the closest number of bytes to the bits specified
+    /// This method truncates
+    fn fetch_nearest_bytes(&self, num_bits: usize) -> Vec<u8> {
+        fn nearest_bytes(num_bits: usize) -> usize {
+            ((num_bits + 7) / 8) * 8
+        }
+
+        let num_bytes = nearest_bytes(num_bits);
+        let num_elements = num_bytes / 8;
+
+        let mut bytes = self.to_be_bytes();
+        bytes.reverse(); // put it in big endian format. XXX(next refactor): we should be explicit about endianness.
+
+        bytes[0..num_elements].to_vec()
+    }
+
+    fn and(&self, rhs: &FieldElement<F>, num_bits: u32) -> FieldElement<F> {
         self.and_xor(rhs, num_bits, false)
     }
-    pub fn xor(&self, rhs: &FieldElement<F>, num_bits: u32) -> FieldElement<F> {
+    fn xor(&self, rhs: &FieldElement<F>, num_bits: u32) -> FieldElement<F> {
         self.and_xor(rhs, num_bits, true)
     }
 }
@@ -489,6 +555,8 @@ fn superscript(n: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::{AcirField, FieldElement};
+
     #[test]
     fn and() {
         let max = 10_000u32;
@@ -496,7 +564,7 @@ mod tests {
         let num_bits = (std::mem::size_of::<u32>() * 8) as u32 - max.leading_zeros();
 
         for x in 0..max {
-            let x = crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(x as i128);
+            let x = FieldElement::<ark_bn254::Fr>::from(x as i128);
             let res = x.and(&x, num_bits);
             assert_eq!(res.to_be_bytes(), x.to_be_bytes());
         }
@@ -513,8 +581,7 @@ mod tests {
         ];
 
         for (i, string) in hex_strings.into_iter().enumerate() {
-            let minus_i_field_element =
-                -crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
+            let minus_i_field_element = -FieldElement::<ark_bn254::Fr>::from(i as i128);
             assert_eq!(minus_i_field_element.to_hex(), string);
         }
     }
@@ -525,12 +592,9 @@ mod tests {
         let hex_strings =
             vec![("0x0", "0x00"), ("0x1", "0x01"), ("0x002", "0x0002"), ("0x00003", "0x000003")];
         for (i, case) in hex_strings.into_iter().enumerate() {
-            let i_field_element =
-                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
-            let odd_field_element =
-                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from_hex(case.0).unwrap();
-            let even_field_element =
-                crate::generic_ark::FieldElement::<ark_bn254::Fr>::from_hex(case.1).unwrap();
+            let i_field_element = FieldElement::<ark_bn254::Fr>::from(i as i128);
+            let odd_field_element = FieldElement::<ark_bn254::Fr>::from_hex(case.0).unwrap();
+            let even_field_element = FieldElement::<ark_bn254::Fr>::from_hex(case.1).unwrap();
 
             assert_eq!(i_field_element, odd_field_element);
             assert_eq!(odd_field_element, even_field_element);
@@ -539,7 +603,7 @@ mod tests {
 
     #[test]
     fn max_num_bits_smoke() {
-        let max_num_bits_bn254 = crate::generic_ark::FieldElement::<ark_bn254::Fr>::max_num_bits();
+        let max_num_bits_bn254 = FieldElement::<ark_bn254::Fr>::max_num_bits();
         assert_eq!(max_num_bits_bn254, 254);
     }
 }

--- a/acvm-repo/acir_field/src/lib.rs
+++ b/acvm-repo/acir_field/src/lib.rs
@@ -9,15 +9,16 @@ mod generic_ark;
 
 pub use generic_ark::AcirField;
 
+/// Temporarily exported generic field to aide migration to `AcirField`
+pub use generic_ark::FieldElement as GenericFieldElement;
+
 cfg_if::cfg_if! {
-    if #[cfg(feature = "bn254")] {
-        pub type FieldElement = generic_ark::FieldElement<ark_bn254::Fr>;
-        pub const CHOSEN_FIELD : FieldOptions = FieldOptions::BN254;
-    } else if #[cfg(feature = "bls12_381")] {
+    if #[cfg(feature = "bls12_381")] {
         pub type FieldElement = generic_ark::FieldElement<ark_bls12_381::Fr>;
         pub const CHOSEN_FIELD : FieldOptions = FieldOptions::BLS12_381;
     } else {
-        compile_error!("please specify a field to compile with");
+        pub type FieldElement = generic_ark::FieldElement<ark_bn254::Fr>;
+        pub const CHOSEN_FIELD : FieldOptions = FieldOptions::BN254;
     }
 }
 

--- a/acvm-repo/acir_field/src/lib.rs
+++ b/acvm-repo/acir_field/src/lib.rs
@@ -13,7 +13,6 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "bn254")] {
         pub type FieldElement = generic_ark::FieldElement<ark_bn254::Fr>;
         pub const CHOSEN_FIELD : FieldOptions = FieldOptions::BN254;
-
     } else if #[cfg(feature = "bls12_381")] {
         pub type FieldElement = generic_ark::FieldElement<ark_bls12_381::Fr>;
         pub const CHOSEN_FIELD : FieldOptions = FieldOptions::BLS12_381;

--- a/acvm-repo/acir_field/src/lib.rs
+++ b/acvm-repo/acir_field/src/lib.rs
@@ -9,7 +9,7 @@ mod generic_ark;
 
 pub use generic_ark::AcirField;
 
-/// Temporarily exported generic field to aide migration to `AcirField`
+/// Temporarily exported generic field to aid migration to `AcirField`
 pub use generic_ark::FieldElement as GenericFieldElement;
 
 cfg_if::cfg_if! {

--- a/acvm-repo/acir_field/src/lib.rs
+++ b/acvm-repo/acir_field/src/lib.rs
@@ -5,15 +5,16 @@
 
 use num_bigint::BigUint;
 use num_traits::Num;
+mod generic_ark;
+
+pub use generic_ark::AcirField;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "bn254")] {
-        mod generic_ark;
         pub type FieldElement = generic_ark::FieldElement<ark_bn254::Fr>;
         pub const CHOSEN_FIELD : FieldOptions = FieldOptions::BN254;
 
     } else if #[cfg(feature = "bls12_381")] {
-        mod generic_ark;
         pub type FieldElement = generic_ark::FieldElement<ark_bls12_381::Fr>;
         pub const CHOSEN_FIELD : FieldOptions = FieldOptions::BLS12_381;
     } else {

--- a/acvm-repo/acvm/Cargo.toml
+++ b/acvm-repo/acvm/Cargo.toml
@@ -24,7 +24,6 @@ acvm_blackbox_solver.workspace = true
 indexmap = "1.7.0"
 
 [features]
-default = ["bn254"]
 bn254 = [
     "acir/bn254",
     "brillig_vm/bn254",

--- a/acvm-repo/acvm/Cargo.toml
+++ b/acvm-repo/acvm/Cargo.toml
@@ -39,3 +39,4 @@ bls12_381 = [
 rand = "0.8.5"
 proptest = "1.2.0"
 paste = "1.0.14"
+ark-bls12-381 = { version = "^0.4.0", default-features = false, features = ["curve"] }

--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -53,10 +53,10 @@ impl AcirTransformationMap {
     }
 }
 
-fn transform_assert_messages(
-    assert_messages: Vec<(OpcodeLocation, AssertionPayload)>,
+fn transform_assert_messages<F>(
+    assert_messages: Vec<(OpcodeLocation, AssertionPayload<F>)>,
     map: &AcirTransformationMap,
-) -> Vec<(OpcodeLocation, AssertionPayload)> {
+) -> Vec<(OpcodeLocation, AssertionPayload<F>)> {
     assert_messages
         .into_iter()
         .flat_map(|(location, message)| {
@@ -67,10 +67,10 @@ fn transform_assert_messages(
 }
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
-pub fn compile(
-    acir: Circuit,
+pub fn compile<F>(
+    acir: Circuit<F>,
     expression_width: ExpressionWidth,
-) -> (Circuit, AcirTransformationMap) {
+) -> (Circuit<F>, AcirTransformationMap) {
     let (acir, acir_opcode_positions) = optimize_internal(acir);
 
     let (mut acir, acir_opcode_positions) =

--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use acir::circuit::{AssertionPayload, Circuit, ExpressionWidth, OpcodeLocation};
+use acir::{
+    circuit::{AssertionPayload, Circuit, ExpressionWidth, OpcodeLocation},
+    AcirField,
+};
 
 // The various passes that we can use over ACIR
 mod optimizers;
@@ -53,7 +56,7 @@ impl AcirTransformationMap {
     }
 }
 
-fn transform_assert_messages<F>(
+fn transform_assert_messages<F: Clone>(
     assert_messages: Vec<(OpcodeLocation, AssertionPayload<F>)>,
     map: &AcirTransformationMap,
 ) -> Vec<(OpcodeLocation, AssertionPayload<F>)> {
@@ -67,7 +70,7 @@ fn transform_assert_messages<F>(
 }
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
-pub fn compile<F>(
+pub fn compile<F: AcirField>(
     acir: Circuit<F>,
     expression_width: ExpressionWidth,
 ) -> (Circuit<F>, AcirTransformationMap) {

--- a/acvm-repo/acvm/src/compiler/optimizers/general.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/general.rs
@@ -1,6 +1,6 @@
 use acir::{
     native_types::{Expression, Witness},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use indexmap::IndexMap;
 

--- a/acvm-repo/acvm/src/compiler/optimizers/general.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/general.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 pub(crate) struct GeneralOptimizer;
 
 impl GeneralOptimizer {
-    pub(crate) fn optimize<F>(opcode: Expression<F>) -> Expression<F> {
+    pub(crate) fn optimize<F: AcirField>(opcode: Expression<F>) -> Expression<F> {
         // XXX: Perhaps this optimization can be done on the fly
         let opcode = remove_zero_coefficients(opcode);
         let opcode = simplify_mul_terms(opcode);
@@ -19,7 +19,7 @@ impl GeneralOptimizer {
 }
 
 // Remove all terms with zero as a coefficient
-fn remove_zero_coefficients<F>(mut opcode: Expression<F>) -> Expression<F> {
+fn remove_zero_coefficients<F: AcirField>(mut opcode: Expression<F>) -> Expression<F> {
     // Check the mul terms
     opcode.mul_terms.retain(|(scale, _, _)| !scale.is_zero());
     // Check the linear combination terms
@@ -28,7 +28,7 @@ fn remove_zero_coefficients<F>(mut opcode: Expression<F>) -> Expression<F> {
 }
 
 // Simplifies all mul terms with the same bi-variate variables
-fn simplify_mul_terms<F>(mut gate: Expression<F>) -> Expression<F> {
+fn simplify_mul_terms<F: AcirField>(mut gate: Expression<F>) -> Expression<F> {
     let mut hash_map: IndexMap<(Witness, Witness), F> = IndexMap::new();
 
     // Canonicalize the ordering of the multiplication, lets just order by variable name
@@ -45,7 +45,7 @@ fn simplify_mul_terms<F>(mut gate: Expression<F>) -> Expression<F> {
 }
 
 // Simplifies all linear terms with the same variables
-fn simplify_linear_terms<F>(mut gate: Expression<F>) -> Expression<F> {
+fn simplify_linear_terms<F: AcirField>(mut gate: Expression<F>) -> Expression<F> {
     let mut hash_map: IndexMap<Witness, F> = IndexMap::new();
 
     // Canonicalize the ordering of the terms, lets just order by variable name

--- a/acvm-repo/acvm/src/compiler/optimizers/general.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/general.rs
@@ -1,6 +1,6 @@
 use acir::{
     native_types::{Expression, Witness},
-    AcirField, FieldElement,
+    AcirField,
 };
 use indexmap::IndexMap;
 
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 pub(crate) struct GeneralOptimizer;
 
 impl GeneralOptimizer {
-    pub(crate) fn optimize(opcode: Expression) -> Expression {
+    pub(crate) fn optimize<F>(opcode: Expression<F>) -> Expression<F> {
         // XXX: Perhaps this optimization can be done on the fly
         let opcode = remove_zero_coefficients(opcode);
         let opcode = simplify_mul_terms(opcode);
@@ -19,7 +19,7 @@ impl GeneralOptimizer {
 }
 
 // Remove all terms with zero as a coefficient
-fn remove_zero_coefficients(mut opcode: Expression) -> Expression {
+fn remove_zero_coefficients<F>(mut opcode: Expression<F>) -> Expression<F> {
     // Check the mul terms
     opcode.mul_terms.retain(|(scale, _, _)| !scale.is_zero());
     // Check the linear combination terms
@@ -28,8 +28,8 @@ fn remove_zero_coefficients(mut opcode: Expression) -> Expression {
 }
 
 // Simplifies all mul terms with the same bi-variate variables
-fn simplify_mul_terms(mut gate: Expression) -> Expression {
-    let mut hash_map: IndexMap<(Witness, Witness), FieldElement> = IndexMap::new();
+fn simplify_mul_terms<F>(mut gate: Expression<F>) -> Expression<F> {
+    let mut hash_map: IndexMap<(Witness, Witness), F> = IndexMap::new();
 
     // Canonicalize the ordering of the multiplication, lets just order by variable name
     for (scale, w_l, w_r) in gate.mul_terms.into_iter() {
@@ -37,7 +37,7 @@ fn simplify_mul_terms(mut gate: Expression) -> Expression {
         // Sort using rust sort algorithm
         pair.sort();
 
-        *hash_map.entry((pair[0], pair[1])).or_insert_with(FieldElement::zero) += scale;
+        *hash_map.entry((pair[0], pair[1])).or_insert_with(F::zero) += scale;
     }
 
     gate.mul_terms = hash_map.into_iter().map(|((w_l, w_r), scale)| (scale, w_l, w_r)).collect();
@@ -45,17 +45,17 @@ fn simplify_mul_terms(mut gate: Expression) -> Expression {
 }
 
 // Simplifies all linear terms with the same variables
-fn simplify_linear_terms(mut gate: Expression) -> Expression {
-    let mut hash_map: IndexMap<Witness, FieldElement> = IndexMap::new();
+fn simplify_linear_terms<F>(mut gate: Expression<F>) -> Expression<F> {
+    let mut hash_map: IndexMap<Witness, F> = IndexMap::new();
 
     // Canonicalize the ordering of the terms, lets just order by variable name
     for (scale, witness) in gate.linear_combinations.into_iter() {
-        *hash_map.entry(witness).or_insert_with(FieldElement::zero) += scale;
+        *hash_map.entry(witness).or_insert_with(F::zero) += scale;
     }
 
     gate.linear_combinations = hash_map
         .into_iter()
-        .filter(|(_, scale)| scale != &FieldElement::zero())
+        .filter(|(_, scale)| !scale.is_zero())
         .map(|(witness, scale)| (scale, witness))
         .collect();
     gate

--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -1,4 +1,7 @@
-use acir::circuit::{Circuit, Opcode};
+use acir::{
+    circuit::{Circuit, Opcode},
+    AcirField,
+};
 
 // mod constant_backpropagation;
 mod general;
@@ -15,7 +18,7 @@ use self::unused_memory::UnusedMemoryOptimizer;
 use super::{transform_assert_messages, AcirTransformationMap};
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
-pub fn optimize<F>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformationMap) {
+pub fn optimize<F: AcirField>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformationMap) {
     let (mut acir, new_opcode_positions) = optimize_internal(acir);
 
     let transformation_map = AcirTransformationMap::new(new_opcode_positions);
@@ -27,7 +30,7 @@ pub fn optimize<F>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformationMap) {
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
 #[tracing::instrument(level = "trace", name = "optimize_acir" skip(acir))]
-pub(super) fn optimize_internal<F>(acir: Circuit<F>) -> (Circuit<F>, Vec<usize>) {
+pub(super) fn optimize_internal<F: AcirField>(acir: Circuit<F>) -> (Circuit<F>, Vec<usize>) {
     // Track original acir opcode positions throughout the transformation passes of the compilation
     // by applying the modifications done to the circuit opcodes and also to the opcode_positions (delete and insert)
     let acir_opcode_positions = (0..acir.opcodes.len()).collect();
@@ -40,7 +43,7 @@ pub(super) fn optimize_internal<F>(acir: Circuit<F>) -> (Circuit<F>, Vec<usize>)
     info!("Number of opcodes before: {}", acir.opcodes.len());
 
     // General optimizer pass
-    let opcodes: Vec<Opcode> = acir
+    let opcodes: Vec<Opcode<F>> = acir
         .opcodes
         .into_iter()
         .map(|opcode| {

--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -15,7 +15,7 @@ use self::unused_memory::UnusedMemoryOptimizer;
 use super::{transform_assert_messages, AcirTransformationMap};
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
-pub fn optimize(acir: Circuit) -> (Circuit, AcirTransformationMap) {
+pub fn optimize<F>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformationMap) {
     let (mut acir, new_opcode_positions) = optimize_internal(acir);
 
     let transformation_map = AcirTransformationMap::new(new_opcode_positions);
@@ -27,7 +27,7 @@ pub fn optimize(acir: Circuit) -> (Circuit, AcirTransformationMap) {
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
 #[tracing::instrument(level = "trace", name = "optimize_acir" skip(acir))]
-pub(super) fn optimize_internal(acir: Circuit) -> (Circuit, Vec<usize>) {
+pub(super) fn optimize_internal<F>(acir: Circuit<F>) -> (Circuit<F>, Vec<usize>) {
     // Track original acir opcode positions throughout the transformation passes of the compilation
     // by applying the modifications done to the circuit opcodes and also to the opcode_positions (delete and insert)
     let acir_opcode_positions = (0..acir.opcodes.len()).collect();

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -27,16 +27,16 @@ use std::collections::{BTreeMap, HashSet};
 ///
 /// This optimization pass will keep the 16-bit range constraint
 /// and remove the 32-bit range constraint opcode.
-pub(crate) struct RangeOptimizer {
+pub(crate) struct RangeOptimizer<F> {
     /// Maps witnesses to their lowest known bit sizes.
     lists: BTreeMap<Witness, u32>,
-    circuit: Circuit,
+    circuit: Circuit<F>,
 }
 
-impl RangeOptimizer {
+impl<F> RangeOptimizer<F> {
     /// Creates a new `RangeOptimizer` by collecting all known range
     /// constraints from `Circuit`.
-    pub(crate) fn new(circuit: Circuit) -> Self {
+    pub(crate) fn new(circuit: Circuit<F>) -> Self {
         let range_list = Self::collect_ranges(&circuit);
         Self { circuit, lists: range_list }
     }
@@ -47,7 +47,7 @@ impl RangeOptimizer {
     /// both 32 bits and 16 bits. This function will
     /// only store the fact that we have constrained it to
     /// be 16 bits.
-    fn collect_ranges(circuit: &Circuit) -> BTreeMap<Witness, u32> {
+    fn collect_ranges(circuit: &Circuit<F>) -> BTreeMap<Witness, u32> {
         let mut witness_to_bit_sizes: BTreeMap<Witness, u32> = BTreeMap::new();
 
         for opcode in &circuit.opcodes {
@@ -96,7 +96,10 @@ impl RangeOptimizer {
 
     /// Returns a `Circuit` where each Witness is only range constrained
     /// once to the lowest number `bit size` possible.
-    pub(crate) fn replace_redundant_ranges(self, order_list: Vec<usize>) -> (Circuit, Vec<usize>) {
+    pub(crate) fn replace_redundant_ranges(
+        self,
+        order_list: Vec<usize>,
+    ) -> (Circuit<F>, Vec<usize>) {
         let mut already_seen_witness = HashSet::new();
 
         let mut new_order_list = Vec::with_capacity(order_list.len());
@@ -149,10 +152,11 @@ mod tests {
             Circuit, ExpressionWidth, Opcode, PublicInputs,
         },
         native_types::{Expression, Witness},
+        FieldElement,
     };
 
-    fn test_circuit(ranges: Vec<(Witness, u32)>) -> Circuit {
-        fn test_range_constraint(witness: Witness, num_bits: u32) -> Opcode {
+    fn test_circuit(ranges: Vec<(Witness, u32)>) -> Circuit<FieldElement> {
+        fn test_range_constraint(witness: Witness, num_bits: u32) -> Opcode<FieldElement> {
             Opcode::BlackBoxFuncCall(BlackBoxFuncCall::RANGE {
                 input: FunctionInput { witness, num_bits },
             })

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -4,6 +4,7 @@ use acir::{
         Circuit, Opcode,
     },
     native_types::Witness,
+    AcirField,
 };
 use std::collections::{BTreeMap, HashSet};
 

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -33,7 +33,7 @@ pub(crate) struct RangeOptimizer<F> {
     circuit: Circuit<F>,
 }
 
-impl<F> RangeOptimizer<F> {
+impl<F: AcirField> RangeOptimizer<F> {
     /// Creates a new `RangeOptimizer` by collecting all known range
     /// constraints from `Circuit`.
     pub(crate) fn new(circuit: Circuit<F>) -> Self {

--- a/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
@@ -2,15 +2,15 @@ use acir::circuit::{opcodes::BlockId, Circuit, Opcode};
 use std::collections::HashSet;
 
 /// `UnusedMemoryOptimizer` will remove initializations of memory blocks which are unused.
-pub(crate) struct UnusedMemoryOptimizer {
+pub(crate) struct UnusedMemoryOptimizer<F> {
     unused_memory_initializations: HashSet<BlockId>,
-    circuit: Circuit,
+    circuit: Circuit<F>,
 }
 
-impl UnusedMemoryOptimizer {
+impl<F> UnusedMemoryOptimizer<F> {
     /// Creates a new `UnusedMemoryOptimizer ` by collecting unused memory init
     /// opcodes from `Circuit`.
-    pub(crate) fn new(circuit: Circuit) -> Self {
+    pub(crate) fn new(circuit: Circuit<F>) -> Self {
         let unused_memory_initializations = Self::collect_unused_memory_initializations(&circuit);
         Self { circuit, unused_memory_initializations }
     }
@@ -18,7 +18,7 @@ impl UnusedMemoryOptimizer {
     /// Creates a set of ids for memory blocks for which no [`Opcode::MemoryOp`]s exist.
     ///
     /// These memory blocks can be safely removed.
-    fn collect_unused_memory_initializations(circuit: &Circuit) -> HashSet<BlockId> {
+    fn collect_unused_memory_initializations(circuit: &Circuit<F>) -> HashSet<BlockId> {
         let mut unused_memory_initialization = HashSet::new();
 
         for opcode in &circuit.opcodes {
@@ -39,7 +39,7 @@ impl UnusedMemoryOptimizer {
     pub(crate) fn remove_unused_memory_initializations(
         self,
         order_list: Vec<usize>,
-    ) -> (Circuit, Vec<usize>) {
+    ) -> (Circuit<F>, Vec<usize>) {
         let mut new_order_list = Vec::with_capacity(order_list.len());
         let mut optimized_opcodes = Vec::with_capacity(self.circuit.opcodes.len());
         for (idx, opcode) in self.circuit.opcodes.into_iter().enumerate() {

--- a/acvm-repo/acvm/src/compiler/transformers/csat.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/csat.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::HashSet};
 
 use acir::{
     native_types::{Expression, Witness},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use indexmap::IndexMap;
 

--- a/acvm-repo/acvm/src/compiler/transformers/csat.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/csat.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::HashSet};
 
 use acir::{
     native_types::{Expression, Witness},
-    AcirField, FieldElement,
+    AcirField,
 };
 use indexmap::IndexMap;
 
@@ -64,10 +64,10 @@ impl CSatTransformer {
     // Still missing dead witness optimization.
     // To do this, we will need the whole set of assert-zero opcodes
     // I think it can also be done before the local optimization seen here, as dead variables will come from the user
-    pub(crate) fn transform<F>(
+    pub(crate) fn transform<F: AcirField>(
         &mut self,
         opcode: Expression<F>,
-        intermediate_variables: &mut IndexMap<Expression<F>, (FieldElement, Witness)>,
+        intermediate_variables: &mut IndexMap<Expression<F>, (F, Witness)>,
         num_witness: &mut u32,
     ) -> Expression<F> {
         // Here we create intermediate variables and constrain them to be equal to any subset of the polynomial that can be represented as a full opcode
@@ -107,10 +107,10 @@ impl CSatTransformer {
     // The polynomial now looks like so t + t2
     // We can no longer extract another full opcode, hence the algorithm terminates. Creating two intermediate variables t and t2.
     // This stage of preprocessing does not guarantee that all polynomials can fit into a opcode. It only guarantees that all full opcodes have been extracted from each polynomial
-    fn full_opcode_scan_optimization<F>(
+    fn full_opcode_scan_optimization<F: AcirField>(
         &mut self,
         mut opcode: Expression<F>,
-        intermediate_variables: &mut IndexMap<Expression<F>, (FieldElement, Witness)>,
+        intermediate_variables: &mut IndexMap<Expression<F>, (F, Witness)>,
         num_witness: &mut u32,
     ) -> Expression<F> {
         // We pass around this intermediate variable IndexMap, so that we do not create intermediate variables that we have created before
@@ -245,7 +245,7 @@ impl CSatTransformer {
     /// Normalize an expression by dividing it by its first coefficient
     /// The first coefficient here means coefficient of the first linear term, or of the first quadratic term if no linear terms exist.
     /// The function panic if the input expression is constant
-    fn normalize<F>(mut expr: Expression<F>) -> (F, Expression<F>) {
+    fn normalize<F: AcirField>(mut expr: Expression<F>) -> (F, Expression<F>) {
         expr.sort();
         let a = if !expr.linear_combinations.is_empty() {
             expr.linear_combinations[0].0
@@ -259,7 +259,7 @@ impl CSatTransformer {
     /// The sets of previously generated witness and their (normalized) expression is cached in the intermediate_variables map
     /// If there is no cache hit, we generate a new witness (and add the expression to the cache)
     /// else, we return the cached witness along with the scaling factor so it is equal to the provided expression
-    fn get_or_create_intermediate_vars<F>(
+    fn get_or_create_intermediate_vars<F: AcirField>(
         intermediate_variables: &mut IndexMap<Expression<F>, (F, Witness)>,
         expr: Expression<F>,
         num_witness: &mut u32,
@@ -315,7 +315,7 @@ impl CSatTransformer {
     // Also remember that since we did full opcode scan, there is no way we can have a non-zero mul term along with the wL and wR terms being non-zero
     //
     // Cases, a lot of mul terms, a lot of fan-in terms, 50/50
-    fn partial_opcode_scan_optimization<F>(
+    fn partial_opcode_scan_optimization<F: AcirField>(
         &mut self,
         mut opcode: Expression<F>,
         intermediate_variables: &mut IndexMap<Expression<F>, (F, Witness)>,
@@ -409,101 +409,113 @@ impl CSatTransformer {
     }
 }
 
-#[test]
-fn simple_reduction_smoke_test() {
-    let a = Witness(0);
-    let b = Witness(1);
-    let c = Witness(2);
-    let d = Witness(3);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acir::{AcirField, FieldElement};
 
-    // a = b + c + d;
-    let opcode_a = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![
-            (FieldElement::one(), a),
-            (-FieldElement::one(), b),
-            (-FieldElement::one(), c),
-            (-FieldElement::one(), d),
-        ],
-        q_c: FieldElement::zero(),
-    };
+    #[test]
+    fn simple_reduction_smoke_test() {
+        let a = Witness(0);
+        let b = Witness(1);
+        let c = Witness(2);
+        let d = Witness(3);
 
-    let mut intermediate_variables: IndexMap<Expression, (FieldElement, Witness)> = IndexMap::new();
+        // a = b + c + d;
+        let opcode_a = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![
+                (FieldElement::one(), a),
+                (-FieldElement::one(), b),
+                (-FieldElement::one(), c),
+                (-FieldElement::one(), d),
+            ],
+            q_c: FieldElement::zero(),
+        };
 
-    let mut num_witness = 4;
+        let mut intermediate_variables: IndexMap<
+            Expression<FieldElement>,
+            (FieldElement, Witness),
+        > = IndexMap::new();
 
-    let mut optimizer = CSatTransformer::new(3);
-    optimizer.mark_solvable(b);
-    optimizer.mark_solvable(c);
-    optimizer.mark_solvable(d);
-    let got_optimized_opcode_a =
-        optimizer.transform(opcode_a, &mut intermediate_variables, &mut num_witness);
+        let mut num_witness = 4;
 
-    // a = b + c + d => a - b - c - d = 0
-    // For width3, the result becomes:
-    // a - d + e = 0
-    // - c - b  - e = 0
-    //
-    // a - b + e = 0
-    let e = Witness(4);
-    let expected_optimized_opcode_a = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![
-            (FieldElement::one(), a),
-            (-FieldElement::one(), d),
-            (FieldElement::one(), e),
-        ],
-        q_c: FieldElement::zero(),
-    };
-    assert_eq!(expected_optimized_opcode_a, got_optimized_opcode_a);
+        let mut optimizer = CSatTransformer::new(3);
+        optimizer.mark_solvable(b);
+        optimizer.mark_solvable(c);
+        optimizer.mark_solvable(d);
+        let got_optimized_opcode_a =
+            optimizer.transform(opcode_a, &mut intermediate_variables, &mut num_witness);
 
-    assert_eq!(intermediate_variables.len(), 1);
+        // a = b + c + d => a - b - c - d = 0
+        // For width3, the result becomes:
+        // a - d + e = 0
+        // - c - b  - e = 0
+        //
+        // a - b + e = 0
+        let e = Witness(4);
+        let expected_optimized_opcode_a = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![
+                (FieldElement::one(), a),
+                (-FieldElement::one(), d),
+                (FieldElement::one(), e),
+            ],
+            q_c: FieldElement::zero(),
+        };
+        assert_eq!(expected_optimized_opcode_a, got_optimized_opcode_a);
 
-    // e = - c - b
-    let expected_intermediate_opcode = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![(-FieldElement::one(), c), (-FieldElement::one(), b)],
-        q_c: FieldElement::zero(),
-    };
-    let (_, normalized_opcode) = CSatTransformer::normalize(expected_intermediate_opcode);
-    assert!(intermediate_variables.contains_key(&normalized_opcode));
-    assert_eq!(intermediate_variables[&normalized_opcode].1, e);
-}
+        assert_eq!(intermediate_variables.len(), 1);
 
-#[test]
-fn stepwise_reduction_test() {
-    let a = Witness(0);
-    let b = Witness(1);
-    let c = Witness(2);
-    let d = Witness(3);
-    let e = Witness(4);
+        // e = - c - b
+        let expected_intermediate_opcode = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![(-FieldElement::one(), c), (-FieldElement::one(), b)],
+            q_c: FieldElement::zero(),
+        };
+        let (_, normalized_opcode) = CSatTransformer::normalize(expected_intermediate_opcode);
+        assert!(intermediate_variables.contains_key(&normalized_opcode));
+        assert_eq!(intermediate_variables[&normalized_opcode].1, e);
+    }
 
-    // a = b + c + d + e;
-    let opcode_a = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![
-            (-FieldElement::one(), a),
-            (FieldElement::one(), b),
-            (FieldElement::one(), c),
-            (FieldElement::one(), d),
-            (FieldElement::one(), e),
-        ],
-        q_c: FieldElement::zero(),
-    };
+    #[test]
+    fn stepwise_reduction_test() {
+        let a = Witness(0);
+        let b = Witness(1);
+        let c = Witness(2);
+        let d = Witness(3);
+        let e = Witness(4);
 
-    let mut intermediate_variables: IndexMap<Expression, (FieldElement, Witness)> = IndexMap::new();
+        // a = b + c + d + e;
+        let opcode_a = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![
+                (-FieldElement::one(), a),
+                (FieldElement::one(), b),
+                (FieldElement::one(), c),
+                (FieldElement::one(), d),
+                (FieldElement::one(), e),
+            ],
+            q_c: FieldElement::zero(),
+        };
 
-    let mut num_witness = 4;
+        let mut intermediate_variables: IndexMap<
+            Expression<FieldElement>,
+            (FieldElement, Witness),
+        > = IndexMap::new();
 
-    let mut optimizer = CSatTransformer::new(3);
-    optimizer.mark_solvable(a);
-    optimizer.mark_solvable(c);
-    optimizer.mark_solvable(d);
-    optimizer.mark_solvable(e);
-    let got_optimized_opcode_a =
-        optimizer.transform(opcode_a, &mut intermediate_variables, &mut num_witness);
+        let mut num_witness = 4;
 
-    // Since b is not known, it cannot be put inside intermediate opcodes, so it must belong to the transformed opcode.
-    let contains_b = got_optimized_opcode_a.linear_combinations.iter().any(|(_, w)| *w == b);
-    assert!(contains_b);
+        let mut optimizer = CSatTransformer::new(3);
+        optimizer.mark_solvable(a);
+        optimizer.mark_solvable(c);
+        optimizer.mark_solvable(d);
+        optimizer.mark_solvable(e);
+        let got_optimized_opcode_a =
+            optimizer.transform(opcode_a, &mut intermediate_variables, &mut num_witness);
+
+        // Since b is not known, it cannot be put inside intermediate opcodes, so it must belong to the transformed opcode.
+        let contains_b = got_optimized_opcode_a.linear_combinations.iter().any(|(_, w)| *w == b);
+        assert!(contains_b);
+    }
 }

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::{brillig::BrilligOutputs, directives::Directive, Circuit, ExpressionWidth, Opcode},
     native_types::{Expression, Witness},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use indexmap::IndexMap;
 

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -12,10 +12,10 @@ pub(crate) use csat::CSatTransformer;
 use super::{transform_assert_messages, AcirTransformationMap};
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
-pub fn transform(
-    acir: Circuit,
+pub fn transform<F>(
+    acir: Circuit<F>,
     expression_width: ExpressionWidth,
-) -> (Circuit, AcirTransformationMap) {
+) -> (Circuit<F>, AcirTransformationMap) {
     // Track original acir opcode positions throughout the transformation passes of the compilation
     // by applying the modifications done to the circuit opcodes and also to the opcode_positions (delete and insert)
     let acir_opcode_positions = acir.opcodes.iter().enumerate().map(|(i, _)| i).collect();
@@ -34,11 +34,11 @@ pub fn transform(
 ///
 /// Accepts an injected `acir_opcode_positions` to allow transformations to be applied directly after optimizations.
 #[tracing::instrument(level = "trace", name = "transform_acir", skip(acir, acir_opcode_positions))]
-pub(super) fn transform_internal(
-    acir: Circuit,
+pub(super) fn transform_internal<F>(
+    acir: Circuit<F>,
     expression_width: ExpressionWidth,
     acir_opcode_positions: Vec<usize>,
-) -> (Circuit, Vec<usize>) {
+) -> (Circuit<F>, Vec<usize>) {
     let mut transformer = match &expression_width {
         ExpressionWidth::Unbounded => {
             return (acir, acir_opcode_positions);

--- a/acvm-repo/acvm/src/lib.rs
+++ b/acvm-repo/acvm/src/lib.rs
@@ -11,7 +11,7 @@ use pwg::OpcodeResolutionError;
 
 // re-export acir
 pub use acir;
-pub use acir::FieldElement;
+pub use acir::{AcirField, FieldElement};
 // re-export brillig vm
 pub use brillig_vm;
 // re-export blackbox solver

--- a/acvm-repo/acvm/src/pwg/arithmetic.rs
+++ b/acvm-repo/acvm/src/pwg/arithmetic.rs
@@ -1,6 +1,6 @@
 use acir::{
     native_types::{Expression, Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 
 use super::{insert_value, ErrorLocation, OpcodeNotSolvable, OpcodeResolutionError};

--- a/acvm-repo/acvm/src/pwg/arithmetic.rs
+++ b/acvm-repo/acvm/src/pwg/arithmetic.rs
@@ -1,6 +1,6 @@
 use acir::{
     native_types::{Expression, Witness, WitnessMap},
-    AcirField, FieldElement,
+    AcirField,
 };
 
 use super::{insert_value, ErrorLocation, OpcodeNotSolvable, OpcodeResolutionError};
@@ -24,8 +24,8 @@ pub(crate) enum MulTerm<F> {
 
 impl ExpressionSolver {
     /// Derives the rest of the witness based on the initial low level variables
-    pub(crate) fn solve<F>(
-        initial_witness: &mut WitnessMap,
+    pub(crate) fn solve<F: AcirField>(
+        initial_witness: &mut WitnessMap<F>,
         opcode: &Expression<F>,
     ) -> Result<(), OpcodeResolutionError<F>> {
         let opcode = &ExpressionSolver::evaluate(opcode, initial_witness);
@@ -133,14 +133,14 @@ impl ExpressionSolver {
     /// If the witness values are not known, then the function returns a None
     /// XXX: Do we need to account for the case where 5xy + 6x = 0 ? We do not know y, but it can be solved given x . But I believe x can be solved with another opcode
     /// XXX: What about making a mul opcode = a constant 5xy + 7 = 0 ? This is the same as the above.
-    fn solve_mul_term<F>(
+    fn solve_mul_term<F: AcirField>(
         arith_opcode: &Expression<F>,
-        witness_assignments: &WitnessMap,
+        witness_assignments: &WitnessMap<F>,
     ) -> Result<MulTerm<F>, OpcodeStatus<F>> {
         // First note that the mul term can only contain one/zero term
         // We are assuming it has been optimized.
         match arith_opcode.mul_terms.len() {
-            0 => Ok(MulTerm::Solved(FieldElement::zero())),
+            0 => Ok(MulTerm::Solved(F::zero())),
             1 => Ok(ExpressionSolver::solve_mul_term_helper(
                 &arith_opcode.mul_terms[0],
                 witness_assignments,
@@ -149,9 +149,9 @@ impl ExpressionSolver {
         }
     }
 
-    fn solve_mul_term_helper<F>(
+    fn solve_mul_term_helper<F: AcirField>(
         term: &(F, Witness, Witness),
-        witness_assignments: &WitnessMap,
+        witness_assignments: &WitnessMap<F>,
     ) -> MulTerm<F> {
         let (q_m, w_l, w_r) = term;
         // Check if these values are in the witness assignments
@@ -166,9 +166,9 @@ impl ExpressionSolver {
         }
     }
 
-    fn solve_fan_in_term_helper<F>(
+    fn solve_fan_in_term_helper<F: AcirField>(
         term: &(F, Witness),
-        witness_assignments: &WitnessMap,
+        witness_assignments: &WitnessMap<F>,
     ) -> Option<F> {
         let (q_l, w_l) = term;
         // Check if we have w_l
@@ -179,17 +179,17 @@ impl ExpressionSolver {
     /// Returns the summation of all of the variables, plus the unknown variable
     /// Returns None, if there is more than one unknown variable
     /// We cannot assign
-    pub(super) fn solve_fan_in_term<F>(
+    pub(super) fn solve_fan_in_term<F: AcirField>(
         arith_opcode: &Expression<F>,
-        witness_assignments: &WitnessMap,
+        witness_assignments: &WitnessMap<F>,
     ) -> OpcodeStatus<F> {
         // This is assuming that the fan-in is more than 0
 
         // This is the variable that we want to assign the value to
-        let mut unknown_variable = (FieldElement::zero(), Witness::default());
+        let mut unknown_variable = (F::zero(), Witness::default());
         let mut num_unknowns = 0;
         // This is the sum of all of the known variables
-        let mut result = FieldElement::zero();
+        let mut result = F::zero();
 
         for term in arith_opcode.linear_combinations.iter() {
             let value = ExpressionSolver::solve_fan_in_term_helper(term, witness_assignments);
@@ -215,7 +215,10 @@ impl ExpressionSolver {
     }
 
     // Partially evaluate the opcode using the known witnesses
-    pub(crate) fn evaluate<F>(expr: &Expression<F>, initial_witness: &WitnessMap) -> Expression<F> {
+    pub(crate) fn evaluate<F: AcirField>(
+        expr: &Expression<F>,
+        initial_witness: &WitnessMap<F>,
+    ) -> Expression<F> {
         let mut result = Expression::default();
         for &(c, w1, w2) in &expr.mul_terms {
             let mul_result = ExpressionSolver::solve_mul_term_helper(&(c, w1, w2), initial_witness);
@@ -245,43 +248,49 @@ impl ExpressionSolver {
     }
 }
 
-#[test]
-fn expression_solver_smoke_test() {
-    let a = Witness(0);
-    let b = Witness(1);
-    let c = Witness(2);
-    let d = Witness(3);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acir::FieldElement;
 
-    // a = b + c + d;
-    let opcode_a = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![
-            (FieldElement::one(), a),
-            (-FieldElement::one(), b),
-            (-FieldElement::one(), c),
-            (-FieldElement::one(), d),
-        ],
-        q_c: FieldElement::zero(),
-    };
+    #[test]
+    fn expression_solver_smoke_test() {
+        let a = Witness(0);
+        let b = Witness(1);
+        let c = Witness(2);
+        let d = Witness(3);
 
-    let e = Witness(4);
-    let opcode_b = Expression {
-        mul_terms: vec![],
-        linear_combinations: vec![
-            (FieldElement::one(), e),
-            (-FieldElement::one(), a),
-            (-FieldElement::one(), b),
-        ],
-        q_c: FieldElement::zero(),
-    };
+        // a = b + c + d;
+        let opcode_a = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![
+                (FieldElement::one(), a),
+                (-FieldElement::one(), b),
+                (-FieldElement::one(), c),
+                (-FieldElement::one(), d),
+            ],
+            q_c: FieldElement::zero(),
+        };
 
-    let mut values = WitnessMap::new();
-    values.insert(b, FieldElement::from(2_i128));
-    values.insert(c, FieldElement::from(1_i128));
-    values.insert(d, FieldElement::from(1_i128));
+        let e = Witness(4);
+        let opcode_b = Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![
+                (FieldElement::one(), e),
+                (-FieldElement::one(), a),
+                (-FieldElement::one(), b),
+            ],
+            q_c: FieldElement::zero(),
+        };
 
-    assert_eq!(ExpressionSolver::solve(&mut values, &opcode_a), Ok(()));
-    assert_eq!(ExpressionSolver::solve(&mut values, &opcode_b), Ok(()));
+        let mut values = WitnessMap::new();
+        values.insert(b, FieldElement::from(2_i128));
+        values.insert(c, FieldElement::from(1_i128));
+        values.insert(d, FieldElement::from(1_i128));
 
-    assert_eq!(values.get(&a).unwrap(), &FieldElement::from(4_i128));
+        assert_eq!(ExpressionSolver::solve(&mut values, &opcode_a), Ok(()));
+        assert_eq!(ExpressionSolver::solve(&mut values, &opcode_b), Ok(()));
+
+        assert_eq!(values.get(&a).unwrap(), &FieldElement::from(4_i128));
+    }
 }

--- a/acvm-repo/acvm/src/pwg/blackbox/aes128.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/aes128.rs
@@ -9,13 +9,13 @@ use crate::{pwg::insert_value, OpcodeResolutionError};
 
 use super::utils::{to_u8_array, to_u8_vec};
 
-pub(super) fn solve_aes128_encryption_opcode(
+pub(super) fn solve_aes128_encryption_opcode<F>(
     initial_witness: &mut WitnessMap,
     inputs: &[FunctionInput],
     iv: &[FunctionInput; 16],
     key: &[FunctionInput; 16],
     outputs: &[Witness],
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let scalars = to_u8_vec(initial_witness, inputs)?;
 
     let iv = to_u8_array(initial_witness, iv)?;

--- a/acvm-repo/acvm/src/pwg/blackbox/aes128.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/aes128.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField,
 };
 use acvm_blackbox_solver::aes128_encrypt;
 
@@ -9,8 +9,8 @@ use crate::{pwg::insert_value, OpcodeResolutionError};
 
 use super::utils::{to_u8_array, to_u8_vec};
 
-pub(super) fn solve_aes128_encryption_opcode<F>(
-    initial_witness: &mut WitnessMap,
+pub(super) fn solve_aes128_encryption_opcode<F: AcirField>(
+    initial_witness: &mut WitnessMap<F>,
     inputs: &[FunctionInput],
     iv: &[FunctionInput; 16],
     key: &[FunctionInput; 16],
@@ -25,7 +25,7 @@ pub(super) fn solve_aes128_encryption_opcode<F>(
 
     // Write witness assignments
     for (output_witness, value) in outputs.iter().zip(ciphertext.into_iter()) {
-        insert_value(output_witness, FieldElement::from(value as u128), initial_witness)?;
+        insert_value(output_witness, F::from(value as u128), initial_witness)?;
     }
 
     Ok(())

--- a/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    BlackBoxFunc, FieldElement,
+    AcirField, BlackBoxFunc, FieldElement,
 };
 
 use acvm_blackbox_solver::BigIntSolver;

--- a/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
@@ -18,13 +18,13 @@ pub(crate) struct AcvmBigIntSolver {
 }
 
 impl AcvmBigIntSolver {
-    pub(crate) fn bigint_from_bytes(
+    pub(crate) fn bigint_from_bytes<F>(
         &mut self,
         inputs: &[FunctionInput],
         modulus: &[u8],
         output: u32,
         initial_witness: &mut WitnessMap,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<(), OpcodeResolutionError<F>> {
         let bytes = inputs
             .iter()
             .map(|input| initial_witness.get(&input.witness).unwrap().to_u128() as u8)
@@ -33,12 +33,12 @@ impl AcvmBigIntSolver {
         Ok(())
     }
 
-    pub(crate) fn bigint_to_bytes(
+    pub(crate) fn bigint_to_bytes<F>(
         &self,
         input: u32,
         outputs: &[Witness],
         initial_witness: &mut WitnessMap,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<(), OpcodeResolutionError<F>> {
         let mut bytes = self.bigint_solver.bigint_to_bytes(input)?;
         while bytes.len() < outputs.len() {
             bytes.push(0);
@@ -49,13 +49,13 @@ impl AcvmBigIntSolver {
         Ok(())
     }
 
-    pub(crate) fn bigint_op(
+    pub(crate) fn bigint_op<F>(
         &mut self,
         lhs: u32,
         rhs: u32,
         output: u32,
         func: BlackBoxFunc,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<(), OpcodeResolutionError<F>> {
         self.bigint_solver.bigint_op(lhs, rhs, output, func)?;
         Ok(())
     }

--- a/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    AcirField, BlackBoxFunc, FieldElement,
+    AcirField, BlackBoxFunc,
 };
 
 use acvm_blackbox_solver::BigIntSolver;
@@ -18,12 +18,12 @@ pub(crate) struct AcvmBigIntSolver {
 }
 
 impl AcvmBigIntSolver {
-    pub(crate) fn bigint_from_bytes<F>(
+    pub(crate) fn bigint_from_bytes<F: AcirField>(
         &mut self,
         inputs: &[FunctionInput],
         modulus: &[u8],
         output: u32,
-        initial_witness: &mut WitnessMap,
+        initial_witness: &mut WitnessMap<F>,
     ) -> Result<(), OpcodeResolutionError<F>> {
         let bytes = inputs
             .iter()
@@ -33,18 +33,18 @@ impl AcvmBigIntSolver {
         Ok(())
     }
 
-    pub(crate) fn bigint_to_bytes<F>(
+    pub(crate) fn bigint_to_bytes<F: AcirField>(
         &self,
         input: u32,
         outputs: &[Witness],
-        initial_witness: &mut WitnessMap,
+        initial_witness: &mut WitnessMap<F>,
     ) -> Result<(), OpcodeResolutionError<F>> {
         let mut bytes = self.bigint_solver.bigint_to_bytes(input)?;
         while bytes.len() < outputs.len() {
             bytes.push(0);
         }
         bytes.iter().zip(outputs.iter()).for_each(|(byte, output)| {
-            initial_witness.insert(*output, FieldElement::from(*byte as u128));
+            initial_witness.insert(*output, F::from(*byte as u128));
         });
         Ok(())
     }

--- a/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
@@ -6,13 +6,13 @@ use acvm_blackbox_solver::BlackBoxFunctionSolver;
 
 use crate::pwg::{insert_value, witness_to_value, OpcodeResolutionError};
 
-pub(super) fn multi_scalar_mul(
+pub(super) fn multi_scalar_mul<F>(
     backend: &impl BlackBoxFunctionSolver,
     initial_witness: &mut WitnessMap,
     points: &[FunctionInput],
     scalars: &[FunctionInput],
     outputs: (Witness, Witness, Witness),
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let points: Result<Vec<_>, _> =
         points.iter().map(|input| witness_to_value(initial_witness, input.witness)).collect();
     let points: Vec<_> = points?.into_iter().cloned().collect();
@@ -39,13 +39,13 @@ pub(super) fn multi_scalar_mul(
     Ok(())
 }
 
-pub(super) fn embedded_curve_add(
+pub(super) fn embedded_curve_add<F>(
     backend: &impl BlackBoxFunctionSolver,
     initial_witness: &mut WitnessMap,
     input1: [FunctionInput; 3],
     input2: [FunctionInput; 3],
     outputs: (Witness, Witness, Witness),
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let input1_x = witness_to_value(initial_witness, input1[0].witness)?;
     let input1_y = witness_to_value(initial_witness, input1[1].witness)?;
     let input1_infinite = witness_to_value(initial_witness, input1[2].witness)?;

--- a/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
@@ -1,14 +1,15 @@
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
+    AcirField,
 };
 use acvm_blackbox_solver::BlackBoxFunctionSolver;
 
 use crate::pwg::{insert_value, witness_to_value, OpcodeResolutionError};
 
-pub(super) fn multi_scalar_mul<F>(
-    backend: &impl BlackBoxFunctionSolver,
-    initial_witness: &mut WitnessMap,
+pub(super) fn multi_scalar_mul<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
     points: &[FunctionInput],
     scalars: &[FunctionInput],
     outputs: (Witness, Witness, Witness),
@@ -39,9 +40,9 @@ pub(super) fn multi_scalar_mul<F>(
     Ok(())
 }
 
-pub(super) fn embedded_curve_add<F>(
-    backend: &impl BlackBoxFunctionSolver,
-    initial_witness: &mut WitnessMap,
+pub(super) fn embedded_curve_add<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
     input1: [FunctionInput; 3],
     input2: [FunctionInput; 3],
     outputs: (Witness, Witness, Witness),

--- a/acvm-repo/acvm/src/pwg/blackbox/hash.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/hash.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use acvm_blackbox_solver::{sha256compression, BlackBoxFunctionSolver, BlackBoxResolutionError};
 

--- a/acvm-repo/acvm/src/pwg/blackbox/logic.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/logic.rs
@@ -8,12 +8,12 @@ use acir::{
 
 /// Solves a [`BlackBoxFunc::And`][acir::circuit::black_box_functions::BlackBoxFunc::AND] opcode and inserts
 /// the result into the supplied witness map
-pub(super) fn and(
+pub(super) fn and<F>(
     initial_witness: &mut WitnessMap,
     lhs: &FunctionInput,
     rhs: &FunctionInput,
     output: &Witness,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     assert_eq!(
         lhs.num_bits, rhs.num_bits,
         "number of bits specified for each input must be the same"
@@ -25,12 +25,12 @@ pub(super) fn and(
 
 /// Solves a [`BlackBoxFunc::XOR`][acir::circuit::black_box_functions::BlackBoxFunc::XOR] opcode and inserts
 /// the result into the supplied witness map
-pub(super) fn xor(
+pub(super) fn xor<F>(
     initial_witness: &mut WitnessMap,
     lhs: &FunctionInput,
     rhs: &FunctionInput,
     output: &Witness,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     assert_eq!(
         lhs.num_bits, rhs.num_bits,
         "number of bits specified for each input must be the same"
@@ -41,13 +41,13 @@ pub(super) fn xor(
 }
 
 /// Derives the rest of the witness based on the initial low level variables
-fn solve_logic_opcode(
+fn solve_logic_opcode<F>(
     initial_witness: &mut WitnessMap,
     a: &Witness,
     b: &Witness,
     result: Witness,
     logic_op: impl Fn(&FieldElement, &FieldElement) -> FieldElement,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let w_l_value = witness_to_value(initial_witness, *a)?;
     let w_r_value = witness_to_value(initial_witness, *b)?;
     let assignment = logic_op(w_l_value, w_r_value);

--- a/acvm-repo/acvm/src/pwg/blackbox/logic.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/logic.rs
@@ -3,7 +3,7 @@ use crate::OpcodeResolutionError;
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 
 /// Solves a [`BlackBoxFunc::And`][acir::circuit::black_box_functions::BlackBoxFunc::AND] opcode and inserts

--- a/acvm-repo/acvm/src/pwg/blackbox/logic.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/logic.rs
@@ -3,13 +3,13 @@ use crate::OpcodeResolutionError;
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    AcirField, FieldElement,
+    AcirField,
 };
 
 /// Solves a [`BlackBoxFunc::And`][acir::circuit::black_box_functions::BlackBoxFunc::AND] opcode and inserts
 /// the result into the supplied witness map
-pub(super) fn and<F>(
-    initial_witness: &mut WitnessMap,
+pub(super) fn and<F: AcirField>(
+    initial_witness: &mut WitnessMap<F>,
     lhs: &FunctionInput,
     rhs: &FunctionInput,
     output: &Witness,
@@ -25,8 +25,8 @@ pub(super) fn and<F>(
 
 /// Solves a [`BlackBoxFunc::XOR`][acir::circuit::black_box_functions::BlackBoxFunc::XOR] opcode and inserts
 /// the result into the supplied witness map
-pub(super) fn xor<F>(
-    initial_witness: &mut WitnessMap,
+pub(super) fn xor<F: AcirField>(
+    initial_witness: &mut WitnessMap<F>,
     lhs: &FunctionInput,
     rhs: &FunctionInput,
     output: &Witness,
@@ -41,12 +41,12 @@ pub(super) fn xor<F>(
 }
 
 /// Derives the rest of the witness based on the initial low level variables
-fn solve_logic_opcode<F>(
-    initial_witness: &mut WitnessMap,
+fn solve_logic_opcode<F: AcirField>(
+    initial_witness: &mut WitnessMap<F>,
     a: &Witness,
     b: &Witness,
     result: Witness,
-    logic_op: impl Fn(&FieldElement, &FieldElement) -> FieldElement,
+    logic_op: impl Fn(&F, &F) -> F,
 ) -> Result<(), OpcodeResolutionError<F>> {
     let w_l_value = witness_to_value(initial_witness, *a)?;
     let w_r_value = witness_to_value(initial_witness, *b)?;

--- a/acvm-repo/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/mod.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::opcodes::{BlackBoxFuncCall, FunctionInput},
     native_types::{Witness, WitnessMap},
-    AcirField, FieldElement,
+    AcirField,
 };
 use acvm_blackbox_solver::{blake2s, blake3, keccak256, keccakf1600, sha256};
 
@@ -37,8 +37,8 @@ use signature::{
 /// Check if all of the inputs to the function have assignments
 ///
 /// Returns the first missing assignment if any are missing
-fn first_missing_assignment(
-    witness_assignments: &WitnessMap,
+fn first_missing_assignment<F>(
+    witness_assignments: &WitnessMap<F>,
     inputs: &[FunctionInput],
 ) -> Option<Witness> {
     inputs.iter().find_map(|input| {
@@ -51,13 +51,13 @@ fn first_missing_assignment(
 }
 
 /// Check if all of the inputs to the function have assignments
-fn contains_all_inputs(witness_assignments: &WitnessMap, inputs: &[FunctionInput]) -> bool {
+fn contains_all_inputs<F>(witness_assignments: &WitnessMap<F>, inputs: &[FunctionInput]) -> bool {
     inputs.iter().all(|input| witness_assignments.contains_key(&input.witness))
 }
 
-pub(crate) fn solve<F>(
-    backend: &impl BlackBoxFunctionSolver,
-    initial_witness: &mut WitnessMap,
+pub(crate) fn solve<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
     bb_func: &BlackBoxFuncCall,
     bigint_solver: &mut AcvmBigIntSolver,
 ) -> Result<(), OpcodeResolutionError<F>> {
@@ -108,7 +108,7 @@ pub(crate) fn solve<F>(
             }
             let output_state = keccakf1600(state)?;
             for (output_witness, value) in outputs.iter().zip(output_state.into_iter()) {
-                insert_value(output_witness, FieldElement::from(value as u128), initial_witness)?;
+                insert_value(output_witness, F::from(value as u128), initial_witness)?;
             }
             Ok(())
         }

--- a/acvm-repo/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/mod.rs
@@ -55,12 +55,12 @@ fn contains_all_inputs(witness_assignments: &WitnessMap, inputs: &[FunctionInput
     inputs.iter().all(|input| witness_assignments.contains_key(&input.witness))
 }
 
-pub(crate) fn solve(
+pub(crate) fn solve<F>(
     backend: &impl BlackBoxFunctionSolver,
     initial_witness: &mut WitnessMap,
     bb_func: &BlackBoxFuncCall,
     bigint_solver: &mut AcvmBigIntSolver,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let inputs = bb_func.get_inputs_vec();
     if !contains_all_inputs(initial_witness, &inputs) {
         let unassigned_witness = first_missing_assignment(initial_witness, &inputs)

--- a/acvm-repo/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/mod.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::opcodes::{BlackBoxFuncCall, FunctionInput},
     native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use acvm_blackbox_solver::{blake2s, blake3, keccak256, keccakf1600, sha256};
 

--- a/acvm-repo/acvm/src/pwg/blackbox/pedersen.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/pedersen.rs
@@ -8,13 +8,13 @@ use crate::{
     BlackBoxFunctionSolver,
 };
 
-pub(super) fn pedersen(
+pub(super) fn pedersen<F>(
     backend: &impl BlackBoxFunctionSolver,
     initial_witness: &mut WitnessMap,
     inputs: &[FunctionInput],
     domain_separator: u32,
     outputs: (Witness, Witness),
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let scalars: Result<Vec<_>, _> =
         inputs.iter().map(|input| witness_to_value(initial_witness, input.witness)).collect();
     let scalars: Vec<_> = scalars?.into_iter().cloned().collect();
@@ -27,13 +27,13 @@ pub(super) fn pedersen(
     Ok(())
 }
 
-pub(super) fn pedersen_hash(
+pub(super) fn pedersen_hash<F>(
     backend: &impl BlackBoxFunctionSolver,
     initial_witness: &mut WitnessMap,
     inputs: &[FunctionInput],
     domain_separator: u32,
     output: Witness,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let scalars: Result<Vec<_>, _> =
         inputs.iter().map(|input| witness_to_value(initial_witness, input.witness)).collect();
     let scalars: Vec<_> = scalars?.into_iter().cloned().collect();

--- a/acvm-repo/acvm/src/pwg/blackbox/pedersen.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/pedersen.rs
@@ -1,6 +1,7 @@
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
+    AcirField,
 };
 
 use crate::{
@@ -8,9 +9,9 @@ use crate::{
     BlackBoxFunctionSolver,
 };
 
-pub(super) fn pedersen<F>(
-    backend: &impl BlackBoxFunctionSolver,
-    initial_witness: &mut WitnessMap,
+pub(super) fn pedersen<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
     inputs: &[FunctionInput],
     domain_separator: u32,
     outputs: (Witness, Witness),
@@ -27,9 +28,9 @@ pub(super) fn pedersen<F>(
     Ok(())
 }
 
-pub(super) fn pedersen_hash<F>(
-    backend: &impl BlackBoxFunctionSolver,
-    initial_witness: &mut WitnessMap,
+pub(super) fn pedersen_hash<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
     inputs: &[FunctionInput],
     domain_separator: u32,
     output: Witness,

--- a/acvm-repo/acvm/src/pwg/blackbox/range.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/range.rs
@@ -4,10 +4,10 @@ use crate::{
 };
 use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap, AcirField};
 
-pub(crate) fn solve_range_opcode(
+pub(crate) fn solve_range_opcode<F>(
     initial_witness: &WitnessMap,
     input: &FunctionInput,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let w_value = witness_to_value(initial_witness, input.witness)?;
     if w_value.num_bits() > input.num_bits {
         return Err(OpcodeResolutionError::UnsatisfiedConstrain {

--- a/acvm-repo/acvm/src/pwg/blackbox/range.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/range.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap, AcirField};
 
-pub(crate) fn solve_range_opcode<F>(
-    initial_witness: &WitnessMap,
+pub(crate) fn solve_range_opcode<F: AcirField>(
+    initial_witness: &WitnessMap<F>,
     input: &FunctionInput,
 ) -> Result<(), OpcodeResolutionError<F>> {
     let w_value = witness_to_value(initial_witness, input.witness)?;

--- a/acvm-repo/acvm/src/pwg/blackbox/range.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/range.rs
@@ -2,7 +2,7 @@ use crate::{
     pwg::{witness_to_value, ErrorLocation},
     OpcodeResolutionError,
 };
-use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap};
+use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap, AcirField};
 
 pub(crate) fn solve_range_opcode(
     initial_witness: &WitnessMap,

--- a/acvm-repo/acvm/src/pwg/blackbox/signature/ecdsa.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/signature/ecdsa.rs
@@ -13,14 +13,14 @@ use crate::{
     OpcodeResolutionError,
 };
 
-pub(crate) fn secp256k1_prehashed(
+pub(crate) fn secp256k1_prehashed<F>(
     initial_witness: &mut WitnessMap,
     public_key_x_inputs: &[FunctionInput; 32],
     public_key_y_inputs: &[FunctionInput; 32],
     signature_inputs: &[FunctionInput; 64],
     hashed_message_inputs: &[FunctionInput],
     output: Witness,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let hashed_message = to_u8_vec(initial_witness, hashed_message_inputs)?;
 
     let pub_key_x: [u8; 32] = to_u8_array(initial_witness, public_key_x_inputs)?;
@@ -32,14 +32,14 @@ pub(crate) fn secp256k1_prehashed(
     insert_value(&output, FieldElement::from(is_valid), initial_witness)
 }
 
-pub(crate) fn secp256r1_prehashed(
+pub(crate) fn secp256r1_prehashed<F>(
     initial_witness: &mut WitnessMap,
     public_key_x_inputs: &[FunctionInput; 32],
     public_key_y_inputs: &[FunctionInput; 32],
     signature_inputs: &[FunctionInput; 64],
     hashed_message_inputs: &[FunctionInput],
     output: Witness,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let hashed_message = to_u8_vec(initial_witness, hashed_message_inputs)?;
 
     let pub_key_x: [u8; 32] = to_u8_array(initial_witness, public_key_x_inputs)?;

--- a/acvm-repo/acvm/src/pwg/blackbox/signature/ecdsa.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/signature/ecdsa.rs
@@ -1,7 +1,7 @@
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField,
 };
 use acvm_blackbox_solver::{ecdsa_secp256k1_verify, ecdsa_secp256r1_verify};
 
@@ -13,8 +13,8 @@ use crate::{
     OpcodeResolutionError,
 };
 
-pub(crate) fn secp256k1_prehashed<F>(
-    initial_witness: &mut WitnessMap,
+pub(crate) fn secp256k1_prehashed<F: AcirField>(
+    initial_witness: &mut WitnessMap<F>,
     public_key_x_inputs: &[FunctionInput; 32],
     public_key_y_inputs: &[FunctionInput; 32],
     signature_inputs: &[FunctionInput; 64],
@@ -29,11 +29,11 @@ pub(crate) fn secp256k1_prehashed<F>(
 
     let is_valid = ecdsa_secp256k1_verify(&hashed_message, &pub_key_x, &pub_key_y, &signature)?;
 
-    insert_value(&output, FieldElement::from(is_valid), initial_witness)
+    insert_value(&output, F::from(is_valid), initial_witness)
 }
 
-pub(crate) fn secp256r1_prehashed<F>(
-    initial_witness: &mut WitnessMap,
+pub(crate) fn secp256r1_prehashed<F: AcirField>(
+    initial_witness: &mut WitnessMap<F>,
     public_key_x_inputs: &[FunctionInput; 32],
     public_key_y_inputs: &[FunctionInput; 32],
     signature_inputs: &[FunctionInput; 64],
@@ -48,5 +48,5 @@ pub(crate) fn secp256r1_prehashed<F>(
 
     let is_valid = ecdsa_secp256r1_verify(&hashed_message, &pub_key_x, &pub_key_y, &signature)?;
 
-    insert_value(&output, FieldElement::from(is_valid), initial_witness)
+    insert_value(&output, F::from(is_valid), initial_witness)
 }

--- a/acvm-repo/acvm/src/pwg/blackbox/signature/schnorr.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/signature/schnorr.rs
@@ -12,7 +12,7 @@ use acir::{
 };
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn schnorr_verify(
+pub(crate) fn schnorr_verify<F>(
     backend: &impl BlackBoxFunctionSolver,
     initial_witness: &mut WitnessMap,
     public_key_x: FunctionInput,
@@ -20,7 +20,7 @@ pub(crate) fn schnorr_verify(
     signature: &[FunctionInput; 64],
     message: &[FunctionInput],
     output: Witness,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let public_key_x: &FieldElement = witness_to_value(initial_witness, public_key_x.witness)?;
     let public_key_y: &FieldElement = witness_to_value(initial_witness, public_key_y.witness)?;
 

--- a/acvm-repo/acvm/src/pwg/blackbox/signature/schnorr.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/signature/schnorr.rs
@@ -8,21 +8,21 @@ use crate::{
 use acir::{
     circuit::opcodes::FunctionInput,
     native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField,
 };
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn schnorr_verify<F>(
-    backend: &impl BlackBoxFunctionSolver,
-    initial_witness: &mut WitnessMap,
+pub(crate) fn schnorr_verify<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
     public_key_x: FunctionInput,
     public_key_y: FunctionInput,
     signature: &[FunctionInput; 64],
     message: &[FunctionInput],
     output: Witness,
 ) -> Result<(), OpcodeResolutionError<F>> {
-    let public_key_x: &FieldElement = witness_to_value(initial_witness, public_key_x.witness)?;
-    let public_key_y: &FieldElement = witness_to_value(initial_witness, public_key_y.witness)?;
+    let public_key_x: &F = witness_to_value(initial_witness, public_key_x.witness)?;
+    let public_key_y: &F = witness_to_value(initial_witness, public_key_y.witness)?;
 
     let signature = to_u8_array(initial_witness, signature)?;
     let message = to_u8_vec(initial_witness, message)?;
@@ -30,7 +30,7 @@ pub(crate) fn schnorr_verify<F>(
     let valid_signature =
         backend.schnorr_verify(public_key_x, public_key_y, &signature, &message)?;
 
-    insert_value(&output, FieldElement::from(valid_signature), initial_witness)?;
+    insert_value(&output, F::from(valid_signature), initial_witness)?;
 
     Ok(())
 }

--- a/acvm-repo/acvm/src/pwg/blackbox/utils.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/utils.rs
@@ -2,8 +2,8 @@ use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap, AcirField}
 
 use crate::pwg::{witness_to_value, OpcodeResolutionError};
 
-pub(crate) fn to_u8_array<const N: usize, F>(
-    initial_witness: &WitnessMap,
+pub(crate) fn to_u8_array<const N: usize, F: AcirField>(
+    initial_witness: &WitnessMap<F>,
     inputs: &[FunctionInput; N],
 ) -> Result<[u8; N], OpcodeResolutionError<F>> {
     let mut result = [0; N];
@@ -17,8 +17,8 @@ pub(crate) fn to_u8_array<const N: usize, F>(
     Ok(result)
 }
 
-pub(crate) fn to_u8_vec<F>(
-    initial_witness: &WitnessMap,
+pub(crate) fn to_u8_vec<F: AcirField>(
+    initial_witness: &WitnessMap<F>,
     inputs: &[FunctionInput],
 ) -> Result<Vec<u8>, OpcodeResolutionError<F>> {
     let mut result = Vec::with_capacity(inputs.len());

--- a/acvm-repo/acvm/src/pwg/blackbox/utils.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/utils.rs
@@ -1,4 +1,4 @@
-use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap};
+use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap, AcirField};
 
 use crate::pwg::{witness_to_value, OpcodeResolutionError};
 

--- a/acvm-repo/acvm/src/pwg/blackbox/utils.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/utils.rs
@@ -2,10 +2,10 @@ use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap, AcirField}
 
 use crate::pwg::{witness_to_value, OpcodeResolutionError};
 
-pub(crate) fn to_u8_array<const N: usize>(
+pub(crate) fn to_u8_array<const N: usize, F>(
     initial_witness: &WitnessMap,
     inputs: &[FunctionInput; N],
-) -> Result<[u8; N], OpcodeResolutionError> {
+) -> Result<[u8; N], OpcodeResolutionError<F>> {
     let mut result = [0; N];
     for (it, input) in result.iter_mut().zip(inputs) {
         let witness_value_bytes = witness_to_value(initial_witness, input.witness)?.to_be_bytes();
@@ -17,10 +17,10 @@ pub(crate) fn to_u8_array<const N: usize>(
     Ok(result)
 }
 
-pub(crate) fn to_u8_vec(
+pub(crate) fn to_u8_vec<F>(
     initial_witness: &WitnessMap,
     inputs: &[FunctionInput],
-) -> Result<Vec<u8>, OpcodeResolutionError> {
+) -> Result<Vec<u8>, OpcodeResolutionError<F>> {
     let mut result = Vec::with_capacity(inputs.len());
     for input in inputs {
         let witness_value_bytes = witness_to_value(initial_witness, input.witness)?.to_be_bytes();

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -9,7 +9,7 @@ use acir::{
         STRING_ERROR_SELECTOR,
     },
     native_types::WitnessMap,
-    AcirField, FieldElement,
+    AcirField,
 };
 use acvm_blackbox_solver::BlackBoxFunctionSolver;
 use brillig_vm::{FailureReason, MemoryValue, VMStatus, VM};
@@ -19,31 +19,31 @@ use crate::{pwg::OpcodeNotSolvable, OpcodeResolutionError};
 use super::{get_value, insert_value, memory_op::MemoryOpSolver};
 
 #[derive(Debug)]
-pub enum BrilligSolverStatus {
+pub enum BrilligSolverStatus<F> {
     Finished,
     InProgress,
-    ForeignCallWait(ForeignCallWaitInfo),
+    ForeignCallWait(ForeignCallWaitInfo<F>),
 }
 
-pub struct BrilligSolver<'b, B: BlackBoxFunctionSolver, F> {
-    vm: VM<'b, B>,
+pub struct BrilligSolver<'b, F, B: BlackBoxFunctionSolver<F>> {
+    vm: VM<'b, F, B>,
     acir_index: usize,
 }
 
-impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
+impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
     /// Assigns the zero value to all outputs of the given [`Brillig`] bytecode.
     pub(super) fn zero_out_brillig_outputs(
-        initial_witness: &mut WitnessMap,
+        initial_witness: &mut WitnessMap<F>,
         outputs: &[BrilligOutputs],
     ) -> Result<(), OpcodeResolutionError<F>> {
         for output in outputs {
             match output {
                 BrilligOutputs::Simple(witness) => {
-                    insert_value(witness, FieldElement::zero(), initial_witness)?;
+                    insert_value(witness, F::zero(), initial_witness)?;
                 }
                 BrilligOutputs::Array(witness_arr) => {
                     for witness in witness_arr {
-                        insert_value(witness, FieldElement::zero(), initial_witness)?;
+                        insert_value(witness, F::zero(), initial_witness)?;
                     }
                 }
             }
@@ -54,10 +54,10 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
     /// Constructs a solver for a Brillig block given the bytecode and initial
     /// witness.
     pub(crate) fn new_call(
-        initial_witness: &WitnessMap,
+        initial_witness: &WitnessMap<F>,
         memory: &HashMap<BlockId, MemoryOpSolver<F>>,
         inputs: &'b [BrilligInputs<F>],
-        brillig_bytecode: &'b [BrilligOpcode],
+        brillig_bytecode: &'b [BrilligOpcode<F>],
         bb_solver: &'b B,
         acir_index: usize,
     ) -> Result<Self, OpcodeResolutionError<F>> {
@@ -67,14 +67,14 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
     }
 
     fn setup_brillig_vm(
-        initial_witness: &WitnessMap,
+        initial_witness: &WitnessMap<F>,
         memory: &HashMap<BlockId, MemoryOpSolver<F>>,
         inputs: &[BrilligInputs<F>],
-        brillig_bytecode: &'b [BrilligOpcode],
+        brillig_bytecode: &'b [BrilligOpcode<F>],
         bb_solver: &'b B,
-    ) -> Result<VM<'b, B>, OpcodeResolutionError<F>> {
+    ) -> Result<VM<'b, F, B>, OpcodeResolutionError<F>> {
         // Set input values
-        let mut calldata: Vec<FieldElement> = Vec::new();
+        let mut calldata: Vec<F> = Vec::new();
         // Each input represents an expression or array of expressions to evaluate.
         // Iterate over each input and evaluate the expression(s) associated with it.
         // Push the results into memory.
@@ -123,11 +123,11 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
         Ok(vm)
     }
 
-    pub fn get_memory(&self) -> &[MemoryValue] {
+    pub fn get_memory(&self) -> &[MemoryValue<F>] {
         self.vm.get_memory()
     }
 
-    pub fn write_memory_at(&mut self, ptr: usize, value: MemoryValue) {
+    pub fn write_memory_at(&mut self, ptr: usize, value: MemoryValue<F>) {
         self.vm.write_memory_at(ptr, value);
     }
 
@@ -135,12 +135,12 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
         self.vm.get_call_stack()
     }
 
-    pub(crate) fn solve(&mut self) -> Result<BrilligSolverStatus, OpcodeResolutionError<F>> {
+    pub(crate) fn solve(&mut self) -> Result<BrilligSolverStatus<F>, OpcodeResolutionError<F>> {
         let status = self.vm.process_opcodes();
         self.handle_vm_status(status)
     }
 
-    pub fn step(&mut self) -> Result<BrilligSolverStatus, OpcodeResolutionError<F>> {
+    pub fn step(&mut self) -> Result<BrilligSolverStatus<F>, OpcodeResolutionError<F>> {
         let status = self.vm.process_opcode();
         self.handle_vm_status(status)
     }
@@ -151,8 +151,8 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
 
     fn handle_vm_status(
         &self,
-        vm_status: VMStatus,
-    ) -> Result<BrilligSolverStatus, OpcodeResolutionError<F>> {
+        vm_status: VMStatus<F>,
+    ) -> Result<BrilligSolverStatus<F>, OpcodeResolutionError<F>> {
         // Check the status of the Brillig VM and return a resolution.
         // It may be finished, in-progress, failed, or may be waiting for results of a foreign call.
         // Return the "resolution" to the caller who may choose to make subsequent calls
@@ -227,7 +227,7 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
 
     pub(crate) fn finalize(
         self,
-        witness: &mut WitnessMap,
+        witness: &mut WitnessMap<F>,
         outputs: &[BrilligOutputs],
     ) -> Result<(), OpcodeResolutionError<F>> {
         // Finish the Brillig execution by writing the outputs to the witness map
@@ -243,7 +243,7 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
 
     fn write_brillig_outputs(
         &self,
-        witness_map: &mut WitnessMap,
+        witness_map: &mut WitnessMap<F>,
         return_data_offset: usize,
         return_data_size: usize,
         outputs: &[BrilligOutputs],
@@ -274,7 +274,7 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
         Ok(())
     }
 
-    pub fn resolve_pending_foreign_call(&mut self, foreign_call_result: ForeignCallResult) {
+    pub fn resolve_pending_foreign_call(&mut self, foreign_call_result: ForeignCallResult<F>) {
         match self.vm.get_status() {
             VMStatus::ForeignCallWait { .. } => self.vm.resolve_foreign_call(foreign_call_result),
             _ => unreachable!("Brillig VM is not waiting for a foreign call"),
@@ -287,9 +287,9 @@ impl<'b, B: BlackBoxFunctionSolver, F> BrilligSolver<'b, B, F> {
 ///
 /// The caller must resolve this opcode externally based upon the information in the request.
 #[derive(Debug, PartialEq, Clone)]
-pub struct ForeignCallWaitInfo {
+pub struct ForeignCallWaitInfo<F> {
     /// An identifier interpreted by the caller process
     pub function: String,
     /// Resolved inputs to a foreign call computed in the previous steps of a Brillig VM process
-    pub inputs: Vec<ForeignCallParam>,
+    pub inputs: Vec<ForeignCallParam<F>>,
 }

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -9,7 +9,7 @@ use acir::{
         STRING_ERROR_SELECTOR,
     },
     native_types::WitnessMap,
-    FieldElement,
+    AcirField, FieldElement,
 };
 use acvm_blackbox_solver::BlackBoxFunctionSolver;
 use brillig_vm::{FailureReason, MemoryValue, VMStatus, VM};

--- a/acvm-repo/acvm/src/pwg/directives/mod.rs
+++ b/acvm-repo/acvm/src/pwg/directives/mod.rs
@@ -1,4 +1,4 @@
-use acir::{circuit::directives::Directive, native_types::WitnessMap, FieldElement};
+use acir::{circuit::directives::Directive, native_types::WitnessMap, AcirField, FieldElement};
 use num_bigint::BigUint;
 
 use crate::OpcodeResolutionError;

--- a/acvm-repo/acvm/src/pwg/directives/mod.rs
+++ b/acvm-repo/acvm/src/pwg/directives/mod.rs
@@ -1,4 +1,4 @@
-use acir::{circuit::directives::Directive, native_types::WitnessMap, AcirField, FieldElement};
+use acir::{circuit::directives::Directive, native_types::WitnessMap, AcirField};
 use num_bigint::BigUint;
 
 use crate::OpcodeResolutionError;
@@ -11,8 +11,8 @@ use super::{get_value, insert_value, ErrorLocation};
 /// Returns `Ok(OpcodeResolution)` to signal whether the directive was successful solved.
 ///
 /// Returns `Err(OpcodeResolutionError)` if a circuit constraint is unsatisfied.
-pub(crate) fn solve_directives<F>(
-    initial_witness: &mut WitnessMap,
+pub(crate) fn solve_directives<F: AcirField>(
+    initial_witness: &mut WitnessMap<F>,
     directive: &Directive<F>,
 ) -> Result<(), OpcodeResolutionError<F>> {
     match directive {

--- a/acvm-repo/acvm/src/pwg/directives/mod.rs
+++ b/acvm-repo/acvm/src/pwg/directives/mod.rs
@@ -11,10 +11,10 @@ use super::{get_value, insert_value, ErrorLocation};
 /// Returns `Ok(OpcodeResolution)` to signal whether the directive was successful solved.
 ///
 /// Returns `Err(OpcodeResolutionError)` if a circuit constraint is unsatisfied.
-pub(crate) fn solve_directives(
+pub(crate) fn solve_directives<F>(
     initial_witness: &mut WitnessMap,
-    directive: &Directive,
-) -> Result<(), OpcodeResolutionError> {
+    directive: &Directive<F>,
+) -> Result<(), OpcodeResolutionError<F>> {
     match directive {
         Directive::ToLeRadix { a, b, radix } => {
             let value_a = get_value(a, initial_witness)?;
@@ -36,8 +36,8 @@ pub(crate) fn solve_directives(
                 // If it is not available, which can happen when the decomposed integer
                 // list is shorter than the witness list, we return 0.
                 let value = match decomposed_integer.get(i) {
-                    Some(digit) => FieldElement::from_be_bytes_reduce(&[*digit]),
-                    None => FieldElement::zero(),
+                    Some(digit) => F::from_be_bytes_reduce(&[*digit]),
+                    None => F::zero(),
                 };
 
                 insert_value(witness, value, initial_witness)?;

--- a/acvm-repo/acvm/src/pwg/memory_op.rs
+++ b/acvm-repo/acvm/src/pwg/memory_op.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use acir::{
     circuit::opcodes::MemOp,
     native_types::{Expression, Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 
 use super::{
@@ -129,7 +129,7 @@ mod tests {
     use acir::{
         circuit::opcodes::MemOp,
         native_types::{Expression, Witness, WitnessMap},
-        FieldElement,
+        AcirField, FieldElement,
     };
 
     use super::MemoryOpSolver;

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -10,7 +10,7 @@ use acir::{
         STRING_ERROR_SELECTOR,
     },
     native_types::{Expression, Witness, WitnessMap},
-    BlackBoxFunc, FieldElement,
+    AcirField, BlackBoxFunc, FieldElement,
 };
 use acvm_blackbox_solver::BlackBoxResolutionError;
 

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -36,7 +36,7 @@ pub use self::brillig::{BrilligSolver, BrilligSolverStatus};
 pub use brillig::ForeignCallWaitInfo;
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum ACVMStatus {
+pub enum ACVMStatus<F> {
     /// All opcodes have been solved.
     Solved,
 
@@ -45,7 +45,7 @@ pub enum ACVMStatus {
 
     /// The ACVM has encountered an irrecoverable error while executing the circuit and can not progress.
     /// Most commonly this will be due to an unsatisfied constraint due to invalid inputs to the circuit.
-    Failure(OpcodeResolutionError),
+    Failure(OpcodeResolutionError<F>),
 
     /// The ACVM has encountered a request for a Brillig [foreign call][acir::brillig_vm::Opcode::ForeignCall]
     /// to retrieve information from outside of the ACVM. The result of the foreign call must be passed back
@@ -61,7 +61,7 @@ pub enum ACVMStatus {
     RequiresAcirCall(AcirCallWaitInfo),
 }
 
-impl std::fmt::Display for ACVMStatus {
+impl<F> std::fmt::Display for ACVMStatus<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ACVMStatus::Solved => write!(f, "Solved"),
@@ -73,9 +73,9 @@ impl std::fmt::Display for ACVMStatus {
     }
 }
 
-pub enum StepResult<'a, B: BlackBoxFunctionSolver> {
-    Status(ACVMStatus),
-    IntoBrillig(BrilligSolver<'a, B>),
+pub enum StepResult<'a, B: BlackBoxFunctionSolver, F> {
+    Status(ACVMStatus<F>),
+    IntoBrillig(BrilligSolver<'a, B, F>),
 }
 
 // This enum represents the different cases in which an
@@ -87,13 +87,13 @@ pub enum StepResult<'a, B: BlackBoxFunctionSolver> {
 // TODO: we could have a error enum for expression solver failure cases in that module
 // TODO that can be converted into an OpcodeNotSolvable or OpcodeResolutionError enum
 #[derive(Clone, PartialEq, Eq, Debug, Error)]
-pub enum OpcodeNotSolvable {
+pub enum OpcodeNotSolvable<F> {
     #[error("missing assignment for witness index {0}")]
     MissingAssignment(u32),
     #[error("Attempted to load uninitialized memory block")]
     MissingMemoryBlock(u32),
     #[error("expression has too many unknowns {0}")]
-    ExpressionHasTooManyUnknowns(Expression),
+    ExpressionHasTooManyUnknowns(Expression<F>),
 }
 
 /// Allows to point to a specific opcode as cause in errors.
@@ -117,9 +117,9 @@ impl std::fmt::Display for ErrorLocation {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Error)]
-pub enum OpcodeResolutionError {
+pub enum OpcodeResolutionError<F> {
     #[error("Cannot solve opcode: {0}")]
-    OpcodeNotSolvable(#[from] OpcodeNotSolvable),
+    OpcodeNotSolvable(#[from] OpcodeNotSolvable<F>),
     #[error("Cannot satisfy constraint")]
     UnsatisfiedConstrain {
         opcode_location: ErrorLocation,
@@ -140,7 +140,7 @@ pub enum OpcodeResolutionError {
     AcirCallOutputsMismatch { opcode_location: ErrorLocation, results_size: u32, outputs_size: u32 },
 }
 
-impl From<BlackBoxResolutionError> for OpcodeResolutionError {
+impl<F> From<BlackBoxResolutionError> for OpcodeResolutionError<F> {
     fn from(value: BlackBoxResolutionError) -> Self {
         match value {
             BlackBoxResolutionError::Failed(func, reason) => {
@@ -150,24 +150,24 @@ impl From<BlackBoxResolutionError> for OpcodeResolutionError {
     }
 }
 
-pub struct ACVM<'a, B: BlackBoxFunctionSolver> {
-    status: ACVMStatus,
+pub struct ACVM<'a, B: BlackBoxFunctionSolver, F> {
+    status: ACVMStatus<F>,
 
     backend: &'a B,
 
     /// Stores the solver for memory operations acting on blocks of memory disambiguated by [block][`BlockId`].
-    block_solvers: HashMap<BlockId, MemoryOpSolver>,
+    block_solvers: HashMap<BlockId, MemoryOpSolver<F>>,
 
     bigint_solver: AcvmBigIntSolver,
 
     /// A list of opcodes which are to be executed by the ACVM.
-    opcodes: &'a [Opcode],
+    opcodes: &'a [Opcode<F>],
     /// Index of the next opcode to be executed.
     instruction_pointer: usize,
 
     witness_map: WitnessMap,
 
-    brillig_solver: Option<BrilligSolver<'a, B>>,
+    brillig_solver: Option<BrilligSolver<'a, B, F>>,
 
     /// A counter maintained throughout an ACVM process that determines
     /// whether the caller has resolved the results of an ACIR [call][Opcode::Call].
@@ -179,16 +179,16 @@ pub struct ACVM<'a, B: BlackBoxFunctionSolver> {
     // Each unconstrained function referenced in the program
     unconstrained_functions: &'a [BrilligBytecode],
 
-    assertion_payloads: &'a [(OpcodeLocation, AssertionPayload)],
+    assertion_payloads: &'a [(OpcodeLocation, AssertionPayload<F>)],
 }
 
-impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
+impl<'a, B: BlackBoxFunctionSolver, F> ACVM<'a, B, F> {
     pub fn new(
         backend: &'a B,
-        opcodes: &'a [Opcode],
+        opcodes: &'a [Opcode<F>],
         initial_witness: WitnessMap,
         unconstrained_functions: &'a [BrilligBytecode],
-        assertion_payloads: &'a [(OpcodeLocation, AssertionPayload)],
+        assertion_payloads: &'a [(OpcodeLocation, AssertionPayload<F>)],
     ) -> Self {
         let status = if opcodes.is_empty() { ACVMStatus::Solved } else { ACVMStatus::InProgress };
         ACVM {
@@ -223,7 +223,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
     }
 
     /// Returns a slice containing the opcodes of the circuit being executed.
-    pub fn opcodes(&self) -> &[Opcode] {
+    pub fn opcodes(&self) -> &[Opcode<F>] {
         self.opcodes
     }
 
@@ -242,24 +242,24 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
 
     /// Updates the current status of the VM.
     /// Returns the given status.
-    fn status(&mut self, status: ACVMStatus) -> ACVMStatus {
+    fn status(&mut self, status: ACVMStatus<F>) -> ACVMStatus<F> {
         self.status = status.clone();
         status
     }
 
-    pub fn get_status(&self) -> &ACVMStatus {
+    pub fn get_status(&self) -> &ACVMStatus<F> {
         &self.status
     }
 
     /// Sets the VM status to [ACVMStatus::Failure] using the provided `error`.
     /// Returns the new status.
-    fn fail(&mut self, error: OpcodeResolutionError) -> ACVMStatus {
+    fn fail(&mut self, error: OpcodeResolutionError<F>) -> ACVMStatus<F> {
         self.status(ACVMStatus::Failure(error))
     }
 
     /// Sets the status of the VM to `RequiresForeignCall`.
     /// Indicating that the VM is now waiting for a foreign call to be resolved.
-    fn wait_for_foreign_call(&mut self, foreign_call: ForeignCallWaitInfo) -> ACVMStatus {
+    fn wait_for_foreign_call(&mut self, foreign_call: ForeignCallWaitInfo) -> ACVMStatus<F> {
         self.status(ACVMStatus::RequiresForeignCall(foreign_call))
     }
 
@@ -289,7 +289,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
 
     /// Sets the status of the VM to `RequiresAcirCall`
     /// Indicating that the VM is now waiting for an ACIR call to be resolved
-    fn wait_for_acir_call(&mut self, acir_call: AcirCallWaitInfo) -> ACVMStatus {
+    fn wait_for_acir_call(&mut self, acir_call: AcirCallWaitInfo) -> ACVMStatus<F> {
         self.status(ACVMStatus::RequiresAcirCall(acir_call))
     }
 
@@ -316,14 +316,14 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
     /// 1. All opcodes have been executed successfully.
     /// 2. The circuit has been found to be unsatisfiable.
     /// 2. A Brillig [foreign call][`ForeignCallWaitInfo`] has been encountered and must be resolved.
-    pub fn solve(&mut self) -> ACVMStatus {
+    pub fn solve(&mut self) -> ACVMStatus<F> {
         while self.status == ACVMStatus::InProgress {
             self.solve_opcode();
         }
         self.status.clone()
     }
 
-    pub fn solve_opcode(&mut self) -> ACVMStatus {
+    pub fn solve_opcode(&mut self) -> ACVMStatus<F> {
         let opcode = &self.opcodes[self.instruction_pointer];
 
         let resolution = match opcode {
@@ -357,8 +357,8 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
 
     fn handle_opcode_resolution(
         &mut self,
-        resolution: Result<(), OpcodeResolutionError>,
-    ) -> ACVMStatus {
+        resolution: Result<(), OpcodeResolutionError<F>>,
+    ) -> ACVMStatus<F> {
         match resolution {
             Ok(()) => {
                 self.instruction_pointer += 1;
@@ -458,7 +458,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
 
     fn solve_brillig_call_opcode(
         &mut self,
-    ) -> Result<Option<ForeignCallWaitInfo>, OpcodeResolutionError> {
+    ) -> Result<Option<ForeignCallWaitInfo>, OpcodeResolutionError<F>> {
         let Opcode::BrilligCall { id, inputs, outputs, predicate } =
             &self.opcodes[self.instruction_pointer]
         else {
@@ -503,7 +503,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
         }
     }
 
-    fn map_brillig_error(&self, mut err: OpcodeResolutionError) -> OpcodeResolutionError {
+    fn map_brillig_error(&self, mut err: OpcodeResolutionError<F>) -> OpcodeResolutionError<F> {
         match &mut err {
             OpcodeResolutionError::BrilligFunctionFailed { call_stack, payload } => {
                 // Some brillig errors have static strings as payloads, we can resolve them here
@@ -528,7 +528,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
         }
     }
 
-    pub fn step_into_brillig(&mut self) -> StepResult<'a, B> {
+    pub fn step_into_brillig(&mut self) -> StepResult<'a, B, F> {
         let Opcode::BrilligCall { id, inputs, outputs, predicate } =
             &self.opcodes[self.instruction_pointer]
         else {
@@ -559,7 +559,7 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
         }
     }
 
-    pub fn finish_brillig_with_solver(&mut self, solver: BrilligSolver<'a, B>) -> ACVMStatus {
+    pub fn finish_brillig_with_solver(&mut self, solver: BrilligSolver<'a, B, F>) -> ACVMStatus<F> {
         if !matches!(self.opcodes[self.instruction_pointer], Opcode::BrilligCall { .. }) {
             unreachable!("Not executing a Brillig/BrilligCall opcode");
         }
@@ -567,7 +567,9 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
         self.solve_opcode()
     }
 
-    pub fn solve_call_opcode(&mut self) -> Result<Option<AcirCallWaitInfo>, OpcodeResolutionError> {
+    pub fn solve_call_opcode(
+        &mut self,
+    ) -> Result<Option<AcirCallWaitInfo>, OpcodeResolutionError<F>> {
         let Opcode::Call { id, inputs, outputs, predicate } =
             &self.opcodes[self.instruction_pointer]
         else {
@@ -621,10 +623,10 @@ impl<'a, B: BlackBoxFunctionSolver> ACVM<'a, B> {
 // Returns the concrete value for a particular witness
 // If the witness has no assignment, then
 // an error is returned
-pub fn witness_to_value(
+pub fn witness_to_value<F>(
     initial_witness: &WitnessMap,
     witness: Witness,
-) -> Result<&FieldElement, OpcodeResolutionError> {
+) -> Result<&FieldElement, OpcodeResolutionError<F>> {
     match initial_witness.get(&witness) {
         Some(value) => Ok(value),
         None => Err(OpcodeNotSolvable::MissingAssignment(witness.0).into()),
@@ -633,10 +635,10 @@ pub fn witness_to_value(
 
 // TODO: There is an issue open to decide on whether we need to get values from Expressions
 // TODO versus just getting values from Witness
-pub fn get_value(
-    expr: &Expression,
+pub fn get_value<F>(
+    expr: &Expression<F>,
     initial_witness: &WitnessMap,
-) -> Result<FieldElement, OpcodeResolutionError> {
+) -> Result<FieldElement, OpcodeResolutionError<F>> {
     let expr = ExpressionSolver::evaluate(expr, initial_witness);
     match expr.to_const() {
         Some(value) => Ok(value),
@@ -650,11 +652,11 @@ pub fn get_value(
 ///
 /// Returns an error if there was already a value in the map
 /// which does not match the value that one is about to insert
-pub fn insert_value(
+pub fn insert_value<F>(
     witness: &Witness,
     value_to_insert: FieldElement,
     initial_witness: &mut WitnessMap,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<(), OpcodeResolutionError<F>> {
     let optional_old_value = initial_witness.insert(*witness, value_to_insert);
 
     let old_value = match optional_old_value {
@@ -675,7 +677,7 @@ pub fn insert_value(
 // Returns one witness belonging to an expression, in no relevant order
 // Returns None if the expression is const
 // The function is used during partial witness generation to report unsolved witness
-fn any_witness_from_expression(expr: &Expression) -> Option<Witness> {
+fn any_witness_from_expression<F>(expr: &Expression<F>) -> Option<Witness> {
     if expr.linear_combinations.is_empty() {
         if expr.mul_terms.is_empty() {
             None
@@ -690,10 +692,10 @@ fn any_witness_from_expression(expr: &Expression) -> Option<Witness> {
 /// Returns `true` if the predicate is zero
 /// A predicate is used to indicate whether we should skip a certain operation.
 /// If we have a zero predicate it means the operation should be skipped.
-pub(crate) fn is_predicate_false(
+pub(crate) fn is_predicate_false<F>(
     witness: &WitnessMap,
-    predicate: &Option<Expression>,
-) -> Result<bool, OpcodeResolutionError> {
+    predicate: &Option<Expression<F>>,
+) -> Result<bool, OpcodeResolutionError<F>> {
     match predicate {
         Some(pred) => get_value(pred, witness).map(|pred_value| pred_value.is_zero()),
         // If the predicate is `None`, then we treat it as an unconditional `true`

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -1,11 +1,15 @@
 use std::collections::BTreeMap;
 
 use acir::{
-    acir_field::GenericFieldElement, brillig::{BinaryFieldOp, HeapArray, MemoryAddress, Opcode as BrilligOpcode, ValueOrArray}, circuit::{
+    acir_field::GenericFieldElement,
+    brillig::{BinaryFieldOp, HeapArray, MemoryAddress, Opcode as BrilligOpcode, ValueOrArray},
+    circuit::{
         brillig::{BrilligBytecode, BrilligInputs, BrilligOutputs},
         opcodes::{BlockId, BlockType, MemOp},
         Opcode, OpcodeLocation,
-    }, native_types::{Expression, Witness, WitnessMap}, AcirField, FieldElement
+    },
+    native_types::{Expression, Witness, WitnessMap},
+    AcirField, FieldElement,
 };
 
 use acvm::pwg::{ACVMStatus, ErrorLocation, ForeignCallWaitInfo, OpcodeResolutionError, ACVM};
@@ -27,22 +31,15 @@ fn bls12_381_circuit() {
         ],
         q_c: Bls12FieldElement::zero(),
     });
-    let opcodes = [addition]; 
+    let opcodes = [addition];
 
     let witness_assignments = BTreeMap::from([
         (Witness(1), Bls12FieldElement::from(2u128)),
         (Witness(2), Bls12FieldElement::from(3u128)),
-
     ])
     .into();
 
-    let mut acvm = ACVM::new(
-        &StubbedBlackBoxSolver,
-        &opcodes,
-        witness_assignments,
-        &[],
-        &[],
-    );
+    let mut acvm = ACVM::new(&StubbedBlackBoxSolver, &opcodes, witness_assignments, &[], &[]);
     // use the partial witness generation solver with our acir program
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -123,7 +123,7 @@ fn inversion_brillig_oracle_equivalence() {
     );
     assert_eq!(acvm.instruction_pointer(), 0, "brillig should have been removed");
 
-    let foreign_call_wait_info: &ForeignCallWaitInfo =
+    let foreign_call_wait_info: &ForeignCallWaitInfo<FieldElement> =
         acvm.get_pending_foreign_call().expect("should have a brillig foreign call request");
     assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
 
@@ -268,7 +268,7 @@ fn double_inversion_brillig_oracle() {
     );
     assert_eq!(acvm.instruction_pointer(), 0, "should stall on brillig");
 
-    let foreign_call_wait_info: &ForeignCallWaitInfo =
+    let foreign_call_wait_info: &ForeignCallWaitInfo<FieldElement> =
         acvm.get_pending_foreign_call().expect("should have a brillig foreign call request");
     assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
 
@@ -405,7 +405,7 @@ fn oracle_dependent_execution() {
     );
     assert_eq!(acvm.instruction_pointer(), 1, "should stall on brillig");
 
-    let foreign_call_wait_info: &ForeignCallWaitInfo =
+    let foreign_call_wait_info: &ForeignCallWaitInfo<FieldElement> =
         acvm.get_pending_foreign_call().expect("should have a brillig foreign call request");
     assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
 
@@ -421,7 +421,7 @@ fn oracle_dependent_execution() {
     );
     assert_eq!(acvm.instruction_pointer(), 1, "should stall on brillig");
 
-    let foreign_call_wait_info: &ForeignCallWaitInfo =
+    let foreign_call_wait_info: &ForeignCallWaitInfo<FieldElement> =
         acvm.get_pending_foreign_call().expect("should have a brillig foreign call request");
     assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
 

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -8,7 +8,7 @@ use acir::{
         Opcode, OpcodeLocation,
     },
     native_types::{Expression, Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 
 use acvm::pwg::{ACVMStatus, ErrorLocation, ForeignCallWaitInfo, OpcodeResolutionError, ACVM};

--- a/acvm-repo/acvm_js/src/black_box_solvers.rs
+++ b/acvm-repo/acvm_js/src/black_box_solvers.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::js_witness_map::{field_element_to_js_string, js_value_to_field_element};
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 
 /// Performs a bitwise AND operation between `lhs` and `rhs`
 #[wasm_bindgen]

--- a/acvm-repo/acvm_js/src/black_box_solvers.rs
+++ b/acvm-repo/acvm_js/src/black_box_solvers.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::js_witness_map::{field_element_to_js_string, js_value_to_field_element};
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 
 /// Performs a bitwise AND operation between `lhs` and `rhs`
 #[wasm_bindgen]

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -2,12 +2,12 @@ use std::{future::Future, pin::Pin};
 
 use acvm::acir::circuit::brillig::BrilligBytecode;
 use acvm::acir::circuit::ResolvedAssertionPayload;
-use acvm::BlackBoxFunctionSolver;
 use acvm::{
     acir::circuit::{Circuit, Program},
     acir::native_types::{WitnessMap, WitnessStack},
     pwg::{ACVMStatus, ErrorLocation, OpcodeResolutionError, ACVM},
 };
+use acvm::{BlackBoxFunctionSolver, FieldElement};
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 
 use js_sys::Error;
@@ -72,7 +72,7 @@ pub async fn execute_circuit_with_return_witness(
 ) -> Result<JsSolvedAndReturnWitness, Error> {
     console_error_panic_hook::set_once();
 
-    let program: Program = Program::deserialize_program(&program)
+    let program: Program<FieldElement> = Program::deserialize_program(&program)
     .map_err(|_| JsExecutionError::new("Failed to deserialize circuit. This is likely due to differing serialization formats between ACVM_JS and your compiler".to_string(), None, None))?;
 
     let mut witness_stack = execute_program_with_native_program_and_return(
@@ -148,8 +148,8 @@ async fn execute_program_with_native_type_return(
     program: Vec<u8>,
     initial_witness: JsWitnessMap,
     foreign_call_executor: &ForeignCallHandler,
-) -> Result<WitnessStack, Error> {
-    let program: Program = Program::deserialize_program(&program)
+) -> Result<WitnessStack<FieldElement>, Error> {
+    let program: Program<FieldElement> = Program::deserialize_program(&program)
     .map_err(|_| JsExecutionError::new(
         "Failed to deserialize circuit. This is likely due to differing serialization formats between ACVM_JS and your compiler".to_string(), 
         None,
@@ -160,10 +160,10 @@ async fn execute_program_with_native_type_return(
 }
 
 async fn execute_program_with_native_program_and_return(
-    program: &Program,
+    program: &Program<FieldElement>,
     initial_witness: JsWitnessMap,
     foreign_call_executor: &ForeignCallHandler,
-) -> Result<WitnessStack, Error> {
+) -> Result<WitnessStack<FieldElement>, Error> {
     let blackbox_solver = Bn254BlackBoxSolver;
     let executor = ProgramExecutor::new(
         &program.functions,
@@ -176,20 +176,20 @@ async fn execute_program_with_native_program_and_return(
     Ok(witness_stack)
 }
 
-struct ProgramExecutor<'a, B: BlackBoxFunctionSolver> {
-    functions: &'a [Circuit],
+struct ProgramExecutor<'a, B: BlackBoxFunctionSolver<FieldElement>> {
+    functions: &'a [Circuit<FieldElement>],
 
-    unconstrained_functions: &'a [BrilligBytecode],
+    unconstrained_functions: &'a [BrilligBytecode<FieldElement>],
 
     blackbox_solver: &'a B,
 
     foreign_call_handler: &'a ForeignCallHandler,
 }
 
-impl<'a, B: BlackBoxFunctionSolver> ProgramExecutor<'a, B> {
+impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ProgramExecutor<'a, B> {
     fn new(
-        functions: &'a [Circuit],
-        unconstrained_functions: &'a [BrilligBytecode],
+        functions: &'a [Circuit<FieldElement>],
+        unconstrained_functions: &'a [BrilligBytecode<FieldElement>],
         blackbox_solver: &'a B,
         foreign_call_handler: &'a ForeignCallHandler,
     ) -> Self {
@@ -201,7 +201,10 @@ impl<'a, B: BlackBoxFunctionSolver> ProgramExecutor<'a, B> {
         }
     }
 
-    async fn execute(&self, initial_witness: WitnessMap) -> Result<WitnessStack, Error> {
+    async fn execute(
+        &self,
+        initial_witness: WitnessMap<FieldElement>,
+    ) -> Result<WitnessStack<FieldElement>, Error> {
         let main = &self.functions[0];
 
         let mut witness_stack = WitnessStack::default();
@@ -212,10 +215,10 @@ impl<'a, B: BlackBoxFunctionSolver> ProgramExecutor<'a, B> {
 
     fn execute_circuit(
         &'a self,
-        circuit: &'a Circuit,
-        initial_witness: WitnessMap,
-        witness_stack: &'a mut WitnessStack,
-    ) -> Pin<Box<dyn Future<Output = Result<WitnessMap, Error>> + 'a>> {
+        circuit: &'a Circuit<FieldElement>,
+        initial_witness: WitnessMap<FieldElement>,
+        witness_stack: &'a mut WitnessStack<FieldElement>,
+    ) -> Pin<Box<dyn Future<Output = Result<WitnessMap<FieldElement>, Error>> + 'a>> {
         Box::pin(async {
             let mut acvm = ACVM::new(
                 self.blackbox_solver,

--- a/acvm-repo/acvm_js/src/foreign_call/inputs.rs
+++ b/acvm-repo/acvm_js/src/foreign_call/inputs.rs
@@ -1,9 +1,9 @@
-use acvm::brillig_vm::brillig::ForeignCallParam;
+use acvm::{brillig_vm::brillig::ForeignCallParam, FieldElement};
 
 use crate::js_witness_map::field_element_to_js_string;
 
 pub(super) fn encode_foreign_call_inputs(
-    foreign_call_inputs: &[ForeignCallParam],
+    foreign_call_inputs: &[ForeignCallParam<FieldElement>],
 ) -> js_sys::Array {
     let inputs = js_sys::Array::default();
     for input in foreign_call_inputs {

--- a/acvm-repo/acvm_js/src/foreign_call/mod.rs
+++ b/acvm-repo/acvm_js/src/foreign_call/mod.rs
@@ -1,4 +1,4 @@
-use acvm::{brillig_vm::brillig::ForeignCallResult, pwg::ForeignCallWaitInfo};
+use acvm::{brillig_vm::brillig::ForeignCallResult, pwg::ForeignCallWaitInfo, FieldElement};
 
 use js_sys::{Error, JsString};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
@@ -29,8 +29,8 @@ extern "C" {
 
 pub(super) async fn resolve_brillig(
     foreign_call_callback: &ForeignCallHandler,
-    foreign_call_wait_info: &ForeignCallWaitInfo,
-) -> Result<ForeignCallResult, Error> {
+    foreign_call_wait_info: &ForeignCallWaitInfo<FieldElement>,
+) -> Result<ForeignCallResult<FieldElement>, Error> {
     // Prepare to call
     let name = JsString::from(foreign_call_wait_info.function.clone());
     let inputs = inputs::encode_foreign_call_inputs(&foreign_call_wait_info.inputs);

--- a/acvm-repo/acvm_js/src/foreign_call/outputs.rs
+++ b/acvm-repo/acvm_js/src/foreign_call/outputs.rs
@@ -1,9 +1,12 @@
-use acvm::brillig_vm::brillig::{ForeignCallParam, ForeignCallResult};
+use acvm::{
+    brillig_vm::brillig::{ForeignCallParam, ForeignCallResult},
+    FieldElement,
+};
 use wasm_bindgen::JsValue;
 
 use crate::js_witness_map::js_value_to_field_element;
 
-fn decode_foreign_call_output(output: JsValue) -> Result<ForeignCallParam, String> {
+fn decode_foreign_call_output(output: JsValue) -> Result<ForeignCallParam<FieldElement>, String> {
     if output.is_string() {
         let value = js_value_to_field_element(output)?;
         Ok(ForeignCallParam::Single(value))
@@ -22,8 +25,9 @@ fn decode_foreign_call_output(output: JsValue) -> Result<ForeignCallParam, Strin
 
 pub(super) fn decode_foreign_call_result(
     js_array: js_sys::Array,
-) -> Result<ForeignCallResult, String> {
-    let mut values: Vec<ForeignCallParam> = Vec::with_capacity(js_array.length() as usize);
+) -> Result<ForeignCallResult<FieldElement>, String> {
+    let mut values: Vec<ForeignCallParam<FieldElement>> =
+        Vec::with_capacity(js_array.length() as usize);
     for elem in js_array.iter() {
         values.push(decode_foreign_call_output(elem)?);
     }

--- a/acvm-repo/acvm_js/src/js_execution_error.rs
+++ b/acvm-repo/acvm_js/src/js_execution_error.rs
@@ -1,4 +1,7 @@
-use acvm::acir::circuit::{OpcodeLocation, RawAssertionPayload};
+use acvm::{
+    acir::circuit::{OpcodeLocation, RawAssertionPayload},
+    FieldElement,
+};
 use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{Array, Error, JsString, Reflect};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
@@ -34,7 +37,7 @@ impl JsExecutionError {
     pub fn new(
         message: String,
         call_stack: Option<Vec<OpcodeLocation>>,
-        assertion_payload: Option<RawAssertionPayload>,
+        assertion_payload: Option<RawAssertionPayload<FieldElement>>,
     ) -> Self {
         let mut error = JsExecutionError::constructor(JsString::from(message));
         let js_call_stack = match call_stack {

--- a/acvm-repo/acvm_js/src/js_witness_map.rs
+++ b/acvm-repo/acvm_js/src/js_witness_map.rs
@@ -1,6 +1,6 @@
 use acvm::{
     acir::native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use js_sys::{JsString, Map, Object};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
@@ -113,7 +113,7 @@ mod test {
 
     use acvm::{
         acir::native_types::{Witness, WitnessMap},
-        FieldElement,
+        AcirField, FieldElement,
     };
     use wasm_bindgen::JsValue;
 

--- a/acvm-repo/acvm_js/src/js_witness_map.rs
+++ b/acvm-repo/acvm_js/src/js_witness_map.rs
@@ -114,7 +114,7 @@ mod test {
 
     use acvm::{
         acir::native_types::{Witness, WitnessMap},
-        FieldElement,
+        AcirField, FieldElement,
     };
     use wasm_bindgen::JsValue;
 

--- a/acvm-repo/acvm_js/src/js_witness_map.rs
+++ b/acvm-repo/acvm_js/src/js_witness_map.rs
@@ -1,6 +1,7 @@
 use acvm::{
     acir::native_types::{Witness, WitnessMap},
-    AcirField, FieldElement,
+    acir::AcirField,
+    FieldElement,
 };
 use js_sys::{JsString, Map, Object};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
@@ -51,8 +52,8 @@ impl Default for JsSolvedAndReturnWitness {
     }
 }
 
-impl From<WitnessMap> for JsWitnessMap {
-    fn from(witness_map: WitnessMap) -> Self {
+impl From<WitnessMap<FieldElement>> for JsWitnessMap {
+    fn from(witness_map: WitnessMap<FieldElement>) -> Self {
         let js_map = JsWitnessMap::new();
         for (key, value) in witness_map {
             js_map.set(
@@ -64,7 +65,7 @@ impl From<WitnessMap> for JsWitnessMap {
     }
 }
 
-impl From<JsWitnessMap> for WitnessMap {
+impl From<JsWitnessMap> for WitnessMap<FieldElement> {
     fn from(js_map: JsWitnessMap) -> Self {
         let mut witness_map = WitnessMap::new();
         js_map.for_each(&mut |value, key| {
@@ -76,8 +77,8 @@ impl From<JsWitnessMap> for WitnessMap {
     }
 }
 
-impl From<(WitnessMap, WitnessMap)> for JsSolvedAndReturnWitness {
-    fn from(witness_maps: (WitnessMap, WitnessMap)) -> Self {
+impl From<(WitnessMap<FieldElement>, WitnessMap<FieldElement>)> for JsSolvedAndReturnWitness {
+    fn from(witness_maps: (WitnessMap<FieldElement>, WitnessMap<FieldElement>)) -> Self {
         let js_solved_witness = JsWitnessMap::from(witness_maps.0);
         let js_return_witness = JsWitnessMap::from(witness_maps.1);
 
@@ -113,7 +114,7 @@ mod test {
 
     use acvm::{
         acir::native_types::{Witness, WitnessMap},
-        AcirField, FieldElement,
+        FieldElement,
     };
     use wasm_bindgen::JsValue;
 

--- a/acvm-repo/acvm_js/src/js_witness_stack.rs
+++ b/acvm-repo/acvm_js/src/js_witness_stack.rs
@@ -1,4 +1,4 @@
-use acvm::acir::native_types::WitnessStack;
+use acvm::{acir::native_types::WitnessStack, FieldElement};
 use js_sys::{Array, Map, Object};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -38,8 +38,8 @@ impl Default for JsWitnessStack {
     }
 }
 
-impl From<WitnessStack> for JsWitnessStack {
-    fn from(mut witness_stack: WitnessStack) -> Self {
+impl From<WitnessStack<FieldElement>> for JsWitnessStack {
+    fn from(mut witness_stack: WitnessStack<FieldElement>) -> Self {
         let js_witness_stack = JsWitnessStack::new();
         while let Some(stack_item) = witness_stack.pop() {
             let js_map = JsWitnessMap::from(stack_item.witness);
@@ -57,7 +57,7 @@ impl From<WitnessStack> for JsWitnessStack {
     }
 }
 
-impl From<JsWitnessStack> for WitnessStack {
+impl From<JsWitnessStack> for WitnessStack<FieldElement> {
     fn from(js_witness_stack: JsWitnessStack) -> Self {
         let mut witness_stack = WitnessStack::default();
         js_witness_stack.for_each(&mut |stack_item, _, _| {

--- a/acvm-repo/acvm_js/src/public_witness.rs
+++ b/acvm-repo/acvm_js/src/public_witness.rs
@@ -1,6 +1,9 @@
-use acvm::acir::{
-    circuit::Program,
-    native_types::{Witness, WitnessMap},
+use acvm::{
+    acir::{
+        circuit::Program,
+        native_types::{Witness, WitnessMap},
+    },
+    FieldElement,
 };
 use js_sys::JsString;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -8,9 +11,9 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use crate::JsWitnessMap;
 
 pub(crate) fn extract_indices(
-    witness_map: &WitnessMap,
+    witness_map: &WitnessMap<FieldElement>,
     indices: Vec<Witness>,
-) -> Result<WitnessMap, String> {
+) -> Result<WitnessMap<FieldElement>, String> {
     let mut extracted_witness_map = WitnessMap::new();
     for witness in indices {
         let witness_value = witness_map.get(&witness).ok_or(format!(
@@ -36,7 +39,7 @@ pub fn get_return_witness(
     witness_map: JsWitnessMap,
 ) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
-    let program: Program =
+    let program: Program<FieldElement> =
         Program::deserialize_program(&program).expect("Failed to deserialize circuit");
     let circuit = match program.functions.len() {
         0 => return Ok(JsWitnessMap::from(WitnessMap::new())),
@@ -63,7 +66,7 @@ pub fn get_public_parameters_witness(
     solved_witness: JsWitnessMap,
 ) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
-    let program: Program =
+    let program: Program<FieldElement> =
         Program::deserialize_program(&program).expect("Failed to deserialize circuit");
     let circuit = match program.functions.len() {
         0 => return Ok(JsWitnessMap::from(WitnessMap::new())),
@@ -90,7 +93,7 @@ pub fn get_public_witness(
     solved_witness: JsWitnessMap,
 ) -> Result<JsWitnessMap, JsString> {
     console_error_panic_hook::set_once();
-    let program: Program =
+    let program: Program<FieldElement> =
         Program::deserialize_program(&program).expect("Failed to deserialize circuit");
     let circuit = match program.functions.len() {
         0 => return Ok(JsWitnessMap::from(WitnessMap::new())),

--- a/acvm-repo/blackbox_solver/Cargo.toml
+++ b/acvm-repo/blackbox_solver/Cargo.toml
@@ -40,6 +40,5 @@ p256 = { version = "0.11.0", features = [
 libaes = "0.7.0"
 
 [features]
-default = ["bn254"]
 bn254 = ["acir/bn254"]
 bls12_381 = ["acir/bls12_381"]

--- a/acvm-repo/blackbox_solver/src/curve_specific_solver.rs
+++ b/acvm-repo/blackbox_solver/src/curve_specific_solver.rs
@@ -1,4 +1,4 @@
-use acir::{BlackBoxFunc, FieldElement};
+use acir::BlackBoxFunc;
 
 use crate::BlackBoxResolutionError;
 
@@ -6,44 +6,44 @@ use crate::BlackBoxResolutionError;
 /// doesn't have a canonical Rust implementation.
 ///
 /// Returns an [`BlackBoxResolutionError`] if the backend does not support the given [`acir::BlackBoxFunc`].
-pub trait BlackBoxFunctionSolver {
+pub trait BlackBoxFunctionSolver<F> {
     fn schnorr_verify(
         &self,
-        public_key_x: &FieldElement,
-        public_key_y: &FieldElement,
+        public_key_x: &F,
+        public_key_y: &F,
         signature: &[u8; 64],
         message: &[u8],
     ) -> Result<bool, BlackBoxResolutionError>;
     fn pedersen_commitment(
         &self,
-        inputs: &[FieldElement],
+        inputs: &[F],
         domain_separator: u32,
-    ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError>;
+    ) -> Result<(F, F), BlackBoxResolutionError>;
     fn pedersen_hash(
         &self,
-        inputs: &[FieldElement],
+        inputs: &[F],
         domain_separator: u32,
-    ) -> Result<FieldElement, BlackBoxResolutionError>;
+    ) -> Result<F, BlackBoxResolutionError>;
     fn multi_scalar_mul(
         &self,
-        points: &[FieldElement],
-        scalars_lo: &[FieldElement],
-        scalars_hi: &[FieldElement],
-    ) -> Result<(FieldElement, FieldElement, FieldElement), BlackBoxResolutionError>;
+        points: &[F],
+        scalars_lo: &[F],
+        scalars_hi: &[F],
+    ) -> Result<(F, F, F), BlackBoxResolutionError>;
     fn ec_add(
         &self,
-        input1_x: &FieldElement,
-        input1_y: &FieldElement,
-        input1_infinite: &FieldElement,
-        input2_x: &FieldElement,
-        input2_y: &FieldElement,
-        input2_infinite: &FieldElement,
-    ) -> Result<(FieldElement, FieldElement, FieldElement), BlackBoxResolutionError>;
+        input1_x: &F,
+        input1_y: &F,
+        input1_infinite: &F,
+        input2_x: &F,
+        input2_y: &F,
+        input2_infinite: &F,
+    ) -> Result<(F, F, F), BlackBoxResolutionError>;
     fn poseidon2_permutation(
         &self,
-        _inputs: &[FieldElement],
+        _inputs: &[F],
         _len: u32,
-    ) -> Result<Vec<FieldElement>, BlackBoxResolutionError>;
+    ) -> Result<Vec<F>, BlackBoxResolutionError>;
 }
 
 pub struct StubbedBlackBoxSolver;
@@ -57,11 +57,11 @@ impl StubbedBlackBoxSolver {
     }
 }
 
-impl BlackBoxFunctionSolver for StubbedBlackBoxSolver {
+impl<F> BlackBoxFunctionSolver<F> for StubbedBlackBoxSolver {
     fn schnorr_verify(
         &self,
-        _public_key_x: &FieldElement,
-        _public_key_y: &FieldElement,
+        _public_key_x: &F,
+        _public_key_y: &F,
         _signature: &[u8; 64],
         _message: &[u8],
     ) -> Result<bool, BlackBoxResolutionError> {
@@ -69,42 +69,42 @@ impl BlackBoxFunctionSolver for StubbedBlackBoxSolver {
     }
     fn pedersen_commitment(
         &self,
-        _inputs: &[FieldElement],
+        _inputs: &[F],
         _domain_separator: u32,
-    ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
+    ) -> Result<(F, F), BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::PedersenCommitment))
     }
     fn pedersen_hash(
         &self,
-        _inputs: &[FieldElement],
+        _inputs: &[F],
         _domain_separator: u32,
-    ) -> Result<FieldElement, BlackBoxResolutionError> {
+    ) -> Result<F, BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::PedersenHash))
     }
     fn multi_scalar_mul(
         &self,
-        _points: &[FieldElement],
-        _scalars_lo: &[FieldElement],
-        _scalars_hi: &[FieldElement],
-    ) -> Result<(FieldElement, FieldElement, FieldElement), BlackBoxResolutionError> {
+        _points: &[F],
+        _scalars_lo: &[F],
+        _scalars_hi: &[F],
+    ) -> Result<(F, F, F), BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::MultiScalarMul))
     }
     fn ec_add(
         &self,
-        _input1_x: &FieldElement,
-        _input1_y: &FieldElement,
-        _input1_infinite: &FieldElement,
-        _input2_x: &FieldElement,
-        _input2_y: &FieldElement,
-        _input2_infinite: &FieldElement,
-    ) -> Result<(FieldElement, FieldElement, FieldElement), BlackBoxResolutionError> {
+        _input1_x: &F,
+        _input1_y: &F,
+        _input1_infinite: &F,
+        _input2_x: &F,
+        _input2_y: &F,
+        _input2_infinite: &F,
+    ) -> Result<(F, F, F), BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::EmbeddedCurveAdd))
     }
     fn poseidon2_permutation(
         &self,
-        _inputs: &[FieldElement],
+        _inputs: &[F],
         _len: u32,
-    ) -> Result<Vec<FieldElement>, BlackBoxResolutionError> {
+    ) -> Result<Vec<F>, BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::Poseidon2Permutation))
     }
 }

--- a/acvm-repo/bn254_blackbox_solver/benches/criterion.rs
+++ b/acvm-repo/bn254_blackbox_solver/benches/criterion.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::{hint::black_box, time::Duration};
 
-use acir::FieldElement;
+use acir::{AcirField, FieldElement};
 use acvm_blackbox_solver::BlackBoxFunctionSolver;
 use bn254_blackbox_solver::{poseidon2_permutation, Bn254BlackBoxSolver};
 

--- a/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
@@ -118,9 +118,9 @@ fn create_point(
 
 #[cfg(test)]
 mod tests {
-    use ark_ff::BigInteger;
-
     use super::*;
+
+    use ark_ff::BigInteger;
 
     fn get_generator() -> [FieldElement; 3] {
         let generator = grumpkin::SWAffine::generator();

--- a/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
@@ -3,7 +3,8 @@ use ark_ec::AffineRepr;
 use ark_ff::MontConfig;
 use num_bigint::BigUint;
 
-use acir::{BlackBoxFunc, FieldElement};
+use acir::BlackBoxFunc;
+use acir::{AcirField, FieldElement};
 
 use crate::BlackBoxResolutionError;
 

--- a/acvm-repo/bn254_blackbox_solver/src/lib.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/lib.rs
@@ -18,7 +18,7 @@ pub use poseidon2::poseidon2_permutation;
 #[derive(Default)]
 pub struct Bn254BlackBoxSolver;
 
-impl BlackBoxFunctionSolver for Bn254BlackBoxSolver {
+impl BlackBoxFunctionSolver<FieldElement> for Bn254BlackBoxSolver {
     fn schnorr_verify(
         &self,
         public_key_x: &FieldElement,

--- a/acvm-repo/bn254_blackbox_solver/src/pedersen/commitment.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/pedersen/commitment.rs
@@ -27,7 +27,7 @@ pub(crate) fn commit_native_with_index(
 #[cfg(test)]
 mod test {
 
-    use acir::FieldElement;
+    use acir::{AcirField, FieldElement};
     use ark_ec::short_weierstrass::Affine;
     use ark_std::{One, Zero};
     use grumpkin::Fq;

--- a/acvm-repo/bn254_blackbox_solver/src/pedersen/hash.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/pedersen/hash.rs
@@ -31,7 +31,7 @@ pub(crate) mod test {
 
     use super::*;
 
-    use acir::FieldElement;
+    use acir::{AcirField, FieldElement};
     use ark_std::One;
     use grumpkin::Fq;
 

--- a/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
@@ -1,4 +1,4 @@
-use acir::FieldElement;
+use acir::{AcirField, FieldElement};
 use acvm_blackbox_solver::BlackBoxResolutionError;
 use lazy_static::lazy_static;
 
@@ -543,7 +543,7 @@ impl<'a> Poseidon2<'a> {
 
 #[cfg(test)]
 mod test {
-    use acir::FieldElement;
+    use acir::{AcirField, FieldElement};
 
     use super::{field_from_hex, poseidon2_permutation};
 

--- a/acvm-repo/bn254_blackbox_solver/src/schnorr/mod.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/schnorr/mod.rs
@@ -65,7 +65,7 @@ fn schnorr_generate_challenge(
 
 #[cfg(test)]
 mod schnorr_tests {
-    use acir::FieldElement;
+    use acir::{AcirField, FieldElement};
 
     use super::verify_signature;
 

--- a/acvm-repo/brillig/Cargo.toml
+++ b/acvm-repo/brillig/Cargo.toml
@@ -17,6 +17,5 @@ acir_field.workspace = true
 serde.workspace = true
 
 [features]
-default = ["bn254"]
 bn254 = ["acir_field/bn254"]
 bls12_381 = ["acir_field/bls12_381"]

--- a/acvm-repo/brillig/src/foreign_call.rs
+++ b/acvm-repo/brillig/src/foreign_call.rs
@@ -1,34 +1,34 @@
-use acir_field::FieldElement;
+use acir_field::AcirField;
 use serde::{Deserialize, Serialize};
 
 /// Single output of a [foreign call][crate::Opcode::ForeignCall].
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-pub enum ForeignCallParam {
-    Single(FieldElement),
-    Array(Vec<FieldElement>),
+pub enum ForeignCallParam<F> {
+    Single(F),
+    Array(Vec<F>),
 }
 
-impl From<FieldElement> for ForeignCallParam {
-    fn from(value: FieldElement) -> Self {
+impl<F> From<F> for ForeignCallParam<F> {
+    fn from(value: F) -> Self {
         ForeignCallParam::Single(value)
     }
 }
 
-impl From<Vec<FieldElement>> for ForeignCallParam {
-    fn from(values: Vec<FieldElement>) -> Self {
+impl<F> From<Vec<F>> for ForeignCallParam<F> {
+    fn from(values: Vec<F>) -> Self {
         ForeignCallParam::Array(values)
     }
 }
 
-impl ForeignCallParam {
-    pub fn fields(&self) -> Vec<FieldElement> {
+impl<F: AcirField> ForeignCallParam<F> {
+    pub fn fields(&self) -> Vec<F> {
         match self {
             ForeignCallParam::Single(value) => vec![*value],
-            ForeignCallParam::Array(values) => values.clone(),
+            ForeignCallParam::Array(values) => values.to_vec(),
         }
     }
 
-    pub fn unwrap_field(&self) -> FieldElement {
+    pub fn unwrap_field(&self) -> F {
         match self {
             ForeignCallParam::Single(value) => *value,
             ForeignCallParam::Array(_) => panic!("Expected single value, found array"),
@@ -38,25 +38,25 @@ impl ForeignCallParam {
 
 /// Represents the full output of a [foreign call][crate::Opcode::ForeignCall].
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Default)]
-pub struct ForeignCallResult {
+pub struct ForeignCallResult<F> {
     /// Resolved output values of the foreign call.
-    pub values: Vec<ForeignCallParam>,
+    pub values: Vec<ForeignCallParam<F>>,
 }
 
-impl From<FieldElement> for ForeignCallResult {
-    fn from(value: FieldElement) -> Self {
+impl<F> From<F> for ForeignCallResult<F> {
+    fn from(value: F) -> Self {
         ForeignCallResult { values: vec![value.into()] }
     }
 }
 
-impl From<Vec<FieldElement>> for ForeignCallResult {
-    fn from(values: Vec<FieldElement>) -> Self {
+impl<F> From<Vec<F>> for ForeignCallResult<F> {
+    fn from(values: Vec<F>) -> Self {
         ForeignCallResult { values: vec![values.into()] }
     }
 }
 
-impl From<Vec<ForeignCallParam>> for ForeignCallResult {
-    fn from(values: Vec<ForeignCallParam>) -> Self {
+impl<F> From<Vec<ForeignCallParam<F>>> for ForeignCallResult<F> {
+    fn from(values: Vec<ForeignCallParam<F>>) -> Self {
         ForeignCallResult { values }
     }
 }

--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -89,7 +89,7 @@ pub enum ValueOrArray {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum BrilligOpcode {
+pub enum BrilligOpcode<F> {
     /// Takes the fields in addresses `lhs` and `rhs`
     /// Performs the specified binary operation
     /// and stores the value in the `result` address.  
@@ -142,7 +142,7 @@ pub enum BrilligOpcode {
     Const {
         destination: MemoryAddress,
         bit_size: u32,
-        value: FieldElement,
+        value: F,
     },
     Return,
     /// Used to get data from an outside source.

--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -1,5 +1,5 @@
 use crate::black_box::BlackBoxOp;
-use acir_field::FieldElement;
+use acir_field::{AcirField, FieldElement};
 use serde::{Deserialize, Serialize};
 
 pub type Label = usize;

--- a/acvm-repo/brillig_vm/Cargo.toml
+++ b/acvm-repo/brillig_vm/Cargo.toml
@@ -20,6 +20,5 @@ num-traits.workspace = true
 thiserror.workspace = true
 
 [features]
-default = ["bn254"]
 bn254 = ["acir/bn254"]
 bls12_381 = ["acir/bls12_381"]

--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -1,5 +1,5 @@
 use acir::brillig::{BinaryFieldOp, BinaryIntOp};
-use acir::FieldElement;
+use acir::{AcirField, FieldElement};
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use num_traits::{One, Zero};

--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -1,5 +1,5 @@
 use acir::brillig::{BinaryFieldOp, BinaryIntOp};
-use acir::{AcirField, FieldElement};
+use acir::AcirField;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use num_traits::{One, Zero};
@@ -19,7 +19,7 @@ pub(crate) enum BrilligArithmeticError {
 }
 
 /// Evaluate a binary operation on two FieldElement memory values.
-pub(crate) fn evaluate_binary_field_op<F>(
+pub(crate) fn evaluate_binary_field_op<F: AcirField>(
     op: &BinaryFieldOp,
     lhs: MemoryValue<F>,
     rhs: MemoryValue<F>,
@@ -27,28 +27,28 @@ pub(crate) fn evaluate_binary_field_op<F>(
     let MemoryValue::Field(a) = lhs else {
         return Err(BrilligArithmeticError::MismatchedLhsBitSize {
             lhs_bit_size: lhs.bit_size(),
-            op_bit_size: FieldElement::max_num_bits(),
+            op_bit_size: F::max_num_bits(),
         });
     };
     let MemoryValue::Field(b) = rhs else {
         return Err(BrilligArithmeticError::MismatchedLhsBitSize {
             lhs_bit_size: rhs.bit_size(),
-            op_bit_size: FieldElement::max_num_bits(),
+            op_bit_size: F::max_num_bits(),
         });
     };
 
     Ok(match op {
         // Perform addition, subtraction, multiplication, and division based on the BinaryOp variant.
-        BinaryFieldOp::Add => (a + b).into(),
-        BinaryFieldOp::Sub => (a - b).into(),
-        BinaryFieldOp::Mul => (a * b).into(),
-        BinaryFieldOp::Div => (a / b).into(),
+        BinaryFieldOp::Add => MemoryValue::new_field(a + b),
+        BinaryFieldOp::Sub => MemoryValue::new_field(a - b),
+        BinaryFieldOp::Mul => MemoryValue::new_field(a * b),
+        BinaryFieldOp::Div => MemoryValue::new_field(a / b),
         BinaryFieldOp::IntegerDiv => {
             let a_big = BigUint::from_bytes_be(&a.to_be_bytes());
             let b_big = BigUint::from_bytes_be(&b.to_be_bytes());
 
             let result = a_big / b_big;
-            FieldElement::from_be_bytes_reduce(&result.to_bytes_be()).into()
+            MemoryValue::new_field(F::from_be_bytes_reduce(&result.to_bytes_be()))
         }
         BinaryFieldOp::Equals => (a == b).into(),
         BinaryFieldOp::LessThan => (a < b).into(),
@@ -57,7 +57,7 @@ pub(crate) fn evaluate_binary_field_op<F>(
 }
 
 /// Evaluate a binary operation on two unsigned big integers with a given bit size.
-pub(crate) fn evaluate_binary_int_op<F>(
+pub(crate) fn evaluate_binary_int_op<F: AcirField>(
     op: &BinaryIntOp,
     lhs: MemoryValue<F>,
     rhs: MemoryValue<F>,
@@ -82,7 +82,7 @@ pub(crate) fn evaluate_binary_int_op<F>(
         }
     })?;
 
-    if bit_size == FieldElement::max_num_bits() {
+    if bit_size == F::max_num_bits() {
         return Err(BrilligArithmeticError::IntegerOperationOnField { op: *op });
     }
 
@@ -155,6 +155,7 @@ pub(crate) fn evaluate_binary_int_op<F>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use acir::{AcirField, FieldElement};
 
     struct TestParams {
         a: u128,
@@ -163,7 +164,7 @@ mod tests {
     }
 
     fn evaluate_u128(op: &BinaryIntOp, a: u128, b: u128, bit_size: u32) -> u128 {
-        let result_value = evaluate_binary_int_op(
+        let result_value: MemoryValue<FieldElement> = evaluate_binary_int_op(
             op,
             MemoryValue::new_integer(a.into(), bit_size),
             MemoryValue::new_integer(b.into(), bit_size),

--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -19,11 +19,11 @@ pub(crate) enum BrilligArithmeticError {
 }
 
 /// Evaluate a binary operation on two FieldElement memory values.
-pub(crate) fn evaluate_binary_field_op(
+pub(crate) fn evaluate_binary_field_op<F>(
     op: &BinaryFieldOp,
-    lhs: MemoryValue,
-    rhs: MemoryValue,
-) -> Result<MemoryValue, BrilligArithmeticError> {
+    lhs: MemoryValue<F>,
+    rhs: MemoryValue<F>,
+) -> Result<MemoryValue<F>, BrilligArithmeticError> {
     let MemoryValue::Field(a) = lhs else {
         return Err(BrilligArithmeticError::MismatchedLhsBitSize {
             lhs_bit_size: lhs.bit_size(),
@@ -57,12 +57,12 @@ pub(crate) fn evaluate_binary_field_op(
 }
 
 /// Evaluate a binary operation on two unsigned big integers with a given bit size.
-pub(crate) fn evaluate_binary_int_op(
+pub(crate) fn evaluate_binary_int_op<F>(
     op: &BinaryIntOp,
-    lhs: MemoryValue,
-    rhs: MemoryValue,
+    lhs: MemoryValue<F>,
+    rhs: MemoryValue<F>,
     bit_size: u32,
-) -> Result<MemoryValue, BrilligArithmeticError> {
+) -> Result<MemoryValue<F>, BrilligArithmeticError> {
     let lhs = lhs.expect_integer_with_bit_size(bit_size).map_err(|err| match err {
         MemoryTypeError::MismatchedBitSize { value_bit_size, expected_bit_size } => {
             BrilligArithmeticError::MismatchedLhsBitSize {

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -1,5 +1,5 @@
 use acir::brillig::{BlackBoxOp, HeapArray, HeapVector};
-use acir::{AcirField, BlackBoxFunc, FieldElement};
+use acir::{AcirField, BlackBoxFunc};
 use acvm_blackbox_solver::BigIntSolver;
 use acvm_blackbox_solver::{
     aes128_encrypt, blake2s, blake3, ecdsa_secp256k1_verify, ecdsa_secp256r1_verify, keccak256,
@@ -10,17 +10,23 @@ use num_bigint::BigUint;
 use crate::memory::MemoryValue;
 use crate::Memory;
 
-fn read_heap_vector<'a, F>(memory: &'a Memory<F>, vector: &HeapVector) -> &'a [MemoryValue<F>] {
+fn read_heap_vector<'a, F: AcirField>(
+    memory: &'a Memory<F>,
+    vector: &HeapVector,
+) -> &'a [MemoryValue<F>] {
     let size = memory.read(vector.size);
     memory.read_slice(memory.read_ref(vector.pointer), size.to_usize())
 }
 
-fn read_heap_array<'a, F>(memory: &'a Memory<F>, array: &HeapArray) -> &'a [MemoryValue<F>] {
+fn read_heap_array<'a, F: AcirField>(
+    memory: &'a Memory<F>,
+    array: &HeapArray,
+) -> &'a [MemoryValue<F>] {
     memory.read_slice(memory.read_ref(array.pointer), array.size)
 }
 
 /// Extracts the last byte of every value
-fn to_u8_vec<F>(inputs: &[MemoryValue<F>]) -> Vec<u8> {
+fn to_u8_vec<F: AcirField>(inputs: &[MemoryValue<F>]) -> Vec<u8> {
     let mut result = Vec::with_capacity(inputs.len());
     for input in inputs {
         result.push(input.try_into().unwrap());
@@ -28,11 +34,11 @@ fn to_u8_vec<F>(inputs: &[MemoryValue<F>]) -> Vec<u8> {
     result
 }
 
-fn to_value_vec<F>(input: &[u8]) -> Vec<MemoryValue<F>> {
+fn to_value_vec<F: AcirField>(input: &[u8]) -> Vec<MemoryValue<F>> {
     input.iter().map(|&x| x.into()).collect()
 }
 
-pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
+pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>>(
     op: &BlackBoxOp,
     solver: &Solver,
     memory: &mut Memory<F>,
@@ -91,7 +97,7 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
 
             let new_state = keccakf1600(state)?;
 
-            let new_state: Vec<MemoryValue> = new_state.into_iter().map(|x| x.into()).collect();
+            let new_state: Vec<MemoryValue<F>> = new_state.into_iter().map(|x| x.into()).collect();
             memory.write_slice(memory.read_ref(output.pointer), &new_state);
             Ok(())
         }
@@ -146,8 +152,8 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
             Ok(())
         }
         BlackBoxOp::SchnorrVerify { public_key_x, public_key_y, message, signature, result } => {
-            let public_key_x = memory.read(*public_key_x).try_into().unwrap();
-            let public_key_y = memory.read(*public_key_y).try_into().unwrap();
+            let public_key_x = *memory.read(*public_key_x).extract_field().unwrap();
+            let public_key_y = *memory.read(*public_key_y).extract_field().unwrap();
             let message: Vec<u8> = to_u8_vec(read_heap_vector(memory, message));
             let signature: [u8; 64] =
                 to_u8_vec(read_heap_vector(memory, signature)).try_into().unwrap();
@@ -157,20 +163,22 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
             Ok(())
         }
         BlackBoxOp::MultiScalarMul { points, scalars, outputs: result } => {
-            let points: Vec<FieldElement> = read_heap_vector(memory, points)
+            let points: Vec<F> = read_heap_vector(memory, points)
                 .iter()
                 .enumerate()
                 .map(|(i, x)| {
                     if i % 3 == 2 {
                         let is_infinite: bool = x.try_into().unwrap();
-                        FieldElement::from(is_infinite as u128)
+                        F::from(is_infinite as u128)
                     } else {
-                        x.try_into().unwrap()
+                        *x.extract_field().unwrap()
                     }
                 })
                 .collect();
-            let scalars: Vec<FieldElement> =
-                read_heap_vector(memory, scalars).iter().map(|x| x.try_into().unwrap()).collect();
+            let scalars: Vec<F> = read_heap_vector(memory, scalars)
+                .iter()
+                .map(|x| *x.extract_field().unwrap())
+                .collect();
             let mut scalars_lo = Vec::with_capacity(scalars.len() / 2);
             let mut scalars_hi = Vec::with_capacity(scalars.len() / 2);
             for (i, scalar) in scalars.iter().enumerate() {
@@ -183,7 +191,11 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
             let (x, y, is_infinite) = solver.multi_scalar_mul(&points, &scalars_lo, &scalars_hi)?;
             memory.write_slice(
                 memory.read_ref(result.pointer),
-                &[x.into(), y.into(), is_infinite.into()],
+                &[
+                    MemoryValue::new_field(x),
+                    MemoryValue::new_field(y),
+                    MemoryValue::new_field(is_infinite),
+                ],
             );
             Ok(())
         }
@@ -196,11 +208,11 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
             input1_infinite,
             input2_infinite,
         } => {
-            let input1_x = memory.read(*input1_x).try_into().unwrap();
-            let input1_y = memory.read(*input1_y).try_into().unwrap();
+            let input1_x = *memory.read(*input1_x).extract_field().unwrap();
+            let input1_y = *memory.read(*input1_y).extract_field().unwrap();
             let input1_infinite: bool = memory.read(*input1_infinite).try_into().unwrap();
-            let input2_x = memory.read(*input2_x).try_into().unwrap();
-            let input2_y = memory.read(*input2_y).try_into().unwrap();
+            let input2_x = *memory.read(*input2_x).extract_field().unwrap();
+            let input2_y = *memory.read(*input2_y).extract_field().unwrap();
             let input2_infinite: bool = memory.read(*input2_infinite).try_into().unwrap();
             let (x, y, infinite) = solver.ec_add(
                 &input1_x,
@@ -212,13 +224,19 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
             )?;
             memory.write_slice(
                 memory.read_ref(result.pointer),
-                &[x.into(), y.into(), infinite.into()],
+                &[
+                    MemoryValue::new_field(x),
+                    MemoryValue::new_field(y),
+                    MemoryValue::new_field(infinite),
+                ],
             );
             Ok(())
         }
         BlackBoxOp::PedersenCommitment { inputs, domain_separator, output } => {
-            let inputs: Vec<FieldElement> =
-                read_heap_vector(memory, inputs).iter().map(|x| x.try_into().unwrap()).collect();
+            let inputs: Vec<F> = read_heap_vector(memory, inputs)
+                .iter()
+                .map(|x| *x.extract_field().unwrap())
+                .collect();
             let domain_separator: u32 =
                 memory.read(*domain_separator).try_into().map_err(|_| {
                     BlackBoxResolutionError::Failed(
@@ -227,12 +245,17 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
                     )
                 })?;
             let (x, y) = solver.pedersen_commitment(&inputs, domain_separator)?;
-            memory.write_slice(memory.read_ref(output.pointer), &[x.into(), y.into()]);
+            memory.write_slice(
+                memory.read_ref(output.pointer),
+                &[MemoryValue::new_field(x), MemoryValue::new_field(y)],
+            );
             Ok(())
         }
         BlackBoxOp::PedersenHash { inputs, domain_separator, output } => {
-            let inputs: Vec<FieldElement> =
-                read_heap_vector(memory, inputs).iter().map(|x| x.try_into().unwrap()).collect();
+            let inputs: Vec<F> = read_heap_vector(memory, inputs)
+                .iter()
+                .map(|x| *x.extract_field().unwrap())
+                .collect();
             let domain_separator: u32 =
                 memory.read(*domain_separator).try_into().map_err(|_| {
                     BlackBoxResolutionError::Failed(
@@ -241,7 +264,7 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
                     )
                 })?;
             let hash = solver.pedersen_hash(&inputs, domain_separator)?;
-            memory.write(*output, hash.into());
+            memory.write(*output, MemoryValue::new_field(hash));
             Ok(())
         }
         BlackBoxOp::BigIntAdd { lhs, rhs, output } => {
@@ -297,12 +320,12 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
         }
         BlackBoxOp::Poseidon2Permutation { message, output, len } => {
             let input = read_heap_vector(memory, message);
-            let input: Vec<FieldElement> = input.iter().map(|x| x.try_into().unwrap()).collect();
+            let input: Vec<F> = input.iter().map(|x| *x.extract_field().unwrap()).collect();
             let len = memory.read(*len).try_into().unwrap();
             let result = solver.poseidon2_permutation(&input, len)?;
             let mut values = Vec::new();
             for i in result {
-                values.push(i.into());
+                values.push(MemoryValue::new_field(i));
             }
             memory.write_slice(memory.read_ref(output.pointer), &values);
             Ok(())
@@ -338,17 +361,16 @@ pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
             Ok(())
         }
         BlackBoxOp::ToRadix { input, radix, output } => {
-            let input: FieldElement =
-                memory.read(*input).try_into().expect("ToRadix input not a field");
+            let input: F = *memory.read(*input).extract_field().expect("ToRadix input not a field");
 
             let mut input = BigUint::from_bytes_be(&input.to_be_bytes());
             let radix = BigUint::from(*radix);
 
-            let mut limbs: Vec<MemoryValue> = Vec::with_capacity(output.size);
+            let mut limbs: Vec<MemoryValue<F>> = Vec::with_capacity(output.size);
 
             for _ in 0..output.size {
                 let limb = &input % &radix;
-                limbs.push(FieldElement::from_be_bytes_reduce(&limb.to_bytes_be()).into());
+                limbs.push(MemoryValue::new_field(F::from_be_bytes_reduce(&limb.to_bytes_be())));
                 input /= &radix;
             }
 
@@ -388,7 +410,10 @@ fn black_box_function_from_op(op: &BlackBoxOp) -> BlackBoxFunc {
 
 #[cfg(test)]
 mod test {
-    use acir::brillig::{BlackBoxOp, MemoryAddress};
+    use acir::{
+        brillig::{BlackBoxOp, MemoryAddress},
+        FieldElement,
+    };
     use acvm_blackbox_solver::{BigIntSolver, StubbedBlackBoxSolver};
 
     use crate::{
@@ -401,7 +426,7 @@ mod test {
         let message: Vec<u8> = b"hello world".to_vec();
         let message_length = message.len();
 
-        let mut memory = Memory::default();
+        let mut memory: Memory<FieldElement> = Memory::default();
         let message_pointer = 3;
         let result_pointer = message_pointer + message_length;
         memory.write(MemoryAddress(0), message_pointer.into());

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -10,17 +10,17 @@ use num_bigint::BigUint;
 use crate::memory::MemoryValue;
 use crate::Memory;
 
-fn read_heap_vector<'a>(memory: &'a Memory, vector: &HeapVector) -> &'a [MemoryValue] {
+fn read_heap_vector<'a, F>(memory: &'a Memory<F>, vector: &HeapVector) -> &'a [MemoryValue<F>] {
     let size = memory.read(vector.size);
     memory.read_slice(memory.read_ref(vector.pointer), size.to_usize())
 }
 
-fn read_heap_array<'a>(memory: &'a Memory, array: &HeapArray) -> &'a [MemoryValue] {
+fn read_heap_array<'a, F>(memory: &'a Memory<F>, array: &HeapArray) -> &'a [MemoryValue<F>] {
     memory.read_slice(memory.read_ref(array.pointer), array.size)
 }
 
 /// Extracts the last byte of every value
-fn to_u8_vec(inputs: &[MemoryValue]) -> Vec<u8> {
+fn to_u8_vec<F>(inputs: &[MemoryValue<F>]) -> Vec<u8> {
     let mut result = Vec::with_capacity(inputs.len());
     for input in inputs {
         result.push(input.try_into().unwrap());
@@ -28,14 +28,14 @@ fn to_u8_vec(inputs: &[MemoryValue]) -> Vec<u8> {
     result
 }
 
-fn to_value_vec(input: &[u8]) -> Vec<MemoryValue> {
+fn to_value_vec<F>(input: &[u8]) -> Vec<MemoryValue<F>> {
     input.iter().map(|&x| x.into()).collect()
 }
 
-pub(crate) fn evaluate_black_box<Solver: BlackBoxFunctionSolver>(
+pub(crate) fn evaluate_black_box<F, Solver: BlackBoxFunctionSolver>(
     op: &BlackBoxOp,
     solver: &Solver,
-    memory: &mut Memory,
+    memory: &mut Memory<F>,
     bigint_solver: &mut BigIntSolver,
 ) -> Result<(), BlackBoxResolutionError> {
     match op {

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -1,5 +1,5 @@
 use acir::brillig::{BlackBoxOp, HeapArray, HeapVector};
-use acir::{BlackBoxFunc, FieldElement};
+use acir::{AcirField, BlackBoxFunc, FieldElement};
 use acvm_blackbox_solver::BigIntSolver;
 use acvm_blackbox_solver::{
     aes128_encrypt, blake2s, blake3, ecdsa_secp256k1_verify, ecdsa_secp256r1_verify, keccak256,

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -627,6 +627,7 @@ impl<'a, B: BlackBoxFunctionSolver> VM<'a, B> {
 
 #[cfg(test)]
 mod tests {
+    use acir::{AcirField, FieldElement};
     use acvm_blackbox_solver::StubbedBlackBoxSolver;
 
     use super::*;

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -505,7 +505,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
                     ValueOrArray::HeapArray(HeapArray { pointer: pointer_index, size }),
                     HeapValueType::Array { value_types, size: type_size },
                 ) if size == type_size => {
-                    if HeapValueType::all_simple(&value_types) {
+                    if HeapValueType::all_simple(value_types) {
                         let bit_sizes_iterator = value_types.iter().map(|typ| match typ {
                             HeapValueType::Simple(bit_size) => *bit_size,
                             _ => unreachable!("Expected simple value type"),
@@ -541,7 +541,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
                     ValueOrArray::HeapVector(HeapVector {pointer: pointer_index, size: size_index }),
                     HeapValueType::Vector { value_types },
                 ) => {
-                    if HeapValueType::all_simple(&value_types) {
+                    if HeapValueType::all_simple(value_types) {
                         let bit_sizes_iterator = value_types.iter().map(|typ| match typ {
                             HeapValueType::Simple(bit_size) => *bit_size,
                             _ => unreachable!("Expected simple value type"),

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -1,4 +1,4 @@
-use acir::{brillig::MemoryAddress, FieldElement};
+use acir::{brillig::MemoryAddress, AcirField, FieldElement};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -5,8 +5,8 @@ use num_traits::{One, Zero};
 pub const MEMORY_ADDRESSING_BIT_SIZE: u32 = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MemoryValue {
-    Field(FieldElement),
+pub enum MemoryValue<F> {
+    Field(F),
     Integer(BigUint, u32),
 }
 
@@ -16,10 +16,10 @@ pub enum MemoryTypeError {
     MismatchedBitSize { value_bit_size: u32, expected_bit_size: u32 },
 }
 
-impl MemoryValue {
+impl<F: AcirField> MemoryValue<F> {
     /// Builds a memory value from a field element.
-    pub fn new_from_field(value: FieldElement, bit_size: u32) -> Self {
-        if bit_size == FieldElement::max_num_bits() {
+    pub fn new_from_field(value: F, bit_size: u32) -> Self {
+        if bit_size == F::max_num_bits() {
             MemoryValue::new_field(value)
         } else {
             MemoryValue::new_integer(BigUint::from_bytes_be(&value.to_be_bytes()), bit_size)
@@ -28,16 +28,16 @@ impl MemoryValue {
 
     /// Builds a memory value from an integer
     pub fn new_from_integer(value: BigUint, bit_size: u32) -> Self {
-        if bit_size == FieldElement::max_num_bits() {
-            MemoryValue::new_field(FieldElement::from_be_bytes_reduce(&value.to_bytes_be()))
+        if bit_size == F::max_num_bits() {
+            MemoryValue::new_field(F::from_be_bytes_reduce(&value.to_bytes_be()))
         } else {
             MemoryValue::new_integer(value, bit_size)
         }
     }
 
     /// Builds a memory value from a field element, checking that the value is within the bit size.
-    pub fn new_checked(value: FieldElement, bit_size: u32) -> Option<Self> {
-        if bit_size < FieldElement::max_num_bits() && value.num_bits() > bit_size {
+    pub fn new_checked(value: F, bit_size: u32) -> Option<Self> {
+        if bit_size < F::max_num_bits() && value.num_bits() > bit_size {
             return None;
         }
 
@@ -45,7 +45,7 @@ impl MemoryValue {
     }
 
     /// Builds a field-typed memory value.
-    pub fn new_field(value: FieldElement) -> Self {
+    pub fn new_field(value: F) -> Self {
         MemoryValue::Field(value)
     }
 
@@ -75,7 +75,7 @@ impl MemoryValue {
     }
 
     /// Converts the memory value to a field element, independent of its type.
-    pub fn to_field(&self) -> FieldElement {
+    pub fn to_field(&self) -> F {
         match self {
             MemoryValue::Field(value) => *value,
             MemoryValue::Integer(value, _) => {
@@ -139,7 +139,7 @@ impl MemoryValue {
     }
 }
 
-impl std::fmt::Display for MemoryValue {
+impl<F> std::fmt::Display for MemoryValue<F> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match self {
             MemoryValue::Field(value) => write!(f, "{}: field", value),
@@ -155,85 +155,85 @@ impl std::fmt::Display for MemoryValue {
     }
 }
 
-impl Default for MemoryValue {
+impl<F> Default for MemoryValue<F> {
     fn default() -> Self {
         MemoryValue::new_integer(BigUint::zero(), 0)
     }
 }
 
-impl From<FieldElement> for MemoryValue {
+impl<F: AcirField> From<F> for MemoryValue<F> {
     fn from(field: FieldElement) -> Self {
         MemoryValue::new_field(field)
     }
 }
 
-impl From<usize> for MemoryValue {
+impl<F> From<usize> for MemoryValue<F> {
     fn from(value: usize) -> Self {
         MemoryValue::new_integer(value.into(), MEMORY_ADDRESSING_BIT_SIZE)
     }
 }
 
-impl From<u64> for MemoryValue {
+impl<F> From<u64> for MemoryValue<F> {
     fn from(value: u64) -> Self {
         MemoryValue::new_integer(value.into(), 64)
     }
 }
 
-impl From<u32> for MemoryValue {
+impl<F> From<u32> for MemoryValue<F> {
     fn from(value: u32) -> Self {
         MemoryValue::new_integer(value.into(), 32)
     }
 }
 
-impl From<u8> for MemoryValue {
+impl<F> From<u8> for MemoryValue<F> {
     fn from(value: u8) -> Self {
         MemoryValue::new_integer(value.into(), 8)
     }
 }
 
-impl From<bool> for MemoryValue {
+impl<F> From<bool> for MemoryValue<F> {
     fn from(value: bool) -> Self {
         let value = if value { BigUint::one() } else { BigUint::zero() };
         MemoryValue::new_integer(value, 1)
     }
 }
 
-impl TryFrom<MemoryValue> for FieldElement {
+impl<F> TryFrom<MemoryValue<F>> for F {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_field().copied()
     }
 }
 
-impl TryFrom<MemoryValue> for u64 {
+impl<F> TryFrom<MemoryValue<F>> for u64 {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_integer_with_bit_size(64).map(|value| value.try_into().unwrap())
     }
 }
 
-impl TryFrom<MemoryValue> for u32 {
+impl<F> TryFrom<MemoryValue<F>> for u32 {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_integer_with_bit_size(32).map(|value| value.try_into().unwrap())
     }
 }
 
-impl TryFrom<MemoryValue> for u8 {
+impl<F> TryFrom<MemoryValue<F>> for u8 {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_integer_with_bit_size(8).map(|value| value.try_into().unwrap())
     }
 }
 
-impl TryFrom<MemoryValue> for bool {
+impl<F> TryFrom<MemoryValue<F>> for bool {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: MemoryValue<F>) -> Result<Self, Self::Error> {
         let as_integer = memory_value.expect_integer_with_bit_size(1)?;
 
         if as_integer.is_zero() {
@@ -246,48 +246,48 @@ impl TryFrom<MemoryValue> for bool {
     }
 }
 
-impl TryFrom<&MemoryValue> for FieldElement {
+impl<F> TryFrom<&MemoryValue<F>> for FieldElement {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: &MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: &MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_field().copied()
     }
 }
 
-impl TryFrom<&MemoryValue> for u64 {
+impl<F> TryFrom<&MemoryValue<F>> for u64 {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: &MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: &MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_integer_with_bit_size(64).map(|value| {
             value.try_into().expect("memory_value has been asserted to contain a 64 bit integer")
         })
     }
 }
 
-impl TryFrom<&MemoryValue> for u32 {
+impl<F> TryFrom<&MemoryValue<F>> for u32 {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: &MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: &MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_integer_with_bit_size(32).map(|value| {
             value.try_into().expect("memory_value has been asserted to contain a 32 bit integer")
         })
     }
 }
 
-impl TryFrom<&MemoryValue> for u8 {
+impl<F> TryFrom<&MemoryValue<F>> for u8 {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: &MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: &MemoryValue<F>) -> Result<Self, Self::Error> {
         memory_value.expect_integer_with_bit_size(8).map(|value| {
             value.try_into().expect("memory_value has been asserted to contain an 8 bit integer")
         })
     }
 }
 
-impl TryFrom<&MemoryValue> for bool {
+impl<F> TryFrom<&MemoryValue<F>> for bool {
     type Error = MemoryTypeError;
 
-    fn try_from(memory_value: &MemoryValue) -> Result<Self, Self::Error> {
+    fn try_from(memory_value: &MemoryValue<F>) -> Result<Self, Self::Error> {
         let as_integer = memory_value.expect_integer_with_bit_size(1)?;
 
         if as_integer.is_zero() {
@@ -301,15 +301,15 @@ impl TryFrom<&MemoryValue> for bool {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Memory {
+pub struct Memory<F> {
     // Memory is a vector of values.
     // We grow the memory when values past the end are set, extending with 0s.
-    inner: Vec<MemoryValue>,
+    inner: Vec<MemoryValue<F>>,
 }
 
-impl Memory {
+impl<F> Memory<F> {
     /// Gets the value at pointer
-    pub fn read(&self, ptr: MemoryAddress) -> MemoryValue {
+    pub fn read(&self, ptr: MemoryAddress) -> MemoryValue<F> {
         self.inner.get(ptr.to_usize()).cloned().unwrap_or_default()
     }
 
@@ -317,12 +317,12 @@ impl Memory {
         MemoryAddress(self.read(ptr).to_usize())
     }
 
-    pub fn read_slice(&self, addr: MemoryAddress, len: usize) -> &[MemoryValue] {
+    pub fn read_slice(&self, addr: MemoryAddress, len: usize) -> &[MemoryValue<F>] {
         &self.inner[addr.to_usize()..(addr.to_usize() + len)]
     }
 
     /// Sets the value at pointer `ptr` to `value`
-    pub fn write(&mut self, ptr: MemoryAddress, value: MemoryValue) {
+    pub fn write(&mut self, ptr: MemoryAddress, value: MemoryValue<F>) {
         self.resize_to_fit(ptr.to_usize() + 1);
         self.inner[ptr.to_usize()] = value;
     }
@@ -335,13 +335,13 @@ impl Memory {
     }
 
     /// Sets the values after pointer `ptr` to `values`
-    pub fn write_slice(&mut self, ptr: MemoryAddress, values: &[MemoryValue]) {
+    pub fn write_slice(&mut self, ptr: MemoryAddress, values: &[MemoryValue<F>]) {
         self.resize_to_fit(ptr.to_usize() + values.len());
         self.inner[ptr.to_usize()..(ptr.to_usize() + values.len())].clone_from_slice(values);
     }
 
     /// Returns the values of the memory
-    pub fn values(&self) -> &[MemoryValue] {
+    pub fn values(&self) -> &[MemoryValue<F>] {
         &self.inner
     }
 }

--- a/aztec_macros/Cargo.toml
+++ b/aztec_macros/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+acvm.workspace = true
 noirc_frontend.workspace = true
 noirc_errors.workspace = true
 iter-extended.workspace = true

--- a/aztec_macros/src/transforms/storage.rs
+++ b/aztec_macros/src/transforms/storage.rs
@@ -1,3 +1,4 @@
+use acvm::AcirField;
 use noirc_errors::Span;
 use noirc_frontend::ast::{
     BlockExpression, Expression, ExpressionKind, FunctionDefinition, Ident, Literal, NoirFunction,

--- a/aztec_macros/src/transforms/storage.rs
+++ b/aztec_macros/src/transforms/storage.rs
@@ -1,4 +1,4 @@
-use acvm::AcirField;
+use acvm::acir::AcirField;
 use noirc_errors::Span;
 use noirc_frontend::ast::{
     BlockExpression, Expression, ExpressionKind, FunctionDefinition, Ident, Literal, NoirFunction,

--- a/aztec_macros/src/utils/hir_utils.rs
+++ b/aztec_macros/src/utils/hir_utils.rs
@@ -1,3 +1,4 @@
+use acvm::AcirField;
 use iter_extended::vecmap;
 use noirc_errors::Location;
 use noirc_frontend::ast;

--- a/aztec_macros/src/utils/hir_utils.rs
+++ b/aztec_macros/src/utils/hir_utils.rs
@@ -1,4 +1,4 @@
-use acvm::AcirField;
+use acvm::acir::AcirField;
 use iter_extended::vecmap;
 use noirc_errors::Location;
 use noirc_frontend::ast;

--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
-use acvm::acir::circuit::Program;
+use acvm::{acir::circuit::Program, FieldElement};
 use fm::FileId;
 use noirc_abi::{Abi, AbiType, AbiValue};
 use noirc_errors::debug_info::DebugInfo;
@@ -51,7 +51,7 @@ pub struct ContractFunction {
         serialize_with = "Program::serialize_program_base64",
         deserialize_with = "Program::deserialize_program_base64"
     )]
-    pub bytecode: Program,
+    pub bytecode: Program<FieldElement>,
 
     pub debug: Vec<DebugInfo>,
 

--- a/compiler/noirc_driver/src/program.rs
+++ b/compiler/noirc_driver/src/program.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use acvm::acir::circuit::Program;
+use acvm::{acir::circuit::Program, FieldElement};
 use fm::FileId;
 
 use noirc_errors::debug_info::DebugInfo;
@@ -22,7 +22,7 @@ pub struct CompiledProgram {
         serialize_with = "Program::serialize_program_base64",
         deserialize_with = "Program::deserialize_program_base64"
     )]
-    pub program: Program,
+    pub program: Program<FieldElement>,
     pub abi: noirc_abi::Abi,
     pub debug: Vec<DebugInfo>,
     pub file_map: BTreeMap<FileId, DebugFile>,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -18,7 +18,7 @@ use crate::ssa::ir::{
 };
 use acvm::acir::brillig::{MemoryAddress, ValueOrArray};
 use acvm::brillig_vm::brillig::HeapVector;
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use iter_extended::vecmap;
 use num_bigint::BigUint;

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -18,7 +18,7 @@ use crate::ssa::ir::{
 };
 use acvm::acir::brillig::{MemoryAddress, ValueOrArray};
 use acvm::brillig_vm::brillig::HeapVector;
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use iter_extended::vecmap;
 use num_bigint::BigUint;

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -1,6 +1,7 @@
 use acvm::{
     acir::brillig::{BinaryFieldOp, BinaryIntOp, MemoryAddress, Opcode as BrilligOpcode},
-    AcirField, FieldElement,
+    acir::AcirField,
+    FieldElement,
 };
 
 use crate::brillig::brillig_ir::artifact::GeneratedBrillig;

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_directive.rs
@@ -1,6 +1,6 @@
 use acvm::{
     acir::brillig::{BinaryFieldOp, BinaryIntOp, MemoryAddress, Opcode as BrilligOpcode},
-    FieldElement,
+    AcirField, FieldElement,
 };
 
 use crate::brillig::brillig_ir::artifact::GeneratedBrillig;

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -27,7 +27,10 @@ pub(crate) use instructions::BrilligBinaryOp;
 
 use self::{artifact::BrilligArtifact, registers::BrilligRegistersContext};
 use crate::ssa::ir::dfg::CallStack;
-use acvm::acir::brillig::{MemoryAddress, Opcode as BrilligOpcode};
+use acvm::{
+    acir::brillig::{MemoryAddress, Opcode as BrilligOpcode},
+    FieldElement,
+};
 use debug_show::DebugShow;
 
 /// The Brillig VM does not apply a limit to the memory address space,
@@ -110,7 +113,7 @@ impl BrilligContext {
         result
     }
     /// Adds a brillig instruction to the brillig byte code
-    fn push_opcode(&mut self, opcode: BrilligOpcode) {
+    fn push_opcode(&mut self, opcode: BrilligOpcode<FieldElement>) {
         self.obj.push_opcode(opcode);
     }
 
@@ -143,7 +146,7 @@ pub(crate) mod tests {
 
     pub(crate) struct DummyBlackBoxSolver;
 
-    impl BlackBoxFunctionSolver for DummyBlackBoxSolver {
+    impl BlackBoxFunctionSolver<FieldElement> for DummyBlackBoxSolver {
         fn schnorr_verify(
             &self,
             _public_key_x: &FieldElement,
@@ -217,8 +220,8 @@ pub(crate) mod tests {
 
     pub(crate) fn create_and_run_vm(
         calldata: Vec<FieldElement>,
-        bytecode: &[BrilligOpcode],
-    ) -> (VM<'_, DummyBlackBoxSolver>, usize, usize) {
+        bytecode: &[BrilligOpcode<FieldElement>],
+    ) -> (VM<'_, FieldElement, DummyBlackBoxSolver>, usize, usize) {
         let mut vm = VM::new(calldata, bytecode, vec![], &DummyBlackBoxSolver);
 
         let status = vm.process_opcodes();
@@ -277,7 +280,7 @@ pub(crate) mod tests {
 
         context.stop_instruction();
 
-        let bytecode: Vec<BrilligOpcode> = context.artifact().finish().byte_code;
+        let bytecode: Vec<BrilligOpcode<FieldElement>> = context.artifact().finish().byte_code;
         let number_sequence: Vec<FieldElement> =
             (0_usize..12_usize).map(FieldElement::from).collect();
         let mut vm = VM::new(

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -1,4 +1,4 @@
-use acvm::acir::brillig::Opcode as BrilligOpcode;
+use acvm::{acir::brillig::Opcode as BrilligOpcode, FieldElement};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::ssa::ir::dfg::CallStack;
@@ -19,7 +19,7 @@ pub(crate) enum BrilligParameter {
 /// This is ready to run bytecode with attached metadata.
 #[derive(Debug, Default)]
 pub(crate) struct GeneratedBrillig {
-    pub(crate) byte_code: Vec<BrilligOpcode>,
+    pub(crate) byte_code: Vec<BrilligOpcode<FieldElement>>,
     pub(crate) locations: BTreeMap<OpcodeLocation, CallStack>,
     pub(crate) assert_messages: BTreeMap<OpcodeLocation, String>,
 }
@@ -28,7 +28,7 @@ pub(crate) struct GeneratedBrillig {
 /// Artifacts resulting from the compilation of a function into brillig byte code.
 /// It includes the bytecode of the function and all the metadata that allows linking with other functions.
 pub(crate) struct BrilligArtifact {
-    pub(crate) byte_code: Vec<BrilligOpcode>,
+    pub(crate) byte_code: Vec<BrilligOpcode<FieldElement>>,
     /// A map of bytecode positions to assertion messages.
     /// Some error messages (compiler intrinsics) are not emitted via revert data,
     /// instead, they are handled externally so they don't add size to user programs.
@@ -154,7 +154,7 @@ impl BrilligArtifact {
     }
 
     /// Adds a brillig instruction to the brillig byte code
-    pub(crate) fn push_opcode(&mut self, opcode: BrilligOpcode) {
+    pub(crate) fn push_opcode(&mut self, opcode: BrilligOpcode<FieldElement>) {
         if !self.call_stack.is_empty() {
             self.locations.insert(self.index_of_next_opcode(), self.call_stack.clone());
         }
@@ -164,7 +164,7 @@ impl BrilligArtifact {
     /// Adds a unresolved jump to be fixed at the end of bytecode processing.
     pub(crate) fn add_unresolved_jump(
         &mut self,
-        jmp_instruction: BrilligOpcode,
+        jmp_instruction: BrilligOpcode<FieldElement>,
         destination: UnresolvedJumpLocation,
     ) {
         assert!(
@@ -178,7 +178,7 @@ impl BrilligArtifact {
     /// Adds a unresolved external call that will be fixed once linking has been done.
     pub(crate) fn add_unresolved_external_call(
         &mut self,
-        call_instruction: BrilligOpcode,
+        call_instruction: BrilligOpcode<FieldElement>,
         destination: UnresolvedJumpLocation,
     ) {
         // TODO: Add a check to ensure that the opcode is a call instruction
@@ -188,7 +188,7 @@ impl BrilligArtifact {
     }
 
     /// Returns true if the opcode is a jump instruction
-    fn is_jmp_instruction(instruction: &BrilligOpcode) -> bool {
+    fn is_jmp_instruction(instruction: &BrilligOpcode<FieldElement>) -> bool {
         matches!(
             instruction,
             BrilligOpcode::JumpIfNot { .. }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
@@ -1,6 +1,6 @@
 use acvm::{
     brillig_vm::brillig::{HeapArray, HeapValueType, HeapVector, MemoryAddress, ValueOrArray},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use serde::{Deserialize, Serialize};
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
@@ -1,6 +1,7 @@
 use acvm::{
+    acir::AcirField,
     brillig_vm::brillig::{HeapArray, HeapValueType, HeapVector, MemoryAddress, ValueOrArray},
-    AcirField, FieldElement,
+    FieldElement,
 };
 use serde::{Deserialize, Serialize};
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
@@ -1,6 +1,6 @@
 use acvm::{
     acir::brillig::{BlackBoxOp, HeapArray},
-    FieldElement,
+    AcirField, FieldElement,
 };
 
 use super::{

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
@@ -1,6 +1,7 @@
 use acvm::{
     acir::brillig::{BlackBoxOp, HeapArray},
-    AcirField, FieldElement,
+    acir::AcirField,
+    FieldElement,
 };
 
 use super::{

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -5,7 +5,7 @@ use super::{
     registers::BrilligRegistersContext,
     BrilligBinaryOp, BrilligContext, ReservedRegisters,
 };
-use acvm::{acir::brillig::MemoryAddress, FieldElement};
+use acvm::{acir::brillig::MemoryAddress, AcirField, FieldElement};
 
 pub(crate) const MAX_STACK_SIZE: usize = 2048;
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -5,7 +5,7 @@ use super::{
     registers::BrilligRegistersContext,
     BrilligBinaryOp, BrilligContext, ReservedRegisters,
 };
-use acvm::{acir::brillig::MemoryAddress, AcirField, FieldElement};
+use acvm::{acir::brillig::MemoryAddress, acir::AcirField, FieldElement};
 
 pub(crate) const MAX_STACK_SIZE: usize = 2048;
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -3,7 +3,7 @@ use acvm::{
         BinaryFieldOp, BinaryIntOp, BlackBoxOp, HeapArray, HeapValueType, MemoryAddress,
         Opcode as BrilligOpcode, ValueOrArray,
     },
-    FieldElement,
+    AcirField, FieldElement,
 };
 
 use super::{

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -3,7 +3,8 @@ use acvm::{
         BinaryFieldOp, BinaryIntOp, BlackBoxOp, HeapArray, HeapValueType, MemoryAddress,
         Opcode as BrilligOpcode, ValueOrArray,
     },
-    AcirField, FieldElement,
+    acir::AcirField,
+    FieldElement,
 };
 
 use super::{
@@ -212,7 +213,7 @@ impl BrilligContext {
     /// Adds a unresolved `Jump` to the bytecode.
     fn add_unresolved_jump(
         &mut self,
-        jmp_instruction: BrilligOpcode,
+        jmp_instruction: BrilligOpcode<FieldElement>,
         destination: UnresolvedJumpLocation,
     ) {
         self.obj.add_unresolved_jump(jmp_instruction, destination);
@@ -380,7 +381,7 @@ impl BrilligContext {
             constant,
             result.bit_size
         );
-        if result.bit_size > 128 && !constant.fits_in_u128() {
+        if result.bit_size > 128 && constant.num_bits() > 128 {
             let high = FieldElement::from_be_bytes_reduce(
                 constant.to_be_bytes().get(0..16).expect("FieldElement::to_be_bytes() too short!"),
             );

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -10,12 +10,15 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::errors::{RuntimeError, SsaReport};
-use acvm::acir::{
-    circuit::{
-        brillig::BrilligBytecode, Circuit, ErrorSelector, ExpressionWidth, Program as AcirProgram,
-        PublicInputs,
+use acvm::{
+    acir::{
+        circuit::{
+            brillig::BrilligBytecode, Circuit, ErrorSelector, ExpressionWidth,
+            Program as AcirProgram, PublicInputs,
+        },
+        native_types::Witness,
     },
-    native_types::Witness,
+    FieldElement,
 };
 
 use noirc_errors::debug_info::{DebugFunctions, DebugInfo, DebugTypes, DebugVariables};
@@ -102,7 +105,7 @@ fn time<T>(name: &str, print_timings: bool, f: impl FnOnce() -> T) -> T {
 
 #[derive(Default)]
 pub struct SsaProgramArtifact {
-    pub program: AcirProgram,
+    pub program: AcirProgram<FieldElement>,
     pub debug: Vec<DebugInfo>,
     pub warnings: Vec<SsaReport>,
     pub main_input_witnesses: Vec<Witness>,
@@ -113,7 +116,7 @@ pub struct SsaProgramArtifact {
 
 impl SsaProgramArtifact {
     fn new(
-        unconstrained_functions: Vec<BrilligBytecode>,
+        unconstrained_functions: Vec<BrilligBytecode<FieldElement>>,
         error_types: BTreeMap<ErrorSelector, HirType>,
     ) -> Self {
         let program = AcirProgram { functions: Vec::default(), unconstrained_functions };
@@ -194,7 +197,7 @@ pub fn create_program(
 
 pub struct SsaCircuitArtifact {
     name: String,
-    circuit: Circuit,
+    circuit: Circuit<FieldElement>,
     debug_info: DebugInfo,
     warnings: Vec<SsaReport>,
     input_witnesses: Vec<Witness>,

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -19,7 +19,7 @@ use acvm::{
         native_types::{Expression, Witness},
         BlackBoxFunc,
     },
-    FieldElement,
+    AcirField, FieldElement,
 };
 use fxhash::FxHashMap as HashMap;
 use iter_extended::{try_vecmap, vecmap};

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/big_int.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/big_int.rs
@@ -1,4 +1,4 @@
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use num_bigint::BigUint;
 
 /// Represents a bigint value in the form (id, modulus) where

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/big_int.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/big_int.rs
@@ -1,4 +1,4 @@
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use num_bigint::BigUint;
 
 /// Represents a bigint value in the form (id, modulus) where

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -18,7 +18,7 @@ use acvm::acir::{
 };
 use acvm::{
     acir::{circuit::directives::Directive, native_types::Expression},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use iter_extended::vecmap;
 use num_bigint::BigUint;

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -17,8 +17,9 @@ use acvm::acir::{
     BlackBoxFunc,
 };
 use acvm::{
+    acir::AcirField,
     acir::{circuit::directives::Directive, native_types::Expression},
-    AcirField, FieldElement,
+    FieldElement,
 };
 use iter_extended::vecmap;
 use num_bigint::BigUint;
@@ -41,7 +42,7 @@ pub(crate) struct GeneratedAcir {
     current_witness_index: Option<u32>,
 
     /// The opcodes of which the compiled ACIR will comprise.
-    opcodes: Vec<AcirOpcode>,
+    opcodes: Vec<AcirOpcode<FieldElement>>,
 
     /// All witness indices that comprise the final return value of the program
     ///
@@ -60,7 +61,7 @@ pub(crate) struct GeneratedAcir {
     pub(crate) call_stack: CallStack,
 
     /// Correspondence between an opcode index and the error message associated with it.
-    pub(crate) assertion_payloads: BTreeMap<OpcodeLocation, AssertionPayload>,
+    pub(crate) assertion_payloads: BTreeMap<OpcodeLocation, AssertionPayload<FieldElement>>,
 
     pub(crate) warnings: Vec<SsaReport>,
 
@@ -99,18 +100,18 @@ impl GeneratedAcir {
     }
 
     /// Adds a new opcode into ACIR.
-    pub(crate) fn push_opcode(&mut self, opcode: AcirOpcode) {
+    pub(crate) fn push_opcode(&mut self, opcode: AcirOpcode<FieldElement>) {
         self.opcodes.push(opcode);
         if !self.call_stack.is_empty() {
             self.locations.insert(self.last_acir_opcode_location(), self.call_stack.clone());
         }
     }
 
-    pub(crate) fn opcodes(&self) -> &[AcirOpcode] {
+    pub(crate) fn opcodes(&self) -> &[AcirOpcode<FieldElement>] {
         &self.opcodes
     }
 
-    pub(crate) fn take_opcodes(&mut self) -> Vec<AcirOpcode> {
+    pub(crate) fn take_opcodes(&mut self) -> Vec<AcirOpcode<FieldElement>> {
         std::mem::take(&mut self.opcodes)
     }
 
@@ -129,7 +130,7 @@ impl GeneratedAcir {
     ///
     /// If `expr` can be represented as a `Witness` then this function will return it,
     /// else a new opcode will be added to create a `Witness` that is equal to `expr`.
-    pub(crate) fn get_or_create_witness(&mut self, expr: &Expression) -> Witness {
+    pub(crate) fn get_or_create_witness(&mut self, expr: &Expression<FieldElement>) -> Witness {
         match expr.to_witness() {
             Some(witness) => witness,
             None => self.create_witness_for_expression(expr),
@@ -142,7 +143,10 @@ impl GeneratedAcir {
     /// This means you cannot multiply an infinite amount of `Expression`s together.
     /// Once the `Expression` goes over degree-2, then it needs to be reduced to a `Witness`
     /// which has degree-1 in order to be able to continue the multiplication chain.
-    pub(crate) fn create_witness_for_expression(&mut self, expression: &Expression) -> Witness {
+    pub(crate) fn create_witness_for_expression(
+        &mut self,
+        expression: &Expression<FieldElement>,
+    ) -> Witness {
         let fresh_witness = self.next_witness_index();
 
         // Create a constraint that sets them to be equal to each other
@@ -392,7 +396,7 @@ impl GeneratedAcir {
     /// Only radix that are a power of two are supported
     pub(crate) fn radix_le_decompose(
         &mut self,
-        input_expr: &Expression,
+        input_expr: &Expression<FieldElement>,
         radix: u32,
         limb_count: u32,
         bit_size: u32,
@@ -438,7 +442,7 @@ impl GeneratedAcir {
     ///
     /// Safety: It is the callers responsibility to ensure that the
     /// resulting `Witness` is constrained to be the inverse.
-    pub(crate) fn brillig_inverse(&mut self, expr: Expression) -> Witness {
+    pub(crate) fn brillig_inverse(&mut self, expr: Expression<FieldElement>) -> Witness {
         // Create the witness for the result
         let inverted_witness = self.next_witness_index();
 
@@ -462,14 +466,18 @@ impl GeneratedAcir {
     ///
     /// If `expr` is not zero, then the constraint system will
     /// fail upon verification.
-    pub(crate) fn assert_is_zero(&mut self, expr: Expression) {
+    pub(crate) fn assert_is_zero(&mut self, expr: Expression<FieldElement>) {
         self.push_opcode(AcirOpcode::AssertZero(expr));
     }
 
     /// Returns a `Witness` that is constrained to be:
     /// - `1` if `lhs == rhs`
     /// - `0` otherwise
-    pub(crate) fn is_equal(&mut self, lhs: &Expression, rhs: &Expression) -> Witness {
+    pub(crate) fn is_equal(
+        &mut self,
+        lhs: &Expression<FieldElement>,
+        rhs: &Expression<FieldElement>,
+    ) -> Witness {
         let t = lhs - rhs;
 
         self.is_zero(&t)
@@ -527,7 +535,7 @@ impl GeneratedAcir {
     /// By setting `z` to be `0`, we can make `y` equal to `1`.
     /// This is easily observed: `y = 1 - t * 0`
     /// Now since `y` is one, this means that `t` needs to be zero, or else `y * t == 0` will fail.
-    fn is_zero(&mut self, t_expr: &Expression) -> Witness {
+    fn is_zero(&mut self, t_expr: &Expression<FieldElement>) -> Witness {
         // We're checking for equality with zero so we can negate the expression without changing the result.
         // This is useful as it will sometimes allow us to simplify an expression down to a witness.
         let t_witness = if let Some(witness) = t_expr.to_witness() {
@@ -588,9 +596,9 @@ impl GeneratedAcir {
 
     pub(crate) fn brillig_call(
         &mut self,
-        predicate: Option<Expression>,
+        predicate: Option<Expression<FieldElement>>,
         generated_brillig: &GeneratedBrillig,
-        inputs: Vec<BrilligInputs>,
+        inputs: Vec<BrilligInputs<FieldElement>>,
         outputs: Vec<BrilligOutputs>,
         brillig_function_index: u32,
         stdlib_func: Option<BrilligStdlibFunc>,

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -37,8 +37,9 @@ use acvm::acir::circuit::{AssertionPayload, ErrorSelector, OpcodeLocation};
 use acvm::acir::native_types::Witness;
 use acvm::acir::BlackBoxFunc;
 use acvm::{
+    acir::AcirField,
     acir::{circuit::opcodes::BlockId, native_types::Expression},
-    AcirField, FieldElement,
+    FieldElement,
 };
 use fxhash::FxHashMap as HashMap;
 use im::Vector;
@@ -278,7 +279,7 @@ impl AcirValue {
 }
 
 pub(crate) type Artifacts =
-    (Vec<GeneratedAcir>, Vec<BrilligBytecode>, BTreeMap<ErrorSelector, ErrorType>);
+    (Vec<GeneratedAcir>, Vec<BrilligBytecode<FieldElement>>, BTreeMap<ErrorSelector, ErrorType>);
 
 impl Ssa {
     #[tracing::instrument(level = "trace", skip_all)]
@@ -3097,7 +3098,7 @@ mod test {
     }
 
     fn check_call_opcode(
-        opcode: &Opcode,
+        opcode: &Opcode<FieldElement>,
         expected_id: u32,
         expected_inputs: Vec<Witness>,
         expected_outputs: Vec<Witness>,
@@ -3425,7 +3426,7 @@ mod test {
 
     fn check_brillig_calls(
         brillig_stdlib_function_locations: &BTreeMap<OpcodeLocation, BrilligStdlibFunc>,
-        opcodes: &[Opcode],
+        opcodes: &[Opcode<FieldElement>],
         num_normal_brillig_functions: u32,
         expected_num_stdlib_calls: u32,
         expected_num_normal_calls: u32,

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -38,7 +38,7 @@ use acvm::acir::native_types::Witness;
 use acvm::acir::BlackBoxFunc;
 use acvm::{
     acir::{circuit::opcodes::BlockId, native_types::Expression},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use fxhash::FxHashMap as HashMap;
 use im::Vector;

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -516,7 +516,7 @@ impl std::ops::Index<BasicBlockId> for FunctionBuilder {
 mod tests {
     use std::rc::Rc;
 
-    use acvm::FieldElement;
+    use acvm::{AcirField, FieldElement};
 
     use crate::ssa::ir::{
         instruction::{Endian, Intrinsic},

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -516,7 +516,7 @@ impl std::ops::Index<BasicBlockId> for FunctionBuilder {
 mod tests {
     use std::rc::Rc;
 
-    use acvm::{AcirField, FieldElement};
+    use acvm::{acir::AcirField, FieldElement};
 
     use crate::ssa::ir::{
         instruction::{Endian, Intrinsic},

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -13,7 +13,7 @@ use super::{
     value::{Value, ValueId},
 };
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use fxhash::FxHashMap as HashMap;
 use iter_extended::vecmap;
 use noirc_errors::Location;

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -13,7 +13,7 @@ use super::{
     value::{Value, ValueId},
 };
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use fxhash::FxHashMap as HashMap;
 use iter_extended::vecmap;
 use noirc_errors::Location;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -1,11 +1,12 @@
 use std::hash::{Hash, Hasher};
 
 use acvm::{
+    acir::AcirField,
     acir::{
         circuit::{ErrorSelector, STRING_ERROR_SELECTOR},
         BlackBoxFunc,
     },
-    AcirField, FieldElement,
+    FieldElement,
 };
 use fxhash::FxHasher;
 use iter_extended::vecmap;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -5,7 +5,7 @@ use acvm::{
         circuit::{ErrorSelector, STRING_ERROR_SELECTOR},
         BlackBoxFunc,
     },
-    FieldElement,
+    AcirField, FieldElement,
 };
 use fxhash::FxHasher;
 use iter_extended::vecmap;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -1,4 +1,4 @@
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 
 use super::{
     DataFlowGraph, Instruction, InstructionResultType, NumericType, SimplifyResult, Type, ValueId,

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -1,4 +1,4 @@
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 
 use super::{
     DataFlowGraph, Instruction, InstructionResultType, NumericType, SimplifyResult, Type, ValueId,

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -1,7 +1,7 @@
 use fxhash::FxHashMap as HashMap;
 use std::{collections::VecDeque, rc::Rc};
 
-use acvm::{acir::BlackBoxFunc, BlackBoxResolutionError, FieldElement};
+use acvm::{acir::BlackBoxFunc, AcirField, BlackBoxResolutionError, FieldElement};
 use iter_extended::vecmap;
 use num_bigint::BigUint;
 

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -1,7 +1,7 @@
 use fxhash::FxHashMap as HashMap;
 use std::{collections::VecDeque, rc::Rc};
 
-use acvm::{acir::BlackBoxFunc, AcirField, BlackBoxResolutionError, FieldElement};
+use acvm::{acir::AcirField, acir::BlackBoxFunc, BlackBoxResolutionError, FieldElement};
 use iter_extended::vecmap;
 use num_bigint::BigUint;
 

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/cast.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/cast.rs
@@ -1,4 +1,4 @@
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use num_bigint::BigUint;
 
 use super::{DataFlowGraph, Instruction, NumericType, SimplifyResult, Type, Value, ValueId};

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/cast.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/cast.rs
@@ -1,4 +1,4 @@
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use num_bigint::BigUint;
 
 use super::{DataFlowGraph, Instruction, NumericType, SimplifyResult, Type, Value, ValueId};

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
@@ -1,4 +1,4 @@
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 
 use super::{Binary, BinaryOp, ConstrainError, DataFlowGraph, Instruction, Type, Value, ValueId};
 

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
@@ -1,4 +1,4 @@
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 
 use super::{Binary, BinaryOp, ConstrainError, DataFlowGraph, Instruction, Type, Value, ValueId};
 

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use acvm::acir::circuit::{ErrorSelector, STRING_ERROR_SELECTOR};
+use acvm::AcirField;
 use iter_extended::vecmap;
 
 use super::{

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use acvm::acir::circuit::{ErrorSelector, STRING_ERROR_SELECTOR};
-use acvm::AcirField;
+use acvm::acir::AcirField;
 use iter_extended::vecmap;
 
 use super::{

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::vecmap;
 
 /// A numeric type in the Intermediate representation

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 
 /// A numeric type in the Intermediate representation

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -21,7 +21,7 @@
 //! different blocks are merged, i.e. after the [`flatten_cfg`][super::flatten_cfg] pass.
 use std::collections::HashSet;
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::vecmap;
 
 use crate::ssa::{
@@ -288,6 +288,7 @@ mod test {
             value::{Value, ValueId},
         },
     };
+    use acvm::AcirField;
 
     #[test]
     fn simple_constant_fold() {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -21,7 +21,7 @@
 //! different blocks are merged, i.e. after the [`flatten_cfg`][super::flatten_cfg] pass.
 use std::collections::HashSet;
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 
 use crate::ssa::{
@@ -288,7 +288,7 @@ mod test {
             value::{Value, ValueId},
         },
     };
-    use acvm::AcirField;
+    use acvm::acir::AcirField;
 
     #[test]
     fn simple_constant_fold() {

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -134,7 +134,7 @@
 use fxhash::FxHashMap as HashMap;
 use std::collections::{BTreeMap, HashSet};
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 
 use crate::ssa::{
@@ -792,7 +792,7 @@ impl<'f> Context<'f> {
 mod test {
     use std::rc::Rc;
 
-    use acvm::AcirField;
+    use acvm::acir::AcirField;
 
     use crate::ssa::{
         function_builder::FunctionBuilder,

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -134,7 +134,7 @@
 use fxhash::FxHashMap as HashMap;
 use std::collections::{BTreeMap, HashSet};
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::vecmap;
 
 use crate::ssa::{
@@ -791,6 +791,8 @@ impl<'f> Context<'f> {
 #[cfg(test)]
 mod test {
     use std::rc::Rc;
+
+    use acvm::AcirField;
 
     use crate::ssa::{
         function_builder::FunctionBuilder,

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/capacity_tracker.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/capacity_tracker.rs
@@ -5,7 +5,7 @@ use crate::ssa::ir::{
     value::{Value, ValueId},
 };
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use fxhash::FxHashMap as HashMap;
 
 pub(crate) struct SliceCapacityTracker<'a> {

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/capacity_tracker.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/capacity_tracker.rs
@@ -5,7 +5,7 @@ use crate::ssa::ir::{
     value::{Value, ValueId},
 };
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use fxhash::FxHashMap as HashMap;
 
 pub(crate) struct SliceCapacityTracker<'a> {

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -1,4 +1,4 @@
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use fxhash::{FxHashMap as HashMap, FxHashSet};
 
 use crate::ssa::ir::{

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -1,4 +1,4 @@
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use fxhash::{FxHashMap as HashMap, FxHashSet};
 
 use crate::ssa::ir::{

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -4,7 +4,7 @@
 //! be a single function remaining when the pass finishes.
 use std::collections::{BTreeSet, HashSet};
 
-use acvm::AcirField;
+use acvm::acir::AcirField;
 use iter_extended::{btree_map, vecmap};
 
 use crate::ssa::{
@@ -563,7 +563,7 @@ impl<'function> PerFunctionContext<'function> {
 
 #[cfg(test)]
 mod test {
-    use acvm::{AcirField, FieldElement};
+    use acvm::{acir::AcirField, FieldElement};
     use noirc_frontend::monomorphization::ast::InlineType;
 
     use crate::ssa::{

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -4,6 +4,7 @@
 //! be a single function remaining when the pass finishes.
 use std::collections::{BTreeSet, HashSet};
 
+use acvm::AcirField;
 use iter_extended::{btree_map, vecmap};
 
 use crate::ssa::{
@@ -562,7 +563,7 @@ impl<'function> PerFunctionContext<'function> {
 
 #[cfg(test)]
 mod test {
-    use acvm::FieldElement;
+    use acvm::{AcirField, FieldElement};
     use noirc_frontend::monomorphization::ast::InlineType;
 
     use crate::ssa::{

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -406,7 +406,7 @@ impl<'f> PerFunctionContext<'f> {
 mod tests {
     use std::rc::Rc;
 
-    use acvm::{AcirField, FieldElement};
+    use acvm::{acir::AcirField, FieldElement};
     use im::vector;
 
     use crate::ssa::{

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -406,7 +406,7 @@ impl<'f> PerFunctionContext<'f> {
 mod tests {
     use std::rc::Rc;
 
-    use acvm::FieldElement;
+    use acvm::{AcirField, FieldElement};
     use im::vector;
 
     use crate::ssa::{

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, rc::Rc};
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 
 use crate::ssa::{
     ir::{

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, rc::Rc};
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 
 use crate::ssa::{
     ir::{

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -10,7 +10,7 @@
 //!       before the [Instruction]. Continue inserting instructions until the next [Instruction::EnableSideEffects] is encountered.
 use std::collections::HashSet;
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 
 use crate::ssa::{
     ir::{

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -10,7 +10,7 @@
 //!       before the [Instruction]. Continue inserting instructions until the next [Instruction::EnableSideEffects] is encountered.
 use std::collections::HashSet;
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 
 use crate::ssa::{
     ir::{

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::Entry;
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use fxhash::FxHashMap as HashMap;
 
 use crate::ssa::ir::value::ValueId;

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::Entry;
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use fxhash::FxHashMap as HashMap;
 
 use crate::ssa::ir::value::ValueId;

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -11,6 +11,8 @@
 //! Currently, 1 and 4 are unimplemented.
 use std::collections::HashSet;
 
+use acvm::AcirField;
+
 use crate::ssa::{
     ir::{
         basic_block::BasicBlockId, cfg::ControlFlowGraph, dfg::CallStack, function::Function,
@@ -159,6 +161,7 @@ mod test {
             types::Type,
         },
     };
+    use acvm::AcirField;
 
     #[test]
     fn inline_blocks() {

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -11,7 +11,7 @@
 //! Currently, 1 and 4 are unimplemented.
 use std::collections::HashSet;
 
-use acvm::AcirField;
+use acvm::acir::AcirField;
 
 use crate::ssa::{
     ir::{
@@ -161,7 +161,7 @@ mod test {
             types::Type,
         },
     };
-    use acvm::AcirField;
+    use acvm::acir::AcirField;
 
     #[test]
     fn inline_blocks() {

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -16,7 +16,7 @@
 //! we remove reference count instructions because they are only used by Brillig bytecode
 use std::collections::HashSet;
 
-use acvm::AcirField;
+use acvm::acir::AcirField;
 
 use crate::{
     errors::RuntimeError,

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -16,6 +16,8 @@
 //! we remove reference count instructions because they are only used by Brillig bytecode
 use std::collections::HashSet;
 
+use acvm::AcirField;
+
 use crate::{
     errors::RuntimeError,
     ssa::{

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::sync::{Mutex, RwLock};
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::Location;
 use noirc_frontend::ast::{BinaryOpKind, Signedness};

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::sync::{Mutex, RwLock};
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::Location;
 use noirc_frontend::ast::{BinaryOpKind, Signedness};

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -6,7 +6,7 @@ use crate::ast::{
     UnresolvedTraitConstraint, UnresolvedType, UnresolvedTypeData, Visibility,
 };
 use crate::token::{Attributes, Token};
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::{Span, Spanned};
 

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -6,7 +6,7 @@ use crate::ast::{
     UnresolvedTraitConstraint, UnresolvedType, UnresolvedTypeData, Visibility,
 };
 use crate::token::{Attributes, Token};
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::{Span, Spanned};
 

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     token::IntType,
     BinaryTypeOperator,
 };
-use acvm::AcirField;
+use acvm::acir::AcirField;
 use iter_extended::vecmap;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     token::IntType,
     BinaryTypeOperator,
 };
+use acvm::AcirField;
 use iter_extended::vecmap;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use acvm::{AcirField, FieldElement};
+use acvm::acir::AcirField;
+use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_errors::{Span, Spanned};
 

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::{Span, Spanned};
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::{Location, Span};
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use acvm::{AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::{Location, Span};
 

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -1,5 +1,5 @@
 use crate::{hir::def_collector::dc_crate::CompilationError, Type};
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use noirc_errors::{CustomDiagnostic, Location};
 
 use super::value::Value;

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -1,5 +1,5 @@
 use crate::{hir::def_collector::dc_crate::CompilationError, Type};
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use noirc_errors::{CustomDiagnostic, Location};
 
 use super::value::Value;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1,6 +1,6 @@
 use std::{collections::hash_map::Entry, rc::Rc};
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use im::Vector;
 use iter_extended::try_vecmap;
 use noirc_errors::Location;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1,6 +1,6 @@
 use std::{collections::hash_map::Entry, rc::Rc};
 
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use im::Vector;
 use iter_extended::try_vecmap;
 use noirc_errors::Location;

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -11,7 +11,7 @@
 // XXX: Change mentions of intern to resolve. In regards to the above comment
 //
 // XXX: Resolver does not check for unused functions
-use acvm::AcirField;
+use acvm::acir::AcirField;
 
 use crate::hir_def::expr::{
     HirArrayLiteral, HirBinaryOp, HirBlockExpression, HirCallExpression, HirCapturedVar,

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -11,6 +11,8 @@
 // XXX: Change mentions of intern to resolve. In regards to the above comment
 //
 // XXX: Resolver does not check for unused functions
+use acvm::AcirField;
+
 use crate::hir_def::expr::{
     HirArrayLiteral, HirBinaryOp, HirBlockExpression, HirCallExpression, HirCapturedVar,
     HirCastExpression, HirConstructorExpression, HirExpression, HirIdent, HirIfExpression,

--- a/compiler/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/stmt.rs
@@ -1,4 +1,4 @@
-use acvm::AcirField;
+use acvm::acir::AcirField;
 use iter_extended::vecmap;
 use noirc_errors::Span;
 

--- a/compiler/noirc_frontend/src/hir/type_check/stmt.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/stmt.rs
@@ -1,3 +1,4 @@
+use acvm::AcirField;
 use iter_extended::vecmap;
 use noirc_errors::Span;
 

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -1,4 +1,4 @@
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use noirc_errors::{Position, Span, Spanned};
 use std::{fmt, iter::Map, vec::IntoIter};
 

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -1,4 +1,4 @@
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use noirc_errors::{Position, Span, Spanned};
 use std::{fmt, iter::Map, vec::IntoIter};
 

--- a/compiler/noirc_frontend/src/monomorphization/debug.rs
+++ b/compiler/noirc_frontend/src/monomorphization/debug.rs
@@ -1,4 +1,4 @@
-use acvm::AcirField;
+use acvm::acir::AcirField;
 use iter_extended::vecmap;
 use noirc_errors::debug_info::DebugVarId;
 use noirc_errors::Location;

--- a/compiler/noirc_frontend/src/monomorphization/debug.rs
+++ b/compiler/noirc_frontend/src/monomorphization/debug.rs
@@ -1,3 +1,4 @@
+use acvm::AcirField;
 use iter_extended::vecmap;
 use noirc_errors::debug_info::DebugVarId;
 use noirc_errors::Location;

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     token::FunctionAttribute,
     Type, TypeBinding, TypeBindings, TypeVariable, TypeVariableKind,
 };
-use acvm::{AcirField, FieldElement};
+use acvm::{acir::AcirField, FieldElement};
 use iter_extended::{btree_map, try_vecmap, vecmap};
 use noirc_errors::Location;
 use noirc_printable_type::PrintableType;

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     token::FunctionAttribute,
     Type, TypeBinding, TypeBindings, TypeVariable, TypeVariableKind,
 };
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::{btree_map, try_vecmap, vecmap};
 use noirc_errors::Location;
 use noirc_printable_type::PrintableType;

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, str};
 
-use acvm::{brillig_vm::brillig::ForeignCallParam, AcirField, FieldElement};
+use acvm::{acir::AcirField, brillig_vm::brillig::ForeignCallParam, FieldElement};
 use iter_extended::vecmap;
 use regex::{Captures, Regex};
 use serde::{Deserialize, Serialize};
@@ -81,10 +81,12 @@ pub enum ForeignCallError {
     ResolvedAssertMessage(String),
 }
 
-impl TryFrom<&[ForeignCallParam]> for PrintableValueDisplay {
+impl TryFrom<&[ForeignCallParam<FieldElement>]> for PrintableValueDisplay {
     type Error = ForeignCallError;
 
-    fn try_from(foreign_call_inputs: &[ForeignCallParam]) -> Result<Self, Self::Error> {
+    fn try_from(
+        foreign_call_inputs: &[ForeignCallParam<FieldElement>],
+    ) -> Result<Self, Self::Error> {
         let (is_fmt_str, foreign_call_inputs) =
             foreign_call_inputs.split_last().ok_or(ForeignCallError::MissingForeignCallInputs)?;
 
@@ -97,7 +99,7 @@ impl TryFrom<&[ForeignCallParam]> for PrintableValueDisplay {
 }
 
 fn convert_string_inputs(
-    foreign_call_inputs: &[ForeignCallParam],
+    foreign_call_inputs: &[ForeignCallParam<FieldElement>],
 ) -> Result<PrintableValueDisplay, ForeignCallError> {
     // Fetch the PrintableType from the foreign call input
     // The remaining input values should hold what is to be printed
@@ -114,7 +116,7 @@ fn convert_string_inputs(
 }
 
 fn convert_fmt_string_inputs(
-    foreign_call_inputs: &[ForeignCallParam],
+    foreign_call_inputs: &[ForeignCallParam<FieldElement>],
 ) -> Result<PrintableValueDisplay, ForeignCallError> {
     let (message, input_and_printable_types) =
         foreign_call_inputs.split_first().ok_or(ForeignCallError::MissingForeignCallInputs)?;
@@ -143,7 +145,7 @@ fn convert_fmt_string_inputs(
 }
 
 fn fetch_printable_type(
-    printable_type: &ForeignCallParam,
+    printable_type: &ForeignCallParam<FieldElement>,
 ) -> Result<PrintableType, ForeignCallError> {
     let printable_type_as_fields = printable_type.fields();
     let printable_type_as_string = decode_string_value(&printable_type_as_fields);

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, str};
 
-use acvm::{brillig_vm::brillig::ForeignCallParam, FieldElement};
+use acvm::{brillig_vm::brillig::ForeignCallParam, AcirField, FieldElement};
 use iter_extended::vecmap;
 use regex::{Captures, Regex};
 use serde::{Deserialize, Serialize};

--- a/compiler/wasm/Cargo.toml
+++ b/compiler/wasm/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-acvm.workspace = true
+acvm = { workspace = true, features = ["bn254"] }
 fm.workspace = true
 nargo.workspace = true
 noirc_driver.workspace = true

--- a/tooling/acvm_cli/src/cli/execute_cmd.rs
+++ b/tooling/acvm_cli/src/cli/execute_cmd.rs
@@ -2,6 +2,7 @@ use std::io::{self, Write};
 
 use acir::circuit::Program;
 use acir::native_types::{WitnessMap, WitnessStack};
+use acir::FieldElement;
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use clap::Args;
 
@@ -63,11 +64,11 @@ pub(crate) fn run(args: ExecuteCommand) -> Result<String, CliError> {
 }
 
 pub(crate) fn execute_program_from_witness(
-    inputs_map: WitnessMap,
+    inputs_map: WitnessMap<FieldElement>,
     bytecode: &[u8],
     foreign_call_resolver_url: Option<&str>,
-) -> Result<WitnessStack, CliError> {
-    let program: Program = Program::deserialize_program(bytecode)
+) -> Result<WitnessStack<FieldElement>, CliError> {
+    let program: Program<FieldElement> = Program::deserialize_program(bytecode)
         .map_err(|_| CliError::CircuitDeserializationError())?;
     execute_program(
         &program,

--- a/tooling/acvm_cli/src/cli/fs/inputs.rs
+++ b/tooling/acvm_cli/src/cli/fs/inputs.rs
@@ -11,7 +11,7 @@ use std::{fs::read, path::Path};
 pub(crate) fn read_inputs_from_file<P: AsRef<Path>>(
     working_directory: P,
     file_name: &String,
-) -> Result<WitnessMap, CliError> {
+) -> Result<WitnessMap<FieldElement>, CliError> {
     let file_path = working_directory.as_ref().join(file_name);
     if !file_path.exists() {
         return Err(CliError::FilesystemError(FilesystemError::MissingTomlFile(
@@ -25,7 +25,7 @@ pub(crate) fn read_inputs_from_file<P: AsRef<Path>>(
     let input_map = input_string
         .parse::<Table>()
         .map_err(|_| FilesystemError::InvalidTomlFile(file_name.clone()))?;
-    let mut witnesses: WitnessMap = WitnessMap::new();
+    let mut witnesses: WitnessMap<FieldElement> = WitnessMap::new();
     for (key, value) in input_map.into_iter() {
         let index =
             Witness(key.trim().parse().map_err(|_| CliError::WitnessIndexError(key.clone()))?);

--- a/tooling/acvm_cli/src/cli/fs/inputs.rs
+++ b/tooling/acvm_cli/src/cli/fs/inputs.rs
@@ -1,6 +1,6 @@
 use acir::{
     native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use toml::Table;
 

--- a/tooling/acvm_cli/src/cli/fs/witness.rs
+++ b/tooling/acvm_cli/src/cli/fs/witness.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use acir::FieldElement;
 use acvm::acir::{
     native_types::{WitnessMap, WitnessStack},
     AcirField,
@@ -34,7 +35,9 @@ fn write_to_file(bytes: &[u8], path: &Path) -> String {
 }
 
 /// Creates a toml representation of the provided witness map
-pub(crate) fn create_output_witness_string(witnesses: &WitnessMap) -> Result<String, CliError> {
+pub(crate) fn create_output_witness_string(
+    witnesses: &WitnessMap<FieldElement>,
+) -> Result<String, CliError> {
     let mut witness_map: BTreeMap<String, String> = BTreeMap::new();
     for (key, value) in witnesses.clone().into_iter() {
         witness_map.insert(key.0.to_string(), format!("0x{}", value.to_hex()));
@@ -44,7 +47,7 @@ pub(crate) fn create_output_witness_string(witnesses: &WitnessMap) -> Result<Str
 }
 
 pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
-    witnesses: WitnessStack,
+    witnesses: WitnessStack<FieldElement>,
     witness_name: &str,
     witness_dir: P,
 ) -> Result<PathBuf, FilesystemError> {

--- a/tooling/acvm_cli/src/cli/fs/witness.rs
+++ b/tooling/acvm_cli/src/cli/fs/witness.rs
@@ -5,7 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use acvm::acir::native_types::{WitnessMap, WitnessStack};
+use acvm::acir::{
+    native_types::{WitnessMap, WitnessStack},
+    AcirField,
+};
 
 use crate::errors::{CliError, FilesystemError};
 

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -625,6 +625,7 @@ mod tests {
                 opcodes::BlockId,
             },
             native_types::Expression,
+            AcirField,
         },
         blackbox_solver::StubbedBlackBoxSolver,
         brillig_vm::brillig::{

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -26,28 +26,28 @@ pub(super) enum DebugCommandResult {
     Error(NargoError),
 }
 
-pub(super) struct DebugContext<'a, B: BlackBoxFunctionSolver> {
-    acvm: ACVM<'a, B>,
-    brillig_solver: Option<BrilligSolver<'a, B>>,
+pub(super) struct DebugContext<'a, B: BlackBoxFunctionSolver<FieldElement>> {
+    acvm: ACVM<'a, FieldElement, B>,
+    brillig_solver: Option<BrilligSolver<'a, FieldElement, B>>,
     foreign_call_executor: Box<dyn DebugForeignCallExecutor + 'a>,
     debug_artifact: &'a DebugArtifact,
     breakpoints: HashSet<OpcodeLocation>,
     source_to_opcodes: BTreeMap<FileId, Vec<(usize, OpcodeLocation)>>,
-    unconstrained_functions: &'a [BrilligBytecode],
+    unconstrained_functions: &'a [BrilligBytecode<FieldElement>],
 
     // Absolute (in terms of all the opcodes ACIR+Brillig) addresses of the ACIR
     // opcodes with one additional entry for to indicate the last valid address.
     acir_opcode_addresses: Vec<usize>,
 }
 
-impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
+impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
     pub(super) fn new(
         blackbox_solver: &'a B,
-        circuit: &'a Circuit,
+        circuit: &'a Circuit<FieldElement>,
         debug_artifact: &'a DebugArtifact,
-        initial_witness: WitnessMap,
+        initial_witness: WitnessMap<FieldElement>,
         foreign_call_executor: Box<dyn DebugForeignCallExecutor + 'a>,
-        unconstrained_functions: &'a [BrilligBytecode],
+        unconstrained_functions: &'a [BrilligBytecode<FieldElement>],
     ) -> Self {
         let source_to_opcodes = build_source_to_opcode_debug_mappings(debug_artifact);
         let acir_opcode_addresses = build_acir_opcode_offsets(circuit, unconstrained_functions);
@@ -70,11 +70,11 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
         }
     }
 
-    pub(super) fn get_opcodes(&self) -> &[Opcode] {
+    pub(super) fn get_opcodes(&self) -> &[Opcode<FieldElement>] {
         self.acvm.opcodes()
     }
 
-    pub(super) fn get_witness_map(&self) -> &WitnessMap {
+    pub(super) fn get_witness_map(&self) -> &WitnessMap<FieldElement> {
         self.acvm.witness_map()
     }
 
@@ -302,7 +302,10 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
         }
     }
 
-    fn handle_foreign_call(&mut self, foreign_call: ForeignCallWaitInfo) -> DebugCommandResult {
+    fn handle_foreign_call(
+        &mut self,
+        foreign_call: ForeignCallWaitInfo<FieldElement>,
+    ) -> DebugCommandResult {
         let foreign_call_result = self.foreign_call_executor.execute(&foreign_call);
         match foreign_call_result {
             Ok(foreign_call_result) => {
@@ -319,7 +322,7 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
         }
     }
 
-    fn handle_acvm_status(&mut self, status: ACVMStatus) -> DebugCommandResult {
+    fn handle_acvm_status(&mut self, status: ACVMStatus<FieldElement>) -> DebugCommandResult {
         if let ACVMStatus::RequiresForeignCall(foreign_call) = status {
             return self.handle_foreign_call(foreign_call);
         }
@@ -465,7 +468,7 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
         }
     }
 
-    pub(super) fn get_brillig_memory(&self) -> Option<&[MemoryValue]> {
+    pub(super) fn get_brillig_memory(&self) -> Option<&[MemoryValue<FieldElement>]> {
         self.brillig_solver.as_ref().map(|solver| solver.get_memory())
     }
 
@@ -539,7 +542,7 @@ impl<'a, B: BlackBoxFunctionSolver> DebugContext<'a, B> {
         matches!(self.acvm.get_status(), ACVMStatus::Solved)
     }
 
-    pub fn finalize(self) -> WitnessMap {
+    pub fn finalize(self) -> WitnessMap<FieldElement> {
         self.acvm.finalize()
     }
 }
@@ -591,8 +594,8 @@ fn build_source_to_opcode_debug_mappings(
 }
 
 fn build_acir_opcode_offsets(
-    circuit: &Circuit,
-    unconstrained_functions: &[BrilligBytecode],
+    circuit: &Circuit<FieldElement>,
+    unconstrained_functions: &[BrilligBytecode<FieldElement>],
 ) -> Vec<usize> {
     let mut result = Vec::with_capacity(circuit.opcodes.len() + 1);
     // address of the first opcode is always 0

--- a/tooling/debugger/src/dap.rs
+++ b/tooling/debugger/src/dap.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 use acvm::acir::circuit::brillig::BrilligBytecode;
 use acvm::acir::circuit::{Circuit, OpcodeLocation};
 use acvm::acir::native_types::WitnessMap;
-use acvm::BlackBoxFunctionSolver;
+use acvm::{BlackBoxFunctionSolver, FieldElement};
 
 use crate::context::DebugCommandResult;
 use crate::context::DebugContext;
@@ -31,7 +31,7 @@ use noirc_driver::CompiledProgram;
 
 type BreakpointId = i64;
 
-pub struct DapSession<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> {
+pub struct DapSession<'a, R: Read, W: Write, B: BlackBoxFunctionSolver<FieldElement>> {
     server: Server<R, W>,
     context: DebugContext<'a, B>,
     debug_artifact: &'a DebugArtifact,
@@ -57,14 +57,14 @@ impl From<i64> for ScopeReferences {
     }
 }
 
-impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> DapSession<'a, R, W, B> {
+impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver<FieldElement>> DapSession<'a, R, W, B> {
     pub fn new(
         server: Server<R, W>,
         solver: &'a B,
-        circuit: &'a Circuit,
+        circuit: &'a Circuit<FieldElement>,
         debug_artifact: &'a DebugArtifact,
-        initial_witness: WitnessMap,
-        unconstrained_functions: &'a [BrilligBytecode],
+        initial_witness: WitnessMap<FieldElement>,
+        unconstrained_functions: &'a [BrilligBytecode<FieldElement>],
     ) -> Self {
         let context = DebugContext::new(
             solver,
@@ -602,11 +602,11 @@ impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver> DapSession<'a, R, W, B> {
     }
 }
 
-pub fn run_session<R: Read, W: Write, B: BlackBoxFunctionSolver>(
+pub fn run_session<R: Read, W: Write, B: BlackBoxFunctionSolver<FieldElement>>(
     server: Server<R, W>,
     solver: &B,
     program: CompiledProgram,
-    initial_witness: WitnessMap,
+    initial_witness: WitnessMap<FieldElement>,
 ) -> Result<(), ServerError> {
     let debug_artifact = DebugArtifact {
         debug_symbols: program.debug,

--- a/tooling/debugger/src/foreign_calls.rs
+++ b/tooling/debugger/src/foreign_calls.rs
@@ -1,7 +1,7 @@
 use acvm::{
     acir::brillig::{ForeignCallParam, ForeignCallResult},
     pwg::ForeignCallWaitInfo,
-    FieldElement,
+    AcirField, FieldElement,
 };
 use nargo::{
     artifacts::debug::{DebugArtifact, DebugVars, StackFrame},

--- a/tooling/debugger/src/foreign_calls.rs
+++ b/tooling/debugger/src/foreign_calls.rs
@@ -93,8 +93,8 @@ fn debug_fn_id(value: &FieldElement) -> DebugFnId {
 impl ForeignCallExecutor for DefaultDebugForeignCallExecutor {
     fn execute(
         &mut self,
-        foreign_call: &ForeignCallWaitInfo,
-    ) -> Result<ForeignCallResult, ForeignCallError> {
+        foreign_call: &ForeignCallWaitInfo<FieldElement>,
+    ) -> Result<ForeignCallResult<FieldElement>, ForeignCallError> {
         let foreign_call_name = foreign_call.function.as_str();
         match DebugForeignCall::lookup(foreign_call_name) {
             Some(DebugForeignCall::VarAssign) => {

--- a/tooling/debugger/src/lib.rs
+++ b/tooling/debugger/src/lib.rs
@@ -10,29 +10,29 @@ use std::io::{Read, Write};
 use ::dap::errors::ServerError;
 use ::dap::server::Server;
 use acvm::acir::circuit::brillig::BrilligBytecode;
-use acvm::BlackBoxFunctionSolver;
 use acvm::{acir::circuit::Circuit, acir::native_types::WitnessMap};
+use acvm::{BlackBoxFunctionSolver, FieldElement};
 
 use nargo::artifacts::debug::DebugArtifact;
 
 use nargo::NargoError;
 use noirc_driver::CompiledProgram;
 
-pub fn debug_circuit<B: BlackBoxFunctionSolver>(
+pub fn debug_circuit<B: BlackBoxFunctionSolver<FieldElement>>(
     blackbox_solver: &B,
-    circuit: &Circuit,
+    circuit: &Circuit<FieldElement>,
     debug_artifact: DebugArtifact,
-    initial_witness: WitnessMap,
-    unconstrained_functions: &[BrilligBytecode],
-) -> Result<Option<WitnessMap>, NargoError> {
+    initial_witness: WitnessMap<FieldElement>,
+    unconstrained_functions: &[BrilligBytecode<FieldElement>],
+) -> Result<Option<WitnessMap<FieldElement>>, NargoError> {
     repl::run(blackbox_solver, circuit, &debug_artifact, initial_witness, unconstrained_functions)
 }
 
-pub fn run_dap_loop<R: Read, W: Write, B: BlackBoxFunctionSolver>(
+pub fn run_dap_loop<R: Read, W: Write, B: BlackBoxFunctionSolver<FieldElement>>(
     server: Server<R, W>,
     solver: &B,
     program: CompiledProgram,
-    initial_witness: WitnessMap,
+    initial_witness: WitnessMap<FieldElement>,
 ) -> Result<(), ServerError> {
     dap::run_session(server, solver, program, initial_witness)
 }

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -15,23 +15,23 @@ use std::cell::RefCell;
 
 use crate::source_code_printer::print_source_code_location;
 
-pub struct ReplDebugger<'a, B: BlackBoxFunctionSolver> {
+pub struct ReplDebugger<'a, B: BlackBoxFunctionSolver<FieldElement>> {
     context: DebugContext<'a, B>,
     blackbox_solver: &'a B,
-    circuit: &'a Circuit,
+    circuit: &'a Circuit<FieldElement>,
     debug_artifact: &'a DebugArtifact,
-    initial_witness: WitnessMap,
+    initial_witness: WitnessMap<FieldElement>,
     last_result: DebugCommandResult,
-    unconstrained_functions: &'a [BrilligBytecode],
+    unconstrained_functions: &'a [BrilligBytecode<FieldElement>],
 }
 
-impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
+impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ReplDebugger<'a, B> {
     pub fn new(
         blackbox_solver: &'a B,
-        circuit: &'a Circuit,
+        circuit: &'a Circuit<FieldElement>,
         debug_artifact: &'a DebugArtifact,
-        initial_witness: WitnessMap,
-        unconstrained_functions: &'a [BrilligBytecode],
+        initial_witness: WitnessMap<FieldElement>,
+        unconstrained_functions: &'a [BrilligBytecode<FieldElement>],
     ) -> Self {
         let foreign_call_executor =
             Box::new(DefaultDebugForeignCallExecutor::from_artifact(true, debug_artifact));
@@ -161,7 +161,7 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
                 ""
             }
         };
-        let print_brillig_bytecode = |acir_index, bytecode: &[BrilligOpcode]| {
+        let print_brillig_bytecode = |acir_index, bytecode: &[BrilligOpcode<FieldElement>]| {
             for (brillig_index, brillig_opcode) in bytecode.iter().enumerate() {
                 println!(
                     "{:>3}.{:<2} |{:2} {:?}",
@@ -371,18 +371,18 @@ impl<'a, B: BlackBoxFunctionSolver> ReplDebugger<'a, B> {
         self.context.is_solved()
     }
 
-    fn finalize(self) -> WitnessMap {
+    fn finalize(self) -> WitnessMap<FieldElement> {
         self.context.finalize()
     }
 }
 
-pub fn run<B: BlackBoxFunctionSolver>(
+pub fn run<B: BlackBoxFunctionSolver<FieldElement>>(
     blackbox_solver: &B,
-    circuit: &Circuit,
+    circuit: &Circuit<FieldElement>,
     debug_artifact: &DebugArtifact,
-    initial_witness: WitnessMap,
-    unconstrained_functions: &[BrilligBytecode],
-) -> Result<Option<WitnessMap>, NargoError> {
+    initial_witness: WitnessMap<FieldElement>,
+    unconstrained_functions: &[BrilligBytecode<FieldElement>],
+) -> Result<Option<WitnessMap<FieldElement>>, NargoError> {
     let context = RefCell::new(ReplDebugger::new(
         blackbox_solver,
         circuit,

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     task::{self, Poll},
 };
 
-use acvm::BlackBoxFunctionSolver;
+use acvm::{BlackBoxFunctionSolver, FieldElement};
 use async_lsp::{
     router::Router, AnyEvent, AnyNotification, AnyRequest, ClientSocket, Error, LspService,
     ResponseError,
@@ -79,7 +79,10 @@ pub struct LspState {
 }
 
 impl LspState {
-    fn new(client: &ClientSocket, solver: impl BlackBoxFunctionSolver + 'static) -> Self {
+    fn new(
+        client: &ClientSocket,
+        solver: impl BlackBoxFunctionSolver<FieldElement> + 'static,
+    ) -> Self {
         Self {
             client: client.clone(),
             root_path: None,
@@ -99,7 +102,10 @@ pub struct NargoLspService {
 }
 
 impl NargoLspService {
-    pub fn new(client: &ClientSocket, solver: impl BlackBoxFunctionSolver + 'static) -> Self {
+    pub fn new(
+        client: &ClientSocket,
+        solver: impl BlackBoxFunctionSolver<FieldElement> + 'static,
+    ) -> Self {
         let state = LspState::new(client, solver);
         let mut router = Router::new(state);
         router

--- a/tooling/lsp/src/solver.rs
+++ b/tooling/lsp/src/solver.rs
@@ -3,9 +3,9 @@ use acvm::BlackBoxFunctionSolver;
 // This is a struct that wraps a dynamically dispatched `BlackBoxFunctionSolver`
 // where we proxy the unimplemented stuff to the wrapped backend, but it
 // allows us to avoid changing function signatures to include the `Box`
-pub(super) struct WrapperSolver(pub(super) Box<dyn BlackBoxFunctionSolver>);
+pub(super) struct WrapperSolver(pub(super) Box<dyn BlackBoxFunctionSolver<acvm::FieldElement>>);
 
-impl BlackBoxFunctionSolver for WrapperSolver {
+impl BlackBoxFunctionSolver<acvm::FieldElement> for WrapperSolver {
     fn schnorr_verify(
         &self,
         public_key_x: &acvm::FieldElement,

--- a/tooling/nargo/src/artifacts/contract.rs
+++ b/tooling/nargo/src/artifacts/contract.rs
@@ -1,4 +1,4 @@
-use acvm::acir::circuit::Program;
+use acvm::{acir::circuit::Program, FieldElement};
 use noirc_abi::{Abi, AbiType, AbiValue};
 use noirc_driver::{CompiledContract, CompiledContractOutputs, ContractFunction};
 use serde::{Deserialize, Serialize};
@@ -65,7 +65,7 @@ pub struct ContractFunctionArtifact {
         serialize_with = "Program::serialize_program_base64",
         deserialize_with = "Program::deserialize_program_base64"
     )]
-    pub bytecode: Program,
+    pub bytecode: Program<FieldElement>,
 
     #[serde(
         serialize_with = "ProgramDebugInfo::serialize_compressed_base64_json",

--- a/tooling/nargo/src/artifacts/program.rs
+++ b/tooling/nargo/src/artifacts/program.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use acvm::acir::circuit::Program;
+use acvm::FieldElement;
 use fm::FileId;
 use noirc_abi::Abi;
 use noirc_driver::CompiledProgram;
@@ -24,7 +25,7 @@ pub struct ProgramArtifact {
         serialize_with = "Program::serialize_program_base64",
         deserialize_with = "Program::deserialize_program_base64"
     )]
-    pub bytecode: Program,
+    pub bytecode: Program<FieldElement>,
 
     #[serde(
         serialize_with = "ProgramDebugInfo::serialize_compressed_base64_json",

--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -6,6 +6,7 @@ use acvm::{
         ResolvedOpcodeLocation,
     },
     pwg::{ErrorLocation, OpcodeResolutionError},
+    FieldElement,
 };
 use noirc_abi::{display_abi_error, Abi, AbiErrorType};
 use noirc_errors::{
@@ -95,10 +96,10 @@ impl NargoError {
 #[derive(Debug, Error)]
 pub enum ExecutionError {
     #[error("Failed assertion")]
-    AssertionFailed(ResolvedAssertionPayload, Vec<ResolvedOpcodeLocation>),
+    AssertionFailed(ResolvedAssertionPayload<FieldElement>, Vec<ResolvedOpcodeLocation>),
 
     #[error("Failed to solve program: '{}'", .0)]
-    SolvingError(OpcodeResolutionError, Option<Vec<ResolvedOpcodeLocation>>),
+    SolvingError(OpcodeResolutionError<FieldElement>, Option<Vec<ResolvedOpcodeLocation>>),
 }
 
 /// Extracts the opcode locations from a nargo error.

--- a/tooling/nargo/src/ops/foreign_calls.rs
+++ b/tooling/nargo/src/ops/foreign_calls.rs
@@ -9,8 +9,8 @@ use noirc_printable_type::{decode_string_value, ForeignCallError, PrintableValue
 pub trait ForeignCallExecutor {
     fn execute(
         &mut self,
-        foreign_call: &ForeignCallWaitInfo,
-    ) -> Result<ForeignCallResult, ForeignCallError>;
+        foreign_call: &ForeignCallWaitInfo<FieldElement>,
+    ) -> Result<ForeignCallResult<FieldElement>, ForeignCallError>;
 }
 
 /// This enumeration represents the Brillig foreign calls that are natively supported by nargo.
@@ -66,11 +66,11 @@ struct MockedCall {
     /// The oracle it's mocking
     name: String,
     /// Optionally match the parameters
-    params: Option<Vec<ForeignCallParam>>,
+    params: Option<Vec<ForeignCallParam<FieldElement>>>,
     /// The parameters with which the mock was last called
-    last_called_params: Option<Vec<ForeignCallParam>>,
+    last_called_params: Option<Vec<ForeignCallParam<FieldElement>>>,
     /// The result to return when this mock is called
-    result: ForeignCallResult,
+    result: ForeignCallResult<FieldElement>,
     /// How many times should this mock be called before it is removed
     times_left: Option<u64>,
 }
@@ -89,7 +89,7 @@ impl MockedCall {
 }
 
 impl MockedCall {
-    fn matches(&self, name: &str, params: &[ForeignCallParam]) -> bool {
+    fn matches(&self, name: &str, params: &[ForeignCallParam<FieldElement>]) -> bool {
         self.name == name && (self.params.is_none() || self.params.as_deref() == Some(params))
     }
 }
@@ -130,8 +130,8 @@ impl DefaultForeignCallExecutor {
 
 impl DefaultForeignCallExecutor {
     fn extract_mock_id(
-        foreign_call_inputs: &[ForeignCallParam],
-    ) -> Result<(usize, &[ForeignCallParam]), ForeignCallError> {
+        foreign_call_inputs: &[ForeignCallParam<FieldElement>],
+    ) -> Result<(usize, &[ForeignCallParam<FieldElement>]), ForeignCallError> {
         let (id, params) =
             foreign_call_inputs.split_first().ok_or(ForeignCallError::MissingForeignCallInputs)?;
         let id =
@@ -148,12 +148,14 @@ impl DefaultForeignCallExecutor {
         self.mocked_responses.iter_mut().find(|response| response.id == id)
     }
 
-    fn parse_string(param: &ForeignCallParam) -> String {
+    fn parse_string(param: &ForeignCallParam<FieldElement>) -> String {
         let fields: Vec<_> = param.fields().to_vec();
         decode_string_value(&fields)
     }
 
-    fn execute_print(foreign_call_inputs: &[ForeignCallParam]) -> Result<(), ForeignCallError> {
+    fn execute_print(
+        foreign_call_inputs: &[ForeignCallParam<FieldElement>],
+    ) -> Result<(), ForeignCallError> {
         let skip_newline = foreign_call_inputs[0].unwrap_field().is_zero();
 
         let foreign_call_inputs =
@@ -166,7 +168,7 @@ impl DefaultForeignCallExecutor {
     }
 
     fn format_printable_value(
-        foreign_call_inputs: &[ForeignCallParam],
+        foreign_call_inputs: &[ForeignCallParam<FieldElement>],
         skip_newline: bool,
     ) -> Result<String, ForeignCallError> {
         let display_values: PrintableValueDisplay = foreign_call_inputs.try_into()?;
@@ -180,8 +182,8 @@ impl DefaultForeignCallExecutor {
 impl ForeignCallExecutor for DefaultForeignCallExecutor {
     fn execute(
         &mut self,
-        foreign_call: &ForeignCallWaitInfo,
-    ) -> Result<ForeignCallResult, ForeignCallError> {
+        foreign_call: &ForeignCallWaitInfo<FieldElement>,
+    ) -> Result<ForeignCallResult<FieldElement>, ForeignCallError> {
         let foreign_call_name = foreign_call.function.as_str();
         match ForeignCall::lookup(foreign_call_name) {
             Some(ForeignCall::Print) => {
@@ -280,7 +282,7 @@ impl ForeignCallExecutor for DefaultForeignCallExecutor {
 
                     let response = external_resolver.send_request(req)?;
 
-                    let parsed_response: ForeignCallResult = response.result()?;
+                    let parsed_response: ForeignCallResult<FieldElement> = response.result()?;
 
                     Ok(parsed_response)
                 } else {
@@ -314,20 +316,32 @@ mod tests {
     #[rpc]
     pub trait OracleResolver {
         #[rpc(name = "echo")]
-        fn echo(&self, param: ForeignCallParam) -> RpcResult<ForeignCallResult>;
+        fn echo(
+            &self,
+            param: ForeignCallParam<FieldElement>,
+        ) -> RpcResult<ForeignCallResult<FieldElement>>;
 
         #[rpc(name = "sum")]
-        fn sum(&self, array: ForeignCallParam) -> RpcResult<ForeignCallResult>;
+        fn sum(
+            &self,
+            array: ForeignCallParam<FieldElement>,
+        ) -> RpcResult<ForeignCallResult<FieldElement>>;
     }
 
     struct OracleResolverImpl;
 
     impl OracleResolver for OracleResolverImpl {
-        fn echo(&self, param: ForeignCallParam) -> RpcResult<ForeignCallResult> {
+        fn echo(
+            &self,
+            param: ForeignCallParam<FieldElement>,
+        ) -> RpcResult<ForeignCallResult<FieldElement>> {
             Ok(vec![param].into())
         }
 
-        fn sum(&self, array: ForeignCallParam) -> RpcResult<ForeignCallResult> {
+        fn sum(
+            &self,
+            array: ForeignCallParam<FieldElement>,
+        ) -> RpcResult<ForeignCallResult<FieldElement>> {
             let mut res: FieldElement = 0_usize.into();
 
             for value in array.fields() {

--- a/tooling/nargo/src/ops/foreign_calls.rs
+++ b/tooling/nargo/src/ops/foreign_calls.rs
@@ -1,7 +1,7 @@
 use acvm::{
     acir::brillig::{ForeignCallParam, ForeignCallResult},
     pwg::ForeignCallWaitInfo,
-    FieldElement,
+    AcirField, FieldElement,
 };
 use jsonrpc::{arg as build_json_rpc_arg, minreq_http::Builder, Client};
 use noirc_printable_type::{decode_string_value, ForeignCallError, PrintableValueDisplay};

--- a/tooling/nargo/src/ops/optimize.rs
+++ b/tooling/nargo/src/ops/optimize.rs
@@ -1,4 +1,4 @@
-use acvm::acir::circuit::Program;
+use acvm::{acir::circuit::Program, FieldElement};
 use iter_extended::vecmap;
 use noirc_driver::{CompiledContract, CompiledProgram};
 use noirc_errors::debug_info::DebugInfo;
@@ -18,7 +18,10 @@ pub fn optimize_contract(contract: CompiledContract) -> CompiledContract {
     CompiledContract { functions, ..contract }
 }
 
-fn optimize_program_internal(mut program: Program, debug: &mut [DebugInfo]) -> Program {
+fn optimize_program_internal(
+    mut program: Program<FieldElement>,
+    debug: &mut [DebugInfo],
+) -> Program<FieldElement> {
     let functions = std::mem::take(&mut program.functions);
 
     let optimized_functions = functions

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -1,6 +1,6 @@
 use acvm::{
     acir::native_types::{WitnessMap, WitnessStack},
-    BlackBoxFunctionSolver,
+    BlackBoxFunctionSolver, FieldElement,
 };
 use noirc_abi::Abi;
 use noirc_driver::{compile_no_check, CompileError, CompileOptions};
@@ -23,7 +23,7 @@ impl TestStatus {
     }
 }
 
-pub fn run_test<B: BlackBoxFunctionSolver>(
+pub fn run_test<B: BlackBoxFunctionSolver<FieldElement>>(
     blackbox_solver: &B,
     context: &mut Context,
     test_function: &TestFunction,
@@ -76,7 +76,7 @@ fn test_status_program_compile_pass(
     test_function: &TestFunction,
     abi: Abi,
     debug: Vec<DebugInfo>,
-    circuit_execution: Result<WitnessStack, NargoError>,
+    circuit_execution: Result<WitnessStack<FieldElement>, NargoError>,
 ) -> TestStatus {
     let circuit_execution_err = match circuit_execution {
         // Circuit execution was successful; ie no errors or unsatisfied constraints

--- a/tooling/nargo/src/ops/transform.rs
+++ b/tooling/nargo/src/ops/transform.rs
@@ -1,4 +1,7 @@
-use acvm::acir::circuit::{ExpressionWidth, Program};
+use acvm::{
+    acir::circuit::{ExpressionWidth, Program},
+    FieldElement,
+};
 use iter_extended::vecmap;
 use noirc_driver::{CompiledContract, CompiledProgram};
 use noirc_errors::debug_info::DebugInfo;
@@ -30,10 +33,10 @@ pub fn transform_contract(
 }
 
 fn transform_program_internal(
-    mut program: Program,
+    mut program: Program<FieldElement>,
     debug: &mut [DebugInfo],
     expression_width: ExpressionWidth,
-) -> Program {
+) -> Program<FieldElement> {
     let functions = std::mem::take(&mut program.functions);
 
     let optimized_functions = functions

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -32,7 +32,7 @@ noirc_driver.workspace = true
 noirc_frontend.workspace = true
 noirc_abi.workspace = true
 noirc_errors.workspace = true
-acvm = { workspace = true, features=["bn254"] }
+acvm = { workspace = true, features = ["bn254"] }
 bn254_blackbox_solver.workspace = true
 toml.workspace = true
 serde.workspace = true

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -32,7 +32,7 @@ noirc_driver.workspace = true
 noirc_frontend.workspace = true
 noirc_abi.workspace = true
 noirc_errors.workspace = true
-acvm.workspace = true
+acvm = { workspace = true, features=["bn254"] }
 bn254_blackbox_solver.workspace = true
 toml.workspace = true
 serde.workspace = true

--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -1,5 +1,6 @@
 use acvm::acir::circuit::ExpressionWidth;
 use acvm::acir::native_types::WitnessMap;
+use acvm::FieldElement;
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use clap::Args;
 use nargo::constants::PROVER_INPUT_FILE;
@@ -101,7 +102,7 @@ fn load_and_compile_project(
     expression_width: ExpressionWidth,
     acir_mode: bool,
     skip_instrumentation: bool,
-) -> Result<(CompiledProgram, WitnessMap), LoadError> {
+) -> Result<(CompiledProgram, WitnessMap<FieldElement>), LoadError> {
     let workspace = find_workspace(project_folder, package)
         .ok_or(LoadError::Generic(workspace_not_found_error_msg(project_folder, package)))?;
     let package = workspace

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use acvm::acir::native_types::{WitnessMap, WitnessStack};
+use acvm::FieldElement;
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use clap::Args;
 
@@ -199,7 +200,7 @@ fn debug_program_and_decode(
     program: CompiledProgram,
     package: &Package,
     prover_name: &str,
-) -> Result<(Option<InputValue>, Option<WitnessMap>), CliError> {
+) -> Result<(Option<InputValue>, Option<WitnessMap<FieldElement>>), CliError> {
     // Parse the initial witness values from Prover.toml
     let (inputs_map, _) =
         read_inputs_from_file(&package.root_dir, prover_name, Format::Toml, &program.abi)?;
@@ -218,7 +219,7 @@ fn debug_program_and_decode(
 pub(crate) fn debug_program(
     compiled_program: &CompiledProgram,
     inputs_map: &InputMap,
-) -> Result<Option<WitnessMap>, CliError> {
+) -> Result<Option<WitnessMap<FieldElement>>, CliError> {
     let initial_witness = compiled_program.abi.encode(inputs_map, None)?;
 
     let debug_artifact = DebugArtifact {

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -1,4 +1,5 @@
 use acvm::acir::native_types::WitnessStack;
+use acvm::FieldElement;
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use clap::Args;
 
@@ -91,7 +92,7 @@ fn execute_program_and_decode(
     package: &Package,
     prover_name: &str,
     foreign_call_resolver_url: Option<&str>,
-) -> Result<(Option<InputValue>, WitnessStack), CliError> {
+) -> Result<(Option<InputValue>, WitnessStack<FieldElement>), CliError> {
     // Parse the initial witness values from Prover.toml
     let (inputs_map, _) =
         read_inputs_from_file(&package.root_dir, prover_name, Format::Toml, &program.abi)?;
@@ -109,7 +110,7 @@ pub(crate) fn execute_program(
     compiled_program: &CompiledProgram,
     inputs_map: &InputMap,
     foreign_call_resolver_url: Option<&str>,
-) -> Result<WitnessStack, CliError> {
+) -> Result<WitnessStack<FieldElement>, CliError> {
     let initial_witness = compiled_program.abi.encode(inputs_map, None)?;
 
     let solved_witness_stack_err = nargo::ops::execute_program(

--- a/tooling/nargo_cli/src/cli/fs/witness.rs
+++ b/tooling/nargo_cli/src/cli/fs/witness.rs
@@ -1,13 +1,13 @@
 use std::path::{Path, PathBuf};
 
-use acvm::acir::native_types::WitnessStack;
+use acvm::{acir::native_types::WitnessStack, FieldElement};
 use nargo::constants::WITNESS_EXT;
 
 use super::{create_named_dir, write_to_file};
 use crate::errors::FilesystemError;
 
 pub(crate) fn save_witness_to_dir<P: AsRef<Path>>(
-    witness_stack: WitnessStack,
+    witness_stack: WitnessStack<FieldElement>,
     witness_name: &str,
     witness_dir: P,
 ) -> Result<PathBuf, FilesystemError> {

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use acvm::BlackBoxFunctionSolver;
+use acvm::{BlackBoxFunctionSolver, FieldElement};
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use clap::Args;
 use fm::FileManager;
@@ -119,7 +119,7 @@ pub(crate) fn run(args: TestCommand, config: NargoConfig) -> Result<(), CliError
     }
 }
 
-fn run_tests<S: BlackBoxFunctionSolver + Default>(
+fn run_tests<S: BlackBoxFunctionSolver<FieldElement> + Default>(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,
     package: &Package,
@@ -157,7 +157,7 @@ fn run_tests<S: BlackBoxFunctionSolver + Default>(
     Ok(test_report)
 }
 
-fn run_test<S: BlackBoxFunctionSolver + Default>(
+fn run_test<S: BlackBoxFunctionSolver<FieldElement> + Default>(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,
     package: &Package,

--- a/tooling/noirc_abi/src/input_parser/json.rs
+++ b/tooling/noirc_abi/src/input_parser/json.rs
@@ -1,6 +1,6 @@
 use super::{parse_str_to_field, InputValue};
 use crate::{errors::InputParserError, Abi, AbiType, MAIN_RETURN_NAME};
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::{try_btree_map, try_vecmap};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -3,7 +3,7 @@ use num_traits::{Num, Zero};
 use std::collections::{BTreeMap, HashSet};
 use thiserror::Error;
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use serde::Serialize;
 
 use crate::errors::InputParserError;
@@ -229,7 +229,7 @@ impl Format {
 mod serialization_tests {
     use std::collections::BTreeMap;
 
-    use acvm::FieldElement;
+    use acvm::{AcirField, FieldElement};
     use strum::IntoEnumIterator;
 
     use crate::{
@@ -362,7 +362,7 @@ fn field_from_big_int(bigint: BigInt) -> FieldElement {
 
 #[cfg(test)]
 mod test {
-    use acvm::FieldElement;
+    use acvm::{AcirField, FieldElement};
     use num_bigint::BigUint;
 
     use super::parse_str_to_field;

--- a/tooling/noirc_abi/src/input_parser/toml.rs
+++ b/tooling/noirc_abi/src/input_parser/toml.rs
@@ -1,6 +1,6 @@
 use super::{parse_str_to_field, parse_str_to_signed, InputValue};
 use crate::{errors::InputParserError, Abi, AbiType, MAIN_RETURN_NAME};
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use iter_extended::{try_btree_map, try_vecmap};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -331,7 +331,7 @@ impl Abi {
         &self,
         input_map: &InputMap,
         return_value: Option<InputValue>,
-    ) -> Result<WitnessMap, AbiError> {
+    ) -> Result<WitnessMap<FieldElement>, AbiError> {
         // Check that no extra witness values have been provided.
         let param_names = self.parameter_names();
         if param_names.len() < input_map.len() {
@@ -439,7 +439,7 @@ impl Abi {
     /// Decode a `WitnessMap` into the types specified in the ABI.
     pub fn decode(
         &self,
-        witness_map: &WitnessMap,
+        witness_map: &WitnessMap<FieldElement>,
     ) -> Result<(InputMap, Option<InputValue>), AbiError> {
         let public_inputs_map =
             try_btree_map(self.parameters.clone(), |AbiParameter { name, typ, .. }| {

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -8,7 +8,7 @@ use acvm::{
         circuit::ErrorSelector,
         native_types::{Witness, WitnessMap},
     },
-    FieldElement,
+    AcirField, FieldElement,
 };
 use errors::AbiError;
 use input_parser::InputValue;
@@ -652,7 +652,7 @@ pub fn display_abi_error(
 mod test {
     use std::collections::BTreeMap;
 
-    use acvm::{acir::native_types::Witness, FieldElement};
+    use acvm::{acir::native_types::Witness, AcirField, FieldElement};
 
     use crate::{
         input_parser::InputValue, Abi, AbiParameter, AbiReturnType, AbiType, AbiVisibility,

--- a/tooling/noirc_abi_wasm/Cargo.toml
+++ b/tooling/noirc_abi_wasm/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-acvm.workspace = true
+acvm = { workspace = true, features = ["bn254"] }
 noirc_abi.workspace = true
 iter-extended.workspace = true
 wasm-bindgen.workspace = true

--- a/tooling/noirc_abi_wasm/src/js_witness_map.rs
+++ b/tooling/noirc_abi_wasm/src/js_witness_map.rs
@@ -25,8 +25,8 @@ impl Default for JsWitnessMap {
     }
 }
 
-impl From<WitnessMap> for JsWitnessMap {
-    fn from(witness_map: WitnessMap) -> Self {
+impl From<WitnessMap<FieldElement>> for JsWitnessMap {
+    fn from(witness_map: WitnessMap<FieldElement>) -> Self {
         let js_map = JsWitnessMap::new();
         for (key, value) in witness_map {
             js_map.set(
@@ -38,7 +38,7 @@ impl From<WitnessMap> for JsWitnessMap {
     }
 }
 
-impl From<JsWitnessMap> for WitnessMap {
+impl From<JsWitnessMap> for WitnessMap<FieldElement> {
     fn from(js_map: JsWitnessMap) -> Self {
         let mut witness_map = WitnessMap::new();
         js_map.for_each(&mut |value, key| {

--- a/tooling/noirc_abi_wasm/src/js_witness_map.rs
+++ b/tooling/noirc_abi_wasm/src/js_witness_map.rs
@@ -2,7 +2,7 @@
 
 use acvm::{
     acir::native_types::{Witness, WitnessMap},
-    FieldElement,
+    AcirField, FieldElement,
 };
 use js_sys::{JsString, Map};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
@@ -73,7 +73,7 @@ mod test {
 
     use acvm::{
         acir::native_types::{Witness, WitnessMap},
-        FieldElement,
+        AcirField, FieldElement,
     };
     use wasm_bindgen::JsValue;
 

--- a/tooling/noirc_abi_wasm/src/lib.rs
+++ b/tooling/noirc_abi_wasm/src/lib.rs
@@ -5,9 +5,12 @@
 // See Cargo.toml for explanation.
 use getrandom as _;
 
-use acvm::acir::{
-    circuit::RawAssertionPayload,
-    native_types::{WitnessMap, WitnessStack},
+use acvm::{
+    acir::{
+        circuit::RawAssertionPayload,
+        native_types::{WitnessMap, WitnessStack},
+    },
+    FieldElement,
 };
 use iter_extended::try_btree_map;
 use noirc_abi::{
@@ -125,8 +128,8 @@ pub fn abi_decode(abi: JsAbi, witness_map: JsWitnessMap) -> Result<JsValue, JsAb
 #[wasm_bindgen(js_name = serializeWitness)]
 pub fn serialise_witness(witness_map: JsWitnessMap) -> Result<Vec<u8>, JsAbiError> {
     console_error_panic_hook::set_once();
-    let converted_witness: WitnessMap = witness_map.into();
-    let witness_stack: WitnessStack = converted_witness.into();
+    let converted_witness: WitnessMap<FieldElement> = witness_map.into();
+    let witness_stack: WitnessStack<FieldElement> = converted_witness.into();
     let output = witness_stack.try_into();
     output.map_err(|_| JsAbiError::new("Failed to convert to Vec<u8>".to_string()))
 }
@@ -140,7 +143,7 @@ pub fn abi_decode_error(
     let mut abi: Abi =
         JsValueSerdeExt::into_serde(&JsValue::from(abi)).map_err(|err| err.to_string())?;
 
-    let raw_error: RawAssertionPayload =
+    let raw_error: RawAssertionPayload<FieldElement> =
         JsValueSerdeExt::into_serde(&JsValue::from(raw_error)).map_err(|err| err.to_string())?;
 
     let error_type = abi.error_types.remove(&raw_error.selector).expect("Missing error type");


### PR DESCRIPTION
# Description

Step towards #5055 

## Summary\*

This PR starts us down the road towards removing the compile-time flags for specifying which field is being used by replacing the usage of the `FieldElement` type with an `AcirField` trait. This trait is mostly all of the external methods from `FieldElement` dumped into it for now but we can break it down in future PRs (XOR and AND are looking ready for culling)

I've taken this route rather than just using `generic_ark::FieldElement` as we'd need to have trait bounds for `PrimeField` anyway so we might as well have our own trait.

I've had to delete a couple of trait implementations which fall afoul of the orphan rule now it's being implemented for a generic type (e.g. we need to use `MemoryValue::new_field` explicitly now) but nothing too bad.

## Additional Context


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
