### PR TITLE
chore: Bundle SSA Evaluator Options

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -552,7 +552,7 @@ pub fn compile_no_check(
     };
 
     let SsaProgramArtifact { program, debug, warnings, names, error_types, .. } =
-        create_program(program, ssa_evaluator_options)?;
+        create_program(program, &ssa_evaluator_options)?;
 
     let abi = abi_gen::gen_abi(context, &main_function, return_visibility, error_types);
     let file_map = filter_relevant_files(&debug, &context.file_manager);

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -544,14 +544,15 @@ pub fn compile_no_check(
         return Ok(cached_program.expect("cache must exist for hashes to match"));
     }
     let return_visibility = program.return_visibility;
+    let ssa_evaluator_options = noirc_evaluator::ssa::SsaEvaluatorOptions {
+        enable_ssa_logging: options.show_ssa,
+        enable_brillig_logging: options.show_brillig,
+        force_brillig_output: options.force_brillig,
+        print_codegen_timings: options.benchmark_codegen,
+    };
 
-    let SsaProgramArtifact { program, debug, warnings, names, error_types, .. } = create_program(
-        program,
-        options.show_ssa,
-        options.show_brillig,
-        options.force_brillig,
-        options.benchmark_codegen,
-    )?;
+    let SsaProgramArtifact { program, debug, warnings, names, error_types, .. } =
+        create_program(program, ssa_evaluator_options)?;
 
     let abi = abi_gen::gen_abi(context, &main_function, return_visibility, error_types);
     let file_map = filter_relevant_files(&debug, &context.file_manager);

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -48,7 +48,7 @@ pub mod ssa_gen;
 /// and Brillig functions for unconstrained execution.
 pub(crate) fn optimize_into_acir(
     program: Program,
-    options: SsaEvaluatorOptions,
+    options: &SsaEvaluatorOptions,
 ) -> Result<Artifacts, RuntimeError> {
     let ssa_gen_span = span!(Level::TRACE, "ssa_generation");
     let ssa_gen_span_guard = ssa_gen_span.enter();
@@ -168,7 +168,7 @@ pub struct SsaEvaluatorOptions {
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn create_program(
     program: Program,
-    options: SsaEvaluatorOptions,
+    options: &SsaEvaluatorOptions,
 ) -> Result<SsaProgramArtifact, RuntimeError> {
     let debug_variables = program.debug_variables.clone();
     let debug_types = program.debug_types.clone();

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -48,47 +48,51 @@ pub mod ssa_gen;
 /// and Brillig functions for unconstrained execution.
 pub(crate) fn optimize_into_acir(
     program: Program,
-    print_passes: bool,
-    print_brillig_trace: bool,
-    force_brillig_output: bool,
-    print_timings: bool,
+    options: SsaEvaluatorOptions,
 ) -> Result<Artifacts, RuntimeError> {
     let ssa_gen_span = span!(Level::TRACE, "ssa_generation");
     let ssa_gen_span_guard = ssa_gen_span.enter();
-    let ssa = SsaBuilder::new(program, print_passes, force_brillig_output, print_timings)?
-        .run_pass(Ssa::defunctionalize, "After Defunctionalization:")
-        .run_pass(Ssa::remove_paired_rc, "After Removing Paired rc_inc & rc_decs:")
-        .run_pass(Ssa::separate_runtime, "After Runtime Separation:")
-        .run_pass(Ssa::resolve_is_unconstrained, "After Resolving IsUnconstrained:")
-        .run_pass(Ssa::inline_functions, "After Inlining:")
-        // Run mem2reg with the CFG separated into blocks
-        .run_pass(Ssa::mem2reg, "After Mem2Reg:")
-        .run_pass(Ssa::as_slice_optimization, "After `as_slice` optimization")
-        .try_run_pass(Ssa::evaluate_assert_constant, "After Assert Constant:")?
-        .try_run_pass(Ssa::unroll_loops_iteratively, "After Unrolling:")?
-        .run_pass(Ssa::simplify_cfg, "After Simplifying:")
-        .run_pass(Ssa::flatten_cfg, "After Flattening:")
-        .run_pass(Ssa::remove_bit_shifts, "After Removing Bit Shifts:")
-        // Run mem2reg once more with the flattened CFG to catch any remaining loads/stores
-        .run_pass(Ssa::mem2reg, "After Mem2Reg:")
-        // Run the inlining pass again to handle functions with `InlineType::NoPredicates`.
-        // Before flattening is run, we treat functions marked with the `InlineType::NoPredicates` as an entry point.
-        // This pass must come immediately following `mem2reg` as the succeeding passes
-        // may create an SSA which inlining fails to handle.
-        .run_pass(Ssa::inline_functions_with_no_predicates, "After Inlining:")
-        .run_pass(Ssa::remove_if_else, "After Remove IfElse:")
-        .run_pass(Ssa::fold_constants, "After Constant Folding:")
-        .run_pass(Ssa::remove_enable_side_effects, "After EnableSideEffects removal:")
-        .run_pass(Ssa::fold_constants_using_constraints, "After Constraint Folding:")
-        .run_pass(Ssa::dead_instruction_elimination, "After Dead Instruction Elimination:")
-        .run_pass(Ssa::array_set_optimization, "After Array Set Optimizations:")
-        .finish();
+    let ssa = SsaBuilder::new(
+        program,
+        options.enable_ssa_logging,
+        options.force_brillig_output,
+        options.print_codegen_timings,
+    )?
+    .run_pass(Ssa::defunctionalize, "After Defunctionalization:")
+    .run_pass(Ssa::remove_paired_rc, "After Removing Paired rc_inc & rc_decs:")
+    .run_pass(Ssa::separate_runtime, "After Runtime Separation:")
+    .run_pass(Ssa::resolve_is_unconstrained, "After Resolving IsUnconstrained:")
+    .run_pass(Ssa::inline_functions, "After Inlining:")
+    // Run mem2reg with the CFG separated into blocks
+    .run_pass(Ssa::mem2reg, "After Mem2Reg:")
+    .run_pass(Ssa::as_slice_optimization, "After `as_slice` optimization")
+    .try_run_pass(Ssa::evaluate_assert_constant, "After Assert Constant:")?
+    .try_run_pass(Ssa::unroll_loops_iteratively, "After Unrolling:")?
+    .run_pass(Ssa::simplify_cfg, "After Simplifying:")
+    .run_pass(Ssa::flatten_cfg, "After Flattening:")
+    .run_pass(Ssa::remove_bit_shifts, "After Removing Bit Shifts:")
+    // Run mem2reg once more with the flattened CFG to catch any remaining loads/stores
+    .run_pass(Ssa::mem2reg, "After Mem2Reg:")
+    // Run the inlining pass again to handle functions with `InlineType::NoPredicates`.
+    // Before flattening is run, we treat functions marked with the `InlineType::NoPredicates` as an entry point.
+    // This pass must come immediately following `mem2reg` as the succeeding passes
+    // may create an SSA which inlining fails to handle.
+    .run_pass(Ssa::inline_functions_with_no_predicates, "After Inlining:")
+    .run_pass(Ssa::remove_if_else, "After Remove IfElse:")
+    .run_pass(Ssa::fold_constants, "After Constant Folding:")
+    .run_pass(Ssa::remove_enable_side_effects, "After EnableSideEffects removal:")
+    .run_pass(Ssa::fold_constants_using_constraints, "After Constraint Folding:")
+    .run_pass(Ssa::dead_instruction_elimination, "After Dead Instruction Elimination:")
+    .run_pass(Ssa::array_set_optimization, "After Array Set Optimizations:")
+    .finish();
 
-    let brillig = time("SSA to Brillig", print_timings, || ssa.to_brillig(print_brillig_trace));
+    let brillig = time("SSA to Brillig", options.print_codegen_timings, || {
+        ssa.to_brillig(options.enable_brillig_logging)
+    });
 
     drop(ssa_gen_span_guard);
 
-    time("SSA to ACIR", print_timings, || ssa.into_acir(&brillig))
+    time("SSA to ACIR", options.print_codegen_timings, || ssa.into_acir(&brillig))
 }
 
 // Helper to time SSA passes
@@ -144,6 +148,19 @@ impl SsaProgramArtifact {
     }
 }
 
+pub struct SsaEvaluatorOptions {
+    /// Emit debug information for the intermediate SSA IR
+    pub enable_ssa_logging: bool,
+
+    pub enable_brillig_logging: bool,
+
+    /// Force Brillig output (for step debugging)
+    pub force_brillig_output: bool,
+
+    /// Pretty print benchmark times of each code generation pass
+    pub print_codegen_timings: bool,
+}
+
 /// Compiles the [`Program`] into [`ACIR``][acvm::acir::circuit::Program].
 ///
 /// The output ACIR is backend-agnostic and so must go through a transformation pass before usage in proof generation.
@@ -151,10 +168,7 @@ impl SsaProgramArtifact {
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn create_program(
     program: Program,
-    enable_ssa_logging: bool,
-    enable_brillig_logging: bool,
-    force_brillig_output: bool,
-    print_codegen_timings: bool,
+    options: SsaEvaluatorOptions,
 ) -> Result<SsaProgramArtifact, RuntimeError> {
     let debug_variables = program.debug_variables.clone();
     let debug_types = program.debug_types.clone();
@@ -163,13 +177,7 @@ pub fn create_program(
     let func_sigs = program.function_signatures.clone();
 
     let recursive = program.recursive;
-    let (generated_acirs, generated_brillig, error_types) = optimize_into_acir(
-        program,
-        enable_ssa_logging,
-        enable_brillig_logging,
-        force_brillig_output,
-        print_codegen_timings,
-    )?;
+    let (generated_acirs, generated_brillig, error_types) = optimize_into_acir(program, options)?;
     assert_eq!(
         generated_acirs.len(),
         func_sigs.len(),

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -164,7 +164,6 @@ pub struct SsaEvaluatorOptions {
 /// Compiles the [`Program`] into [`ACIR``][acvm::acir::circuit::Program].
 ///
 /// The output ACIR is backend-agnostic and so must go through a transformation pass before usage in proof generation.
-#[allow(clippy::type_complexity)]
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn create_program(
     program: Program,


### PR DESCRIPTION
Better reviewed with "Diff -> Hide whitespace".

# Description

## Problem

Resolves #4667

## Summary

Introduces an `SsaEvaluatorOptions` struct that bundles a bunch of booleans that are passed down several functions.

## Additional Context

None

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
