### PR TITLE
fix: use proper serialization in `AbiValue`

### DIFF
--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use acvm::acir::circuit::ErrorSelector;
+use acvm::AcirField;
 use iter_extended::vecmap;
 use noirc_abi::{
     Abi, AbiErrorType, AbiParameter, AbiReturnType, AbiType, AbiValue, AbiVisibility, Sign,
@@ -197,9 +198,7 @@ pub(super) fn value_from_hir_expression(context: &Context, expression: HirExpres
             },
             HirLiteral::Bool(value) => AbiValue::Boolean { value },
             HirLiteral::Str(value) => AbiValue::String { value },
-            HirLiteral::Integer(field, sign) => {
-                AbiValue::Integer { value: field.to_string(), sign }
-            }
+            HirLiteral::Integer(field, sign) => AbiValue::Integer { value: field.to_hex(), sign },
             _ => unreachable!("Literal cannot be used in the abi"),
         },
         _ => unreachable!("Type cannot be used in the abi {:?}", expression),


### PR DESCRIPTION
# Description

## Problem\*

Resolves slack issue https://aztecprotocol.slack.com/archives/C02M7VC7TN0/p1718697469796579?thread_ts=1718697265.759469&cid=C02M7VC7TN0

## Summary\*

Looks like when this was added the author used the display method rather than one for serialization.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
