### PR TITLE
feat: add `std::meta::type_of` and `impl Eq for Type`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -55,6 +55,8 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             }
             "quoted_as_trait_constraint" => quoted_as_trait_constraint(self, arguments, location),
             "quoted_as_type" => quoted_as_type(self, arguments, location),
+            "type_eq" => type_eq(arguments, location),
+            "type_of" => type_of(arguments, location),
             "zeroed" => zeroed(return_type),
             _ => {
                 let item = format!("Comptime evaluation for builtin function {name}");
@@ -431,6 +433,22 @@ fn quoted_as_type(
         .elaborator
         .elaborate_item_from_comptime(interpreter.current_function, |elab| elab.resolve_type(typ));
 
+    Ok(Value::Type(typ))
+}
+
+fn type_eq(mut arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+    check_argument_count(2, &arguments, location)?;
+
+    let value1 = arguments.pop().unwrap().0;
+    let value2 = arguments.pop().unwrap().0;
+    Ok(Value::Bool(value1 == value2))
+}
+
+fn type_of(mut arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+    check_argument_count(1, &arguments, location)?;
+
+    let value = arguments.pop().unwrap().0;
+    let typ = value.get_type().into_owned();
     Ok(Value::Type(typ))
 }
 

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -1,5 +1,6 @@
 mod trait_constraint;
 mod trait_def;
+mod typ;
 mod type_def;
 mod quoted;
 
@@ -9,3 +10,7 @@ mod quoted;
 pub comptime fn unquote(code: Quoted) -> Quoted {
     code
 }
+
+#[builtin(type_of)]
+pub comptime fn type_of<T>(x: T) -> Type {}
+

--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -1,0 +1,10 @@
+use crate::cmp::Eq;
+
+impl Eq for Type {
+    fn eq(self, other: Self) -> bool {
+        type_eq(self, other)
+    }
+}
+
+#[builtin(type_eq)]
+fn type_eq(_first: Type, _second: Type) -> bool {}

--- a/test_programs/compile_success_empty/comptime_type/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -1,8 +1,9 @@
 use std::meta::type_of;
 
 fn main() {
-    // Check type_of works correctly (relies on Eq for Type)
-    let _ = comptime {
+    comptime
+    {
+        // Check type_of works correctly (relies on Eq for Type)
         let a_field = 0;
         let another_field = 1;
         let an_i32: i32 = 0;
@@ -11,5 +12,5 @@ fn main() {
         let i32_type = type_of(an_i32);
         assert(field_type_1 == field_type_2);
         assert(field_type_1 != i32_type);
-    };
+    }
 }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -2,7 +2,7 @@ use std::meta::type_of;
 
 fn main() {
     // Check type_of works correctly (relies on Eq for Type)
-    {
+    let _ = comptime {
         let a_field = 0;
         let another_field = 1;
         let an_i32: i32 = 0;
@@ -11,5 +11,5 @@ fn main() {
         let i32_type = type_of(an_i32);
         assert(field_type_1 == field_type_2);
         assert(field_type_1 != i32_type);
-    }
+    };
 }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -1,0 +1,15 @@
+use std::meta::type_of;
+
+fn main() {
+    // Check type_of works correctly (relies on Eq for Type)
+    {
+        let a_field = 0;
+        let another_field = 1;
+        let an_i32: i32 = 0;
+        let field_type_1 = type_of(a_field);
+        let field_type_2 = type_of(another_field);
+        let i32_type = type_of(an_i32);
+        assert(field_type_1 == field_type_2);
+        assert(field_type_1 != i32_type);
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

I originally wanted to just add `type_of`, but in order to test it in some way I thought of comparing two types and checking whether they are equal or not... which required implementing `Eq` for `Type`, which I guess is useful any way.

## Additional Context

Another way could have been to be able to turn a `Type` into a string and check that, but there's no unbounded `String` type at comptime... Another way would be to `println` the type and check the program's output, but there's no quick way to do it right now... but I think asserting on equality is fine too, especially because the implementation of `type_of` is very simple.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
