### PR TITLE
fix: incorrect parsing of `dep::{foo, bar}`

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -1187,6 +1187,7 @@ mod test {
     use super::test_helpers::*;
     use super::*;
     use crate::ast::ArrayLiteral;
+    use crate::macros_api::PathKind;
 
     #[test]
     fn parse_infix() {
@@ -1495,6 +1496,17 @@ mod test {
             };
 
             prototype_parse_use_tree(expected_use_statement.as_ref(), &use_statement_str);
+        }
+    }
+
+    #[test]
+    fn parse_use_dep() {
+        let str = "use dep::{foo, bar}";
+        let result = parse_with(use_statement(), str);
+        if let Ok(TopLevelStatement::Import(UseTree { prefix, .. })) = result {
+            assert_eq!(prefix.kind, PathKind::Dep);
+        } else {
+            panic!("Expected a use statement, got {:?}", result);
         }
     }
 

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -25,7 +25,7 @@ fn empty_path() -> impl NoirParser<Path> {
     let make_path = |kind| move |_, span| Path { segments: Vec::new(), kind, span };
     let path_kind = |key, kind| keyword(key).map_with_span(make_path(kind));
 
-    choice((path_kind(Keyword::Crate, PathKind::Crate), path_kind(Keyword::Dep, PathKind::Plain)))
+    choice((path_kind(Keyword::Crate, PathKind::Crate), path_kind(Keyword::Dep, PathKind::Dep)))
 }
 
 pub(super) fn maybe_empty_path() -> impl NoirParser<Path> {

--- a/tooling/nargo_fmt/tests/expected/use_dep_tree.nr
+++ b/tooling/nargo_fmt/tests/expected/use_dep_tree.nr
@@ -1,0 +1,1 @@
+use dep::{foo, bar};

--- a/tooling/nargo_fmt/tests/input/use_dep_tree.nr
+++ b/tooling/nargo_fmt/tests/input/use_dep_tree.nr
@@ -1,0 +1,1 @@
+use dep::{ foo, bar };


### PR DESCRIPTION
# Description

## Problem

Resolves #5299

## Summary

It seems that for an empty path, `dep` was parsed as a plain path (so the bug wasn't just formatting, it was incorrectly interpreting the import).

I do wonder if the existing code was like that so that `use dep;` imported a module named `dep.nr`? Though maybe that should be disallowed... 🤔 

## Additional Context

None

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
