### PR TITLE
chore(docs): Supplement Noir Debugger's dependency versions

### DIFF
--- a/docs/docs/tooling/debugger.md
+++ b/docs/docs/tooling/debugger.md
@@ -14,9 +14,8 @@ There are currently two ways of debugging Noir programs:
 
 In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
 
-- Noir 0.xx 
-- Nargo 0.xx
-- vscode-noir 0.xx
+- Noir & Nargo ≥0.28.0
+- Noir's VS Code extension ≥0.0.11
 
 :::info
 At the moment, the debugger supports debugging binary projects, but not contracts.

--- a/docs/versioned_docs/version-v0.28.0/tooling/debugger.md
+++ b/docs/versioned_docs/version-v0.28.0/tooling/debugger.md
@@ -14,9 +14,8 @@ There are currently two ways of debugging Noir programs:
 
 In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
 
-- Noir 0.xx 
-- Nargo 0.xx
-- vscode-noir 0.xx
+- Noir & Nargo ≥0.28.0
+- Noir's VS Code extension ≥0.0.11
 
 :::info
 At the moment, the debugger supports debugging binary projects, but not contracts.

--- a/docs/versioned_docs/version-v0.29.0/tooling/debugger.md
+++ b/docs/versioned_docs/version-v0.29.0/tooling/debugger.md
@@ -14,9 +14,8 @@ There are currently two ways of debugging Noir programs:
 
 In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
 
-- Noir 0.xx 
-- Nargo 0.xx
-- vscode-noir 0.xx
+- Noir & Nargo ≥0.28.0
+- Noir's VS Code extension ≥0.0.11
 
 :::info
 At the moment, the debugger supports debugging binary projects, but not contracts.

--- a/docs/versioned_docs/version-v0.30.0/tooling/debugger.md
+++ b/docs/versioned_docs/version-v0.30.0/tooling/debugger.md
@@ -14,9 +14,8 @@ There are currently two ways of debugging Noir programs:
 
 In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
 
-- Noir 0.xx 
-- Nargo 0.xx
-- vscode-noir 0.xx
+- Noir & Nargo ≥0.28.0
+- Noir's VS Code extension ≥0.0.11
 
 :::info
 At the moment, the debugger supports debugging binary projects, but not contracts.


### PR DESCRIPTION
# Description

## Problem\*

Dependency versions of Noir / Nargo / vscode-noir for using the Noir Debugger are currently listed as "0.xx" in the docs.

## Summary\*

This PR updates to docs to specify the actual versions required:
- Noir & Nargo ≥0.28.0
- Noir's VS Code extension ≥0.0.11

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
