### PR TITLE
chore: merge `BarretenbergVerifierBackend` and `BarretenbergBackend`

### DIFF
--- a/tooling/noir_js_backend_barretenberg/src/backend.ts
+++ b/tooling/noir_js_backend_barretenberg/src/backend.ts
@@ -10,7 +10,7 @@ import { type Barretenberg } from '@aztec/bb.js';
 // minus the public inputs.
 const numBytesInProofWithoutPublicInputs: number = 2144;
 
-export class BarretenbergVerifierBackend implements VerifierBackend {
+export class BarretenbergBackend implements Backend, VerifierBackend {
   // These type assertions are used so that we don't
   // have to initialize `api` and `acirComposer` in the constructor.
   // These are initialized asynchronously in the `init` function,
@@ -60,29 +60,6 @@ export class BarretenbergVerifierBackend implements VerifierBackend {
     }
   }
 
-  /** @description Verifies a proof */
-  async verifyProof(proofData: ProofData): Promise<boolean> {
-    const proof = reconstructProofWithPublicInputs(proofData);
-    await this.instantiate();
-    await this.api.acirInitVerificationKey(this.acirComposer);
-    return await this.api.acirVerifyProof(this.acirComposer, proof);
-  }
-
-  async getVerificationKey(): Promise<Uint8Array> {
-    await this.instantiate();
-    await this.api.acirInitVerificationKey(this.acirComposer);
-    return await this.api.acirGetVerificationKey(this.acirComposer);
-  }
-
-  async destroy(): Promise<void> {
-    if (!this.api) {
-      return;
-    }
-    await this.api.destroy();
-  }
-}
-
-export class BarretenbergBackend extends BarretenbergVerifierBackend implements Backend {
   /** @description Generates a proof */
   async generateProof(compressedWitness: Uint8Array): Promise<ProofData> {
     await this.instantiate();
@@ -143,5 +120,26 @@ export class BarretenbergBackend extends BarretenbergVerifierBackend implements 
       vkAsFields: vk[0].map((vk) => vk.toString()),
       vkHash: vk[1].toString(),
     };
+  }
+
+  /** @description Verifies a proof */
+  async verifyProof(proofData: ProofData): Promise<boolean> {
+    const proof = reconstructProofWithPublicInputs(proofData);
+    await this.instantiate();
+    await this.api.acirInitVerificationKey(this.acirComposer);
+    return await this.api.acirVerifyProof(this.acirComposer, proof);
+  }
+
+  async getVerificationKey(): Promise<Uint8Array> {
+    await this.instantiate();
+    await this.api.acirInitVerificationKey(this.acirComposer);
+    return await this.api.acirGetVerificationKey(this.acirComposer);
+  }
+
+  async destroy(): Promise<void> {
+    if (!this.api) {
+      return;
+    }
+    await this.api.destroy();
   }
 }

--- a/tooling/noir_js_backend_barretenberg/src/verifier.ts
+++ b/tooling/noir_js_backend_barretenberg/src/verifier.ts
@@ -1,9 +1,9 @@
-import { ProofData } from '@noir-lang/types';
+import { ProofData, VerifierBackend } from '@noir-lang/types';
 import { BackendOptions } from './types.js';
 import { flattenPublicInputsAsArray } from './public_inputs.js';
 import { type Barretenberg } from '@aztec/bb.js';
 
-export class BarretenbergVerifier {
+export class BarretenbergVerifier implements VerifierBackend {
   // These type assertions are used so that we don't
   // have to initialize `api` and `acirComposer` in the constructor.
   // These are initialized asynchronously in the `init` function,

--- a/tooling/noir_js_backend_barretenberg/src/verifier.ts
+++ b/tooling/noir_js_backend_barretenberg/src/verifier.ts
@@ -1,9 +1,9 @@
-import { ProofData, VerifierBackend } from '@noir-lang/types';
+import { ProofData } from '@noir-lang/types';
 import { BackendOptions } from './types.js';
 import { flattenPublicInputsAsArray } from './public_inputs.js';
 import { type Barretenberg } from '@aztec/bb.js';
 
-export class BarretenbergVerifier implements VerifierBackend {
+export class BarretenbergVerifier {
   // These type assertions are used so that we don't
   // have to initialize `api` and `acirComposer` in the constructor.
   // These are initialized asynchronously in the `init` function,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

As pointed out by Palla in the bb.js doc, we're exporting two different verifiers here. I'm not sure why this is the case so I've folded `BarretenbergVerifierBackend` into `BarretenbergBackend` so `BarretenbergVerifier` is the only `VerifierBackend` that doesn't also implement `Backend`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
