### PR TITLE
feat: add `Type` methods: `as_tuple`, `as_slice`, `as_array`, `as_constant`, `is_bool`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -57,6 +57,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "trait_def_hash" => trait_def_hash(interner, arguments, location),
             "quoted_as_trait_constraint" => quoted_as_trait_constraint(self, arguments, location),
             "quoted_as_type" => quoted_as_type(self, arguments, location),
+            "type_as_array" => type_as_array(arguments, return_type, location),
             "type_as_integer" => type_as_integer(arguments, return_type, location),
             "type_as_slice" => type_as_slice(arguments, return_type, location),
             "type_as_tuple" => type_as_tuple(arguments, return_type, location),
@@ -487,6 +488,21 @@ fn quoted_as_type(
         interpreter.elaborate_item(interpreter.current_function, |elab| elab.resolve_type(typ));
 
     Ok(Value::Type(typ))
+}
+
+// fn as_array(self) -> Option<(Type, Type)>
+fn type_as_array(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    type_as(arguments, return_type, location, |typ| {
+        if let Type::Array(length, array_type) = typ {
+            Some(Value::Tuple(vec![Value::Type(*array_type), Value::Type(*length)]))
+        } else {
+            None
+        }
+    })
 }
 
 // fn as_integer(self) -> Option<(bool, u8)>

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -58,6 +58,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "quoted_as_trait_constraint" => quoted_as_trait_constraint(self, arguments, location),
             "quoted_as_type" => quoted_as_type(self, arguments, location),
             "type_as_integer" => type_as_integer(arguments, return_type, location),
+            "type_as_slice" => type_as_slice(arguments, return_type, location),
             "type_as_tuple" => type_as_tuple(arguments, return_type, location),
             "type_eq" => type_eq(arguments, location),
             "type_is_field" => type_is_field(arguments, location),
@@ -502,6 +503,21 @@ fn type_as_integer(
     } else {
         None
     };
