### PR TITLE
fix: Don't lazily elaborate functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -11,11 +11,10 @@ use crate::{
     },
     hir_def::{
         expr::{HirIdent, ImplKind},
-        function::FunctionBody,
         stmt::HirPattern,
     },
     macros_api::{HirExpression, Ident, Path, Pattern},
-    node_interner::{DefinitionId, DefinitionKind, DependencyId, ExprId, GlobalId, TraitImplKind},
+    node_interner::{DefinitionId, DefinitionKind, ExprId, GlobalId, TraitImplKind},
     Shared, StructType, Type, TypeBindings,
 };
 
@@ -415,16 +414,6 @@ impl<'context> Elaborator<'context> {
                 match self.interner.definition(hir_ident.id).kind {
                     DefinitionKind::Function(id) => {
                         if let Some(current_item) = self.current_item {
-                            // Lazily evaluate functions found within globals if necessary.
-                            // Otherwise if we later attempt to evaluate the global it will
-                            // see an empty function body.
-                            if matches!(current_item, DependencyId::Global(_)) {
-                                let meta = self.interner.function_meta(&id);
-
-                                if matches!(&meta.function_body, FunctionBody::Unresolved(..)) {
-                                    self.elaborate_function(id);
-                                }
-                            }
                             self.interner.add_function_dependency(current_item, id);
                         }
                     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5271

## Summary\*

Lazily elaborating functions wasn't correct since the FuncMeta object never stored the LocalModuleId carried by the set of unresolved functions. This lead to lazily elaborated functions be elaborated in a different module than intended.

## Additional Context

Lazily elaborated functions seem to no longer be necessary to run our tests, nor to run the tests in aztec-nr so I've just removed them rather than adding the additional fields to FuncMeta. 

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
