### PR TITLE
chore: replace cached `in_contract` with `in_contract()` method

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -254,8 +254,7 @@ impl<'context> Elaborator<'context> {
                 }
 
                 let expected_generic_count = struct_type.borrow().generics.len();
-
-                if !self.in_contract
+                if !self.in_contract()
                     && self
                         .interner
                         .struct_attributes(&struct_type.borrow().id)


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/5298#discussion_r1648054135

## Summary\*

This PR replaces the `in_contract` field with a `in_contract` function. This does expand the `self_type.is_some()` override to a couple of locations however which I need to check whether it's going to cause issues.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
