### PR TITLE
fix: let lexer treat unicode whitespace as whitespace

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -654,7 +654,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn is_code_whitespace(c: char) -> bool {
-        c == '\t' || c == '\n' || c == '\r' || c == ' '
+        c.is_whitespace()
     }
 
     /// Skips white space. They are not significant in the source language
@@ -1361,6 +1361,19 @@ mod tests {
             for token in Lexer::new(source) {
                 assert!(token.is_err(), "Expected Err, found {token:?}");
             }
+        }
+    }
+
+    #[test]
+    fn test_unicode_whitespace() {
+        let source = "let\u{00a0}x";
+
+        let expected = vec![Token::Keyword(Keyword::Let), Token::Ident("x".to_string())];
+
+        let mut lexer = Lexer::new(source);
+        for token in expected.into_iter() {
+            let got = lexer.next_token().unwrap();
+            assert_eq!(got, token);
         }
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #5163

## Summary

Instead of just treating ascii whitespace as whitespace, here we treat unicode whitespace as whitespace. I think this is what all modern languages do.

## Additional Context

None.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
