### PR TITLE
chore: bump bb to 0.45.1

### DIFF
--- a/scripts/bump-bb.sh
+++ b/scripts/bump-bb.sh
@@ -2,7 +2,7 @@
 
 BB_VERSION=$1
 
-sed -i "s/^VERSION=.*/VERSION=\"$BB_VERSION\"/" ./scripts/install_bb.sh
+sed -i.bak "s/^VERSION=.*/VERSION=\"$BB_VERSION\"/" ./scripts/install_bb.sh  && rm ./scripts/install_bb.sh.bak
 
 tmp=$(mktemp)
 BACKEND_BARRETENBERG_PACKAGE_JSON=./tooling/noir_js_backend_barretenberg/package.json

--- a/scripts/bump-bb.sh
+++ b/scripts/bump-bb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+BB_VERSION=$1
+
+sed -i "s/^VERSION=.*/VERSION=\"$BB_VERSION\"/" ./scripts/install_bb.sh
+
+tmp=$(mktemp)
+BACKEND_BARRETENBERG_PACKAGE_JSON=./tooling/noir_js_backend_barretenberg/package.json
+jq --arg v $BB_VERSION '.dependencies."@aztec/bb.js" = $v' $BACKEND_BARRETENBERG_PACKAGE_JSON > $tmp && mv $tmp $BACKEND_BARRETENBERG_PACKAGE_JSON
+
+YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install

--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.43.0"
+VERSION="0.45.1"
 
 BBUP_PATH=~/.bb/bbup
 

--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.45.0"
+VERSION="0.45.1"
 
 BBUP_PATH=~/.bb/bbup
 

--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.45.1"
+VERSION="0.45.0"
 
 BBUP_PATH=~/.bb/bbup
 

--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -19,6 +19,7 @@ ITER="1"
 for pathname in $test_dirs; do    
     ARTIFACT_NAME=$(basename "$pathname")
     if [[ " ${excluded_dirs[@]} " =~ "$ARTIFACT_NAME" ]]; then
+        ITER=$(( $ITER + 1 ))
         continue
     fi
 

--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -4,7 +4,7 @@ set -e
 BACKEND=${BACKEND:-bb}
 
 # These tests are incompatible with gas reporting
-excluded_dirs=("workspace" "workspace_default_member" "double_verify_nested_proof" "databus")
+excluded_dirs=("workspace" "workspace_default_member" "databus")
 
 current_dir=$(pwd)
 artifacts_path="$current_dir/acir_artifacts"
@@ -18,6 +18,9 @@ NUM_ARTIFACTS=$(ls -1q "$artifacts_path" | wc -l)
 ITER="1"
 for pathname in $test_dirs; do    
     ARTIFACT_NAME=$(basename "$pathname")
+    if [[ " ${excluded_dirs[@]} " =~ "$ARTIFACT_NAME" ]]; then
+        continue
+    fi
 
     GATES_INFO=$($BACKEND gates -b "$artifacts_path/$ARTIFACT_NAME/target/program.json")
     MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r '.functions[0] | .name = "main"')

--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -4,7 +4,7 @@ set -e
 BACKEND=${BACKEND:-bb}
 
 # These tests are incompatible with gas reporting
-excluded_dirs=("workspace" "workspace_default_member" "double_verify_nested_proof")
+excluded_dirs=("workspace" "workspace_default_member" "double_verify_nested_proof" "databus")
 
 current_dir=$(pwd)
 artifacts_path="$current_dir/acir_artifacts"

--- a/tooling/noir_js_backend_barretenberg/package.json
+++ b/tooling/noir_js_backend_barretenberg/package.json
@@ -41,7 +41,7 @@
     "lint": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ./.eslintignore  --max-warnings 0"
   },
   "dependencies": {
-    "@aztec/bb.js": "0.45.0",
+    "@aztec/bb.js": "0.45.1",
     "@noir-lang/types": "workspace:*",
     "fflate": "^0.8.0"
   },

--- a/tooling/noir_js_backend_barretenberg/package.json
+++ b/tooling/noir_js_backend_barretenberg/package.json
@@ -41,7 +41,7 @@
     "lint": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ./.eslintignore  --max-warnings 0"
   },
   "dependencies": {
-    "@aztec/bb.js": "0.43.0",
+    "@aztec/bb.js": "0.45.1",
     "@noir-lang/types": "workspace:*",
     "fflate": "^0.8.0"
   },

