### PR TITLE
fix: lsp find struct reference in return locations and paths

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -27,7 +27,7 @@ use crate::{
         HirLiteral, HirStatement, Ident, IndexExpression, Literal, MemberAccessExpression,
         MethodCallExpression, PrefixExpression,
     },
-    node_interner::{DefinitionKind, DependencyId, ExprId, FuncId},
+    node_interner::{DefinitionKind, ExprId, FuncId, ReferenceId},
     token::Tokens,
     Kind, QuotedType, Shared, StructType, Type,
 };
@@ -432,8 +432,8 @@ impl<'context> Elaborator<'context> {
             struct_generics,
         });
 
-        let referenced = DependencyId::Struct(struct_type.borrow().id);
-        let reference = DependencyId::Variable(Location::new(span, self.file));
+        let referenced = ReferenceId::Struct(struct_type.borrow().id);
+        let reference = ReferenceId::Variable(Location::new(span, self.file));
         self.interner.add_reference(referenced, reference);
 
         (expr, Type::Struct(struct_type, generics))

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -534,7 +534,7 @@ impl<'context> Elaborator<'context> {
     fn resolve_trait_by_path(&mut self, path: Path) -> Option<TraitId> {
         let path_resolver = StandardPathResolver::new(self.module_id());
 
-        let error = match path_resolver.resolve(self.def_maps, path.clone()) {
+        let error = match path_resolver.resolve(self.def_maps, path.clone(), &mut None) {
             Ok(PathResolution { module_def_id: ModuleDefId::TraitId(trait_id), error }) => {
                 if let Some(error) = error {
                     self.push_err(error);

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -15,7 +15,7 @@ use crate::{
         stmt::HirPattern,
     },
     macros_api::{HirExpression, Ident, Path, Pattern},
-    node_interner::{DefinitionId, DefinitionKind, DependencyId, ExprId, GlobalId, TraitImplKind},
+    node_interner::{DefinitionId, DefinitionKind, ExprId, GlobalId, ReferenceId, TraitImplKind},
     Shared, StructType, Type, TypeBindings,
 };
 
@@ -199,8 +199,8 @@ impl<'context> Elaborator<'context> {
             new_definitions,
         );
 
-        let referenced = DependencyId::Struct(struct_type.borrow().id);
-        let reference = DependencyId::Variable(Location::new(name_span, self.file));
+        let referenced = ReferenceId::Struct(struct_type.borrow().id);
+        let reference = ReferenceId::Variable(Location::new(name_span, self.file));
         self.interner.add_reference(referenced, reference);
 
         HirPattern::Struct(expected_type, fields, location)
@@ -446,8 +446,8 @@ impl<'context> Elaborator<'context> {
                             self.interner.add_function_dependency(current_item, func_id);
                         }
 
-                        let variable = DependencyId::Variable(hir_ident.location);
-                        let function = DependencyId::Function(func_id);
+                        let variable = ReferenceId::Variable(hir_ident.location);
+                        let function = ReferenceId::Function(func_id);
                         self.interner.add_reference(function, variable);
                     }
                     DefinitionKind::Global(global_id) => {
@@ -458,8 +458,8 @@ impl<'context> Elaborator<'context> {
                             self.interner.add_global_dependency(current_item, global_id);
                         }
 
-                        let variable = DependencyId::Variable(hir_ident.location);
-                        let global = DependencyId::Global(global_id);
+                        let variable = ReferenceId::Variable(hir_ident.location);
+                        let global = ReferenceId::Global(global_id);
                         self.interner.add_reference(global, variable);
                     }
                     DefinitionKind::GenericType(_) => {

--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -1,4 +1,4 @@
-use noirc_errors::Spanned;
+use noirc_errors::{Location, Spanned};
 
 use crate::ast::ERROR_IDENT;
 use crate::hir::def_map::{LocalModuleId, ModuleId};
@@ -6,6 +6,7 @@ use crate::hir::resolution::path_resolver::{PathResolver, StandardPathResolver};
 use crate::hir::resolution::resolver::SELF_TYPE_NAME;
 use crate::hir::scope::{Scope as GenericScope, ScopeTree as GenericScopeTree};
 use crate::macros_api::Ident;
+use crate::node_interner::DependencyId;
 use crate::{
     hir::{
         def_map::{ModuleDefId, TryFromModuleDefId},
@@ -44,7 +45,20 @@ impl<'context> Elaborator<'context> {
 
     pub(super) fn resolve_path(&mut self, path: Path) -> Result<ModuleDefId, ResolverError> {
         let resolver = StandardPathResolver::new(self.module_id());
-        let path_resolution = resolver.resolve(self.def_maps, path)?;
+        let path_resolution;
+
+        if self.interner.track_references {
+            let mut dependencies: Vec<DependencyId> = Vec::new();
+            path_resolution =
+                resolver.resolve(self.def_maps, path.clone(), &mut Some(&mut dependencies))?;
+
+            for (referenced, ident) in dependencies.iter().zip(path.segments) {
+                let reference = DependencyId::Variable(Location::new(ident.span(), self.file));
+                self.interner.add_reference(*referenced, reference);
+            }
+        } else {
+            path_resolution = resolver.resolve(self.def_maps, path, &mut None)?;
+        }
 
         if let Some(error) = path_resolution.error {
             self.push_err(error);

--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -6,7 +6,7 @@ use crate::hir::resolution::path_resolver::{PathResolver, StandardPathResolver};
 use crate::hir::resolution::resolver::SELF_TYPE_NAME;
 use crate::hir::scope::{Scope as GenericScope, ScopeTree as GenericScopeTree};
 use crate::macros_api::Ident;
-use crate::node_interner::DependencyId;
+use crate::node_interner::ReferenceId;
 use crate::{
     hir::{
         def_map::{ModuleDefId, TryFromModuleDefId},
@@ -48,12 +48,12 @@ impl<'context> Elaborator<'context> {
         let path_resolution;
 
         if self.interner.track_references {
-            let mut dependencies: Vec<DependencyId> = Vec::new();
+            let mut dependencies: Vec<ReferenceId> = Vec::new();
             path_resolution =
                 resolver.resolve(self.def_maps, path.clone(), &mut Some(&mut dependencies))?;
 
             for (referenced, ident) in dependencies.iter().zip(path.segments) {
-                let reference = DependencyId::Variable(Location::new(ident.span(), self.file));
+                let reference = ReferenceId::Variable(Location::new(ident.span(), self.file));
                 self.interner.add_reference(*referenced, reference);
             }
         } else {

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -31,7 +31,8 @@ use crate::{
         UnaryOp, UnresolvedType, UnresolvedTypeData,
     },
     node_interner::{
-        DefinitionKind, DependencyId, ExprId, GlobalId, TraitId, TraitImplKind, TraitMethodId,
+        DefinitionKind, DependencyId, ExprId, GlobalId, ReferenceId, TraitId, TraitImplKind,
+        TraitMethodId,
     },
     Generics, Kind, ResolvedGeneric, Type, TypeBinding, TypeVariable, TypeVariableKind,
 };
@@ -154,8 +155,8 @@ impl<'context> Elaborator<'context> {
                     Location::new(unresolved_span, self.file),
                 );
 
-                let referenced = DependencyId::Struct(struct_type.borrow().id);
-                let reference = DependencyId::Variable(Location::new(unresolved_span, self.file));
+                let referenced = ReferenceId::Struct(struct_type.borrow().id);
+                let reference = ReferenceId::Variable(Location::new(unresolved_span, self.file));
                 self.interner.add_reference(referenced, reference);
             }
         }

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -330,7 +330,7 @@ impl DefCollector {
         // Resolve unresolved imports collected from the crate, one by one.
         for collected_import in std::mem::take(&mut def_collector.imports) {
             let module_id = collected_import.module_id;
-            match resolve_import(crate_id, &collected_import, &context.def_maps) {
+            match resolve_import(crate_id, &collected_import, &context.def_maps, &mut None) {
                 Ok(resolved_import) => {
                     if let Some(error) = resolved_import.error {
                         errors.push((
@@ -524,6 +524,7 @@ fn inject_prelude(
             &context.def_maps,
             ModuleId { krate: crate_id, local_id: crate_root },
             path,
+            &mut None,
         ) {
             assert!(error.is_none(), "Tried to add private item to prelude");
             let module_id = module_def_id.as_module().expect("std::prelude should be a module");

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -20,7 +20,7 @@ use crate::hir::Context;
 
 use crate::macros_api::{MacroError, MacroProcessor};
 use crate::node_interner::{
-    DependencyId, FuncId, GlobalId, NodeInterner, StructId, TraitId, TraitImplId, TypeAliasId,
+    FuncId, GlobalId, NodeInterner, ReferenceId, StructId, TraitId, TraitImplId, TypeAliasId,
 };
 
 use crate::ast::{
@@ -491,12 +491,12 @@ fn add_import_reference(
 
     match def_id {
         crate::macros_api::ModuleDefId::FunctionId(func_id) => {
-            let variable = DependencyId::Variable(Location::new(name.span(), file_id));
-            interner.add_reference(DependencyId::Function(func_id), variable);
+            let variable = ReferenceId::Variable(Location::new(name.span(), file_id));
+            interner.add_reference(ReferenceId::Function(func_id), variable);
         }
         crate::macros_api::ModuleDefId::TypeId(struct_id) => {
-            let variable = DependencyId::Variable(Location::new(name.span(), file_id));
-            interner.add_reference(DependencyId::Struct(struct_id), variable);
+            let variable = ReferenceId::Variable(Location::new(name.span(), file_id));
+            interner.add_reference(ReferenceId::Struct(struct_id), variable);
         }
         _ => (),
     }

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -14,7 +14,7 @@ use crate::ast::{
     TypeImpl,
 };
 use crate::macros_api::NodeInterner;
-use crate::node_interner::DependencyId;
+use crate::node_interner::ReferenceId;
 use crate::{
     graph::CrateId,
     hir::def_collector::dc_crate::{UnresolvedStruct, UnresolvedTrait},
@@ -314,7 +314,7 @@ impl<'a> ModCollector<'a> {
             self.def_collector.items.types.insert(id, unresolved);
 
             context.def_interner.add_struct_location(id, name_location);
-            context.def_interner.add_definition_location(DependencyId::Struct(id));
+            context.def_interner.add_definition_location(ReferenceId::Struct(id));
         }
         definition_errors
     }

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::graph::CrateId;
 use crate::hir::def_collector::dc_crate::CompilationError;
-use crate::node_interner::DependencyId;
+use crate::node_interner::ReferenceId;
 use std::collections::BTreeMap;
 
 use crate::ast::{Ident, ItemVisibility, Path, PathKind};
@@ -81,14 +81,14 @@ pub fn resolve_import(
     crate_id: CrateId,
     import_directive: &ImportDirective,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
-    dependencies: &mut Option<&mut Vec<DependencyId>>,
+    path_references: &mut Option<&mut Vec<ReferenceId>>,
 ) -> Result<ResolvedImport, PathResolutionError> {
     let module_scope = import_directive.module_id;
     let NamespaceResolution {
         module_id: resolved_module,
         namespace: resolved_namespace,
         mut error,
-    } = resolve_path_to_ns(import_directive, crate_id, crate_id, def_maps, dependencies)?;
+    } = resolve_path_to_ns(import_directive, crate_id, crate_id, def_maps, path_references)?;
 
     let name = resolve_path_name(import_directive);
 
@@ -126,7 +126,7 @@ fn resolve_path_to_ns(
     crate_id: CrateId,
     importing_crate: CrateId,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
-    dependencies: &mut Option<&mut Vec<DependencyId>>,
+    path_references: &mut Option<&mut Vec<ReferenceId>>,
 ) -> NamespaceResolutionResult {
     let import_path = &import_directive.path.segments;
     let def_map = &def_maps[&crate_id];
@@ -139,7 +139,7 @@ fn resolve_path_to_ns(
                 importing_crate,
                 import_path,
                 def_maps,
-                dependencies,
+                path_references,
             )
         }
         crate::ast::PathKind::Plain => {
@@ -152,7 +152,7 @@ fn resolve_path_to_ns(
                     import_path,
                     import_directive.module_id,
                     def_maps,
-                    dependencies,
+                    path_references,
                 );
             }
 
@@ -165,7 +165,7 @@ fn resolve_path_to_ns(
                     def_map,
                     import_directive,
                     def_maps,
-                    dependencies,
+                    path_references,
                     importing_crate,
                 );
             }
@@ -176,13 +176,17 @@ fn resolve_path_to_ns(
                 import_path,
                 import_directive.module_id,
                 def_maps,
-                dependencies,
+                path_references,
             )
         }
 
-        crate::ast::PathKind::Dep => {
-            resolve_external_dep(def_map, import_directive, def_maps, dependencies, importing_crate)
-        }
+        crate::ast::PathKind::Dep => resolve_external_dep(
+            def_map,
+            import_directive,
+            def_maps,
+            path_references,
+            importing_crate,
+        ),
     }
 }
 
@@ -192,7 +196,7 @@ fn resolve_path_from_crate_root(
 
     import_path: &[Ident],
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
-    dependencies: &mut Option<&mut Vec<DependencyId>>,
+    path_references: &mut Option<&mut Vec<ReferenceId>>,
 ) -> NamespaceResolutionResult {
     resolve_name_in_module(
         crate_id,
@@ -200,7 +204,7 @@ fn resolve_path_from_crate_root(
         import_path,
         def_maps[&crate_id].root,
         def_maps,
-        dependencies,
+        path_references,
     )
 }
 
@@ -210,7 +214,7 @@ fn resolve_name_in_module(
     import_path: &[Ident],
     starting_mod: LocalModuleId,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
-    dependencies: &mut Option<&mut Vec<DependencyId>>,
+    path_references: &mut Option<&mut Vec<ReferenceId>>,
 ) -> NamespaceResolutionResult {
     let def_map = &def_maps[&krate];
     let mut current_mod_id = ModuleId { krate, local_id: starting_mod };
@@ -242,23 +246,23 @@ fn resolve_name_in_module(
         // In the type namespace, only Mod can be used in a path.
         current_mod_id = match typ {
             ModuleDefId::ModuleId(id) => {
-                if let Some(dependencies) = dependencies {
-                    dependencies.push(DependencyId::Module(id));
+                if let Some(path_references) = path_references {
+                    path_references.push(ReferenceId::Module(id));
                 }
                 id
             }
             ModuleDefId::FunctionId(_) => panic!("functions cannot be in the type namespace"),
             // TODO: If impls are ever implemented, types can be used in a path
             ModuleDefId::TypeId(id) => {
-                if let Some(dependencies) = dependencies {
-                    dependencies.push(DependencyId::Struct(id));
+                if let Some(path_references) = path_references {
+                    path_references.push(ReferenceId::Struct(id));
                 }
                 id.module_id()
             }
             ModuleDefId::TypeAliasId(_) => panic!("type aliases cannot be used in type namespace"),
             ModuleDefId::TraitId(id) => {
-                if let Some(dependencies) = dependencies {
-                    dependencies.push(DependencyId::Trait(id));
+                if let Some(path_references) = path_references {
+                    path_references.push(ReferenceId::Trait(id));
                 }
                 id.0
             }
@@ -305,7 +309,7 @@ fn resolve_external_dep(
     current_def_map: &CrateDefMap,
     directive: &ImportDirective,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
-    dependencies: &mut Option<&mut Vec<DependencyId>>,
+    path_references: &mut Option<&mut Vec<ReferenceId>>,
     importing_crate: CrateId,
 ) -> NamespaceResolutionResult {
     // Use extern_prelude to get the dep
@@ -335,7 +339,7 @@ fn resolve_external_dep(
         is_prelude: false,
     };
 
-    resolve_path_to_ns(&dep_directive, dep_module.krate, importing_crate, def_maps, dependencies)
+    resolve_path_to_ns(&dep_directive, dep_module.krate, importing_crate, def_maps, path_references)
 }
 
 // Issue an error if the given private function is being called from a non-child module, or

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 use crate::graph::CrateId;
 use crate::hir::def_collector::dc_crate::CompilationError;
+use crate::node_interner::DependencyId;
 use std::collections::BTreeMap;
 
 use crate::ast::{Ident, ItemVisibility, Path, PathKind};
@@ -80,13 +81,14 @@ pub fn resolve_import(
     crate_id: CrateId,
     import_directive: &ImportDirective,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    dependencies: &mut Option<&mut Vec<DependencyId>>,
 ) -> Result<ResolvedImport, PathResolutionError> {
     let module_scope = import_directive.module_id;
     let NamespaceResolution {
         module_id: resolved_module,
         namespace: resolved_namespace,
         mut error,
-    } = resolve_path_to_ns(import_directive, crate_id, crate_id, def_maps)?;
+    } = resolve_path_to_ns(import_directive, crate_id, crate_id, def_maps, dependencies)?;
 
     let name = resolve_path_name(import_directive);
 
@@ -124,6 +126,7 @@ fn resolve_path_to_ns(
     crate_id: CrateId,
     importing_crate: CrateId,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    dependencies: &mut Option<&mut Vec<DependencyId>>,
 ) -> NamespaceResolutionResult {
     let import_path = &import_directive.path.segments;
     let def_map = &def_maps[&crate_id];
@@ -131,7 +134,13 @@ fn resolve_path_to_ns(
     match import_directive.path.kind {
         crate::ast::PathKind::Crate => {
             // Resolve from the root of the crate
-            resolve_path_from_crate_root(crate_id, importing_crate, import_path, def_maps)
+            resolve_path_from_crate_root(
+                crate_id,
+                importing_crate,
+                import_path,
+                def_maps,
+                dependencies,
+            )
         }
         crate::ast::PathKind::Plain => {
             // There is a possibility that the import path is empty
@@ -143,6 +152,7 @@ fn resolve_path_to_ns(
                     import_path,
                     import_directive.module_id,
                     def_maps,
+                    dependencies,
                 );
             }
 
@@ -151,7 +161,13 @@ fn resolve_path_to_ns(
             let first_segment = import_path.first().expect("ice: could not fetch first segment");
             if current_mod.find_name(first_segment).is_none() {
                 // Resolve externally when first segment is unresolved
-                return resolve_external_dep(def_map, import_directive, def_maps, importing_crate);
+                return resolve_external_dep(
+                    def_map,
+                    import_directive,
+                    def_maps,
+                    dependencies,
+                    importing_crate,
+                );
             }
 
             resolve_name_in_module(
@@ -160,11 +176,12 @@ fn resolve_path_to_ns(
                 import_path,
                 import_directive.module_id,
                 def_maps,
+                dependencies,
             )
         }
 
         crate::ast::PathKind::Dep => {
-            resolve_external_dep(def_map, import_directive, def_maps, importing_crate)
+            resolve_external_dep(def_map, import_directive, def_maps, dependencies, importing_crate)
         }
     }
 }
@@ -175,6 +192,7 @@ fn resolve_path_from_crate_root(
 
     import_path: &[Ident],
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    dependencies: &mut Option<&mut Vec<DependencyId>>,
 ) -> NamespaceResolutionResult {
     resolve_name_in_module(
         crate_id,
@@ -182,6 +200,7 @@ fn resolve_path_from_crate_root(
         import_path,
         def_maps[&crate_id].root,
         def_maps,
+        dependencies,
     )
 }
 
@@ -191,6 +210,7 @@ fn resolve_name_in_module(
     import_path: &[Ident],
     starting_mod: LocalModuleId,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    dependencies: &mut Option<&mut Vec<DependencyId>>,
 ) -> NamespaceResolutionResult {
     let def_map = &def_maps[&krate];
     let mut current_mod_id = ModuleId { krate, local_id: starting_mod };
@@ -221,12 +241,27 @@ fn resolve_name_in_module(
 
         // In the type namespace, only Mod can be used in a path.
         current_mod_id = match typ {
-            ModuleDefId::ModuleId(id) => id,
+            ModuleDefId::ModuleId(id) => {
+                if let Some(dependencies) = dependencies {
+                    dependencies.push(DependencyId::Module(id));
+                }
+                id
+            }
             ModuleDefId::FunctionId(_) => panic!("functions cannot be in the type namespace"),
             // TODO: If impls are ever implemented, types can be used in a path
-            ModuleDefId::TypeId(id) => id.module_id(),
+            ModuleDefId::TypeId(id) => {
+                if let Some(dependencies) = dependencies {
+                    dependencies.push(DependencyId::Struct(id));
+                }
+                id.module_id()
+            }
             ModuleDefId::TypeAliasId(_) => panic!("type aliases cannot be used in type namespace"),
-            ModuleDefId::TraitId(id) => id.0,
+            ModuleDefId::TraitId(id) => {
+                if let Some(dependencies) = dependencies {
+                    dependencies.push(DependencyId::Trait(id));
+                }
+                id.0
+            }
             ModuleDefId::GlobalId(_) => panic!("globals cannot be in the type namespace"),
         };
 
@@ -270,6 +305,7 @@ fn resolve_external_dep(
     current_def_map: &CrateDefMap,
     directive: &ImportDirective,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    dependencies: &mut Option<&mut Vec<DependencyId>>,
     importing_crate: CrateId,
 ) -> NamespaceResolutionResult {
     // Use extern_prelude to get the dep
@@ -299,7 +335,7 @@ fn resolve_external_dep(
         is_prelude: false,
     };
 
-    resolve_path_to_ns(&dep_directive, dep_module.krate, importing_crate, def_maps)
+    resolve_path_to_ns(&dep_directive, dep_module.krate, importing_crate, def_maps, dependencies)
 }
 
 // Issue an error if the given private function is being called from a non-child module, or

--- a/compiler/noirc_frontend/src/hir/resolution/path_resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/path_resolver.rs
@@ -1,5 +1,6 @@
 use super::import::{resolve_import, ImportDirective, PathResolution, PathResolutionResult};
 use crate::ast::Path;
+use crate::node_interner::DependencyId;
 use std::collections::BTreeMap;
 
 use crate::graph::CrateId;
@@ -7,10 +8,13 @@ use crate::hir::def_map::{CrateDefMap, LocalModuleId, ModuleId};
 
 pub trait PathResolver {
     /// Resolve the given path returning the resolved ModuleDefId.
+    /// If `dependencies` is `Some`, a `DependencyId` for each segment in `path`
+    /// will be pushed.
     fn resolve(
         &self,
         def_maps: &BTreeMap<CrateId, CrateDefMap>,
         path: Path,
+        dependencies: &mut Option<&mut Vec<DependencyId>>,
     ) -> PathResolutionResult;
 
     fn local_module_id(&self) -> LocalModuleId;
@@ -34,8 +38,9 @@ impl PathResolver for StandardPathResolver {
         &self,
         def_maps: &BTreeMap<CrateId, CrateDefMap>,
         path: Path,
+        dependencies: &mut Option<&mut Vec<DependencyId>>,
     ) -> PathResolutionResult {
-        resolve_path(def_maps, self.module_id, path)
+        resolve_path(def_maps, self.module_id, path, dependencies)
     }
 
     fn local_module_id(&self) -> LocalModuleId {
@@ -53,11 +58,12 @@ pub fn resolve_path(
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
     module_id: ModuleId,
     path: Path,
+    dependencies: &mut Option<&mut Vec<DependencyId>>,
 ) -> PathResolutionResult {
     // lets package up the path into an ImportDirective and resolve it using that
     let import =
         ImportDirective { module_id: module_id.local_id, path, alias: None, is_prelude: false };
-    let resolved_import = resolve_import(module_id.krate, &import, def_maps)?;
+    let resolved_import = resolve_import(module_id.krate, &import, def_maps, dependencies)?;
 
     let namespace = resolved_import.resolved_namespace;
     let id =

--- a/compiler/noirc_frontend/src/hir/resolution/path_resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/path_resolver.rs
@@ -1,6 +1,6 @@
 use super::import::{resolve_import, ImportDirective, PathResolution, PathResolutionResult};
 use crate::ast::Path;
-use crate::node_interner::DependencyId;
+use crate::node_interner::ReferenceId;
 use std::collections::BTreeMap;
 
 use crate::graph::CrateId;
@@ -8,13 +8,13 @@ use crate::hir::def_map::{CrateDefMap, LocalModuleId, ModuleId};
 
 pub trait PathResolver {
     /// Resolve the given path returning the resolved ModuleDefId.
-    /// If `dependencies` is `Some`, a `DependencyId` for each segment in `path`
-    /// will be pushed.
+    /// If `path_references` is `Some`, a `ReferenceId` for each segment in `path`
+    /// will be resolved and pushed.
     fn resolve(
         &self,
         def_maps: &BTreeMap<CrateId, CrateDefMap>,
         path: Path,
-        dependencies: &mut Option<&mut Vec<DependencyId>>,
+        path_references: &mut Option<&mut Vec<ReferenceId>>,
     ) -> PathResolutionResult;
 
     fn local_module_id(&self) -> LocalModuleId;
@@ -38,9 +38,9 @@ impl PathResolver for StandardPathResolver {
         &self,
         def_maps: &BTreeMap<CrateId, CrateDefMap>,
         path: Path,
-        dependencies: &mut Option<&mut Vec<DependencyId>>,
+        path_references: &mut Option<&mut Vec<ReferenceId>>,
     ) -> PathResolutionResult {
-        resolve_path(def_maps, self.module_id, path, dependencies)
+        resolve_path(def_maps, self.module_id, path, path_references)
     }
 
     fn local_module_id(&self) -> LocalModuleId {
@@ -58,12 +58,12 @@ pub fn resolve_path(
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
     module_id: ModuleId,
     path: Path,
-    dependencies: &mut Option<&mut Vec<DependencyId>>,
+    path_references: &mut Option<&mut Vec<ReferenceId>>,
 ) -> PathResolutionResult {
     // lets package up the path into an ImportDirective and resolve it using that
     let import =
         ImportDirective { module_id: module_id.local_id, path, alias: None, is_prelude: false };
-    let resolved_import = resolve_import(module_id.krate, &import, def_maps, dependencies)?;
+    let resolved_import = resolve_import(module_id.krate, &import, def_maps, path_references)?;
 
     let namespace = resolved_import.resolved_namespace;
     let id =

--- a/compiler/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/resolver.rs
@@ -765,7 +765,7 @@ impl<'a> Resolver<'a> {
         }
 
         // If we cannot find a local generic of the same name, try to look up a global
-        match self.path_resolver.resolve(self.def_maps, path.clone()) {
+        match self.path_resolver.resolve(self.def_maps, path.clone(), &mut None) {
             Ok(PathResolution { module_def_id: ModuleDefId::GlobalId(id), error }) => {
                 if let Some(current_item) = self.current_item {
                     self.interner.add_global_dependency(current_item, id);
@@ -2017,7 +2017,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_path(&mut self, path: Path) -> Result<ModuleDefId, ResolverError> {
-        let path_resolution = self.path_resolver.resolve(self.def_maps, path)?;
+        let path_resolution = self.path_resolver.resolve(self.def_maps, path, &mut None)?;
 
         if let Some(error) = path_resolution.error {
             self.push_err(error.into());

--- a/compiler/noirc_frontend/src/hir/resolution/traits.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/traits.rs
@@ -388,7 +388,7 @@ pub(crate) fn resolve_trait_by_path(
 ) -> Result<(TraitId, Option<PathResolutionError>), DefCollectorErrorKind> {
     let path_resolver = StandardPathResolver::new(module);
 
-    match path_resolver.resolve(def_maps, path.clone()) {
+    match path_resolver.resolve(def_maps, path.clone(), &mut None) {
         Ok(PathResolution { module_def_id: ModuleDefId::TraitId(trait_id), error }) => {
             Ok((trait_id, error))
         }

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -462,7 +462,7 @@ pub mod test {
         stmt::HirStatement,
     };
     use crate::node_interner::{
-        DefinitionKind, DependencyId, FuncId, NodeInterner, TraitId, TraitMethodId,
+        DefinitionKind, FuncId, NodeInterner, ReferenceId, TraitId, TraitMethodId,
     };
     use crate::{
         hir::{
@@ -694,7 +694,7 @@ pub mod test {
             &self,
             _def_maps: &BTreeMap<CrateId, CrateDefMap>,
             path: Path,
-            _dependencies: &mut Option<&mut Vec<DependencyId>>,
+            _path_references: &mut Option<&mut Vec<ReferenceId>>,
         ) -> PathResolutionResult {
             // Not here that foo::bar and hello::foo::bar would fetch the same thing
             let name = path.segments.last().unwrap();

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -461,7 +461,9 @@ pub mod test {
         function::{FuncMeta, HirFunction},
         stmt::HirStatement,
     };
-    use crate::node_interner::{DefinitionKind, FuncId, NodeInterner, TraitId, TraitMethodId};
+    use crate::node_interner::{
+        DefinitionKind, DependencyId, FuncId, NodeInterner, TraitId, TraitMethodId,
+    };
     use crate::{
         hir::{
             def_map::{CrateDefMap, LocalModuleId, ModuleDefId},
@@ -692,6 +694,7 @@ pub mod test {
             &self,
             _def_maps: &BTreeMap<CrateId, CrateDefMap>,
             path: Path,
+            _dependencies: &mut Option<&mut Vec<DependencyId>>,
         ) -> PathResolutionResult {
             // Not here that foo::bar and hello::foo::bar would fetch the same thing
             let name = path.segments.last().unwrap();

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -3,7 +3,7 @@ use noirc_errors::Location;
 use rangemap::RangeMap;
 use rustc_hash::FxHashMap;
 
-use crate::{macros_api::NodeInterner, node_interner::DependencyId};
+use crate::{macros_api::NodeInterner, node_interner::ReferenceId};
 use petgraph::prelude::NodeIndex as PetGraphIndex;
 
 #[derive(Debug, Default)]
@@ -29,43 +29,43 @@ impl LocationIndices {
 }
 
 impl NodeInterner {
-    pub fn dependency_location(&self, dependency: DependencyId) -> Location {
-        match dependency {
-            DependencyId::Module(_) => todo!(),
-            DependencyId::Function(id) => self.function_modifiers(&id).name_location,
-            DependencyId::Struct(id) => self.struct_location(&id),
-            DependencyId::Trait(_) => todo!(),
-            DependencyId::Global(id) => self.get_global(id).location,
-            DependencyId::Alias(id) => self.get_type_alias(id).borrow().location,
-            DependencyId::Variable(location) => location,
+    pub fn reference_location(&self, reference: ReferenceId) -> Location {
+        match reference {
+            ReferenceId::Module(_) => todo!(),
+            ReferenceId::Function(id) => self.function_modifiers(&id).name_location,
+            ReferenceId::Struct(id) => self.struct_location(&id),
+            ReferenceId::Trait(_) => todo!(),
+            ReferenceId::Global(id) => self.get_global(id).location,
+            ReferenceId::Alias(id) => self.get_type_alias(id).borrow().location,
+            ReferenceId::Variable(location) => location,
         }
     }
 
-    pub(crate) fn add_reference(&mut self, referenced: DependencyId, reference: DependencyId) {
+    pub(crate) fn add_reference(&mut self, referenced: ReferenceId, reference: ReferenceId) {
         if !self.track_references {
             return;
         }
 
         let referenced_index = self.get_or_insert_reference(referenced);
-        let reference_location = self.dependency_location(reference);
+        let reference_location = self.reference_location(reference);
         let reference_index = self.reference_graph.add_node(reference);
 
         self.reference_graph.add_edge(reference_index, referenced_index, ());
         self.location_indices.add_location(reference_location, reference_index);
     }
 
-    pub(crate) fn add_definition_location(&mut self, referenced: DependencyId) {
+    pub(crate) fn add_definition_location(&mut self, referenced: ReferenceId) {
         if !self.track_references {
             return;
         }
 
         let referenced_index = self.get_or_insert_reference(referenced);
-        let referenced_location = self.dependency_location(referenced);
+        let referenced_location = self.reference_location(referenced);
         self.location_indices.add_location(referenced_location, referenced_index);
     }
 
     #[tracing::instrument(skip(self), ret)]
-    pub(crate) fn get_or_insert_reference(&mut self, id: DependencyId) -> PetGraphIndex {
+    pub(crate) fn get_or_insert_reference(&mut self, id: ReferenceId) -> PetGraphIndex {
         if let Some(index) = self.reference_graph_indices.get(&id) {
             return *index;
         }
@@ -80,7 +80,7 @@ impl NodeInterner {
         self.location_indices
             .get_node_from_location(reference_location)
             .and_then(|node_index| self.referenced_index(node_index))
-            .map(|node_index| self.dependency_location(self.reference_graph[node_index]))
+            .map(|node_index| self.reference_location(self.reference_graph[node_index]))
     }
 
     // Is the given location known to this interner?
@@ -101,15 +101,15 @@ impl NodeInterner {
 
         let reference_node = self.reference_graph[node_index];
         let found_locations: Vec<Location> = match reference_node {
-            DependencyId::Alias(_)
-            | DependencyId::Global(_)
-            | DependencyId::Module(_)
-            | DependencyId::Trait(_) => todo!(),
-            DependencyId::Function(_) | DependencyId::Struct(_) => {
+            ReferenceId::Alias(_)
+            | ReferenceId::Global(_)
+            | ReferenceId::Module(_)
+            | ReferenceId::Trait(_) => todo!(),
+            ReferenceId::Function(_) | ReferenceId::Struct(_) => {
                 self.find_all_references_for_index(node_index, include_reference)
             }
 
-            DependencyId::Variable(_) => {
+            ReferenceId::Variable(_) => {
                 let referenced_node_index = self.referenced_index(node_index)?;
                 self.find_all_references_for_index(referenced_node_index, include_reference)
             }
@@ -127,14 +127,14 @@ impl NodeInterner {
         let id = self.reference_graph[referenced_node_index];
         let mut edit_locations = Vec::new();
         if include_reference {
-            edit_locations.push(self.dependency_location(id));
+            edit_locations.push(self.reference_location(id));
         }
 
         self.reference_graph
             .neighbors_directed(referenced_node_index, petgraph::Direction::Incoming)
             .for_each(|reference_node_index| {
                 let id = self.reference_graph[reference_node_index];
-                edit_locations.push(self.dependency_location(id));
+                edit_locations.push(self.reference_location(id));
             });
         edit_locations
     }

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -31,8 +31,10 @@ impl LocationIndices {
 impl NodeInterner {
     pub fn dependency_location(&self, dependency: DependencyId) -> Location {
         match dependency {
+            DependencyId::Module(_) => todo!(),
             DependencyId::Function(id) => self.function_modifiers(&id).name_location,
             DependencyId::Struct(id) => self.struct_location(&id),
+            DependencyId::Trait(_) => todo!(),
             DependencyId::Global(id) => self.get_global(id).location,
             DependencyId::Alias(id) => self.get_type_alias(id).borrow().location,
             DependencyId::Variable(location) => location,
@@ -99,7 +101,10 @@ impl NodeInterner {
 
         let reference_node = self.reference_graph[node_index];
         let found_locations: Vec<Location> = match reference_node {
-            DependencyId::Alias(_) | DependencyId::Global(_) => todo!(),
+            DependencyId::Alias(_)
+            | DependencyId::Global(_)
+            | DependencyId::Module(_)
+            | DependencyId::Trait(_) => todo!(),
             DependencyId::Function(_) | DependencyId::Struct(_) => {
                 self.find_all_references_for_index(node_index, include_reference)
             }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -228,7 +228,9 @@ pub struct NodeInterner {
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DependencyId {
+    Module(ModuleId),
     Struct(StructId),
+    Trait(TraitId),
     Global(GlobalId),
     Function(FuncId),
     Alias(TypeAliasId),
@@ -1800,6 +1802,8 @@ impl NodeInterner {
                         DependencyId::Variable(loc) => unreachable!(
                             "Variable used at location {loc:?} caught in a dependency cycle"
                         ),
+                        // These two are never put in the dependency graph
+                        DependencyId::Module(_) | DependencyId::Trait(_) => (),
                     }
                 }
             }
@@ -1823,6 +1827,10 @@ impl NodeInterner {
             }
             DependencyId::Variable(loc) => {
                 unreachable!("Variable used at location {loc:?} caught in a dependency cycle")
+            }
+            // These two are never put in the dependency graph
+            DependencyId::Module(_) | DependencyId::Trait(_) => {
+                unreachable!("Module or trait dependency shouldn't exist in the dependency graph")
             }
         };
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -207,10 +207,10 @@ pub struct NodeInterner {
     /// //         |      |
     /// //         +------+
     /// ```
-    pub(crate) reference_graph: DiGraph<DependencyId, ()>,
+    pub(crate) reference_graph: DiGraph<ReferenceId, ()>,
 
     /// Tracks the index of the references in the graph
-    pub(crate) reference_graph_indices: HashMap<DependencyId, PetGraphIndex>,
+    pub(crate) reference_graph_indices: HashMap<ReferenceId, PetGraphIndex>,
 
     /// Store the location of the references in the graph
     pub(crate) location_indices: LocationIndices,
@@ -228,6 +228,17 @@ pub struct NodeInterner {
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DependencyId {
+    Struct(StructId),
+    Global(GlobalId),
+    Function(FuncId),
+    Alias(TypeAliasId),
+    Variable(Location),
+}
+
+/// A reference to a module, struct, trait, etc., mainly used by the LSP code
+/// to keep track of how symbols reference each other.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ReferenceId {
     Module(ModuleId),
     Struct(StructId),
     Trait(TraitId),
@@ -860,7 +871,7 @@ impl NodeInterner {
 
         // This needs to be done after pushing the definition since it will reference the
         // location that was stored
-        self.add_definition_location(DependencyId::Function(id));
+        self.add_definition_location(ReferenceId::Function(id));
         definition_id
     }
 
@@ -1802,8 +1813,6 @@ impl NodeInterner {
                         DependencyId::Variable(loc) => unreachable!(
                             "Variable used at location {loc:?} caught in a dependency cycle"
                         ),
-                        // These two are never put in the dependency graph
-                        DependencyId::Module(_) | DependencyId::Trait(_) => (),
                     }
                 }
             }
@@ -1827,10 +1836,6 @@ impl NodeInterner {
             }
             DependencyId::Variable(loc) => {
                 unreachable!("Variable used at location {loc:?} caught in a dependency cycle")
-            }
-            // These two are never put in the dependency graph
-            DependencyId::Module(_) | DependencyId::Trait(_) => {
-                unreachable!("Module or trait dependency shouldn't exist in the dependency graph")
             }
         };
 

--- a/tooling/lsp/src/requests/rename.rs
+++ b/tooling/lsp/src/requests/rename.rs
@@ -102,7 +102,7 @@ mod rename_tests {
             let changes = response.changes.expect("Expected to find rename changes");
             let mut changes: Vec<Range> =
                 changes.values().flatten().map(|edit| edit.range).collect();
-            changes.sort_by_key(|range| range.start.line);
+            changes.sort_by_key(|range| (range.start.line, range.start.character));
             assert_eq!(changes, ranges);
         }
     }

--- a/tooling/lsp/src/test_utils.rs
+++ b/tooling/lsp/src/test_utils.rs
@@ -46,9 +46,8 @@ pub(crate) fn search_in_file(filename: &str, search_string: &str) -> Vec<Range> 
     file_lines
         .iter()
         .enumerate()
-        .filter_map(|(line_num, line)| {
-            // Note: this only finds the first instance of `search_string` on this line.
-            line.find(search_string).map(|index| {
+        .flat_map(|(line_num, line)| {
+            line.match_indices(search_string).map(move |(index, _)| {
                 let start = Position { line: line_num as u32, character: index as u32 };
                 let end = Position {
                     line: line_num as u32,

--- a/tooling/lsp/test_programs/rename_struct/src/main.nr
+++ b/tooling/lsp/test_programs/rename_struct/src/main.nr
@@ -15,4 +15,6 @@ fn main(x: Field) -> pub Field {
     x
 }
 
-fn foo(foo: Foo) {}
+fn foo(foo: Foo) -> Foo {
+    foo
+}

--- a/tooling/lsp/test_programs/rename_struct/src/main.nr
+++ b/tooling/lsp/test_programs/rename_struct/src/main.nr
@@ -3,6 +3,10 @@ mod foo {
         struct Foo {
             field: Field,
         }
+
+        impl Foo {
+            fn foo() {}
+        }
     }
 }
 
@@ -12,6 +16,7 @@ fn main(x: Field) -> pub Field {
     let foo1 = Foo { field: 1 };
     let foo2 = Foo { field: 2 };
     let Foo { field } = foo1;
+    Foo::foo();
     x
 }
 


### PR DESCRIPTION
# Description

## Problem

Resolves #5394

## Summary

Finds struct locations in return types and inside paths.

## Additional Context

Making it work for the return type was simple: the code to register it is now done a bit earlier so it works in all cases where a type is referred as the last segment in a Path.

Making it work when the type is in the middle of a Path (like in `foo::Foo::new`) was a bit trickier: the existing Path lookup only cared about (and registered) the result of the last segment. So now there's code to register each segment in turn... but this is only done if running in LSP mode. So in `foo::Foo::new`, `foo` is linked to a module and `Foo` is linked to a struct. The existing code relied on the `DependencyId` for this, but a "module" dependency didn't exist... to avoid introducing new variants that are only used in this reference tracking I instead created a new enum, `ReferenceId`.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
