### PR TITLE
chore: fixing all relative paths

### DIFF
--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = &[];
 ```

--- a/docs/docs/noir/concepts/data_types/booleans.md
+++ b/docs/docs/noir/concepts/data_types/booleans.md
@@ -24,5 +24,5 @@ fn main() {
 ```
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/docs/noir/concepts/data_types/strings.md
+++ b/docs/docs/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/docs/noir/concepts/generics.md
+++ b/docs/docs/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/docs/noir/concepts/unconstrained.md
+++ b/docs/docs/noir/concepts/unconstrained.md
@@ -96,4 +96,4 @@ Generally we want to use brillig whenever there's something that's easy to verif
 
 ## Break and Continue
 
-In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow/#break-and-continue)
+In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow.md#break-and-continue)

--- a/docs/docs/noir/modules_packages_crates/dependencies.md
+++ b/docs/docs/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/docs/noir/standard_library/black_box_fns.md
+++ b/docs/docs/noir/standard_library/black_box_fns.md
@@ -25,7 +25,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/docs/noir/standard_library/recursion.md
+++ b/docs/docs/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ pub fn verify_proof(verification_key: [Field], proof: [Field], public_inputs: [F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/docs/tooling/debugger.md
+++ b/docs/docs/tooling/debugger.md
@@ -12,7 +12,7 @@ There are currently two ways of debugging Noir programs:
 1. From VS Code, via the [vscode-noir](https://github.com/noir-lang/vscode-noir) extension. You can install it via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir).
 2. Via the REPL debugger, which ships with Nargo.
 
-In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
+In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation/index.md) and vscode-noir:
 
 - Noir & Nargo ≥0.28.0
 - Noir's VS Code extension ≥0.0.11

--- a/docs/versioned_docs/version-v0.17.0/getting_started/01_hello_world.md
+++ b/docs/versioned_docs/version-v0.17.0/getting_started/01_hello_world.md
@@ -74,7 +74,7 @@ x : Field, y : pub Field
 
 Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the
 keyword `pub` (e.g. `y`). To learn more about private and public values, check the
-[Data Types](../language_concepts/data_types) section.
+[Data Types](../language_concepts/data_types.md) section.
 
 The next line of the program specifies its body:
 
@@ -84,7 +84,7 @@ assert(x != y);
 
 The Noir syntax `assert` can be interpreted as something similar to constraints in other zk-contract languages.
 
-For more Noir syntax, check the [Language Concepts](../language_concepts/comments) chapter.
+For more Noir syntax, check the [Language Concepts](../language_concepts/comments.md) chapter.
 
 ## Build In/Output Files
 

--- a/docs/versioned_docs/version-v0.17.0/getting_started/02_breakdown.md
+++ b/docs/versioned_docs/version-v0.17.0/getting_started/02_breakdown.md
@@ -51,7 +51,7 @@ license = "MIT"
 ecrecover = {tag = "v0.9.0", git = "https://github.com/colinnielsen/ecrecover-noir.git"}
 ```
 
-Nargo.toml for a [workspace](../modules_packages_crates/workspaces) will look a bit different. For example:
+Nargo.toml for a [workspace](../modules_packages_crates/workspaces.md) will look a bit different. For example:
 
 ```toml
 [workspace]
@@ -74,7 +74,7 @@ The package section requires a number of fields including:
 
 #### Dependencies section
 
-This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies) for more info.
+This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies.md)for more info.
 
 `./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
 verifier contract respectively.

--- a/docs/versioned_docs/version-v0.17.0/index.md
+++ b/docs/versioned_docs/version-v0.17.0/index.md
@@ -34,7 +34,7 @@ Noir can be used for a variety of purposes.
 ### Solidity Developers
 
 Noir currently includes a command to create a Solidity contract which verifies your Noir program. This will
-be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier) command to create
+be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands.md#nargo-codegen-verifier) command to create
 a verifier contract.
 
 ### Protocol Developers
@@ -96,4 +96,4 @@ Some libraries that are available today include:
 - [Signed Int](https://github.com/resurgencelabs/signed_int) - a library for accessing a custom Signed Integer data type, allowing access to negative numbers on Noir
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
 
-See the section on [dependencies](./modules_packages_crates/dependencies) for more information.
+See the section on [dependencies](./modules_packages_crates/dependencies.md) for more information.

--- a/docs/versioned_docs/version-v0.17.0/language_concepts/data_types/02_booleans.md
+++ b/docs/versioned_docs/version-v0.17.0/language_concepts/data_types/02_booleans.md
@@ -26,5 +26,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.17.0/language_concepts/data_types/03_strings.md
+++ b/docs/versioned_docs/version-v0.17.0/language_concepts/data_types/03_strings.md
@@ -16,7 +16,7 @@ keywords:
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`std::println()`. See more about [Logging](../../standard_library/logging).
+`std::println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.17.0/language_concepts/data_types/04_arrays.md
+++ b/docs/versioned_docs/version-v0.17.0/language_concepts/data_types/04_arrays.md
@@ -56,7 +56,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];

