### PR TITLE
fix(experimental elaborator): Fix definition kind of globals and tuple patterns with `--use-elaborator` flag

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -79,7 +79,7 @@ impl<'context> Elaborator<'context> {
                 HirPattern::Mutable(Box::new(pattern), location)
             }
             Pattern::Tuple(fields, span) => {
-                let field_types = match expected_type {
+                let field_types = match expected_type.follow_bindings() {
                     Type::Tuple(fields) => fields,
                     Type::Error => Vec::new(),
                     expected_type => {

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -65,11 +65,13 @@ impl<'context> Elaborator<'context> {
 
         // To apply the changes from the fresh id created in elaborate_let to this global
         // we need to change the definition kind and update the type.
-        let definition_id = self.interner.get_global(global_id).definition_id;
-        self.interner.definition_mut(definition_id).kind = DefinitionKind::Global(global_id);
-
         assert_eq!(new_ids.len(), 1, "Globals should only define 1 value");
-        let definition_type = self.interner.definition_type(new_ids[0].id);
+        let new_id = new_ids[0].id;
+
+        self.interner.definition_mut(new_id).kind = DefinitionKind::Global(global_id);
+
+        let definition_id = self.interner.get_global(global_id).definition_id;
+        let definition_type = self.interner.definition_type(new_id);
         self.interner.push_definition_type(definition_id, definition_type);
 
         self.interner.replace_statement(statement_id, let_statement);


### PR DESCRIPTION
# Description

## Problem\*

Resolves two issues:
1. A type error on some tuple patterns because a `follow_bindings` call was missing
2. When elaborating global lets we were setting the existing definition id to a DefinitionKind::Global, but it already was one. The fresh ID created by the let should have been marked global instead.

## Summary\*



## Additional Context

After this PR and https://github.com/noir-lang/noir/pull/5138 all test_programs are expected to work in the elaborator.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
