### PR TITLE
chore(docs): fix incorrect docs github link in footer

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -109,7 +109,7 @@ export default {
             },
             {
               label: 'Docs GitHub',
-              href: 'https://github.com/noir-lang/docs',
+              href: 'https://github.com/noir-lang/noir/tree/master/docs',
             },
           ],
         },


### PR DESCRIPTION
# Description

## Problem\*

This PR solves a broken link in the project documentation that incorrectly points users to an obsolete GitHub repository URL.

## Summary\*

This change corrects the 'Docs GitHub' hyperlink in the footer of the documentation to direct users to the new correct repository path. Before, the link directed users to [https://github.com/noir-lang/docs](https://github.com/noir-lang/docs), which has been archived. The updated link now correctly points to [https://github.com/noir-lang/noir/tree/master/docs](https://github.com/noir-lang/noir/tree/master/docs).

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
