### PR TITLE
feat: support casting in globals

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -5,7 +5,7 @@ use noirc_errors::{CustomDiagnostic, Location};
 use super::value::Value;
 
 /// The possible errors that can halt the interpreter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InterpreterError {
     ArgumentCountMismatch { expected: usize, actual: usize, location: Location },
     TypeMismatch { expected: Type, value: Value, location: Location },

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -5,7 +5,7 @@ use noirc_errors::{CustomDiagnostic, Location};
 use super::value::Value;
 
 /// The possible errors that can halt the interpreter.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum InterpreterError {
     ArgumentCountMismatch { expected: usize, actual: usize, location: Location },
     TypeMismatch { expected: Type, value: Value, location: Location },

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -306,7 +306,7 @@ impl<'a> Interpreter<'a> {
             HirExpression::MemberAccess(access) => self.evaluate_access(access, id),
             HirExpression::Call(call) => self.evaluate_call(call, id),
             HirExpression::MethodCall(call) => self.evaluate_method_call(call, id),
-            HirExpression::Cast(cast) => self.evaluate_cast(cast, id),
+            HirExpression::Cast(cast) => self.evaluate_cast(&cast, id),
             HirExpression::If(if_) => self.evaluate_if(if_, id),
             HirExpression::Tuple(tuple) => self.evaluate_tuple(tuple),
             HirExpression::Lambda(lambda) => self.evaluate_lambda(lambda, id),
@@ -945,7 +945,18 @@ impl<'a> Interpreter<'a> {
         }
     }
 
