### PR TITLE
chore: filter warnings from elaborator in Aztec Macros

### DIFF
--- a/aztec_macros/src/utils/hir_utils.rs
+++ b/aztec_macros/src/utils/hir_utils.rs
@@ -1,6 +1,6 @@
 use acvm::acir::AcirField;
 use iter_extended::vecmap;
-use noirc_errors::Location;
+use noirc_errors::{CustomDiagnostic, Location};
 use noirc_frontend::ast;
 use noirc_frontend::elaborator::Elaborator;
 use noirc_frontend::hir::def_collector::dc_crate::{
@@ -195,7 +195,8 @@ pub fn inject_fn(
     let trait_id = None;
     items.functions.push(UnresolvedFunctions { file_id, functions, trait_id, self_type: None });
 
-    let errors = Elaborator::elaborate(context, *crate_id, items, None);
+    let mut errors = Elaborator::elaborate(context, *crate_id, items, None);
+    errors.retain(|(error, _)| !CustomDiagnostic::from(error).is_warning());
 
     if !errors.is_empty() {
         return Err(MacroError {


### PR DESCRIPTION
# Description

## Problem\*

Do not report the warnings as error during Aztec Macro compilation

## Summary\*
When Aztec Macro is calling the elaborator, warnings are not discriminated from errors, so they break contract compilation.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
