### PR TITLE
chore: Remove dbg on find_func_with_name

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -108,7 +108,7 @@ impl ModuleData {
     }
 
     pub fn find_func_with_name(&self, name: &Ident) -> Option<FuncId> {
-        dbg!(&self.scope).find_func_with_name(name)
+        self.scope.find_func_with_name(name)
     }
 
     pub fn import(


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Looks like we missed a dbg in one of the recent PRs. This was causing a lot of unnecessary dbg output.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
