### PR TITLE
fix: Add `comptime` to trait impls and structs

### DIFF
--- a/aztec_macros/src/transforms/note_interface.rs
+++ b/aztec_macros/src/transforms/note_interface.rs
@@ -73,6 +73,7 @@ pub fn generate_note_interface_impl(module: &mut SortedModule) -> Result<(), Azt
                 generics: vec![],
                 methods: vec![],
                 where_clause: vec![],
+                is_comptime: false,
             };
             module.impls.push(default_impl.clone());
             module.impls.last_mut().unwrap()

--- a/aztec_macros/src/transforms/storage.rs
+++ b/aztec_macros/src/transforms/storage.rs
@@ -248,6 +248,7 @@ pub fn generate_storage_implementation(
         methods: vec![(init, Span::default())],
 
         where_clause: vec![],
+        is_comptime: false,
     };
     module.impls.push(storage_impl);
 

--- a/compiler/noirc_frontend/src/ast/structure.rs
+++ b/compiler/noirc_frontend/src/ast/structure.rs
@@ -14,18 +14,7 @@ pub struct NoirStruct {
     pub generics: UnresolvedGenerics,
     pub fields: Vec<(Ident, UnresolvedType)>,
     pub span: Span,
-}
-
-impl NoirStruct {
-    pub fn new(
-        name: Ident,
-        attributes: Vec<SecondaryAttribute>,
-        generics: UnresolvedGenerics,
-        fields: Vec<(Ident, UnresolvedType)>,
-        span: Span,
-    ) -> NoirStruct {
-        NoirStruct { name, attributes, generics, fields, span }
-    }
+    pub is_comptime: bool,
 }
 
 impl Display for NoirStruct {

--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -53,6 +53,7 @@ pub struct TypeImpl {
     pub generics: UnresolvedGenerics,
     pub where_clause: Vec<UnresolvedTraitConstraint>,
     pub methods: Vec<(NoirFunction, Span)>,
+    pub is_comptime: bool,
 }
 
 /// Ast node for an implementation of a trait for a particular type
@@ -69,6 +70,8 @@ pub struct NoirTraitImpl {
     pub where_clause: Vec<UnresolvedTraitConstraint>,
 
     pub items: Vec<TraitImplItem>,
+
+    pub is_comptime: bool,
 }
 
 /// Represents a simple trait constraint such as `where Foo: TraitY<U, V>`

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1300,9 +1300,7 @@ impl<'a> Interpreter<'a> {
 
     fn store_lvalue(&mut self, lvalue: HirLValue, rhs: Value) -> IResult<()> {
         match lvalue {
-            HirLValue::Ident(ident, typ) => {
-                self.mutate(ident.id, rhs, ident.location)
-            }
+            HirLValue::Ident(ident, typ) => self.mutate(ident.id, rhs, ident.location),
             HirLValue::Dereference { lvalue, element_type: _, location } => {
                 match self.evaluate_lvalue(&lvalue)? {
                     Value::Pointer(value) => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1300,7 +1300,9 @@ impl<'a> Interpreter<'a> {
 
     fn store_lvalue(&mut self, lvalue: HirLValue, rhs: Value) -> IResult<()> {
         match lvalue {
-            HirLValue::Ident(ident, typ) => self.mutate(ident.id, rhs, ident.location),
+            HirLValue::Ident(ident, typ) => {
+                self.mutate(ident.id, rhs, ident.location)
+            }
             HirLValue::Dereference { lvalue, element_type: _, location } => {
                 match self.evaluate_lvalue(&lvalue)? {
                     Value::Pointer(value) => {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -124,6 +124,7 @@ pub struct UnresolvedTraitImpl {
     pub methods: UnresolvedFunctions,
     pub generics: UnresolvedGenerics,
     pub where_clause: Vec<UnresolvedTraitConstraint>,
+    pub is_comptime: bool,
 
     // Every field after this line is filled in later in the elaborator
     pub trait_id: Option<TraitId>,
@@ -279,7 +280,7 @@ impl DefCollector {
     /// Collect all of the definitions in a given crate into a CrateDefMap
     /// Modules which are not a part of the module hierarchy starting with
     /// the root module, will be ignored.
-    pub fn collect(
+    pub fn collect_crate_and_dependencies(
         mut def_map: CrateDefMap,
         context: &mut Context,
         ast: SortedModule,

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -185,6 +185,7 @@ impl<'a> ModCollector<'a> {
                 generics: trait_impl.impl_generics,
                 where_clause: trait_impl.where_clause,
                 trait_generics: trait_impl.trait_generics,
+                is_comptime: trait_impl.is_comptime,
 
                 // These last fields are filled later on
                 trait_id: None,

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -118,7 +118,7 @@ impl CrateDefMap {
         };
 
         // Now we want to populate the CrateDefMap using the DefCollector
-        errors.extend(DefCollector::collect(
+        errors.extend(DefCollector::collect_crate_and_dependencies(
             def_map,
             context,
             ast,

--- a/compiler/noirc_frontend/src/parser/mod.rs
+++ b/compiler/noirc_frontend/src/parser/mod.rs
@@ -39,6 +39,24 @@ pub enum TopLevelStatement {
     Error,
 }
 
+impl TopLevelStatement {
+    pub fn into_item_kind(self) -> Option<ItemKind> {
+        match self {
+            TopLevelStatement::Function(f) => Some(ItemKind::Function(f)),
+            TopLevelStatement::Module(m) => Some(ItemKind::ModuleDecl(m)),
+            TopLevelStatement::Import(i) => Some(ItemKind::Import(i)),
+            TopLevelStatement::Struct(s) => Some(ItemKind::Struct(s)),
+            TopLevelStatement::Trait(t) => Some(ItemKind::Trait(t)),
+            TopLevelStatement::TraitImpl(t) => Some(ItemKind::TraitImpl(t)),
+            TopLevelStatement::Impl(i) => Some(ItemKind::Impl(i)),
+            TopLevelStatement::TypeAlias(t) => Some(ItemKind::TypeAlias(t)),
+            TopLevelStatement::SubModule(s) => Some(ItemKind::Submodules(s)),
+            TopLevelStatement::Global(c) => Some(ItemKind::Global(c)),
+            TopLevelStatement::Error => None,
+        }
+    }
+}
+
 // Helper trait that gives us simpler type signatures for return types:
 // e.g. impl Parser<T> versus impl Parser<Token, T, Error = Simple<Token>>
 pub trait NoirParser<T>: Parser<Token, T, Error = ParserError> + Sized + Clone {}

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -171,20 +171,8 @@ fn module() -> impl NoirParser<ParsedModule> {
             .to(ParsedModule::default())
             .then(spanned(top_level_statement(module_parser)).repeated())
             .foldl(|mut program, (statement, span)| {
-                let mut push_item = |kind| program.items.push(Item { kind, span });
-
-                match statement {
-                    TopLevelStatement::Function(f) => push_item(ItemKind::Function(f)),
-                    TopLevelStatement::Module(m) => push_item(ItemKind::ModuleDecl(m)),
-                    TopLevelStatement::Import(i) => push_item(ItemKind::Import(i)),
-                    TopLevelStatement::Struct(s) => push_item(ItemKind::Struct(s)),
-                    TopLevelStatement::Trait(t) => push_item(ItemKind::Trait(t)),
-                    TopLevelStatement::TraitImpl(t) => push_item(ItemKind::TraitImpl(t)),
-                    TopLevelStatement::Impl(i) => push_item(ItemKind::Impl(i)),
-                    TopLevelStatement::TypeAlias(t) => push_item(ItemKind::TypeAlias(t)),
-                    TopLevelStatement::SubModule(s) => push_item(ItemKind::Submodules(s)),
-                    TopLevelStatement::Global(c) => push_item(ItemKind::Global(c)),
-                    TopLevelStatement::Error => (),
+                if let Some(kind) = statement.into_item_kind() {
+                    program.items.push(Item { kind, span });
                 }
                 program
             })
@@ -204,9 +192,9 @@ pub fn top_level_items() -> impl NoirParser<Vec<TopLevelStatement>> {
 ///                    | module_declaration
 ///                    | use_statement
 ///                    | global_declaration
-fn top_level_statement(
-    module_parser: impl NoirParser<ParsedModule>,
-) -> impl NoirParser<TopLevelStatement> {
+fn top_level_statement<'a>(
+    module_parser: impl NoirParser<ParsedModule> + 'a,
+) -> impl NoirParser<TopLevelStatement> + 'a {
     choice((
         function::function_definition(false).map(TopLevelStatement::Function),
         structs::struct_definition(),
@@ -227,8 +215,9 @@ fn top_level_statement(
 ///
 /// implementation: 'impl' generics type '{' function_definition ... '}'
 fn implementation() -> impl NoirParser<TopLevelStatement> {
-    keyword(Keyword::Impl)
-        .ignore_then(function::generics())
+    maybe_comp_time()
+        .then_ignore(keyword(Keyword::Impl))
+        .then(function::generics())
         .then(parse_type().map_with_span(|typ, span| (typ, span)))
         .then(where_clause())
         .then_ignore(just(Token::LeftBrace))
@@ -236,13 +225,14 @@ fn implementation() -> impl NoirParser<TopLevelStatement> {
         .then_ignore(just(Token::RightBrace))
         .map(|args| {
             let ((other_args, where_clause), methods) = args;
-            let (generics, (object_type, type_span)) = other_args;
+            let ((is_comptime, generics), (object_type, type_span)) = other_args;
             TopLevelStatement::Impl(TypeImpl {
                 generics,
                 object_type,
                 type_span,
                 where_clause,
                 methods,
+                is_comptime,
             })
         })
 }

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -36,7 +36,14 @@ pub(super) fn struct_definition() -> impl NoirParser<TopLevelStatement> {
         .then(fields)
         .validate(|((((attributes, is_comptime), name), generics), fields), span, emit| {
             let attributes = validate_secondary_attributes(attributes, span, emit);
-            TopLevelStatement::Struct(NoirStruct { name, attributes, generics, fields, span, is_comptime })
+            TopLevelStatement::Struct(NoirStruct {
+                name,
+                attributes,
+                generics,
+                fields,
+                span,
+                is_comptime,
+            })
         })
 }
 

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -1,6 +1,7 @@
 use chumsky::prelude::*;
 
 use crate::ast::{Ident, NoirStruct, UnresolvedType};
+use crate::parser::parser::types::maybe_comp_time;
 use crate::{
     parser::{
         parser::{
@@ -28,13 +29,14 @@ pub(super) fn struct_definition() -> impl NoirParser<TopLevelStatement> {
         .or(just(Semicolon).to(Vec::new()));
 
     attributes()
+        .then(maybe_comp_time())
         .then_ignore(keyword(Struct))
         .then(ident())
         .then(function::generics())
         .then(fields)
-        .validate(|(((raw_attributes, name), generics), fields), span, emit| {
-            let attributes = validate_secondary_attributes(raw_attributes, span, emit);
-            TopLevelStatement::Struct(NoirStruct { name, attributes, generics, fields, span })
+        .validate(|((((attributes, is_comptime), name), generics), fields), span, emit| {
+            let attributes = validate_secondary_attributes(attributes, span, emit);
+            TopLevelStatement::Struct(NoirStruct { name, attributes, generics, fields, span, is_comptime })
         })
 }
 

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -2,6 +2,7 @@ use chumsky::prelude::*;
 
 use super::attributes::{attributes, validate_secondary_attributes};
 use super::function::function_return_type;
+use super::types::maybe_comp_time;
 use super::{block, expression, fresh_statement, function, function_declaration_parameters};
 
 use crate::ast::{
@@ -103,8 +104,9 @@ fn trait_type_declaration() -> impl NoirParser<TraitItem> {
 ///
 /// trait_implementation: 'impl' generics ident generic_args for type '{' trait_implementation_body '}'
 pub(super) fn trait_implementation() -> impl NoirParser<TopLevelStatement> {
-    keyword(Keyword::Impl)
-        .ignore_then(function::generics())
+    maybe_comp_time()
+        .then_ignore(keyword(Keyword::Impl))
+        .then(function::generics())
         .then(path())
         .then(generic_type_args(parse_type()))
         .then_ignore(keyword(Keyword::For))
@@ -114,8 +116,8 @@ pub(super) fn trait_implementation() -> impl NoirParser<TopLevelStatement> {
         .then(trait_implementation_body())
         .then_ignore(just(Token::RightBrace))
         .map(|args| {
-            let ((other_args, where_clause), items) = args;
-            let (((impl_generics, trait_name), trait_generics), object_type) = other_args;
+            let (((other_args, object_type), where_clause), items) = args;
+            let (((is_comptime, impl_generics), trait_name), trait_generics) = other_args;
 
             TopLevelStatement::TraitImpl(NoirTraitImpl {
                 impl_generics,
@@ -124,6 +126,7 @@ pub(super) fn trait_implementation() -> impl NoirParser<TopLevelStatement> {
                 object_type,
                 items,
                 where_clause,
+                is_comptime,
             })
         })
 }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -80,7 +80,7 @@ pub(crate) fn get_program(
         };
 
         // Now we want to populate the CrateDefMap using the DefCollector
-        errors.extend(DefCollector::collect(
+        errors.extend(DefCollector::collect_crate_and_dependencies(
             def_map,
             &mut context,
             program.clone().into_sorted(),

--- a/noir_stdlib/src/meta/trait_constraint.nr
+++ b/noir_stdlib/src/meta/trait_constraint.nr
@@ -1,4 +1,4 @@
-use crate::hash::{ Hash, Hasher };
+use crate::hash::{Hash, Hasher};
 use crate::cmp::Eq;
 
 impl Eq for TraitConstraint {

--- a/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
@@ -23,16 +23,19 @@ fn main() {
     }
 }
 
-struct TestHasher {
+comptime struct TestHasher {
     result: Field,
 }
 
-impl Hasher for TestHasher {
-    fn finish(self) -> Field {
+comptime impl Hasher for TestHasher {
+    comptime fn finish(self) -> Field {
+        println(self.result);
         self.result
     }
     
-    fn write(&mut self, input: Field) {
+    comptime fn write(&mut self, input: Field) {
+        println(self.result);
         self.result += input;
+        println(self.result);
     }
 }

--- a/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
@@ -30,13 +30,10 @@ comptime struct TestHasher {
 
 comptime impl Hasher for TestHasher {
     comptime fn finish(self) -> Field {
-        println(self.result);
         self.result
     }
     
     comptime fn write(&mut self, input: Field) {
-        println(self.result);
         self.result += input;
-        println(self.result);
     }
 }

--- a/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
@@ -1,11 +1,12 @@
-use std::hash::{ Hash, Hasher };
+use std::hash::{Hash, Hasher};
 
 trait TraitWithGenerics<A, B> {
     fn foo(self) -> (A, B);
 }
 
 fn main() {
-    comptime {
+    comptime
+    {
         let constraint1 = quote { Default }.as_trait_constraint();
         let constraint2 = quote { TraitWithGenerics<Field, u32> }.as_trait_constraint();
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is somewhat of a quick fix to the issue in the trait constraint PR and in @asterite's comptime prefix operator PR.

The issue was that the comptime functions/blocks were using other functions which weren't elaborated yet. So they saw an empty function body. Just adding `comptime` to a function in an impl wasn't sufficient since the compiler didn't look in every function within an impl to know whether to add the impl to the list of comptime items. Moreover, it wouldn't be possible to only add this `comptime` to a subset of functions within an impl so I decided to allow `comptime` as a keyword on an entire impl as well - and this is what decides whether or not to add it to the comptime items.

I'm not really satisfied with this solution since it overloads `comptime` to mean both "run this at compile-time (always)" and "_able to be run_ at compile-time" but I don't have a better solution right now. To some degree the separation is necessary since we need to separate runtime functions that can be modified by comptime functions from comptime functions that cannot be modified (because we've already run them).

## Additional Context

Requires https://github.com/noir-lang/noir/pull/5517 to work

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
