### PR TITLE
fix: update `in_contract` flag before handling function metadata in elaborator

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1302,6 +1302,7 @@ impl<'context> Elaborator<'context> {
 
         for (local_module, id, func) in &mut function_set.functions {
             self.local_module = *local_module;
+            self.in_contract = self.module_id().module(&self.def_maps).is_contract;
             self.recover_generics(|this| {
                 this.define_function_meta(func, *id, false);
             });

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1302,7 +1302,7 @@ impl<'context> Elaborator<'context> {
 
         for (local_module, id, func) in &mut function_set.functions {
             self.local_module = *local_module;
-            self.in_contract = self.module_id().module(&self.def_maps).is_contract;
+            self.in_contract = self.module_id().module(self.def_maps).is_contract;
             self.recover_generics(|this| {
                 this.define_function_meta(func, *id, false);
             });

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1302,10 +1302,12 @@ impl<'context> Elaborator<'context> {
 
         for (local_module, id, func) in &mut function_set.functions {
             self.local_module = *local_module;
+            let was_in_contract = self.in_contract;
             self.in_contract = self.module_id().module(self.def_maps).is_contract;
             self.recover_generics(|this| {
                 this.define_function_meta(func, *id, false);
             });
+            self.in_contract = was_in_contract;
         }
     }
 

--- a/test_programs/compile_success_contract/recursive_method/Nargo.toml
+++ b/test_programs/compile_success_contract/recursive_method/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "recursive_method"
+type = "contract"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_contract/recursive_method/src/main.nr
+++ b/test_programs/compile_success_contract/recursive_method/src/main.nr
@@ -1,0 +1,6 @@
+contract Foo {
+    #[recursive]
+    fn contract_entrypoint() -> pub Field {
+        1
+    }
+}


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves #5288 

## Summary\*

This PR fixes #5288 by updating `self.in_contract` before we define function metadata to match `self.local_module`. This is mildly hacky and we may want to have a nicer "switch modules and update everything which depends on it" helper function in future.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