-    fn evaluate_cast(&mut self, cast: HirCastExpression, id: ExprId) -> IResult<Value> {
+    fn evaluate_cast(&mut self, cast: &HirCastExpression, id: ExprId) -> IResult<Value> {
+        let evaluated_lhs = self.evaluate(cast.lhs)?;
+        Self::evaluate_cast_one_step(cast, id, evaluated_lhs, self.interner)
+    }
+
+    /// evaluate_cast without recursion
+    pub fn evaluate_cast_one_step(
+        cast: &HirCastExpression,
+        id: ExprId,
+        evaluated_lhs: Value,
+        interner: &NodeInterner,
+    ) -> IResult<Value> {
         macro_rules! signed_int_to_field {
             ($x:expr) => {{
                 // Need to convert the signed integer to an i128 before
@@ -959,7 +970,7 @@ impl<'a> Interpreter<'a> {
             }};
         }
 
-        let (mut lhs, lhs_is_negative) = match self.evaluate(cast.lhs)? {
+        let (mut lhs, lhs_is_negative) = match evaluated_lhs {
             Value::Field(value) => (value, false),
             Value::U8(value) => ((value as u128).into(), false),
             Value::U16(value) => ((value as u128).into(), false),
@@ -973,7 +984,7 @@ impl<'a> Interpreter<'a> {
                 (if value { FieldElement::one() } else { FieldElement::zero() }, false)
             }
             value => {
-                let location = self.interner.expr_location(&id);
+                let location = interner.expr_location(&id);
                 return Err(InterpreterError::NonNumericCasted { value, location });
             }
         };
@@ -998,8 +1009,8 @@ impl<'a> Interpreter<'a> {
             }
             Type::Integer(sign, bit_size) => match (sign, bit_size) {
                 (Signedness::Unsigned, IntegerBitSize::One) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InterpreterError::TypeUnsupported { typ: cast.r#type, location })
+                    let location = interner.expr_location(&id);
+                    Err(InterpreterError::TypeUnsupported { typ: cast.r#type.clone(), location })
                 }
                 (Signedness::Unsigned, IntegerBitSize::Eight) => cast_to_int!(lhs, to_u128, u8, U8),
                 (Signedness::Unsigned, IntegerBitSize::Sixteen) => {
@@ -1012,8 +1023,8 @@ impl<'a> Interpreter<'a> {
                     cast_to_int!(lhs, to_u128, u64, U64)
                 }
                 (Signedness::Signed, IntegerBitSize::One) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InterpreterError::TypeUnsupported { typ: cast.r#type, location })
+                    let location = interner.expr_location(&id);
+                    Err(InterpreterError::TypeUnsupported { typ: cast.r#type.clone(), location })
                 }
                 (Signedness::Signed, IntegerBitSize::Eight) => cast_to_int!(lhs, to_i128, i8, I8),
                 (Signedness::Signed, IntegerBitSize::Sixteen) => {
@@ -1028,7 +1039,7 @@ impl<'a> Interpreter<'a> {
             },
             Type::Bool => Ok(Value::Bool(!lhs.is_zero() || lhs_is_negative)),
             typ => {
-                let location = self.interner.expr_location(&id);
+                let location = interner.expr_location(&id);
                 Err(InterpreterError::CastToNonNumericType { typ, location })
             }
         }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -181,11 +181,7 @@ impl Value {
         match self {
             Self::Field(value) => Some(value.to_u128()),
             Self::I8(value) => {
-                if value < &0 {
-                    None
-                } else {
-                    Some(*value as u128)
-                }
+                (*value >= 0).then(|| *value as u128)
             }
             Self::I16(value) => {
                 if value < &0 {

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -177,7 +177,7 @@ impl Value {
 
     /// Converts any unsigned `Value` into a `u128`.
     /// Returns `None` for negative integers.
-    pub(crate) fn into_u128(&self) -> Option<u128> {
+    pub(crate) fn to_u128(&self) -> Option<u128> {
         match self {
             Self::Field(value) => Some(value.to_u128()),
             Self::I8(value) => {

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, rc::Rc};
 
-use acvm::FieldElement;
+use acvm::{AcirField, FieldElement};
 use im::Vector;
 use iter_extended::{try_vecmap, vecmap};
 use noirc_errors::Location;
@@ -155,12 +155,12 @@ impl Value {
             }
             Value::Array(elements, _) => {
                 let elements =
-                    try_vecmap(elements, |elements| elements.into_expression(interner, location))?;
+                    try_vecmap(elements, |element| element.into_expression(interner, location))?;
                 HirExpression::Literal(HirLiteral::Array(HirArrayLiteral::Standard(elements)))
             }
             Value::Slice(elements, _) => {
                 let elements =
-                    try_vecmap(elements, |elements| elements.into_expression(interner, location))?;
+                    try_vecmap(elements, |element| element.into_expression(interner, location))?;
                 HirExpression::Literal(HirLiteral::Slice(HirArrayLiteral::Standard(elements)))
             }
             Value::Code(block) => HirExpression::Unquote(unwrap_rc(block)),
@@ -173,6 +173,47 @@ impl Value {
         interner.push_expr_location(id, location.span, location.file);
         interner.push_expr_type(id, typ);
         Ok(id)
+    }
+
+    /// Converts any unsigned `Value` into a `u128`.
+    /// Returns `None` for negative integers.
+    pub(crate) fn into_u128(&self) -> Option<u128> {
+        match self {
+            Self::Field(value) => Some(value.to_u128()),
+            Self::I8(value) => {
+                if value < &0 {
+                    None
+                } else {
+                    Some(*value as u128)
+                }
+            }
+            Self::I16(value) => {
+                if value < &0 {
+                    None
+                } else {
+                    Some(*value as u128)
+                }
+            }
+            Self::I32(value) => {
+                if value < &0 {
+                    None
+                } else {
+                    Some(*value as u128)
+                }
+            }
+            Self::I64(value) => {
+                if value < &0 {
+                    None
+                } else {
+                    Some(*value as u128)
+                }
+            }
+            Self::U8(value) => Some(*value as u128),
+            Self::U16(value) => Some(*value as u128),
+            Self::U32(value) => Some(*value as u128),
+            Self::U64(value) => Some(*value as u128),
+            _ => None,
+        }
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -184,25 +184,13 @@ impl Value {
                 (*value >= 0).then(|| *value as u128)
             }
             Self::I16(value) => {
-                if value < &0 {
-                    None
-                } else {
-                    Some(*value as u128)
-                }
+                (*value >= 0).then(|| *value as u128)
             }
             Self::I32(value) => {
-                if value < &0 {
-                    None
-                } else {
-                    Some(*value as u128)
-                }
+                (*value >= 0).then(|| *value as u128)
             }
             Self::I64(value) => {
-                if value < &0 {
-                    None
-                } else {
-                    Some(*value as u128)
-                }
+                (*value >= 0).then(|| *value as u128)
             }
             Self::U8(value) => Some(*value as u128),
             Self::U16(value) => Some(*value as u128),

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -180,18 +180,10 @@ impl Value {
     pub(crate) fn to_u128(&self) -> Option<u128> {
         match self {
             Self::Field(value) => Some(value.to_u128()),
-            Self::I8(value) => {
-                (*value >= 0).then(|| *value as u128)
-            }
-            Self::I16(value) => {
-                (*value >= 0).then(|| *value as u128)
-            }
-            Self::I32(value) => {
-                (*value >= 0).then(|| *value as u128)
-            }
-            Self::I64(value) => {
-                (*value >= 0).then(|| *value as u128)
-            }
+            Self::I8(value) => (*value >= 0).then_some(*value as u128),
+            Self::I16(value) => (*value >= 0).then_some(*value as u128),
+            Self::I32(value) => (*value >= 0).then_some(*value as u128),
+            Self::I64(value) => (*value >= 0).then_some(*value as u128),
             Self::U8(value) => Some(*value as u128),
             Self::U16(value) => Some(*value as u128),
             Self::U32(value) => Some(*value as u128),

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -14,7 +14,7 @@ pub enum PubPosition {
     ReturnType,
 }
 
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone)]
 pub enum ResolverError {
     #[error("Duplicate definition")]
     DuplicateDefinition { name: String, first_span: Span, second_span: Span },

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -95,7 +95,7 @@ pub enum ResolverError {
     #[error("#[fold] attribute is only allowed on constrained functions")]
     FoldAttributeOnUnconstrained { ident: Ident },
     #[error("Invalid array length construction")]
-    ArrayLengthInterpreter { error: InterpreterError, span: Span },
+    ArrayLengthInterpreter { error: InterpreterError },
 }
 
 impl ResolverError {
@@ -388,7 +388,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 diag.add_note("The `#[fold]` attribute specifies whether a constrained function should be treated as a separate circuit rather than inlined into the program entry point".to_owned());
                 diag
             }
-            ResolverError::ArrayLengthInterpreter { error, span } => Diagnostic::from(error),
+            ResolverError::ArrayLengthInterpreter { error } => Diagnostic::from(error),
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -94,7 +94,7 @@ pub enum ResolverError {
     NoPredicatesAttributeOnUnconstrained { ident: Ident },
     #[error("#[fold] attribute is only allowed on constrained functions")]
     FoldAttributeOnUnconstrained { ident: Ident },
-    #[error("Interpreting array-length failed")]
+    #[error("Invalid array length construction")]
     ArrayLengthInterpreter { error: InterpreterError, span: Span },
 }
 
@@ -388,11 +388,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 diag.add_note("The `#[fold]` attribute specifies whether a constrained function should be treated as a separate circuit rather than inlined into the program entry point".to_owned());
                 diag
             }
-            ResolverError::ArrayLengthInterpreter { error, span } => Diagnostic::simple_error(
-                "Interpreting array length failed".into(),
-                format!("with error: {}", Diagnostic::from(error)),
-                *span,
-            ),
+            ResolverError::ArrayLengthInterpreter { error, span } => Diagnostic::from(error),
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -14,7 +14,7 @@ pub enum PubPosition {
     ReturnType,
 }
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum ResolverError {
     #[error("Duplicate definition")]
     DuplicateDefinition { name: String, first_span: Span, second_span: Span },

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -2077,11 +2077,7 @@ impl<'a> Resolver<'a> {
                             Some(ResolverError::ArrayLengthInterpreter { error, span })
                         })?;
 
-                if let Some(result) = evaluated_value.to_u128() {
-                    Ok(result)
-                } else {
-                    Err(Some(ResolverError::InvalidArrayLengthExpr { span }))
-                }
+                evaluated_value.to_u128().ok_or_else(|| Some(ResolverError::InvalidArrayLengthExpr { span }))
             }
             _other => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
         }

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -2073,11 +2073,11 @@ impl<'a> Resolver<'a> {
                 let lhs_value = Value::Field(lhs.into());
                 let evaluated_value =
                     Interpreter::evaluate_cast_one_step(&cast, rhs, lhs_value, self.interner)
-                        .map_err(|error| {
-                            Some(ResolverError::ArrayLengthInterpreter { error, span })
-                        })?;
+                        .map_err(|error| Some(ResolverError::ArrayLengthInterpreter { error }))?;
 
-                evaluated_value.to_u128().ok_or_else(|| Some(ResolverError::InvalidArrayLengthExpr { span }))
+                evaluated_value
+                    .to_u128()
+                    .ok_or_else(|| Some(ResolverError::InvalidArrayLengthExpr { span }))
             }
             _other => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
         }

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -2077,7 +2077,7 @@ impl<'a> Resolver<'a> {
                             Some(ResolverError::ArrayLengthInterpreter { error, span })
                         })?;
 
-                if let Some(result) = evaluated_value.into_u128() {
+                if let Some(result) = evaluated_value.to_u128() {
                     Ok(result)
                 } else {
                     Err(Some(ResolverError::InvalidArrayLengthExpr { span }))

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -28,7 +28,7 @@ pub enum Source {
     Return(FunctionReturnType, Span),
 }
 
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone)]
 pub enum TypeCheckError {
     #[error("Operator {op:?} cannot be used in a {place:?}")]
     OpCannotBeUsed { op: HirBinaryOp, place: &'static str, span: Span },

--- a/test_programs/execution_success/cast_and_shift_global/Nargo.toml
+++ b/test_programs/execution_success/cast_and_shift_global/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cast_and_shift_global"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.30.0"
+
+[dependencies]

--- a/test_programs/execution_success/cast_and_shift_global/src/main.nr
+++ b/test_programs/execution_success/cast_and_shift_global/src/main.nr
@@ -1,0 +1,8 @@
+global THREE: u64 = 3;
+global EIGHT: u64 = 1 << THREE as u8;
+global SEVEN: u64 = EIGHT - 1;
+
+fn main() {
+    assert([0; EIGHT] == [0; 8]);
+    assert([0; SEVEN] == [0; 7]);
+}


### PR DESCRIPTION

# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5160

## Summary\*

Adds a case for casts in comptime globals

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
