### PR TITLE
chore: default to using bn254 in `noirc_frontend`

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -741,12 +741,10 @@ fn should_check_siblings_for_module(module_path: &Path, parent_path: &Path) -> b
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "bn254")] {
-        pub const CHOSEN_FIELD: &str = "bn254";
-    } else if #[cfg(feature = "bls12_381")] {
+    if #[cfg(feature = "bls12_381")] {
         pub const CHOSEN_FIELD: &str = "bls12_381";
     } else {
-        compile_error!("please specify a field to compile with");
+        pub const CHOSEN_FIELD: &str = "bn254";
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR sets `noirc_frontend` to default to bn254 if no feature flag is set.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
