### PR TITLE
chore: remove warnings field from `DebugArtifact`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,7 +2482,6 @@ dependencies = [
  "noirc_abi",
  "noirc_driver",
  "noirc_errors",
- "noirc_evaluator",
  "noirc_frontend",
  "noirc_printable_type",
  "rayon",

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -675,8 +675,7 @@ mod tests {
 
         let debug_symbols = vec![];
         let file_map = BTreeMap::new();
-        let warnings = vec![];
-        let debug_artifact = &DebugArtifact { debug_symbols, file_map, warnings };
+        let debug_artifact = &DebugArtifact { debug_symbols, file_map };
 
         let initial_witness = BTreeMap::from([(Witness(1), fe_1)]).into();
 
@@ -785,8 +784,7 @@ mod tests {
 
         let debug_symbols = vec![];
         let file_map = BTreeMap::new();
-        let warnings = vec![];
-        let debug_artifact = &DebugArtifact { debug_symbols, file_map, warnings };
+        let debug_artifact = &DebugArtifact { debug_symbols, file_map };
 
         let initial_witness = BTreeMap::from([(Witness(1), fe_1), (Witness(2), fe_1)]).into();
 
@@ -843,8 +841,7 @@ mod tests {
             Opcode::AssertZero(Expression::default()),
         ];
         let circuit = Circuit { opcodes, ..Circuit::default() };
-        let debug_artifact =
-            DebugArtifact { debug_symbols: vec![], file_map: BTreeMap::new(), warnings: vec![] };
+        let debug_artifact = DebugArtifact { debug_symbols: vec![], file_map: BTreeMap::new() };
         let brillig_funcs = &vec![brillig_bytecode];
         let context = DebugContext::new(
             &StubbedBlackBoxSolver,

--- a/tooling/debugger/src/dap.rs
+++ b/tooling/debugger/src/dap.rs
@@ -608,10 +608,7 @@ pub fn run_session<R: Read, W: Write, B: BlackBoxFunctionSolver>(
     program: CompiledProgram,
     initial_witness: WitnessMap,
 ) -> Result<(), ServerError> {
-    let debug_artifact = DebugArtifact {
-        debug_symbols: program.debug,
-        file_map: program.file_map,
-    };
+    let debug_artifact = DebugArtifact { debug_symbols: program.debug, file_map: program.file_map };
     let mut session = DapSession::new(
         server,
         solver,

--- a/tooling/debugger/src/dap.rs
+++ b/tooling/debugger/src/dap.rs
@@ -611,7 +611,6 @@ pub fn run_session<R: Read, W: Write, B: BlackBoxFunctionSolver>(
     let debug_artifact = DebugArtifact {
         debug_symbols: program.debug,
         file_map: program.file_map,
-        warnings: program.warnings,
     };
     let mut session = DapSession::new(
         server,

--- a/tooling/nargo/Cargo.toml
+++ b/tooling/nargo/Cargo.toml
@@ -15,7 +15,6 @@ fm.workspace = true
 noirc_abi.workspace = true
 noirc_driver.workspace = true
 noirc_errors.workspace = true
-noirc_evaluator.workspace = true
 noirc_frontend.workspace = true
 noirc_printable_type.workspace = true
 iter-extended.workspace = true

--- a/tooling/nargo/src/artifacts/debug.rs
+++ b/tooling/nargo/src/artifacts/debug.rs
@@ -1,7 +1,6 @@
 use codespan_reporting::files::{Error, Files, SimpleFile};
 use noirc_driver::{CompiledContract, CompiledProgram, DebugFile};
 use noirc_errors::{debug_info::DebugInfo, Location};
-use noirc_evaluator::errors::SsaReport;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -18,7 +17,6 @@ use fm::{FileId, FileManager, PathString};
 pub struct DebugArtifact {
     pub debug_symbols: Vec<DebugInfo>,
     pub file_map: BTreeMap<FileId, DebugFile>,
-    pub warnings: Vec<SsaReport>,
 }
 
 impl DebugArtifact {
@@ -45,7 +43,7 @@ impl DebugArtifact {
             );
         }
 
-        Self { debug_symbols, file_map, warnings: Vec::new() }
+        Self { debug_symbols, file_map }
     }
 
     /// Given a location, returns its file's source code
@@ -121,11 +119,7 @@ impl DebugArtifact {
 
 impl From<CompiledProgram> for DebugArtifact {
     fn from(compiled_program: CompiledProgram) -> Self {
-        DebugArtifact {
-            debug_symbols: compiled_program.debug,
-            file_map: compiled_program.file_map,
-            warnings: compiled_program.warnings,
-        }
+        DebugArtifact { debug_symbols: compiled_program.debug, file_map: compiled_program.file_map }
     }
 }
 
@@ -134,7 +128,6 @@ impl From<ProgramArtifact> for DebugArtifact {
         DebugArtifact {
             debug_symbols: program_artifact.debug_symbols.debug_infos,
             file_map: program_artifact.file_map,
-            warnings: Vec::new(),
         }
     }
 }
@@ -147,11 +140,7 @@ impl From<CompiledContract> for DebugArtifact {
             .flat_map(|contract_function| contract_function.debug)
             .collect();
 
-        DebugArtifact {
-            debug_symbols: all_functions_debug,
-            file_map: compiled_artifact.file_map,
-            warnings: compiled_artifact.warnings,
-        }
+        DebugArtifact { debug_symbols: all_functions_debug, file_map: compiled_artifact.file_map }
     }
 }
 
@@ -163,11 +152,7 @@ impl From<ContractArtifact> for DebugArtifact {
             .flat_map(|contract_function| contract_function.debug_symbols.debug_infos)
             .collect();
 
-        DebugArtifact {
-            debug_symbols: all_functions_debug,
-            file_map: compiled_artifact.file_map,
-            warnings: Vec::new(),
-        }
+        DebugArtifact { debug_symbols: all_functions_debug, file_map: compiled_artifact.file_map }
     }
 }
 

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -224,7 +224,6 @@ pub(crate) fn debug_program(
     let debug_artifact = DebugArtifact {
         debug_symbols: compiled_program.debug.clone(),
         file_map: compiled_program.file_map.clone(),
-        warnings: compiled_program.warnings.clone(),
     };
 
     noir_debugger::debug_circuit(

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -124,7 +124,6 @@ pub(crate) fn execute_program(
             let debug_artifact = DebugArtifact {
                 debug_symbols: compiled_program.debug.clone(),
                 file_map: compiled_program.file_map.clone(),
-                warnings: compiled_program.warnings.clone(),
             };
 
             if let Some(diagnostic) =


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I'm not sure why the SSA warnings were ever added onto the `DebugArtifact` but we don't use it at all so we can just remove them (which avoids a dependency on `noirc_evaluator`)

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
