### PR TITLE
fix: Mutability in the comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1377,7 +1377,10 @@ impl<'a> Interpreter<'a> {
 
     fn evaluate_lvalue(&mut self, lvalue: &HirLValue) -> IResult<Value> {
         match lvalue {
-            HirLValue::Ident(ident, _) => self.lookup(ident),
+            HirLValue::Ident(ident, _) => match self.lookup(ident)? {
+                Value::Pointer(elem, true) => Ok(elem.borrow().clone()),
+                other => Ok(other),
+            },
             HirLValue::Dereference { lvalue, element_type: _, location } => {
                 match self.evaluate_lvalue(lvalue)? {
                     Value::Pointer(value, _) => Ok(value.borrow().clone()),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -241,6 +241,8 @@ impl<'a> Interpreter<'a> {
                 Ok(())
             }
             HirPattern::Mutable(pattern, _) => {
+                // Create a mutable reference to store to
+                let argument = Value::Pointer(Shared::new(argument), true);
                 self.define_pattern(pattern, typ, argument, location)
             }
             HirPattern::Tuple(pattern_fields, _) => match (argument, typ) {
@@ -334,8 +336,19 @@ impl<'a> Interpreter<'a> {
         }
     }
 
-    /// Evaluate an expression and return the result
+    /// Evaluate an expression and return the result.
+    /// This will automatically dereference a mutable variable if used.
     pub fn evaluate(&mut self, id: ExprId) -> IResult<Value> {
+        match self.evaluate_no_dereference(id)? {
+            Value::Pointer(elem, true) => Ok(elem.borrow().clone()),
+            other => Ok(other),
+        }
+    }
+
+    /// Evaluating a mutable variable will dereference it automatically.
+    /// This function should be used when that is not desired - e.g. when
+    /// compiling a `&mut var` expression to grab the original reference.
+    fn evaluate_no_dereference(&mut self, id: ExprId) -> IResult<Value> {
         match self.interner.expression(&id) {
             HirExpression::Ident(ident, _) => self.evaluate_ident(ident, id),
             HirExpression::Literal(literal) => self.evaluate_literal(literal, id),
@@ -592,7 +605,10 @@ impl<'a> Interpreter<'a> {
     }
 
     fn evaluate_prefix(&mut self, prefix: HirPrefixExpression, id: ExprId) -> IResult<Value> {
-        let rhs = self.evaluate(prefix.rhs)?;
+        let rhs = match prefix.operator {
+            UnaryOp::MutableReference => self.evaluate_no_dereference(prefix.rhs)?,
+            _ => self.evaluate(prefix.rhs)?,
+        };
         self.evaluate_prefix_with_value(rhs, prefix.operator, id)
     }
 
@@ -634,9 +650,17 @@ impl<'a> Interpreter<'a> {
                     Err(InterpreterError::InvalidValueForUnary { value, location, operator: "not" })
                 }
             },
-            UnaryOp::MutableReference => Ok(Value::Pointer(Shared::new(rhs))),
+            UnaryOp::MutableReference => {
+                // If this is a mutable variable (auto_deref = true), turn this into an explicit
+                // mutable reference just by switching the value of `auto_deref`. Otherwise, wrap
+                // the value in a fresh reference.
+                match rhs {
+                    Value::Pointer(elem, true) => Ok(Value::Pointer(elem, false)),
+                    other => Ok(Value::Pointer(Shared::new(other), false)),
+                }
+            }
             UnaryOp::Dereference { implicitly_added: _ } => match rhs {
-                Value::Pointer(element) => Ok(element.borrow().clone()),
+                Value::Pointer(element, _) => Ok(element.borrow().clone()),
                 value => {
                     let location = self.interner.expr_location(&id);
                     Err(InterpreterError::NonPointerDereferenced { value, location })
@@ -1303,7 +1327,7 @@ impl<'a> Interpreter<'a> {
             HirLValue::Ident(ident, typ) => self.mutate(ident.id, rhs, ident.location),
             HirLValue::Dereference { lvalue, element_type: _, location } => {
                 match self.evaluate_lvalue(&lvalue)? {
-                    Value::Pointer(value) => {
+                    Value::Pointer(value, _) => {
                         *value.borrow_mut() = rhs;
                         Ok(())
                     }
@@ -1356,7 +1380,7 @@ impl<'a> Interpreter<'a> {
             HirLValue::Ident(ident, _) => self.lookup(ident),
             HirLValue::Dereference { lvalue, element_type: _, location } => {
                 match self.evaluate_lvalue(lvalue)? {
-                    Value::Pointer(value) => Ok(value.borrow().clone()),
+                    Value::Pointer(value, _) => Ok(value.borrow().clone()),
                     value => {
                         Err(InterpreterError::NonPointerDereferenced { value, location: *location })
                     }

--- a/compiler/noirc_frontend/src/hir/comptime/tests.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/tests.rs
@@ -78,6 +78,18 @@ fn mutating_mutable_references() {
 }
 
 #[test]
+fn mutation_leaks() {
+    let program = "comptime fn main() -> pub i8 {
+        let mut x = 3;
+        let y = &mut x;
+        *y = 5;
+        x
+    }";
+    let result = interpret(program, vec!["main".into()]);
+    assert_eq!(result, Value::I8(5));
+}
+
+#[test]
 fn mutating_arrays() {
     let program = "comptime fn main() -> pub u8 {
         let mut a1 = [1, 2, 3, 4];

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -32,16 +32,9 @@ pub(super) fn struct_definition() -> impl NoirParser<TopLevelStatement> {
         .then(ident())
         .then(function::generics())
         .then(fields)
-        .validate(|((((attributes, is_comptime), name), generics), fields), span, emit| {
-            let attributes = validate_secondary_attributes(attributes, span, emit);
-            TopLevelStatement::Struct(NoirStruct {
-                name,
-                attributes,
-                generics,
-                fields,
-                span,
-                is_comptime,
-            })
+        .validate(|(((raw_attributes, name), generics), fields), span, emit| {
+            let attributes = validate_secondary_attributes(raw_attributes, span, emit);
+            TopLevelStatement::Struct(NoirStruct { name, attributes, generics, fields, span })
         })
 }
 

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -32,9 +32,16 @@ pub(super) fn struct_definition() -> impl NoirParser<TopLevelStatement> {
         .then(ident())
         .then(function::generics())
         .then(fields)
-        .validate(|(((raw_attributes, name), generics), fields), span, emit| {
-            let attributes = validate_secondary_attributes(raw_attributes, span, emit);
-            TopLevelStatement::Struct(NoirStruct { name, attributes, generics, fields, span })
+        .validate(|((((attributes, is_comptime), name), generics), fields), span, emit| {
+            let attributes = validate_secondary_attributes(attributes, span, emit);
+            TopLevelStatement::Struct(NoirStruct {
+                name,
+                attributes,
+                generics,
+                fields,
+                span,
+                is_comptime,
+            })
         })
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5504

## Summary\*

Mutable variables weren't wrapped in a mutable reference before like they are in SSA - they are now.

## Additional Context

This is an alternate version from the last PR - I've cherry-picked the last PR so this can be merged into master instead of another branch.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
