### PR TITLE
fix: Fix issue with unresolved results

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -105,15 +105,7 @@ impl Context {
             .iter()
             .chain(function.returns())
             .filter(|id| function.dfg.get_numeric_constant(**id).is_none())
-            .copied()
-            .chain(
-                function
-                    .parameters()
-                    .iter()
-                    .chain(function.returns())
-                    .filter(|id| function.dfg.get_numeric_constant(**id).is_none())
-                    .map(|value_id| function.dfg.resolve(*value_id)),
-            );
+            .map(|value_id| function.dfg.resolve(*value_id));
 
         let mut connected_sets_indices: HashSet<usize> = HashSet::new();
 
@@ -177,14 +169,12 @@ impl Context {
             // Insert non-constant instruction arguments
             function.dfg[*instruction].for_each_value(|value_id| {
                 if function.dfg.get_numeric_constant(value_id).is_none() {
-                    instruction_arguments_and_results.insert(value_id);
                     instruction_arguments_and_results.insert(function.dfg.resolve(value_id));
                 }
             });
             // And non-constant results
             for value_id in function.dfg.instruction_results(*instruction).iter() {
                 if function.dfg.get_numeric_constant(*value_id).is_none() {
-                    instruction_arguments_and_results.insert(*value_id);
                     instruction_arguments_and_results.insert(function.dfg.resolve(*value_id));
                 }
             }

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -105,7 +105,15 @@ impl Context {
             .iter()
             .chain(function.returns())
             .filter(|id| function.dfg.get_numeric_constant(**id).is_none())
-            .copied();
+            .copied()
+            .chain(
+                function
+                    .parameters()
+                    .iter()
+                    .chain(function.returns())
+                    .filter(|id| function.dfg.get_numeric_constant(**id).is_none())
+                    .map(|value_id| function.dfg.resolve(*value_id)),
+            );
 
         let mut connected_sets_indices: HashSet<usize> = HashSet::new();
 
@@ -170,12 +178,14 @@ impl Context {
             function.dfg[*instruction].for_each_value(|value_id| {
                 if function.dfg.get_numeric_constant(value_id).is_none() {
                     instruction_arguments_and_results.insert(value_id);
+                    instruction_arguments_and_results.insert(function.dfg.resolve(value_id));
                 }
             });
             // And non-constant results
             for value_id in function.dfg.instruction_results(*instruction).iter() {
                 if function.dfg.get_numeric_constant(*value_id).is_none() {
                     instruction_arguments_and_results.insert(*value_id);
+                    instruction_arguments_and_results.insert(function.dfg.resolve(*value_id));
                 }
             }
 


### PR DESCRIPTION
# Description

## Problem\*

check_for_underconstrained_values pass was producing false positives because the value ids of results in the function were different from the value ids used in other constraints and had to be resolved.

## Summary\*
Added checks to ensure we also resolve all values before using


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
