### PR TITLE
feat: turbofish in struct pattern

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -461,6 +461,18 @@ pub struct PathSegment {
     pub span: Span,
 }
 
+impl PathSegment {
+    /// Returns the span where turbofish happen. For example:
+    ///
+    ///    foo::<T>
+    ///       ~^^^^
+    ///
+    /// Returns an empty span at the end of `foo` if there's no turbofish.
+    pub fn turbofish_span(&self) -> Span {
+        Span::from(self.ident.span().end()..self.span.end())
+    }
+}
+
 impl From<Ident> for PathSegment {
     fn from(ident: Ident) -> PathSegment {
         let span = ident.span();

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -430,11 +430,13 @@ impl<'context> Elaborator<'context> {
             }
         };
 
+        let turbofish_span = last_segment.turbofish_span();
+
         let struct_generics = self.resolve_struct_turbofish_generics(
             &r#type.borrow(),
             struct_generics,
             last_segment.generics,
-            Span::from(last_segment.ident.span().end()..last_segment.span.end()),
+            turbofish_span,
         );
 
         let struct_type = r#type.clone();

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -430,23 +430,12 @@ impl<'context> Elaborator<'context> {
             }
         };
 
-        let struct_generics = if let Some(turbofish_generics) = &last_segment.generics {
-            if turbofish_generics.len() == struct_generics.len() {
-                let struct_type = r#type.borrow();
-                self.resolve_turbofish_generics(&struct_type.generics, turbofish_generics.clone())
-            } else {
-                self.push_err(TypeCheckError::GenericCountMismatch {
-                    item: format!("struct {}", last_segment.ident),
-                    expected: struct_generics.len(),
-                    found: turbofish_generics.len(),
-                    span: Span::from(last_segment.ident.span().end()..last_segment.span.end()),
-                });
-
-                struct_generics
-            }
-        } else {
-            struct_generics
-        };
+        let struct_generics = self.resolve_struct_turbofish_generics(
+            &r#type.borrow(),
+            struct_generics,
+            last_segment.generics,
+            Span::from(last_segment.ident.span().end()..last_segment.span.end()),
+        );
 
         let struct_type = r#type.clone();
         let generics = struct_generics.clone();

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -182,11 +182,13 @@ impl<'context> Elaborator<'context> {
             }
         };
 
+        let turbofish_span = last_segment.turbofish_span();
+
         let generics = self.resolve_struct_turbofish_generics(
             &struct_type.borrow(),
             generics,
             last_segment.generics,
-            Span::from(last_segment.ident.span().end()..last_segment.span.end()),
+            turbofish_span,
         );
 
         let actual_type = Type::Struct(struct_type.clone(), generics);

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -453,7 +453,7 @@ impl<'context> Elaborator<'context> {
                 item: format!("struct {}", struct_type.name),
                 expected: generics.len(),
                 found: turbofish_generics.len(),
-                span: span,
+                span,
             });
             return generics;
         }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1623,8 +1623,7 @@ impl<'context> Elaborator<'context> {
             }
 
             if segment.generics.is_some() {
-                // From "foo::<T>", create a span for just "::<T>"
-                let span = Span::from(segment.ident.span().end()..segment.span.end());
+                let span = segment.turbofish_span();
                 self.push_err(TypeCheckError::UnsupportedTurbofishUsage { span });
             }
         }

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -559,7 +559,7 @@ fn pattern() -> impl NoirParser<Pattern> {
             .separated_by(just(Token::Comma))
             .delimited_by(just(Token::LeftBrace), just(Token::RightBrace));
 
-        let struct_pattern = path()
+        let struct_pattern = path(super::parse_type())
             .then(struct_pattern_fields)
             .map_with_span(|(typename, fields), span| Pattern::Struct(typename, fields, span));
 
@@ -1130,7 +1130,7 @@ fn constructor(expr_parser: impl ExprParser) -> impl NoirParser<ExpressionKind> 
         .allow_trailing()
         .delimited_by(just(Token::LeftBrace), just(Token::RightBrace));
 
-    path().then(args).map(ExpressionKind::constructor)
+    path(super::parse_type()).then(args).map(ExpressionKind::constructor)
 }
 
 fn constructor_field<P>(expr_parser: P) -> impl NoirParser<(Ident, Expression)>

--- a/compiler/noirc_frontend/src/parser/parser/primitives.rs
+++ b/compiler/noirc_frontend/src/parser/parser/primitives.rs
@@ -33,10 +33,14 @@ pub(super) fn token_kind(token_kind: TokenKind) -> impl NoirParser<Token> {
     })
 }
 
