### PR TITLE
chore(docs): Remove persona boxes from the landing page

### DIFF
--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -36,38 +36,6 @@ export default function Landing() {
               </Link>
             </div>
           </div>
-
-          <div className="homepage_cta_lj_container">
-            <div className="homepage_cta_container">
-              <h2 className="homepage_h2">Learn</h2>
-              <Link to="/docs/getting_started/installation" target="_blank" rel="noopener noreferrer">
-                <button className="cta-button button button--primary button--lg homepage_cta">Try Noir</button>
-              </Link>
-              <Link to="/docs" target="_blank" rel="noopener noreferrer">
-                <button className="cta-button button button--secondary button--lg homepage_cta">
-                  Noir Cryptography
-                </button>
-              </Link>
-            </div>
-            <div className="homepage_cta_container">
-              <h2 className="homepage_h2">Coming from...</h2>
-              <Link to="/docs/how_to/how-to-solidity-verifier" target="_blank" rel="noopener noreferrer">
-                <button className="cta-button button button--primary button--lg homepage_cta">Solidity</button>
-              </Link>
-              <Link to="/docs" target="_blank" rel="noopener noreferrer">
-                <button className="cta-button button button--secondary button--lg homepage_cta">Aztec</button>
-              </Link>
-            </div>
-            <div className="homepage_cta_container">
-              <h2 className="homepage_h2">New to Everything</h2>
-              <Link to="/docs" target="_blank" rel="noopener noreferrer">
-                <button className="cta-button button button--primary button--lg homepage_cta">Noir Basics</button>
-              </Link>
-              <Link to="/docs/tutorials/noirjs_app" target="_blank" rel="noopener noreferrer">
-                <button className="cta-button button button--secondary button--lg homepage_cta">NoirJS</button>
-              </Link>
-            </div>
-          </div>
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4982

## Summary\*

These persona boxes were a rudimentary way to get some info about who was coming to the docs. We have proper analytics now, so we can remove them.


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
