### PR TITLE
fix: fix usage of `#[abi(tag)]` attribute with elaborator

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1190,7 +1190,7 @@ impl<'context> Elaborator<'context> {
         self.current_item = Some(DependencyId::Global(global_id));
         let let_stmt = global.stmt_def;
 
-        if !self.in_contract
+        if !self.module_id().module(self.def_maps).is_contract
             && let_stmt.attributes.iter().any(|attr| matches!(attr, SecondaryAttribute::Abi(_)))
         {
             let span = let_stmt.pattern.span();

--- a/test_programs/compile_success_contract/abi_attribute/Nargo.toml
+++ b/test_programs/compile_success_contract/abi_attribute/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "abi_attribute"
+type = "contract"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_contract/abi_attribute/src/main.nr
+++ b/test_programs/compile_success_contract/abi_attribute/src/main.nr
@@ -1,0 +1,4 @@
+contract Foo {
+    #[abi(foo)]
+    global foo: Field = 42;
+}

--- a/test_programs/compile_success_contract/abi_attribute/src/main.nr
+++ b/test_programs/compile_success_contract/abi_attribute/src/main.nr
@@ -1,4 +1,9 @@
 contract Foo {
     #[abi(foo)]
     global foo: Field = 42;
+    
+    #[abi(bar)]
+    struct Bar {
+        inner: Field
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Followup to #5292 to handle globals as well

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
