### PR TITLE
fix(elaborator): Lazily elaborate globals

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -429,6 +429,9 @@ impl<'context> Elaborator<'context> {
                         }
                     }
                     DefinitionKind::Global(global_id) => {
+                        if let Some(global) = self.remove_unresolved_global(global_id) {
+                            self.elaborate_global(global);
+                        }
                         if let Some(current_item) = self.current_item {
                             self.interner.add_global_dependency(current_item, global_id);
                         }

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -429,7 +429,7 @@ impl<'context> Elaborator<'context> {
                         }
                     }
                     DefinitionKind::Global(global_id) => {
-                        if let Some(global) = self.remove_unresolved_global(global_id) {
+                        if let Some(global) = self.unresolved_globals.remove(&global_id) {
                             self.elaborate_global(global);
                         }
                         if let Some(current_item) = self.current_item {

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -399,11 +399,16 @@ impl<'context> Elaborator<'context> {
             .or_else(|| self.resolve_trait_method_by_named_generic(path))
     }
 
-    fn eval_global_as_array_length(&mut self, global: GlobalId, path: &Path) -> u32 {
-        let Some(stmt) = self.interner.get_global_let_statement(global) else {
-            let path = path.clone();
-            self.push_err(ResolverError::NoSuchNumericTypeVariable { path });
-            return 0;
+    fn eval_global_as_array_length(&mut self, global_id: GlobalId, path: &Path) -> u32 {
+        let Some(stmt) = self.interner.get_global_let_statement(global_id) else {
+            if let Some(global) = self.remove_unresolved_global(global_id) {
+                self.elaborate_global(global);
+                return self.eval_global_as_array_length(global_id, path);
+            } else {
+                let path = path.clone();
+                self.push_err(ResolverError::NoSuchNumericTypeVariable { path });
+                return 0;
+            }
         };
 
         let length = stmt.expression;

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -401,7 +401,7 @@ impl<'context> Elaborator<'context> {
 
     fn eval_global_as_array_length(&mut self, global_id: GlobalId, path: &Path) -> u32 {
         let Some(stmt) = self.interner.get_global_let_statement(global_id) else {
-            if let Some(global) = self.remove_unresolved_global(global_id) {
+            if let Some(global) = self.unresolved_globals.remove(&global_id) {
                 self.elaborate_global(global);
                 return self.eval_global_as_array_length(global_id, path);
             } else {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -139,7 +139,7 @@ pub struct UnresolvedTypeAlias {
     pub type_alias_def: NoirTypeAlias,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct UnresolvedGlobal {
     pub file_id: FileId,
     pub module_id: LocalModuleId,

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -279,7 +279,7 @@ impl DefinitionId {
 }
 
 /// An ID for a global value
-#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy, PartialOrd, Ord)]
 pub struct GlobalId(usize);
 
 impl GlobalId {


### PR DESCRIPTION
# Description

## Problem\*

Resolves some issues with resolving globals in a type position in certain Noir repositories.
These were an issue before because `non_literal_globals` were resolved after `func_metas` were defined, but `func_metas` may refer to them in their type signature.

## Summary\*

Keeps a list of any unresolved globals and resolve them on demand if needed.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
