### PR TITLE
fix(elaborator): Fix regression introduced by lazy-global changes

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -333,7 +333,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 "Usage of the `#[foreign]` or `#[builtin]` function attributes are not allowed outside of the Noir standard library".into(),
                 ident.span(),
             ),
-            ResolverError::OracleMarkedAsConstrained { ident } => Diagnostic::simple_error(
+            ResolverError::OracleMarkedAsConstrained { ident } => Diagnostic::simple_warning(
                 error.to_string(),
                 "Oracle functions must have the `unconstrained` keyword applied".into(),
                 ident.span(),

--- a/compiler/noirc_frontend/src/hir/resolution/traits.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/traits.rs
@@ -300,6 +300,7 @@ fn collect_trait_impl(
         let file = def_maps[&crate_id].file_id(trait_impl.module_id);
         let mut resolver = Resolver::new(interner, &path_resolver, def_maps, file);
         resolver.add_generics(&trait_impl.generics);
+
         let typ = resolver.resolve_type(unresolved_type);
         errors.extend(take_errors(trait_impl.file_id, resolver));
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1411,6 +1411,13 @@ impl NodeInterner {
     ) -> Result<(), (Span, FileId)> {
         self.trait_implementations.insert(impl_id, trait_impl.clone());
 
+        // Avoid adding error types to impls since they'll conflict with every other type.
+        // We don't need to return an error since we expect an error to already be issued when
+        // the error type is created.
+        if object_type == Type::Error {
+            return Ok(());
+        }
+
         // Replace each generic with a fresh type variable
         let substitutions = impl_generics
             .into_iter()


### PR DESCRIPTION
# Description

## Problem\*

Fixes a regression introduced by #5191

## Summary\*

When a global is lazily evaluated, the local module id and file id of the elaborator would change without being reset to the previous value. This lead to scoping issues after the global was evaluated.

## Additional Context

I was unable to create a repro for this aside from running `nargo t --use-elaborator` on `aztec-nr` unfortunately.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
