### PR TITLE
fix: Replace panic in monomorphization with an error

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -6,6 +6,7 @@ use crate::hir::comptime::InterpreterError;
 pub enum MonomorphizationError {
     UnknownArrayLength { location: Location },
     TypeAnnotationsNeeded { location: Location },
+    InternalError { message: &'static str, location: Location },
     InterpreterError(InterpreterError),
 }
 
@@ -13,6 +14,7 @@ impl MonomorphizationError {
     fn location(&self) -> Location {
         match self {
             MonomorphizationError::UnknownArrayLength { location }
+            | MonomorphizationError::InternalError { location, .. }
             | MonomorphizationError::TypeAnnotationsNeeded { location } => *location,
             MonomorphizationError::InterpreterError(error) => error.get_location(),
         }
@@ -36,6 +38,7 @@ impl MonomorphizationError {
             }
             MonomorphizationError::TypeAnnotationsNeeded { .. } => "Type annotations needed",
             MonomorphizationError::InterpreterError(error) => return (&error).into(),
+            MonomorphizationError::InternalError { message, .. } => message,
         };
 
         let location = self.location();

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -889,7 +889,11 @@ impl<'interner> Monomorphizer<'interner> {
             DefinitionKind::Local(_) => match self.lookup_captured_expr(ident.id) {
                 Some(expr) => expr,
                 None => {
-                    let ident = self.local_ident(&ident)?.unwrap();
+                    let Some(ident) = self.local_ident(&ident)? else {
+                        let location = self.interner.id_location(expr_id);
+                        let message = "ICE: Variable not found during monomorphization";
+                        return Err(MonomorphizationError::InternalError { location, message });
+                    };
                     ast::Expression::Ident(ident)
                 }
             },


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

Replaces an `unwrap` and panic in the monomorphizer with an ICE issued to the user instead. This isn't expected to be issued normally, but is being issued currently when a `comptime let` variable is used in runtime code since `comptime let` is still unimplemented in the evaluator.

## Additional Context

This does not fix the underlying `comptime let` error, only the resulting panic.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
