### PR TITLE
fix: error for allocate instructions in acir-gen

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -43,6 +43,8 @@ pub enum RuntimeError {
     UnconstrainedSliceReturnToConstrained { call_stack: CallStack },
     #[error("All `oracle` methods should be wrapped in an unconstrained fn")]
     UnconstrainedOracleReturnToConstrained { call_stack: CallStack },
+    #[error("Could not resolve some references to the array. All references must be resolved at compile time")]
+    UnknownReference { call_stack: CallStack },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,7 +125,8 @@ impl RuntimeError {
             | RuntimeError::NestedSlice { call_stack, .. }
             | RuntimeError::BigIntModulus { call_stack, .. }
             | RuntimeError::UnconstrainedSliceReturnToConstrained { call_stack }
-            | RuntimeError::UnconstrainedOracleReturnToConstrained { call_stack } => call_stack,
+            | RuntimeError::UnconstrainedOracleReturnToConstrained { call_stack }
+            | RuntimeError::UnknownReference { call_stack } => call_stack,
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -682,7 +682,9 @@ impl<'a> Context<'a> {
                 self.handle_array_operation(instruction_id, dfg)?;
             }
             Instruction::Allocate => {
-                unreachable!("Expected all allocate instructions to be removed before acir_gen")
+                return Err(RuntimeError::UnknownReference {
+                    call_stack: self.acir_context.get_call_stack().clone(),
+                });
             }
             Instruction::Store { .. } => {
                 unreachable!("Expected all store instructions to be removed before acir_gen")
@@ -1305,6 +1307,9 @@ impl<'a> Context<'a> {
                     }
                 }
                 Ok(AcirValue::Array(values))
+            }
+            Type::Reference(reference_type) => {
+                self.array_get_value(reference_type.as_ref(), block_id, var_index)
             }
             _ => unreachable!("ICE: Expected an array or numeric but got {ssa_type:?}"),
         }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5175 

## Summary\*
When we cannot resolve some references to an array, its allocate is not simplified and we get a panic.
I changed this to an error message saying that we could not resolve all references from the array.
I believe an error message is better than the panic, however I am not sure whether having remaining allocates only happens because of this case.


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
