### PR TITLE
feat: Implement closures in the comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -226,8 +226,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn call_closure(
         &mut self,
         closure: HirLambda,
-        // TODO: How to define environment here?
-        _environment: Vec<Value>,
+        environment: Vec<Value>,
         arguments: Vec<(Value, Location)>,
         call_location: Location,
     ) -> IResult<Value> {
@@ -244,6 +243,10 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         let parameters = closure.parameters.iter().zip(arguments);
         for ((parameter, typ), (argument, arg_location)) in parameters {
             self.define_pattern(parameter, typ, argument, arg_location)?;
+        }
+
+        for (param, arg) in closure.captures.into_iter().zip(environment) {
+            self.define(param.ident.id, arg);
         }
 
         let result = self.evaluate(closure.body)?;

--- a/test_programs/compile_success_empty/comptime_closures/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_closures/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_closures"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.32.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_closures/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_closures/src/main.nr
@@ -1,0 +1,39 @@
+fn main() {
+    comptime
+    {
+        closure_test(0);
+    }
+}
+
+fn closure_test(mut x: Field) {
+    let one = 1;
+    let add1 = |z| {
+        (|| {
+            *z += one;
+        })()
+    };
+
+    let two = 2;
+    let add2 = |z| {
+        *z = *z + two;
+    };
+
+    add1(&mut x);
+    assert(x == 1);
+
+    add2(&mut x);
+    assert(x == 3);
+
+    issue_2120();
+}
+
+fn issue_2120() {
+    let x1 = &mut 42;
+    let set_x1 = |y| { *x1 = y; };
+
+    assert(*x1 == 42);
+    set_x1(44);
+    assert(*x1 == 44);
+    set_x1(*x1);
+    assert(*x1 == 44);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/4879

## Summary\*

Implements closures in the comptime interpreter.

## Additional Context

This ended up being much easier than expected. Almost makes me suspicious.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
