### PR TITLE
fix(nargo_fmt): Account for spaces before the generic list of a function

### DIFF
--- a/tooling/nargo_fmt/src/visitor/item.rs
+++ b/tooling/nargo_fmt/src/visitor/item.rs
@@ -44,9 +44,9 @@ impl super::FmtVisitor<'_> {
 
         if !func.def.generics.is_empty() {
             let full_span = name_span.end()..params_open;
-
             let start = self.span_before(full_span.clone(), Token::Less).start();
             let end = self.span_after(full_span, Token::Greater).start();
+
             let generics = func.def.generics;
             let span = (start..end).into();
             let generics = format_seq(

--- a/tooling/nargo_fmt/src/visitor/item.rs
+++ b/tooling/nargo_fmt/src/visitor/item.rs
@@ -44,9 +44,9 @@ impl super::FmtVisitor<'_> {
 
         if !func.def.generics.is_empty() {
             let full_span = name_span.end()..params_open;
-            let start = name_span.end();
-            let end = self.span_after(full_span, Token::Greater).start();
 
+            let start = self.span_before(full_span.clone(), Token::Less).start();
+            let end = self.span_after(full_span, Token::Greater).start();
             let generics = func.def.generics;
             let span = (start..end).into();
             let generics = format_seq(

--- a/tooling/nargo_fmt/tests/expected/fn.nr
+++ b/tooling/nargo_fmt/tests/expected/fn.nr
@@ -61,3 +61,7 @@ fn main(
 ) {}
 
 pub fn from_baz(x: [Field; crate::foo::MAGIC_NUMBER]) {}
+
+fn whitespace_before_generics<T>(foo: T) {}
+
+fn more_whitespace_before_generics<T>(foo: T) {}

--- a/tooling/nargo_fmt/tests/input/fn.nr
+++ b/tooling/nargo_fmt/tests/input/fn.nr
@@ -44,3 +44,8 @@ fn main(
 ) {}
 
 pub fn from_baz(x: [Field; crate::foo::MAGIC_NUMBER]) {}
+
+fn whitespace_before_generics <    T   >  (foo: T) {}
+
+fn more_whitespace_before_generics   <    
+T   >  (foo: T) {}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5300 

## Summary\*

Previously the formatter was inserting an extra `<` when formatting functions with a space before `<` when specifying generics. We currently mark the starting span for a list of generics as the end of the function name. Having this be the starting span would cause the first generic of the sequence to have `<` marked as a leading string when it should not have been. We now start the span for a function's generics by looking for `<` rather than starting the span at the end of the function name. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
