### PR TITLE
fix: Fix `uhashmap` test name

### DIFF
--- a/test_programs/execution_success/uhashmap/Nargo.toml
+++ b/test_programs/execution_success/uhashmap/Nargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hashmap"
+name = "uhashmap"
 type = "bin"
 authors = [""]
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The wrong test name here is causing CI on other PRs to fail (namely https://github.com/noir-lang/noir/pull/5540) - not sure how the original PR passed checks with this.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
