### PR TITLE
feat: add debug codelens action

### DIFF
--- a/tooling/lsp/src/requests/code_lens_request.rs
+++ b/tooling/lsp/src/requests/code_lens_request.rs
@@ -21,6 +21,8 @@ const INFO_COMMAND: &str = "nargo.info";
 const INFO_CODELENS_TITLE: &str = "Info";
 const EXECUTE_COMMAND: &str = "nargo.execute";
 const EXECUTE_CODELENS_TITLE: &str = "Execute";
+const DEBUG_COMMAND: &str = "nargo.debug.dap";
+const DEBUG_CODELENS_TITLE: &str = "Debug";
 
 const PROFILE_COMMAND: &str = "nargo.profile";
 const PROFILE_CODELENS_TITLE: &str = "Profile";
@@ -183,6 +185,17 @@ pub(crate) fn collect_lenses_for_package(
             let profile_lens = CodeLens { range, command: Some(profile_command), data: None };
 
             lenses.push(profile_lens);
+
+
+            let debug_command = Command {
+                title: DEBUG_CODELENS_TITLE.to_string(),
+                command: DEBUG_COMMAND.into(),
+                arguments: Some(package_selection_args(workspace, package)),
+            };
+
+            let debug_lens = CodeLens { range, command: Some(debug_command), data: None };
+
+            lenses.push(debug_lens);
         }
     }
 

--- a/tooling/lsp/src/requests/code_lens_request.rs
+++ b/tooling/lsp/src/requests/code_lens_request.rs
@@ -156,46 +156,22 @@ pub(crate) fn collect_lenses_for_package(
 
             lenses.push(compile_lens);
 
-            let info_command = Command {
-                title: INFO_CODELENS_TITLE.to_string(),
-                command: INFO_COMMAND.into(),
-                arguments: Some(package_selection_args(workspace, package)),
-            };
+            let internal_command_lenses = [
+                (INFO_CODELENS_TITLE, INFO_COMMAND),
+                (EXECUTE_CODELENS_TITLE, EXECUTE_COMMAND),
+                (PROFILE_CODELENS_TITLE, PROFILE_COMMAND),
+                (DEBUG_CODELENS_TITLE, DEBUG_COMMAND),
+            ]
+            .map(|(title, command)| {
+                let command = Command {
+                    title: title.to_string(),
+                    command: command.into(),
+                    arguments: Some(package_selection_args(workspace, package)),
+                };
+                CodeLens { range, command: Some(command), data: None }
+            });
 
-            let info_lens = CodeLens { range, command: Some(info_command), data: None };
-
-            lenses.push(info_lens);
-
-            let execute_command = Command {
-                title: EXECUTE_CODELENS_TITLE.to_string(),
-                command: EXECUTE_COMMAND.into(),
-                arguments: Some(package_selection_args(workspace, package)),
-            };
-
-            let execute_lens = CodeLens { range, command: Some(execute_command), data: None };
-
-            lenses.push(execute_lens);
-
-            let profile_command = Command {
-                title: PROFILE_CODELENS_TITLE.to_string(),
-                command: PROFILE_COMMAND.into(),
-                arguments: Some(package_selection_args(workspace, package)),
-            };
-
-            let profile_lens = CodeLens { range, command: Some(profile_command), data: None };
-
-            lenses.push(profile_lens);
-
-
-            let debug_command = Command {
-                title: DEBUG_CODELENS_TITLE.to_string(),
-                command: DEBUG_COMMAND.into(),
-                arguments: Some(package_selection_args(workspace, package)),
-            };
-
-            let debug_lens = CodeLens { range, command: Some(debug_command), data: None };
-
-            lenses.push(debug_lens);
+            lenses.append(&mut Vec::from(internal_command_lenses));
         }
     }
 

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -63,7 +63,6 @@ enum NargoCommand {
     Execute(execute_cmd::ExecuteCommand),
     #[command(hide = true)] // Hidden while the feature is being built out
     Export(export_cmd::ExportCommand),
-    #[command(hide = true)] // Hidden while the feature is being built out
     Debug(debug_cmd::DebugCommand),
     Test(test_cmd::TestCommand),
     Info(info_cmd::InfoCommand),


### PR DESCRIPTION
# Description
Give more visibility to debugger

## Summary\*

- Add a new `Debug` codelens action to main functions
- Unhid the `debug` command from nargo_cli

https://github.com/noir-lang/vscode-noir/assets/13237343/6e83d28c-126a-41ff-a23b-bc7ce9a50ccb

## Additional Context

This PR has its sibling in vscode-noir repo noir-lang/vscode-noir#85

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
