### PR TITLE
chore: add no predicate to poseidon2

### DIFF
--- a/noir_stdlib/src/hash/poseidon2.nr
+++ b/noir_stdlib/src/hash/poseidon2.nr
@@ -11,7 +11,7 @@ struct Poseidon2 {
 }
 
 impl Poseidon2 {
-
+    #[no_predicates]
     pub fn hash<N>(input: [Field; N], message_size: u32) -> Field {
         if message_size == N {
             Poseidon2::hash_internal(input, N, false)


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4688 

## Summary\*
Adding the no_predicates attribute to poseidon2 because hashing operations have no side-effect.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
