### PR TITLE
chore: standardize experimental feature disclaimer across documentation

### DIFF
--- a/docs/docs/noir/concepts/data_bus.mdx
+++ b/docs/docs/noir/concepts/data_bus.mdx
@@ -2,7 +2,9 @@
 title: Data Bus
 sidebar_position: 13
 ---
-**Disclaimer** this feature is experimental, do not use it!
+import Experimental from '@site/src/components/Notes/_experimental.mdx';
+
+<Experimental />
 
 The data bus is an optimization that the backend can use to make recursion more efficient.
 In order to use it, you must define some inputs of the program entry points (usually the `main()`

--- a/docs/docs/noir/concepts/oracles.mdx
+++ b/docs/docs/noir/concepts/oracles.mdx
@@ -11,11 +11,9 @@ keywords:
 sidebar_position: 6
 ---
 
-:::note
+import Experimental from '@site/src/components/Notes/_experimental.mdx';
 
-This is an experimental feature that is not fully documented. If you notice any outdated information or potential improvements to this page, pull request contributions are very welcome: https://github.com/noir-lang/noir
-
-:::
+<Experimental />
 
 Noir has support for Oracles via RPC calls. This means Noir will make an RPC call and use the return value for proof generation.
 

--- a/docs/src/components/Notes/_experimental.mdx
+++ b/docs/src/components/Notes/_experimental.mdx
@@ -1,6 +1,7 @@
-:::caution
+:::caution Experimental Feature
 
-This feature is experimental. You should expect it to change in future versions,
-cause unexpected behavior, or simply not work at all.
+This feature is experimental. The documentation may be incomplete or out of date, which means it could change in future versions, potentially causing unexpected behavior or not working as expected. 
+
+**Contributions Welcome:** If you notice any inaccuracies or potential improvements, please consider contributing. Visit our GitHub repository to make your contributions: [Contribute Here](https://github.com/noir-lang/noir).
 
 :::


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4935

## Summary\*

This pull request makes the experimental feature warnings the same across different parts of the documentation. I've created one warning message that all pages can show. This helps in keeping the docs consistent and easy to update.

## Additional Context

The new disclaimer meets all the requirements set out in issue #4935 by:
- Clearly stating that the feature is experimental;
- Noting that the documentation may be incomplete or out of date, and thus subject to changes that could impact its behavior or functionality;
- Encouraging contributions and providing a direct link to the project's GitHub repository.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