+
+    option(return_type, option_value)
+}
+
+// fn as_slice(self) -> Option<Type>
+fn type_as_slice(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    let value = check_one_argument(arguments, location)?;
+    let typ = get_type(value, location)?;
+
+    let option_value =
+        if let Type::Slice(slice_type) = typ { Some(Value::Type(*slice_type)) } else { None };
 
     option(return_type, option_value)
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -58,6 +58,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "quoted_as_trait_constraint" => quoted_as_trait_constraint(self, arguments, location),
             "quoted_as_type" => quoted_as_type(self, arguments, location),
             "type_as_array" => type_as_array(arguments, return_type, location),
+            "type_as_constant" => type_as_constant(arguments, return_type, location),
             "type_as_integer" => type_as_integer(arguments, return_type, location),
             "type_as_slice" => type_as_slice(arguments, return_type, location),
             "type_as_tuple" => type_as_tuple(arguments, return_type, location),
@@ -499,6 +500,21 @@ fn type_as_array(
     type_as(arguments, return_type, location, |typ| {
         if let Type::Array(length, array_type) = typ {
             Some(Value::Tuple(vec![Value::Type(*array_type), Value::Type(*length)]))
+        } else {
+            None
+        }
+    })
+}
+
+// fn as_constant(self) -> Option<u32>
+fn type_as_constant(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    type_as(arguments, return_type, location, |typ| {
+        if let Type::Constant(n) = typ {
+            Some(Value::U32(n))
         } else {
             None
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -531,13 +531,13 @@ fn type_as_tuple(
     let value = check_one_argument(arguments, location)?;
     let typ = get_type(value, location)?;
 
-    let t = extract_option_generic_type(return_type.clone());
-
-    let Type::Slice(slice_type) = t else {
-        panic!("Expected T to be a slice");
-    };
-
     let option_value = if let Type::Tuple(types) = typ {
+        let t = extract_option_generic_type(return_type.clone());
+
+        let Type::Slice(slice_type) = t else {
+            panic!("Expected T to be a slice");
+        };
+
         Some(Value::Slice(types.into_iter().map(Value::Type).collect(), *slice_type))
     } else {
         None

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -63,6 +63,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "type_as_slice" => type_as_slice(arguments, return_type, location),
             "type_as_tuple" => type_as_tuple(arguments, return_type, location),
             "type_eq" => type_eq(arguments, location),
+            "type_is_bool" => type_is_bool(arguments, location),
             "type_is_field" => type_is_field(arguments, location),
             "type_of" => type_of(arguments, location),
             "zeroed" => zeroed(return_type),
@@ -595,6 +596,14 @@ fn type_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Val
     let (self_type, other_type) = check_two_arguments(arguments, location)?;
 
     Ok(Value::Bool(self_type == other_type))
+}
+
+// fn is_bool(self) -> bool
+fn type_is_bool(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+    let value = check_one_argument(arguments, location)?;
+    let typ = get_type(value, location)?;
+
+    Ok(Value::Bool(matches!(typ, Type::Bool)))
 }
 
 // fn is_field(self) -> bool

--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -17,6 +17,9 @@ impl Type {
     #[builtin(type_as_tuple)]
     fn as_tuple(self) -> Option<[Type]> {}
 
+    #[builtin(type_is_bool)]
+    fn is_bool(self) -> bool {}
+
     #[builtin(type_is_field)]
     fn is_field(self) -> bool {}
 }

--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -5,6 +5,9 @@ impl Type {
     #[builtin(type_as_integer)]
     fn as_integer(self) -> Option<(bool, u8)> {}
 
+    #[builtin(type_as_tuple)]
+    fn as_tuple(self) -> Option<[Type]> {}
+
     #[builtin(type_is_field)]
     fn is_field(self) -> bool {}
 }

--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -5,6 +5,9 @@ impl Type {
     #[builtin(type_as_array)]
     fn as_array(self) -> Option<(Type, Type)> {}
 
+    #[builtin(type_as_constant)]
+    fn as_constant(self) -> Option<u32> {}
+
     #[builtin(type_as_integer)]
     fn as_integer(self) -> Option<(bool, u8)> {}
 

--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -5,6 +5,9 @@ impl Type {
     #[builtin(type_as_integer)]
     fn as_integer(self) -> Option<(bool, u8)> {}
 
+    #[builtin(type_as_slice)]
+    fn as_slice(self) -> Option<Type> {}
+
     #[builtin(type_as_tuple)]
     fn as_tuple(self) -> Option<[Type]> {}
 

--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -2,6 +2,9 @@ use crate::cmp::Eq;
 use crate::option::Option;
 
 impl Type {
+    #[builtin(type_as_array)]
+    fn as_array(self) -> Option<(Type, Type)> {}
+
     #[builtin(type_as_integer)]
     fn as_integer(self) -> Option<(bool, u8)> {}
 

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -47,5 +47,13 @@ fn main() {
         let slice_type = type_of(slice);
         let slice_type_element_type = slice_type.as_slice().unwrap();
         assert_eq(slice_type_element_type, field_type_1);
+
+        // Check Type::as_array
+        assert(u8_type.as_array().is_none());
+
+        let array = [1, 2, 3];
+        let array_type = type_of(array);
+        let (array_type_element_type , _array_length) = array_type.as_array().unwrap();
+        assert_eq(array_type_element_type, field_type_1);
     }
 }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -53,7 +53,11 @@ fn main() {
 
         let array = [1, 2, 3];
         let array_type = type_of(array);
-        let (array_type_element_type , _array_length) = array_type.as_array().unwrap();
+        let (array_type_element_type , array_length) = array_type.as_array().unwrap();
         assert_eq(array_type_element_type, field_type_1);
+
+        // Check Type::as_constant
+        assert(u8_type.as_constant().is_none());
+        assert_eq(array_length.as_constant().unwrap(), 3);
     }
 }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -59,5 +59,12 @@ fn main() {
         // Check Type::as_constant
         assert(u8_type.as_constant().is_none());
         assert_eq(array_length.as_constant().unwrap(), 3);
+
+        // Check Type::is_bool
+        assert(!u8_type.is_bool());
+
+        let yes = true;
+        let bool_type = type_of(yes);
+        assert(bool_type.is_bool());
     }
 }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -29,5 +29,15 @@ fn main() {
         let (signed, bits) = u8_type.as_integer().unwrap();
         assert(!signed);
         assert_eq(bits, 8);
+
+        // Check Type::as_tuple
+        assert(u8_type.as_tuple().is_none());
+
+        let tuple = (an_i32, a_u8);
+        let tuple_type = type_of(tuple);
+        let tuple_types = tuple_type.as_tuple().unwrap();
+        assert_eq(tuple_types.len(), 2);
+        assert_eq(tuple_types[0], i32_type);
+        assert_eq(tuple_types[1], u8_type);
     }
 }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -39,5 +39,13 @@ fn main() {
         assert_eq(tuple_types.len(), 2);
         assert_eq(tuple_types[0], i32_type);
         assert_eq(tuple_types[1], u8_type);
+
+        // Check Type::as_slice
+        assert(u8_type.as_slice().is_none());
+
+        let slice = &[1];
+        let slice_type = type_of(slice);
+        let slice_type_element_type = slice_type.as_slice().unwrap();
+        assert_eq(slice_type_element_type, field_type_1);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

I'm leaving `as_struct` for a next PR.

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
