### PR TITLE
fix: Implement interpretation of member access on tuples

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -927,6 +927,14 @@ impl<'a> Interpreter<'a> {
     fn evaluate_access(&mut self, access: HirMemberAccess, id: ExprId) -> IResult<Value> {
         let (fields, struct_type) = match self.evaluate(access.lhs)? {
             Value::Struct(fields, typ) => (fields, typ),
+            Value::Tuple(fields) => {
+                let mut field_types = Vec::with_capacity(fields.len());
+                let fields = fields.into_iter().enumerate().map(|(i, field)| {
+                    field_types.push(field.get_type().into_owned());
+                    (Rc::new(i.to_string()), field)
+                }).collect();
+                (fields, Type::Tuple(field_types))
+            }
             value => {
                 let location = self.interner.expr_location(&id);
                 return Err(InterpreterError::NonTupleOrStructInMemberAccess { value, location });

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -929,10 +929,14 @@ impl<'a> Interpreter<'a> {
             Value::Struct(fields, typ) => (fields, typ),
             Value::Tuple(fields) => {
                 let mut field_types = Vec::with_capacity(fields.len());
-                let fields = fields.into_iter().enumerate().map(|(i, field)| {
-                    field_types.push(field.get_type().into_owned());
-                    (Rc::new(i.to_string()), field)
-                }).collect();
+                let fields = fields
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, field)| {
+                        field_types.push(field.get_type().into_owned());
+                        (Rc::new(i.to_string()), field)
+                    })
+                    .collect();
                 (fields, Type::Tuple(field_types))
             }
             value => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -928,15 +928,15 @@ impl<'a> Interpreter<'a> {
         let (fields, struct_type) = match self.evaluate(access.lhs)? {
             Value::Struct(fields, typ) => (fields, typ),
             Value::Tuple(fields) => {
-                let mut field_types = Vec::with_capacity(fields.len());
-                let fields = fields
+                let (fields, field_types): (HashMap<Rc<String>, Value>, Vec<Type>) = fields
                     .into_iter()
                     .enumerate()
                     .map(|(i, field)| {
-                        field_types.push(field.get_type().into_owned());
-                        (Rc::new(i.to_string()), field)
+                        let field_type = field.get_type().into_owned();
+                        let key_val_pair = (Rc::new(i.to_string()), field);
+                        (key_val_pair, field_type)
                     })
-                    .collect();
+                    .unzip();
                 (fields, Type::Tuple(field_types))
             }
             value => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -19,6 +19,7 @@ pub(super) fn call_builtin(
     match name {
         "array_len" => array_len(&arguments),
         "as_slice" => as_slice(arguments),
+        "slice_push_back" => slice_push_back(arguments),
         "type_def_as_type" => type_def_as_type(interner, arguments),
         "type_def_generics" => type_def_generics(interner, arguments),
         "type_def_fields" => type_def_fields(interner, arguments),
@@ -45,6 +46,20 @@ fn as_slice(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
         Value::Array(values, Type::Array(_, typ)) => Ok(Value::Slice(values, Type::Slice(typ))),
         // Type checking should prevent this branch being taken.
         _ => unreachable!("ICE: Cannot convert types other than arrays into slices"),
+    }
+}
+
+fn slice_push_back(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
+    assert_eq!(arguments.len(), 2, "ICE: `slice_push_back` should only receive two arguments");
+    let (element, _) = arguments.pop().unwrap();
+    let (slice, _) = arguments.pop().unwrap();
+    match slice {
+        Value::Slice(mut values, typ) => {
+            values.push_back(element);
+            Ok(Value::Slice(values, typ))
+        }
+        // Type checking should prevent this branch being taken.
+        _ => unreachable!("ICE: `slice_push_back` expects a slice as its first argument"),
     }
 }
 

--- a/test_programs/compile_success_empty/derive_impl/Nargo.toml
+++ b/test_programs/compile_success_empty/derive_impl/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "derive_impl"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.30.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/derive_impl/src/main.nr
+++ b/test_programs/compile_success_empty/derive_impl/src/main.nr
@@ -1,0 +1,44 @@
+comptime fn derive_default(typ: TypeDefinition) -> Quoted {
+    let generics: [Quoted] = typ.generics();
+    assert_eq(
+        generics.len(), 0, "derive_default: Deriving Default on generic types is currently unimplemented"
+    );
+
+    let type_name = typ.as_type();
+    let fields = typ.fields();
+
+    let fields = join(make_field_exprs(fields));
+
+    quote {
+        impl Default for $type_name {
+            fn default() -> Self {
+                Self { $fields }
+            }
+        }
+    }
+}
+
+#[derive_default]
+struct Foo {
+    x: Field,
+    y: u32,
+}
+
+comptime fn make_field_exprs(fields: [(Quoted, Quoted)]) -> [Quoted] {
+    let mut result = &[];
+    for my_field in fields {
+        let name = my_field.0;
+        result = result.push_back(quote { $name: Default::default(), });
+    }
+    result
+}
+
+comptime fn join(slice: [Quoted]) -> Quoted {
+    let mut result = quote {};
+    for elem in slice {
+        result = quote { $result $elem };
+    }
+    result
+}
+
+fn main() {}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Fixes an issue in the interpreter where the interpreter would error for member access expressions on tuples. This prevented e.g. `my_tuple.0`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
