### PR TITLE
chore: replace `is_bn254` which doesn't rely on truncation of literals

### DIFF
--- a/noir_stdlib/src/compat.nr
+++ b/noir_stdlib/src/compat.nr
@@ -1,4 +1,18 @@
+global BN254_MODULUS_BE_BYTES: [u8; 32] =[
+    48, 100, 78, 114, 225, 49, 160, 41, 184, 80, 69, 182, 129, 129, 88, 93, 40, 51, 232, 72, 121, 185, 112, 145, 67, 225, 245, 147, 240, 0, 0, 1
+];
+
 pub fn is_bn254() -> bool {
-    // bn254 truncates its curve order to 0
-    21888242871839275222246405745257275088548364400416034343698204186575808495617 == 0
+    // TODO: refactor this once https://github.com/noir-lang/noir/issues/5245 is resolved.
+    let modulus_bytes = dep::std::field::modulus_be_bytes();
+    if modulus_bytes.len() == 32 {
+        let mut modulus_bytes_array: [u8; 32] = [0; 32];
+        for i in 0..32 {
+            modulus_bytes_array[i] = modulus_bytes[i];
+        }
+
+        modulus_bytes_array == BN254_MODULUS_BE_BYTES
+    } else {
+        false
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the `is_bn254` function so we don't rely on the footgun-y behaviour being reported in #4631 in order to determine the field choice

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
