### PR TITLE
chore: add back Pedersen blackbox functions (revert PR 5221)

### DIFF
--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -82,9 +82,9 @@ pub enum BlackBoxFunc {
     ///
     /// [grumpkin]: https://hackmd.io/@aztec-network/ByzgNxBfd#2-Grumpkin---A-curve-on-top-of-BN-254-for-SNARK-efficient-group-operations
     SchnorrVerify,
-    /// Deprecated. To be removed with a sync from aztec-packages
+    /// Will be deprecated
     PedersenCommitment,
-    /// Deprecated. To be removed with a sync from aztec-packages
+    /// Will be deprecated
     PedersenHash,
     /// Verifies a ECDSA signature over the secp256k1 curve.
     /// - inputs:
@@ -227,8 +227,8 @@ impl BlackBoxFunc {
             BlackBoxFunc::BigIntToLeBytes => "bigint_to_le_bytes",
             BlackBoxFunc::Poseidon2Permutation => "poseidon2_permutation",
             BlackBoxFunc::Sha256Compression => "sha256_compression",
-            BlackBoxFunc::PedersenCommitment => "deprecated pedersen commitment",
-            BlackBoxFunc::PedersenHash => "deprecated pedersen hash",
+            BlackBoxFunc::PedersenCommitment => "pedersen_commitment",
+            BlackBoxFunc::PedersenHash => "pedersen_hash",
         }
     }
 
@@ -257,8 +257,8 @@ impl BlackBoxFunc {
             "bigint_to_le_bytes" => Some(BlackBoxFunc::BigIntToLeBytes),
             "poseidon2_permutation" => Some(BlackBoxFunc::Poseidon2Permutation),
             "sha256_compression" => Some(BlackBoxFunc::Sha256Compression),
-            "deprecated pedersen commitment" => Some(BlackBoxFunc::PedersenCommitment),
-            "deprecated pedersen hash" => Some(BlackBoxFunc::PedersenHash),
+            "pedersen_commitment" => Some(BlackBoxFunc::PedersenCommitment),
+            "pedersen_hash" => Some(BlackBoxFunc::PedersenHash),
             _ => None,
         }
     }

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -54,13 +54,13 @@ pub enum BlackBoxFuncCall {
         message: Vec<FunctionInput>,
         output: Witness,
     },
-    /// Deprecated. To be removed with a sync from aztec-packages
+    /// Will be deprecated
     PedersenCommitment {
         inputs: Vec<FunctionInput>,
         domain_separator: u32,
         outputs: (Witness, Witness),
     },
-    /// Deprecated. To be removed with a sync from aztec-packages
+    /// Will be deprecated
     PedersenHash {
         inputs: Vec<FunctionInput>,
         domain_separator: u32,
@@ -222,6 +222,8 @@ impl BlackBoxFuncCall {
             | BlackBoxFuncCall::Blake2s { inputs, .. }
             | BlackBoxFuncCall::Blake3 { inputs, .. }
             | BlackBoxFuncCall::BigIntFromLeBytes { inputs, .. }
+            | BlackBoxFuncCall::PedersenCommitment { inputs, .. }
+            | BlackBoxFuncCall::PedersenHash { inputs, .. }
             | BlackBoxFuncCall::Poseidon2Permutation { inputs, .. } => inputs.to_vec(),
 
             BlackBoxFuncCall::Keccakf1600 { inputs, .. } => inputs.to_vec(),
@@ -318,8 +320,6 @@ impl BlackBoxFuncCall {
                 inputs.push(*key_hash);
                 inputs
             }
-            BlackBoxFuncCall::PedersenCommitment { .. } => todo!(),
-            BlackBoxFuncCall::PedersenHash { .. } => todo!(),
         }
     }
 
@@ -341,7 +341,9 @@ impl BlackBoxFuncCall {
             | BlackBoxFuncCall::XOR { output, .. }
             | BlackBoxFuncCall::SchnorrVerify { output, .. }
             | BlackBoxFuncCall::EcdsaSecp256k1 { output, .. }
+            | BlackBoxFuncCall::PedersenHash { output, .. }
             | BlackBoxFuncCall::EcdsaSecp256r1 { output, .. } => vec![*output],
+            BlackBoxFuncCall::PedersenCommitment { outputs, .. } => vec![outputs.0, outputs.1],
             BlackBoxFuncCall::MultiScalarMul { outputs, .. }
             | BlackBoxFuncCall::EmbeddedCurveAdd { outputs, .. } => {
                 vec![outputs.0, outputs.1, outputs.2]
@@ -356,8 +358,6 @@ impl BlackBoxFuncCall {
                 vec![]
             }
             BlackBoxFuncCall::BigIntToLeBytes { outputs, .. } => outputs.to_vec(),
-            BlackBoxFuncCall::PedersenCommitment { .. } => todo!(),
-            BlackBoxFuncCall::PedersenHash { .. } => todo!(),
         }
     }
 }

