### PR TITLE
feat: disable nargo color output if stderr is tty

### DIFF
--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use crate::{FileDiagnostic, Location, Span};
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::Files;
@@ -148,7 +150,9 @@ pub fn report<'files>(
     call_stack: &[Location],
     deny_warnings: bool,
 ) -> bool {
-    let writer = StandardStream::stderr(ColorChoice::Always);
+    let color_choice =
+        if std::io::stderr().is_terminal() { ColorChoice::Auto } else { ColorChoice::Never };
+    let writer = StandardStream::stderr(color_choice);
     let config = codespan_reporting::term::Config::default();
 
     let stack_trace = stack_trace(files, call_stack);


### PR DESCRIPTION
This will also honor `TERM=dumb` and the `NO_COLOR` env vars.

# Description

## Problem

Resolves #5074

## Summary

`nargo` errors are written to stderr. These were always using colors. In this PR we check if stderr is a terminal and just then use colors, otherwise we don't. Actually, if is a terminal we don't always output colors: we use `[ColorChoice::Auto](https://docs.rs/termcolor/latest/termcolor/enum.ColorChoice.html#variant.Auto)` which will honor some standard env vars like `TERM=dumb` or `NO_COLOR`.

This change will also improve error messages outputted in `cargo test` inside `nargo_cli` when something is supposed to compile but doesn't.

Note that this does just one alternative proposed in #5074. Another thing is adding a `--color` option. I think that could be done in a separate PR (if really wanted/needed).

## Additional Context

None.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
