### PR TITLE
fix: address compiler warnings coming from stdlib

### DIFF
--- a/compiler/noirc_driver/tests/stdlib_warnings.rs
+++ b/compiler/noirc_driver/tests/stdlib_warnings.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use noirc_driver::{file_manager_with_stdlib, prepare_crate, ErrorsAndWarnings};
 use noirc_frontend::hir::{def_map::parse_file, Context};
 
-#[ignore = "Temporarily ignoring the test until the stdlib is updated to use explicit numeric generics"]
 #[test]
 fn stdlib_does_not_produce_constant_warnings() -> Result<(), ErrorsAndWarnings> {
     // We use a minimal source file so that if stdlib produces warnings then we can expect these warnings to _always_

--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -51,7 +51,7 @@ pub fn assert_constant<T>(x: T) {}
 
 // Asserts that the given value is both true and known at compile-time
 #[builtin(static_assert)]
-pub fn static_assert<N>(predicate: bool, message: str<N>) {}
+pub fn static_assert<let N: u32>(predicate: bool, message: str<N>) {}
 
 // from_field and as_field are private since they are not valid for every type.
 // `as` should be the default for users to cast between primitive types, and in the future


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR turns back on the test that the stdlib shouldn't produce compiler warnings.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