--- a/acvm-repo/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod bigint;
 mod embedded_curve_ops;
 mod hash;
 mod logic;
+mod pedersen;
 mod range;
 mod signature;
 pub(crate) mod utils;
@@ -26,6 +27,7 @@ use embedded_curve_ops::{embedded_curve_add, multi_scalar_mul};
 // Hash functions should eventually be exposed for external consumers.
 use hash::{solve_generic_256_hash_opcode, solve_sha_256_permutation_opcode};
 use logic::{and, xor};
+use pedersen::{pedersen, pedersen_hash};
 pub(crate) use range::solve_range_opcode;
 use signature::{
     ecdsa::{secp256k1_prehashed, secp256r1_prehashed},
@@ -125,6 +127,12 @@ pub(crate) fn solve<F: AcirField>(
             message,
             *output,
         ),
+        BlackBoxFuncCall::PedersenCommitment { inputs, domain_separator, outputs } => {
+            pedersen(backend, initial_witness, inputs, *domain_separator, *outputs)
+        }
+        BlackBoxFuncCall::PedersenHash { inputs, domain_separator, output } => {
+            pedersen_hash(backend, initial_witness, inputs, *domain_separator, *output)
+        }
         BlackBoxFuncCall::EcdsaSecp256k1 {
             public_key_x,
             public_key_y,
@@ -179,7 +187,5 @@ pub(crate) fn solve<F: AcirField>(
         BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs, len } => {
             solve_poseidon2_permutation_opcode(backend, initial_witness, inputs, outputs, *len)
         }
-        BlackBoxFuncCall::PedersenCommitment { .. } => todo!("Deprecated BlackBox"),
-        BlackBoxFuncCall::PedersenHash { .. } => todo!("Deprecated BlackBox"),
     }
 }

--- a/acvm-repo/acvm/src/pwg/blackbox/pedersen.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/pedersen.rs
@@ -1,0 +1,47 @@
+use acir::{
+    circuit::opcodes::FunctionInput,
+    native_types::{Witness, WitnessMap},
+    AcirField,
+};
+
+use crate::{
+    pwg::{insert_value, witness_to_value, OpcodeResolutionError},
+    BlackBoxFunctionSolver,
+};
+
+pub(super) fn pedersen<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
+    inputs: &[FunctionInput],
+    domain_separator: u32,
+    outputs: (Witness, Witness),
+) -> Result<(), OpcodeResolutionError<F>> {
+    let scalars: Result<Vec<_>, _> =
+        inputs.iter().map(|input| witness_to_value(initial_witness, input.witness)).collect();
+    let scalars: Vec<_> = scalars?.into_iter().cloned().collect();
+
+    let (res_x, res_y) = backend.pedersen_commitment(&scalars, domain_separator)?;
+
+    insert_value(&outputs.0, res_x, initial_witness)?;
+    insert_value(&outputs.1, res_y, initial_witness)?;
+
+    Ok(())
+}
+
+pub(super) fn pedersen_hash<F: AcirField>(
+    backend: &impl BlackBoxFunctionSolver<F>,
+    initial_witness: &mut WitnessMap<F>,
+    inputs: &[FunctionInput],
+    domain_separator: u32,
+    output: Witness,
+) -> Result<(), OpcodeResolutionError<F>> {
+    let scalars: Result<Vec<_>, _> =
+        inputs.iter().map(|input| witness_to_value(initial_witness, input.witness)).collect();
+    let scalars: Vec<_> = scalars?.into_iter().cloned().collect();
+
+    let res = backend.pedersen_hash(&scalars, domain_separator)?;
+
+    insert_value(&output, res, initial_witness)?;
+
+    Ok(())
+}

--- a/acvm-repo/blackbox_solver/src/curve_specific_solver.rs
+++ b/acvm-repo/blackbox_solver/src/curve_specific_solver.rs
@@ -14,6 +14,16 @@ pub trait BlackBoxFunctionSolver<F> {
         signature: &[u8; 64],
         message: &[u8],
     ) -> Result<bool, BlackBoxResolutionError>;
