### PR TITLE
chore: run all test programs in brillig as well as ACIR

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -38,6 +38,26 @@ fn main() {
     generate_compile_failure_tests(&mut test_file, &test_dir);
 }
 
+/// Some tests are explicitly ignored in brillig due to them failing.
+/// These should be fixed and removed from this list.
+const IGNORED_BRILLIG_TESTS: [&str; 11] = [
+    // Takes a very long time to execute as large loops do not get simplified.
+    &"regression_4709",
+    // bit sizes for bigint operation doesn't match up.
+    &"bigint",
+    // ICE due to looking for function which doesn't exist.
+    &"fold_after_inlined_calls",
+    &"fold_basic",
+    &"fold_basic_nested_call",
+    &"fold_call_witness_condition",
+    &"fold_complex_outputs",
+    &"fold_distinct_return",
+    &"fold_fibonacci",
+    &"fold_numeric_generic_poseidon",
+    // Expected to fail as test asserts on which runtime it is in.
+    &"is_unconstrained",
+];
+
 fn generate_execution_success_tests(test_file: &mut File, test_data_dir: &Path) {
     let test_sub_dir = "execution_success";
     let test_data_dir = test_data_dir.join(test_sub_dir);
@@ -55,9 +75,13 @@ fn generate_execution_success_tests(test_file: &mut File, test_data_dir: &Path) 
         };
         let test_dir = &test_dir.path();
 
+        let brillig_ignored =
+            if IGNORED_BRILLIG_TESTS.contains(&test_name.as_str()) { "\n#[ignore]" } else { "" };
+
         write!(
             test_file,
             r#"
+
 #[test]
 fn execution_success_{test_name}() {{
     let test_program_dir = PathBuf::from("{test_dir}");
@@ -65,6 +89,17 @@ fn execution_success_{test_name}() {{
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("execute").arg("--force");
+
+    cmd.assert().success();
+}}
+
+#[test]{brillig_ignored}
+fn execution_success_{test_name}_brillig() {{
+    let test_program_dir = PathBuf::from("{test_dir}");
+
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("--program-dir").arg(test_program_dir);
+    cmd.arg("execute").arg("--force").arg("--force-brillig");
 
     cmd.assert().success();
 }}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR helps ensure consistency between ACIR and brillig by checking that every `execution_success` test case were compiled and run in brillig then it would succeed.

This has thrown up a couple of test case failures which I've added to a list to be ignored for now. We can address these in follow-up PRs

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
