### PR TITLE
chore: remove `is_unconstrained_fn` field from elaborator

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -90,7 +90,6 @@ pub struct Elaborator<'context> {
 
     file: FileId,
 
-    in_unconstrained_fn: bool,
     nested_loops: usize,
 
     /// Contains a mapping of the current struct or functions's generics to
@@ -173,7 +172,6 @@ impl<'context> Elaborator<'context> {
             interner: &mut context.def_interner,
             def_maps: &mut context.def_maps,
             file: FileId::dummy(),
-            in_unconstrained_fn: false,
             nested_loops: 0,
             generics: Vec::new(),
             lambda_stack: Vec::new(),
@@ -317,10 +315,6 @@ impl<'context> Elaborator<'context> {
 
         self.trait_bounds = func_meta.trait_constraints.clone();
 
-        if self.interner.function_modifiers(&id).is_unconstrained {
-            self.in_unconstrained_fn = true;
-        }
-
         // Introduce all numeric generics into scope
         for generic in &func_meta.all_generics {
             if let Kind::Numeric(typ) = &generic.kind {
@@ -412,7 +406,6 @@ impl<'context> Elaborator<'context> {
 
         self.trait_bounds.clear();
         self.type_variables.clear();
-        self.in_unconstrained_fn = false;
         self.interner.update_fn(id, hir_func);
         self.current_function = old_function;
         self.current_item = old_item;

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -206,7 +206,10 @@ impl<'context> Elaborator<'context> {
     }
 
     fn elaborate_jump(&mut self, is_break: bool, span: noirc_errors::Span) -> (HirStatement, Type) {
-        if !self.in_unconstrained_fn {
+        let in_constrained_function = self
+            .current_function
+            .map_or(true, |func_id| !self.interner.function_modifiers(&func_id).is_unconstrained);
+        if in_constrained_function {
             self.push_err(ResolverError::JumpInConstrainedFn { is_break, span });
         }
         if self.nested_loops == 0 {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

In the vein of #5324, we now just look up whether the `current_function` is unconstrained rather than tracking this on the elaborator.

This does come with a little bit of a perf degradation as we need to look up the function on each jump but that should be pretty negligible.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