+    fn pedersen_commitment(
+        &self,
+        inputs: &[F],
+        domain_separator: u32,
+    ) -> Result<(F, F), BlackBoxResolutionError>;
+    fn pedersen_hash(
+        &self,
+        inputs: &[F],
+        domain_separator: u32,
+    ) -> Result<F, BlackBoxResolutionError>;
     fn multi_scalar_mul(
         &self,
         points: &[F],
@@ -57,6 +67,21 @@ impl<F> BlackBoxFunctionSolver<F> for StubbedBlackBoxSolver {
     ) -> Result<bool, BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::SchnorrVerify))
     }
+    fn pedersen_commitment(
+        &self,
+        _inputs: &[F],
+        _domain_separator: u32,
+    ) -> Result<(F, F), BlackBoxResolutionError> {
+        Err(Self::fail(BlackBoxFunc::PedersenCommitment))
+    }
+    fn pedersen_hash(
+        &self,
+        _inputs: &[F],
+        _domain_separator: u32,
+    ) -> Result<F, BlackBoxResolutionError> {
+        Err(Self::fail(BlackBoxFunc::PedersenHash))
+    }
+
     fn multi_scalar_mul(
         &self,
         _points: &[F],

--- a/acvm-repo/bn254_blackbox_solver/src/lib.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/lib.rs
@@ -10,6 +10,7 @@ mod pedersen;
 mod poseidon2;
 mod schnorr;
 
+use ark_ec::AffineRepr;
 pub use embedded_curve_ops::{embedded_curve_add, multi_scalar_mul};
 pub use generator::generators::derive_generators;
 pub use poseidon2::poseidon2_permutation;
@@ -38,6 +39,33 @@ impl BlackBoxFunctionSolver<FieldElement> for Bn254BlackBoxSolver {
             sig_e,
             message,
         ))
+    }
+
+    fn pedersen_commitment(
+        &self,
+        inputs: &[FieldElement],
+        domain_separator: u32,
+    ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
+        let inputs: Vec<grumpkin::Fq> = inputs.iter().map(|input| input.into_repr()).collect();
+        let result = pedersen::commitment::commit_native_with_index(&inputs, domain_separator);
+        let result = if let Some((x, y)) = result.xy() {
+            (FieldElement::from_repr(*x), FieldElement::from_repr(*y))
+        } else {
+            (FieldElement::from(0_u128), FieldElement::from(0_u128))
+        };
+
+        Ok(result)
+    }
+
+    fn pedersen_hash(
+        &self,
+        inputs: &[FieldElement],
+        domain_separator: u32,
+    ) -> Result<FieldElement, BlackBoxResolutionError> {
+        let inputs: Vec<grumpkin::Fq> = inputs.iter().map(|input| input.into_repr()).collect();
+        let result = pedersen::hash::hash_with_index(&inputs, domain_separator);
+        let result = FieldElement::from_repr(result);
+        Ok(result)
     }
 
     fn multi_scalar_mul(

--- a/acvm-repo/brillig/src/black_box.rs
+++ b/acvm-repo/brillig/src/black_box.rs
@@ -61,13 +61,13 @@ pub enum BlackBoxOp {
         signature: HeapVector,
         result: MemoryAddress,
     },
-    /// Deprecated. To be removed with a sync from aztec-packages
+    /// Will be deprecated
     PedersenCommitment {
         inputs: HeapVector,
         domain_separator: MemoryAddress,
         output: HeapArray,
     },
-    /// Deprecated. To be removed with a sync from aztec-packages
+    /// Will be deprecated
     PedersenHash {
         inputs: HeapVector,
         domain_separator: MemoryAddress,

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -241,7 +241,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 memory.read(*domain_separator).try_into().map_err(|_| {
                     BlackBoxResolutionError::Failed(
                         BlackBoxFunc::PedersenCommitment,
-                        "Invalid signature length".to_string(),
+                        "Invalid separator length".to_string(),
                     )
                 })?;
             let (x, y) = solver.pedersen_commitment(&inputs, domain_separator)?;
@@ -260,7 +260,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 memory.read(*domain_separator).try_into().map_err(|_| {
                     BlackBoxResolutionError::Failed(
                         BlackBoxFunc::PedersenCommitment,
-                        "Invalid signature length".to_string(),
+                        "Invalid separator length".to_string(),
                     )
                 })?;
             let hash = solver.pedersen_hash(&inputs, domain_separator)?;

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -232,6 +232,41 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
             );
             Ok(())
         }
