### PR TITLE
fix: Switch verify proof to arrays

### DIFF
--- a/compiler/integration-tests/circuits/recursion/src/main.nr
+++ b/compiler/integration-tests/circuits/recursion/src/main.nr
@@ -4,10 +4,5 @@ fn main(
     public_inputs: [Field; 1],
     key_hash: Field
 ) {
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    )
+    std::verify_proof(verification_key, proof, public_inputs, key_hash)
 }

--- a/docs/docs/noir/standard_library/recursion.md
+++ b/docs/docs/noir/standard_library/recursion.md
@@ -49,16 +49,16 @@ fn main(
     proof_b : [Field; 93],
 ) {
     std::verify_proof(
-        verification_key.as_slice(),
-        proof.as_slice(),
-        public_inputs.as_slice(),
+        verification_key,
+        proof,
+        public_inputs,
         key_hash
     );
 
     std::verify_proof(
-        verification_key.as_slice(),
-        proof_b.as_slice(),
-        public_inputs.as_slice(),
+        verification_key,
+        proof_b,
+        public_inputs,
         key_hash
     );
 }

--- a/examples/recursion/recurse_leaf/src/main.nr
+++ b/examples/recursion/recurse_leaf/src/main.nr
@@ -7,12 +7,7 @@ fn main(
     num: u64
 ) -> pub u64 {
     // verify sum so far was computed correctly
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof, public_inputs, key_hash);
     // Take output of previous proof and add another number to it.
     public_inputs[2] as u64 + num
 }

--- a/examples/recursion/recurse_node/src/main.nr
+++ b/examples/recursion/recurse_node/src/main.nr
@@ -5,11 +5,6 @@ fn main(
     proof: [Field; 109]
 ) -> pub u64 {
     // verify sum was computed correctly
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof, public_inputs, key_hash);
     public_inputs[3] as u64
 }

--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -43,7 +43,12 @@ unconstrained pub fn println<T>(input: T) {
 }
 
 #[foreign(recursive_aggregation)]
-pub fn verify_proof<N>(verification_key: [Field], proof: [Field], public_inputs: [Field], key_hash: Field) {}
+pub fn verify_proof<let N: u32, let M: u32, let K: u32>(
+    verification_key: [Field; N],
+    proof: [Field; M],
+    public_inputs: [Field; K],
+    key_hash: Field
+) {}
 
 // Asserts that the given value is known at compile-time.
 // Useful for debugging for-loop bounds.

--- a/test_programs/execution_success/double_verify_nested_proof/src/main.nr
+++ b/test_programs/execution_success/double_verify_nested_proof/src/main.nr
@@ -19,17 +19,7 @@ fn main(
     key_hash: Field,
     proof_b: [Field; 109]
 ) {
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof, public_inputs, key_hash);
 
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof_b.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof_b, public_inputs, key_hash);
 }

--- a/test_programs/execution_success/double_verify_proof/src/main.nr
+++ b/test_programs/execution_success/double_verify_proof/src/main.nr
@@ -12,17 +12,7 @@ fn main(
     key_hash: Field,
     proof_b: [Field; 93]
 ) {
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof, public_inputs, key_hash);
 
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof_b.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof_b, public_inputs, key_hash);
 }

--- a/test_programs/execution_success/double_verify_proof_recursive/src/main.nr
+++ b/test_programs/execution_success/double_verify_proof_recursive/src/main.nr
@@ -13,17 +13,7 @@ fn main(
     key_hash: Field,
     proof_b: [Field; 93]
 ) {
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof, public_inputs, key_hash);
 
-    std::verify_proof(
-        verification_key.as_slice(),
-        proof_b.as_slice(),
-        public_inputs.as_slice(),
-        key_hash
-    );
+    std::verify_proof(verification_key, proof_b, public_inputs, key_hash);
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5660

## Summary\*

Switches verify proof to arrays

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
