### PR TITLE
fix: Avoid issuing duplicate errors during interpreting

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -676,7 +676,7 @@ impl<'context> Elaborator<'context> {
         span: Span,
     ) -> (ExprId, Type) {
         let make_error = |this: &mut Self, error: InterpreterError| {
-            this.errors.push(error.into_compilation_error_pair());
+            this.try_push_interpreter_error(error);
             let error = this.interner.push_expr(HirExpression::Error);
             this.interner.push_expr_location(error, span, this.file);
             (error, Type::Error)

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -13,88 +13,32 @@ use super::value::Value;
 /// The possible errors that can halt the interpreter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InterpreterError {
-    ArgumentCountMismatch {
-        expected: usize,
-        actual: usize,
-        location: Location,
-    },
-    TypeMismatch {
-        expected: Type,
-        value: Value,
-        location: Location,
-    },
-    NonComptimeVarReferenced {
-        name: String,
-        location: Location,
-    },
-    IntegerOutOfRangeForType {
-        value: FieldElement,
-        typ: Type,
-        location: Location,
-    },
-    ErrorNodeEncountered {
-        location: Location,
-    },
-    FailingConstraint {
-        message: Option<Value>,
-        location: Location,
-    },
-    NoMethodFound {
-        name: String,
-        typ: Type,
-        location: Location,
-    },
-    NonNumericCasted {
-        value: Value,
-        location: Location,
-    },
-    IndexOutOfBounds {
-        index: usize,
-        length: usize,
-        location: Location,
-    },
-    TypeUnsupported {
-        typ: Type,
-        location: Location,
-    },
-    QuoteInRuntimeCode {
-        location: Location,
-    },
-    CannotInlineMacro {
-        value: Value,
-        location: Location,
-    },
-    UnquoteFoundDuringEvaluation {
-        location: Location,
-    },
-    FailedToParseMacro {
-        error: ParserError,
-        tokens: Rc<Tokens>,
-        rule: &'static str,
-        file: FileId,
-    },
-    NonComptimeFnCallInSameCrate {
-        function: String,
-        location: Location,
-    },
+    ArgumentCountMismatch { expected: usize, actual: usize, location: Location },
+    TypeMismatch { expected: Type, value: Value, location: Location },
+    NonComptimeVarReferenced { name: String, location: Location },
+    IntegerOutOfRangeForType { value: FieldElement, typ: Type, location: Location },
+    ErrorNodeEncountered { location: Location },
+    FailingConstraint { message: Option<Value>, location: Location },
+    NoMethodFound { name: String, typ: Type, location: Location },
+    NonNumericCasted { value: Value, location: Location },
+    IndexOutOfBounds { index: usize, length: usize, location: Location },
+    TypeUnsupported { typ: Type, location: Location },
+    QuoteInRuntimeCode { location: Location },
+    CannotInlineMacro { value: Value, location: Location },
+    UnquoteFoundDuringEvaluation { location: Location },
+    FailedToParseMacro { error: ParserError, tokens: Rc<Tokens>, rule: &'static str, file: FileId },
+    NonComptimeFnCallInSameCrate { function: String, location: Location },
 
-    /// SilentFail is for silently failing without reporting an error. This is used to avoid
-    /// issuing repeated errors, e.g. for cases the type checker is already expected to catch.
+    // SilentFail is for silently failing without reporting an error. This is used to avoid
+    // issuing repeated errors, e.g. for cases the type checker is already expected to catch.
     SilentFail,
 
-    Unimplemented {
-        item: String,
-        location: Location,
-    },
+    Unimplemented { item: String, location: Location },
 
     // Perhaps this should be unreachable! due to type checking also preventing this error?
     // Currently it and the Continue variant are the only interpreter errors without a Location field
-    BreakNotInLoop {
-        location: Location,
-    },
-    ContinueNotInLoop {
-        location: Location,
-    },
+    BreakNotInLoop { location: Location },
+    ContinueNotInLoop { location: Location },
 
     // These cases are not errors, they are just used to prevent us from running more code
     // until the loop can be resumed properly. These cases will never be displayed to users.

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -57,17 +57,6 @@ pub enum InterpreterError {
         typ: Type,
         location: Location,
     },
-    InvalidValueForUnary {
-        value: Value,
-        operator: &'static str,
-        location: Location,
-    },
-    InvalidValuesForBinary {
-        lhs: Value,
-        rhs: Value,
-        operator: &'static str,
-        location: Location,
-    },
     QuoteInRuntimeCode {
         location: Location,
     },
@@ -92,6 +81,7 @@ pub enum InterpreterError {
     /// SilentFail is for silently failing without reporting an error. This is used to avoid
     /// issuing repeated errors, e.g. for cases the type checker is already expected to catch.
     SilentFail,
+
     Unimplemented {
         item: String,
         location: Location,
@@ -139,8 +129,6 @@ impl InterpreterError {
             | InterpreterError::NonNumericCasted { location, .. }
             | InterpreterError::IndexOutOfBounds { location, .. }
             | InterpreterError::TypeUnsupported { location, .. }
-            | InterpreterError::InvalidValueForUnary { location, .. }
-            | InterpreterError::InvalidValuesForBinary { location, .. }
             | InterpreterError::QuoteInRuntimeCode { location, .. }
             | InterpreterError::CannotInlineMacro { location, .. }
             | InterpreterError::UnquoteFoundDuringEvaluation { location, .. }
@@ -222,16 +210,6 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             InterpreterError::TypeUnsupported { typ, location } => {
                 let msg =
                     format!("The type `{typ}` is currently unsupported in comptime expressions");
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
-            InterpreterError::InvalidValueForUnary { value, operator, location } => {
-                let msg = format!("`{}` cannot be used with unary {operator}", value.get_type());
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
-            InterpreterError::InvalidValuesForBinary { lhs, rhs, operator, location } => {
-                let lhs = lhs.get_type();
-                let rhs = rhs.get_type();
-                let msg = format!("No implementation for `{lhs}` {operator} `{rhs}`",);
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
             InterpreterError::QuoteInRuntimeCode { location } => {

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -13,43 +13,98 @@ use super::value::Value;
 /// The possible errors that can halt the interpreter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InterpreterError {
-    ArgumentCountMismatch { expected: usize, actual: usize, location: Location },
-    TypeMismatch { expected: Type, value: Value, location: Location },
-    NonComptimeVarReferenced { name: String, location: Location },
-    IntegerOutOfRangeForType { value: FieldElement, typ: Type, location: Location },
-    ErrorNodeEncountered { location: Location },
-    NonFunctionCalled { value: Value, location: Location },
-    NonBoolUsedInIf { value: Value, location: Location },
-    NonBoolUsedInConstrain { value: Value, location: Location },
-    FailingConstraint { message: Option<Value>, location: Location },
-    NoMethodFound { name: String, typ: Type, location: Location },
-    NonIntegerUsedInLoop { value: Value, location: Location },
-    NonPointerDereferenced { value: Value, location: Location },
-    NonTupleOrStructInMemberAccess { value: Value, location: Location },
-    NonArrayIndexed { value: Value, location: Location },
-    NonIntegerUsedAsIndex { value: Value, location: Location },
-    NonIntegerIntegerLiteral { typ: Type, location: Location },
-    NonIntegerArrayLength { typ: Type, location: Location },
-    NonNumericCasted { value: Value, location: Location },
-    IndexOutOfBounds { index: usize, length: usize, location: Location },
-    ExpectedStructToHaveField { value: Value, field_name: String, location: Location },
-    TypeUnsupported { typ: Type, location: Location },
-    InvalidValueForUnary { value: Value, operator: &'static str, location: Location },
-    InvalidValuesForBinary { lhs: Value, rhs: Value, operator: &'static str, location: Location },
-    CastToNonNumericType { typ: Type, location: Location },
-    QuoteInRuntimeCode { location: Location },
-    NonStructInConstructor { typ: Type, location: Location },
-    CannotInlineMacro { value: Value, location: Location },
-    UnquoteFoundDuringEvaluation { location: Location },
-    FailedToParseMacro { error: ParserError, tokens: Rc<Tokens>, rule: &'static str, file: FileId },
-    NonComptimeFnCallInSameCrate { function: String, location: Location },
+    ArgumentCountMismatch {
+        expected: usize,
+        actual: usize,
+        location: Location,
+    },
+    TypeMismatch {
+        expected: Type,
+        value: Value,
+        location: Location,
+    },
+    NonComptimeVarReferenced {
+        name: String,
+        location: Location,
+    },
+    IntegerOutOfRangeForType {
+        value: FieldElement,
+        typ: Type,
+        location: Location,
+    },
+    ErrorNodeEncountered {
+        location: Location,
+    },
+    FailingConstraint {
+        message: Option<Value>,
+        location: Location,
+    },
+    NoMethodFound {
+        name: String,
+        typ: Type,
+        location: Location,
+    },
+    NonNumericCasted {
+        value: Value,
+        location: Location,
+    },
+    IndexOutOfBounds {
+        index: usize,
+        length: usize,
+        location: Location,
+    },
+    TypeUnsupported {
+        typ: Type,
+        location: Location,
+    },
+    InvalidValueForUnary {
+        value: Value,
+        operator: &'static str,
+        location: Location,
+    },
+    InvalidValuesForBinary {
+        lhs: Value,
+        rhs: Value,
+        operator: &'static str,
+        location: Location,
+    },
+    QuoteInRuntimeCode {
+        location: Location,
+    },
+    CannotInlineMacro {
+        value: Value,
+        location: Location,
+    },
+    UnquoteFoundDuringEvaluation {
+        location: Location,
+    },
+    FailedToParseMacro {
+        error: ParserError,
+        tokens: Rc<Tokens>,
+        rule: &'static str,
+        file: FileId,
+    },
+    NonComptimeFnCallInSameCrate {
+        function: String,
+        location: Location,
+    },
 
-    Unimplemented { item: String, location: Location },
+    /// SilentFail is for silently failing without reporting an error. This is used to avoid
+    /// issuing repeated errors, e.g. for cases the type checker is already expected to catch.
+    SilentFail,
+    Unimplemented {
+        item: String,
+        location: Location,
+    },
 
     // Perhaps this should be unreachable! due to type checking also preventing this error?
     // Currently it and the Continue variant are the only interpreter errors without a Location field
-    BreakNotInLoop { location: Location },
-    ContinueNotInLoop { location: Location },
+    BreakNotInLoop {
+        location: Location,
+    },
+    ContinueNotInLoop {
+        location: Location,
+    },
 
     // These cases are not errors, they are just used to prevent us from running more code
     // until the loop can be resumed properly. These cases will never be displayed to users.
@@ -79,27 +134,14 @@ impl InterpreterError {
             | InterpreterError::NonComptimeVarReferenced { location, .. }
             | InterpreterError::IntegerOutOfRangeForType { location, .. }
             | InterpreterError::ErrorNodeEncountered { location, .. }
-            | InterpreterError::NonFunctionCalled { location, .. }
-            | InterpreterError::NonBoolUsedInIf { location, .. }
-            | InterpreterError::NonBoolUsedInConstrain { location, .. }
             | InterpreterError::FailingConstraint { location, .. }
             | InterpreterError::NoMethodFound { location, .. }
-            | InterpreterError::NonIntegerUsedInLoop { location, .. }
-            | InterpreterError::NonPointerDereferenced { location, .. }
-            | InterpreterError::NonTupleOrStructInMemberAccess { location, .. }
-            | InterpreterError::NonArrayIndexed { location, .. }
-            | InterpreterError::NonIntegerUsedAsIndex { location, .. }
-            | InterpreterError::NonIntegerIntegerLiteral { location, .. }
-            | InterpreterError::NonIntegerArrayLength { location, .. }
             | InterpreterError::NonNumericCasted { location, .. }
             | InterpreterError::IndexOutOfBounds { location, .. }
-            | InterpreterError::ExpectedStructToHaveField { location, .. }
             | InterpreterError::TypeUnsupported { location, .. }
             | InterpreterError::InvalidValueForUnary { location, .. }
             | InterpreterError::InvalidValuesForBinary { location, .. }
-            | InterpreterError::CastToNonNumericType { location, .. }
             | InterpreterError::QuoteInRuntimeCode { location, .. }
-            | InterpreterError::NonStructInConstructor { location, .. }
             | InterpreterError::CannotInlineMacro { location, .. }
             | InterpreterError::UnquoteFoundDuringEvaluation { location, .. }
             | InterpreterError::NonComptimeFnCallInSameCrate { location, .. }
@@ -111,6 +153,9 @@ impl InterpreterError {
             }
             InterpreterError::Break | InterpreterError::Continue => {
                 panic!("Tried to get the location of Break/Continue error!")
+            }
+            InterpreterError::SilentFail => {
+                panic!("Tried to get the location of InterpreterError::SilentFail!")
             }
         }
     }
@@ -154,20 +199,6 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 let secondary = "This is a bug, please report this if found!".to_string();
                 CustomDiagnostic::simple_error(msg, secondary, location.span)
             }
-            InterpreterError::NonFunctionCalled { value, location } => {
-                let msg = "Only functions may be called".to_string();
-                let secondary = format!("Expression has type {}", value.get_type());
-                CustomDiagnostic::simple_error(msg, secondary, location.span)
-            }
-            InterpreterError::NonBoolUsedInIf { value, location } => {
-                let msg = format!("Expected a `bool` but found `{}`", value.get_type());
-                let secondary = "If conditions must be a boolean value".to_string();
-                CustomDiagnostic::simple_error(msg, secondary, location.span)
-            }
-            InterpreterError::NonBoolUsedInConstrain { value, location } => {
-                let msg = format!("Expected a `bool` but found `{}`", value.get_type());
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
             InterpreterError::FailingConstraint { message, location } => {
                 let (primary, secondary) = match message {
                     Some(msg) => (format!("{msg:?}"), "Assertion failed".into()),
@@ -179,46 +210,6 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 let msg = format!("No method named `{name}` found for type `{typ}`");
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
-            InterpreterError::NonIntegerUsedInLoop { value, location } => {
-                let typ = value.get_type();
-                let msg = format!("Non-integer type `{typ}` used in for loop");
-                let secondary = if matches!(typ.as_ref(), &Type::FieldElement) {
-                    "`field` is not an integer type, try `u32` instead".to_string()
-                } else {
-                    String::new()
-                };
-                CustomDiagnostic::simple_error(msg, secondary, location.span)
-            }
-            InterpreterError::NonPointerDereferenced { value, location } => {
-                let typ = value.get_type();
-                let msg = format!("Only references may be dereferenced, but found `{typ}`");
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
-            InterpreterError::NonTupleOrStructInMemberAccess { value, location } => {
-                let msg = format!("The type `{}` has no fields to access", value.get_type());
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
-            InterpreterError::NonArrayIndexed { value, location } => {
-                let msg = format!("Expected an array or slice but found a(n) {}", value.get_type());
-                let secondary = "Only arrays or slices may be indexed".into();
-                CustomDiagnostic::simple_error(msg, secondary, location.span)
-            }
-            InterpreterError::NonIntegerUsedAsIndex { value, location } => {
-                let msg = format!("Expected an integer but found a(n) {}", value.get_type());
-                let secondary =
-                    "Only integers may be indexed. Note that this excludes `field`s".into();
-                CustomDiagnostic::simple_error(msg, secondary, location.span)
-            }
-            InterpreterError::NonIntegerIntegerLiteral { typ, location } => {
-                let msg = format!("This integer literal somehow has the type `{typ}`");
-                let secondary = "This is likely a bug".into();
-                CustomDiagnostic::simple_error(msg, secondary, location.span)
-            }
-            InterpreterError::NonIntegerArrayLength { typ, location } => {
-                let msg = format!("Non-integer array length: `{typ}`");
-                let secondary = "Array lengths must be integers".into();
-                CustomDiagnostic::simple_error(msg, secondary, location.span)
-            }
             InterpreterError::NonNumericCasted { value, location } => {
                 let msg = "Only numeric types may be casted".into();
                 let secondary = format!("`{}` is non-numeric", value.get_type());
@@ -226,11 +217,6 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             }
             InterpreterError::IndexOutOfBounds { index, length, location } => {
                 let msg = format!("{index} is out of bounds for the array of length {length}");
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
-            InterpreterError::ExpectedStructToHaveField { value, field_name, location } => {
-                let typ = value.get_type();
-                let msg = format!("The type `{typ}` has no field named `{field_name}`");
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
             InterpreterError::TypeUnsupported { typ, location } => {
@@ -248,16 +234,8 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 let msg = format!("No implementation for `{lhs}` {operator} `{rhs}`",);
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
-            InterpreterError::CastToNonNumericType { typ, location } => {
-                let msg = format!("Cannot cast to non-numeric type `{typ}`");
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
             InterpreterError::QuoteInRuntimeCode { location } => {
                 let msg = "`quote` may only be used in comptime code".into();
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
-            }
-            InterpreterError::NonStructInConstructor { typ, location } => {
-                let msg = format!("`{typ}` is not a struct type");
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
             InterpreterError::CannotInlineMacro { value, location } => {
@@ -315,6 +293,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             }
             InterpreterError::Break => unreachable!("Uncaught InterpreterError::Break"),
             InterpreterError::Continue => unreachable!("Uncaught InterpreterError::Continue"),
+            InterpreterError::SilentFail => unreachable!("Uncaught InterpreterError::SilentFail"),
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -577,11 +577,7 @@ impl<'a> Interpreter<'a> {
                 Value::U16(value) => Ok(Value::U16(0 - value)),
                 Value::U32(value) => Ok(Value::U32(0 - value)),
                 Value::U64(value) => Ok(Value::U64(0 - value)),
-                value => {
-                    let location = self.interner.expr_location(&id);
-                    let operator = "minus";
-                    Err(InterpreterError::InvalidValueForUnary { value, location, operator })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             crate::ast::UnaryOp::Not => match rhs {
                 Value::Bool(value) => Ok(Value::Bool(!value)),
@@ -593,10 +589,7 @@ impl<'a> Interpreter<'a> {
                 Value::U16(value) => Ok(Value::U16(!value)),
                 Value::U32(value) => Ok(Value::U32(!value)),
                 Value::U64(value) => Ok(Value::U64(!value)),
-                value => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InterpreterError::InvalidValueForUnary { value, location, operator: "not" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             crate::ast::UnaryOp::MutableReference => Ok(Value::Pointer(Shared::new(rhs))),
             crate::ast::UnaryOp::Dereference { implicitly_added: _ } => match rhs {
@@ -619,7 +612,6 @@ impl<'a> Interpreter<'a> {
             });
         }
 
-        use InterpreterError::InvalidValuesForBinary;
         match infix.operator.kind {
             BinaryOpKind::Add => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Field(lhs + rhs)),
@@ -631,10 +623,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs + rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs + rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs + rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "+" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Subtract => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Field(lhs - rhs)),
@@ -646,10 +635,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs - rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs - rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs - rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "-" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Multiply => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Field(lhs * rhs)),
@@ -661,10 +647,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs * rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs * rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs * rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "*" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Divide => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Field(lhs / rhs)),
@@ -676,10 +659,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs / rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs / rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs / rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "/" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Equal => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Bool(lhs == rhs)),
@@ -691,10 +671,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs == rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs == rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs == rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "==" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::NotEqual => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Bool(lhs != rhs)),
@@ -706,10 +683,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs != rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs != rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs != rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "!=" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Less => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Bool(lhs < rhs)),
@@ -721,10 +695,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs < rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs < rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs < rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "<" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::LessEqual => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Bool(lhs <= rhs)),
@@ -736,10 +707,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs <= rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs <= rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs <= rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "<=" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Greater => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Bool(lhs > rhs)),
@@ -751,10 +719,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs > rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs > rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs > rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: ">" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::GreaterEqual => match (lhs, rhs) {
                 (Value::Field(lhs), Value::Field(rhs)) => Ok(Value::Bool(lhs >= rhs)),
@@ -766,10 +731,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs >= rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs >= rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs >= rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: ">=" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::And => match (lhs, rhs) {
                 (Value::Bool(lhs), Value::Bool(rhs)) => Ok(Value::Bool(lhs & rhs)),
@@ -781,10 +743,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs & rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs & rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs & rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "&" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Or => match (lhs, rhs) {
                 (Value::Bool(lhs), Value::Bool(rhs)) => Ok(Value::Bool(lhs | rhs)),
@@ -796,10 +755,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs | rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs | rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs | rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "|" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Xor => match (lhs, rhs) {
                 (Value::Bool(lhs), Value::Bool(rhs)) => Ok(Value::Bool(lhs ^ rhs)),
@@ -811,10 +767,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs ^ rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs ^ rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs ^ rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "^" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::ShiftRight => match (lhs, rhs) {
                 (Value::I8(lhs), Value::I8(rhs)) => Ok(Value::I8(lhs >> rhs)),
@@ -825,10 +778,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs >> rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs >> rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs >> rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: ">>" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::ShiftLeft => match (lhs, rhs) {
                 (Value::I8(lhs), Value::I8(rhs)) => Ok(Value::I8(lhs << rhs)),
@@ -839,10 +789,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs << rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs << rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs << rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "<<" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
             BinaryOpKind::Modulo => match (lhs, rhs) {
                 (Value::I8(lhs), Value::I8(rhs)) => Ok(Value::I8(lhs % rhs)),
@@ -853,10 +800,7 @@ impl<'a> Interpreter<'a> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::U16(lhs % rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::U32(lhs % rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::U64(lhs % rhs)),
-                (lhs, rhs) => {
-                    let location = self.interner.expr_location(&id);
-                    Err(InvalidValuesForBinary { lhs, rhs, location, operator: "%" })
-                }
+                _ => Err(InterpreterError::SilentFail),
             },
         }
     }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -30,26 +30,33 @@ pub(super) fn call_builtin(
 }
 
 fn array_len(arguments: &[(Value, Location)]) -> IResult<Value> {
-    assert_eq!(arguments.len(), 1, "ICE: `array_len` should only receive a single argument");
+    if arguments.len() != 1 {
+        return Err(InterpreterError::SilentFail);
+    }
+
     match &arguments[0].0 {
         Value::Array(values, _) | Value::Slice(values, _) => Ok(Value::U32(values.len() as u32)),
-        // Type checking should prevent this branch being taken.
-        _ => unreachable!("ICE: Cannot query length of types other than arrays or slices"),
+        _ => Err(InterpreterError::SilentFail),
     }
 }
 
 fn as_slice(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
-    assert_eq!(arguments.len(), 1, "ICE: `as_slice` should only receive a single argument");
+    if arguments.len() != 1 {
+        return Err(InterpreterError::SilentFail);
+    }
+
     let (array, _) = arguments.pop().unwrap();
     match array {
         Value::Array(values, Type::Array(_, typ)) => Ok(Value::Slice(values, Type::Slice(typ))),
-        // Type checking should prevent this branch being taken.
-        _ => unreachable!("ICE: Cannot convert types other than arrays into slices"),
+        _ => Err(InterpreterError::SilentFail),
     }
 }
 
 fn slice_push_back(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
-    assert_eq!(arguments.len(), 2, "ICE: `slice_push_back` should only receive two arguments");
+    if arguments.len() != 2 {
+        return Err(InterpreterError::SilentFail);
+    }
+
     let (element, _) = arguments.pop().unwrap();
     let (slice, _) = arguments.pop().unwrap();
     match slice {
@@ -57,8 +64,7 @@ fn slice_push_back(mut arguments: Vec<(Value, Location)>) -> IResult<Value> {
             values.push_back(element);
             Ok(Value::Slice(values, typ))
         }
-        // Type checking should prevent this branch being taken.
-        _ => unreachable!("ICE: `slice_push_back` expects a slice as its first argument"),
+        _ => Err(InterpreterError::SilentFail),
     }
 }
 
@@ -67,12 +73,12 @@ fn type_def_as_type(
     interner: &NodeInterner,
     mut arguments: Vec<(Value, Location)>,
 ) -> IResult<Value> {
-    assert_eq!(arguments.len(), 1, "ICE: `generics` should only receive a single argument");
+    if arguments.len() != 1 {
+        return Err(InterpreterError::SilentFail);
+    }
     let (type_def, span) = match arguments.pop() {
         Some((Value::TypeDefinition(id), location)) => (id, location.span),
-        other => {
-            unreachable!("ICE: `as_type` expected a `TypeDefinition` argument, found {other:?}")
-        }
+        _ => return Err(InterpreterError::SilentFail),
     };
 
     let struct_def = interner.get_struct(type_def);
@@ -96,12 +102,12 @@ fn type_def_generics(
     interner: &NodeInterner,
     mut arguments: Vec<(Value, Location)>,
 ) -> IResult<Value> {
-    assert_eq!(arguments.len(), 1, "ICE: `generics` should only receive a single argument");
+    if arguments.len() != 1 {
+        return Err(InterpreterError::SilentFail);
+    }
     let (type_def, span) = match arguments.pop() {
         Some((Value::TypeDefinition(id), location)) => (id, location.span),
-        other => {
-            unreachable!("ICE: `as_type` expected a `TypeDefinition` argument, found {other:?}")
-        }
+        _ => return Err(InterpreterError::SilentFail),
     };
 
     let struct_def = interner.get_struct(type_def);
@@ -126,12 +132,12 @@ fn type_def_fields(
     interner: &mut NodeInterner,
     mut arguments: Vec<(Value, Location)>,
 ) -> IResult<Value> {
-    assert_eq!(arguments.len(), 1, "ICE: `generics` should only receive a single argument");
+    if arguments.len() != 1 {
+        return Err(InterpreterError::SilentFail);
+    }
     let (type_def, span) = match arguments.pop() {
         Some((Value::TypeDefinition(id), location)) => (id, location.span),
-        other => {
-            unreachable!("ICE: `as_type` expected a `TypeDefinition` argument, found {other:?}")
-        }
+        _ => return Err(InterpreterError::SilentFail),
     };
 
     let struct_def = interner.get_struct(type_def);

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -154,7 +154,7 @@ impl Value {
 
                 let struct_type = match typ.follow_bindings() {
                     Type::Struct(def, _) => Some(def.borrow().id),
-                    _ => return Err(InterpreterError::NonStructInConstructor { typ, location }),
+                    typ => unreachable!("Value::Struct has non-struct type `{typ:?}`"),
                 };
 
                 // Since we've provided the struct_type, the path should be ignored.
@@ -270,7 +270,7 @@ impl Value {
 
                 let (r#type, struct_generics) = match typ.follow_bindings() {
                     Type::Struct(def, generics) => (def, generics),
-                    _ => return Err(InterpreterError::NonStructInConstructor { typ, location }),
+                    typ => unreachable!("Value::Struct has non-struct type `{typ:?}`"),
                 };
 
                 HirExpression::Constructor(HirConstructorExpression {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -553,7 +553,9 @@ impl ResolvedModule {
 
             for (_file, global) in &self.globals {
                 if let Err(error) = interpreter.scan_global(*global) {
-                    self.errors.push(error.into_compilation_error_pair());
+                    if !matches!(&error, InterpreterError::SilentFail) {
+                        self.errors.push(error.into_compilation_error_pair());
+                    }
                 }
             }
 
@@ -561,7 +563,9 @@ impl ResolvedModule {
                 // The file returned by the error may be different than the file the
                 // function is in so only use the error's file id.
                 if let Err(error) = interpreter.scan_function(*function) {
-                    self.errors.push(error.into_compilation_error_pair());
+                    if !matches!(&error, InterpreterError::SilentFail) {
+                        self.errors.push(error.into_compilation_error_pair());
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

The interpreter can issue duplicate errors if there were e.g. type errors that occurred within the comptime block being run.

For example:
```rs
fn main() {
    comptime {
        let _x = 1 + "two";
    }
}
```
Will give:
```
error: Types in a binary operation should match, but found Field and str<3>
  ┌─ /.../short/src/main.nr:3:18
  │
3 │         let _x = 1 + "two";
  │                  ---------
  │

error: No implementation for `Field` + `str<3>`
  ┌─ /.../short/src/main.nr:3:18
  │
3 │         let _x = 1 + "two";
  │                  ---------
  │
```
The first of which is a type error, and the second an interpreter error. Similarly, if we have a type error in some builtin methods like `slice_push_back`, these will lead to panics in the interpreter which assume errors will already be caught during type checking (they are caught, but the interpreter is still run on this code afterwards anyway).

To fix this, I've added a `SilentFail` error variant to avoid issuing these errors that are expected to be caught by the type system already.

## Additional Context

The interpreter is still run even on code that previously errored since it is difficult to track for a given block if any code reachable from it has errored.

One alternative could be to only run the interpreter if there has been zero errors in the whole program so far. I'm open to discussion here.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
