### PR TITLE
fix: type_of for pointer types

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -80,9 +80,13 @@ impl Value {
             Value::Slice(_, typ) => return Cow::Borrowed(typ),
             Value::Code(_) => Type::Quoted(QuotedType::Quoted),
             Value::StructDefinition(_) => Type::Quoted(QuotedType::StructDefinition),
-            Value::Pointer(element, _) => {
-                let element = element.borrow().get_type().into_owned();
-                Type::MutableReference(Box::new(element))
+            Value::Pointer(element, auto_deref) => {
+                if *auto_deref {
+                    element.borrow().get_type().into_owned()
+                } else {
+                    let element = element.borrow().get_type().into_owned();
+                    Type::MutableReference(Box::new(element))
+                }
             }
             Value::TraitConstraint { .. } => Type::Quoted(QuotedType::TraitConstraint),
             Value::TraitDefinition(_) => Type::Quoted(QuotedType::TraitDefinition),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

With the mutability change in the interpreter we now use `Type::Pointer` for non-`&mut` types. If `auto_deref` is type it signals the variable is mutable, but not an actual mutable reference type.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
