### PR TITLE
fix: downgrade `IndexOutOfBounds` to a warning

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -196,6 +196,13 @@ impl RuntimeError {
                     location.span,
                 )
             }
+            RuntimeError::IndexOutOfBounds { .. } => {
+                let message = self.to_string();
+                let location =
+                    self.call_stack().back().unwrap_or_else(|| panic!("Expected RuntimeError to have a location. Error message: {message}"));
+
+                Diagnostic::simple_warning(message, String::new(), location.span)
+            }
             _ => {
                 let message = self.to_string();
                 let location =


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5464 

## Summary\*

This test was failing due to the error being found at compile-time and so a compile-time error was returned rather than the expected runtime error. I've then downgraded this error into a warning so that circuit execution can be performed so that the expected error is thrown.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
