### PR TITLE
feat: migrate to arkworks 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 name = "acir_field"
 version = "0.47.0"
 dependencies = [
- "ark-bls12-381",
+ "ark-bls12-381 0.5.0-alpha.0",
  "ark-bn254",
- "ark-ff",
+ "ark-ff 0.5.0-alpha.0",
  "cfg-if 1.0.0",
  "hex",
  "num-bigint",
@@ -44,7 +44,7 @@ version = "0.47.0"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
- "ark-bls12-381",
+ "ark-bls12-381 0.4.0",
  "brillig_vm",
  "indexmap 1.9.3",
  "num-bigint",
@@ -161,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,21 +247,33 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21a6b4df2bb83e21620b39dec0f856e64203e701c43b0ffcdc5b8b1386ec5b1"
+dependencies = [
+ "ark-ec 0.5.0-alpha.0",
+ "ark-ff 0.5.0-alpha.0",
+ "ark-serialize 0.5.0-alpha.0",
+ "ark-std 0.5.0-alpha.0",
 ]
 
 [[package]]
 name = "ark-bn254"
-version = "0.4.0"
+version = "0.5.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+checksum = "c662c88acb89e9a9fb4c62fc5f6f102d9e1cfbd7bb6386cdb872b52a801fbece"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0-alpha.0",
+ "ark-ff 0.5.0-alpha.0",
+ "ark-std 0.5.0-alpha.0",
 ]
 
 [[package]]
@@ -264,13 +282,34 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfd2059d3f93e1e1d6895f0d605e5f5a256fe8aeaafa3e4f0fa49812daa151e9"
+dependencies = [
+ "ahash 0.8.11",
+ "ark-ff 0.5.0-alpha.0",
+ "ark-poly 0.5.0-alpha.0",
+ "ark-serialize 0.5.0-alpha.0",
+ "ark-std 0.5.0-alpha.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.14.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "zeroize",
 ]
@@ -281,10 +320,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest",
  "itertools 0.10.5",