+        BlackBoxOp::PedersenCommitment { inputs, domain_separator, output } => {
+            let inputs: Vec<F> = read_heap_vector(memory, inputs)
+                .iter()
+                .map(|x| *x.extract_field().unwrap())
+                .collect();
+            let domain_separator: u32 =
+                memory.read(*domain_separator).try_into().map_err(|_| {
+                    BlackBoxResolutionError::Failed(
+                        BlackBoxFunc::PedersenCommitment,
+                        "Invalid signature length".to_string(),
+                    )
+                })?;
+            let (x, y) = solver.pedersen_commitment(&inputs, domain_separator)?;
+            memory.write_slice(
+                memory.read_ref(output.pointer),
+                &[MemoryValue::new_field(x), MemoryValue::new_field(y)],
+            );
+            Ok(())
+        }
+        BlackBoxOp::PedersenHash { inputs, domain_separator, output } => {
+            let inputs: Vec<F> = read_heap_vector(memory, inputs)
+                .iter()
+                .map(|x| *x.extract_field().unwrap())
+                .collect();
+            let domain_separator: u32 =
+                memory.read(*domain_separator).try_into().map_err(|_| {
+                    BlackBoxResolutionError::Failed(
+                        BlackBoxFunc::PedersenCommitment,
+                        "Invalid signature length".to_string(),
+                    )
+                })?;
+            let hash = solver.pedersen_hash(&inputs, domain_separator)?;
+            memory.write(*output, MemoryValue::new_field(hash));
+            Ok(())
+        }
         BlackBoxOp::BigIntAdd { lhs, rhs, output } => {
             let lhs = memory.read(*lhs).try_into().unwrap();
             let rhs = memory.read(*rhs).try_into().unwrap();
@@ -343,8 +378,6 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
 
             Ok(())
         }
-        BlackBoxOp::PedersenCommitment { .. } => todo!("Deprecated Blackbox"),
-        BlackBoxOp::PedersenHash { .. } => todo!("Deprecated Blackbox"),
     }
 }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
@@ -137,6 +137,39 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString>(
                 )
             }
         }
+
+        BlackBoxFunc::PedersenCommitment => {
+            if let (
+                [message, BrilligVariable::SingleAddr(domain_separator)],
+                [BrilligVariable::BrilligArray(result_array)],
+            ) = (function_arguments, function_results)
+            {
+                let message_vector = convert_array_or_vector(brillig_context, message, bb_func);
+                brillig_context.black_box_op_instruction(BlackBoxOp::PedersenCommitment {
+                    inputs: message_vector.to_heap_vector(),
+                    domain_separator: domain_separator.address,
+                    output: result_array.to_heap_array(),
+                });
+            } else {
+                unreachable!("ICE: Pedersen expects one array argument, a register for the domain separator, and one array result")
+            }
+        }
+        BlackBoxFunc::PedersenHash => {
+            if let (
+                [message, BrilligVariable::SingleAddr(domain_separator)],
+                [BrilligVariable::SingleAddr(result)],
+            ) = (function_arguments, function_results)
+            {
+                let message_vector = convert_array_or_vector(brillig_context, message, bb_func);
+                brillig_context.black_box_op_instruction(BlackBoxOp::PedersenHash {
+                    inputs: message_vector.to_heap_vector(),
+                    domain_separator: domain_separator.address,
+                    output: result.address,
+                });
+            } else {
+                unreachable!("ICE: Pedersen hash expects one array argument, a register for the domain separator, and one register result")
+            }
+        }
         BlackBoxFunc::SchnorrVerify => {
             if let (
                 [BrilligVariable::SingleAddr(public_key_x), BrilligVariable::SingleAddr(public_key_y), BrilligVariable::BrilligArray(signature), message],
@@ -391,8 +424,6 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString>(
                 unreachable!("ICE: AES128Encrypt expects three array arguments, one array result")
             }
         }
-        BlackBoxFunc::PedersenCommitment => todo!("Deprecated Blackbox"),
-        BlackBoxFunc::PedersenHash => todo!("Deprecated Blackbox"),
     }
 }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -158,7 +158,20 @@ pub(crate) mod tests {
         ) -> Result<bool, BlackBoxResolutionError> {
             Ok(true)
         }
-
+        fn pedersen_commitment(
+            &self,
+            _inputs: &[FieldElement],
+            _domain_separator: u32,
+        ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
+            Ok((2_u128.into(), 3_u128.into()))
+        }
+        fn pedersen_hash(
+            &self,
+            _inputs: &[FieldElement],
+            _domain_separator: u32,
+        ) -> Result<FieldElement, BlackBoxResolutionError> {
+            Ok(6_u128.into())
+        }
         fn multi_scalar_mul(
             &self,
             _points: &[FieldElement],

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
@@ -347,6 +347,24 @@ impl DebugShow {
                     result
                 );
             }
