### PR TITLE
fix: lsp hover wasn't always working

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -732,7 +732,11 @@ impl<'a> ModCollector<'a> {
 
             context.def_interner.add_module_attributes(
                 mod_id,
-                ModuleAttributes { name: mod_name.0.contents.clone(), location: mod_location },
+                ModuleAttributes {
+                    name: mod_name.0.contents.clone(),
+                    location: mod_location,
+                    parent: self.module_id,
+                },
             );
         }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -48,6 +48,7 @@ const IMPL_SEARCH_RECURSION_LIMIT: u32 = 10;
 pub struct ModuleAttributes {
     pub name: String,
     pub location: Location,
+    pub parent: LocalModuleId,
 }
 
 type StructAttributes = Vec<SecondaryAttribute>;
@@ -1014,6 +1015,10 @@ impl NodeInterner {
 
     pub fn try_module_attributes(&self, module_id: &ModuleId) -> Option<&ModuleAttributes> {
         self.module_attributes.get(module_id)
+    }
+
+    pub fn try_module_parent(&self, module_id: &ModuleId) -> Option<LocalModuleId> {
+        self.try_module_attributes(module_id).map(|attrs| attrs.parent)
     }
 
     pub fn global_attributes(&self, global_id: &GlobalId) -> &[SecondaryAttribute] {

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    future::Future,
-};
+use std::{collections::HashMap, future::Future};
 
 use crate::{
     parse_diff, resolve_workspace_for_source_path,
@@ -17,11 +14,7 @@ use lsp_types::{
 use nargo::insert_all_files_for_workspace_into_file_manager;
 use nargo_fmt::Config;
 use noirc_driver::file_manager_with_stdlib;
-use noirc_frontend::{
-    graph::{CrateId, Dependency},
-    hir::def_map::CrateDefMap,
-    macros_api::NodeInterner,
-};
+use noirc_frontend::{graph::Dependency, macros_api::NodeInterner};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -285,7 +278,6 @@ pub(crate) struct ProcessRequestCallbackArgs<'a> {
     interners: &'a HashMap<String, NodeInterner>,
     root_crate_name: String,
     root_crate_dependencies: &'a Vec<Dependency>,
-    def_maps: &'a BTreeMap<CrateId, CrateDefMap>,
 }
 
 pub(crate) fn process_request<F, T>(
@@ -340,7 +332,6 @@ where
         interners: &state.cached_definitions,
         root_crate_name: package.name.to_string(),
         root_crate_dependencies: &context.crate_graph[context.root_crate_id()].dependencies,
-        def_maps: &context.def_maps,
     }))
 }
 pub(crate) fn find_all_references_in_workspace(


### PR DESCRIPTION
# Description

## Problem

Resolves #5516

## Summary

It seems hover broke in 70dabfa454516b839b57554fb2e2574a84748d66 . However, our tests still pass. I still don't understand why it only breaks when the request comes from an actual VS Code instance and not in tests... but for now I'd rather revert the commit that broke it and eventually try to do the refactor again, because having hover is pretty nice :-)

## Additional Context

None.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
