### PR TITLE
chore: Add remaining slice methods to the interpreter

### DIFF
--- a/docs/docs/noir/standard_library/is_unconstrained.md
+++ b/docs/docs/noir/standard_library/is_unconstrained.md
@@ -57,3 +57,13 @@ pub fn external_interface(){
 ```
 
 The is_unconstrained result is resolved at compile time, so in unconstrained contexts the compiler removes the else branch, and in constrained contexts the compiler removes the if branch, reducing the amount of compute necessary to run external_interface.
+
+Note that using `is_unconstrained` in a `comptime` context will also return `true`:
+
+```
+fn main() {
+    comptime {
+        assert(is_unconstrained());
+    }
+}
+```

--- a/test_programs/compile_success_empty/comptime_slice_methods/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_slice_methods/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_slice_methods"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_slice_methods/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_slice_methods/src/main.nr
@@ -1,0 +1,26 @@
+fn main() {
+    comptime {
+        // Comptime scopes are counted as unconstrained
+        assert(std::runtime::is_unconstrained());
+
+        let slice = &[2];
+        let slice = slice.push_back(3);
+        let slice = slice.push_front(1);
+        assert_eq(slice, &[1, 2, 3]);
+
+        let slice = slice.insert(1, 10);
+        assert_eq(slice, &[1, 10, 2, 3]);
+
+        let (slice, ten) = slice.remove(1);
+        assert_eq(slice, &[1, 2, 3]);
+        assert_eq(ten, 10);
+
+        let (one, slice) = slice.pop_front();
+        assert_eq(slice, &[2, 3]);
+        assert_eq(one, 1);
+
+        let (slice, three) = slice.pop_back();
+        assert_eq(slice, &[2]);
+        assert_eq(three, 3);
+    }
+}

--- a/test_programs/compile_success_empty/comptime_slice_methods/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_slice_methods/src/main.nr
@@ -1,5 +1,6 @@
 fn main() {
-    comptime {
+    comptime
+    {
         // Comptime scopes are counted as unconstrained
         assert(std::runtime::is_unconstrained());
 

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -61,13 +61,14 @@ const IGNORED_BRILLIG_TESTS: [&str; 11] = [
 /// Certain features are only available in the elaborator.
 /// We skip these tests for non-elaborator code since they are not
 /// expected to work there. This can be removed once the old code is removed.
-const IGNORED_NEW_FEATURE_TESTS: [&str; 6] = [
+const IGNORED_NEW_FEATURE_TESTS: [&str; 7] = [
     "macros",
     "wildcard_type",
     "type_definition_annotation",
     "numeric_generics_explicit",
     "derive_impl",
     "comptime_traits",
+    "comptime_slice_methods",
 ];
 
 fn read_test_cases(


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

Adds the remaining builtin slice methods to the interpreter.

Also adds `is_unconstrained` which always returns true. This way `comptime` can also take advantage of any `if is_unconstrained()` optimizations (like `break`) used in unconstrained code in called functions.

## Additional Context

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
