### PR TITLE
chore: use `push_err` more in elaborator

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -491,12 +491,11 @@ impl<'context> Elaborator<'context> {
                 self.resolve_type(typ.clone())
             };
             if !matches!(typ, Type::FieldElement | Type::Integer(_, _)) {
-                let unsupported_typ_err =
-                    CompilationError::ResolverError(ResolverError::UnsupportedNumericGenericType {
-                        ident: ident.clone(),
-                        typ: typ.clone(),
-                    });
-                self.errors.push((unsupported_typ_err, self.file));
+                let unsupported_typ_err = ResolverError::UnsupportedNumericGenericType {
+                    ident: ident.clone(),
+                    typ: typ.clone(),
+                };
+                self.push_err(unsupported_typ_err);
             }
             Kind::Numeric(Box::new(typ))
         } else {
@@ -795,12 +794,7 @@ impl<'context> Elaborator<'context> {
                 let definition = DefinitionKind::GenericType(type_variable);
                 self.add_variable_decl_inner(ident.clone(), false, false, false, definition);
 
-                self.errors.push((
-                    CompilationError::ResolverError(ResolverError::UseExplicitNumericGeneric {
-                        ident,
-                    }),
-                    self.file,
-                ));
+                self.push_err(ResolverError::UseExplicitNumericGeneric { ident });
             }
         }
     }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -11,7 +11,6 @@ use crate::{
     },
     hir::{
         comptime::{Interpreter, Value},
-        def_collector::dc_crate::CompilationError,
         def_map::ModuleDefId,
         resolution::{
             errors::ResolverError,
@@ -170,12 +169,11 @@ impl<'context> Elaborator<'context> {
         // }
         if let Type::NamedGeneric(_, name, resolved_kind) = &resolved_type {
             if matches!(resolved_kind, Kind::Numeric { .. }) && matches!(kind, Kind::Normal) {
-                let expected_typ_err =
-                    CompilationError::ResolverError(ResolverError::NumericGenericUsedForType {
-                        name: name.to_string(),
-                        span: span.expect("Type should have span"),
-                    });
-                self.errors.push((expected_typ_err, self.file));
+                let expected_typ_err = ResolverError::NumericGenericUsedForType {
+                    name: name.to_string(),
+                    span: span.expect("Type should have span"),
+                };
+                self.push_err(expected_typ_err);
                 return Type::Error;
             }
         }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Quick PR to make more use of the `push_err` helper when creating errors in the elaborator.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
