### PR TITLE
feat: add comptime support for `modulus_*` compiler builtins

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -26,6 +26,11 @@ pub(super) fn call_builtin(
         "array_len" => array_len(interner, arguments, location),
         "as_slice" => as_slice(interner, arguments, location),
         "is_unconstrained" => Ok(Value::Bool(true)),
+        "modulus_num_bits" => modulus_num_bits(interner, arguments, location),
+        "modulus_be_bits" => modulus_be_bits(interner, arguments, location),
+        "modulus_be_bytes" => modulus_be_bytes(interner, arguments, location),
+        "modulus_le_bits" => modulus_le_bits(interner, arguments, location),
+        "modulus_le_bytes" => modulus_le_bytes(interner, arguments, location),
         "slice_insert" => slice_insert(interner, arguments, location),
         "slice_pop_back" => slice_pop_back(interner, arguments, location),
         "slice_pop_front" => slice_pop_front(interner, arguments, location),
@@ -38,11 +43,6 @@ pub(super) fn call_builtin(
         "trait_constraint_eq" => trait_constraint_eq(interner, arguments, location),
         "trait_constraint_hash" => trait_constraint_hash(interner, arguments, location),
         "quoted_as_trait_constraint" => quoted_as_trait_constraint(interner, arguments, location),
-        "modulus_num_bits" => modulus_num_bits(interner, arguments, location),
-        "modulus_le_bits" => modulus_le_bits(interner, arguments, location),
-        "modulus_be_bits" => modulus_be_bits(interner, arguments, location),
-        "modulus_be_bytes" => modulus_be_bytes(interner, arguments, location),
-        "modulus_le_bytes" => modulus_le_bytes(interner, arguments, location),
         _ => {
             let item = format!("Comptime evaluation for builtin function {name}");
             Err(InterpreterError::Unimplemented { item, location })
@@ -418,18 +418,6 @@ fn modulus_be_bits(
     Ok(Value::Slice(bits_vector, typ))
 }
 
-fn modulus_le_bits(
-    interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    location: Location,
-) -> IResult<Value> {
-    let Value::Slice(bits, typ) = modulus_be_bits(interner, arguments, location)? else {
-        unreachable!("modulus_be_bits must return slice")
-    };
-    let reversed_bits = bits.into_iter().rev().collect();
-    Ok(Value::Slice(reversed_bits, typ))
-}
-
 fn modulus_be_bytes(
     _interner: &mut NodeInterner,
     arguments: Vec<(Value, Location)>,
@@ -443,6 +431,18 @@ fn modulus_be_bytes(
     let int_type = Type::Integer(crate::ast::Signedness::Unsigned, IntegerBitSize::Eight);
     let typ = Type::Slice(Box::new(int_type));
     Ok(Value::Slice(bytes_vector, typ))
+}
+
+fn modulus_le_bits(
+    interner: &mut NodeInterner,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    let Value::Slice(bits, typ) = modulus_be_bits(interner, arguments, location)? else {
+        unreachable!("modulus_be_bits must return slice")
+    };
+    let reversed_bits = bits.into_iter().rev().collect();
+    Ok(Value::Slice(reversed_bits, typ))
 }
 
 fn modulus_le_bytes(

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -26,11 +26,11 @@ pub(super) fn call_builtin(
         "array_len" => array_len(interner, arguments, location),
         "as_slice" => as_slice(interner, arguments, location),
         "is_unconstrained" => Ok(Value::Bool(true)),
-        "modulus_num_bits" => modulus_num_bits(interner, arguments, location),
         "modulus_be_bits" => modulus_be_bits(interner, arguments, location),
         "modulus_be_bytes" => modulus_be_bytes(interner, arguments, location),
         "modulus_le_bits" => modulus_le_bits(interner, arguments, location),
         "modulus_le_bytes" => modulus_le_bytes(interner, arguments, location),
+        "modulus_num_bits" => modulus_num_bits(interner, arguments, location),
         "slice_insert" => slice_insert(interner, arguments, location),
         "slice_pop_back" => slice_pop_back(interner, arguments, location),
         "slice_pop_front" => slice_pop_front(interner, arguments, location),
@@ -393,16 +393,6 @@ fn trait_constraint_eq(
     Ok(Value::Bool(constraint_a == constraint_b))
 }
 
-fn modulus_num_bits(
-    _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    location: Location,
-) -> IResult<Value> {
-    check_argument_count(0, &arguments, location)?;
-    let bits = FieldElement::max_num_bits().into();
-    Ok(Value::U64(bits))
-}
-
 fn modulus_be_bits(
     _interner: &mut NodeInterner,
     arguments: Vec<(Value, Location)>,
@@ -455,4 +445,14 @@ fn modulus_le_bytes(
     };
     let reversed_bytes = bytes.into_iter().rev().collect();
     Ok(Value::Slice(reversed_bytes, typ))
+}
+
+fn modulus_num_bits(
+    _interner: &mut NodeInterner,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    check_argument_count(0, &arguments, location)?;
+    let bits = FieldElement::max_num_bits().into();
+    Ok(Value::U64(bits))
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -438,7 +438,7 @@ fn modulus_be_bytes(
     check_argument_count(0, &arguments, location)?;
 
     let bytes = FieldElement::modulus().to_bytes_be();
-    let bytes_vector = bytes.into_iter().map(|byte| Value::U8(byte)).collect();
+    let bytes_vector = bytes.into_iter().map(Value::U8).collect();
 
     let int_type = Type::Integer(crate::ast::Signedness::Unsigned, IntegerBitSize::Eight);
     let typ = Type::Slice(Box::new(int_type));

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -3,7 +3,7 @@ use std::{
     rc::Rc,
 };
 
-use acvm::{FieldElement, AcirField};
+use acvm::{AcirField, FieldElement};
 use chumsky::Parser;
 use noirc_errors::Location;
 
@@ -393,7 +393,6 @@ fn trait_constraint_eq(
     Ok(Value::Bool(constraint_a == constraint_b))
 }
 
-
 fn modulus_num_bits(
     _interner: &mut NodeInterner,
     arguments: Vec<(Value, Location)>,
@@ -412,9 +411,7 @@ fn modulus_be_bits(
     check_argument_count(0, &arguments, location)?;
 
     let bits = FieldElement::modulus().to_radix_be(2);
-    let bits_vector = bits.into_iter().map(|bit| {
-        Value::U1(bit != 0)
-    }).collect();
+    let bits_vector = bits.into_iter().map(|bit| Value::U1(bit != 0)).collect();
 
     let int_type = Type::Integer(crate::ast::Signedness::Unsigned, IntegerBitSize::One);
     let typ = Type::Slice(Box::new(int_type));
@@ -441,11 +438,7 @@ fn modulus_be_bytes(
     check_argument_count(0, &arguments, location)?;
 
     let bytes = FieldElement::modulus().to_bytes_be();
-    let bytes_vector = bytes.into_iter().map(|byte| {
-        Value::U8(
-            byte
-        )
-    }).collect();
+    let bytes_vector = bytes.into_iter().map(|byte| Value::U8(byte)).collect();
 
     let int_type = Type::Integer(crate::ast::Signedness::Unsigned, IntegerBitSize::Eight);
     let typ = Type::Slice(Box::new(int_type));

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -32,6 +32,7 @@ pub enum Value {
     I16(i16),
     I32(i32),
     I64(i64),
+    U1(bool),
     U8(u8),
     U16(u16),
     U32(u32),
@@ -62,6 +63,7 @@ impl Value {
             Value::I16(_) => Type::Integer(Signedness::Signed, IntegerBitSize::Sixteen),
             Value::I32(_) => Type::Integer(Signedness::Signed, IntegerBitSize::ThirtyTwo),
             Value::I64(_) => Type::Integer(Signedness::Signed, IntegerBitSize::SixtyFour),
+            Value::U1(_) => Type::Integer(Signedness::Unsigned, IntegerBitSize::One),
             Value::U8(_) => Type::Integer(Signedness::Unsigned, IntegerBitSize::Eight),
             Value::U16(_) => Type::Integer(Signedness::Unsigned, IntegerBitSize::Sixteen),
             Value::U32(_) => Type::Integer(Signedness::Unsigned, IntegerBitSize::ThirtyTwo),
@@ -123,6 +125,9 @@ impl Value {
                 let value = value.abs();
                 let value = (value as u128).into();
                 ExpressionKind::Literal(Literal::Integer(value, negative))
+            }
+            Value::U1(value) => {
+                ExpressionKind::Literal(Literal::Integer((value as u128).into(), false))
             }
             Value::U8(value) => {
                 ExpressionKind::Literal(Literal::Integer((value as u128).into(), false))
@@ -248,6 +253,9 @@ impl Value {
                 let value = value.abs();
                 let value = (value as u128).into();
                 HirExpression::Literal(HirLiteral::Integer(value, negative))
+            }
+            Value::U1(value) => {
+                HirExpression::Literal(HirLiteral::Integer((value as u128).into(), false))
             }
             Value::U8(value) => {
                 HirExpression::Literal(HirLiteral::Integer((value as u128).into(), false))
@@ -385,6 +393,7 @@ impl Display for Value {
             Value::I16(value) => write!(f, "{value}"),
             Value::I32(value) => write!(f, "{value}"),
             Value::I64(value) => write!(f, "{value}"),
+            Value::U1(value) => write!(f, "{value}"),
             Value::U8(value) => write!(f, "{value}"),
             Value::U16(value) => write!(f, "{value}"),
             Value::U32(value) => write!(f, "{value}"),

--- a/noir_stdlib/src/compat.nr
+++ b/noir_stdlib/src/compat.nr
@@ -1,7 +1,20 @@
-global BN254_MODULUS_BE_BYTES: [u8] = &[
+comptime global BN254_MODULUS_BE_BYTES: [u8] = &[
     48, 100, 78, 114, 225, 49, 160, 41, 184, 80, 69, 182, 129, 129, 88, 93, 40, 51, 232, 72, 121, 185, 112, 145, 67, 225, 245, 147, 240, 0, 0, 1
 ];
 
 pub fn is_bn254() -> bool {
-    crate::field::modulus_be_bytes() == BN254_MODULUS_BE_BYTES
+    comptime {
+        // We can't use the `Eq` trait here due to limitations on calling non-comptime functions
+        // defined within the same crate.
+        let mut eq = true;
+
+        let modulus_be_bytes = crate::field::modulus_be_bytes();
+        // We can't do `BN254_MODULUS_BE_BYTES.len()` due to limitations on calling non-comptime functions.
+        assert_eq(crate::field::modulus_num_bits(), 254);
+        for i in 0..32 {
+            eq &= modulus_be_bytes[i] == BN254_MODULUS_BE_BYTES[i];
+        }
+
+        eq
+    }
 }

--- a/noir_stdlib/src/compat.nr
+++ b/noir_stdlib/src/compat.nr
@@ -3,7 +3,8 @@ comptime global BN254_MODULUS_BE_BYTES: [u8] = &[
 ];
 
 pub fn is_bn254() -> bool {
-    comptime {
+    comptime
+    {
         // We can't use the `Eq` trait here due to limitations on calling non-comptime functions
         // defined within the same crate.
         let mut eq = true;

--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -84,19 +84,21 @@ impl Field {
 }
 
 #[builtin(modulus_num_bits)]
-pub fn modulus_num_bits() -> u64 {}
+pub comptime fn modulus_num_bits() -> u64 {}
 
 #[builtin(modulus_be_bits)]
-pub fn modulus_be_bits() -> [u1] {}
+pub comptime fn modulus_be_bits() -> [u1] {}
 
 #[builtin(modulus_le_bits)]
-pub fn modulus_le_bits() -> [u1] {}
+pub comptime fn modulus_le_bits() -> [u1] {}
 
 #[builtin(modulus_be_bytes)]
-pub fn modulus_be_bytes() -> [u8] {}
+pub comptime fn modulus_be_bytes() -> [u8] {}
 
 #[builtin(modulus_le_bytes)]
-pub fn modulus_le_bytes() -> [u8] {}
+pub comptime fn modulus_le_bytes() -> [u8] {}
+
+
 // Convert a 32 byte array to a field element by modding
 pub fn bytes32_to_field(bytes32: [u8; 32]) -> Field {
     // Convert it to a field element

--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -98,7 +98,6 @@ pub comptime fn modulus_be_bytes() -> [u8] {}
 #[builtin(modulus_le_bytes)]
 pub comptime fn modulus_le_bytes() -> [u8] {}
 
-
 // Convert a 32 byte array to a field element by modding
 pub fn bytes32_to_field(bytes32: [u8; 32]) -> Field {
     // Convert it to a field element

--- a/test_programs/execution_success/comptime_slice_equality/Nargo.toml
+++ b/test_programs/execution_success/comptime_slice_equality/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_slice_equality"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/execution_success/comptime_slice_equality/src/main.nr
+++ b/test_programs/execution_success/comptime_slice_equality/src/main.nr
@@ -1,5 +1,6 @@
 fn main() {
-    comptime {
-       assert_eq(&[1], &[1]);
+    comptime
+    {
+        assert_eq(&[1], &[1]);
     }
 }

--- a/test_programs/execution_success/comptime_slice_equality/src/main.nr
+++ b/test_programs/execution_success/comptime_slice_equality/src/main.nr
@@ -1,0 +1,5 @@
+fn main() {
+    comptime {
+       assert_eq(&[1], &[1]);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR changes the function `std::compat::is_bn254` to run in a `comptime` context. To do this I've had to implement a few compiler builtins within the interpreter.

I've had to mangle `std::compat::is_bn254` a bit to get around restrictions on when a function can be called in a `comptime` context however.

This works around around the loop unrolling issue experienced in #4535.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
