### PR TITLE
feat: allow inserting LSP inlay type hints

### DIFF
--- a/tooling/lsp/test_programs/inlay_hints/src/main.nr
+++ b/tooling/lsp/test_programs/inlay_hints/src/main.nr
@@ -92,3 +92,6 @@ fn call_yet_another_function() {
     yet_another_function(some_name) // Should not show parameter names ("name" is a suffix of "some_name")
 }
 
+fn struct_member_hint() {
+    let SomeStruct { one } = SomeStruct { one: 1 };
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #5527

## Summary

Makes type hints insertable, though not all of them can be inserted. For example a for variable can't have a type annotation, and a struct member pattern can't either.

I also added a test for when the type hint is shown for a struct member pattern, which was missing (mainly to assert that the type there isn't insertable).


https://github.com/user-attachments/assets/b3a02f2b-be82-49b5-9ac5-cebf8cb83214



## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