--- a/docs/versioned_docs/version-v0.17.0/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.17.0/modules_packages_crates/dependencies.md
@@ -81,14 +81,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.17.0/nargo/01_commands.md
+++ b/docs/versioned_docs/version-v0.17.0/nargo/01_commands.md
@@ -213,7 +213,7 @@ you run `nargo test`. To print `println` statements in tests, use the `--show-ou
 
 Takes an optional `--exact` flag which allows you to select tests based on an exact name.
 
-See an example on the [testing page](./testing).
+See an example on the [testing page](./testing.md).
 
 ### Options
 

--- a/docs/versioned_docs/version-v0.17.0/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.17.0/standard_library/black_box_fns.md
@@ -26,19 +26,19 @@ fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 Here is a list of the current black box functions that are supported by UltraPlonk:
 
 - AES
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Pedersen](./cryptographic_primitives/hashes#pedersen)
-- [HashToField128Security](./cryptographic_primitives/hashes#hash_to_field)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Pedersen](./cryptographic_primitives/hashes.mdx#pedersen)
+- [HashToField128Security](./cryptographic_primitives/hashes.mdx#hash_to_field)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
+- [Compute merkle root](./merkle_trees.md#compute_merkle_root)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
 

--- a/docs/versioned_docs/version-v0.17.0/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.17.0/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.19.0/getting_started/01_hello_world.md
+++ b/docs/versioned_docs/version-v0.19.0/getting_started/01_hello_world.md
@@ -74,7 +74,7 @@ x : Field, y : pub Field
 
 Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the
 keyword `pub` (e.g. `y`). To learn more about private and public values, check the
-[Data Types](../language_concepts/data_types) section.
+[Data Types](../language_concepts/data_types.md) section.
 
 The next line of the program specifies its body:
 
@@ -84,7 +84,7 @@ assert(x != y);
 
 The Noir syntax `assert` can be interpreted as something similar to constraints in other zk-contract languages.
 
-For more Noir syntax, check the [Language Concepts](../language_concepts/comments) chapter.
+For more Noir syntax, check the [Language Concepts](../language_concepts/comments.md) chapter.
 
 ## Build In/Output Files
 

--- a/docs/versioned_docs/version-v0.19.0/getting_started/02_breakdown.md
+++ b/docs/versioned_docs/version-v0.19.0/getting_started/02_breakdown.md
@@ -51,7 +51,7 @@ license = "MIT"
 ecrecover = {tag = "v0.9.0", git = "https://github.com/colinnielsen/ecrecover-noir.git"}
 ```
 
-Nargo.toml for a [workspace](../modules_packages_crates/workspaces) will look a bit different. For example:
+Nargo.toml for a [workspace](../modules_packages_crates/workspaces.md) will look a bit different. For example:
 
 ```toml
 [workspace]
@@ -74,7 +74,7 @@ The package section requires a number of fields including:
 
 #### Dependencies section
 
-This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies) for more info.
+This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies.md)for more info.
 
 `./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
 verifier contract respectively.

--- a/docs/versioned_docs/version-v0.19.0/index.md
+++ b/docs/versioned_docs/version-v0.19.0/index.md
@@ -34,7 +34,7 @@ Noir can be used for a variety of purposes.
 ### Solidity Developers
 
 Noir currently includes a command to create a Solidity contract which verifies your Noir program. This will
-be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier) command to create
+be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier.md) command to create
 a verifier contract.
 
 ### Protocol Developers
