### PR TITLE
feat: standardize pedersen functions to return `EmbeddedCurvePoint`

### DIFF
--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -5,6 +5,7 @@ mod poseidon2;
 use crate::default::Default;
 use crate::uint128::U128;
 use crate::sha256::{digest, sha256_var};
+use crate::embedded_curve_ops::EmbeddedCurvePoint;
 
 #[foreign(sha256)]
 // docs:start:sha256
@@ -25,12 +26,7 @@ pub fn blake3<N>(input: [u8; N]) -> [u8; 32]
 {}
 
 // docs:start:pedersen_commitment
-struct PedersenPoint {
-   x : Field,
-   y : Field,
-}
-
-pub fn pedersen_commitment<N>(input: [Field; N]) -> PedersenPoint {
+pub fn pedersen_commitment<N>(input: [Field; N]) -> EmbeddedCurvePoint {
     // docs:end:pedersen_commitment
     pedersen_commitment_with_separator(input, 0)
 }
@@ -38,9 +34,9 @@ pub fn pedersen_commitment<N>(input: [Field; N]) -> PedersenPoint {
 #[foreign(pedersen_commitment)]
 pub fn __pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> [Field; 2] {}
 
-pub fn pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> PedersenPoint {
+pub fn pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
     let values = __pedersen_commitment_with_separator(input, separator);
-    PedersenPoint { x: values[0], y: values[1] }
+    EmbeddedCurvePoint { x: values[0], y: values[1], is_infinite: false }
 }
 
 // docs:start:pedersen_hash

--- a/test_programs/execution_success/pedersen_commitment/Prover.toml
+++ b/test_programs/execution_success/pedersen_commitment/Prover.toml
@@ -4,3 +4,4 @@ y = "1"
 [expected_commitment]
 x = "0x054aa86a73cb8a34525e5bbed6e43ba1198e860f5f3950268f71df4591bde402"
 y = "0x209dcfbf2cfb57f9f6046f44d71ac6faf87254afc7407c04eb621a6287cac126"
+is_infinite = false

--- a/test_programs/execution_success/pedersen_commitment/src/main.nr
+++ b/test_programs/execution_success/pedersen_commitment/src/main.nr
@@ -1,7 +1,7 @@
 // docs:start:pedersen-commitment
 use dep::std;
 
-fn main(x: Field, y: Field, expected_commitment: std::hash::PedersenPoint) {
+fn main(x: Field, y: Field, expected_commitment: std::embedded_curve_ops::EmbeddedCurvePoint) {
     let commitment = std::hash::pedersen_commitment([x, y]);
     assert_eq(commitment.x, expected_commitment.x);
     assert_eq(commitment.y, expected_commitment.y);

--- a/test_programs/execution_success/schnorr/src/main.nr
+++ b/test_programs/execution_success/schnorr/src/main.nr
@@ -30,7 +30,7 @@ fn main(
     let pub_key = embedded_curve_ops::EmbeddedCurvePoint { x: pub_key_x, y: pub_key_y, is_infinite: false };
     let valid_signature = verify_signature_noir(pub_key, signature, message2);
     assert(valid_signature);
-    assert_valid_signature(pub_key,signature,message2);
+    assert_valid_signature(pub_key, signature, message2);
 }
 
 // TODO: to put in the stdlib once we have numeric generics

--- a/test_programs/noir_test_success/should_fail_with_matches/src/main.nr
+++ b/test_programs/noir_test_success/should_fail_with_matches/src/main.nr
@@ -19,10 +19,10 @@ fn test_should_fail_without_runtime_match() {
 }
 
 struct InvalidPointError {
-    point: dep::std::hash::PedersenPoint,
+    point: dep::std::embedded_curve_ops::EmbeddedCurvePoint,
 }
 
-#[test(should_fail_with = "InvalidPointError { point: PedersenPoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 } }")]
+#[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 } }")]
 fn test_should_fail_with_struct() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, InvalidPointError { point: hash });
@@ -35,7 +35,7 @@ fn test_should_fail_with_basic_type_fmt_string() {
     assert_eq(a, b, f"A: {a} is not 1!");
 }
 
-#[test(should_fail_with = "Invalid hash: PedersenPoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 }")]
+#[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 }")]
 fn test_should_fail_with_struct_fmt_string() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, f"Invalid hash: {hash}");
@@ -63,7 +63,7 @@ unconstrained fn unconstrained_test_should_fail_without_runtime_match() {
     assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0);
 }
 
-#[test(should_fail_with = "InvalidPointError { point: PedersenPoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 } }")]
+#[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 } }")]
 unconstrained fn unconstrained_test_should_fail_with_struct() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, InvalidPointError { point: hash });
@@ -76,7 +76,7 @@ unconstrained fn unconstrained_test_should_fail_with_basic_type_fmt_string() {
     assert_eq(a, b, f"A: {a} is not 1!");
 }
 
-#[test(should_fail_with = "Invalid hash: PedersenPoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 }")]
+#[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 }")]
 unconstrained fn unconstrained_test_should_fail_with_struct_fmt_string() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, f"Invalid hash: {hash}");

--- a/test_programs/noir_test_success/should_fail_with_matches/src/main.nr
+++ b/test_programs/noir_test_success/should_fail_with_matches/src/main.nr
@@ -22,7 +22,7 @@ struct InvalidPointError {
     point: dep::std::embedded_curve_ops::EmbeddedCurvePoint,
 }
 
-#[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 } }")]
+#[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false } }")]
 fn test_should_fail_with_struct() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, InvalidPointError { point: hash });
@@ -35,7 +35,7 @@ fn test_should_fail_with_basic_type_fmt_string() {
     assert_eq(a, b, f"A: {a} is not 1!");
 }
 
-#[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 }")]
+#[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false }")]
 fn test_should_fail_with_struct_fmt_string() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, f"Invalid hash: {hash}");
@@ -63,7 +63,7 @@ unconstrained fn unconstrained_test_should_fail_without_runtime_match() {
     assert_eq(dep::std::hash::pedersen_commitment([27]).x, 0);
 }
 
-#[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 } }")]
+#[test(should_fail_with = "InvalidPointError { point: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false } }")]
 unconstrained fn unconstrained_test_should_fail_with_struct() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, InvalidPointError { point: hash });
@@ -76,7 +76,7 @@ unconstrained fn unconstrained_test_should_fail_with_basic_type_fmt_string() {
     assert_eq(a, b, f"A: {a} is not 1!");
 }
 
-#[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8 }")]
+#[test(should_fail_with = "Invalid hash: EmbeddedCurvePoint { x: 0x1cea3a116d01eb94d568ef04c3dfbc39f96f015ed801ab8958e360d406503ce0, y: 0x2721b237df87234acc36a238b8f231a3d31d18fe3845fff4cc59f0bd873818f8, is_infinite: false }")]
 unconstrained fn unconstrained_test_should_fail_with_struct_fmt_string() {
     let hash = dep::std::hash::pedersen_commitment([27]);
     assert_eq(hash.x, 0, f"Invalid hash: {hash}");


### PR DESCRIPTION
# Description

## Problem\*

Related to #4931 

## Summary\*
Replace PedersenPoint in the std lib with EmbeddedPoint


## Additional Context



## Documentation\*

Check one:
- [X ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
