### PR TITLE
feat: add some `Module` comptime functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1088,6 +1088,11 @@ impl<'context> Elaborator<'context> {
         self.self_type = None;
     }
 
+    pub fn get_module(&self, module: ModuleId) -> &ModuleData {
+        let message = "A crate should always be present for a given crate id";
+        &self.def_maps.get(&module.krate).expect(message).modules[module.local_id.0]
+    }
+
     fn get_module_mut(def_maps: &mut DefMaps, module: ModuleId) -> &mut ModuleData {
         let message = "A crate should always be present for a given crate id";
         &mut def_maps.get_mut(&module.krate).expect(message).modules[module.local_id.0]

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -885,7 +885,11 @@ impl<'context> Elaborator<'context> {
     /// Since they should be within a child module, they should be elaborated as if
     /// `in_contract` is `false` so we can still resolve them in the parent module without them being in a contract.
     fn in_contract(&self) -> bool {
-        self.module_id().module(self.def_maps).is_contract
+        self.module_is_contract(self.module_id())
+    }
+
+    pub(crate) fn module_is_contract(&self, module_id: ModuleId) -> bool {
+        module_id.module(self.def_maps).is_contract
     }
 
     fn is_entry_point_function(&self, func: &NoirFunction, in_contract: bool) -> bool {

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -623,6 +623,21 @@ impl<'context> Elaborator<'context> {
         }
     }
 
+    pub fn resolve_module_by_path(&self, path: Path) -> Option<ModuleId> {
+        let path_resolver = StandardPathResolver::new(self.module_id());
+
+        match path_resolver.resolve(self.def_maps, path.clone(), &mut None) {
+            Ok(PathResolution { module_def_id: ModuleDefId::ModuleId(module_id), error }) => {
+                if let Some(_) = error {
+                    None
+                } else {
+                    Some(module_id)
+                }
+            }
+            _ => None,
+        }
+    }
+
     fn resolve_trait_by_path(&mut self, path: Path) -> Option<TraitId> {
         let path_resolver = StandardPathResolver::new(self.module_id());
 

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -628,7 +628,7 @@ impl<'context> Elaborator<'context> {
 
         match path_resolver.resolve(self.def_maps, path.clone(), &mut None) {
             Ok(PathResolution { module_def_id: ModuleDefId::ModuleId(module_id), error }) => {
-                if let Some(_) = error {
+                if error.is_some() {
                     None
                 } else {
                     Some(module_id)

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -16,7 +16,6 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     ast::IntegerBitSize,
-    elaborator,
     hir::comptime::{errors::IResult, value::add_token_spans, InterpreterError, Value},
     macros_api::{ModuleDefId, NodeInterner, Signedness},
     parser,
@@ -45,6 +44,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "function_def_return_type" => function_def_return_type(interner, arguments, location),
             "module_functions" => module_functions(self, arguments, location),
             "module_is_contract" => module_is_contract(self, arguments, location),
+            "module_name" => module_name(interner, arguments, location),
             "modulus_be_bits" => modulus_be_bits(interner, arguments, location),
             "modulus_be_bytes" => modulus_be_bytes(interner, arguments, location),
             "modulus_le_bits" => modulus_le_bits(interner, arguments, location),
@@ -756,6 +756,19 @@ fn module_is_contract(
     let self_argument = check_one_argument(arguments, location)?;
     let module_id = get_module(self_argument, location)?;
     Ok(Value::Bool(interpreter.elaborator.module_is_contract(module_id)))
+}
+
+// fn name(self) -> Quoted
+fn module_name(
+    interner: &NodeInterner,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    let self_argument = check_one_argument(arguments, location)?;
+    let module_id = get_module(self_argument, location)?;
+    let name = &interner.module_attributes(&module_id).name;
+    let tokens = Rc::new(vec![Token::Ident(name.clone())]);
+    Ok(Value::Quoted(tokens))
 }
 
 fn modulus_be_bits(

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -40,6 +40,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "array_len" => array_len(interner, arguments, location),
             "as_slice" => as_slice(interner, arguments, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
+            "function_def_name" => function_def_name(interner, arguments, location),
             "function_def_parameters" => function_def_parameters(interner, arguments, location),
             "function_def_return_type" => function_def_return_type(interner, arguments, location),
             "module_functions" => module_functions(self, arguments, location),
@@ -679,6 +680,20 @@ fn zeroed(return_type: Type) -> IResult<Value> {
         | Type::TraitAsType(_, _, _)
         | Type::NamedGeneric(_, _, _) => Ok(Value::Zeroed(return_type)),
     }
+}
+
+// fn name(self) -> Quoted
+fn function_def_name(
+    interner: &NodeInterner,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    let self_argument = check_one_argument(arguments, location)?;
+    let func_id = get_function_def(self_argument, location)?;
+    let func_meta = interner.function_meta(&func_id);
+    let name = &interner.definition(func_meta.name.id).name;
+    let tokens = Rc::new(vec![Token::Ident(name.clone())]);
+    Ok(Value::Quoted(tokens))
 }
 
 // fn parameters(self) -> [(Quoted, Type)]

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -329,7 +329,7 @@ fn quoted_as_module(
         let module = interpreter.elaborate_item(interpreter.current_function, |elaborator| {
             elaborator.resolve_module_by_path(path)
         });
-        Value::ModuleDefinition(module)
+        module.map(Value::ModuleDefinition)
     });
 
     option(return_type, option_value)
@@ -688,7 +688,7 @@ fn function_def_name(
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
     let func_id = get_function_def(self_argument, location)?;
-    let name = interner.function_name(&func_id).clone();
+    let name = interner.function_name(&func_id).to_string();
     let tokens = Rc::new(vec![Token::Ident(name)]);
     Ok(Value::Quoted(tokens))
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -5,7 +5,10 @@ use noirc_errors::Location;
 
 use crate::{
     ast::{IntegerBitSize, Signedness},
-    hir::comptime::{errors::IResult, InterpreterError, Value},
+    hir::{
+        comptime::{errors::IResult, InterpreterError, Value},
+        def_map::ModuleId,
+    },
     hir_def::stmt::HirPattern,
     macros_api::NodeInterner,
     node_interner::{FuncId, TraitId},
@@ -118,6 +121,17 @@ pub(crate) fn get_function_def(value: Value, location: Location) -> IResult<Func
         Value::FunctionDefinition(id) => Ok(id),
         value => {
             let expected = Type::Quoted(QuotedType::FunctionDefinition);
+            let actual = value.get_type().into_owned();
+            Err(InterpreterError::TypeMismatch { expected, actual, location })
+        }
+    }
+}
+
+pub(crate) fn get_module(value: Value, location: Location) -> IResult<ModuleId> {
+    match value {
+        Value::ModuleDefinition(module_id) => Ok(module_id),
+        value => {
+            let expected = Type::Quoted(QuotedType::Module);
             let actual = value.get_type().into_owned();
             Err(InterpreterError::TypeMismatch { expected, actual, location })
         }

--- a/compiler/noirc_frontend/src/parser/mod.rs
+++ b/compiler/noirc_frontend/src/parser/mod.rs
@@ -22,7 +22,9 @@ use chumsky::primitive::Container;
 pub use errors::ParserError;
 pub use errors::ParserErrorReason;
 use noirc_errors::Span;
-pub use parser::{expression, parse_program, parse_type, top_level_items, trait_bound};
+pub use parser::{
+    expression, parse_program, parse_type, path_no_turbofish, top_level_items, trait_bound,
+};
 
 #[derive(Debug, Clone)]
 pub enum TopLevelStatement {

--- a/compiler/noirc_frontend/src/parser/mod.rs
+++ b/compiler/noirc_frontend/src/parser/mod.rs
@@ -22,9 +22,9 @@ use chumsky::primitive::Container;
 pub use errors::ParserError;
 pub use errors::ParserErrorReason;
 use noirc_errors::Span;
-pub use parser::{
-    expression, parse_program, parse_type, path_no_turbofish, top_level_items, trait_bound,
-};
+pub use parser::path::path_no_turbofish;
+pub use parser::traits::trait_bound;
+pub use parser::{expression, parse_program, parse_type, top_level_items};
 
 #[derive(Debug, Clone)]
 pub enum TopLevelStatement {

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -71,7 +71,7 @@ lalrpop_mod!(pub noir_parser);
 mod test_helpers;
 
 use literals::literal;
-use path::{maybe_empty_path, path, path_no_turbofish};
+use path::{maybe_empty_path, path};
 use primitives::{dereference, ident, negation, not, nothing, right_shift_operator, token_kind};
 use traits::where_clause;
 
@@ -368,6 +368,10 @@ fn function_declaration_parameters() -> impl NoirParser<Vec<(Ident, UnresolvedTy
 
 pub fn trait_bound() -> impl NoirParser<TraitBound> {
     traits::trait_bound()
+}
+
+pub fn path_no_turbofish() -> impl NoirParser<Path> {
+    path::path_no_turbofish()
 }
 
 fn block_expr<'a>(

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -37,8 +37,8 @@ use super::{spanned, Item, ItemKind};
 use crate::ast::{
     BinaryOp, BinaryOpKind, BlockExpression, ForLoopStatement, ForRange, Ident, IfExpression,
     InfixExpression, LValue, Literal, ModuleDeclaration, NoirTypeAlias, Param, Path, Pattern,
-    Recoverable, Statement, TraitBound, TypeImpl, UnaryRhsMemberAccess, UnaryRhsMethodCall,
-    UseTree, UseTreeKind, Visibility,
+    Recoverable, Statement, TypeImpl, UnaryRhsMemberAccess, UnaryRhsMethodCall, UseTree,
+    UseTreeKind, Visibility,
 };
 use crate::ast::{
     Expression, ExpressionKind, LetStatement, StatementKind, UnresolvedType, UnresolvedTypeData,
@@ -58,10 +58,10 @@ mod attributes;
 mod function;
 mod lambdas;
 mod literals;
-mod path;
+pub(super) mod path;
 mod primitives;
 mod structs;
-mod traits;
+pub(super) mod traits;
 mod types;
 
 // synthesized by LALRPOP
@@ -366,14 +366,6 @@ fn function_declaration_parameters() -> impl NoirParser<Vec<(Ident, UnresolvedTy
         .labelled(ParsingRuleLabel::Parameter)
 }
 
-pub fn trait_bound() -> impl NoirParser<TraitBound> {
-    traits::trait_bound()
-}
-
-pub fn path_no_turbofish() -> impl NoirParser<Path> {
-    path::path_no_turbofish()
-}
-
 fn block_expr<'a>(
     statement: impl NoirParser<StatementKind> + 'a,
 ) -> impl NoirParser<Expression> + 'a {
@@ -435,7 +427,7 @@ fn rename() -> impl NoirParser<Option<Ident>> {
 
 fn use_tree() -> impl NoirParser<UseTree> {
     recursive(|use_tree| {
-        let simple = path_no_turbofish().then(rename()).map(|(mut prefix, alias)| {
+        let simple = path::path_no_turbofish().then(rename()).map(|(mut prefix, alias)| {
             let ident = prefix.pop().ident;
             UseTree { prefix, kind: UseTreeKind::Path(ident, alias) }
         });

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -14,7 +14,7 @@ pub(super) fn path<'a>(
     path_inner(path_segment(type_parser))
 }
 
-pub(super) fn path_no_turbofish() -> impl NoirParser<Path> {
+pub fn path_no_turbofish() -> impl NoirParser<Path> {
     path_inner(path_segment_no_turbofish())
 }
 

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -182,7 +182,7 @@ fn trait_bounds() -> impl NoirParser<Vec<TraitBound>> {
     trait_bound().separated_by(just(Token::Plus)).at_least(1).allow_trailing()
 }
 
-pub(super) fn trait_bound() -> impl NoirParser<TraitBound> {
+pub fn trait_bound() -> impl NoirParser<TraitBound> {
     path_no_turbofish().then(generic_type_args(parse_type())).map(|(trait_path, trait_generics)| {
         TraitBound { trait_path, trait_generics, trait_id: None }
     })

--- a/noir_stdlib/src/meta/function_def.nr
+++ b/noir_stdlib/src/meta/function_def.nr
@@ -1,4 +1,7 @@
 impl FunctionDefinition {
+    #[builtin(function_def_name)]
+    fn name(self) -> Quoted {}
+
     #[builtin(function_def_parameters)]
     fn parameters(self) -> [(Quoted, Type)] {}
 

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -3,6 +3,7 @@ use crate::hash::BuildHasherDefault;
 use crate::hash::poseidon2::Poseidon2Hasher;
 
 mod function_def;
+mod module;
 mod struct_def;
 mod trait_constraint;
 mod trait_def;

--- a/noir_stdlib/src/meta/module.nr
+++ b/noir_stdlib/src/meta/module.nr
@@ -1,4 +1,7 @@
 impl Module {
     #[builtin(module_is_contract)]
     fn is_contract(self) -> bool {}
+
+    #[builtin(module_functions)]
+    fn functions(self) -> [FunctionDefinition] {}
 }

--- a/noir_stdlib/src/meta/module.nr
+++ b/noir_stdlib/src/meta/module.nr
@@ -4,4 +4,7 @@ impl Module {
 
     #[builtin(module_functions)]
     fn functions(self) -> [FunctionDefinition] {}
+
+    #[builtin(module_name)]
+    fn name(self) -> Quoted {}
 }

--- a/noir_stdlib/src/meta/module.nr
+++ b/noir_stdlib/src/meta/module.nr
@@ -1,0 +1,4 @@
+impl Module {
+    #[builtin(module_is_contract)]
+    fn is_contract(self) -> bool {}
+}

--- a/noir_stdlib/src/meta/quoted.nr
+++ b/noir_stdlib/src/meta/quoted.nr
@@ -1,6 +1,10 @@
 use crate::cmp::Eq;
+use crate::option::Option;
 
 impl Quoted {
+    #[builtin(quoted_as_module)]
+    fn as_module(self) -> Option<Module> {}
+
     #[builtin(quoted_as_trait_constraint)]
     fn as_trait_constraint(self) -> TraitConstraint {}
 

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -28,6 +28,9 @@ comptime fn function_attr(f: FunctionDefinition) {
 
     // Check FunctionDefinition::return_type
     assert_eq(f.return_type(), type_of(an_i32));
+
+    // Check FunctionDefinition::name
+    assert_eq(f.name(), quote { foo });
 }
 
 fn main() {}

--- a/test_programs/compile_success_empty/comptime_module/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_module/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_module"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -18,5 +18,9 @@ fn main() {
         // Check Module::functions
         assert_eq(foo.functions().len(), 2);
         assert_eq(bar.functions().len(), 0);
+
+        // Check Module::name
+        assert_eq(foo.name(), quote { foo });
+        assert_eq(bar.name(), quote { bar });
     }
 }

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -1,0 +1,8 @@
+mod foo {}
+
+fn main() {
+    comptime
+    {
+        let foo = quote { foo }.as_module().unwrap();
+    }
+}

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -1,14 +1,22 @@
-mod foo {}
+mod foo {
+    fn x() {}
+    fn y() {}
+}
 
 contract bar {}
 
 fn main() {
     comptime
     {
+        // Check Module::is_contract
         let foo = quote { foo }.as_module().unwrap();
         assert(!foo.is_contract());
 
         let bar = quote { bar }.as_module().unwrap();
         assert(bar.is_contract());
+
+        // Check Module::functions
+        assert_eq(foo.functions().len(), 2);
+        assert_eq(bar.functions().len(), 0);
     }
 }

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -1,8 +1,14 @@
 mod foo {}
 
+contract bar {}
+
 fn main() {
     comptime
     {
         let foo = quote { foo }.as_module().unwrap();
+        assert(!foo.is_contract());
+
+        let bar = quote { bar }.as_module().unwrap();
+        assert(bar.is_contract());
     }
 }


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

Adds these comptime functions:
- `Quoted::as_module`
- `Module::name`
- `Module::is_contract`
- `Module::functions`
- `FunctionDefinition::name`

## Additional Context

Some notes:
- I made `Quoted::as_module` return `Option<ModuleId>`, while other `Quoted::as_...` methods currently return a non-Option instead. Eventually it would be nice to unify these but doing that in this PR would have made it much bigger and complex, mainly because those methods rely on methods that are used in many places in the compiler.
- For now I made `Module::name` and `FunctionDefinition::name` return `Quoted`. Once we have a `String` type we could change them to `String`, and the logic from going to Quoted -> String is very simple.

I was wondering... would a `String` type be what a Slice is for Arrays?

One more thought: I wonder if instead of returning `Option<ModuleId>` it wouldn't be better to return some kind of `Result`. That way the caller would know what the error is, if it happens. But I think we don't have `Result` yet in Noir, right?

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
