### PR TITLE
fix: let std::unsafe::zeroed() work for slices

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1595,7 +1595,7 @@ impl<'interner> Monomorphizer<'interner> {
                 self.create_zeroed_function(parameter_types, ret_type, env, location)
             }
             ast::Type::Slice(element_type) => {
-                ast::Expression::Literal(ast::Literal::Array(ast::ArrayLiteral {
+                ast::Expression::Literal(ast::Literal::Slice(ast::ArrayLiteral {
                     contents: vec![],
                     typ: ast::Type::Slice(element_type.clone()),
                 }))

--- a/test_programs/compile_success_empty/zeroed_slice/Nargo.toml
+++ b/test_programs/compile_success_empty/zeroed_slice/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "zeroed_slice"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/zeroed_slice/src/main.nr
+++ b/test_programs/compile_success_empty/zeroed_slice/src/main.nr
@@ -1,0 +1,3 @@
+fn main() {
+    let _: [u8] = std::unsafe::zeroed();
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #5429

## Summary

An incorrect type literal type was being passed.

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
