### PR TITLE
fix: Lazily elaborate functions in comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -1,9 +1,4 @@
-use std::mem::replace;
-
-use crate::{
-    hir_def::expr::HirIdent,
-    node_interner::{DependencyId, FuncId},
-};
+use crate::{hir_def::expr::HirIdent, node_interner::FuncId};
 
 use super::{Elaborator, FunctionContext, ResolverMeta};
 
@@ -11,42 +6,35 @@ impl<'context> Elaborator<'context> {
     /// Elaborate an expression from the middle of a comptime scope.
     /// When this happens we require additional information to know
     /// what variables should be in scope.
-    pub fn elaborate_item_from_comptime<T>(
-        &mut self,
+    pub fn elaborate_item_from_comptime<'a, T>(
+        &'a mut self,
         current_function: Option<FuncId>,
-        f: impl FnOnce(&mut Self) -> T,
+        f: impl FnOnce(&mut Elaborator<'a>) -> T,
     ) -> T {
-        self.function_context.push(FunctionContext::default());
-        let old_scope = self.scopes.end_function();
-        self.scopes.start_function();
-        let function_id = current_function.map(DependencyId::Function);
-        let old_item = replace(&mut self.current_item, function_id);
+        // Create a fresh elaborator to ensure no state is changed from
+        // this elaborator
+        let mut elaborator = Elaborator::new(
+            self.interner,
+            self.def_maps,
+            self.crate_id,
+            self.debug_comptime_in_file,
+        );
 
-        // Note: recover_generics isn't good enough here because any existing generics
-        // should not be in scope of this new function
-        let old_generics = std::mem::take(&mut self.generics);
+        elaborator.function_context.push(FunctionContext::default());
+        elaborator.scopes.start_function();
 
-        let old_crate_and_module = current_function.map(|function| {
-            let meta = self.interner.function_meta(&function);
-            let old_crate = replace(&mut self.crate_id, meta.source_crate);
-            let old_module = replace(&mut self.local_module, meta.source_module);
-            self.introduce_generics_into_scope(meta.all_generics.clone());
-            (old_crate, old_module)
-        });
-
-        self.populate_scope_from_comptime_scopes();
-        let result = f(self);
-
-        if let Some((old_crate, old_module)) = old_crate_and_module {
-            self.crate_id = old_crate;
-            self.local_module = old_module;
+        if let Some(function) = current_function {
+            let meta = elaborator.interner.function_meta(&function);
+            elaborator.crate_id = meta.source_crate;
+            elaborator.local_module = meta.source_module;
+            elaborator.introduce_generics_into_scope(meta.all_generics.clone());
         }
 
-        self.generics = old_generics;
-        self.current_item = old_item;
-        self.scopes.end_function();
-        self.scopes.0.push(old_scope);
-        self.check_and_pop_function_context();
+        elaborator.populate_scope_from_comptime_scopes();
+        let result = f(&mut elaborator);
+        elaborator.check_and_pop_function_context();
+
+        self.errors.append(&mut elaborator.errors);
         result
     }
 

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -395,6 +395,7 @@ impl<'context> Elaborator<'context> {
         self.local_module = func_meta.source_module;
         self.file = func_meta.source_file;
         self.self_type = func_meta.self_type.clone();
+        self.current_trait_impl = func_meta.trait_impl;
 
         self.scopes.start_function();
         let old_item = std::mem::replace(&mut self.current_item, Some(DependencyId::Function(id)));

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -413,7 +413,7 @@ impl<'context> Elaborator<'context> {
         path: &Path,
     ) -> Option<(TraitMethodId, TraitConstraint, bool)> {
         let trait_impl = self.current_trait_impl?;
-        let trait_id = self.interner.get_trait_implementation(trait_impl).borrow().trait_id;
+        let trait_id = self.interner.try_get_trait_implementation(trait_impl)?.borrow().trait_id;
 
         if path.kind == PathKind::Plain && path.segments.len() == 2 {
             let name = &path.segments[0].0.contents;

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -412,7 +412,8 @@ impl<'context> Elaborator<'context> {
         &mut self,
         path: &Path,
     ) -> Option<(TraitMethodId, TraitConstraint, bool)> {
-        let trait_id = self.trait_id?;
+        let trait_impl = self.current_trait_impl?;
+        let trait_id = self.interner.get_trait_implementation(trait_impl).borrow().trait_id;
 
         if path.kind == PathKind::Plain && path.segments.len() == 2 {
             let name = &path.segments[0].0.contents;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -10,6 +10,7 @@ use crate::ast::{BinaryOpKind, FunctionKind, IntegerBitSize, Signedness};
 use crate::elaborator::Elaborator;
 use crate::graph::CrateId;
 use crate::hir_def::expr::ImplKind;
+use crate::hir_def::function::FunctionBody;
 use crate::macros_api::UnaryOp;
 use crate::monomorphization::{
     perform_impl_bindings, perform_instantiation_bindings, resolve_trait_method,
@@ -134,16 +135,33 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             self.define_pattern(parameter, typ, argument, arg_location)?;
         }
 
-        let function_body =
-            self.elaborator.interner.function(&function).try_as_expr().ok_or_else(|| {
-                let function = self.elaborator.interner.function_name(&function).to_owned();
-                InterpreterError::NonComptimeFnCallInSameCrate { function, location }
-            })?;
-
+        let function_body = self.get_function_body(function, location)?;
         let result = self.evaluate(function_body)?;
-
         self.exit_function(previous_state);
         Ok(result)
+    }
+
+    /// Try to retrieve a function's body.
+    /// If the function has not yet been resolved this will attempt to lazily resolve it.
+    /// Afterwards, if the function's body is still not known or the function is still
+    /// in a Resolving state we issue an error.
+    fn get_function_body(&mut self, function: FuncId, location: Location) -> IResult<ExprId> {
+        let meta = self.elaborator.interner.function_meta(&function);
+        match self.elaborator.interner.function(&function).try_as_expr() {
+            Some(body) => Ok(body),
+            None => {
+                if matches!(&meta.function_body, FunctionBody::Unresolved(..)) {
+                    self.elaborator.elaborate_item_from_comptime(None, |elaborator| {
+                        elaborator.elaborate_function(function);
+                    });
+
+                    self.get_function_body(function, location)
+                } else {
+                    let function = self.elaborator.interner.function_name(&function).to_owned();
+                    Err(InterpreterError::NonComptimeFnCallInSameCrate { function, location })
+                }
+            }
+        }
     }
 
     fn call_special(

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -48,10 +48,12 @@ impl ModuleId {
 }
 
 impl ModuleId {
-    pub fn module(self, def_maps: &BTreeMap<CrateId, CrateDefMap>) -> &ModuleData {
+    pub fn module(self, def_maps: &DefMaps) -> &ModuleData {
         &def_maps[&self.krate].modules()[self.local_id.0]
     }
 }
+
+pub type DefMaps = BTreeMap<CrateId, CrateDefMap>;
 
 /// Map of all modules and scopes defined within a crate.
 ///

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -1,3 +1,4 @@
+use fm::FileId;
 use iter_extended::vecmap;
 use noirc_errors::{Location, Span};
 
@@ -156,6 +157,13 @@ pub struct FuncMeta {
 
     /// The module this function was defined in
     pub source_module: LocalModuleId,
+
+    /// THe file this function was defined in
+    pub source_file: FileId,
+
+    /// If this function is from an impl (trait or regular impl), this
+    /// is the object type of the impl. Otherwise this is None.
+    pub self_type: Option<Type>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/5538#issuecomment-2237533285

## Summary\*

If a function with an empty body is found within the comptime interpreter we now lazily elaborate it instead of failing with an error.

## Additional Context

The test for this is `noir_test_success_comptime_globals` which after #5538 requires lazy elaboration due to comptime globals themselves now being elaborated before functions.

This PR opens the way to be more lax about marking functions `comptime` and potentially lets us remove the restriction that you can only call non-comptime functions in separate modules.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
