### PR TITLE
fix: error on duplicate struct field

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -26,6 +26,8 @@ pub enum DuplicateType {
 pub enum DefCollectorErrorKind {
     #[error("duplicate {typ} found in namespace")]
     Duplicate { typ: DuplicateType, first_def: Ident, second_def: Ident },
+    #[error("duplicate struct field {first_def}")]
+    DuplicateField { first_def: Ident, second_def: Ident },
     #[error("unresolved import")]
     UnresolvedModuleDecl { mod_name: Ident, expected_path: String, alternative_path: String },
     #[error("overlapping imports")]
@@ -129,6 +131,23 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
                         first_span,
                     );
                     diag.add_secondary(format!("Second {} found here", &typ), second_span);
+                    diag
+                }
+            }
+            DefCollectorErrorKind::DuplicateField { first_def, second_def } => {
+                let primary_message = format!(
+                    "Duplicate definitions of struct field with name {} found",
+                    &first_def.0.contents
+                );
+                {
+                    let first_span = first_def.0.span();
+                    let second_span = second_def.0.span();
+                    let mut diag = Diagnostic::simple_error(
+                        primary_message,
+                        format!("First definition found here"),
+                        first_span,
+                    );
+                    diag.add_secondary(format!("Second definition found here"), second_span);
                     diag
                 }
             }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2459,3 +2459,31 @@ fn no_super() {
     assert_eq!(span.start(), 4);
     assert_eq!(span.end(), 9);
 }
+
+#[test]
+fn duplicate_struct_field() {
+    let src = r#"
+    struct Foo {
+        x: i32,
+        x: i32,
+    }
+
+    fn main() {}
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::DefinitionError(DefCollectorErrorKind::DuplicateField {
+        first_def,
+        second_def,
+    }) = &errors[0].0
+    else {
+        panic!("Expected a duplicate field error, got {:?}", errors[0].0);
+    };
+
+    assert_eq!(first_def.to_string(), "x");
+    assert_eq!(second_def.to_string(), "x");
+
+    assert_eq!(first_def.span().start(), 26);
+    assert_eq!(second_def.span().start(), 42);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #5030

## Summary

We weren't checking for duplicate struct fields anywhere.

## Additional Context

None.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
