### PR TITLE
fix: go to definition from aliased use

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -348,7 +348,12 @@ impl DefCollector {
                             .import(name.clone(), ns, resolved_import.is_prelude);
 
                         let file_id = current_def_map.file_id(module_id);
-                        add_import_reference(ns, &name, &mut context.def_interner, file_id);
+                        let last_segment = collected_import.path.last_segment();
+
+                        add_import_reference(ns, &last_segment, &mut context.def_interner, file_id);
+                        if let Some(ref alias) = collected_import.alias {
+                            add_import_reference(ns, alias, &mut context.def_interner, file_id);
+                        }
 
                         if let Err((first_def, second_def)) = result {
                             let err = DefCollectorErrorKind::Duplicate {

--- a/tooling/lsp/test_programs/go_to_definition/src/main.nr
+++ b/tooling/lsp/test_programs/go_to_definition/src/main.nr
@@ -5,6 +5,7 @@ mod foo {
 }
 
 use foo::another_function;
+use foo::another_function as aliased_function;
 
 fn some_function() -> Field {
     1 + 2


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/pull/5390#issuecomment-2205880047

## Summary

Go to definition didn't work in this case:

```rust
use some::name as aliased_name;
//        ~~~~ click here
```


https://github.com/noir-lang/noir/assets/209371/e35ca028-69e0-4e74-8fce-9c63a1376232



Also adds a test that clicking "aliased_name" also works the same way.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
