### PR TITLE
fix: Fix evaluation of globals from other crates

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -59,13 +59,11 @@ impl<'context> Elaborator<'context> {
             elaborator.introduce_generics_into_scope(meta.all_generics.clone());
         }
 
-        elaborator.comptime_scopes = std::mem::take(&mut self.comptime_scopes);
         elaborator.populate_scope_from_comptime_scopes();
 
         let result = f(&mut elaborator);
         elaborator.check_and_pop_function_context();
 
-        self.comptime_scopes = elaborator.comptime_scopes;
         self.errors.append(&mut elaborator.errors);
         result
     }
@@ -74,7 +72,7 @@ impl<'context> Elaborator<'context> {
         // Take the comptime scope to be our runtime scope.
         // Iterate from global scope to the most local scope so that the
         // later definitions will naturally shadow the former.
-        for scope in &self.comptime_scopes {
+        for scope in &self.interner.comptime_scopes {
             for definition_id in scope.keys() {
                 let definition = self.interner.definition(*definition_id);
                 let name = definition.name.clone();

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -6,7 +6,6 @@ use std::{
 use crate::{
     ast::{FunctionKind, UnresolvedTraitConstraint},
     hir::{
-        comptime::Value,
         def_collector::dc_crate::{
             filter_literal_globals, CompilationError, ImplMap, UnresolvedGlobal, UnresolvedStruct,
             UnresolvedTypeAlias,
@@ -27,8 +26,7 @@ use crate::{
         SecondaryAttribute, StructId,
     },
     node_interner::{
-        DefinitionId, DefinitionKind, DependencyId, ExprId, FuncId, GlobalId, ReferenceId, TraitId,
-        TypeAliasId,
+        DefinitionKind, DependencyId, ExprId, FuncId, GlobalId, ReferenceId, TraitId, TypeAliasId,
     },
     Shared, Type, TypeVariable,
 };
@@ -68,7 +66,6 @@ mod unquote;
 use fm::FileId;
 use iter_extended::vecmap;
 use noirc_errors::{Location, Span};
-use rustc_hash::FxHashMap as HashMap;
 
 use self::traits::check_trait_impl_method_matches_declaration;
 
@@ -157,11 +154,6 @@ pub struct Elaborator<'context> {
 
     crate_id: CrateId,
 
-    /// Each value currently in scope in the comptime interpreter.
-    /// Each element of the Vec represents a scope with every scope together making
-    /// up all currently visible definitions. The first scope is always the global scope.
-    pub(crate) comptime_scopes: Vec<HashMap<DefinitionId, Value>>,
-
     /// The scope of --debug-comptime, or None if unset
     debug_comptime_in_file: Option<FileId>,
 
@@ -209,7 +201,6 @@ impl<'context> Elaborator<'context> {
             trait_bounds: Vec::new(),
             function_context: vec![FunctionContext::default()],
             current_trait_impl: None,
-            comptime_scopes: vec![HashMap::default()],
             debug_comptime_in_file,
             unresolved_globals: BTreeMap::new(),
         }

--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -144,12 +144,12 @@ impl<'context> Elaborator<'context> {
 
     pub fn push_scope(&mut self) {
         self.scopes.start_scope();
-        self.comptime_scopes.push(Default::default());
+        self.interner.comptime_scopes.push(Default::default());
     }
 
     pub fn pop_scope(&mut self) {
         let scope = self.scopes.end_scope();
-        self.comptime_scopes.pop();
+        self.interner.comptime_scopes.pop();
         self.check_for_unused_variables_in_scope_tree(scope.into());
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -258,8 +258,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     pub(super) fn enter_function(&mut self) -> (bool, Vec<HashMap<DefinitionId, Value>>) {
         // Drain every scope except the global scope
         let mut scope = Vec::new();
-        if self.elaborator.comptime_scopes.len() > 1 {
-            scope = self.elaborator.comptime_scopes.drain(1..).collect();
+        if self.elaborator.interner.comptime_scopes.len() > 1 {
+            scope = self.elaborator.interner.comptime_scopes.drain(1..).collect();
         }
         self.push_scope();
         (std::mem::take(&mut self.in_loop), scope)
@@ -269,21 +269,21 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         self.in_loop = state.0;
 
         // Keep only the global scope
-        self.elaborator.comptime_scopes.truncate(1);
-        self.elaborator.comptime_scopes.append(&mut state.1);
+        self.elaborator.interner.comptime_scopes.truncate(1);
+        self.elaborator.interner.comptime_scopes.append(&mut state.1);
     }
 
     pub(super) fn push_scope(&mut self) {
-        self.elaborator.comptime_scopes.push(HashMap::default());
+        self.elaborator.interner.comptime_scopes.push(HashMap::default());
     }
 
     pub(super) fn pop_scope(&mut self) {
-        self.elaborator.comptime_scopes.pop();
+        self.elaborator.interner.comptime_scopes.pop();
     }
 
     fn current_scope_mut(&mut self) -> &mut HashMap<DefinitionId, Value> {
         // the global scope is always at index zero, so this is always Some
-        self.elaborator.comptime_scopes.last_mut().unwrap()
+        self.elaborator.interner.comptime_scopes.last_mut().unwrap()
     }
 
     fn unbind_generics_from_previous_function(&mut self) {
@@ -403,7 +403,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             return Ok(());
         }
 
-        for scope in self.elaborator.comptime_scopes.iter_mut().rev() {
+        for scope in self.elaborator.interner.comptime_scopes.iter_mut().rev() {
             if let Entry::Occupied(mut entry) = scope.entry(id) {
                 entry.insert(argument);
                 return Ok(());
@@ -417,7 +417,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     }
 
     pub fn lookup_id(&self, id: DefinitionId, location: Location) -> IResult<Value> {
-        for scope in self.elaborator.comptime_scopes.iter().rev() {
+        for scope in self.elaborator.interner.comptime_scopes.iter().rev() {
             if let Some(value) = scope.get(&id) {
                 return Ok(value.clone());
             }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We stored `comptime_scopes` in the Elaborator, but elaborators are created one per each crate. So any globals from other crates would be invisible to each next crate, or their value would be reset. I've moved `comptime_scopes` to the NodeInterner to fix this.

## Additional Context

With this, `derive` now works in the stdlib. I've decided to split adding that into a separate PR though.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
