### PR TITLE
chore: `static_assert` error message fix and split into is-dynamic and is-false

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -37,7 +37,7 @@ pub enum RuntimeError {
     AssertConstantFailed { call_stack: CallStack },
     #[error("The static_assert message is not constant")]
     StaticAssertDynamicMessage { call_stack: CallStack },
-    #[error("Nested slices are not supported")]
+    #[error("Argument is false or dynamic")]
     StaticAssertFailed { call_stack: CallStack },
     #[error("Nested slices are not supported")]
     NestedSlice { call_stack: CallStack },

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -37,7 +37,9 @@ pub enum RuntimeError {
     AssertConstantFailed { call_stack: CallStack },
     #[error("The static_assert message is not constant")]
     StaticAssertDynamicMessage { call_stack: CallStack },
-    #[error("Argument is false or dynamic")]
+    #[error("Argument is dynamic")]
+    StaticAssertDynamicPredicate { call_stack: CallStack },
+    #[error("Argument is false")]
     StaticAssertFailed { call_stack: CallStack },
     #[error("Nested slices are not supported")]
     NestedSlice { call_stack: CallStack },
@@ -124,8 +126,9 @@ impl RuntimeError {
             | RuntimeError::UnInitialized { call_stack, .. }
             | RuntimeError::UnknownLoopBound { call_stack }
             | RuntimeError::AssertConstantFailed { call_stack }
-            | RuntimeError::StaticAssertFailed { call_stack }
             | RuntimeError::StaticAssertDynamicMessage { call_stack }
+            | RuntimeError::StaticAssertDynamicPredicate { call_stack }
+            | RuntimeError::StaticAssertFailed { call_stack }
             | RuntimeError::IntegerOutOfBounds { call_stack, .. }
             | RuntimeError::UnsupportedIntegerSize { call_stack, .. }
             | RuntimeError::NestedSlice { call_stack, .. }

--- a/compiler/noirc_evaluator/src/ssa/opt/assert_constant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/assert_constant.rs
@@ -112,6 +112,10 @@ fn evaluate_static_assert(
         Ok(false)
     } else {
         let call_stack = function.dfg.get_call_stack(instruction);
-        Err(RuntimeError::StaticAssertFailed { call_stack })
+        if function.dfg.is_constant(arguments[0]) {
+            Err(RuntimeError::StaticAssertFailed { call_stack })
+        } else {
+            Err(RuntimeError::StaticAssertDynamicPredicate { call_stack })
+        }
     }
 }


### PR DESCRIPTION
# Description

Fix `static_assert` error message

## Problem\*

Error message for `static_assert` was ~"Argument to static_assert is false or dynamic" at some point, but currently is copy/pasted from the nested slices error

## Summary\*


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
