### PR TITLE
chore: dummy workflow

### DIFF
--- a/.github/workflows/mirror-external_libs.yml
+++ b/.github/workflows/mirror-external_libs.yml
@@ -1,9 +1,6 @@
 name: Mirror Repositories
-
 on:
-  pull_request:
-    branches:
-    - master
+  workflow_dispatch: {} 
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/mirror-external_libs.yml
+++ b/.github/workflows/mirror-external_libs.yml
@@ -1,0 +1,11 @@
+name: Mirror Repositories
+
+on:
+  pull_request:
+    branches:
+    - master
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Dummy workflow TODO


### PR DESCRIPTION
# Description

## Problem\*

Adds a dummy workflow for the PR #5417

## Summary\*
This will allow the workflow to be run, so that it can be run from the #5417 PR once the dummy version is merged and ran once.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