-pub(super) fn path_segment() -> impl NoirParser<PathSegment> {
-    ident()
-        .then(turbofish(super::parse_type()))
-        .map_with_span(|(ident, generics), span| PathSegment { ident, generics, span })
+pub(super) fn path_segment<'a>(
+    type_parser: impl NoirParser<UnresolvedType> + 'a,
+) -> impl NoirParser<PathSegment> + 'a {
+    ident().then(turbofish(type_parser)).map_with_span(|(ident, generics), span| PathSegment {
+        ident,
+        generics,
+        span,
+    })
 }
 
 pub(super) fn path_segment_no_turbofish() -> impl NoirParser<PathSegment> {
@@ -96,7 +100,7 @@ pub(super) fn turbofish<'a>(
 }
 
 pub(super) fn variable() -> impl NoirParser<ExpressionKind> {
-    path().map(ExpressionKind::Variable)
+    path(super::parse_type()).map(ExpressionKind::Variable)
 }
 
 pub(super) fn variable_no_turbofish() -> impl NoirParser<ExpressionKind> {

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -1,4 +1,4 @@
-use super::path::{path, path_no_turbofish};
+use super::path::path_no_turbofish;
 use super::primitives::token_kind;
 use super::{
     expression_with_precedence, keyword, nothing, parenthesized, NoirParser, ParserError,
@@ -181,9 +181,9 @@ pub(super) fn int_type() -> impl NoirParser<UnresolvedType> {
 pub(super) fn named_type<'a>(
     type_parser: impl NoirParser<UnresolvedType> + 'a,
 ) -> impl NoirParser<UnresolvedType> + 'a {
-    path(type_parser.clone()).then(generic_type_args(type_parser)).map_with_span(
-        |(path, args), span| UnresolvedTypeData::Named(path, args, false).with_span(span),
-    )
+    path_no_turbofish().then(generic_type_args(type_parser)).map_with_span(|(path, args), span| {
+        UnresolvedTypeData::Named(path, args, false).with_span(span)
+    })
 }
 
 pub(super) fn named_trait<'a>(

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -1,4 +1,4 @@
-use super::path::path_no_turbofish;
+use super::path::{path, path_no_turbofish};
 use super::primitives::token_kind;
 use super::{
     expression_with_precedence, keyword, nothing, parenthesized, NoirParser, ParserError,
@@ -181,9 +181,9 @@ pub(super) fn int_type() -> impl NoirParser<UnresolvedType> {
 pub(super) fn named_type<'a>(
     type_parser: impl NoirParser<UnresolvedType> + 'a,
 ) -> impl NoirParser<UnresolvedType> + 'a {
-    path_no_turbofish().then(generic_type_args(type_parser)).map_with_span(|(path, args), span| {
-        UnresolvedTypeData::Named(path, args, false).with_span(span)
-    })
+    path(type_parser.clone()).then(generic_type_args(type_parser)).map_with_span(
+        |(path, args), span| UnresolvedTypeData::Named(path, args, false).with_span(span),
+    )
 }
 
 pub(super) fn named_trait<'a>(

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2610,3 +2610,58 @@ fn turbofish_in_middle_of_variable_unsupported_yet() {
         CompilationError::TypeError(TypeCheckError::UnsupportedTurbofishUsage { .. }),
     ));
 }
+
+#[test]
+fn turbofish_in_struct_pattern() {
+    let src = r#"
+    struct Foo<T> {
+        x: T
+    }
+
+    fn main() {
+        let value: Field = 0;
+        let Foo::<i32> { x } = Foo { x: value };
+        let _ = x;
+    }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::TypeMismatchWithSource { .. }) = &errors[0].0
+    else {
+        panic!("Expected a type mismatch error, got {:?}", errors[0].0);
+    };
+}
+
+#[test]
+fn turbofish_in_struct_pattern_generic_count_mismatch() {
+    let src = r#"
+    struct Foo<T> {
+        x: T
+    }
+
+    fn main() {
+        let value = 0;
+        let Foo::<i32, i64> { x } = Foo { x: value };
+        let _ = x;
+    }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::GenericCountMismatch {
+        item,
+        expected,
+        found,
+        ..
+    }) = &errors[0].0
+    else {
+        panic!("Expected a generic count mismatch error, got {:?}", errors[0].0);
+    };
+
+    assert_eq!(item, "struct Foo");
+    assert_eq!(*expected, 1);
+    assert_eq!(*found, 2);
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2620,6 +2620,22 @@ fn turbofish_in_struct_pattern() {
 
     fn main() {
         let value: Field = 0;
+        let Foo::<Field> { x } = Foo { x: value };
+        let _ = x;
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn turbofish_in_struct_pattern_errors_if_type_mismatch() {
+    let src = r#"
+    struct Foo<T> {
+        x: T
+    }
+
+    fn main() {
+        let value: Field = 0;
         let Foo::<i32> { x } = Foo { x: value };
         let _ = x;
     }


### PR DESCRIPTION
# Description

## Problem

Part of https://github.com/noir-lang/noir/issues/5584

## Summary

Allows parsing turbofish in a struct pattern path segments, then uses those turbofish generics for type binding/inference.

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
