### PR TITLE
chore: add some property tests to ACVM crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "hex",
  "num-bigint",
+ "proptest",
  "serde",
 ]
 
@@ -47,9 +48,6 @@ dependencies = [
  "brillig_vm",
  "indexmap 1.9.3",
  "num-bigint",
- "paste",
- "proptest",
- "rand 0.8.5",
  "serde",
  "thiserror",
  "tracing",
@@ -67,6 +65,7 @@ dependencies = [
  "libaes",
  "num-bigint",
  "p256",
+ "proptest",
  "sha2",
  "sha3",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ tempfile = "3.6.0"
 jsonrpc = { version = "0.16.0", features = ["minreq_http"] }
 flate2 = "1.0.24"
 rand = "0.8.5"
+proptest = "1.2.0"
 
 im = { version = "15.1", features = ["serde"] }
 tracing = "0.1.40"

--- a/acvm-repo/acir_field/Cargo.toml
+++ b/acvm-repo/acir_field/Cargo.toml
@@ -23,6 +23,9 @@ ark-ff = { version = "^0.4.0", default-features = false }
 
 cfg-if = "1.0.0"
 
+[dev-dependencies]
+proptest.workspace = true
+
 [features]
 bn254 = []
 bls12_381 = ["dep:ark-bls12-381"]

--- a/acvm-repo/acir_field/proptest-regressions/field_element.txt
+++ b/acvm-repo/acir_field/proptest-regressions/field_element.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c1b2755b427c874de3ee55c2969e8adc1b4b0331a28173e9e1e492b3fee6b7b7 # shrinks to hex = "3a0aaaa0aa0aaa00000aaaaaaaa0000a000aaa0a00a0000aa00a00aa0a000a0a"

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -426,6 +426,7 @@ fn superscript(n: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::{AcirField, FieldElement};
+    use proptest::prelude::*;
 
     #[test]
     fn serialize_fixed_test_vectors() {
@@ -444,23 +445,35 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_even_and_odd_length_hex() {
-        // Test cases of (odd, even) length hex strings
-        let hex_strings =
-            vec![("0x0", "0x00"), ("0x1", "0x01"), ("0x002", "0x0002"), ("0x00003", "0x000003")];
-        for (i, case) in hex_strings.into_iter().enumerate() {
-            let i_field_element = FieldElement::<ark_bn254::Fr>::from(i as i128);
-            let odd_field_element = FieldElement::<ark_bn254::Fr>::from_hex(case.0).unwrap();
-            let even_field_element = FieldElement::<ark_bn254::Fr>::from_hex(case.1).unwrap();
-
-            assert_eq!(i_field_element, odd_field_element);
-            assert_eq!(odd_field_element, even_field_element);
-        }
-    }
-
-    #[test]
     fn max_num_bits_smoke() {
         let max_num_bits_bn254 = FieldElement::<ark_bn254::Fr>::max_num_bits();
         assert_eq!(max_num_bits_bn254, 254);
+    }
+
+    proptest! {
+        // This currently panics due to the fact that we allow inputs which are greater than the field modulus,
+        // automatically reducing them to fit within the canonical range.
+        #[test]
+        #[should_panic(expected = "serialized field element is not equal to input")]
+        fn recovers_original_hex_string(hex in "[0-9a-f]{64}") {
+            let fe: FieldElement::<ark_bn254::Fr> = FieldElement::from_hex(&hex).expect("should accept any 32 byte hex string");
+            let output_hex = fe.to_hex();
+
+            prop_assert_eq!(hex, output_hex, "serialized field element is not equal to input");
+        }
+
+        #[test]
+        fn accepts_odd_length_hex_strings(hex in "(?:0x)[0-9a-fA-F]+") {
+            // Here we inject a "0" immediately after the "0x" (if it exists) to construct an equivalent
+            // hex string with the opposite parity length.
+            let insert_index = if hex.starts_with("0x") { 2 } else { 0 };
+            let mut opposite_parity_string = hex.to_string();
+            opposite_parity_string.insert(insert_index, '0');
+
+            let fe_1: FieldElement::<ark_bn254::Fr> = FieldElement::from_hex(&hex).unwrap();
+            let fe_2: FieldElement::<ark_bn254::Fr> = FieldElement::from_hex(&opposite_parity_string).unwrap();
+
+            prop_assert_eq!(fe_1, fe_2, "equivalent hex strings with opposite parity deserialized to different values");
+        }
     }
 }

--- a/acvm-repo/acvm/Cargo.toml
+++ b/acvm-repo/acvm/Cargo.toml
@@ -37,7 +37,4 @@ bls12_381 = [
 ]
 
 [dev-dependencies]
-rand.workspace = true
-proptest = "1.2.0"
-paste = "1.0.14"
 ark-bls12-381 = { version = "^0.4.0", default-features = false, features = ["curve"] }

--- a/acvm-repo/blackbox_solver/Cargo.toml
+++ b/acvm-repo/blackbox_solver/Cargo.toml
@@ -39,6 +39,9 @@ p256 = { version = "0.11.0", features = [
 
 libaes = "0.7.0"
 
+[dev-dependencies]
+proptest.workspace = true
+
 [features]
 bn254 = ["acir/bn254"]
 bls12_381 = ["acir/bls12_381"]

--- a/acvm-repo/blackbox_solver/src/logic.rs
+++ b/acvm-repo/blackbox_solver/src/logic.rs
@@ -68,20 +68,32 @@ fn mask_vector_le(bytes: &mut [u8], num_bits: usize) {
 
 #[cfg(test)]
 mod tests {
-    use acir::{AcirField, FieldElement};
+    use acir::FieldElement;
+    use proptest::prelude::*;
 
-    use crate::bit_and;
+    use crate::{bit_and, bit_xor};
 
-    #[test]
-    fn and() {
-        let max = 10_000u32;
+    proptest! {
+        #[test]
+        fn matches_bitwise_and_on_u128s(x in 0..=u128::MAX, y in 0..=u128::MAX, bit_size in 128u32..) {
+            let x_as_field = FieldElement::from(x);
+            let y_as_field = FieldElement::from(y);
 
-        let num_bits = (std::mem::size_of::<u32>() * 8) as u32 - max.leading_zeros();
+            let x_and_y = x & y;
+            let x_and_y_as_field = bit_and(x_as_field, y_as_field, bit_size);
 
-        for x in 0..max {
-            let x = FieldElement::from(x as i128);
-            let res = bit_and(x, x, num_bits);
-            assert_eq!(res.to_be_bytes(), x.to_be_bytes());
+            prop_assert_eq!(x_and_y_as_field, FieldElement::from(x_and_y), "AND on fields should match that on integers");
+        }
+
+        #[test]
+        fn matches_bitwise_xor_on_u128s(x in 0..=u128::MAX, y in 0..=u128::MAX, bit_size in 128u32..) {
+            let x_as_field = FieldElement::from(x);
+            let y_as_field = FieldElement::from(y);
+
+            let x_xor_y = x ^ y;
+            let x_xor_y_as_field = bit_xor(x_as_field, y_as_field, bit_size);
+
+            prop_assert_eq!(x_xor_y_as_field, FieldElement::from(x_xor_y), "AND on fields should match that on integers");
         }
     }
 }

--- a/acvm-repo/blackbox_solver/src/logic.rs
+++ b/acvm-repo/blackbox_solver/src/logic.rs
@@ -93,7 +93,7 @@ mod tests {
             let x_xor_y = x ^ y;
             let x_xor_y_as_field = bit_xor(x_as_field, y_as_field, bit_size);
 
-            prop_assert_eq!(x_xor_y_as_field, FieldElement::from(x_xor_y), "AND on fields should match that on integers");
+            prop_assert_eq!(x_xor_y_as_field, FieldElement::from(x_xor_y), "XOR on fields should match that on integers");
         }
     }
 }

--- a/cspell.json
+++ b/cspell.json
@@ -157,6 +157,7 @@
         "preprocess",
         "prettytable",
         "printstd",
+        "proptest",
         "pseudocode",
         "pubkey",
         "quantile",


### PR DESCRIPTION
# Description

## Problem\*

Related to #5173 

## Summary\*

This PR adds some usage of the `proptest` crate into ACVM crates to replace some smoke-tests which use hardcoded values.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
