### PR TITLE
fix(elaborator): Fix duplicate methods error

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -232,21 +232,18 @@ impl<'context> Elaborator<'context> {
         // Must resolve structs before we resolve globals.
         this.collect_struct_definitions(items.types);
 
-        // Bind trait impls to their trait. Collect trait functions, that have a
-        // default implementation, which hasn't been overridden.
-        for trait_impl in &mut items.trait_impls {
-            this.collect_trait_impl(trait_impl);
-        }
-
         // Before we resolve any function symbols we must go through our impls and
         // re-collect the methods within into their proper module. This cannot be
         // done during def collection since we need to be able to resolve the type of
         // the impl since that determines the module we should collect into.
-        //
-        // These are resolved after trait impls so that struct methods are chosen
-        // over trait methods if there are name conflicts.
         for ((_self_type, module), impls) in &mut items.impls {
             this.collect_impls(*module, impls);
+        }
+
+        // Bind trait impls to their trait. Collect trait functions, that have a
+        // default implementation, which hasn't been overridden.
+        for trait_impl in &mut items.trait_impls {
+            this.collect_trait_impl(trait_impl);
         }
 
         // We must wait to resolve non-literal globals until after we resolve structs since struct

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1466,6 +1466,7 @@ impl NodeInterner {
         force_type_check: bool,
     ) -> Option<FuncId> {
         let methods = self.struct_methods.get(&(id, method_name.to_owned()));
+
         // If there is only one method, just return it immediately.
         // It will still be typechecked later.
         if !force_type_check {

--- a/test_programs/compile_success_empty/no_duplicate_methods/Nargo.toml
+++ b/test_programs/compile_success_empty/no_duplicate_methods/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "no_duplicate_methods"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/no_duplicate_methods/src/main.nr
+++ b/test_programs/compile_success_empty/no_duplicate_methods/src/main.nr
@@ -1,0 +1,26 @@
+// Test that declaring several methods & trait methods with the same name
+// does not trigger a duplicate method error
+trait ToField {
+    fn to_field(self) -> Field;
+}
+trait ToField2 {
+    fn to_field(self) -> Field;
+}
+
+struct Foo { x: Field }
+
+impl ToField for Foo {
+    fn to_field(self) -> Field { self.x }
+}
+
+impl ToField2 for Foo {
+    fn to_field(self) -> Field { self.x }
+}
+
+impl Foo {
+    fn to_field(self) -> Field {
+        self.x
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
# Description

## Problem\*

Resolves "duplicate method" error when declaring trait methods on different traits with the same method name in the elaborator.

## Summary\*



## Additional Context

This was the last error type in aztec packages for the elaborator. ~~After this, there are still some extra unused variable warnings I will fix but the entire crate tests successfully.~~ Nevermind, looks like aztec-nr just naturally has many unused variables

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
