### PR TITLE
fix: Fix where clause issue in items generated from attributes

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1300,6 +1300,11 @@ impl<'context> Elaborator<'context> {
             self.add_generics(&trait_impl.generics);
             trait_impl.resolved_generics = self.generics.clone();
 
+            for (_, _, method) in trait_impl.methods.functions.iter_mut() {
+                // Attach any trait constraints on the impl to the function
+                method.def.where_clause.append(&mut trait_impl.where_clause.clone());
+            }
+
             // Fetch trait constraints here
             let trait_generics = trait_impl
                 .trait_id

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -173,8 +173,6 @@ impl<'a> ModCollector<'a> {
             let module = ModuleId { krate, local_id: self.module_id };
 
             for (_, func_id, noir_function) in &mut unresolved_functions.functions {
-                // Attach any trait constraints on the impl to the function
-                noir_function.def.where_clause.append(&mut trait_impl.where_clause.clone());
                 let location = Location::new(noir_function.def.span, self.file_id);
                 context.def_interner.push_function(*func_id, &noir_function.def, module, location);
             }

--- a/test_programs/compile_success_empty/regression_5671/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_5671/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_5671"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.32.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_5671/src/main.nr
+++ b/test_programs/compile_success_empty/regression_5671/src/main.nr
@@ -1,0 +1,20 @@
+#[foo]
+struct MyOtherStruct<A, B> {
+    field1: A,
+    field2: B,
+}
+
+comptime fn foo(_s: StructDefinition) -> Quoted {
+    quote {
+        impl<A, B> Eq for MyOtherStruct<A, B> where A: Eq, B: Eq {
+            fn eq(self, other: Self) -> bool {
+                (self.field1 == other.field1) & (self.field2 == other.field2)
+            }
+        }
+    }
+}
+
+fn main() {
+    let x = MyOtherStruct { field1: 1, field2: 2 };
+    assert_eq(x, x);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5671

## Summary\*

The issue was that we were adding trait constraints to the methods themselves in `dc_mod` but this code isn't run for items generated from attributes which only go through the elaborator. I've just moved this code to the elaborator instead.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
