### PR TITLE
feat: Add some metaprogramming methods on `TypeDefinition`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -98,14 +98,7 @@ impl<'a> Interpreter<'a> {
             .expect("all builtin functions must contain a function  attribute which contains the opcode which it links to");
 
         if let Some(builtin) = func_attrs.builtin() {
-            match builtin.as_str() {
-                "array_len" => builtin::array_len(&arguments),
-                "as_slice" => builtin::as_slice(arguments),
-                _ => {
-                    let item = format!("Comptime evaluation for builtin function {builtin}");
-                    Err(InterpreterError::Unimplemented { item, location })
-                }
-            }
+            builtin::call_builtin(self.interner, builtin, arguments, location)
         } else if let Some(foreign) = func_attrs.foreign() {
             let item = format!("Comptime evaluation for foreign functions like {foreign}");
             Err(InterpreterError::Unimplemented { item, location })

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -19,6 +19,7 @@ pub(super) fn call_builtin(
     match name {
         "array_len" => array_len(&arguments),
         "as_slice" => as_slice(arguments),
+        "slice_push_back" => slice_push_back(arguments),
         "type_def_as_type" => type_def_as_type(interner, arguments),
         "type_def_generics" => type_def_generics(interner, arguments),
         "type_def_fields" => type_def_fields(interner, arguments),
@@ -45,6 +46,20 @@ fn as_slice(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
         Value::Array(values, Type::Array(_, typ)) => Ok(Value::Slice(values, Type::Slice(typ))),
         // Type checking should prevent this branch being taken.
         _ => unreachable!("ICE: Cannot convert types other than arrays into slices"),
+    }
+}
+
+fn slice_push_back(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
+    assert_eq!(arguments.len(), 2, "ICE: `slice_push_back` should only receive two arguments");
+    let (element, _) = arguments.pop().unwrap();
+    let (slice, _) = arguments.pop().unwrap();
+    match slice {
+        Value::Slice(mut values, typ) => {
+            values.push_back(element);
+            Ok(Value::Slice(values, typ))
+        }
+        // Type checking should prevent this branch being taken.
+        _ => unreachable!("ICE: `slice_push_back` expects a slice as its first argument"),
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -141,8 +141,9 @@ fn type_def_fields(
     Ok(Value::Slice(fields, typ))
 }
 
-/// This code is temporary. It will produce poor results for type variables
-/// and will result in incorrect spans on the returned tokens.
+/// FIXME(https://github.com/noir-lang/noir/issues/5309): This code is temporary.
+/// It will produce poor results for type variables and will result in incorrect
+/// spans on the returned tokens.
 fn type_to_tokens(typ: &Type) -> IResult<Tokens> {
     let (mut tokens, mut errors) = Lexer::lex(&typ.to_string());
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1,11 +1,27 @@
+use std::rc::Rc;
+
 use noirc_errors::Location;
 
 use crate::{
-    hir::comptime::{errors::IResult, Value},
-    Type,
+    hir::comptime::{errors::IResult, Value, InterpreterError},
+    Type, macros_api::{NodeInterner, NoirStruct}, QuotedType, token::{Tokens, SpannedToken, Token},
 };
 
-pub(super) fn array_len(arguments: &[(Value, Location)]) -> IResult<Value> {
+pub(super) fn call_builtin(interner: &mut NodeInterner, name: &str, arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+    match name {
+        "array_len" => array_len(&arguments),
+        "as_slice" => as_slice(arguments),
+        "type_def_as_type" => type_def_as_type(interner, arguments),
+        "type_def_generics" => type_def_generics(interner, arguments),
+        "type_def_fields" => type_def_fields(interner, arguments),
+        _ => {
+            let item = format!("Comptime evaluation for builtin function {name}");
+            Err(InterpreterError::Unimplemented { item, location })
+        }
+    }
+}
+
+fn array_len(arguments: &[(Value, Location)]) -> IResult<Value> {
     assert_eq!(arguments.len(), 1, "ICE: `array_len` should only receive a single argument");
     match &arguments[0].0 {
         Value::Array(values, _) | Value::Slice(values, _) => Ok(Value::U32(values.len() as u32)),
@@ -14,7 +30,7 @@ pub(super) fn array_len(arguments: &[(Value, Location)]) -> IResult<Value> {
     }
 }
 
-pub(super) fn as_slice(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
+fn as_slice(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
     assert_eq!(arguments.len(), 1, "ICE: `as_slice` should only receive a single argument");
     let (array, _) = arguments.pop().unwrap();
     match array {
@@ -22,4 +38,77 @@ pub(super) fn as_slice(mut arguments: Vec<(Value, Location)>) -> IResult<Value> 
         // Type checking should prevent this branch being taken.
         _ => unreachable!("ICE: Cannot convert types other than arrays into slices"),
     }
+}
+
+/// fn as_type(self) -> Quoted
+fn type_def_as_type(interner: &mut NodeInterner, mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
+    assert_eq!(arguments.len(), 1, "ICE: `generics` should only receive a single argument");
+    let (type_def, span) = match arguments.pop() {
+        Some((Value::TypeDefinition(id), location)) => (id, location.span),
+        other => unreachable!("ICE: `as_type` expected a `TypeDefinition` argument, found {other:?}"),
+    };
+
+    let struct_def = interner.get_struct(type_def);
+    let struct_def = struct_def.borrow();
+    let make_token = |name| SpannedToken::new(Token::Str(name), span);
+
+    let mut tokens = vec![make_token(struct_def.name.to_string())];
+
+    for (i, generic) in struct_def.generics.iter().enumerate() {
+        if i != 0 {
+            tokens.push(SpannedToken::new(Token::Comma, span));
+        }
+        tokens.push(make_token(generic.borrow().to_string()))
+    }
+
+    Ok(Value::Code(Rc::new(Tokens(tokens))))
+}
+
+/// fn generics(self) -> [Quoted]
+fn type_def_generics(interner: &mut NodeInterner, mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
+    assert_eq!(arguments.len(), 1, "ICE: `generics` should only receive a single argument");
+    let (type_def, span) = match arguments.pop() {
+        Some((Value::TypeDefinition(id), location)) => (id, location.span),
+        other => unreachable!("ICE: `as_type` expected a `TypeDefinition` argument, found {other:?}"),
+    };
+
+    let struct_def = interner.get_struct(type_def);
+
+    let generics = struct_def.borrow().generics.iter().map(|generic| {
+        let name = SpannedToken::new(Token::Str(generic.borrow().to_string()), span);
+        Value::Code(Rc::new(Tokens(vec![name])))
+    }).collect();
+
+    let typ = Type::Slice(Box::new(Type::Quoted(QuotedType::Quoted)));
+    Ok(Value::Slice(generics, typ))
+}
+
+/// fn fields(self) -> [(Quoted, Quoted)]
+/// Returns (name, type) pairs of each field of this TypeDefinition
+fn type_def_fields(interner: &mut NodeInterner, mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
+    assert_eq!(arguments.len(), 1, "ICE: `generics` should only receive a single argument");
+    let (type_def, span) = match arguments.pop() {
+        Some((Value::TypeDefinition(id), location)) => (id, location.span),
+        other => unreachable!("ICE: `as_type` expected a `TypeDefinition` argument, found {other:?}"),
+    };
+
+    let struct_def = interner.get_struct(type_def);
+    let struct_def = struct_def.borrow();
+
+    let make_token = |name| SpannedToken::new(Token::Str(name), span);
+    let make_quoted = |tokens| Value::Code(Rc::new(Tokens(tokens)));
+
+    let mut fields = im::Vector::new();
+
+    for (name, typ) in struct_def.get_fields_as_written() {
+        let name = make_quoted(vec![make_token(name)]);
+        let typ = make_quoted(typ.as_tokens());
+        fields.push_back(Value::Tuple(vec![name, typ]));
+    }
+
+    let typ = Type::Slice(Box::new(Type::Tuple(vec![
+        Type::Quoted(QuotedType::Quoted),
+        Type::Quoted(QuotedType::Quoted),
+    ])));
+    Ok(Value::Slice(fields, typ))
 }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -45,7 +45,6 @@ pub enum Value {
     Slice(Vector<Value>, Type),
     Code(Rc<Tokens>),
     TypeDefinition(StructId),
-    Type(Type),
 }
 
 impl Value {
@@ -80,7 +79,6 @@ impl Value {
                 let element = element.borrow().get_type().into_owned();
                 Type::MutableReference(Box::new(element))
             }
-            Value::Type(_) => Type::Quoted(QuotedType::Type),
         })
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -45,6 +45,7 @@ pub enum Value {
     Slice(Vector<Value>, Type),
     Code(Rc<Tokens>),
     TypeDefinition(StructId),
+    Type(Type),
 }
 
 impl Value {
@@ -79,6 +80,7 @@ impl Value {
                 let element = element.borrow().get_type().into_owned();
                 Type::MutableReference(Box::new(element))
             }
+            Value::Type(_) => Type::Quoted(QuotedType::Type),
         })
     }
 

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -303,9 +303,7 @@ impl StructType {
     /// This method is almost never what is wanted for type checking or monomorphization,
     /// prefer to use `get_fields` whenever possible.
     pub fn get_fields_as_written(&self) -> Vec<(String, Type)> {
-        vecmap(&self.fields, |(name, typ)| {
-            (name.0.contents.clone(), typ.clone())
-        })
+        vecmap(&self.fields, |(name, typ)| (name.0.contents.clone(), typ.clone()))
     }
 
     pub fn field_names(&self) -> BTreeSet<Ident> {
@@ -821,9 +819,7 @@ impl Type {
             // environment is the interpreter. In this environment, they are valid.
             Type::Quoted(_) => true,
 
-            Type::MutableReference(_)
-            | Type::Forall(_, _)
-            | Type::TraitAsType(..) => false,
+            Type::MutableReference(_) | Type::Forall(_, _) | Type::TraitAsType(..) => false,
 
             Type::Alias(alias, generics) => {
                 let alias = alias.borrow();

--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -26,6 +26,7 @@ mod prelude;
 mod uint128;
 mod bigint;
 mod runtime;
+mod meta;
 
 // Oracle calls are required to be wrapped in an unconstrained function
 // Thus, the only argument to the `println` oracle is expected to always be an ident

--- a/noir_stdlib/src/meta.nr
+++ b/noir_stdlib/src/meta.nr
@@ -1,0 +1,1 @@
+mod type_def;

--- a/noir_stdlib/src/meta/type_def.nr
+++ b/noir_stdlib/src/meta/type_def.nr
@@ -1,6 +1,6 @@
 impl TypeDefinition {
     /// Return a syntactic version of this type definition as a type.
-    /// For example, as_type(`type Foo<A, B> { ... }`) would return `Foo<A, B>`
+    /// For example, `as_type(quote { type Foo<A, B> { ... } })` would return `Foo<A, B>`
     #[builtin(type_def_as_type)]
     fn as_type(self) -> Quoted {}
 

--- a/noir_stdlib/src/meta/type_def.nr
+++ b/noir_stdlib/src/meta/type_def.nr
@@ -1,0 +1,16 @@
+impl TypeDefinition {
+    /// Return a syntactic version of this type definition as a type.
+    /// For example, as_type(`type Foo<A, B> { ... }`) would return `Foo<A, B>`
+    #[builtin(type_def_as_type)]
+    fn as_type(self) -> Quoted {}
+
+    /// Return each generic on this type. The names of these generics are unchanged
+    /// so users may need to keep name collisions in mind if this is used directly in a macro.
+    #[builtin(type_def_generics)]
+    fn generics(self) -> [Quoted] {}
+
+    /// Returns (name, type) pairs of each field in this type. Each type is as-is
+    /// with any generic arguments unchanged.
+    #[builtin(type_def_fields)]
+    fn fields(self) -> [(Quoted, Quoted)] {}
+}

--- a/test_programs/compile_success_empty/comptime_type_definition/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_type_definition/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_type_definition"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_type_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type_definition/src/main.nr
@@ -1,4 +1,3 @@
-
 fn main() {}
 
 #[my_comptime_fn]

--- a/test_programs/compile_success_empty/comptime_type_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type_definition/src/main.nr
@@ -1,0 +1,14 @@
+
+fn main() {}
+
+#[my_comptime_fn]
+struct MyType<A, B, C> {
+    field1: [A; 10],
+    field2: (B, C),
+}
+
+comptime fn my_comptime_fn(typ: TypeDefinition) {
+    let _ = typ.as_type();
+    assert_eq(typ.generics().len(), 3);
+    assert_eq(typ.fields().len(), 2);
+}

--- a/test_programs/compile_success_empty/derive_impl/Nargo.toml
+++ b/test_programs/compile_success_empty/derive_impl/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "derive_impl"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.30.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/derive_impl/src/main.nr
+++ b/test_programs/compile_success_empty/derive_impl/src/main.nr
@@ -1,0 +1,44 @@
+comptime fn derive_default(typ: TypeDefinition) -> Quoted {
+    let generics: [Quoted] = typ.generics();
+    assert_eq(
+        generics.len(), 0, "derive_default: Deriving Default on generic types is currently unimplemented"
+    );
+
+    let type_name = typ.as_type();
+    let fields = typ.fields();
+
+    let fields = join(make_field_exprs(fields));
+
+    quote {
+        impl Default for $type_name {
+            fn default() -> Self {
+                Self { $fields }
+            }
+        }
+    }
+}
+
+#[derive_default]
+struct Foo {
+    x: Field,
+    y: u32,
+}
+
+comptime fn make_field_exprs(fields: [(Quoted, Quoted)]) -> [Quoted] {
+    let mut result = &[];
+    for my_field in fields {
+        let name = my_field.0;
+        result = result.push_back(quote { $name: Default::default(), });
+    }
+    result
+}
+
+comptime fn join(slice: [Quoted]) -> Quoted {
+    let mut result = quote {};
+    for elem in slice {
+        result = quote { $result $elem };
+    }
+    result
+}
+
+fn main() {}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5285 

## Summary\*

Implements `as_type`, `generics`, and `fields` on the `TypeDefinition` type.

The `Type` type isn't really supported yet so `as_type` and `fields` return `Quoted` token streams instead of `Type`s for now.

## Additional Context

A few bugs still need to be fixed after this PR for the vertical slice to work.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
