### PR TITLE
fix(frontend): Disallow signed numeric generics

### DIFF
--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -324,7 +324,6 @@ impl UnresolvedTypeExpression {
     fn from_expr_helper(expr: Expression) -> Result<UnresolvedTypeExpression, Expression> {
         match expr.kind {
             ExpressionKind::Literal(Literal::Integer(int, sign)) => {
-                assert!(!sign, "Negative literal is not allowed here");
                 match int.try_to_u32() {
                     Some(int) => Ok(UnresolvedTypeExpression::Constant(int, expr.span)),
                     None => Err(expr),

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -323,12 +323,11 @@ impl UnresolvedTypeExpression {
 
     fn from_expr_helper(expr: Expression) -> Result<UnresolvedTypeExpression, Expression> {
         match expr.kind {
-            ExpressionKind::Literal(Literal::Integer(int, sign)) => {
-                match int.try_to_u32() {
-                    Some(int) => Ok(UnresolvedTypeExpression::Constant(int, expr.span)),
-                    None => Err(expr),
-                }
-            }
+            // TODO(https://github.com/noir-lang/noir/issues/5571): The `sign` bool from `Literal::Integer` should be used to construct the constant type expression.
+            ExpressionKind::Literal(Literal::Integer(int, _)) => match int.try_to_u32() {
+                Some(int) => Ok(UnresolvedTypeExpression::Constant(int, expr.span)),
+                None => Err(expr),
+            },
             ExpressionKind::Variable(path, _) => Ok(UnresolvedTypeExpression::Variable(path)),
             ExpressionKind::Prefix(prefix) if prefix.operator == UnaryOp::Minus => {
                 let lhs = Box::new(UnresolvedTypeExpression::Constant(0, expr.span));

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -44,6 +44,8 @@ pub enum ParserErrorReason {
     InvalidBitSize(u32),
     #[error("{0}")]
     Lexer(LexerErrorKind),
+    #[error("Only unsigned integers allowed for numeric generics")]
+    SignedNumericGeneric,
 }
 
 /// Represents a parsing error, or a parsing error in the making.

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -44,8 +44,7 @@ pub enum ParserErrorReason {
     InvalidBitSize(u32),
     #[error("{0}")]
     Lexer(LexerErrorKind),
-    // TODO(https://github.com/noir-lang/noir/issues/5571): This error can be removed once
-    // support is expanded for type-level integers.
+    // TODO(https://github.com/noir-lang/noir/issues/5571): This error can be removed once support is expanded for type-level integers.
     // This error reason was added to prevent the panic outline in this issue: https://github.com/noir-lang/noir/issues/5552.
     #[error("Only unsigned integers allowed for numeric generics")]
     SignedNumericGeneric,

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -44,6 +44,9 @@ pub enum ParserErrorReason {
     InvalidBitSize(u32),
     #[error("{0}")]
     Lexer(LexerErrorKind),
+    // TODO(https://github.com/noir-lang/noir/issues/5571): This error can be removed once
+    // support is expanded for type-level integers.
+    // This error reason was added to prevent the panic outline in this issue: https://github.com/noir-lang/noir/issues/5552.
     #[error("Only unsigned integers allowed for numeric generics")]
     SignedNumericGeneric,
 }

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -4,13 +4,13 @@ use super::{
     parameter_name_recovery, parameter_recovery, parenthesized, parse_type, pattern,
     self_parameter, where_clause, NoirParser,
 };
-use crate::ast::{
+use crate::{ast::{
     FunctionDefinition, FunctionReturnType, ItemVisibility, NoirFunction, Param, Visibility,
-};
+}, macros_api::UnresolvedTypeData, parser::{ParserError, ParserErrorReason}};
 use crate::parser::spanned;
 use crate::token::{Keyword, Token};
 use crate::{
-    ast::{UnresolvedGeneric, UnresolvedGenerics},
+    ast::{UnresolvedGeneric, UnresolvedGenerics, Signedness},
     parser::labels::ParsingRuleLabel,
 };
 
@@ -84,7 +84,19 @@ pub(super) fn numeric_generic() -> impl NoirParser<UnresolvedGeneric> {
         .ignore_then(ident())
         .then_ignore(just(Token::Colon))
         .then(parse_type())
-        .map(|(ident, typ)| UnresolvedGeneric::Numeric { ident, typ })
+        .map(|(ident, typ)| {
+            UnresolvedGeneric::Numeric { ident, typ }
+        })
+        .validate(|generic, span, emit| {
+            if let UnresolvedGeneric::Numeric { typ, .. } = &generic {
+                if let UnresolvedTypeData::Integer(signedness, _) = typ.typ {
+                    if matches!(signedness, Signedness::Signed) {
+                        emit(ParserError::with_reason(ParserErrorReason::SignedNumericGeneric, span));
+                    }
+                }
+            }
+            generic
+        })
 }
 
 pub(super) fn generic_type() -> impl NoirParser<UnresolvedGeneric> {
@@ -233,6 +245,7 @@ mod test {
                 "fn func_name<let T:>(y: T) {}",
                 "fn func_name<T:>(y: T) {}",
                 "fn func_name<T: u64>(y: T) {}",
+                "fn func_name<let N: i8>() {}",
             ],
         );
     }

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -4,13 +4,17 @@ use super::{
     parameter_name_recovery, parameter_recovery, parenthesized, parse_type, pattern,
     self_parameter, where_clause, NoirParser,
 };
-use crate::{ast::{
-    FunctionDefinition, FunctionReturnType, ItemVisibility, NoirFunction, Param, Visibility,
-}, macros_api::UnresolvedTypeData, parser::{ParserError, ParserErrorReason}};
 use crate::parser::spanned;
 use crate::token::{Keyword, Token};
 use crate::{
-    ast::{UnresolvedGeneric, UnresolvedGenerics, Signedness},
+    ast::{
+        FunctionDefinition, FunctionReturnType, ItemVisibility, NoirFunction, Param, Visibility,
+    },
+    macros_api::UnresolvedTypeData,
+    parser::{ParserError, ParserErrorReason},
+};
+use crate::{
+    ast::{Signedness, UnresolvedGeneric, UnresolvedGenerics},
     parser::labels::ParsingRuleLabel,
 };
 
@@ -84,14 +88,16 @@ pub(super) fn numeric_generic() -> impl NoirParser<UnresolvedGeneric> {
         .ignore_then(ident())
         .then_ignore(just(Token::Colon))
         .then(parse_type())
-        .map(|(ident, typ)| {
-            UnresolvedGeneric::Numeric { ident, typ }
-        })
+        .map(|(ident, typ)| UnresolvedGeneric::Numeric { ident, typ })
         .validate(|generic, span, emit| {
+            dbg!(generic.clone());
             if let UnresolvedGeneric::Numeric { typ, .. } = &generic {
                 if let UnresolvedTypeData::Integer(signedness, _) = typ.typ {
                     if matches!(signedness, Signedness::Signed) {
-                        emit(ParserError::with_reason(ParserErrorReason::SignedNumericGeneric, span));
+                        emit(ParserError::with_reason(
+                            ParserErrorReason::SignedNumericGeneric,
+                            span,
+                        ));
                     }
                 }
             }

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -90,7 +90,6 @@ pub(super) fn numeric_generic() -> impl NoirParser<UnresolvedGeneric> {
         .then(parse_type())
         .map(|(ident, typ)| UnresolvedGeneric::Numeric { ident, typ })
         .validate(|generic, span, emit| {
-            dbg!(generic.clone());
             if let UnresolvedGeneric::Numeric { typ, .. } = &generic {
                 if let UnresolvedTypeData::Integer(signedness, _) = typ.typ {
                     if matches!(signedness, Signedness::Signed) {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -62,7 +62,7 @@ pub(crate) fn get_program(src: &str) -> (ParsedModule, Context, Vec<(Compilation
     let (program, parser_errors) = parse_program(src);
     let mut errors = vecmap(parser_errors, |e| (e.into(), root_file_id));
     remove_experimental_warnings(&mut errors);
-    dbg!(!has_parser_error(&errors));
+
     if !has_parser_error(&errors) {
         // Allocate a default Module for the root, giving it a ModuleId
         let mut modules: Arena<ModuleData> = Arena::default();

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -28,7 +28,7 @@ use crate::hir::def_collector::dc_crate::DefCollector;
 use crate::hir_def::expr::HirExpression;
 use crate::hir_def::stmt::HirStatement;
 use crate::monomorphization::monomorphize;
-use crate::parser::{ParserError, ParserErrorReason};
+use crate::parser::ParserErrorReason;
 use crate::ParsedModule;
 use crate::{
     hir::def_map::{CrateDefMap, LocalModuleId},
@@ -2458,29 +2458,4 @@ fn no_super() {
 
     assert_eq!(span.start(), 4);
     assert_eq!(span.end(), 9);
-}
-
-// TODO(https://github.com/noir-lang/noir/issues/5571): This test can be removed once 
-// support is expanded for type-level integers. 
-// This test provides a regression against the panic in https://github.com/noir-lang/noir/issues/5552
-#[test]
-fn numeric_generic_signed() {
-    let src= r"#
-    struct Foo<let N: i8> { }
-
-    fn main() {
-        let _: Foo<-1> = Foo { };
-    }
-    #";
-
-    let errors = get_program_errors(src);
-    dbg!(errors.clone());
-    assert_eq!(errors.len(), 1);
-    let CompilationError::ParseError(parser_error) = &errors[0].0
-    else {
-        panic!("Expected a parser error, got {:?}", errors[0].0);
-    };
-
-    let parser_err_reason = parser_error.reason().expect("Should have a parser error reason");
-    assert!(matches!(parser_err_reason, ParserErrorReason::SignedNumericGeneric));
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5552

## Summary\*

This temporarily disallows signed numeric generics as to prevent the panic in the issue until they are fully supported. In general type-level integers need to be updated to support numeric generics. It is deceiving to not ban them until type-level integers are updated as otherwise users can declare signed numeric generics but not actually use them as per the linked issue.

For the code in the issue we now get this error:
<img width="697" alt="Screenshot 2024-07-19 at 5 41 13 PM" src="https://github.com/user-attachments/assets/17979de7-8c82-40af-aa0f-a32f73992d48">


## Additional Context



## Documentation\*

Check one:
- [] No documentation needed.
- [ ] Documentation included in this PR.
- [X] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
