### PR TITLE
chore: avoid `bn254_blackbox_solver` polluting feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ version = "0.46.0"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
+ "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,14 @@ noirc_abi = { path = "tooling/noirc_abi" }
 bb_abstraction_leaks = { path = "tooling/bb_abstraction_leaks" }
 acvm_cli = { path = "tooling/acvm_cli" }
 
+# Arkworks
+ark-bn254 = { version = "^0.4.0", default-features = false, features = ["curve"] }
+ark-bls12-381 = { version = "^0.4.0", default-features = false, features = ["curve"] }
+grumpkin = { version = "0.1.0", package = "noir_grumpkin", features = ["std"] } 
+ark-ec = { version = "^0.4.0", default-features = false }
+ark-ff = { version = "^0.4.0", default-features = false }
+ark-std = { version = "^0.4.0", default-features = false }
+
 # Misc utils crates
 iter-extended = { path = "utils/iter-extended" }
 

--- a/acvm-repo/acir_field/Cargo.toml
+++ b/acvm-repo/acir_field/Cargo.toml
@@ -17,9 +17,9 @@ hex.workspace = true
 num-bigint.workspace = true
 serde.workspace = true
 
-ark-bn254 = { version = "^0.4.0", default-features = false, features = ["curve"] }
-ark-bls12-381 = { version = "^0.4.0", optional = true, default-features = false, features = ["curve"] }
-ark-ff = { version = "^0.4.0", default-features = false }
+ark-bn254.workspace = true
+ark-bls12-381 = { workspace = true, optional = true }
+ark-ff.workspace = true
 
 cfg-if = "1.0.0"
 

--- a/acvm-repo/bn254_blackbox_solver/Cargo.toml
+++ b/acvm-repo/bn254_blackbox_solver/Cargo.toml
@@ -18,14 +18,14 @@ acvm_blackbox_solver.workspace = true
 hex.workspace = true
 lazy_static = "1.4"
 
-# BN254 fixed base scalar multiplication solver
-grumpkin = { version = "0.1.0", package = "noir_grumpkin", features = ["std"] } 
-ark-ec = { version = "^0.4.0", default-features = false }
-ark-ff = { version = "^0.4.0", default-features = false }
+ark-bn254.workspace = true
+grumpkin.workspace = true 
+ark-ec.workspace = true
+ark-ff.workspace = true
 num-bigint.workspace = true
 
 [dev-dependencies]
-ark-std = { version = "^0.4.0", default-features = false }
+ark-std.workspace = true
 criterion = "0.5.0"
 pprof = { version = "0.12", features = [
     "flamegraph",
@@ -36,7 +36,3 @@ pprof = { version = "0.12", features = [
 [[bench]]
 name = "criterion"
 harness = false
-
-[features]
-default = ["bn254"]
-bn254 = ["acir/bn254"]

--- a/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
@@ -3,8 +3,9 @@ use ark_ec::AffineRepr;
 use ark_ff::MontConfig;
 use num_bigint::BigUint;
 
+use crate::FieldElement;
+use acir::AcirField;
 use acir::BlackBoxFunc;
-use acir::{AcirField, FieldElement};
 
 use crate::BlackBoxResolutionError;
 

--- a/acvm-repo/bn254_blackbox_solver/src/lib.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/lib.rs
@@ -2,7 +2,6 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
-use acir::FieldElement;
 use acvm_blackbox_solver::{BlackBoxFunctionSolver, BlackBoxResolutionError};
 
 mod embedded_curve_ops;
@@ -14,6 +13,10 @@ mod schnorr;
 use ark_ec::AffineRepr;
 pub use embedded_curve_ops::{embedded_curve_add, multi_scalar_mul};
 pub use poseidon2::poseidon2_permutation;
+
+// Temporary hack, this ensure that we always use a bn254 field here
+// without polluting the feature flags of the `acir_field` crate.
+type FieldElement = acir::acir_field::GenericFieldElement<ark_bn254::Fr>;
 
 #[derive(Default)]
 pub struct Bn254BlackBoxSolver;

--- a/acvm-repo/bn254_blackbox_solver/src/pedersen/commitment.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/pedersen/commitment.rs
@@ -27,12 +27,13 @@ pub(crate) fn commit_native_with_index(
 #[cfg(test)]
 mod test {
 
-    use acir::{AcirField, FieldElement};
+    use acir::AcirField;
     use ark_ec::short_weierstrass::Affine;
     use ark_std::{One, Zero};
     use grumpkin::Fq;
 
     use crate::pedersen::commitment::commit_native_with_index;
+    use crate::FieldElement;
 
     #[test]
     fn commitment() {

--- a/acvm-repo/bn254_blackbox_solver/src/pedersen/hash.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/pedersen/hash.rs
@@ -30,8 +30,9 @@ fn length_generator() -> &'static Affine<GrumpkinParameters> {
 pub(crate) mod test {
 
     use super::*;
+    use crate::FieldElement;
 
-    use acir::{AcirField, FieldElement};
+    use acir::AcirField;
     use ark_std::One;
     use grumpkin::Fq;
 

--- a/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
@@ -1,6 +1,8 @@
-use acir::{AcirField, FieldElement};
+use acir::AcirField;
 use acvm_blackbox_solver::BlackBoxResolutionError;
 use lazy_static::lazy_static;
+
+use crate::FieldElement;
 
 pub fn poseidon2_permutation(
     inputs: &[FieldElement],
@@ -543,9 +545,9 @@ impl<'a> Poseidon2<'a> {
 
 #[cfg(test)]
 mod test {
-    use acir::{AcirField, FieldElement};
+    use acir::AcirField;
 
-    use super::{field_from_hex, poseidon2_permutation};
+    use super::{field_from_hex, poseidon2_permutation, FieldElement};
 
     #[test]
     fn smoke_test() {

--- a/acvm-repo/bn254_blackbox_solver/src/schnorr/mod.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/schnorr/mod.rs
@@ -65,9 +65,10 @@ fn schnorr_generate_challenge(
 
 #[cfg(test)]
 mod schnorr_tests {
-    use acir::{AcirField, FieldElement};
+    use acir::AcirField;
 
     use super::verify_signature;
+    use crate::FieldElement;
 
     #[test]
     fn verifies_valid_signature() {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Depending on `bn254_blackbox_solver` results in the `bn254` feature flag being applied to the `acir` crate. This is unnecessary as we can just have this crate use a `GenericFieldElement` and construct it as a BN254 field.

This simplifies the lives of people attempting to use Noir with an alternative field choice.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
