### PR TITLE
chore: Display comptime assertion errors, not Debug

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -207,7 +207,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             }
             InterpreterError::FailingConstraint { message, location } => {
                 let (primary, secondary) = match message {
-                    Some(msg) => (format!("{msg:?}"), "Assertion failed".into()),
+                    Some(msg) => (format!("{msg}"), "Assertion failed".into()),
                     None => ("Assertion failed".into(), String::new()),
                 };
                 CustomDiagnostic::simple_error(primary, secondary, location.span)


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Changes:
```
error: FormatString("No derive function registered for `quote { Default }`", fmtstr<53, (Quoted)>)
   ┌─ /.../derive/src/main.nr:19:16
   │
19 │         assert(handler.is_some(), f"No derive function registered for `{trait_to_derive}`");
   │                ----------------- Assertion failed
   │
```

To:
```
error: No derive function registered for `quote { Default }`
   ┌─ /.../derive/src/main.nr:19:16
   │
19 │         assert(handler.is_some(), f"No derive function registered for `{trait_to_derive}`");
   │                ----------------- Assertion failed
   │
```

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
