### PR TITLE
fix(elaborator): Invert unconstrained check

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -41,7 +41,7 @@ pub(super) fn deprecated_function(interner: &NodeInterner, expr: ExprId) -> Opti
 /// as all unconstrained functions are not inlined and so
 /// associated attributes are disallowed.
 pub(super) fn inlining_attributes(func: &NoirFunction) -> Option<ResolverError> {
-    if !func.def.is_unconstrained {
+    if func.def.is_unconstrained {
         let attributes = func.attributes().clone();
 
         if attributes.is_no_predicates() {


### PR DESCRIPTION
# Description

## Problem\*

A check from https://github.com/noir-lang/noir/pull/5165 was inverted leading to CI issues in https://github.com/noir-lang/noir/pull/5172

## Summary\*

Fixed an accidentally inverted check for checking if a function is unconstrained

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