--- a/tooling/noir_js_backend_barretenberg/package.json
+++ b/tooling/noir_js_backend_barretenberg/package.json
@@ -41,7 +41,7 @@
     "lint": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ./.eslintignore  --max-warnings 0"
   },
   "dependencies": {
-    "@aztec/bb.js": "0.45.1",
+    "@aztec/bb.js": "0.45.0",
     "@noir-lang/types": "workspace:*",
     "fflate": "^0.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,9 +221,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aztec/bb.js@npm:0.43.0":
-  version: 0.43.0
-  resolution: "@aztec/bb.js@npm:0.43.0"
+"@aztec/bb.js@npm:0.45.1":
+  version: 0.45.1
+  resolution: "@aztec/bb.js@npm:0.45.1"
   dependencies:
     comlink: ^4.4.1
     commander: ^10.0.1
@@ -231,7 +231,7 @@ __metadata:
     tslib: ^2.4.0
   bin:
     bb.js: dest/node/main.js
-  checksum: 63d2617529e00a05e1ac9364639dc10761e50cb6a16e010ac6354011440de037112a82d7cdd29a65b139af528c7d865b047e157b25d15ac36ff701863d550a5b
+  checksum: 25c3db288207f25f8f43e1a9819b6e948d2e67caa41cd8767afc4a7910f7ed5d02afa17f33c349751f8befbc4d64fbd7541988f12aeba2bb15df73fd8b667195
   languageName: node
   linkType: hard
 
@@ -4396,7 +4396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@noir-lang/backend_barretenberg@workspace:tooling/noir_js_backend_barretenberg"
   dependencies:
-    "@aztec/bb.js": 0.43.0
+    "@aztec/bb.js": 0.45.1
     "@noir-lang/types": "workspace:*"
     "@types/node": ^20.6.2
     "@types/prettier": ^3

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,9 +221,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aztec/bb.js@npm:0.45.1":
-  version: 0.45.1
-  resolution: "@aztec/bb.js@npm:0.45.1"
+"@aztec/bb.js@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@aztec/bb.js@npm:0.45.0"
   dependencies:
     comlink: ^4.4.1
     commander: ^10.0.1
@@ -231,7 +231,7 @@ __metadata:
     tslib: ^2.4.0
   bin:
     bb.js: dest/node/main.js
-  checksum: 25c3db288207f25f8f43e1a9819b6e948d2e67caa41cd8767afc4a7910f7ed5d02afa17f33c349751f8befbc4d64fbd7541988f12aeba2bb15df73fd8b667195
+  checksum: 02cf21a75580e4e1187bc346404d92456decd52db46bb32de4dcfa2784baf74bb05a62d31ed2d71de48b7ddf449ce579a11e31ea242afe6ed7ac7fd7da1699c2
   languageName: node
   linkType: hard
 
@@ -4396,7 +4396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@noir-lang/backend_barretenberg@workspace:tooling/noir_js_backend_barretenberg"
   dependencies:
-    "@aztec/bb.js": 0.45.1
+    "@aztec/bb.js": 0.45.0
     "@noir-lang/types": "workspace:*"
     "@types/node": ^20.6.2
     "@types/prettier": ^3

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,9 +221,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aztec/bb.js@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@aztec/bb.js@npm:0.45.0"
+"@aztec/bb.js@npm:0.45.1":
+  version: 0.45.1
+  resolution: "@aztec/bb.js@npm:0.45.1"
   dependencies:
     comlink: ^4.4.1
     commander: ^10.0.1
@@ -231,7 +231,7 @@ __metadata:
     tslib: ^2.4.0
   bin:
     bb.js: dest/node/main.js
-  checksum: 02cf21a75580e4e1187bc346404d92456decd52db46bb32de4dcfa2784baf74bb05a62d31ed2d71de48b7ddf449ce579a11e31ea242afe6ed7ac7fd7da1699c2
+  checksum: 25c3db288207f25f8f43e1a9819b6e948d2e67caa41cd8767afc4a7910f7ed5d02afa17f33c349751f8befbc4d64fbd7541988f12aeba2bb15df73fd8b667195
   languageName: node
   linkType: hard
 
@@ -4396,7 +4396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@noir-lang/backend_barretenberg@workspace:tooling/noir_js_backend_barretenberg"
   dependencies:
-    "@aztec/bb.js": 0.45.0
+    "@aztec/bb.js": 0.45.1
     "@noir-lang/types": "workspace:*"
     "@types/node": ^20.6.2
     "@types/prettier": ^3


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR bumps bb to the latest version before the recent serialization change.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
