### PR TITLE
chore: remove panic for unimplemented trait dispatch

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -609,6 +609,7 @@ impl<'a> Interpreter<'a> {
         let rhs = self.evaluate(infix.rhs)?;
 
         // TODO: Need to account for operator overloading
+        // See https://github.com/noir-lang/noir/issues/4925
         if self.interner.get_selected_impl_for_expression(id).is_some() {
             return Err(InterpreterError::Unimplemented {
                 item: "Operator overloading in the interpreter".to_string(),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -609,7 +609,6 @@ impl<'a> Interpreter<'a> {
         let rhs = self.evaluate(infix.rhs)?;
 
         // TODO: Need to account for operator overloading
-        // See https://github.com/noir-lang/noir/issues/4925
         if self.interner.get_selected_impl_for_expression(id).is_some() {
             return Err(InterpreterError::Unimplemented {
                 item: "Operator overloading is unimplemented in the interpreter. See https://github.com/noir-lang/noir/issues/4925".to_string(),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -611,7 +611,7 @@ impl<'a> Interpreter<'a> {
         // TODO: Need to account for operator overloading
         if self.interner.get_selected_impl_for_expression(id).is_some() {
             return Err(InterpreterError::Unimplemented {
-                item: "Operator overloading is unimplemented in the interpreter. See https://github.com/noir-lang/noir/issues/4925".to_string(),
+                item: "Operator overloading in the interpreter".to_string(),
                 location: infix.operator.location,
             });
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -609,10 +609,13 @@ impl<'a> Interpreter<'a> {
         let rhs = self.evaluate(infix.rhs)?;
 
         // TODO: Need to account for operator overloading
-        assert!(
-            self.interner.get_selected_impl_for_expression(id).is_none(),
-            "Operator overloading is unimplemented in the interpreter"
-        );
+        // See https://github.com/noir-lang/noir/issues/4925
+        if self.interner.get_selected_impl_for_expression(id).is_some() {
+            return Err(InterpreterError::Unimplemented {
+                item: "Operator overloading is unimplemented in the interpreter. See https://github.com/noir-lang/noir/issues/4925".to_string(),
+                location: infix.operator.location,
+            });
+        }
 
         use InterpreterError::InvalidValuesForBinary;
         match infix.operator.kind {


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

This PR replaces a panic with a nicer error plus a link to the relevant issue: https://github.com/noir-lang/noir/issues/4925

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
