### PR TITLE
feat: let filenames in errors be relative to the current dir if possible

### DIFF
--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::{collections::HashMap, future::Future};
 
 use crate::insert_all_files_for_workspace_into_file_manager;
@@ -324,7 +325,12 @@ where
     let file_name = files.name(file_id).ok()?;
 
     let path = file_name.to_string();
-    let uri = Url::from_file_path(path).ok()?;
+
+    // `path` might be a relative path so we canonicalize it to get an absolute path
+    let path_buf = PathBuf::from(path);
+    let path_buf = path_buf.canonicalize().unwrap_or(path_buf);
+
+    let uri = Url::from_file_path(path_buf.to_str()?).ok()?;
 
     Some(Location { uri, range })
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #5641

## Summary

It seems `FileMap`'s `name` function was the one that needed that change.

To avoid doing a syscall to get the current directory every time a name is needed, `FileMap` gets it at the beginning of the program. I think this is fine as the current directory can't change while the compilation is happening.

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
