### PR TITLE
feat: Implement trait dispatch in the comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -547,7 +547,7 @@ impl<'context> Elaborator<'context> {
                         trait_id: trait_id.trait_id,
                         trait_generics: Vec::new(),
                     };
-                    self.trait_constraints.push((constraint, expr_id));
+                    self.push_trait_constraint(constraint, expr_id);
                     self.type_check_operator_method(expr_id, trait_id, &lhs_type, span);
                 }
                 typ
@@ -663,7 +663,16 @@ impl<'context> Elaborator<'context> {
     }
 
     fn elaborate_comptime_block(&mut self, block: BlockExpression, span: Span) -> (ExprId, Type) {
+        // We have to push a new trait constraints Vec so that we can resolve any constraints
+        // in this comptime block early before the function as a whole finishes elaborating.
+        // Otherwise the interpreter below may find expressions for which the underlying trait
+        // call is not yet solved for.
+        self.trait_constraints.push(Vec::new());
+        self.type_variables.push(Vec::new());
         let (block, _typ) = self.elaborate_block_expression(block);
+        self.pop_and_default_type_variables();
+        self.pop_and_verify_current_trait_constraints();
+
         let mut interpreter =
             Interpreter::new(self.interner, &mut self.comptime_scopes, self.crate_id);
         let value = interpreter.evaluate_block(block);

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -663,15 +663,13 @@ impl<'context> Elaborator<'context> {
     }
 
     fn elaborate_comptime_block(&mut self, block: BlockExpression, span: Span) -> (ExprId, Type) {
-        // We have to push a new trait constraints Vec so that we can resolve any constraints
+        // We have to push a new FunctionContext so that we can resolve any constraints
         // in this comptime block early before the function as a whole finishes elaborating.
         // Otherwise the interpreter below may find expressions for which the underlying trait
         // call is not yet solved for.
-        self.trait_constraints.push(Vec::new());
-        self.type_variables.push(Vec::new());
+        self.function_context.push(Default::default());
         let (block, _typ) = self.elaborate_block_expression(block);
-        self.pop_and_default_type_variables();
-        self.pop_and_verify_current_trait_constraints();
+        self.check_and_pop_function_context();
 
         let mut interpreter =
             Interpreter::new(self.interner, &mut self.comptime_scopes, self.crate_id);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -138,31 +138,14 @@ pub struct Elaborator<'context> {
 
     current_function: Option<FuncId>,
 
-    /// All type variables created in the current function.
-    /// This map is used to default any integer type variables at the end of
-    /// a function (before checking trait constraints) if a type wasn't already chosen.
-    ///
-    /// This is a stack of vectors of type variables. Most of the time, for each function we
-    /// expect the outer Vec to be of length one, containing each type variable in the
-    /// function. This outer Vec is pushed to when a `comptime {}` block is used within
-    /// the function, which can force us to resolve that block's trait constraints earlier
+    /// This is a stack of function contexts. Most of the time, for each function we
+    /// expect this to be of length one, containing each type variable and trait constraint
+    /// used in the function. This is also pushed to when a `comptime {}` block is used within
+    /// the function. Since it can force us to resolve that block's trait constraints earlier
     /// so that they are resolved when the interpreter is run before the enclosing function
     /// is finished elaborating. When this happens, we need to resolve any type variables
     /// that were made within this block as well so that we can solve these traits.
-    type_variables: Vec<Vec<Type>>,
-
-    /// Trait constraints are collected during type checking until they are
-    /// verified at the end of a function. This is because constraints arise
-    /// on each variable, but it is only until function calls when the types
-    /// needed for the trait constraint may become known.
-    ///
-    /// This is a stack of constraint lists. Most of the time, for each function we
-    /// expect the outer Vec to be of length one, containing each constraint in the
-    /// function. This outer Vec is pushed to when a `comptime {}` block is used within
-    /// the function, which can force us to resolve that block's trait constraints earlier
-    /// so that they are resolved when the interpreter is run before the enclosing function
-    /// is finished elaborating.
-    trait_constraints: Vec<Vec<(TraitConstraint, ExprId)>>,
+    function_context: Vec<FunctionContext>,
 
     /// The current module this elaborator is in.
     /// Initially empty, it is set whenever a new top-level item is resolved.
@@ -179,6 +162,20 @@ pub struct Elaborator<'context> {
     /// This map is used to lazily evaluate these globals if they're encountered before
     /// they are elaborated (e.g. in a function's type or another global's RHS).
     unresolved_globals: BTreeMap<GlobalId, UnresolvedGlobal>,
+}
+
+#[derive(Default)]
+struct FunctionContext {
+    /// All type variables created in the current function.
+    /// This map is used to default any integer type variables at the end of
+    /// a function (before checking trait constraints) if a type wasn't already chosen.
+    type_variables: Vec<Type>,
+
+    /// Trait constraints are collected during type checking until they are
+    /// verified at the end of a function. This is because constraints arise
+    /// on each variable, but it is only until function calls when the types
+    /// needed for the trait constraint may become known.
+    trait_constraints: Vec<(TraitConstraint, ExprId)>,
 }
 
 impl<'context> Elaborator<'context> {
@@ -200,8 +197,7 @@ impl<'context> Elaborator<'context> {
             resolving_ids: BTreeSet::new(),
             trait_bounds: Vec::new(),
             current_function: None,
-            type_variables: vec![Vec::new()],
-            trait_constraints: Vec::new(),
+            function_context: vec![FunctionContext::default()],
             current_trait_impl: None,
             comptime_scopes: vec![HashMap::default()],
             unresolved_globals: BTreeMap::new(),
@@ -341,8 +337,7 @@ impl<'context> Elaborator<'context> {
         let func_meta = func_meta.clone();
 
         self.trait_bounds = func_meta.trait_constraints.clone();
-        self.trait_constraints.push(Vec::new());
-        self.type_variables.push(Vec::new());
+        self.function_context.push(FunctionContext::default());
 
         // Introduce all numeric generics into scope
         for generic in &func_meta.all_generics {
@@ -384,14 +379,11 @@ impl<'context> Elaborator<'context> {
             self.type_check_function_body(body_type, &func_meta, hir_func.as_expr());
         }
 
-        // Default any type variables that still need defaulting.
+        // Default any type variables that still need defaulting and
+        // verify any remaining trait constraints arising from the function body.
         // This is done before trait impl search since leaving them bindable can lead to errors
         // when multiple impls are available. Instead we default first to choose the Field or u64 impl.
-        self.pop_and_default_type_variables();
-
-        // Verify any remaining trait constraints arising from the function body
-        self.pop_and_verify_current_trait_constraints();
-        assert_eq!(self.trait_constraints.len(), 0);
+        self.check_and_pop_function_context();
 
         // Now remove all the `where` clause constraints we added
         for constraint in &func_meta.trait_constraints {
@@ -419,20 +411,18 @@ impl<'context> Elaborator<'context> {
         self.current_item = old_item;
     }
 
-    fn pop_and_default_type_variables(&mut self) {
-        if let Some(type_variables) = self.type_variables.pop() {
-            for typ in type_variables {
+    /// Defaults all type variables used in this function context then solves
+    /// all still-unsolved trait constraints in this context.
+    fn check_and_pop_function_context(&mut self) {
+        if let Some(context) = self.function_context.pop() {
+            for typ in context.type_variables {
                 if let Type::TypeVariable(variable, kind) = typ.follow_bindings() {
                     let msg = "TypeChecker should only track defaultable type vars";
                     variable.bind(kind.default_type().expect(msg));
                 }
             }
-        }
-    }
 
-    fn pop_and_verify_current_trait_constraints(&mut self) {
-        if let Some(constraints) = self.trait_constraints.pop() {
-            for (mut constraint, expr_id) in constraints {
+            for (mut constraint, expr_id) in context.trait_constraints {
                 let span = self.interner.expr_span(&expr_id);
 
                 if matches!(&constraint.typ, Type::MutableReference(_)) {

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -396,6 +396,7 @@ impl<'context> Elaborator<'context> {
         let expr = self.resolve_variable(variable);
 
         let id = self.interner.push_expr(HirExpression::Ident(expr.clone(), generics.clone()));
+
         self.interner.push_expr_location(id, span, self.file);
         let typ = self.type_check_variable(expr, id, generics);
         self.interner.push_expr_type(id, typ.clone());
@@ -516,7 +517,7 @@ impl<'context> Elaborator<'context> {
 
                 for mut constraint in function.trait_constraints.clone() {
                     constraint.apply_bindings(&bindings);
-                    self.trait_constraints.push((constraint, expr_id));
+                    self.push_trait_constraint(constraint, expr_id);
                 }
             }
         }
@@ -533,7 +534,7 @@ impl<'context> Elaborator<'context> {
                 // Currently only one impl can be selected per expr_id, so this
                 // constraint needs to be pushed after any other constraints so
                 // that monomorphization can resolve this trait method to the correct impl.
-                self.trait_constraints.push((constraint, expr_id));
+                self.push_trait_constraint(constraint, expr_id);
             }
         }
 

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -433,16 +433,14 @@ impl<'context> Elaborator<'context> {
     }
 
     fn elaborate_comptime_statement(&mut self, statement: Statement) -> (HirStatement, Type) {
-        // We have to push a new trait constraints Vec so that we can resolve any constraints
+        // We have to push a new FunctionContext so that we can resolve any constraints
         // in this comptime block early before the function as a whole finishes elaborating.
         // Otherwise the interpreter below may find expressions for which the underlying trait
         // call is not yet solved for.
-        self.type_variables.push(Vec::new());
-        self.trait_constraints.push(Vec::new());
+        self.function_context.push(Default::default());
         let span = statement.span;
         let (hir_statement, _typ) = self.elaborate_statement(statement);
-        self.pop_and_default_type_variables();
-        self.pop_and_verify_current_trait_constraints();
+        self.check_and_pop_function_context();
 
         let mut interpreter =
             Interpreter::new(self.interner, &mut self.comptime_scopes, self.crate_id);

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -433,8 +433,17 @@ impl<'context> Elaborator<'context> {
     }
 
     fn elaborate_comptime_statement(&mut self, statement: Statement) -> (HirStatement, Type) {
+        // We have to push a new trait constraints Vec so that we can resolve any constraints
+        // in this comptime block early before the function as a whole finishes elaborating.
+        // Otherwise the interpreter below may find expressions for which the underlying trait
+        // call is not yet solved for.
+        self.type_variables.push(Vec::new());
+        self.trait_constraints.push(Vec::new());
         let span = statement.span;
         let (hir_statement, _typ) = self.elaborate_statement(statement);
+        self.pop_and_default_type_variables();
+        self.pop_and_verify_current_trait_constraints();
+
         let mut interpreter =
             Interpreter::new(self.interner, &mut self.comptime_scopes, self.crate_id);
         let value = interpreter.evaluate_statement(hir_statement);

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -615,7 +615,7 @@ impl<'context> Elaborator<'context> {
     /// in self.type_variables to default it later.
     pub(super) fn polymorphic_integer_or_field(&mut self) -> Type {
         let typ = Type::polymorphic_integer_or_field(self.interner);
-        self.type_variables.push(typ.clone());
+        self.type_variables.last_mut().unwrap().push(typ.clone());
         typ
     }
 
@@ -623,7 +623,7 @@ impl<'context> Elaborator<'context> {
     /// in self.type_variables to default it later.
     pub(super) fn polymorphic_integer(&mut self) -> Type {
         let typ = Type::polymorphic_integer(self.interner);
-        self.type_variables.push(typ.clone());
+        self.type_variables.last_mut().unwrap().push(typ.clone());
         typ
     }
 
@@ -1556,5 +1556,12 @@ impl<'context> Elaborator<'context> {
                 Self::find_numeric_generics_in_type(fields, found);
             }
         }
+    }
+
+    pub fn push_trait_constraint(&mut self, constraint: TraitConstraint, expr_id: ExprId) {
+        self.trait_constraints
+            .last_mut()
+            .expect("trait_constraints should never be empty within a function body")
+            .push((constraint, expr_id));
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -615,7 +615,7 @@ impl<'context> Elaborator<'context> {
     /// in self.type_variables to default it later.
     pub(super) fn polymorphic_integer_or_field(&mut self) -> Type {
         let typ = Type::polymorphic_integer_or_field(self.interner);
-        self.type_variables.last_mut().unwrap().push(typ.clone());
+        self.push_type_variable(typ.clone());
         typ
     }
 
@@ -623,7 +623,7 @@ impl<'context> Elaborator<'context> {
     /// in self.type_variables to default it later.
     pub(super) fn polymorphic_integer(&mut self) -> Type {
         let typ = Type::polymorphic_integer(self.interner);
-        self.type_variables.last_mut().unwrap().push(typ.clone());
+        self.push_type_variable(typ.clone());
         typ
     }
 
@@ -1542,10 +1542,19 @@ impl<'context> Elaborator<'context> {
         }
     }
 
+    /// Push a type variable into the current FunctionContext to be defaulted if needed
+    /// at the end of the earlier of either the current function or the current comptime scope.
+    fn push_type_variable(&mut self, typ: Type) {
+        let context = self.function_context.last_mut();
+        let context = context.expect("The function_context stack should always be non-empty");
+        context.type_variables.push(typ);
+    }
+
+    /// Push a trait constraint into the current FunctionContext to be solved if needed
+    /// at the end of the earlier of either the current function or the current comptime scope.
     pub fn push_trait_constraint(&mut self, constraint: TraitConstraint, expr_id: ExprId) {
-        self.trait_constraints
-            .last_mut()
-            .expect("trait_constraints should never be empty within a function body")
-            .push((constraint, expr_id));
+        let context = self.function_context.last_mut();
+        let context = context.expect("The function_context stack should always be non-empty");
+        context.trait_constraints.push((constraint, expr_id));
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -2,15 +2,17 @@ use std::{collections::hash_map::Entry, rc::Rc};
 
 use acvm::{acir::AcirField, FieldElement};
 use im::Vector;
-use iter_extended::{try_vecmap, vecmap};
+use iter_extended::try_vecmap;
 use noirc_errors::Location;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::ast::{BinaryOpKind, FunctionKind, IntegerBitSize, Signedness};
 use crate::graph::CrateId;
 use crate::hir_def::expr::ImplKind;
-use crate::monomorphization::{perform_instantiation_bindings, undo_instantiation_bindings, perform_impl_bindings};
-use crate::node_interner::{TraitMethodId, TraitImplKind};
+use crate::monomorphization::{
+    perform_impl_bindings, perform_instantiation_bindings, resolve_trait_method,
+    undo_instantiation_bindings,
+};
 use crate::token::Tokens;
 use crate::{
     hir_def::{
@@ -354,10 +356,10 @@ impl<'a> Interpreter<'a> {
         let definition = self.interner.definition(ident.id);
 
         if let ImplKind::TraitMethod(method, _, _) = ident.impl_kind {
-            let method_id = self.resolve_trait_method(method, id)?;
+            let method_id = resolve_trait_method(self.interner, method, id)?;
             let typ = self.interner.id_type(id).follow_bindings();
             let bindings = self.interner.get_instantiation_bindings(id).clone();
-            return Ok(Value::Function(method_id, typ, Rc::new(bindings)))
+            return Ok(Value::Function(method_id, typ, Rc::new(bindings)));
         }
 
         match &definition.kind {
@@ -862,11 +864,17 @@ impl<'a> Interpreter<'a> {
         }
     }
 
-    fn evaluate_overloaded_infix(&mut self, infix: HirInfixExpression, lhs: Value, rhs: Value, id: ExprId) -> IResult<Value> {
+    fn evaluate_overloaded_infix(
+        &mut self,
+        infix: HirInfixExpression,
+        lhs: Value,
+        rhs: Value,
+        id: ExprId,
+    ) -> IResult<Value> {
         let method = infix.trait_method_id;
         let operator = infix.operator.kind;
 
-        let method_id = self.resolve_trait_method(method, id)?;
+        let method_id = resolve_trait_method(self.interner, method, id)?;
         let type_bindings = self.interner.get_instantiation_bindings(id).clone();
 
         let lhs = (lhs, self.interner.expr_location(&infix.lhs));
@@ -874,50 +882,6 @@ impl<'a> Interpreter<'a> {
 
         let location = self.interner.expr_location(&id);
         self.call_function(method_id, vec![lhs, rhs], type_bindings, location)
-    }
-
-    fn resolve_trait_method(&mut self, method: TraitMethodId, expr_id: ExprId) -> IResult<FuncId> {
-        let trait_impl = self.interner.get_selected_impl_for_expression(expr_id)
-            .expect("ICE: missing trait impl");
-
-        let func_id = match trait_impl {
-            TraitImplKind::Normal(impl_id) => {
-                self.interner.get_trait_implementation(impl_id).borrow().methods
-                    [method.method_index]
-            }
-            TraitImplKind::Assumed { object_type, trait_generics } => {
-                match self.interner.lookup_trait_implementation(
-                    &object_type,
-                    method.trait_id,
-                    &trait_generics,
-                ) {
-                    Ok(TraitImplKind::Normal(impl_id)) => {
-                        self.interner.get_trait_implementation(impl_id).borrow().methods
-                            [method.method_index]
-                    }
-                    Ok(TraitImplKind::Assumed { .. }) => unreachable!(
-                        "There should be no remaining Assumed impls during monomorphization"
-                    ),
-                    Err(constraints) => {
-                        let failed_constraints = vecmap(constraints, |constraint| {
-                            let id = constraint.trait_id;
-                            let mut name = self.interner.get_trait(id).name.to_string();
-                            if !constraint.trait_generics.is_empty() {
-                                let types =
-                                    vecmap(&constraint.trait_generics, |t| format!("{t:?}"));
-                                name += &format!("<{}>", types.join(", "));
-                            }
-                            format!("  {}: {name}", constraint.typ)
-                        })
-                        .join("\n");
-
-                        unreachable!("Failed to find trait impl during monomorphization. The failed constraint(s) are:\n{failed_constraints}")
-                    }
-                }
-            }
-        };
-
-        Ok(func_id)
     }
 
     fn evaluate_index(&mut self, index: HirIndexExpression, id: ExprId) -> IResult<Value> {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::ast::{BinaryOpKind, FunctionKind, IntegerBitSize, Signedness};
 use crate::graph::CrateId;
 use crate::hir_def::expr::ImplKind;
-use crate::monomorphization::{perform_instantiation_bindings, undo_instantiation_bindings};
+use crate::monomorphization::{perform_instantiation_bindings, undo_instantiation_bindings, perform_impl_bindings};
 use crate::node_interner::{TraitMethodId, TraitImplKind};
 use crate::token::Tokens;
 use crate::{
@@ -68,8 +68,12 @@ impl<'a> Interpreter<'a> {
         instantiation_bindings: TypeBindings,
         location: Location,
     ) -> IResult<Value> {
+        let trait_method = self.interner.get_trait_method_id(function);
+
         perform_instantiation_bindings(&instantiation_bindings);
+        let impl_bindings = perform_impl_bindings(self.interner, trait_method, function);
         let result = self.call_function_inner(function, arguments, location);
+        undo_instantiation_bindings(impl_bindings);
         undo_instantiation_bindings(instantiation_bindings);
         result
     }

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -1,4 +1,5 @@
 use acvm::FieldElement;
+use iter_extended::vecmap;
 use noirc_errors::CustomDiagnostic as Diagnostic;
 use noirc_errors::Span;
 use thiserror::Error;
@@ -6,7 +7,9 @@ use thiserror::Error;
 use crate::ast::{BinaryOpKind, FunctionReturnType, IntegerBitSize, Signedness};
 use crate::hir::resolution::errors::ResolverError;
 use crate::hir_def::expr::HirBinaryOp;
+use crate::hir_def::traits::TraitConstraint;
 use crate::hir_def::types::Type;
+use crate::macros_api::NodeInterner;
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum Source {
@@ -114,7 +117,7 @@ pub enum TypeCheckError {
         parameter_index: usize,
     },
     #[error("No matching impl found")]
-    NoMatchingImplFound { constraints: Vec<(Type, String)>, span: Span },
+    NoMatchingImplFound(NoMatchingImplFoundError),
     #[error("Constraint for `{typ}: {trait_name}` is not needed, another matching impl is already in scope")]
     UnneededTraitConstraint { trait_name: String, typ: Type, span: Span },
     #[error(
@@ -147,6 +150,12 @@ pub enum TypeCheckError {
     StringIndexAssign { span: Span },
     #[error("Macro calls may only return `Quoted` values")]
     MacroReturningNonExpr { typ: Type, span: Span },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoMatchingImplFoundError {
+    constraints: Vec<(Type, String)>,
+    pub span: Span,
 }
 
 impl TypeCheckError {
@@ -307,20 +316,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                 let msg = format!("Unused expression result of type {expr_type}");
                 Diagnostic::simple_warning(msg, String::new(), *expr_span)
             }
-            TypeCheckError::NoMatchingImplFound { constraints, span } => {
-                assert!(!constraints.is_empty());
-                let msg = format!("No matching impl found for `{}: {}`", constraints[0].0, constraints[0].1);
-                let mut diagnostic = Diagnostic::from_message(&msg);
-
-                diagnostic.add_secondary(format!("No impl for `{}: {}`", constraints[0].0, constraints[0].1), *span);
-
-                // These must be notes since secondaries are unordered
-                for (typ, trait_name) in &constraints[1..] {
-                    diagnostic.add_note(format!("Required by `{typ}: {trait_name}`"));
-                }
-
-                diagnostic
-            }
+            TypeCheckError::NoMatchingImplFound(error) => error.into(),
             TypeCheckError::UnneededTraitConstraint { trait_name, typ, span } => {
                 let msg = format!("Constraint for `{typ}: {trait_name}` is not needed, another matching impl is already in scope");
                 Diagnostic::simple_warning(msg, "Unnecessary trait constraint in where clause".into(), *span)
@@ -350,7 +346,54 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                 format!("Expected macro call to return a `Quoted` but found a(n) `{typ}`"),
                 "Macro calls must return quoted values, otherwise there is no code to insert".into(),
                 *span,
-                ),
+            ),
         }
+    }
+}
+
+impl<'a> From<&'a NoMatchingImplFoundError> for Diagnostic {
+    fn from(error: &'a NoMatchingImplFoundError) -> Self {
+        let constraints = &error.constraints;
+        let span = error.span;
+
+        assert!(!constraints.is_empty());
+        let msg =
+            format!("No matching impl found for `{}: {}`", constraints[0].0, constraints[0].1);
+        let mut diagnostic = Diagnostic::from_message(&msg);
+
+        let secondary = format!("No impl for `{}: {}`", constraints[0].0, constraints[0].1);
+        diagnostic.add_secondary(secondary, span);
+
+        // These must be notes since secondaries are unordered
+        for (typ, trait_name) in &constraints[1..] {
+            diagnostic.add_note(format!("Required by `{typ}: {trait_name}`"));
+        }
+
+        diagnostic
+    }
+}
+
+impl NoMatchingImplFoundError {
+    pub fn new(
+        interner: &NodeInterner,
+        failing_constraints: Vec<TraitConstraint>,
+        span: Span,
+    ) -> Option<Self> {
+        // Don't show any errors where try_get_trait returns None.
+        // This can happen if a trait is used that was never declared.
+        let constraints = failing_constraints
+            .into_iter()
+            .map(|constraint| {
+                let r#trait = interner.try_get_trait(constraint.trait_id)?;
+                let mut name = r#trait.name.to_string();
+                if !constraint.trait_generics.is_empty() {
+                    let generics = vecmap(&constraint.trait_generics, ToString::to_string);
+                    name += &format!("<{}>", generics.join(", "));
+                }
+                Some((constraint.typ, name))
+            })
+            .collect::<Option<Vec<_>>>()?;
+
+        Some(Self { constraints, span })
     }
 }

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -11,7 +11,7 @@ mod errors;
 mod expr;
 mod stmt;
 
-pub use errors::TypeCheckError;
+pub use errors::{NoMatchingImplFoundError, TypeCheckError};
 use noirc_errors::Span;
 
 use crate::{

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -832,7 +832,6 @@ impl<'interner> Monomorphizer<'interner> {
         let typ = self.interner.id_type(expr_id);
 
         if let ImplKind::TraitMethod(method, _, _) = ident.impl_kind {
-            eprintln!("TraitMethod!  {method:?}   {expr_id:?}");
             return self.resolve_trait_method_expr(expr_id, typ, method);
         }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1775,7 +1775,12 @@ impl NodeInterner {
     }
 
     /// Returns the type of an operator (which is always a function), along with its return type.
-    pub fn get_operator_type(&self, lhs: ExprId, operator: BinaryOpKind, operator_expr: ExprId) -> (Type, Type) {
+    pub fn get_operator_type(
+        &self,
+        lhs: ExprId,
+        operator: BinaryOpKind,
+        operator_expr: ExprId,
+    ) -> (Type, Type) {
         let lhs_type = self.id_type(lhs);
         let args = vec![lhs_type.clone(), lhs_type];
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1762,6 +1762,24 @@ impl NodeInterner {
     pub fn get_quoted_type(&self, id: QuotedTypeId) -> &Type {
         &self.quoted_types[id.0]
     }
+
+    /// Returns the type of an operator (which is always a function), along with its return type.
+    pub fn get_operator_type(&self, lhs: ExprId, operator: BinaryOpKind, operator_expr: ExprId) -> (Type, Type) {
+        let lhs_type = self.id_type(lhs);
+        let args = vec![lhs_type.clone(), lhs_type];
+
+        // If this is a comparison operator, the result is a boolean but
+        // the actual method call returns an Ordering
+        use crate::ast::BinaryOpKind::*;
+        let ret = if matches!(operator, Less | LessEqual | Greater | GreaterEqual) {
+            self.ordering_type()
+        } else {
+            self.id_type(operator_expr)
+        };
+
+        let env = Box::new(Type::Unit);
+        (Type::Function(args, Box::new(ret.clone()), env), ret)
+    }
 }
 
 impl Methods {

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1194,6 +1194,17 @@ impl NodeInterner {
         self.trait_implementations[&id].clone()
     }
 
+    /// If the given function belongs to a trait impl, return its trait method id.
+    /// Otherwise, return None.
+    pub fn get_trait_method_id(&self, function: FuncId) -> Option<TraitMethodId> {
+        let impl_id = self.function_meta(&function).trait_impl?;
+        let trait_impl = self.get_trait_implementation(impl_id);
+        let trait_impl = trait_impl.borrow();
+
+        let method_index = trait_impl.methods.iter().position(|id| *id == function)?;
+        Some(TraitMethodId { trait_id: trait_impl.trait_id, method_index })
+    }
+
     /// Given a `ObjectType: TraitId` pair, try to find an existing impl that satisfies the
     /// constraint. If an impl cannot be found, this will return a vector of each constraint
     /// in the path to get to the failing constraint. Usually this is just the single failing

--- a/test_programs/compile_success_empty/comptime_traits/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_traits/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_traits"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_traits/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_traits/src/main.nr
@@ -1,0 +1,14 @@
+fn main() {
+    comptime {
+        // impl Eq for Field
+        println(3 == 3);
+
+        // impl<T, let N: u32> Default for [T; N] where T: Default
+        // impl Default for Field
+        let array = Default::default();
+
+        // impl<T, let N: u32> Eq for [T; N] where T: Eq
+        // impl Eq for Field
+        println([1, 2] == array);
+    }
+}

--- a/test_programs/compile_success_empty/comptime_traits/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_traits/src/main.nr
@@ -1,5 +1,6 @@
 fn main() {
-    comptime {
+    comptime
+    {
         // impl Eq for Field
         println(3 == 3);
 

--- a/test_programs/compile_success_empty/comptime_traits/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_traits/src/main.nr
@@ -2,7 +2,7 @@ fn main() {
     comptime
     {
         // impl Eq for Field
-        println(3 == 3);
+        assert(3 == 3);
 
         // impl<T, let N: u32> Default for [T; N] where T: Default
         // impl Default for Field
@@ -10,6 +10,6 @@ fn main() {
 
         // impl<T, let N: u32> Eq for [T; N] where T: Eq
         // impl Eq for Field
-        println([1, 2] == array);
+        assert([1, 2] != array);
     }
 }

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -61,12 +61,13 @@ const IGNORED_BRILLIG_TESTS: [&str; 11] = [
 /// Certain features are only available in the elaborator.
 /// We skip these tests for non-elaborator code since they are not
 /// expected to work there. This can be removed once the old code is removed.
-const IGNORED_NEW_FEATURE_TESTS: [&str; 5] = [
+const IGNORED_NEW_FEATURE_TESTS: [&str; 6] = [
     "macros",
     "wildcard_type",
     "type_definition_annotation",
     "numeric_generics_explicit",
     "derive_impl",
+    "comptime_traits",
 ];
 
 fn read_test_cases(


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4925

## Summary\*

Implements trait dispatch in the interpreter - which includes operator overloading.

## Additional Context

I've tried to share as much code as I can between the interpreter and monomorphization.

Most of this PR is rather straightforward adapting code in the monomorphizer to use in the interpreter. The main new bit of code is a stack of `FunctionContext`s in the elaborator. I found at that when having a comptime block in the middle of a function, even a known trait would panic that it had no impl. This was because we previously delayed solving impls to the very end of a function when types were known. I've had to change this into a stack instead so that we can solve impls that were done within a comptime block at the end of that comptime block, just before interpreting so that they'd be defined. Similarly, the `type_variables` list also needed to be placed here since defaulting types can cause some trait constraints to succeed/fail without it. I settled on `function_context` for the name of this stack but am not sure if it fits the case where we have a stack of comptime contexts instead. Similarly, `ComptimeContext` also didn't make sense for the more common case of only having one of them for a function with no comptime blocks.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
