### PR TITLE
feat: Push ArrayGet instructions backwards through IfElse instructions to avoid expensive array merges

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -84,6 +84,7 @@ pub(crate) fn optimize_into_acir(
     // This pass must come immediately following `mem2reg` as the succeeding passes
     // may create an SSA which inlining fails to handle.
     .run_pass(Ssa::inline_functions_with_no_predicates, "After Inlining:")
+    .run_pass(Ssa::array_get_optimization, "After Array Get Optimizations:")
     .run_pass(Ssa::remove_if_else, "After Remove IfElse:")
     .run_pass(Ssa::fold_constants, "After Constant Folding:")
     .run_pass(Ssa::remove_enable_side_effects, "After EnableSideEffects removal:")

--- a/compiler/noirc_evaluator/src/ssa/opt/array_get.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/array_get.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use crate::ssa::{
     ir::{
         dfg::CallStack, function::Function, instruction::Instruction, map::Id, types::Type,
@@ -10,9 +8,19 @@ use crate::ssa::{
 use fxhash::FxHashMap as HashMap;
 
 impl Ssa {
-    /// Map arrays with the last instruction that uses it
-    /// For this we simply process all the instructions in execution order
-    /// and update the map whenever there is a match
+    // Given an original IfElse instruction is this:
+    //
+    //     v10 = if v0 then v2 else if v1 then v3
+    //
+    // and a later ArrayGet instruction is this:
+    //
+    //     v11 = array_get v4, index v4
+    //
+    // we optimize it to this:
+    //
+    //     v12 = array_get v2, index v4
+    //     v13 = array_get v3, index v4
+    //     v14 = if v0 then v12 else if v1 then v13
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) fn array_get_optimization(mut self) -> Self {
         for function in self.functions.values_mut() {
@@ -30,6 +38,8 @@ impl Ssa {
 
 #[derive(Default)]
 struct Context {
+    // Given an IfElse instruction, here we map its result to that instruction.
+    // We only capture such values if the IfElse values are arrays.
     result_if_else: HashMap<ValueId, Id<Instruction>>,
 }
 
@@ -57,6 +67,7 @@ impl Context {
                     function.dfg[block].instructions_mut().push(instruction_id);
                 }
                 Instruction::ArrayGet { array, index } => {
+                    // If this array get is for an array that is the result of a previous IfElse...
                     if let Some(if_else) = self.result_if_else.get(array) {
                         if let Instruction::IfElse {
                             then_condition,
@@ -78,6 +89,17 @@ impl Context {
                             };
                             let element_type: &Vec<Type> = &element_type;
 
+                            // Given the original IfElse instruction is this:
+                            //
+                            //     v10 = if v0 then v2 else if v1 then v3
+                            //
+                            // and the ArrayGet instruction is this:
+                            //
+                            //     v11 = array_get v4, index v4
+
+                            // First create an instruction like this, for the then branch:
+                            //
+                            //     v12 = array_get v2, index v4
                             let then_result = function.dfg.insert_instruction_and_results(
                                 Instruction::ArrayGet { array: then_value, index: *index },
                                 block,
@@ -86,6 +108,9 @@ impl Context {
                             );
                             let then_result = then_result.first();
 
+                            // Then create an instruction like this, for the else branch:
+                            //
+                            //     v13 = array_get v3, index v4
                             let else_result = function.dfg.insert_instruction_and_results(
                                 Instruction::ArrayGet { array: else_value, index: *index },
                                 block,
@@ -94,6 +119,9 @@ impl Context {
                             );
                             let else_result = else_result.first();
 
+                            // Finally create an IfElse instruction like this:
+                            //
+                            //     v14 = if v0 then v12 else if v1 then v13
                             let new_result = function.dfg.insert_instruction_and_results(
                                 Instruction::IfElse {
                                     then_condition: then_condition,
@@ -107,6 +135,7 @@ impl Context {
                             );
                             let new_result = new_result.first();
 
+                            // And replace the original instruction's value with this final value
                             let results = function.dfg.instruction_results(instruction_id);
                             let result = results[0];
                             function.dfg.set_value_from_id(result, new_result);

--- a/compiler/noirc_evaluator/src/ssa/opt/array_get.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/array_get.rs
@@ -1,0 +1,126 @@
+use std::rc::Rc;
+
+use crate::ssa::{
+    ir::{
+        dfg::CallStack, function::Function, instruction::Instruction, map::Id, types::Type,
+        value::ValueId,
+    },
+    ssa_gen::Ssa,
+};
+use fxhash::FxHashMap as HashMap;
+
+impl Ssa {
+    /// Map arrays with the last instruction that uses it
+    /// For this we simply process all the instructions in execution order
+    /// and update the map whenever there is a match
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub(crate) fn array_get_optimization(mut self) -> Self {
+        for function in self.functions.values_mut() {
+            // This should match the check in flatten_cfg
+            if let crate::ssa::ir::function::RuntimeType::Brillig = function.runtime() {
+                continue;
+            }
+
+            Context::default().optimize_array_get(function);
+        }
+
+        self
+    }
+}
+
+#[derive(Default)]
+struct Context {
+    result_if_else: HashMap<ValueId, Id<Instruction>>,
+}
+
+impl Context {
+    fn optimize_array_get(&mut self, function: &mut Function) {
+        let block = function.entry_block();
+        let instructions = function.dfg[block].take_instructions();
+
+        for instruction_id in instructions {
+            let instruction = function.dfg[instruction_id].clone();
+
+            match &instruction {
+                Instruction::IfElse { then_value, .. } => {
+                    let then_value = *then_value;
+
+                    // Only apply this optimization to IfElse where values are arrays
+                    let Type::Array(..) = function.dfg.type_of_value(then_value) else {
+                        continue;
+                    };
+
+                    let results = function.dfg.instruction_results(instruction_id);
+                    let result = results[0];
+                    self.result_if_else.insert(result, instruction_id);
+
+                    function.dfg[block].instructions_mut().push(instruction_id);
+                }
+                Instruction::ArrayGet { array, index } => {
+                    if let Some(if_else) = self.result_if_else.get(array) {
+                        if let Instruction::IfElse {
+                            then_condition,
+                            then_value,
+                            else_condition,
+                            else_value,
+                            ..
+                        } = &function.dfg[*if_else]
+                        {
+                            let then_condition = *then_condition;
+                            let then_value = *then_value;
+                            let else_condition = *else_condition;
+                            let else_value = *else_value;
+
+                            let then_value_type = function.dfg.type_of_value(then_value);
+
+                            let Type::Array(element_type, _) = then_value_type else {
+                                panic!("ice: expected array type, got {:?}", then_value_type);
+                            };
+                            let element_type: &Vec<Type> = &element_type;
+
+                            let then_result = function.dfg.insert_instruction_and_results(
+                                Instruction::ArrayGet { array: then_value, index: *index },
+                                block,
+                                Some(element_type.clone()),
+                                CallStack::new(), // TODO: check callstack
+                            );
+                            let then_result = then_result.first();
+
+                            let else_result = function.dfg.insert_instruction_and_results(
+                                Instruction::ArrayGet { array: else_value, index: *index },
+                                block,
+                                Some(element_type.clone()),
+                                CallStack::new(), // TODO: check callstack
+                            );
+                            let else_result = else_result.first();
+
+                            let new_result = function.dfg.insert_instruction_and_results(
+                                Instruction::IfElse {
+                                    then_condition: then_condition,
+                                    then_value: then_result,
+                                    else_condition: else_condition,
+                                    else_value: else_result,
+                                },
+                                block,
+                                None,             // TODO: are these needed?
+                                CallStack::new(), // TODO: check callstack
+                            );
+                            let new_result = new_result.first();
+
+                            let results = function.dfg.instruction_results(instruction_id);
+                            let result = results[0];
+                            function.dfg.set_value_from_id(result, new_result);
+
+                            continue;
+                        }
+                    }
+
+                    function.dfg[block].instructions_mut().push(instruction_id);
+                }
+                _ => {
+                    function.dfg[block].instructions_mut().push(instruction_id);
+                }
+            }
+        }
+    }
+}

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -3,6 +3,7 @@
 //! Each pass is generally expected to mutate the SSA IR into a gradually
 //! simpler form until the IR only has a single function remaining with 1 block within it.
 //! Generally, these passes are also expected to minimize the final amount of instructions.
+mod array_get;
 mod array_set;
 mod as_slice_length;
 mod assert_constant;


### PR DESCRIPTION
# Description

## Problem

Resolves #5501

## Summary

Implements #5501 but with bad Rust for now.

Pending:
- [ ] Use good Rust
- [ ] Add a test

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
