### PR TITLE
chore: inline `FieldElement.is_negative` and document

### DIFF
--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -174,10 +174,6 @@ impl<F: PrimeField> FieldElement<F> {
         self.0
     }
 
-    fn is_negative(&self) -> bool {
-        self.neg().num_bits() < self.num_bits()
-    }
-
     fn fits_in_u128(&self) -> bool {
         self.num_bits() <= 128
     }
@@ -278,8 +274,12 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
     }
 
     fn to_i128(self) -> i128 {
-        let is_negative = self.is_negative();
+        // Negative integers are represented by the range [p + i128::MIN, p) whilst
+        // positive integers are represented by the range [0, i128::MAX).
+        // We can then differentiate positive from negative values by their MSB.
+        let is_negative = self.neg().num_bits() < self.num_bits();
         let bytes = if is_negative { self.neg() } else { self }.to_be_bytes();
+
         i128::from_be_bytes(bytes[16..32].try_into().unwrap()) * if is_negative { -1 } else { 1 }
     }
 

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -279,7 +279,6 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
         // We can then differentiate positive from negative values by their MSB.
         let is_negative = self.neg().num_bits() < self.num_bits();
         let bytes = if is_negative { self.neg() } else { self }.to_be_bytes();
-
         i128::from_be_bytes(bytes[16..32].try_into().unwrap()) * if is_negative { -1 } else { 1 }
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5174

## Summary\*

This PR inlines `FieldElement.is_negative` into `FieldElement.to_i128` so it can't be misused elsewhere while documenting the reasoning behind it.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
