### PR TITLE
fix: error on incorrect generic count for impl and type alias

### DIFF
--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2610,3 +2610,55 @@ fn turbofish_in_middle_of_variable_unsupported_yet() {
         CompilationError::TypeError(TypeCheckError::UnsupportedTurbofishUsage { .. }),
     ));
 }
+
+#[test]
+fn incorrect_generic_count_on_struct_impl() {
+    let src = r#"
+    struct Foo {}
+
+    impl <T> Foo<T> {}
+
+    fn main() {}
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ResolverError(ResolverError::IncorrectGenericCount {
+        actual,
+        expected,
+        ..
+    }) = errors[0].0
+    else {
+        panic!("Expected an incorrect generic count mismatch error, got {:?}", errors[0].0);
+    };
+
+    assert_eq!(actual, 1);
+    assert_eq!(expected, 0);
+}
+
+#[test]
+fn incorrect_generic_count_on_type_alias() {
+    let src = r#"
+    struct Foo {}
+
+    type Bar = Foo<i32>;
+
+    fn main() {}
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ResolverError(ResolverError::IncorrectGenericCount {
+        actual,
+        expected,
+        ..
+    }) = errors[0].0
+    else {
+        panic!("Expected an incorrect generic count mismatch error, got {:?}", errors[0].0);
+    };
+
+    assert_eq!(actual, 1);
+    assert_eq!(expected, 0);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #5583

## Summary

There's a call, `verify_generics_count`, that's supposed to do this check. The problem is that the `args` given to it are the results of zipping the struct's generics with the given generics. That will always produce an `args` the size of the smallest of the two. So, if a struct doesn't have generics, `args` will end up empty and no error is produced. However, if a struct has more generics than given, an error was correctly produced. The solution is to get the actual and expected numbers before shadowing `args`.

## Additional Context

In Rust this program gives two errors:

```rust
struct Foo {}

impl Foo<T> {}

fn main() { }
```

1. cannot find T in this scope
2. struct takes 0 generic arguments but 1 generic argument was supplied

With this PR, in Noir we'll be just giving one error (the second one). The reason is that only generics that match the struct generics count are checked. I thought about changing the code to produce the same number of errors as Rust... but I didn't know if it was worth it. Here you'll get the "incorrect generics count" error, so you'll have to fix that by either removing the generic (solved) or by adding a generic to `struct Foo` (likely not what you are going to do), at which point you'll get the other error... so I thought that with just one error it's good enough.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