+            BlackBoxOp::PedersenCommitment { inputs, domain_separator, output } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  PEDERSEN {} {} -> {}",
+                    inputs,
+                    domain_separator,
+                    output
+                );
+            }
+            BlackBoxOp::PedersenHash { inputs, domain_separator, output } => {
+                debug_println!(
+                    self.enable_debug_trace,
+                    "  PEDERSEN_HASH {} {} -> {}",
+                    inputs,
+                    domain_separator,
+                    output
+                );
+            }
             BlackBoxOp::SchnorrVerify {
                 public_key_x,
                 public_key_y,
@@ -444,8 +462,6 @@ impl DebugShow {
                     output
                 );
             }
-            BlackBoxOp::PedersenCommitment { .. } => todo!("Deprecated Blackbox"),
-            BlackBoxOp::PedersenHash { .. } => todo!("Deprecated Blackbox"),
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -1215,6 +1215,31 @@ impl<F: AcirField> AcirContext<F> {
     ) -> Result<Vec<AcirVar>, RuntimeError> {
         // Separate out any arguments that should be constants
         let (constant_inputs, constant_outputs) = match name {
+            BlackBoxFunc::PedersenCommitment | BlackBoxFunc::PedersenHash => {
+                // The last argument of pedersen is the domain separator, which must be a constant
+                let domain_var = match inputs.pop() {
+                    Some(domain_var) => domain_var.into_var()?,
+                    None => {
+                        return Err(RuntimeError::InternalError(InternalError::MissingArg {
+                            name: "pedersen call".to_string(),
+                            arg: "domain separator".to_string(),
+                            call_stack: self.get_call_stack(),
+                        }))
+                    }
+                };
+
+                let domain_constant = match self.vars[&domain_var].as_constant() {
+                    Some(domain_constant) => domain_constant,
+                    None => {
+                        return Err(RuntimeError::InternalError(InternalError::NotAConstant {
+                            name: "domain separator".to_string(),
+                            call_stack: self.get_call_stack(),
+                        }))
+                    }
+                };
+
+                (vec![*domain_constant], Vec::new())
+            }
             BlackBoxFunc::Poseidon2Permutation => {
                 // The last argument is the state length, which must be a constant
                 let state_len = match inputs.pop() {

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/generated_acir.rs
@@ -224,6 +224,16 @@ impl<F: AcirField> GeneratedAcir<F> {
                     output: outputs[0],
                 }
             }
+            BlackBoxFunc::PedersenCommitment => BlackBoxFuncCall::PedersenCommitment {
+                inputs: inputs[0].clone(),
+                outputs: (outputs[0], outputs[1]),
+                domain_separator: constant_inputs[0].to_u128() as u32,
+            },
+            BlackBoxFunc::PedersenHash => BlackBoxFuncCall::PedersenHash {
+                inputs: inputs[0].clone(),
+                output: outputs[0],
+                domain_separator: constant_inputs[0].to_u128() as u32,
+            },
             BlackBoxFunc::EcdsaSecp256k1 => {
                 BlackBoxFuncCall::EcdsaSecp256k1 {
                     // 32 bytes for each public key co-ordinate
@@ -361,8 +371,6 @@ impl<F: AcirField> GeneratedAcir<F> {
                     .expect("Compiler should generate correct size inputs"),
                 outputs: outputs.try_into().expect("Compiler should generate correct size outputs"),
             },
-            BlackBoxFunc::PedersenCommitment => todo!("Deprecated Blackbox"),
-            BlackBoxFunc::PedersenHash => todo!("Deprecated Blackbox"),
         };
 
         self.push_opcode(AcirOpcode::BlackBoxFuncCall(black_box_func_call));
@@ -641,7 +649,9 @@ fn black_box_func_expected_input_size(name: BlackBoxFunc) -> Option<usize> {
         | BlackBoxFunc::Keccak256
         | BlackBoxFunc::SHA256
         | BlackBoxFunc::Blake2s
-        | BlackBoxFunc::Blake3 => None,
+        | BlackBoxFunc::Blake3
+        | BlackBoxFunc::PedersenCommitment
+        | BlackBoxFunc::PedersenHash => None,
 
         BlackBoxFunc::Keccakf1600 => Some(25),
         // The permutation takes a fixed number of inputs, but the inputs length depends on the proving system implementation.
@@ -677,8 +687,6 @@ fn black_box_func_expected_input_size(name: BlackBoxFunc) -> Option<usize> {
 
         // FromLeBytes takes a variable array of bytes as input
         BlackBoxFunc::BigIntFromLeBytes => None,
-        BlackBoxFunc::PedersenCommitment => todo!(),
-        BlackBoxFunc::PedersenHash => todo!(),
     }
 }
 
@@ -701,6 +709,12 @@ fn black_box_expected_output_size(name: BlackBoxFunc) -> Option<usize> {
         BlackBoxFunc::Poseidon2Permutation => None,
 
         BlackBoxFunc::Sha256Compression => Some(8),
+
+        // Pedersen commitment returns a point
+        BlackBoxFunc::PedersenCommitment => Some(2),
+
+        // Pedersen hash returns a field
+        BlackBoxFunc::PedersenHash => Some(1),
 
         // Can only apply a range constraint to one
         // witness at a time.
@@ -730,8 +744,6 @@ fn black_box_expected_output_size(name: BlackBoxFunc) -> Option<usize> {
 
         // AES encryption returns a variable number of outputs
         BlackBoxFunc::AES128Encrypt => None,
-        BlackBoxFunc::PedersenCommitment => todo!(),
-        BlackBoxFunc::PedersenHash => todo!(),
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -446,7 +446,9 @@ fn simplify_black_box_func(
         BlackBoxFunc::SHA256 => simplify_hash(dfg, arguments, acvm::blackbox_solver::sha256),
         BlackBoxFunc::Blake2s => simplify_hash(dfg, arguments, acvm::blackbox_solver::blake2s),
         BlackBoxFunc::Blake3 => simplify_hash(dfg, arguments, acvm::blackbox_solver::blake3),
-        BlackBoxFunc::Keccakf1600 => SimplifyResult::None, //TODO(Guillaume)
+        BlackBoxFunc::PedersenCommitment
+        | BlackBoxFunc::PedersenHash
+        | BlackBoxFunc::Keccakf1600 => SimplifyResult::None, //TODO(Guillaume)
         BlackBoxFunc::Keccak256 => {
             match (dfg.get_array_constant(arguments[0]), dfg.get_numeric_constant(arguments[1])) {
                 (Some((input, _)), Some(num_bytes)) if array_is_constant(dfg, &input) => {
@@ -501,8 +503,6 @@ fn simplify_black_box_func(
         }
         BlackBoxFunc::Sha256Compression => SimplifyResult::None, //TODO(Guillaume)
         BlackBoxFunc::AES128Encrypt => SimplifyResult::None,
-        BlackBoxFunc::PedersenCommitment => todo!("Deprecated Blackbox"),
-        BlackBoxFunc::PedersenHash => todo!("Deprecated Blackbox"),
     }
 }
 

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -259,9 +259,9 @@ impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D:
 }
 
 #[test]
-fn assert_pedersen_noir(input: [Field; 10], separator: u32) {
-    assert_eq(pedersen_hash_with_separator(input, separator), pedersen_hash_with_separator_noir(input, separator));
+fn assert_pedersen_noir(input: [Field; 10]) {
+    assert_eq(pedersen_hash_with_separator(input, 4), pedersen_hash_with_separator_noir(input, 4));
     assert_eq(
-        pedersen_commitment_with_separator(input, separator), pedersen_commitment_with_separator_noir(input, separator)
+        pedersen_commitment_with_separator(input, 4), pedersen_commitment_with_separator_noir(input, 4)
     );
 }

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -82,7 +82,7 @@ fn pedersen_hash_with_separator_noir<N>(input: [Field; N], separator: u32) -> Fi
 pub fn pedersen_hash_with_separator<N>(input: [Field; N], separator: u32) -> Field {}
 
 #[foreign(pedersen_commitment)]
-pub fn __pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> [Field; 2] {}
+fn __pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> [Field; 2] {}
 
 pub fn hash_to_field(inputs: [Field]) -> Field {
     let mut sum = 0;

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -36,7 +36,7 @@ pub fn pedersen_commitment<N>(input: [Field; N]) -> EmbeddedCurvePoint {
     }
 }
 
-pub fn pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
+pub fn pedersen_commitment_with_separator_noir<N>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
     let mut points = [EmbeddedCurveScalar { lo: 0, hi: 0 }; N];
     for i in 0..N {
         points[i] = EmbeddedCurveScalar::from_field(input[i]);
@@ -44,6 +44,11 @@ pub fn pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) 
     let generators = derive_generators("DEFAULT_DOMAIN_SEPARATOR".as_bytes(), separator);
     let values = multi_scalar_mul(generators, points);
     EmbeddedCurvePoint { x: values[0], y: values[1], is_infinite: values[2] as bool }
+}
+
+pub fn pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
+    let values = __pedersen_commitment_with_separator(input, separator);
+    EmbeddedCurvePoint { x: values[0], y: values[1], is_infinite: false }
 }
 
 // docs:start:pedersen_hash
@@ -64,7 +69,7 @@ fn derive_generators<N, M>(domain_separator_bytes: [u8; M], starting_index: u32)
 #[field(bn254)]
 fn __derive_generators<N, M>(domain_separator_bytes: [u8; M], starting_index: u32) -> [EmbeddedCurvePoint; N] {}
 
-pub fn pedersen_hash_with_separator<N>(input: [Field; N], separator: u32) -> Field {
+pub fn pedersen_hash_with_separator_noir<N>(input: [Field; N], separator: u32) -> Field {
     let v1 = pedersen_commitment(input);
     let length_generator :[EmbeddedCurvePoint;1] = derive_generators("pedersen_hash_length".as_bytes(), separator);
     multi_scalar_mul(
@@ -72,6 +77,12 @@ pub fn pedersen_hash_with_separator<N>(input: [Field; N], separator: u32) -> Fie
         [EmbeddedCurveScalar { lo: N as Field, hi: 0 }, EmbeddedCurveScalar { lo: 1, hi: 0 }]
     )[0]
 }
+
+#[foreign(pedersen_hash)]
+pub fn pedersen_hash_with_separator<N>(input: [Field; N], separator: u32) -> Field {}
+
+#[foreign(pedersen_commitment)]
+pub fn __pedersen_commitment_with_separator<N>(input: [Field; N], separator: u32) -> [Field; 2] {}
 
 pub fn hash_to_field(inputs: [Field]) -> Field {
     let mut sum = 0;
@@ -245,4 +256,12 @@ impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D:
         self.3.hash(state);
         self.4.hash(state);
     }
+}
+
+#[test]
+fn assert_pedersen_noir() {
+    assert_eq(pedersen_hash_with_separator([1, 2, 3], 4), pedersen_hash_with_separator_noir([1, 2, 3], 4));
+    assert_eq(
+        pedersen_commitment_with_separator([1, 2, 3], 4), pedersen_commitment_with_separator_noir([1, 2, 3], 4)
+    );
 }

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -259,7 +259,9 @@ impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D:
 }
 
 #[test]
-fn assert_pedersen_noir(input: [Field; 10]) {
+fn assert_pedersen_noir() {
+    // TODO: make this a fuzzer test once fuzzer supports curve-specific blackbox functions.
+    let input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     assert_eq(pedersen_hash_with_separator(input, 4), pedersen_hash_with_separator_noir(input, 4));
     assert_eq(pedersen_commitment_with_separator(input, 4), pedersen_commitment_with_separator_noir(input, 4));
 }

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -260,7 +260,7 @@ impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D:
 
 #[test]
 fn assert_pedersen_noir() {
-    assert_eq(pedersen_hash_with_separator([1, 2, 3], 4), pedersen_hash_with_separator_noir([1, 2, 3], 4));
+    //TODO: assert_eq(pedersen_hash_with_separator([1, 2, 3], 4), pedersen_hash_with_separator_noir([1, 2, 3], 4));
     assert_eq(
         pedersen_commitment_with_separator([1, 2, 3], 4), pedersen_commitment_with_separator_noir([1, 2, 3], 4)
     );

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -36,7 +36,7 @@ pub fn pedersen_commitment<N>(input: [Field; N]) -> EmbeddedCurvePoint {
     }
 }
 
-pub fn pedersen_commitment_with_separator_noir<N>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
+fn pedersen_commitment_with_separator_noir<N>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
     let mut points = [EmbeddedCurveScalar { lo: 0, hi: 0 }; N];
     for i in 0..N {
         points[i] = EmbeddedCurveScalar::from_field(input[i]);
@@ -69,9 +69,9 @@ fn derive_generators<N, M>(domain_separator_bytes: [u8; M], starting_index: u32)
 #[field(bn254)]
 fn __derive_generators<N, M>(domain_separator_bytes: [u8; M], starting_index: u32) -> [EmbeddedCurvePoint; N] {}
 
-pub fn pedersen_hash_with_separator_noir<N>(input: [Field; N], separator: u32) -> Field {
-    let v1 = pedersen_commitment(input);
-    let length_generator :[EmbeddedCurvePoint;1] = derive_generators("pedersen_hash_length".as_bytes(), separator);
+fn pedersen_hash_with_separator_noir<N>(input: [Field; N], separator: u32) -> Field {
+    let v1 = pedersen_commitment_with_separator(input, separator);
+    let length_generator : [EmbeddedCurvePoint; 1] = derive_generators("pedersen_hash_length".as_bytes(), 0);
     multi_scalar_mul(
         [length_generator[0], v1],
         [EmbeddedCurveScalar { lo: N as Field, hi: 0 }, EmbeddedCurveScalar { lo: 1, hi: 0 }]
@@ -260,7 +260,7 @@ impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D:
 
 #[test]
 fn assert_pedersen_noir() {
-    //TODO: assert_eq(pedersen_hash_with_separator([1, 2, 3], 4), pedersen_hash_with_separator_noir([1, 2, 3], 4));
+    assert_eq(pedersen_hash_with_separator([1, 2, 3], 4), pedersen_hash_with_separator_noir([1, 2, 3], 4));
     assert_eq(
         pedersen_commitment_with_separator([1, 2, 3], 4), pedersen_commitment_with_separator_noir([1, 2, 3], 4)
     );

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -259,9 +259,9 @@ impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D:
 }
 
 #[test]
-fn assert_pedersen_noir() {
-    assert_eq(pedersen_hash_with_separator([1, 2, 3], 4), pedersen_hash_with_separator_noir([1, 2, 3], 4));
+fn assert_pedersen_noir(input: [Field; 10], separator: u32) {
+    assert_eq(pedersen_hash_with_separator(input, separator), pedersen_hash_with_separator_noir(input, separator));
     assert_eq(
-        pedersen_commitment_with_separator([1, 2, 3], 4), pedersen_commitment_with_separator_noir([1, 2, 3], 4)
+        pedersen_commitment_with_separator(input, separator), pedersen_commitment_with_separator_noir(input, separator)
     );
 }

--- a/noir_stdlib/src/hash.nr
+++ b/noir_stdlib/src/hash.nr
@@ -261,7 +261,5 @@ impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D:
 #[test]
 fn assert_pedersen_noir(input: [Field; 10]) {
     assert_eq(pedersen_hash_with_separator(input, 4), pedersen_hash_with_separator_noir(input, 4));
-    assert_eq(
-        pedersen_commitment_with_separator(input, 4), pedersen_commitment_with_separator_noir(input, 4)
-    );
+    assert_eq(pedersen_commitment_with_separator(input, 4), pedersen_commitment_with_separator_noir(input, 4));
 }

--- a/tooling/lsp/src/solver.rs
+++ b/tooling/lsp/src/solver.rs
@@ -16,6 +16,22 @@ impl BlackBoxFunctionSolver<acvm::FieldElement> for WrapperSolver {
         self.0.schnorr_verify(public_key_x, public_key_y, signature, message)
     }
 
+    fn pedersen_commitment(
+        &self,
+        inputs: &[acvm::FieldElement],
+        domain_separator: u32,
+    ) -> Result<(acvm::FieldElement, acvm::FieldElement), acvm::BlackBoxResolutionError> {
+        self.0.pedersen_commitment(inputs, domain_separator)
+    }
+
+    fn pedersen_hash(
+        &self,
+        inputs: &[acvm::FieldElement],
+        domain_separator: u32,
+    ) -> Result<acvm::FieldElement, acvm::BlackBoxResolutionError> {
+        self.0.pedersen_hash(inputs, domain_separator)
+    }
+
     fn multi_scalar_mul(
         &self,
         points: &[acvm::FieldElement],

--- a/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 use std::{collections::BTreeMap, path::PathBuf};
 
-use acvm::blackbox_solver::StubbedBlackBoxSolver;
 use fm::FileManager;
 use noirc_driver::{check_crate, compile_no_check, file_manager_with_stdlib, CompileOptions};
 use noirc_frontend::hir::FunctionNameMatch;
@@ -56,7 +55,7 @@ fn run_stdlib_tests() {
 
             let status = if test_function_has_no_arguments {
                 run_test(
-                    &StubbedBlackBoxSolver,
+                    &bn254_blackbox_solver::Bn254BlackBoxSolver,
                     &mut context,
                     &test_function,
                     false,


### PR DESCRIPTION
# Description

## Problem\*

This PR adds (back) the blackbox functions for Pedersen hash/commitment, until we get a similar circuit (in term of number of gates) with the Noir implementation.

## Summary\*
The Noir version is kept and assert to ouput the same value in a test.


## Additional Context
This PR reverts the PR #5221


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
