### PR TITLE
fix: error on unbound generics in structs

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1053,13 +1053,15 @@ impl<'interner> Monomorphizer<'interner> {
             | HirType::Integer(..)
             | HirType::Bool
             | HirType::String(..)
-            | HirType::Unit => None,
+            | HirType::Unit
+            | HirType::TraitAsType(..)
+            | HirType::Forall(_, _)
+            | HirType::Constant(_)
+            | HirType::Error
+            | HirType::Quoted(_) => None,
             HirType::FmtString(_size, fields) => Self::check_type(fields.as_ref(), location),
             HirType::Array(_length, element) => Self::check_type(element.as_ref(), location),
             HirType::Slice(element) => Self::check_type(element.as_ref(), location),
-            HirType::TraitAsType(..) => {
-                unreachable!("All TraitAsType should be replaced before calling convert_type");
-            }
             HirType::NamedGeneric(binding, _, _) => {
                 if let TypeBinding::Bound(binding) = &*binding.borrow() {
                     return Self::check_type(binding, location);
@@ -1118,11 +1120,6 @@ impl<'interner> Monomorphizer<'interner> {
             }
 
             HirType::MutableReference(element) => Self::check_type(element, location),
-
-            HirType::Forall(_, _) | HirType::Constant(_) | HirType::Error => {
-                unreachable!("Unexpected type {} found", typ)
-            }
-            HirType::Quoted(_) => unreachable!("Tried to translate Code type into runtime code"),
         }
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -977,17 +977,8 @@ impl<'interner> Monomorphizer<'interner> {
             }
 
             HirType::Struct(def, args) => {
-                // Even though we later call `convert_type` on `fields`, it might be the types
-                // in `args` end up not being part of fields. For example:
-                //
-                //     struct Foo<let N: u32> {}
-                //
-                //     fn main() {
-                //         let _ = Foo {};
-                //     }
-                //
-                // In the above case args is `[N]` but fields is `[]`, so T will never be checked.
-                // However, we want the above program to not compile.
+                // Not all generic arguments may be used in a struct's fields so we have to check
+                // the arguments as well as the fields in case any need to be defaulted or are unbound.
                 for arg in args {
                     if let Some(error) = Self::check_type(arg, location) {
                         return Err(error);

--- a/test_programs/compile_failure/type_annotation_needed_on_struct_constructor/Nargo.toml
+++ b/test_programs/compile_failure/type_annotation_needed_on_struct_constructor/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "type_annotation_needed_on_struct_constructor"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_failure/type_annotation_needed_on_struct_constructor/src/main.nr
+++ b/test_programs/compile_failure/type_annotation_needed_on_struct_constructor/src/main.nr
@@ -1,0 +1,6 @@
+struct Foo<T> {
+}
+
+fn main() {
+    let foo = Foo {};
+}

--- a/test_programs/compile_failure/type_annotation_needed_on_struct_new/Nargo.toml
+++ b/test_programs/compile_failure/type_annotation_needed_on_struct_new/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "type_annotation_needed_on_struct_new"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_failure/type_annotation_needed_on_struct_new/src/main.nr
+++ b/test_programs/compile_failure/type_annotation_needed_on_struct_new/src/main.nr
@@ -1,0 +1,12 @@
+struct Foo<T> {
+}
+
+impl <T> Foo<T> {
+    fn new() -> Foo<T> {
+        Foo {}
+    }
+}
+
+fn main() {
+    let foo = Foo::new();
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #5436

## Summary

The monomorphizer checks that no types exist that aren't unbound and can't have a default type. This is also the case for structs, but this check is done on field types after they are paired with generics. For example:

```rust
struct Foo<T> {
  x: T
}

fn main() {
  let _ = Foo { x: 1 };
}
```

Here we pair `T` with the generic type of 1, then it's defaulted to `Field`, no error.

However, it can happen that a generic parameter isn't mentioned at all in a struct field. For example:

```rust
struct Foo<T> {
}

fn main() {
  let _ = Foo {};
}
```

Here `T` isn't paired with anything, so it's left unbound. However, because we only check that the resulting field types aren't unbound, no error happens.

The solution in this PR is to check that generic parameters aren't unbound. This required a method like `convert_type`, called `check_type`, that only checks for this errors. The reason is that I wanted to avoid converting types twice. But let me know if that would be fine (or if there's another solution for this).

## Additional Context

In Rust if a generic parameter isn't used in a field, an error about that is made. However, no error happens if the generic parameter is a `const` (similar to a `let N: u32` parameter in Noir) so here I chose to error un unbound generics, not check if a generic is unused.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
