### PR TITLE
chore: Optimize the elaborator

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -402,6 +402,7 @@ impl<'context> Elaborator<'context> {
         meta.function_body = FunctionBody::Resolved;
 
         self.trait_bounds.clear();
+        self.type_variables.clear();
         self.in_unconstrained_fn = false;
         self.interner.update_fn(id, hir_func);
         self.in_contract = was_in_contract;


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5194

## Summary\*

Fixes a performance issue where the elaborator was ~2x as slow running `nargo t --use-elaborator` on aztec-nr versus the same tests without the elaborator  (4s versus 2s).

Found via flamegraph - `self.type_variables` wasn't cleared after each function was elaborated. This Vec is meant to just store type variables local to a function so that we can check if any need type hints after it is done but since it wasn't cleared out, we'd be checking an increasingly large Vec for each function.

## Additional Context

With this change the elaborator is slightly faster (but not noticeably) than our current code. 1.9 versus 2.0s average across 10 runs for `nargo t` (with lower std. deviation than our current code as well).

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
