### PR TITLE
feat: Allow arguments to attribute functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1344,7 +1344,7 @@ impl<'context> Elaborator<'context> {
 
             use crate::lexer::token::Token::*;
             if let (Ident(name), LeftParen, RightParen) = (first, second, last) {
-                let args = tokens.split(|token| matches!(token.token(), Comma));
+                let args = tokens.split(|token| *token.token() == Comma);
                 let args =
                     vecmap(args, |arg| (Value::Code(Rc::new(Tokens(arg.to_vec()))), location));
                 return Some((name, args));

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -202,7 +202,7 @@ pub enum CompilationError {
 }
 
 impl CompilationError {
-    fn is_error(&self) -> bool {
+    pub fn is_error(&self) -> bool {
         let diagnostic = CustomDiagnostic::from(self);
         diagnostic.is_error()
     }

--- a/cspell.json
+++ b/cspell.json
@@ -206,6 +206,8 @@
         "unoptimized",
         "urem",
         "USERPROFILE",
+        "vararg",
+        "varargs",
         "vecmap",
         "vitkov",
         "wasi",

--- a/test_programs/compile_success_empty/attribute_args/Nargo.toml
+++ b/test_programs/compile_success_empty/attribute_args/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "attribute_args"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/attribute_args/src/main.nr
+++ b/test_programs/compile_success_empty/attribute_args/src/main.nr
@@ -17,4 +17,4 @@ comptime fn varargs(s: StructDefinition, t: [Quoted]) {
     assert(t.len() < 5);
 }
 
-fn main(){}
+fn main() {}

--- a/test_programs/compile_success_empty/attribute_args/src/main.nr
+++ b/test_programs/compile_success_empty/attribute_args/src/main.nr
@@ -1,0 +1,20 @@
+#[attr_with_args(a b, c d)]
+#[varargs(one, two)]
+#[varargs(one, two, three, four)]
+struct Foo {}
+
+comptime fn attr_with_args(s: StructDefinition, a: Quoted, b: Quoted) {
+    // Ensure all variables are in scope.
+    // We can't print them since that breaks the test runner.
+    let _ = s;
+    let _ = a;
+    let _ = b;
+}
+
+comptime fn varargs(s: StructDefinition, t: [Quoted]) {
+    let _ = s;
+    for _ in t {}
+    assert(t.len() < 5);
+}
+
+fn main(){}


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5473
Resolves https://github.com/noir-lang/noir/issues/5476

## Summary\*

Allows arguments to attribute functions.
- These arguments are all quoted by default. This is to replicate something like Rust's `#[derive(Foo, Bar)]` where  `Foo` and `Bar` are meant to be traits rather than values in scope.
- Varargs is also possible if the attribute accepts a slice of Quoted values rather than individual Quoted arguments.

## Additional Context

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
