### PR TITLE
chore: fix `slice_regex` name in Nargo.toml

### DIFF
--- a/test_programs/execution_success/slice_regex/Nargo.toml
+++ b/test_programs/execution_success/slice_regex/Nargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "regex"
+name = "slice_regex"
 type = "bin"
 authors = [""]
 compiler_version = ">=0.31.0"


### PR DESCRIPTION
# Description

## Problem

CI is failing for all PRs.

## Summary



## Additional Context

I wonder if we should have a CI script to check these? It's also strange that they go through CI.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
