### PR TITLE
fix: revert PR #5449

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -602,18 +602,6 @@ impl Instruction {
                 }
             }
             Instruction::ArrayGet { array, index } => {
-                if let Value::Instruction { instruction, .. } = &dfg[*array] {
-                    if let Instruction::ArraySet { index: write_index, value, .. } =
-                        dfg[*instruction]
-                    {
-                        // If we're reading from an index of the array which we just wrote to, we can return
-                        // the value which we wrote without performing the read.
-                        if dfg.resolve(write_index) == dfg.resolve(*index) {
-                            return SimplifiedTo(value);
-                        }
-                    }
-                }
-
                 let array = dfg.get_array_constant(*array);
                 let index = dfg.get_numeric_constant(*index);
                 if let (Some((array, _)), Some(index)) = (array, index) {


### PR DESCRIPTION
# Description

## Problem\*

PR #5449 introduces a new issue in aztec protocol circuits

## Summary\*
Revert the PR


## Additional Context
The test 'sort_get_split_order_hints_desc_non_zero_split_counter_empty' is failing with the PR.
It is not clear to me why the PR is making this to fail.
One corner case that we could have when you replace a load with the stored value is:
- loose the index bound check (i.e `A[i]=y; x=A[i] +5; `becomes `x=y+5`, whether or not i is out-of-bounds.
- loose the side-effect; if the store is under a side-effect, replacing it uses by the stored value is not conditional to the enable-side-effect value anymore.


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
