### PR TITLE
fix: wrapping in signed division

### DIFF
--- a/test_programs/execution_success/signed_div/src/main.nr
+++ b/test_programs/execution_success/signed_div/src/main.nr
@@ -5,15 +5,6 @@ struct SignedDivOp {
 }
 
 fn main(ops: [SignedDivOp; 15]) {
-    unsafe_div(ops);
-    test_div(ops);
-}
-
-unconstrained fn unsafe_div(ops: [SignedDivOp; 15]) {
-    test_div(ops);
-}
-
-fn test_div(ops: [SignedDivOp; 15]) {
     for i in 0..15 {
         assert_eq(ops[i].lhs / ops[i].rhs, ops[i].result);
     }

--- a/test_programs/execution_success/signed_div/src/main.nr
+++ b/test_programs/execution_success/signed_div/src/main.nr
@@ -4,7 +4,16 @@ struct SignedDivOp {
     result: i8,
 }
 
-unconstrained fn main(ops: [SignedDivOp; 15]) {
+fn main(ops: [SignedDivOp; 15]) {
+    unsafe_div(ops);
+    test_div(ops);
+}
+
+unconstrained fn unsafe_div(ops: [SignedDivOp; 15]) {
+    test_div(ops);
+}
+
+fn test_div(ops: [SignedDivOp; 15]) {
     for i in 0..15 {
         assert_eq(ops[i].lhs / ops[i].rhs, ops[i].result);
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5129

## Summary\*
A negative and null quotient was computed as -0=2^{bit_size}, which wraps over the bit size.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
