### PR TITLE
feat: Implement `poseidon2_permutation` in comptime interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ version = "0.32.0"
 dependencies = [
  "acvm",
  "base64 0.21.2",
+ "bn254_blackbox_solver",
  "cfg-if 1.0.0",
  "chumsky",
  "fm",

--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [dependencies]
 acvm.workspace = true
+bn254_blackbox_solver.workspace = true
 noirc_arena.workspace = true
 noirc_errors.workspace = true
 noirc_printable_type.workspace = true

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -38,6 +38,7 @@ use super::errors::{IResult, InterpreterError};
 use super::value::{unwrap_rc, Value};
 
 mod builtin;
+mod foreign;
 mod unquote;
 
 #[allow(unused)]
@@ -144,8 +145,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             let builtin = builtin.clone();
             builtin::call_builtin(self.elaborator.interner, &builtin, arguments, location)
         } else if let Some(foreign) = func_attrs.foreign() {
-            let item = format!("Comptime evaluation for foreign functions like {foreign}");
-            Err(InterpreterError::Unimplemented { item, location })
+            let foreign = foreign.clone();
+            foreign::call_foreign(self.elaborator.interner, &foreign, arguments, location)
         } else if let Some(oracle) = func_attrs.oracle() {
             if oracle == "print" {
                 self.print_oracle(arguments)

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -103,6 +103,15 @@ fn get_slice(
     }
 }
 
+pub(super) fn get_field(value: Value, location: Location) -> IResult<FieldElement> {
+    match value {
+        Value::Field(value) => Ok(value),
+        value => {
+            Err(InterpreterError::TypeMismatch { expected: Type::FieldElement, value, location })
+        }
+    }
+}
+
 pub(super) fn get_u32(value: Value, location: Location) -> IResult<u32> {
     match value {
         Value::U32(value) => Ok(value),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -55,7 +55,7 @@ pub(super) fn call_builtin(
     }
 }
 
-fn check_argument_count(
+pub(super) fn check_argument_count(
     expected: usize,
     arguments: &[(Value, Location)],
     location: Location,
@@ -73,6 +73,21 @@ fn failing_constraint<T>(message: impl Into<String>, location: Location) -> IRes
     Err(InterpreterError::FailingConstraint { message, location })
 }
 
+pub(super) fn get_array(
+    interner: &NodeInterner,
+    value: Value,
+    location: Location,
+) -> IResult<(im::Vector<Value>, Type)> {
+    match value {
+        Value::Array(values, typ) => Ok((values, typ)),
+        value => {
+            let type_var = Box::new(interner.next_type_variable());
+            let expected = Type::Array(type_var.clone(), type_var);
+            Err(InterpreterError::TypeMismatch { expected, value, location })
+        }
+    }
+}
+
 fn get_slice(
     interner: &NodeInterner,
     value: Value,
@@ -88,7 +103,7 @@ fn get_slice(
     }
 }
 
-fn get_u32(value: Value, location: Location) -> IResult<u32> {
+pub(super) fn get_u32(value: Value, location: Location) -> IResult<u32> {
     match value {
         Value::U32(value) => Ok(value),
         value => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -1,13 +1,14 @@
-
-use acvm::{AcirField, FieldElement, BlackBoxFunctionSolver};
+use acvm::BlackBoxFunctionSolver;
+use bn254_blackbox_solver::Bn254BlackBoxSolver;
+use iter_extended::try_vecmap;
 use noirc_errors::Location;
 
 use crate::{
-    hir::comptime::{errors::IResult, InterpreterError, Value},
+    hir::comptime::{errors::IResult, interpreter::builtin::get_field, InterpreterError, Value},
     macros_api::NodeInterner,
 };
 
-use super::builtin::{check_argument_count, get_u32, get_array};
+use super::builtin::{check_argument_count, get_array, get_u32};
 
 pub(super) fn call_foreign(
     interner: &mut NodeInterner,
@@ -25,15 +26,23 @@ pub(super) fn call_foreign(
 }
 
 // poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32) -> [Field; N]
-fn posdon2_permutation(
+fn poseidon2_permutation(
     interner: &mut NodeInterner,
     mut arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     check_argument_count(2, &arguments, location)?;
 
-    let state_length = get_u32(arguments.pop().unwrap().0, location);
-    let input = get_array(interner, arguments.pop().unwrap().0, location);
+    let state_length = get_u32(arguments.pop().unwrap().0, location)?;
+    let (input, typ) = get_array(interner, arguments.pop().unwrap().0, location)?;
 
-    let result = Bn254BlackBoxSolver.poseidon2_permutation(inputs, state_length);
+    let input = try_vecmap(input, |integer| get_field(integer, location))?;
+
+    // Currently locked to only bn254!
+    let fields = Bn254BlackBoxSolver
+        .poseidon2_permutation(&input, state_length)
+        .map_err(|error| InterpreterError::BlackBoxError(error, location))?;
+
+    let array = fields.into_iter().map(Value::Field).collect();
+    Ok(Value::Array(array, typ))
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -1,0 +1,39 @@
+
+use acvm::{AcirField, FieldElement, BlackBoxFunctionSolver};
+use noirc_errors::Location;
+
+use crate::{
+    hir::comptime::{errors::IResult, InterpreterError, Value},
+    macros_api::NodeInterner,
+};
+
+use super::builtin::{check_argument_count, get_u32, get_array};
+
+pub(super) fn call_foreign(
+    interner: &mut NodeInterner,
+    name: &str,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    match name {
+        "poseidon2_permutation" => poseidon2_permutation(interner, arguments, location),
+        _ => {
+            let item = format!("Comptime evaluation for builtin function {name}");
+            Err(InterpreterError::Unimplemented { item, location })
+        }
+    }
+}
+
+// poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32) -> [Field; N]
+fn posdon2_permutation(
+    interner: &mut NodeInterner,
+    mut arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    check_argument_count(2, &arguments, location)?;
+
+    let state_length = get_u32(arguments.pop().unwrap().0, location);
+    let input = get_array(interner, arguments.pop().unwrap().0, location);
+
+    let result = Bn254BlackBoxSolver.poseidon2_permutation(inputs, state_length);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves another of the many builtin/foreign functions that still need to be implemented in the interpreter

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
