### PR TITLE
feat!: add session id to foreign call RPC requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "paste",
  "proptest",
  "rand 0.8.5",
+ "serde",
  "thiserror",
  "tracing",
 ]
@@ -2485,6 +2486,7 @@ dependencies = [
  "noirc_errors",
  "noirc_frontend",
  "noirc_printable_type",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ similar-asserts = "1.5.0"
 tempfile = "3.6.0"
 jsonrpc = { version = "0.16.0", features = ["minreq_http"] }
 flate2 = "1.0.24"
+rand = "0.8.5"
 
 im = { version = "15.1", features = ["serde"] }
 tracing = "0.1.40"

--- a/acvm-repo/acvm/Cargo.toml
+++ b/acvm-repo/acvm/Cargo.toml
@@ -16,6 +16,7 @@ repository.workspace = true
 num-bigint.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+serde.workspace = true
 
 acir.workspace = true
 brillig_vm.workspace = true
@@ -36,7 +37,7 @@ bls12_381 = [
 ]
 
 [dev-dependencies]
-rand = "0.8.5"
+rand.workspace = true
 proptest = "1.2.0"
 paste = "1.0.14"
 ark-bls12-381 = { version = "^0.4.0", default-features = false, features = ["curve"] }

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -13,6 +13,7 @@ use acir::{
 };
 use acvm_blackbox_solver::BlackBoxFunctionSolver;
 use brillig_vm::{FailureReason, MemoryValue, VMStatus, VM};
+use serde::{Deserialize, Serialize};
 
 use crate::{pwg::OpcodeNotSolvable, OpcodeResolutionError};
 
@@ -286,7 +287,7 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
 /// where the result of the foreign call has not yet been provided.
 ///
 /// The caller must resolve this opcode externally based upon the information in the request.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ForeignCallWaitInfo<F> {
     /// An identifier interpreted by the caller process
     pub function: String,

--- a/acvm-repo/brillig/src/foreign_call.rs
+++ b/acvm-repo/brillig/src/foreign_call.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Single output of a [foreign call][crate::Opcode::ForeignCall].
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
 pub enum ForeignCallParam<F> {
     Single(F),
     Array(Vec<F>),

--- a/tooling/acvm_cli/Cargo.toml
+++ b/tooling/acvm_cli/Cargo.toml
@@ -33,6 +33,6 @@ tracing-subscriber.workspace = true
 tracing-appender = "0.2.3"
 
 [dev-dependencies]
-rand = "0.8.5"
+rand.workspace = true
 proptest = "1.2.0"
 paste = "1.0.14"

--- a/tooling/nargo/Cargo.toml
+++ b/tooling/nargo/Cargo.toml
@@ -24,6 +24,7 @@ codespan-reporting.workspace = true
 tracing.workspace = true
 rayon = "1.8.0"
 jsonrpc.workspace = true
+rand.workspace = true
 
 [dev-dependencies]
 # TODO: This dependency is used to generate unit tests for `get_all_paths_in_dir`


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds an `id` field to RPC foreign call requests so that the TriXE is able to maintain separate internal state for different test functions so that Aztec integration tests can be run in parallel. This has necessitated some changes to the request format so this is a breaking change.


The RPC request now looks like

```
'{
    "jsonrpc":"2.0",
    "method":"resolve_foreign_call",
    "params":[{
        "id":3789997497881369652,
        "function": "foo",
        "inputs": [
            "0000000000000000000000000000000000000000000000000000000000000001", 
["0000000000000000000000000000000000000000000000000000000000000001","0000000000000000000000000000000000000000000000000000000000000002"
    ]]
}]}
```

## Additional Context



## Documentation\*

Check one:
- [] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
