### PR TITLE
chore: perform dead instruction elimination through `std::as_witness`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -284,7 +284,7 @@ impl DataFlowGraph {
         intrinsic_value_id
     }
 
-    pub(crate) fn get_intrinsic(&mut self, intrinsic: Intrinsic) -> Option<&ValueId> {
+    pub(crate) fn get_intrinsic(&self, intrinsic: Intrinsic) -> Option<&ValueId> {
         self.intrinsics.get(&intrinsic)
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -7,7 +7,7 @@ use crate::ssa::{
         basic_block::{BasicBlock, BasicBlockId},
         dfg::DataFlowGraph,
         function::Function,
-        instruction::{Instruction, InstructionId},
+        instruction::{Instruction, InstructionId, Intrinsic},
         post_order::PostOrder,
         value::{Value, ValueId},
     },
@@ -112,8 +112,13 @@ impl Context {
             let results = function.dfg.instruction_results(instruction_id);
             results.iter().all(|result| !self.used_values.contains(result))
         } else {
-            // If the instruction has side effects we should never remove it.
-            false
+            // TODO: Gross hack for std::as_witness
+            let Instruction::Call { func, arguments } = instruction else {
+                return false;
+            };
+
+            let as_witness_id = function.dfg.get_intrinsic(Intrinsic::AsWitness);
+            as_witness_id == Some(func) && !self.used_values.contains(&arguments[0])
         }
     }
 
@@ -255,5 +260,49 @@ mod test {
 
         assert_eq!(main.dfg[main.entry_block()].instructions().len(), 1);
         assert_eq!(main.dfg[b1].instructions().len(), 6);
+    }
+
+
+    #[test]
+    fn as_witness_die() {
+        // fn main f0 {
+        //   b0(v0: Field):
+        //     v1 = add v0, Field 1
+        //     v2 = add v0, Field 2
+        //     call as_witness(v2)
+        //     return v1
+        // }
+        let main_id = Id::test_new(0);
+
+        // Compiling main
+        let mut builder = FunctionBuilder::new("main".into(), main_id);
+        let v0 = builder.add_parameter(Type::field());
+
+        let one = builder.field_constant(1u128);
+        let two = builder.field_constant(2u128);
+
+        let v1 = builder.insert_binary(v0, BinaryOp::Add, one);
+        let v2 = builder.insert_binary(v0, BinaryOp::Add, two);
+        let as_witness = builder.import_intrinsic("as_witness").unwrap();
+        builder.insert_call(as_witness, vec![v2], Vec::new());
+        builder.terminate_with_return(vec![v1]);
+
+        let ssa = builder.finish();
+        let main = ssa.main();
+
+        // The instruction count never includes the terminator instruction
+        assert_eq!(main.dfg[main.entry_block()].instructions().len(), 3);
+
+        // Expected output:
+        //
+        // acir(inline) fn main f0 {
+        //    b0(v0: Field):
+        //      v3 = add v0, Field 1
+        //      return v3
+        //  }
+        let ssa = ssa.dead_instruction_elimination();
+        let main = ssa.main();
+
+        assert_eq!(main.dfg[main.entry_block()].instructions().len(), 1);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds handling for `std::as_witness` in dead instruction elimination. i.e. if we're asking for an SSA value to be assigned to a witness when that value would not otherwise be represented in the ACIR then we can remove it.

This issue can be seen in #5122 where making two calls to the same function with the same inputs and asserting that the outputs are the same results in constraints whereas this can be determined at runtime.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
