### PR TITLE
chore: add more lints related to oracle calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -842,7 +842,7 @@ impl<'a> Context<'a> {
                         // TODO: Remove this once elaborator is default frontend. This is now caught by a lint inside the frontend.
                         return Err(RuntimeError::UnconstrainedOracleReturnToConstrained {
                             call_stack: self.acir_context.get_call_stack(),
-                        })
+                        });
                     }
                     _ => unreachable!("expected calling a function but got {function_value:?}"),
                 }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -839,6 +839,7 @@ impl<'a> Context<'a> {
                         self.handle_ssa_call_outputs(result_ids, outputs, dfg)?;
                     }
                     Value::ForeignFunction(_) => {
+                        // TODO: Remove this once elaborator is default frontend. This is now caught by a lint inside the frontend.
                         return Err(RuntimeError::UnconstrainedOracleReturnToConstrained {
                             call_stack: self.acir_context.get_call_stack(),
                         })

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -89,8 +89,13 @@ pub(super) fn oracle_not_marked_unconstrained(func: &NoirFunction) -> Option<Res
 pub(super) fn oracle_called_from_constrained_function(
     interner: &NodeInterner,
     called_func: &FuncId,
+    calling_from_constrained_runtime: bool,
     span: Span,
 ) -> Option<ResolverError> {
+    if !calling_from_constrained_runtime {
+        return None;
+    }
+
     let function_attributes = interner.function_attributes(called_func);
     let is_oracle_call =
         function_attributes.function.as_ref().map_or(false, |func| func.is_oracle());

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -10,7 +10,7 @@ use crate::{
         HirExpression, HirLiteral, NodeInterner, NoirFunction, UnaryOp, UnresolvedTypeData,
         Visibility,
     },
-    node_interner::{DefinitionKind, ExprId},
+    node_interner::{DefinitionKind, ExprId, FuncId},
     Type,
 };
 use acvm::AcirField;
@@ -67,6 +67,35 @@ pub(super) fn low_level_function_outside_stdlib(
         func.attributes().function.as_ref().map_or(false, |func| func.is_low_level());
     if !crate_id.is_stdlib() && is_low_level_function {
         Some(ResolverError::LowLevelFunctionOutsideOfStdlib { ident: func.name_ident().clone() })
+    } else {
+        None
+    }
+}
+
+/// Oracle definitions (functions with the `#[oracle]` attribute) must be marked as unconstrained.
+pub(super) fn oracle_not_marked_unconstrained(func: &NoirFunction) -> Option<ResolverError> {
+    let is_oracle_function =
+        func.attributes().function.as_ref().map_or(false, |func| func.is_oracle());
+    if is_oracle_function && !func.def.is_unconstrained {
+        Some(ResolverError::OracleMarkedAsConstrained { ident: func.name_ident().clone() })
+    } else {
+        None
+    }
+}
+
+/// Oracle functions may not be called by constrained functions directly.
+///
+/// In order for a constrained function to call an oracle it must first call through an unconstrained function.
+pub(super) fn oracle_called_from_constrained_function(
+    interner: &NodeInterner,
+    called_func: &FuncId,
+    span: Span,
+) -> Option<ResolverError> {
+    let function_attributes = interner.function_attributes(called_func);
+    let is_oracle_call =
+        function_attributes.function.as_ref().map_or(false, |func| func.is_oracle());
+    if is_oracle_call {
+        Some(ResolverError::UnconstrainedOracleReturnToConstrained { span })
     } else {
         None
     }

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -556,6 +556,7 @@ impl<'context> Elaborator<'context> {
         self.run_lint(|elaborator| {
             lints::unnecessary_pub_return(func, elaborator.pub_allowed(func)).map(Into::into)
         });
+        self.run_lint(|_| lints::oracle_not_marked_unconstrained(func).map(Into::into));
         self.run_lint(|elaborator| {
             lints::low_level_function_outside_stdlib(func, elaborator.crate_id).map(Into::into)
         });

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1158,6 +1158,7 @@ impl<'context> Elaborator<'context> {
                 lints::oracle_called_from_constrained_function(
                     elaborator.interner,
                     &called_func_id,
+                    is_current_func_constrained,
                     span,
                 )
                 .map(Into::into)

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -20,6 +20,7 @@ use crate::hir::def_map::{LocalModuleId, ModuleId};
 
 use crate::ast::{BinaryOpKind, FunctionDefinition, ItemVisibility};
 use crate::hir::resolution::errors::ResolverError;
+use crate::hir_def::expr::HirIdent;
 use crate::hir_def::stmt::HirLetStatement;
 use crate::hir_def::traits::TraitImpl;
 use crate::hir_def::traits::{Trait, TraitConstraint};
@@ -822,6 +823,21 @@ impl NodeInterner {
     /// Returns the module this function was defined within
     pub fn function_module(&self, func: FuncId) -> ModuleId {
         self.function_modules[&func]
+    }
+
+    /// Returns the [`FuncId`] corresponding to the function referred to by `expr_id`
+    pub fn lookup_function_from_expr(&self, expr: &ExprId) -> Option<FuncId> {
+        if let HirExpression::Ident(HirIdent { id, .. }, _) = self.expression(expr) {
+            if let Some(DefinitionKind::Function(func_id)) =
+                self.try_definition(id).map(|def| &def.kind)
+            {
+                Some(*func_id)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 
     /// Returns the interned HIR function corresponding to `func_id`

--- a/test_programs/execution_success/schnorr/src/main.nr
+++ b/test_programs/execution_success/schnorr/src/main.nr
@@ -30,7 +30,7 @@ fn main(
     let pub_key = embedded_curve_ops::EmbeddedCurvePoint { x: pub_key_x, y: pub_key_y, is_infinite: false };
     let valid_signature = verify_signature_noir(pub_key, signature, message2);
     assert(valid_signature);
-    assert_valid_signature(pub_key,signature,message2);
+    assert_valid_signature(pub_key, signature, message2);
 }
 
 // TODO: to put in the stdlib once we have numeric generics


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a new lint inspired by the review of https://github.com/AztecProtocol/aztec-packages/pull/6751 which enforces that oracle functions must be marked as unconstrained.

I've also moved the error for calling an oracle function from a constrained function into the frontend rather than waiting until ACIR gen.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
