### PR TITLE
feat: add BoundedVec::map

### DIFF
--- a/docs/docs/noir/standard_library/containers/boundedvec.md
+++ b/docs/docs/noir/standard_library/containers/boundedvec.md
@@ -249,16 +249,14 @@ let bounded_vec: BoundedVec<Field, 10> = BoundedVec::from_array([1, 2, 3])
 ### map
 
 ```rust
-pub fn map<Env>(self, f: fn[Env](T) -> T) -> Self
+pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> BoundedVec<U, MaxLen>
 ```
 
 Creates a new vector of equal size by calling a closure on each element in this vector.  
 
 Example:
-```rust
-let bounded_vec: BoundedVec<Field, 10> = BoundedVec::from_array([1, 2, 3])
-let doubled = bounded_vec.map(|x| x * 2);
-```
+
+#include_code bounded-vec-map-example noir_stdlib/src/collections/bounded_vec.nr rust
 
 ### any
 

--- a/docs/docs/noir/standard_library/containers/boundedvec.md
+++ b/docs/docs/noir/standard_library/containers/boundedvec.md
@@ -246,6 +246,20 @@ Example:
 let bounded_vec: BoundedVec<Field, 10> = BoundedVec::from_array([1, 2, 3])
 ```
 
+### map
+
+```rust
+pub fn map<Env>(self, f: fn[Env](T) -> T) -> Self
+```
+
+Creates a new vector of equal size by calling a closure on each element in this vector.  
+
+Example:
+```rust
+let bounded_vec: BoundedVec<Field, 10> = BoundedVec::from_array([1, 2, 3])
+let doubled = bounded_vec.map(|x| x * 2);
+```
+
 ### any
 
 ```rust

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -121,6 +121,17 @@ impl<T, MaxLen> BoundedVec<T, MaxLen> {
         }
         ret
     }
+
+    pub fn map<Env>(self, f: fn[Env](T) -> T) -> Self {
+        let mut ret = BoundedVec::new();
+        ret.len = self.len();
+        for i in 0..MaxLen {
+            if i < self.len() {
+                ret.storage[i] = f(self.get_unchecked(i));
+            }
+        }
+        ret
+    }
 }
 
 impl<T, MaxLen> Eq for BoundedVec<T, MaxLen> where T: Eq {
@@ -192,6 +203,29 @@ mod bounded_vec_tests {
 
             // Need to use println to avoid DIE removing the write operation.
             crate::println(vec.get(0));
+        }
+    }
+
+    mod map {
+        use crate::collections::bounded_vec::BoundedVec;
+
+        #[test]
+        fn applies_function_correctly() {
+            let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
+            let result = vec.map(|value| if value > 2 { value * 2 } else { value });
+            let expected = BoundedVec::from_array([1, 2, 6, 8]);
+
+            assert_eq(result, expected);
+        }
+
+        #[test]
+        fn does_not_apply_function_past_len() {
+            let vec: BoundedVec<u32, 3> = BoundedVec::from_array([0, 1]);
+            let result = vec.map(|value| if value == 0 { 5 } else { value });
+            let expected = BoundedVec::from_array([5, 1]);
+
+            assert_eq(result, expected);
+            assert_eq(result.storage()[2], 0);
         }
     }
 

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -122,7 +122,7 @@ impl<T, MaxLen> BoundedVec<T, MaxLen> {
         ret
     }
 
-    pub fn map<Env>(self, f: fn[Env](T) -> T) -> Self {
+    pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> BoundedVec<U, MaxLen> {
         let mut ret = BoundedVec::new();
         ret.len = self.len();
         for i in 0..MaxLen {
@@ -211,9 +211,20 @@ mod bounded_vec_tests {
 
         #[test]
         fn applies_function_correctly() {
+            // docs:start:bounded-vec-map-example
             let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
-            let result = vec.map(|value| if value > 2 { value * 2 } else { value });
-            let expected = BoundedVec::from_array([1, 2, 6, 8]);
+            let result = vec.map(|value| value * 2);
+            // docs:end:bounded-vec-map-example
+            let expected = BoundedVec::from_array([2, 4, 6, 8]);
+
+            assert_eq(result, expected);
+        }
+
+        #[test]
+        fn applies_function_that_changes_return_type() {
+            let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
+            let result = vec.map(|value| (value * 2)  as Field);
+            let expected: BoundedVec<Field, 4> = BoundedVec::from_array([2, 4, 6, 8]);
 
             assert_eq(result, expected);
         }


### PR DESCRIPTION
# Description

This adds a `map` function to `BoundedMap`, which I've found to be a relatively common need, and quite annoying to implement outside of the stdlib as it requires raw access to the internals of the data structure.

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
 
# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
