### PR TITLE
feat: place return value witnesses directly after function arguments

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -269,16 +269,6 @@ impl AcirContext {
         Ok(witness)
     }
 
-    /// Creates a new [`Witness`] which is constrained to be equal to an [`AcirVar`]
-    pub(crate) fn force_var_to_new_witness(
-        &mut self,
-        var: AcirVar,
-    ) -> Result<Witness, InternalError> {
-        let expression = self.var_to_expression(var)?;
-        let witness = self.acir_ir.create_witness_for_expression(&expression);
-        Ok(witness)
-    }
-
     /// Converts an [`AcirVar`] to an [`Expression`]
     pub(crate) fn var_to_expression(
         &self,

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -255,7 +255,7 @@ impl AcirContext {
     }
 
     /// Converts an [`AcirVar`] to a [`Witness`]
-    fn var_to_witness(&mut self, var: AcirVar) -> Result<Witness, InternalError> {
+    pub(crate) fn var_to_witness(&mut self, var: AcirVar) -> Result<Witness, InternalError> {
         let expression = self.var_to_expression(var)?;
         let witness = if let Some(constant) = expression.to_const() {
             // Check if a witness has been assigned this value already, if so reuse it.
@@ -266,6 +266,16 @@ impl AcirContext {
         } else {
             self.acir_ir.get_or_create_witness(&expression)
         };
+        Ok(witness)
+    }
+
+    /// Creates a new [`Witness`] which is constrained to be equal to an [`AcirVar`]
+    pub(crate) fn force_var_to_new_witness(
+        &mut self,
+        var: AcirVar,
+    ) -> Result<Witness, InternalError> {
+        let expression = self.var_to_expression(var)?;
+        let witness = self.acir_ir.create_witness_for_expression(&expression);
         Ok(witness)
     }
 
@@ -1017,15 +1027,6 @@ impl AcirContext {
         Ok(remainder)
     }
 
-    /// Converts the `AcirVar` to a `Witness` if it hasn't been already, and appends it to the
-    /// `GeneratedAcir`'s return witnesses.
-    pub(crate) fn return_var(&mut self, acir_var: AcirVar) -> Result<(), InternalError> {
-        let return_var = self.get_or_create_witness_var(acir_var)?;
-        let witness = self.var_to_witness(return_var)?;
-        self.acir_ir.push_return_witness(witness);
-        Ok(())
-    }
-
     /// Constrains the `AcirVar` variable to be of type `NumericType`.
     pub(crate) fn range_constrain_var(
         &mut self,
@@ -1528,9 +1529,11 @@ impl AcirContext {
     pub(crate) fn finish(
         mut self,
         inputs: Vec<Witness>,
+        return_values: Vec<Witness>,
         warnings: Vec<SsaReport>,
     ) -> GeneratedAcir {
         self.acir_ir.input_witnesses = inputs;
+        self.acir_ir.return_witnesses = return_values;
         self.acir_ir.warnings = warnings;
         self.acir_ir
     }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -45,9 +45,6 @@ pub(crate) struct GeneratedAcir {
     opcodes: Vec<AcirOpcode<FieldElement>>,
 
     /// All witness indices that comprise the final return value of the program
-    ///
-    /// Note: This may contain repeated indices, which is necessary for later mapping into the
-    /// abi's return type.
     pub(crate) return_witnesses: Vec<Witness>,
 
     /// All witness indices which are inputs to the main function
@@ -163,11 +160,6 @@ impl GeneratedAcir {
         self.assert_is_zero(constraint);
 
         fresh_witness
-    }
-
-    /// Adds a witness index to the program's return witnesses.
-    pub(crate) fn push_return_witness(&mut self, witness: Witness) {
-        self.return_witnesses.push(witness);
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -1738,11 +1738,11 @@ impl<'a> Context<'a> {
                 .return_data
                 .map_or(false, |return_databus| dfg[*value_id] == dfg[return_databus]);
 
-            if !is_databus {
+            if is_databus {
                 // We do not return value for the data bus.
-                acc + dfg.type_of_value(*value_id).flattened_size()
-            } else {
                 acc
+            } else {
+                acc + dfg.type_of_value(*value_id).flattened_size()
             }
         })
     }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -3103,8 +3103,8 @@ mod test {
         check_call_opcode(
             &func_with_nested_call_opcodes[1],
             2,
-            vec![Witness(2), Witness(1)],
-            vec![Witness(3)],
+            vec![Witness(3), Witness(1)],
+            vec![Witness(4)],
         );
     }
 
@@ -3124,13 +3124,13 @@ mod test {
                 for (expected_input, input) in expected_inputs.iter().zip(inputs) {
                     assert_eq!(
                         expected_input, input,
-                        "Expected witness {expected_input:?} but got {input:?}"
+                        "Expected input witness {expected_input:?} but got {input:?}"
                     );
                 }
                 for (expected_output, output) in expected_outputs.iter().zip(outputs) {
                     assert_eq!(
                         expected_output, output,
-                        "Expected witness {expected_output:?} but got {output:?}"
+                        "Expected output witness {expected_output:?} but got {output:?}"
                     );
                 }
             }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -404,13 +404,11 @@ impl<'a> Context<'a> {
         // the function's return values can then be determined through knowledge of its ABI alone.
         let return_witness_vars =
             vecmap(0..num_return_witnesses, |_| self.acir_context.add_variable());
-        let return_witnesses: Vec<Witness> = return_witness_vars
-            .iter()
-            .map(|return_var| {
-                let expr = self.acir_context.var_to_expression(*return_var).unwrap();
-                expr.to_witness().expect("return vars should be witnesses")
-            })
-            .collect();
+
+        let return_witnesses = vecmap(&return_witness_vars, |return_var| {
+            let expr = self.acir_context.var_to_expression(*return_var).unwrap();
+            expr.to_witness().expect("return vars should be witnesses")
+        });
 
         self.data_bus = dfg.data_bus.to_owned();
         let mut warnings = Vec::new();


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5104 
## Summary\*

This PR preallocates some witnesses to hold the return values at the beginning of ACIR gen and then adds assertions to fill these witnesses with the return values. This ensures that the return values will be placed in the witness map directly after any function inputs (reasons for this being desirable are laid out in #5104)

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
