### PR TITLE
fix: Runtime bigint id assignment

### DIFF
--- a/acvm-repo/blackbox_solver/src/bigint.rs
+++ b/acvm-repo/blackbox_solver/src/bigint.rs
@@ -15,6 +15,7 @@ use crate::BlackBoxResolutionError;
 pub struct BigIntSolver {
     bigint_id_to_value: HashMap<u32, BigUint>,
     bigint_id_to_modulus: HashMap<u32, BigUint>,
+    last_id: usize,
 }
 
 impl BigIntSolver {
@@ -45,6 +46,13 @@ impl BigIntSolver {
             ))
             .cloned()
     }
+
+    pub fn create_bigint_id(&mut self) -> u32 {
+        let output = self.last_id as u32;
+        self.last_id += 1;
+        output
+    }
+
     pub fn bigint_from_bytes(
         &mut self,
         inputs: &[u8],

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -270,29 +270,33 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
         BlackBoxOp::BigIntAdd { lhs, rhs, output } => {
             let lhs = memory.read(*lhs).try_into().unwrap();
             let rhs = memory.read(*rhs).try_into().unwrap();
-            let output = memory.read(*output).try_into().unwrap();
-            bigint_solver.bigint_op(lhs, rhs, output, BlackBoxFunc::BigIntAdd)?;
+            let new_id = bigint_solver.create_bigint_id();
+            bigint_solver.bigint_op(lhs, rhs, new_id, BlackBoxFunc::BigIntAdd)?;
+            memory.write(*output, new_id.into());
             Ok(())
         }
         BlackBoxOp::BigIntSub { lhs, rhs, output } => {
             let lhs = memory.read(*lhs).try_into().unwrap();
             let rhs = memory.read(*rhs).try_into().unwrap();
-            let output = memory.read(*output).try_into().unwrap();
-            bigint_solver.bigint_op(lhs, rhs, output, BlackBoxFunc::BigIntSub)?;
+            let new_id = bigint_solver.create_bigint_id();
+            bigint_solver.bigint_op(lhs, rhs, new_id, BlackBoxFunc::BigIntSub)?;
+            memory.write(*output, new_id.into());
             Ok(())
         }
         BlackBoxOp::BigIntMul { lhs, rhs, output } => {
             let lhs = memory.read(*lhs).try_into().unwrap();
             let rhs = memory.read(*rhs).try_into().unwrap();
-            let output = memory.read(*output).try_into().unwrap();
-            bigint_solver.bigint_op(lhs, rhs, output, BlackBoxFunc::BigIntMul)?;
+            let new_id = bigint_solver.create_bigint_id();
+            bigint_solver.bigint_op(lhs, rhs, new_id, BlackBoxFunc::BigIntMul)?;
+            memory.write(*output, new_id.into());
             Ok(())
         }
         BlackBoxOp::BigIntDiv { lhs, rhs, output } => {
             let lhs = memory.read(*lhs).try_into().unwrap();
             let rhs = memory.read(*rhs).try_into().unwrap();
-            let output = memory.read(*output).try_into().unwrap();
-            bigint_solver.bigint_op(lhs, rhs, output, BlackBoxFunc::BigIntDiv)?;
+            let new_id = bigint_solver.create_bigint_id();
+            bigint_solver.bigint_op(lhs, rhs, new_id, BlackBoxFunc::BigIntDiv)?;
+            memory.write(*output, new_id.into());
             Ok(())
         }
         BlackBoxOp::BigIntFromLeBytes { inputs, modulus, output } => {
@@ -300,8 +304,12 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
             let input: Vec<u8> = input.iter().map(|x| x.try_into().unwrap()).collect();
             let modulus = read_heap_vector(memory, modulus);
             let modulus: Vec<u8> = modulus.iter().map(|x| x.try_into().unwrap()).collect();
-            let output = memory.read(*output).try_into().unwrap();
-            bigint_solver.bigint_from_bytes(&input, &modulus, output)?;
+            let next_id = bigint_solver.create_bigint_id();
+            bigint_solver.bigint_from_bytes(&input, &modulus, next_id)?;
+            println!("Built bigint from bytes: {:?} {:?} with id {}", input, modulus, next_id);
+
+            memory.write(*output, next_id.into());
+
             Ok(())
         }
         BlackBoxOp::BigIntToLeBytes { input, output } => {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
@@ -243,13 +243,7 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString>(
                 [BrilligVariable::SingleAddr(output), BrilligVariable::SingleAddr(modulus_id)],
             ) = (function_arguments, function_results)
             {
-                prepare_bigint_output(
-                    brillig_context,
-                    lhs_modulus,
-                    rhs_modulus,
-                    output,
-                    modulus_id,
-                );
+                prepare_bigint_output(brillig_context, lhs_modulus, rhs_modulus, modulus_id);
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntAdd {
                     lhs: lhs.address,
                     rhs: rhs.address,
@@ -267,13 +261,7 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString>(
                 [BrilligVariable::SingleAddr(output), BrilligVariable::SingleAddr(modulus_id)],
             ) = (function_arguments, function_results)
             {
-                prepare_bigint_output(
-                    brillig_context,
-                    lhs_modulus,
-                    rhs_modulus,
-                    output,
-                    modulus_id,
-                );
+                prepare_bigint_output(brillig_context, lhs_modulus, rhs_modulus, modulus_id);
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntSub {
                     lhs: lhs.address,
                     rhs: rhs.address,
@@ -291,13 +279,7 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString>(
                 [BrilligVariable::SingleAddr(output), BrilligVariable::SingleAddr(modulus_id)],
             ) = (function_arguments, function_results)
             {
-                prepare_bigint_output(
-                    brillig_context,
-                    lhs_modulus,
-                    rhs_modulus,
-                    output,
-                    modulus_id,
-                );
+                prepare_bigint_output(brillig_context, lhs_modulus, rhs_modulus, modulus_id);
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntMul {
                     lhs: lhs.address,
                     rhs: rhs.address,
@@ -315,13 +297,7 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString>(
                 [BrilligVariable::SingleAddr(output), BrilligVariable::SingleAddr(modulus_id)],
             ) = (function_arguments, function_results)
             {
-                prepare_bigint_output(
-                    brillig_context,
-                    lhs_modulus,
-                    rhs_modulus,
-                    output,
-                    modulus_id,
-                );
+                prepare_bigint_output(brillig_context, lhs_modulus, rhs_modulus, modulus_id);
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntDiv {
                     lhs: lhs.address,
                     rhs: rhs.address,
@@ -341,8 +317,6 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString>(
             {
                 let inputs_vector = convert_array_or_vector(brillig_context, inputs, bb_func);
                 let modulus_vector = convert_array_or_vector(brillig_context, modulus, bb_func);
-                let output_id = brillig_context.get_new_bigint_id();
-                brillig_context.const_instruction(*output, F::from(output_id as u128));
                 brillig_context.black_box_op_instruction(BlackBoxOp::BigIntFromLeBytes {
                     inputs: inputs_vector.to_heap_vector(),
                     modulus: modulus_vector.to_heap_vector(),
@@ -447,7 +421,6 @@ fn prepare_bigint_output<F: AcirField + DebugToString>(
     brillig_context: &mut BrilligContext<F>,
     lhs_modulus: &SingleAddrVariable,
     rhs_modulus: &SingleAddrVariable,
-    output: &SingleAddrVariable,
     modulus_id: &SingleAddrVariable,
 ) {
     // Check moduli
@@ -464,8 +437,6 @@ fn prepare_bigint_output<F: AcirField + DebugToString>(
         Some("moduli should be identical in BigInt operation".to_string()),
     );
     brillig_context.deallocate_register(condition);
-    // Set output id
-    let output_id = brillig_context.get_new_bigint_id();
-    brillig_context.const_instruction(*output, F::from(output_id as u128));
+
     brillig_context.mov_instruction(modulus_id.address, lhs_modulus.address);
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -91,8 +91,6 @@ pub(crate) struct BrilligContext<F> {
     next_section: usize,
     /// IR printer
     debug_show: DebugShow,
-    /// Counter for generating bigint ids in unconstrained functions
-    bigint_new_id: u32,
 }
 
 impl<F: AcirField + DebugToString> BrilligContext<F> {
@@ -105,15 +103,9 @@ impl<F: AcirField + DebugToString> BrilligContext<F> {
             section_label: 0,
             next_section: 1,
             debug_show: DebugShow::new(enable_debug_trace),
-            bigint_new_id: 0,
         }
     }
 
-    pub(crate) fn get_new_bigint_id(&mut self) -> u32 {
-        let result = self.bigint_new_id;
-        self.bigint_new_id += 1;
-        result
-    }
     /// Adds a brillig instruction to the brillig byte code
     fn push_opcode(&mut self, opcode: BrilligOpcode<F>) {
         self.obj.push_opcode(opcode);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -23,7 +23,6 @@ impl<F: AcirField + DebugToString> BrilligContext<F> {
             section_label: 0,
             next_section: 1,
             debug_show: DebugShow::new(false),
-            bigint_new_id: 0,
         };
 
         context.codegen_entry_point(&arguments, &return_parameters);


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5368

## Summary\*

Switches BigInd id assignment to be done in runtime, to fix assignment within control flow.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
