### PR TITLE
fix: fix incorrect return type being applied to stdlib functions `modulus_be_bytes()`, `modulus_be_bits()`, etc.

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1271,19 +1271,19 @@ impl<'interner> Monomorphizer<'interner> {
                     }
                     "modulus_le_bits" => {
                         let bits = FieldElement::modulus().to_radix_le(2);
-                        Some(self.modulus_array_literal(bits, IntegerBitSize::One, location))
+                        Some(self.modulus_slice_literal(bits, IntegerBitSize::One, location))
                     }
                     "modulus_be_bits" => {
                         let bits = FieldElement::modulus().to_radix_be(2);
-                        Some(self.modulus_array_literal(bits, IntegerBitSize::One, location))
+                        Some(self.modulus_slice_literal(bits, IntegerBitSize::One, location))
                     }
                     "modulus_be_bytes" => {
                         let bytes = FieldElement::modulus().to_bytes_be();
-                        Some(self.modulus_array_literal(bytes, IntegerBitSize::Eight, location))
+                        Some(self.modulus_slice_literal(bytes, IntegerBitSize::Eight, location))
                     }
                     "modulus_le_bytes" => {
                         let bytes = FieldElement::modulus().to_bytes_le();
-                        Some(self.modulus_array_literal(bytes, IntegerBitSize::Eight, location))
+                        Some(self.modulus_slice_literal(bytes, IntegerBitSize::Eight, location))
                     }
                     _ => None,
                 };
@@ -1292,7 +1292,7 @@ impl<'interner> Monomorphizer<'interner> {
         None
     }
 
-    fn modulus_array_literal(
+    fn modulus_slice_literal(
         &self,
         bytes: Vec<u8>,
         arr_elem_bits: IntegerBitSize,
@@ -1306,10 +1306,9 @@ impl<'interner> Monomorphizer<'interner> {
             Expression::Literal(Literal::Integer((byte as u128).into(), int_type.clone(), location))
         });
 
-        let typ = Type::Array(bytes_as_expr.len() as u32, Box::new(int_type));
-
+        let typ = Type::Slice(Box::new(int_type));
         let arr_literal = ArrayLiteral { typ, contents: bytes_as_expr };
-        Expression::Literal(Literal::Array(arr_literal))
+        Expression::Literal(Literal::Slice(arr_literal))
     }
 
     fn queue_function(

--- a/test_programs/execution_success/modulus/src/main.nr
+++ b/test_programs/execution_success/modulus/src/main.nr
@@ -3,6 +3,8 @@ fn main(bn254_modulus_be_bytes: [u8; 32], bn254_modulus_be_bits: [u1; 254]) {
     // NOTE: The constraints used in this circuit will only work when testing nargo with the plonk bn254 backend
     assert(modulus_size == 254);
 
+    assert_reverse(std::field::modulus_be_bytes(), std::field::modulus_le_bytes());
+
     let modulus_be_byte_array = std::field::modulus_be_bytes();
     for i in 0..32 {
         assert(modulus_be_byte_array[i] == bn254_modulus_be_bytes[i]);
@@ -19,5 +21,12 @@ fn main(bn254_modulus_be_bytes: [u8; 32], bn254_modulus_be_bits: [u1; 254]) {
     let modulus_le_bits = std::field::modulus_le_bits();
     for i in 0..254 {
         assert(modulus_le_bits[i] == bn254_modulus_be_bits[253 - i]);
+    }
+}
+
+
+fn assert_reverse(forwards: [u8], backwards: [u8]) {
+    for i in 0..254 {
+        assert_eq(forwards[i], backwards[253-i]);
     }
 }

--- a/test_programs/execution_success/modulus/src/main.nr
+++ b/test_programs/execution_success/modulus/src/main.nr
@@ -28,7 +28,7 @@ fn main(bn254_modulus_be_bytes: [u8; 32], bn254_modulus_be_bits: [u1; 254]) {
 }
 
 fn assert_reverse(forwards: [u8], backwards: [u8]) {
-    for i in 0..31 {
+    for i in 0..32 {
         assert_eq(forwards[i], backwards[31 - i]);
     }
 }

--- a/test_programs/execution_success/modulus/src/main.nr
+++ b/test_programs/execution_success/modulus/src/main.nr
@@ -3,7 +3,10 @@ fn main(bn254_modulus_be_bytes: [u8; 32], bn254_modulus_be_bits: [u1; 254]) {
     // NOTE: The constraints used in this circuit will only work when testing nargo with the plonk bn254 backend
     assert(modulus_size == 254);
 
-    assert_reverse(std::field::modulus_be_bytes(), std::field::modulus_le_bytes());
+    assert_reverse(
+        std::field::modulus_be_bytes(),
+        std::field::modulus_le_bytes()
+    );
 
     let modulus_be_byte_array = std::field::modulus_be_bytes();
     for i in 0..32 {
@@ -24,9 +27,8 @@ fn main(bn254_modulus_be_bytes: [u8; 32], bn254_modulus_be_bits: [u1; 254]) {
     }
 }
 
-
 fn assert_reverse(forwards: [u8], backwards: [u8]) {
-    for i in 0..254 {
-        assert_eq(forwards[i], backwards[253-i]);
+    for i in 0..31 {
+        assert_eq(forwards[i], backwards[31 - i]);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently returning an array literal for these methods in the stdlib whereas the Noir code states that it should return a slice. This results in issues when passing these "slices" into other functions such that it causes the inlining pass to panic.

I've fixed this by replacing the array literal with a slice literal.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
