### PR TITLE
chore: copy across typo PR script from aztec-packages

### DIFF
--- a/scripts/redo-typo-pr.sh
+++ b/scripts/redo-typo-pr.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eux
+
+# Configuration
+ORIGINAL_PR_NUMBER=$1
+REPO='noir-lang/noir'
+NEW_BRANCH="chore/typo-redo-$ORIGINAL_PR_NUMBER"
+AUTHOR=`gh pr view $ORIGINAL_PR_NUMBER --json author --jq '.author.login'`
+
+# Step 1: Checkout the PR locally
+echo "Checking out PR #$ORIGINAL_PR_NUMBER"
+gh pr checkout $ORIGINAL_PR_NUMBER
+
+# Step 2: Create a new local branch
+echo "Creating new local branch $NEW_BRANCH"
+git checkout -b $NEW_BRANCH
+
+# Step 3: Push the new branch to GitHub
+echo "Pushing new branch $NEW_BRANCH to GitHub"
+git commit --amend --no-edit
+git push origin $NEW_BRANCH
+
+# Step 4: create a new pull request
+echo "Creating a new pull request for $NEW_BRANCH"
+gh pr create --base master --head $NEW_BRANCH --title "chore: redo typo PR by $AUTHOR" --body "Thanks $AUTHOR for https://github.com/$REPO/pull/$ORIGINAL_PR_NUMBER. Our policy is to redo typo changes to dissuade metric farming. This is an automated script."
+
+# Step 5: Close the original PR
+echo "Closing original PR #$ORIGINAL_PR_NUMBER"
+gh pr close $ORIGINAL_PR_NUMBER
+
+echo "Script completed."


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR pulls across the typo PR script from aztec-packages so we can use it here as well.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
