### PR TITLE
fix: allow using Self for function calls

### DIFF
--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2773,3 +2773,39 @@ fn uses_self_type_inside_trait() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn uses_self_type_in_trait_where_clause() {
+    let src = r#"
+    trait Trait {
+        fn trait_func() -> bool;
+    }
+
+    trait Foo where Self: Trait {
+        fn foo(self) -> bool {
+            self.trait_func()
+        }
+    }
+
+    struct Bar {
+
+    }
+
+    impl Foo for Bar {
+
+    }
+
+    fn main() {}
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::UnresolvedMethodCall { method_name, .. }) =
+        &errors[0].0
+    else {
+        panic!("Expected an unresolved method call error, got {:?}", errors[0].0);
+    };
+
+    assert_eq!(method_name, "trait_func");
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2729,3 +2729,23 @@ fn incorrect_generic_count_on_type_alias() {
     assert_eq!(actual, 1);
     assert_eq!(expected, 0);
 }
+
+#[test]
+fn uses_self_for_struct_function_call() {
+    let src = r#"
+    struct S { }
+
+    impl S {
+        fn one() -> Field {
+            1
+        }
+
+        fn two() -> Field {
+            Self::one() + Self::one()
+        }
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2731,7 +2731,7 @@ fn incorrect_generic_count_on_type_alias() {
 }
 
 #[test]
-fn uses_self_for_struct_function_call() {
+fn uses_self_type_for_struct_function_call() {
     let src = r#"
     struct S { }
 
@@ -2746,6 +2746,30 @@ fn uses_self_for_struct_function_call() {
     }
 
     fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn uses_self_type_inside_trait() {
+    let src = r#"
+    trait Foo {
+        fn foo() -> Self {
+            Self::bar()
+        }
+
+        fn bar() -> Self;
+    }
+
+    impl Foo for Field {
+        fn bar() -> Self {
+            1
+        }
+    }
+
+    fn main() {
+        let _: Field = Foo::foo();
+    }
     "#;
     assert_no_errors(src);
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #1791

## Summary

When resolving a path (any path), we now check if the first segment is `Self` (a similar check is done in another places of our codebase). If so, resolve the next path segments relative to that type. Only struct types are supported here... in theory a trait type can also show up, but that case is handled as a special case in the compiler. I'll create a follow-up PR removing that special case and seeing if it works.

## Additional Context

None.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
