### PR TITLE
fix: let trait calls work in globals

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -193,6 +193,17 @@ struct FunctionContext {
     trait_constraints: Vec<(TraitConstraint, ExprId)>,
 }
 
+impl FunctionContext {
+    fn default_type_variables(&self) {
+        for typ in &self.type_variables {
+            if let Type::TypeVariable(variable, kind) = typ.follow_bindings() {
+                let msg = "TypeChecker should only track defaultable type vars";
+                variable.bind(kind.default_type().expect(msg));
+            }
+        }
+    }
+}
+
 impl<'context> Elaborator<'context> {
     pub fn new(
         context: &'context mut Context,
@@ -449,14 +460,17 @@ impl<'context> Elaborator<'context> {
     /// all still-unsolved trait constraints in this context.
     fn check_and_pop_function_context(&mut self) {
         let context = self.function_context.pop().expect("Imbalanced function_context pushes");
+        context.default_type_variables();
+        self.verify_trait_constraints(context);
+    }
 
-        for typ in context.type_variables {
-            if let Type::TypeVariable(variable, kind) = typ.follow_bindings() {
-                let msg = "TypeChecker should only track defaultable type vars";
-                variable.bind(kind.default_type().expect(msg));
-            }
-        }
+    /// Similar to `check_and_pop_function_context` but doesn't default all type varialbes.
+    fn check_trait_constraints_and_pop_function_context(&mut self) {
+        let context = self.function_context.pop().expect("Imbalanced function_context pushes");
+        self.verify_trait_constraints(context);
+    }
 
+    fn verify_trait_constraints(&mut self, context: FunctionContext) {
         for (mut constraint, expr_id) in context.trait_constraints {
             let span = self.interner.expr_span(&expr_id);
 
@@ -1339,7 +1353,10 @@ impl<'context> Elaborator<'context> {
 
         let comptime = let_stmt.comptime;
 
+        self.function_context.push(FunctionContext::default());
         let (let_statement, _typ) = self.elaborate_let(let_stmt, Some(global_id));
+        self.check_trait_constraints_and_pop_function_context();
+
         let statement_id = self.interner.get_global(global_id).let_statement;
         self.interner.replace_statement(statement_id, let_statement);
 

--- a/test_programs/compile_success_empty/trait_call_in_global/Nargo.toml
+++ b/test_programs/compile_success_empty/trait_call_in_global/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "trait_call_in_global"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/trait_call_in_global/src/main.nr
+++ b/test_programs/compile_success_empty/trait_call_in_global/src/main.nr
@@ -1,0 +1,5 @@
+global s: BoundedVec<Field, 2> = From::from([0]);
+
+fn main() {
+    println(s);
+}

--- a/test_programs/compile_success_empty/trait_call_in_global/src/main.nr
+++ b/test_programs/compile_success_empty/trait_call_in_global/src/main.nr
@@ -1,3 +1,5 @@
 global s: BoundedVec<Field, 2> = From::from([0]);
 
-fn main() {}
+fn main() {
+    let _ = s;
+}

--- a/test_programs/compile_success_empty/trait_call_in_global/src/main.nr
+++ b/test_programs/compile_success_empty/trait_call_in_global/src/main.nr
@@ -1,5 +1,3 @@
 global s: BoundedVec<Field, 2> = From::from([0]);
 
-fn main() {
-    println(s);
-}
+fn main() {}


### PR DESCRIPTION
# Description

## Problem

Resolves #5029

## Summary

Trait constraints weren't checked after elaborating a global.

## Additional Context

I couldn't just call `check_and_pop_function_context()` because that also defaults type variables... and if we do that the usage of a global will not have an effect on its type. I guess this is one scenario:

```rust
global x = 1; // What's the type of x?
```

We don't know. I guess it ends up being `Field` later on (where?) But if we have this:

```rust
global x = 1;

fn main() {
  let y: i32 = 0;
  assert_eq(x, y);
}
```

now x's type will be `i32` because of that comparison. So if we eagerly bind `1` to its default type, this will break.

All of this to say: in Rust a global's type (well, for a `const`) must be explicitly specified. I guess that if we also did that in Noir then this wouldn't be a problem. And given that globals are, well, global, it might be strange to have `global x = 1` expecting that to be a Field, used as a Field in many places, but you accidentally compare it to an `i32` and the type changes under the hood. But that's a bigger discussion, so maybe the fix in this PR is good for now?

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