@@ -97,4 +97,4 @@ Some libraries that are available today include:
 - [Signed Int](https://github.com/resurgencelabs/signed_int) - a library for accessing a custom Signed Integer data type, allowing access to negative numbers on Noir
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
 
-See the section on [dependencies](./modules_packages_crates/dependencies) for more information.
+See the section on [dependencies](./modules_packages_crates/dependencies.md) for more information.

--- a/docs/versioned_docs/version-v0.19.0/language_concepts/data_types/02_booleans.md
+++ b/docs/versioned_docs/version-v0.19.0/language_concepts/data_types/02_booleans.md
@@ -26,5 +26,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.19.0/language_concepts/data_types/03_strings.md
+++ b/docs/versioned_docs/version-v0.19.0/language_concepts/data_types/03_strings.md
@@ -16,7 +16,7 @@ keywords:
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`std::println()`. See more about [Logging](../../standard_library/logging).
+`std::println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.19.0/language_concepts/data_types/04_arrays.md
+++ b/docs/versioned_docs/version-v0.19.0/language_concepts/data_types/04_arrays.md
@@ -56,7 +56,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];

--- a/docs/versioned_docs/version-v0.19.0/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.19.0/modules_packages_crates/dependencies.md
@@ -81,14 +81,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.19.0/nargo/01_commands.md
+++ b/docs/versioned_docs/version-v0.19.0/nargo/01_commands.md
@@ -213,7 +213,7 @@ you run `nargo test`. To print `println` statements in tests, use the `--show-ou
 
 Takes an optional `--exact` flag which allows you to select tests based on an exact name.
 
-See an example on the [testing page](./testing).
+See an example on the [testing page](./testing.md).
 
 ### Options
 

--- a/docs/versioned_docs/version-v0.19.0/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.19.0/standard_library/black_box_fns.md
@@ -26,20 +26,20 @@ fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 Here is a list of the current black box functions that are supported by UltraPlonk:
 
 - AES
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
-- [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
-- [HashToField128Security](./cryptographic_primitives/hashes#hash_to_field)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Pedersen Hash](./cryptographic_primitives/hashes.mdx#pedersen_hash)
+- [Pedersen Commitment](./cryptographic_primitives/hashes.mdx#pedersen_commitment)
+- [HashToField128Security](./cryptographic_primitives/hashes.mdx#hash_to_field)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
+- [Compute merkle root](./merkle_trees.md#compute_merkle_root)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
 

--- a/docs/versioned_docs/version-v0.19.0/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.19.0/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.19.1/getting_started/01_hello_world.md
+++ b/docs/versioned_docs/version-v0.19.1/getting_started/01_hello_world.md
@@ -74,7 +74,7 @@ x : Field, y : pub Field
 
 Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the
 keyword `pub` (e.g. `y`). To learn more about private and public values, check the
-[Data Types](../language_concepts/data_types) section.
+[Data Types](../language_concepts/data_types.md) section.
 
 The next line of the program specifies its body:
 
@@ -84,7 +84,7 @@ assert(x != y);
 
 The Noir syntax `assert` can be interpreted as something similar to constraints in other zk-contract languages.
 
-For more Noir syntax, check the [Language Concepts](../language_concepts/comments) chapter.
+For more Noir syntax, check the [Language Concepts](../language_concepts/comments.md) chapter.
 
 ## Build In/Output Files
 

--- a/docs/versioned_docs/version-v0.19.1/getting_started/02_breakdown.md
+++ b/docs/versioned_docs/version-v0.19.1/getting_started/02_breakdown.md
@@ -51,7 +51,7 @@ license = "MIT"
 ecrecover = {tag = "v0.9.0", git = "https://github.com/colinnielsen/ecrecover-noir.git"}
 ```
 
-Nargo.toml for a [workspace](../modules_packages_crates/workspaces) will look a bit different. For example:
+Nargo.toml for a [workspace](../modules_packages_crates/workspaces.md) will look a bit different. For example:
 
 ```toml
 [workspace]
@@ -74,7 +74,7 @@ The package section requires a number of fields including:
 
 #### Dependencies section
 
-This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies) for more info.
+This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies.md)for more info.
 
 `./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
 verifier contract respectively.

--- a/docs/versioned_docs/version-v0.19.1/index.md
+++ b/docs/versioned_docs/version-v0.19.1/index.md
@@ -34,7 +34,7 @@ Noir can be used for a variety of purposes.
 ### Solidity Developers
 
 Noir currently includes a command to create a Solidity contract which verifies your Noir program. This will
-be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier) command to create
+be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier.md) command to create
 a verifier contract.
 
 ### Protocol Developers
@@ -97,4 +97,4 @@ Some libraries that are available today include:
 - [Signed Int](https://github.com/resurgencelabs/signed_int) - a library for accessing a custom Signed Integer data type, allowing access to negative numbers on Noir
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
 
-See the section on [dependencies](./modules_packages_crates/dependencies) for more information.
+See the section on [dependencies](./modules_packages_crates/dependencies.md) for more information.

--- a/docs/versioned_docs/version-v0.19.1/language_concepts/data_types/02_booleans.md
+++ b/docs/versioned_docs/version-v0.19.1/language_concepts/data_types/02_booleans.md
@@ -26,5 +26,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.19.1/language_concepts/data_types/03_strings.md
+++ b/docs/versioned_docs/version-v0.19.1/language_concepts/data_types/03_strings.md
@@ -16,7 +16,7 @@ keywords:
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`std::println()`. See more about [Logging](../../standard_library/logging).
+`std::println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.19.1/language_concepts/data_types/04_arrays.md
+++ b/docs/versioned_docs/version-v0.19.1/language_concepts/data_types/04_arrays.md
@@ -56,7 +56,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];

--- a/docs/versioned_docs/version-v0.19.1/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.19.1/modules_packages_crates/dependencies.md
@@ -81,14 +81,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.19.1/nargo/01_commands.md
+++ b/docs/versioned_docs/version-v0.19.1/nargo/01_commands.md
@@ -213,7 +213,7 @@ you run `nargo test`. To print `println` statements in tests, use the `--show-ou
 
 Takes an optional `--exact` flag which allows you to select tests based on an exact name.
 
-See an example on the [testing page](./testing).
+See an example on the [testing page](./testing.md).
 
 ### Options
 

--- a/docs/versioned_docs/version-v0.19.1/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.19.1/standard_library/black_box_fns.md
@@ -26,20 +26,20 @@ fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 Here is a list of the current black box functions that are supported by UltraPlonk:
 
 - AES
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
-- [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
-- [HashToField128Security](./cryptographic_primitives/hashes#hash_to_field)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Pedersen Hash](./cryptographic_primitives/hashes.mdx#pedersen_hash)
+- [Pedersen Commitment](./cryptographic_primitives/hashes.mdx#pedersen_commitment)
+- [HashToField128Security](./cryptographic_primitives/hashes.mdx#hash_to_field)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
+- [Compute merkle root](./merkle_trees.md#compute_merkle_root)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
 

--- a/docs/versioned_docs/version-v0.19.1/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.19.1/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.19.2/getting_started/01_hello_world.md
+++ b/docs/versioned_docs/version-v0.19.2/getting_started/01_hello_world.md
@@ -74,7 +74,7 @@ x : Field, y : pub Field
 
 Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the
 keyword `pub` (e.g. `y`). To learn more about private and public values, check the
-[Data Types](../language_concepts/data_types) section.
+[Data Types](../language_concepts/data_types.md) section.
 
 The next line of the program specifies its body:
 
@@ -84,7 +84,7 @@ assert(x != y);
 
 The Noir syntax `assert` can be interpreted as something similar to constraints in other zk-contract languages.
 
-For more Noir syntax, check the [Language Concepts](../language_concepts/comments) chapter.
+For more Noir syntax, check the [Language Concepts](../language_concepts/comments.md) chapter.
 
 ## Build In/Output Files
 

--- a/docs/versioned_docs/version-v0.19.2/getting_started/02_breakdown.md
+++ b/docs/versioned_docs/version-v0.19.2/getting_started/02_breakdown.md
@@ -51,7 +51,7 @@ license = "MIT"
 ecrecover = {tag = "v0.9.0", git = "https://github.com/colinnielsen/ecrecover-noir.git"}
 ```
 
-Nargo.toml for a [workspace](../modules_packages_crates/workspaces) will look a bit different. For example:
+Nargo.toml for a [workspace](../modules_packages_crates/workspaces.md) will look a bit different. For example:
 
 ```toml
 [workspace]
@@ -74,7 +74,7 @@ The package section requires a number of fields including:
 
 #### Dependencies section
 
-This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies) for more info.
+This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies.md)for more info.
 
 `./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
 verifier contract respectively.

--- a/docs/versioned_docs/version-v0.19.2/index.md
+++ b/docs/versioned_docs/version-v0.19.2/index.md
@@ -34,7 +34,7 @@ Noir can be used for a variety of purposes.
 ### Solidity Developers
 
 Noir currently includes a command to create a Solidity contract which verifies your Noir program. This will
-be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier) command to create
+be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier.md) command to create
 a verifier contract.
 
 ### Protocol Developers
@@ -97,4 +97,4 @@ Some libraries that are available today include:
 - [Signed Int](https://github.com/resurgencelabs/signed_int) - a library for accessing a custom Signed Integer data type, allowing access to negative numbers on Noir
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
 
-See the section on [dependencies](./modules_packages_crates/dependencies) for more information.
+See the section on [dependencies](./modules_packages_crates/dependencies.md) for more information.

--- a/docs/versioned_docs/version-v0.19.2/language_concepts/data_types/02_booleans.md
+++ b/docs/versioned_docs/version-v0.19.2/language_concepts/data_types/02_booleans.md
@@ -26,5 +26,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.19.2/language_concepts/data_types/03_strings.md
+++ b/docs/versioned_docs/version-v0.19.2/language_concepts/data_types/03_strings.md
@@ -16,7 +16,7 @@ keywords:
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`std::println()`. See more about [Logging](../../standard_library/logging).
+`std::println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.19.2/language_concepts/data_types/04_arrays.md
+++ b/docs/versioned_docs/version-v0.19.2/language_concepts/data_types/04_arrays.md
@@ -56,7 +56,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];

--- a/docs/versioned_docs/version-v0.19.2/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.19.2/modules_packages_crates/dependencies.md
@@ -81,14 +81,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.19.2/nargo/01_commands.md
+++ b/docs/versioned_docs/version-v0.19.2/nargo/01_commands.md
@@ -213,7 +213,7 @@ you run `nargo test`. To print `println` statements in tests, use the `--show-ou
 
 Takes an optional `--exact` flag which allows you to select tests based on an exact name.
 
-See an example on the [testing page](./testing).
+See an example on the [testing page](./testing.md).
 
 ### Options
 

--- a/docs/versioned_docs/version-v0.19.2/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.19.2/standard_library/black_box_fns.md
@@ -26,20 +26,20 @@ fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 Here is a list of the current black box functions that are supported by UltraPlonk:
 
 - AES
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
-- [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
-- [HashToField128Security](./cryptographic_primitives/hashes#hash_to_field)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Pedersen Hash](./cryptographic_primitives/hashes.mdx#pedersen_hash)
+- [Pedersen Commitment](./cryptographic_primitives/hashes.mdx#pedersen_commitment)
+- [HashToField128Security](./cryptographic_primitives/hashes.mdx#hash_to_field)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
+- [Compute merkle root](./merkle_trees.md#compute_merkle_root)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
 

--- a/docs/versioned_docs/version-v0.19.2/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.19.2/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.19.3/getting_started/01_hello_world.md
+++ b/docs/versioned_docs/version-v0.19.3/getting_started/01_hello_world.md
@@ -74,7 +74,7 @@ x : Field, y : pub Field
 
 Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the
 keyword `pub` (e.g. `y`). To learn more about private and public values, check the
-[Data Types](../language_concepts/data_types) section.
+[Data Types](../language_concepts/data_types.md) section.
 
 The next line of the program specifies its body:
 
@@ -84,7 +84,7 @@ assert(x != y);
 
 The Noir syntax `assert` can be interpreted as something similar to constraints in other zk-contract languages.
 
-For more Noir syntax, check the [Language Concepts](../language_concepts/comments) chapter.
+For more Noir syntax, check the [Language Concepts](../language_concepts/comments.md) chapter.
 
 ## Build In/Output Files
 

--- a/docs/versioned_docs/version-v0.19.3/getting_started/02_breakdown.md
+++ b/docs/versioned_docs/version-v0.19.3/getting_started/02_breakdown.md
@@ -51,7 +51,7 @@ license = "MIT"
 ecrecover = {tag = "v0.9.0", git = "https://github.com/colinnielsen/ecrecover-noir.git"}
 ```
 
-Nargo.toml for a [workspace](../modules_packages_crates/workspaces) will look a bit different. For example:
+Nargo.toml for a [workspace](../modules_packages_crates/workspaces.md) will look a bit different. For example:
 
 ```toml
 [workspace]
@@ -74,7 +74,7 @@ The package section requires a number of fields including:
 
 #### Dependencies section
 
-This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies) for more info.
+This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies.md)for more info.
 
 `./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
 verifier contract respectively.

--- a/docs/versioned_docs/version-v0.19.3/index.md
+++ b/docs/versioned_docs/version-v0.19.3/index.md
@@ -34,7 +34,7 @@ Noir can be used for a variety of purposes.
 ### Solidity Developers
 
 Noir currently includes a command to create a Solidity contract which verifies your Noir program. This will
-be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier) command to create
+be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier.md) command to create
 a verifier contract.
 
 ### Protocol Developers
@@ -97,4 +97,4 @@ Some libraries that are available today include:
 - [Signed Int](https://github.com/resurgencelabs/signed_int) - a library for accessing a custom Signed Integer data type, allowing access to negative numbers on Noir
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
 
-See the section on [dependencies](./modules_packages_crates/dependencies) for more information.
+See the section on [dependencies](./modules_packages_crates/dependencies.md) for more information.

--- a/docs/versioned_docs/version-v0.19.3/language_concepts/data_types/02_booleans.md
+++ b/docs/versioned_docs/version-v0.19.3/language_concepts/data_types/02_booleans.md
@@ -26,5 +26,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.19.3/language_concepts/data_types/03_strings.md
+++ b/docs/versioned_docs/version-v0.19.3/language_concepts/data_types/03_strings.md
@@ -16,7 +16,7 @@ keywords:
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`std::println()`. See more about [Logging](../../standard_library/logging).
+`std::println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.19.3/language_concepts/data_types/04_arrays.md
+++ b/docs/versioned_docs/version-v0.19.3/language_concepts/data_types/04_arrays.md
@@ -56,7 +56,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];

--- a/docs/versioned_docs/version-v0.19.3/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.19.3/modules_packages_crates/dependencies.md
@@ -81,14 +81,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.19.3/nargo/01_commands.md
+++ b/docs/versioned_docs/version-v0.19.3/nargo/01_commands.md
@@ -213,7 +213,7 @@ you run `nargo test`. To print `println` statements in tests, use the `--show-ou
 
 Takes an optional `--exact` flag which allows you to select tests based on an exact name.
 
-See an example on the [testing page](./testing).
+See an example on the [testing page](./testing.md).
 
 ### Options
 

--- a/docs/versioned_docs/version-v0.19.3/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.19.3/standard_library/black_box_fns.md
@@ -26,20 +26,20 @@ fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 Here is a list of the current black box functions that are supported by UltraPlonk:
 
 - AES
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
-- [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
-- [HashToField128Security](./cryptographic_primitives/hashes#hash_to_field)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Pedersen Hash](./cryptographic_primitives/hashes.mdx#pedersen_hash)
+- [Pedersen Commitment](./cryptographic_primitives/hashes.mdx#pedersen_commitment)
+- [HashToField128Security](./cryptographic_primitives/hashes.mdx#hash_to_field)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
+- [Compute merkle root](./merkle_trees.md#compute_merkle_root)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
 

--- a/docs/versioned_docs/version-v0.19.3/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.19.3/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.19.4/getting_started/01_hello_world.md
+++ b/docs/versioned_docs/version-v0.19.4/getting_started/01_hello_world.md
@@ -74,7 +74,7 @@ x : Field, y : pub Field
 
 Program inputs in Noir are private by default (e.g. `x`), but can be labeled public using the
 keyword `pub` (e.g. `y`). To learn more about private and public values, check the
-[Data Types](../language_concepts/data_types) section.
+[Data Types](../language_concepts/data_types.md) section.
 
 The next line of the program specifies its body:
 
@@ -84,7 +84,7 @@ assert(x != y);
 
 The Noir syntax `assert` can be interpreted as something similar to constraints in other zk-contract languages.
 
-For more Noir syntax, check the [Language Concepts](../language_concepts/comments) chapter.
+For more Noir syntax, check the [Language Concepts](../language_concepts/comments.md) chapter.
 
 ## Build In/Output Files
 

--- a/docs/versioned_docs/version-v0.19.4/getting_started/02_breakdown.md
+++ b/docs/versioned_docs/version-v0.19.4/getting_started/02_breakdown.md
@@ -51,7 +51,7 @@ license = "MIT"
 ecrecover = {tag = "v0.9.0", git = "https://github.com/colinnielsen/ecrecover-noir.git"}
 ```
 
-Nargo.toml for a [workspace](../modules_packages_crates/workspaces) will look a bit different. For example:
+Nargo.toml for a [workspace](../modules_packages_crates/workspaces.md) will look a bit different. For example:
 
 ```toml
 [workspace]
@@ -74,7 +74,7 @@ The package section requires a number of fields including:
 
 #### Dependencies section
 
-This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies) for more info.
+This is where you will specify any dependencies for your project. See the [Dependencies page](../modules_packages_crates/dependencies.md)for more info.
 
 `./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
 verifier contract respectively.

--- a/docs/versioned_docs/version-v0.19.4/index.md
+++ b/docs/versioned_docs/version-v0.19.4/index.md
@@ -34,7 +34,7 @@ Noir can be used for a variety of purposes.
 ### Solidity Developers
 
 Noir currently includes a command to create a Solidity contract which verifies your Noir program. This will
-be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier) command to create
+be modularized in the future; however, as of the alpha, you can use the [`nargo codegen-verifier`](./nargo/commands#nargo-codegen-verifier.md) command to create
 a verifier contract.
 
 ### Protocol Developers
@@ -97,4 +97,4 @@ Some libraries that are available today include:
 - [Signed Int](https://github.com/resurgencelabs/signed_int) - a library for accessing a custom Signed Integer data type, allowing access to negative numbers on Noir
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
 
-See the section on [dependencies](./modules_packages_crates/dependencies) for more information.
+See the section on [dependencies](./modules_packages_crates/dependencies.md) for more information.

--- a/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/02_booleans.md
+++ b/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/02_booleans.md
@@ -26,5 +26,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/03_strings.md
+++ b/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/03_strings.md
@@ -15,7 +15,7 @@ keywords:
 
 The string type is a fixed length value defined with `str<N>`.
 
-You can use strings in `assert()` functions or print them with `std::println()`. See more about [Logging](../../standard_library/logging).
+You can use strings in `assert()` functions or print them with `std::println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/04_arrays.md
+++ b/docs/versioned_docs/version-v0.19.4/language_concepts/data_types/04_arrays.md
@@ -56,7 +56,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];

--- a/docs/versioned_docs/version-v0.19.4/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.19.4/modules_packages_crates/dependencies.md
@@ -81,14 +81,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.19.4/nargo/01_commands.md
+++ b/docs/versioned_docs/version-v0.19.4/nargo/01_commands.md
@@ -213,7 +213,7 @@ you run `nargo test`. To print `println` statements in tests, use the `--show-ou
 
 Takes an optional `--exact` flag which allows you to select tests based on an exact name.
 
-See an example on the [testing page](./testing).
+See an example on the [testing page](./testing.md).
 
 ### Options
 

--- a/docs/versioned_docs/version-v0.19.4/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.19.4/standard_library/black_box_fns.md
@@ -26,20 +26,20 @@ fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 Here is a list of the current black box functions that are supported by UltraPlonk:
 
 - AES
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
-- [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
-- [HashToField128Security](./cryptographic_primitives/hashes#hash_to_field)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Pedersen Hash](./cryptographic_primitives/hashes.mdx#pedersen_hash)
+- [Pedersen Commitment](./cryptographic_primitives/hashes.mdx#pedersen_commitment)
+- [HashToField128Security](./cryptographic_primitives/hashes.mdx#hash_to_field)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
+- [Compute merkle root](./merkle_trees.md#compute_merkle_root)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
 

--- a/docs/versioned_docs/version-v0.19.4/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.19.4/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.22.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.22.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.22.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.22.0/noir/standard_library/black_box_fns.md
@@ -26,20 +26,20 @@ fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 Here is a list of the current black box functions that are supported by UltraPlonk:
 
 - AES
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
-- [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
-- [HashToField128Security](./cryptographic_primitives/hashes#hash_to_field)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
-- [Compute merkle root](./merkle_trees#compute_merkle_root)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Pedersen Hash](./cryptographic_primitives/hashes.mdx#pedersen_hash)
+- [Pedersen Commitment](./cryptographic_primitives/hashes.mdx#pedersen_commitment)
+- [HashToField128Security](./cryptographic_primitives/hashes.mdx#hash_to_field)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
+- [Compute merkle root](./merkle_trees.md#compute_merkle_root)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function. To ensure compatibility across backends, the ACVM has fallback implementations of `AND`, `XOR` and `RANGE` defined in its standard library which it can seamlessly fallback to if the backend doesn't support them.
 

--- a/docs/versioned_docs/version-v0.22.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.22.0/noir/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.22.0/noir/syntax/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.22.0/noir/syntax/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];

--- a/docs/versioned_docs/version-v0.22.0/noir/syntax/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.22.0/noir/syntax/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.22.0/noir/syntax/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.22.0/noir/syntax/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`std::println()`. See more about [Logging](../../standard_library/logging).
+`std::println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = [];
 ```

--- a/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.23.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.23.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/black_box_fns.md
@@ -12,19 +12,19 @@ The ACVM spec defines a set of blackbox functions which backends will be expecte
 
 Here is a list of the current black box functions:
 
-- [SHA256](./cryptographic_primitives/hashes#sha256)
-- [Schnorr signature verification](./cryptographic_primitives/schnorr)
-- [Blake2s](./cryptographic_primitives/hashes#blake2s)
-- [Blake3](./cryptographic_primitives/hashes#blake3)
-- [Pedersen Hash](./cryptographic_primitives/hashes#pedersen_hash)
-- [Pedersen Commitment](./cryptographic_primitives/hashes#pedersen_commitment)
-- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification)
-- [Fixed base scalar multiplication](./cryptographic_primitives/scalar)
+- [SHA256](./cryptographic_primitives/hashes.mdx#sha256)
+- [Schnorr signature verification](./cryptographic_primitives/schnorr.mdx)
+- [Blake2s](./cryptographic_primitives/hashes.mdx#blake2s)
+- [Blake3](./cryptographic_primitives/hashes.mdx#blake3)
+- [Pedersen Hash](./cryptographic_primitives/hashes.mdx#pedersen_hash)
+- [Pedersen Commitment](./cryptographic_primitives/hashes.mdx#pedersen_commitment)
+- [ECDSA signature verification](./cryptographic_primitives/ecdsa_sig_verification.mdx)
+- [Fixed base scalar multiplication](./cryptographic_primitives/scalar.mdx)
 - AND
 - XOR
 - RANGE
-- [Keccak256](./cryptographic_primitives/hashes#keccak256)
-- [Recursive proof verification](./recursion)
+- [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.23.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.23.0/noir/standard_library/recursion.md
@@ -15,7 +15,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.24.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = [];
 ```

--- a/docs/versioned_docs/version-v0.24.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.24.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.24.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.24.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.24.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/standard_library/black_box_fns.md
@@ -24,7 +24,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.24.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.24.0/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.25.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = [];
 ```

--- a/docs/versioned_docs/version-v0.25.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.25.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.25.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.25.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.25.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/standard_library/black_box_fns.md
@@ -24,7 +24,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.25.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.25.0/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ fn verify_proof(_verification_key : [Field], _proof : [Field], _public_input : F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.26.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = &[];
 ```

--- a/docs/versioned_docs/version-v0.26.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.26.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.26.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.26.0/noir/concepts/unconstrained.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/concepts/unconstrained.md
@@ -96,4 +96,4 @@ Generally we want to use brillig whenever there's something that's easy to verif
 
 ## Break and Continue
 
-In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow/#break-and-continue)
+In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow.md#break-and-continue)

--- a/docs/versioned_docs/version-v0.26.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.26.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/standard_library/black_box_fns.md
@@ -24,7 +24,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.26.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.26.0/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ pub fn verify_proof(verification_key: [Field], proof: [Field], public_inputs: [F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.27.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = &[];
 ```

--- a/docs/versioned_docs/version-v0.27.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.27.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.27.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.27.0/noir/concepts/unconstrained.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/concepts/unconstrained.md
@@ -96,4 +96,4 @@ Generally we want to use brillig whenever there's something that's easy to verif
 
 ## Break and Continue
 
-In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow/#break-and-continue)
+In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow.md#break-and-continue)

--- a/docs/versioned_docs/version-v0.27.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.27.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/standard_library/black_box_fns.md
@@ -24,7 +24,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.27.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.27.0/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ pub fn verify_proof(verification_key: [Field], proof: [Field], public_inputs: [F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.28.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = &[];
 ```

--- a/docs/versioned_docs/version-v0.28.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.28.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.28.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.28.0/noir/concepts/unconstrained.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/concepts/unconstrained.md
@@ -96,4 +96,4 @@ Generally we want to use brillig whenever there's something that's easy to verif
 
 ## Break and Continue
 
-In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow/#break-and-continue)
+In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow.md#break-and-continue)

--- a/docs/versioned_docs/version-v0.28.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.28.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/standard_library/black_box_fns.md
@@ -24,7 +24,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.28.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.28.0/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ pub fn verify_proof(verification_key: [Field], proof: [Field], public_inputs: [F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.28.0/tooling/debugger.md
+++ b/docs/versioned_docs/version-v0.28.0/tooling/debugger.md
@@ -12,7 +12,7 @@ There are currently two ways of debugging Noir programs:
 1. From VS Code, via the [vscode-noir](https://github.com/noir-lang/vscode-noir) extension. You can install it via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir).
 2. Via the REPL debugger, which ships with Nargo.
 
-In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
+In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation.md) and vscode-noir:
 
 - Noir & Nargo ≥0.28.0
 - Noir's VS Code extension ≥0.0.11

--- a/docs/versioned_docs/version-v0.29.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = &[];
 ```

--- a/docs/versioned_docs/version-v0.29.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.29.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.29.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.29.0/noir/concepts/unconstrained.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/concepts/unconstrained.md
@@ -96,4 +96,4 @@ Generally we want to use brillig whenever there's something that's easy to verif
 
 ## Break and Continue
 
-In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow/#break-and-continue)
+In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow.md#break-and-continue)

--- a/docs/versioned_docs/version-v0.29.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.29.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/standard_library/black_box_fns.md
@@ -24,7 +24,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.29.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.29.0/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ pub fn verify_proof(verification_key: [Field], proof: [Field], public_inputs: [F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.29.0/tooling/debugger.md
+++ b/docs/versioned_docs/version-v0.29.0/tooling/debugger.md
@@ -12,7 +12,7 @@ There are currently two ways of debugging Noir programs:
 1. From VS Code, via the [vscode-noir](https://github.com/noir-lang/vscode-noir) extension. You can install it via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir).
 2. Via the REPL debugger, which ships with Nargo.
 
-In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
+In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation.md) and vscode-noir:
 
 - Noir & Nargo ≥0.28.0
 - Noir's VS Code extension ≥0.0.11

--- a/docs/versioned_docs/version-v0.30.0/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/concepts/data_types/arrays.md
@@ -57,7 +57,7 @@ You can instantiate a new array of a fixed size with the same value repeated for
 let array: [Field; 32] = [0; 32];
 ```
 
-Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices), you can just call `as_slice` on your array:
+Like in Rust, arrays in Noir are a fixed size. However, if you wish to convert an array to a [slice](./slices.mdx), you can just call `as_slice` on your array:
 
 ```rust
 let array: [Field; 32] = [0; 32];
@@ -70,7 +70,9 @@ You can define multidimensional arrays:
 let array : [[Field; 2]; 2];
 let element = array[0][0];
 ```
+
 However, multidimensional slices are not supported. For example, the following code will error at compile time:
+
 ```rust
 let slice : [[Field]] = &[];
 ```

--- a/docs/versioned_docs/version-v0.30.0/noir/concepts/data_types/booleans.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/concepts/data_types/booleans.md
@@ -27,5 +27,5 @@ fn main() {
 > `false` in _Verifier.toml_.
 
 The boolean type is most commonly used in conditionals like `if` expressions and `assert`
-statements. More about conditionals is covered in the [Control Flow](../control_flow) and
-[Assert Function](../assert) sections.
+statements. More about conditionals is covered in the [Control Flow](../control_flow.md) and
+[Assert Function](../assert.md) sections.

--- a/docs/versioned_docs/version-v0.30.0/noir/concepts/data_types/strings.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/concepts/data_types/strings.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 The string type is a fixed length value defined with `str<N>`.
 
 You can use strings in `assert()` functions or print them with
-`println()`. See more about [Logging](../../standard_library/logging).
+`println()`. See more about [Logging](../../standard_library/logging.md).
 
 ```rust
 use dep::std;

--- a/docs/versioned_docs/version-v0.30.0/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/concepts/generics.md
@@ -73,7 +73,7 @@ impl<N> BigInt<N> {
 Since a generic type `T` can represent any type, how can we call functions on the underlying type?
 In other words, how can we go from "any type `T`" to "any type `T` that has certain methods available?"
 
-This is what [traits](../concepts/traits) are for in Noir. Here's an example of a function generic over
+This is what [traits](../concepts/traits.md) are for in Noir. Here's an example of a function generic over
 any type `T` that implements the `Eq` trait for equality:
 
 ```rust
@@ -103,4 +103,4 @@ impl Eq for MyStruct {
 }
 ```
 
-You can find more details on traits and trait implementations on the [traits page](../concepts/traits).
+You can find more details on traits and trait implementations on the [traits page](../concepts/traits.md).

--- a/docs/versioned_docs/version-v0.30.0/noir/concepts/unconstrained.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/concepts/unconstrained.md
@@ -96,4 +96,4 @@ Generally we want to use brillig whenever there's something that's easy to verif
 
 ## Break and Continue
 
-In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow/#break-and-continue)
+In addition to loops over runtime bounds, `break` and `continue` are also available in unconstrained code. See [break and continue](../concepts/control_flow.md#break-and-continue)

--- a/docs/versioned_docs/version-v0.30.0/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/modules_packages_crates/dependencies.md
@@ -82,14 +82,14 @@ use dep::std::scalar_mul::fixed_base_embedded_curve;
 ```
 
 Lastly, as demonstrated in the
-[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives#examples), you
+[elliptic curve example](../standard_library/cryptographic_primitives/ec_primitives.md#examples), you
 can import multiple items in the same line by enclosing them in curly braces:
 
 ```rust
 use dep::std::ec::tecurve::affine::{Curve, Point};
 ```
 
-We don't have a way to consume libraries from inside a [workspace](./workspaces) as external dependencies right now.
+We don't have a way to consume libraries from inside a [workspace](./workspaces.md) as external dependencies right now.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 

--- a/docs/versioned_docs/version-v0.30.0/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/standard_library/black_box_fns.md
@@ -25,7 +25,7 @@ Here is a list of the current black box functions:
 - XOR
 - RANGE
 - [Keccak256](./cryptographic_primitives/hashes.mdx#keccak256)
-- [Recursive proof verification](./recursion)
+- [Recursive proof verification](./recursion.md)
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 

--- a/docs/versioned_docs/version-v0.30.0/noir/standard_library/recursion.md
+++ b/docs/versioned_docs/version-v0.30.0/noir/standard_library/recursion.md
@@ -35,7 +35,7 @@ pub fn verify_proof(verification_key: [Field], proof: [Field], public_inputs: [F
 
 :::info
 
-This is a black box function. Read [this section](./black_box_fns) to learn more about black box functions in Noir.
+This is a black box function. Read [this section](./black_box_fns.md) to learn more about black box functions in Noir.
 
 :::
 

--- a/docs/versioned_docs/version-v0.30.0/tooling/debugger.md
+++ b/docs/versioned_docs/version-v0.30.0/tooling/debugger.md
@@ -12,7 +12,7 @@ There are currently two ways of debugging Noir programs:
 1. From VS Code, via the [vscode-noir](https://github.com/noir-lang/vscode-noir) extension. You can install it via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir).
 2. Via the REPL debugger, which ships with Nargo.
 
-In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation) and vscode-noir:
+In order to use either version of the debugger, you will need to install recent enough versions of Noir, [Nargo](../getting_started/installation.md) and vscode-noir:
 
 - Noir & Nargo ≥0.28.0
 - Noir's VS Code extension ≥0.0.11


### PR DESCRIPTION
Making the change as per the [docusaurus documentation](https://docusaurus.io/docs/advanced/routing#docs-routing) as this avoids mistakes when for some reason a link comes with a trailing slash, and other benefits