@@ -296,6 +335,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c882014dad87209b9c504b3d74d786be0c33bab9736d2596583255d52cf4c1"
+dependencies = [
+ "ark-ff-asm 0.5.0-alpha.0",
+ "ark-ff-macros 0.5.0-alpha.0",
+ "ark-serialize 0.5.0-alpha.0",
+ "ark-std 0.5.0-alpha.0",
+ "arrayvec",
+ "digest",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +362,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c989d1176288a7a591c662e16b98219505366bf48ccb5efa27984748d31b785f"
+dependencies = [
+ "quote",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -319,16 +388,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9fbc6fa5c2cb1936287236cc76572f773dbfb5df5dd814386b180e668904371"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
+
+[[package]]
+name = "ark-grumpkin"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fe79c88625d79113ee03c110eeef902eaa0ba907a79d9b04080119c8e1b794"
+dependencies = [
+ "ark-bn254",
+ "ark-ec 0.5.0-alpha.0",
+ "ark-ff 0.5.0-alpha.0",
+ "ark-std 0.5.0-alpha.0",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c85f512876fd2b8763fcb0c045d2819bbda24b6020e6a893f15985d6d1ccf"
+dependencies = [
+ "ahash 0.8.11",
+ "ark-ff 0.5.0-alpha.0",
+ "ark-serialize 0.5.0-alpha.0",
+ "ark-std 0.5.0-alpha.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -337,8 +446,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.4.2",
+ "ark-std 0.4.0",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a69fbd004ea7b7fc8946475495298341e961381d33dc5c89c112cdf319b11d"
+dependencies = [
+ "ark-serialize-derive 0.5.0-alpha.0",
+ "ark-std 0.5.0-alpha.0",
+ "arrayvec",
  "digest",
  "num-bigint",
 ]
@@ -355,10 +477,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95905921bd063ddeade5b8b992a6ee509d47c765abcbd38e70c71af1c61ee2f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd37a4e913a2fa8885035d8ae16b73f79e76db9c236c4275658b58580b47f03"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -576,13 +719,13 @@ dependencies = [
  "acir",
  "acvm_blackbox_solver",
  "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0-alpha.0",
+ "ark-ff 0.5.0-alpha.0",
+ "ark-grumpkin",
+ "ark-std 0.5.0-alpha.0",
  "criterion",
  "hex",
  "lazy_static",
- "noir_grumpkin",
  "num-bigint",
  "pprof 0.12.1",
 ]
@@ -1344,6 +1487,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1550,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
 
 [[package]]
 name = "env_logger"
@@ -1803,6 +1978,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2118,6 +2296,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2700,18 +2887,6 @@ dependencies = [
  "noirc_artifacts",
  "proptest",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "noir_grumpkin"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7d49a4b14b13c0dc730b05780b385828ab88f4148daaad7db080ecdce07350"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,12 +83,12 @@ bb_abstraction_leaks = { path = "tooling/bb_abstraction_leaks" }
 acvm_cli = { path = "tooling/acvm_cli" }
 
 # Arkworks
-ark-bn254 = { version = "^0.4.0", default-features = false, features = ["curve"] }
-ark-bls12-381 = { version = "^0.4.0", default-features = false, features = ["curve"] }
-grumpkin = { version = "0.1.0", package = "noir_grumpkin", features = ["std"] }
-ark-ec = { version = "^0.4.0", default-features = false }
-ark-ff = { version = "^0.4.0", default-features = false }
-ark-std = { version = "^0.4.0", default-features = false }
+ark-bn254 = { version = "0.5.0-alpha.0", default-features = false, features = ["curve"] }
+ark-bls12-381 = { version = "0.5.0-alpha.0", default-features = false, features = ["curve"] }
+ark-grumpkin = { version = "0.5.0-alpha.0", default-features = false }
+ark-ec = { version = "0.5.0-alpha.0", default-features = false }
+ark-ff = { version = "0.5.0-alpha.0", default-features = false }
+ark-std = { version = "0.5.0-alpha.0", default-features = false }
 
 # Misc utils crates
 iter-extended = { path = "utils/iter-extended" }

--- a/acvm-repo/bn254_blackbox_solver/Cargo.toml
+++ b/acvm-repo/bn254_blackbox_solver/Cargo.toml
@@ -19,7 +19,7 @@ hex.workspace = true
 lazy_static = "1.4"
 
 ark-bn254.workspace = true
-grumpkin.workspace = true 
+ark-grumpkin.workspace = true 
 ark-ec.workspace = true
 ark-ff.workspace = true
 num-bigint.workspace = true

--- a/acvm-repo/bn254_blackbox_solver/src/generator/generators.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/generator/generators.rs
@@ -7,16 +7,15 @@ use std::sync::OnceLock;
 use ark_ec::short_weierstrass::Affine;
 
 use acvm_blackbox_solver::blake3;
-use grumpkin::GrumpkinParameters;
+use ark_grumpkin::GrumpkinConfig;
 
 use super::hash_to_curve::hash_to_curve;
 
 pub(crate) const DEFAULT_DOMAIN_SEPARATOR: &[u8] = "DEFAULT_DOMAIN_SEPARATOR".as_bytes();
 const NUM_DEFAULT_GENERATORS: usize = 8;
 
-fn default_generators() -> &'static [Affine<GrumpkinParameters>; NUM_DEFAULT_GENERATORS] {
-    static INSTANCE: OnceLock<[Affine<GrumpkinParameters>; NUM_DEFAULT_GENERATORS]> =
-        OnceLock::new();
+fn default_generators() -> &'static [Affine<GrumpkinConfig>; NUM_DEFAULT_GENERATORS] {
+    static INSTANCE: OnceLock<[Affine<GrumpkinConfig>; NUM_DEFAULT_GENERATORS]> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         _derive_generators(DEFAULT_DOMAIN_SEPARATOR, NUM_DEFAULT_GENERATORS as u32, 0)
             .try_into()
@@ -42,7 +41,7 @@ pub fn derive_generators(
     domain_separator_bytes: &[u8],
     num_generators: u32,
     starting_index: u32,
-) -> Vec<Affine<GrumpkinParameters>> {
+) -> Vec<Affine<GrumpkinConfig>> {
     // We cache a small number of the default generators so we can reuse them without needing to repeatedly recalculate them.
     if domain_separator_bytes == DEFAULT_DOMAIN_SEPARATOR
         && starting_index + num_generators <= NUM_DEFAULT_GENERATORS as u32
@@ -59,7 +58,7 @@ fn _derive_generators(
     domain_separator_bytes: &[u8],
     num_generators: u32,
     starting_index: u32,
-) -> Vec<Affine<GrumpkinParameters>> {
+) -> Vec<Affine<GrumpkinConfig>> {
     let mut generator_preimage = [0u8; 64];
     let domain_hash = blake3(domain_separator_bytes).expect("hash should succeed");
     //1st 32 bytes are blake3 domain_hash

--- a/acvm-repo/bn254_blackbox_solver/src/generator/hash_to_curve.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/generator/hash_to_curve.rs
@@ -7,7 +7,7 @@ use acvm_blackbox_solver::blake3;
 use ark_ec::{short_weierstrass::Affine, AffineRepr, CurveConfig};
 use ark_ff::Field;
 use ark_ff::{BigInteger, PrimeField};
-use grumpkin::GrumpkinParameters;
+use ark_grumpkin::GrumpkinConfig;
 
 /// Hash a seed buffer into a point
 ///
@@ -40,7 +40,7 @@ use grumpkin::GrumpkinParameters;
 ///
 ///  N.B. steps c. and e. are because the `sqrt()` algorithm can return 2 values,
 ///  we need to a way to canonically distinguish between these 2 values and select a "preferred" one
-pub(crate) fn hash_to_curve(seed: &[u8], attempt_count: u8) -> Affine<GrumpkinParameters> {
+pub(crate) fn hash_to_curve(seed: &[u8], attempt_count: u8) -> Affine<GrumpkinConfig> {
     let seed_size = seed.len();
     // expand by 2 bytes to cover incremental hash attempts
     let mut target_seed = seed.to_vec();
@@ -56,10 +56,10 @@ pub(crate) fn hash_to_curve(seed: &[u8], attempt_count: u8) -> Affine<GrumpkinPa
     hash.extend_from_slice(&hash_lo);
 
     // Here we reduce the 512 bit number modulo the base field modulus to calculate `x`
-    let x = <<GrumpkinParameters as CurveConfig>::BaseField as Field>::BasePrimeField::from_be_bytes_mod_order(&hash);
-    let x = <GrumpkinParameters as CurveConfig>::BaseField::from_base_prime_field(x);
+    let x = <<GrumpkinConfig as CurveConfig>::BaseField as Field>::BasePrimeField::from_be_bytes_mod_order(&hash);
+    let x = <GrumpkinConfig as CurveConfig>::BaseField::from_base_prime_field(x);
 
-    if let Some(point) = Affine::<GrumpkinParameters>::get_point_from_x_unchecked(x, false) {
+    if let Some(point) = Affine::<GrumpkinConfig>::get_point_from_x_unchecked(x, false) {
         let parity_bit = hash_hi[0] > 127;
         let y_bit_set = point.y().unwrap().into_bigint().get_bit(0);
         if (parity_bit && !y_bit_set) || (!parity_bit && y_bit_set) {

--- a/acvm-repo/bn254_blackbox_solver/src/lib.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/lib.rs
@@ -11,6 +11,8 @@ mod poseidon2;
 mod schnorr;
 
 use ark_ec::AffineRepr;
+use ark_grumpkin::Fq;
+
 pub use embedded_curve_ops::{embedded_curve_add, multi_scalar_mul};
 pub use generator::generators::derive_generators;
 pub use poseidon2::poseidon2_permutation;
@@ -46,10 +48,10 @@ impl BlackBoxFunctionSolver<FieldElement> for Bn254BlackBoxSolver {
         inputs: &[FieldElement],
         domain_separator: u32,
     ) -> Result<(FieldElement, FieldElement), BlackBoxResolutionError> {
-        let inputs: Vec<grumpkin::Fq> = inputs.iter().map(|input| input.into_repr()).collect();
+        let inputs: Vec<Fq> = inputs.iter().map(|input| input.into_repr()).collect();
         let result = pedersen::commitment::commit_native_with_index(&inputs, domain_separator);
         let result = if let Some((x, y)) = result.xy() {
-            (FieldElement::from_repr(*x), FieldElement::from_repr(*y))
+            (FieldElement::from_repr(x), FieldElement::from_repr(y))
         } else {
             (FieldElement::from(0_u128), FieldElement::from(0_u128))
         };
@@ -62,7 +64,7 @@ impl BlackBoxFunctionSolver<FieldElement> for Bn254BlackBoxSolver {
         inputs: &[FieldElement],
         domain_separator: u32,
     ) -> Result<FieldElement, BlackBoxResolutionError> {
-        let inputs: Vec<grumpkin::Fq> = inputs.iter().map(|input| input.into_repr()).collect();
+        let inputs: Vec<Fq> = inputs.iter().map(|input| input.into_repr()).collect();
         let result = pedersen::hash::hash_with_index(&inputs, domain_separator);
         let result = FieldElement::from_repr(result);
         Ok(result)

--- a/acvm-repo/bn254_blackbox_solver/src/pedersen/commitment.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/pedersen/commitment.rs
@@ -2,7 +2,7 @@
 
 use ark_ec::{short_weierstrass::Affine, AffineRepr, CurveGroup};
 use ark_ff::{MontConfig, PrimeField};
-use grumpkin::{Fq, FqConfig, Fr, FrConfig, GrumpkinParameters};
+use ark_grumpkin::{Fq, FqConfig, Fr, FrConfig, GrumpkinConfig};
 
 use crate::generator::generators::{derive_generators, DEFAULT_DOMAIN_SEPARATOR};
 
@@ -10,7 +10,7 @@ use crate::generator::generators::{derive_generators, DEFAULT_DOMAIN_SEPARATOR};
 pub(crate) fn commit_native_with_index(
     inputs: &[Fq],
     starting_index: u32,
-) -> Affine<GrumpkinParameters> {
+) -> Affine<GrumpkinConfig> {
     let generators =
         derive_generators(DEFAULT_DOMAIN_SEPARATOR, inputs.len() as u32, starting_index);
 

--- a/acvm-repo/bn254_blackbox_solver/src/pedersen/hash.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/pedersen/hash.rs
@@ -3,7 +3,8 @@
 use std::sync::OnceLock;
 
 use ark_ec::{short_weierstrass::Affine, CurveConfig, CurveGroup};
-use grumpkin::GrumpkinParameters;
+use ark_grumpkin::Fq;
+use ark_grumpkin::GrumpkinConfig;
 
 use crate::generator::generators::derive_generators;
 
@@ -11,18 +12,18 @@ use super::commitment::commit_native_with_index;
 
 /// Given a vector of fields, generate a pedersen hash using the indexed generators.
 pub(crate) fn hash_with_index(
-    inputs: &[grumpkin::Fq],
+    inputs: &[Fq],
     starting_index: u32,
-) -> <GrumpkinParameters as CurveConfig>::BaseField {
-    let length_as_scalar: <GrumpkinParameters as CurveConfig>::ScalarField =
+) -> <ark_grumpkin::GrumpkinConfig as CurveConfig>::BaseField {
+    let length_as_scalar: <GrumpkinConfig as CurveConfig>::ScalarField =
         (inputs.len() as u64).into();
     let length_prefix = *length_generator() * length_as_scalar;
     let result = length_prefix + commit_native_with_index(inputs, starting_index);
     result.into_affine().x
 }
 
-fn length_generator() -> &'static Affine<GrumpkinParameters> {
-    static INSTANCE: OnceLock<Affine<GrumpkinParameters>> = OnceLock::new();
+fn length_generator() -> &'static Affine<ark_grumpkin::GrumpkinConfig> {
+    static INSTANCE: OnceLock<Affine<GrumpkinConfig>> = OnceLock::new();
     INSTANCE.get_or_init(|| derive_generators("pedersen_hash_length".as_bytes(), 1, 0)[0])
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.75.0"
 components = [ "rust-src" ]
 targets = [ "wasm32-unknown-unknown", "wasm32-wasi", "aarch64-apple-darwin" ]
 profile = "default"


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR moves us to the arkworks 0.5.0 release so we can use the upstream grumpkin package.

Note this is currently just an alpha release so this PR is in draft.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
