### PR TITLE
feat: add mutating FunctionDefinition functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -39,7 +39,7 @@ impl<'context> Elaborator<'context> {
 
     /// Equivalent to `elaborate_pattern`, this version just also
     /// adds any new DefinitionIds that were created to the given Vec.
-    pub(super) fn elaborate_pattern_and_store_ids(
+    pub fn elaborate_pattern_and_store_ids(
         &mut self,
         pattern: Pattern,
         expected_type: Type,

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -185,7 +185,7 @@ pub enum InterpreterError {
     FailedToResolveTraitDefinition {
         location: Location,
     },
-    CannotMutateFunction {
+    FunctionAlreadyResolved {
         location: Location,
     },
 
@@ -258,7 +258,7 @@ impl InterpreterError {
             | InterpreterError::TraitDefinitionMustBeAPath { location }
             | InterpreterError::FailedToResolveTraitDefinition { location }
             | InterpreterError::FailedToResolveTraitBound { location, .. } => *location,
-            InterpreterError::CannotMutateFunction { location, .. } => *location,
+            InterpreterError::FunctionAlreadyResolved { location, .. } => *location,
 
             InterpreterError::FailedToParseMacro { error, file, .. } => {
                 Location::new(error.span(), *file)
@@ -520,9 +520,12 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 let msg = "Failed to resolve to a trait definition".to_string();
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
-            InterpreterError::CannotMutateFunction { location } => {
-                let msg = "Cannot mutate function at this point".to_string();
-                CustomDiagnostic::simple_error(msg, String::new(), location.span)
+            InterpreterError::FunctionAlreadyResolved { location } => {
+                let msg = "Function already resolved".to_string();
+                let secondary =
+                    "The function was previously called at compile-time or is in another crate"
+                        .to_string();
+                CustomDiagnostic::simple_error(msg, secondary, location.span)
             }
         }
     }

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -185,6 +185,9 @@ pub enum InterpreterError {
     FailedToResolveTraitDefinition {
         location: Location,
     },
+    CannotMutateFunction {
+        location: Location,
+    },
 
     Unimplemented {
         item: String,
@@ -255,6 +258,7 @@ impl InterpreterError {
             | InterpreterError::TraitDefinitionMustBeAPath { location }
             | InterpreterError::FailedToResolveTraitDefinition { location }
             | InterpreterError::FailedToResolveTraitBound { location, .. } => *location,
+            InterpreterError::CannotMutateFunction { location, .. } => *location,
 
             InterpreterError::FailedToParseMacro { error, file, .. } => {
                 Location::new(error.span(), *file)
@@ -514,6 +518,10 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             }
             InterpreterError::FailedToResolveTraitDefinition { location } => {
                 let msg = "Failed to resolve to a trait definition".to_string();
+                CustomDiagnostic::simple_error(msg, String::new(), location.span)
+            }
+            InterpreterError::CannotMutateFunction { location } => {
+                let msg = "Cannot mutate function at this point".to_string();
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -44,6 +44,8 @@ mod builtin;
 mod foreign;
 mod unquote;
 
+pub(crate) type ValueAndLocation = (Value, Location);
+
 #[allow(unused)]
 pub struct Interpreter<'local, 'interner> {
     /// To expand macros the Interpreter needs access to the Elaborator
@@ -76,7 +78,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     pub(crate) fn call_function(
         &mut self,
         function: FuncId,
-        arguments: Vec<(Value, Location)>,
+        arguments: Vec<ValueAndLocation>,
         mut instantiation_bindings: TypeBindings,
         location: Location,
     ) -> IResult<Value> {
@@ -110,7 +112,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn call_function_inner(
         &mut self,
         function: FuncId,
-        arguments: Vec<(Value, Location)>,
+        arguments: Vec<ValueAndLocation>,
         location: Location,
     ) -> IResult<Value> {
         let meta = self.elaborator.interner.function_meta(&function);
@@ -139,7 +141,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn call_user_defined_function(
         &mut self,
         function: FuncId,
-        arguments: Vec<(Value, Location)>,
+        arguments: Vec<ValueAndLocation>,
         location: Location,
     ) -> IResult<Value> {
         let meta = self.elaborator.interner.function_meta(&function);
@@ -193,7 +195,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn call_special(
         &mut self,
         function: FuncId,
-        arguments: Vec<(Value, Location)>,
+        arguments: Vec<ValueAndLocation>,
         return_type: Type,
         location: Location,
     ) -> IResult<Value> {
@@ -227,7 +229,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         &mut self,
         closure: HirLambda,
         environment: Vec<Value>,
-        arguments: Vec<(Value, Location)>,
+        arguments: Vec<ValueAndLocation>,
         call_location: Location,
     ) -> IResult<Value> {
         let previous_state = self.enter_function();
@@ -1641,7 +1643,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         self.evaluate_statement(statement)
     }
 
-    fn print_oracle(&self, arguments: Vec<(Value, Location)>) -> Result<Value, InterpreterError> {
+    fn print_oracle(&self, arguments: Vec<ValueAndLocation>) -> Result<Value, InterpreterError> {
         assert_eq!(arguments.len(), 2);
 
         let print_newline = arguments[0].0 == Value::Bool(true);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -44,8 +44,6 @@ mod builtin;
 mod foreign;
 mod unquote;
 
-pub(crate) type ValueAndLocation = (Value, Location);
-
 #[allow(unused)]
 pub struct Interpreter<'local, 'interner> {
     /// To expand macros the Interpreter needs access to the Elaborator
@@ -78,7 +76,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     pub(crate) fn call_function(
         &mut self,
         function: FuncId,
-        arguments: Vec<ValueAndLocation>,
+        arguments: Vec<(Value, Location)>,
         mut instantiation_bindings: TypeBindings,
         location: Location,
     ) -> IResult<Value> {
@@ -112,7 +110,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn call_function_inner(
         &mut self,
         function: FuncId,
-        arguments: Vec<ValueAndLocation>,
+        arguments: Vec<(Value, Location)>,
         location: Location,
     ) -> IResult<Value> {
         let meta = self.elaborator.interner.function_meta(&function);
@@ -141,7 +139,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn call_user_defined_function(
         &mut self,
         function: FuncId,
-        arguments: Vec<ValueAndLocation>,
+        arguments: Vec<(Value, Location)>,
         location: Location,
     ) -> IResult<Value> {
         let meta = self.elaborator.interner.function_meta(&function);
@@ -195,7 +193,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn call_special(
         &mut self,
         function: FuncId,
-        arguments: Vec<ValueAndLocation>,
+        arguments: Vec<(Value, Location)>,
         return_type: Type,
         location: Location,
     ) -> IResult<Value> {
@@ -229,7 +227,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         &mut self,
         closure: HirLambda,
         environment: Vec<Value>,
-        arguments: Vec<ValueAndLocation>,
+        arguments: Vec<(Value, Location)>,
         call_location: Location,
     ) -> IResult<Value> {
         let previous_state = self.enter_function();
@@ -1643,7 +1641,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         self.evaluate_statement(statement)
     }
 
-    fn print_oracle(&self, arguments: Vec<ValueAndLocation>) -> Result<Value, InterpreterError> {
+    fn print_oracle(&self, arguments: Vec<(Value, Location)>) -> Result<Value, InterpreterError> {
         assert_eq!(arguments.len(), 2);
 
         let print_newline = arguments[0].0 == Value::Bool(true);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -773,7 +773,7 @@ fn function_def_set_parameters(
         parameter_types.push(parameter_type);
     }
 
-    mutate_func_meta(&mut interpreter.elaborator.interner, func_id, |func_meta| {
+    mutate_func_meta_type(&mut interpreter.elaborator.interner, func_id, |func_meta| {
         func_meta.parameters = parameters.into();
         func_meta.parameter_idents = parameter_idents;
         replace_func_meta_parameters(&mut func_meta.typ, parameter_types);
@@ -796,7 +796,7 @@ fn function_def_set_return_type(
 
     let quoted_type_id = interpreter.elaborator.interner.push_quoted_type(return_type.clone());
 
-    mutate_func_meta(&mut interpreter.elaborator.interner, func_id, |func_meta| {
+    mutate_func_meta_type(&mut interpreter.elaborator.interner, func_id, |func_meta| {
         func_meta.return_type = FunctionReturnType::Ty(UnresolvedType {
             typ: UnresolvedTypeData::Resolved(quoted_type_id),
             span: Some(location.span),
@@ -1010,7 +1010,7 @@ fn parse_tokens<T>(
     })
 }
 
-fn mutate_func_meta<F>(interner: &mut NodeInterner, func_id: FuncId, f: F)
+fn mutate_func_meta_type<F>(interner: &mut NodeInterner, func_id: FuncId, f: F)
 where
     F: FnOnce(&mut FuncMeta),
 {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -5,9 +5,10 @@ use std::{
 
 use acvm::{AcirField, FieldElement};
 use builtin_helpers::{
-    check_argument_count, check_one_argument, check_three_arguments, check_two_arguments,
-    get_function_def, get_module, get_quoted, get_slice, get_struct, get_trait_constraint,
-    get_trait_def, get_tuple, get_type, get_u32, hir_pattern_to_tokens,
+    check_argument_count, check_function_not_yet_resolved, check_one_argument,
+    check_three_arguments, check_two_arguments, get_function_def, get_module, get_quoted,
+    get_slice, get_struct, get_trait_constraint, get_trait_def, get_tuple, get_type, get_u32,
+    hir_pattern_to_tokens,
 };
 use iter_extended::{try_vecmap, vecmap};
 use noirc_errors::Location;
@@ -986,20 +987,6 @@ pub(crate) fn extract_option_generic_type(typ: Type) -> Type {
     assert_eq!(struct_type.name.0.contents, "Option");
 
     generics.pop().expect("Expected Option to have a T generic type")
-}
-
-fn check_function_not_yet_resolved(
-    interpreter: &Interpreter,
-    func_id: FuncId,
-    location: Location,
-) -> Result<(), InterpreterError> {
-    let func_meta = interpreter.elaborator.interner.function_meta(&func_id);
-    match func_meta.function_body {
-        FunctionBody::Unresolved(_, _, _) => Ok(()),
-        FunctionBody::Resolving | FunctionBody::Resolved => {
-            Err(InterpreterError::FunctionAlreadyResolved { location })
-        }
-    }
 }
 
 fn parse<T>(

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -786,12 +786,10 @@ fn function_def_set_parameters(
 
     interpreter.elaborator.interner.push_definition_type(func_meta.name.id, function_type.clone());
 
-    {
-        let func_meta = interpreter.elaborator.interner.function_meta_mut(&func_id);
-        func_meta.parameters = parameters.into();
-        func_meta.parameter_idents = parameter_idents;
-        func_meta.typ = function_type;
-    }
+    let func_meta = interpreter.elaborator.interner.function_meta_mut(&func_id);
+    func_meta.parameters = parameters.into();
+    func_meta.parameter_idents = parameter_idents;
+    func_meta.typ = function_type;
 
     Ok(Value::Unit)
 }
@@ -822,14 +820,12 @@ fn function_def_set_return_type(
 
     let quoted_type_id = interpreter.elaborator.interner.push_quoted_type(return_type);
 
-    {
-        let func_meta = interpreter.elaborator.interner.function_meta_mut(&func_id);
-        func_meta.return_type = FunctionReturnType::Ty(UnresolvedType {
-            typ: UnresolvedTypeData::Resolved(quoted_type_id),
-            span: Some(location.span),
-        });
-        func_meta.typ = function_type;
-    }
+    let func_meta = interpreter.elaborator.interner.function_meta_mut(&func_id);
+    func_meta.return_type = FunctionReturnType::Ty(UnresolvedType {
+        typ: UnresolvedTypeData::Resolved(quoted_type_id),
+        span: Some(location.span),
+    });
+    func_meta.typ = function_type;
 
     Ok(Value::Unit)
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 use self::builtin_helpers::{get_array, get_u8};
-use super::{Interpreter, ValueAndLocation};
+use super::Interpreter;
 
 pub(crate) mod builtin_helpers;
 
@@ -37,7 +37,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
     pub(super) fn call_builtin(
         &mut self,
         name: &str,
-        arguments: Vec<ValueAndLocation>,
+        arguments: Vec<(Value, Location)>,
         return_type: Type,
         location: Location,
     ) -> IResult<Value> {
@@ -108,7 +108,7 @@ fn failing_constraint<T>(message: impl Into<String>, location: Location) -> IRes
 
 fn array_len(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (argument, argument_location) = check_one_argument(arguments, location)?;
@@ -139,7 +139,7 @@ fn array_as_str_unchecked(
 
 fn as_slice(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (array, array_location) = check_one_argument(arguments, location)?;
@@ -157,7 +157,7 @@ fn as_slice(
 
 fn slice_push_back(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, (element, _)) = check_two_arguments(arguments, location)?;
@@ -170,7 +170,7 @@ fn slice_push_back(
 /// fn as_type(self) -> Type
 fn struct_def_as_type(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -189,7 +189,7 @@ fn struct_def_as_type(
 /// fn generics(self) -> [Type]
 fn struct_def_generics(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -208,7 +208,7 @@ fn struct_def_generics(
 /// Returns (name, type) pairs of each field of this StructDefinition
 fn struct_def_fields(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -233,7 +233,7 @@ fn struct_def_fields(
 
 fn slice_remove(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, index) = check_two_arguments(arguments, location)?;
@@ -259,7 +259,7 @@ fn slice_remove(
 
 fn slice_push_front(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, (element, _)) = check_two_arguments(arguments, location)?;
@@ -271,7 +271,7 @@ fn slice_push_front(
 
 fn slice_pop_front(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -285,7 +285,7 @@ fn slice_pop_front(
 
 fn slice_pop_back(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -299,7 +299,7 @@ fn slice_pop_back(
 
 fn slice_insert(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, index, (element, _)) = check_three_arguments(arguments, location)?;
@@ -313,7 +313,7 @@ fn slice_insert(
 // fn as_module(quoted: Quoted) -> Option<Module>
 fn quoted_as_module(
     interpreter: &mut Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -333,7 +333,7 @@ fn quoted_as_module(
 // fn as_trait_constraint(quoted: Quoted) -> TraitConstraint
 fn quoted_as_trait_constraint(
     interpreter: &mut Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -349,7 +349,7 @@ fn quoted_as_trait_constraint(
 // fn as_type(quoted: Quoted) -> Type
 fn quoted_as_type(
     interpreter: &mut Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -361,7 +361,7 @@ fn quoted_as_type(
 
 // fn as_array(self) -> Option<(Type, Type)>
 fn type_as_array(
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -376,7 +376,7 @@ fn type_as_array(
 
 // fn as_constant(self) -> Option<u32>
 fn type_as_constant(
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -391,7 +391,7 @@ fn type_as_constant(
 
 // fn as_integer(self) -> Option<(bool, u8)>
 fn type_as_integer(
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -406,7 +406,7 @@ fn type_as_integer(
 
 // fn as_slice(self) -> Option<Type>
 fn type_as_slice(
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -421,7 +421,7 @@ fn type_as_slice(
 
 // fn as_struct(self) -> Option<(StructDefinition, [Type])>
 fn type_as_struct(
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -442,7 +442,7 @@ fn type_as_struct(
 
 // fn as_tuple(self) -> Option<[Type]>
 fn type_as_tuple(
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -463,7 +463,7 @@ fn type_as_tuple(
 
 // Helper function for implementing the `type_as_...` functions.
 fn type_as<F>(
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
     f: F,
@@ -480,7 +480,7 @@ where
 }
 
 // fn type_eq(_first: Type, _second: Type) -> bool
-fn type_eq(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
+fn type_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
     let (self_type, other_type) = check_two_arguments(arguments, location)?;
 
     let self_type = get_type(self_type)?;
@@ -490,7 +490,7 @@ fn type_eq(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Valu
 }
 
 // fn is_bool(self) -> bool
-fn type_is_bool(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
+fn type_is_bool(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
     let value = check_one_argument(arguments, location)?;
     let typ = get_type(value)?;
 
@@ -498,7 +498,7 @@ fn type_is_bool(arguments: Vec<ValueAndLocation>, location: Location) -> IResult
 }
 
 // fn is_field(self) -> bool
-fn type_is_field(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
+fn type_is_field(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
     let value = check_one_argument(arguments, location)?;
     let typ = get_type(value)?;
 
@@ -506,7 +506,7 @@ fn type_is_field(arguments: Vec<ValueAndLocation>, location: Location) -> IResul
 }
 
 // fn type_of<T>(x: T) -> Type
-fn type_of(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
+fn type_of(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
     let (value, _) = check_one_argument(arguments, location)?;
     let typ = value.get_type().into_owned();
     Ok(Value::Type(typ))
@@ -515,7 +515,7 @@ fn type_of(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Valu
 // fn constraint_hash(constraint: TraitConstraint) -> Field
 fn trait_constraint_hash(
     _interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -532,7 +532,7 @@ fn trait_constraint_hash(
 // fn constraint_eq(constraint_a: TraitConstraint, constraint_b: TraitConstraint) -> bool
 fn trait_constraint_eq(
     _interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (value_a, value_b) = check_two_arguments(arguments, location)?;
@@ -546,7 +546,7 @@ fn trait_constraint_eq(
 // fn trait_def_hash(def: TraitDefinition) -> Field
 fn trait_def_hash(
     _interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -563,7 +563,7 @@ fn trait_def_hash(
 // fn trait_def_eq(def_a: TraitDefinition, def_b: TraitDefinition) -> bool
 fn trait_def_eq(
     _interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (id_a, id_b) = check_two_arguments(arguments, location)?;
@@ -658,7 +658,7 @@ fn zeroed(return_type: Type) -> IResult<Value> {
 // fn name(self) -> Quoted
 fn function_def_name(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -671,7 +671,7 @@ fn function_def_name(
 // fn parameters(self) -> [(Quoted, Type)]
 fn function_def_parameters(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -699,7 +699,7 @@ fn function_def_parameters(
 // fn return_type(self) -> Type
 fn function_def_return_type(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -712,7 +712,7 @@ fn function_def_return_type(
 // fn set_body(self, body: Quoted)
 fn function_def_set_body(
     interpreter: &mut Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, body_argument) = check_two_arguments(arguments, location)?;
@@ -746,7 +746,7 @@ fn function_def_set_body(
 // fn set_parameters(self, parameters: [(Quoted, Type)])
 fn function_def_set_parameters(
     interpreter: &mut Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, parameters_argument) = check_two_arguments(arguments, location)?;
@@ -801,7 +801,7 @@ fn function_def_set_parameters(
 // fn set_return_type(self, return_type: Type)
 fn function_def_set_return_type(
     interpreter: &mut Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, return_type_argument) = check_two_arguments(arguments, location)?;
@@ -826,7 +826,7 @@ fn function_def_set_return_type(
 // fn functions(self) -> [FunctionDefinition]
 fn module_functions(
     interpreter: &Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -850,7 +850,7 @@ fn module_functions(
 // fn is_contract(self) -> bool
 fn module_is_contract(
     interpreter: &Interpreter,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -861,7 +861,7 @@ fn module_is_contract(
 // fn name(self) -> Quoted
 fn module_name(
     interner: &NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -873,7 +873,7 @@ fn module_name(
 
 fn modulus_be_bits(
     _interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     check_argument_count(0, &arguments, location)?;
@@ -888,7 +888,7 @@ fn modulus_be_bits(
 
 fn modulus_be_bytes(
     _interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     check_argument_count(0, &arguments, location)?;
@@ -903,7 +903,7 @@ fn modulus_be_bytes(
 
 fn modulus_le_bits(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let Value::Slice(bits, typ) = modulus_be_bits(interner, arguments, location)? else {
@@ -915,7 +915,7 @@ fn modulus_le_bits(
 
 fn modulus_le_bytes(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let Value::Slice(bytes, typ) = modulus_be_bytes(interner, arguments, location)? else {
@@ -927,7 +927,7 @@ fn modulus_le_bytes(
 
 fn modulus_num_bits(
     _interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     check_argument_count(0, &arguments, location)?;
@@ -936,7 +936,7 @@ fn modulus_num_bits(
 }
 
 // fn quoted_eq(_first: Quoted, _second: Quoted) -> bool
-fn quoted_eq(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
+fn quoted_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
     let (self_value, other_value) = check_two_arguments(arguments, location)?;
 
     let self_quoted = get_quoted(self_value)?;
@@ -947,7 +947,7 @@ fn quoted_eq(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Va
 
 fn trait_def_as_trait_constraint(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> Result<Value, InterpreterError> {
     let argument = check_one_argument(arguments, location)?;
@@ -990,7 +990,7 @@ pub(crate) fn extract_option_generic_type(typ: Type) -> Type {
 }
 
 fn parse<T>(
-    (value, location): ValueAndLocation,
+    (value, location): (Value, Location),
     parser: impl NoirParser<T>,
     rule: &'static str,
 ) -> IResult<T> {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -774,17 +774,15 @@ fn function_def_set_parameters(
     }
 
     let func_meta = interpreter.elaborator.interner.function_meta(&func_id);
-    let function_type = Type::Function(
+    let mut function_type = Type::Function(
         parameter_types,
         Box::new(func_meta.return_type().clone()),
         Box::new(Type::Unit),
     );
 
-    // TODO: generics. In Elaborator::define_function_meta there's this code:
-    //
-    //     if !generics.is_empty() {
-    //         typ = Type::Forall(generics, Box::new(typ));
-    //     }
+    if let Type::Forall(generics, _) = &func_meta.typ {
+        function_type = Type::Forall(generics.clone(), Box::new(function_type));
+    }
 
     interpreter.elaborator.interner.push_definition_type(func_meta.name.id, function_type.clone());
 
@@ -813,14 +811,12 @@ fn function_def_set_return_type(
     let parameter_types = func_meta.parameters.iter().map(|(_, typ, _)| typ.clone()).collect();
 
     let func_meta = interpreter.elaborator.interner.function_meta(&func_id);
-    let function_type =
+    let mut function_type =
         Type::Function(parameter_types, Box::new(return_type.clone()), Box::new(Type::Unit));
 
-    // TODO: generics. In Elaborator::define_function_meta there's this code:
-    //
-    //     if !generics.is_empty() {
-    //         typ = Type::Forall(generics, Box::new(typ));
-    //     }
+    if let Type::Forall(generics, _) = &func_meta.typ {
+        function_type = Type::Forall(generics.clone(), Box::new(function_type));
+    }
 
     interpreter.elaborator.interner.push_definition_type(func_meta.name.id, function_type.clone());
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -8,7 +8,8 @@ use builtin_helpers::{
     check_argument_count, check_function_not_yet_resolved, check_one_argument,
     check_three_arguments, check_two_arguments, get_function_def, get_module, get_quoted,
     get_slice, get_struct, get_trait_constraint, get_trait_def, get_tuple, get_type, get_u32,
-    hir_pattern_to_tokens,
+    hir_pattern_to_tokens, mutate_func_meta_type, parse, parse_tokens,
+    replace_func_meta_parameters, replace_func_meta_return_type,
 };
 use iter_extended::{try_vecmap, vecmap};
 use noirc_errors::Location;
@@ -20,11 +21,11 @@ use crate::{
         Visibility,
     },
     hir::comptime::{errors::IResult, value::add_token_spans, InterpreterError, Value},
-    hir_def::function::{FuncMeta, FunctionBody},
+    hir_def::function::FunctionBody,
     macros_api::{ModuleDefId, NodeInterner, Signedness},
-    node_interner::{DefinitionKind, FuncId},
-    parser::{self, NoirParser},
-    token::{SpannedToken, Token, Tokens},
+    node_interner::DefinitionKind,
+    parser::{self},
+    token::{SpannedToken, Token},
     QuotedType, Shared, Type,
 };
 
@@ -987,60 +988,4 @@ pub(crate) fn extract_option_generic_type(typ: Type) -> Type {
     assert_eq!(struct_type.name.0.contents, "Option");
 
     generics.pop().expect("Expected Option to have a T generic type")
-}
-
-fn parse<T>(
-    (value, location): (Value, Location),
-    parser: impl NoirParser<T>,
-    rule: &'static str,
-) -> IResult<T> {
-    let tokens = get_quoted((value, location))?;
-    let quoted = add_token_spans(tokens.clone(), location.span);
-    parse_tokens(tokens, quoted, location, parser, rule)
-}
-
-fn parse_tokens<T>(
-    tokens: Rc<Vec<Token>>,
-    quoted: Tokens,
-    location: Location,
-    parser: impl NoirParser<T>,
-    rule: &'static str,
-) -> IResult<T> {
-    parser.parse(quoted).map_err(|mut errors| {
-        let error = errors.swap_remove(0);
-        InterpreterError::FailedToParseMacro { error, tokens, rule, file: location.file }
-    })
-}
-
-fn mutate_func_meta_type<F>(interner: &mut NodeInterner, func_id: FuncId, f: F)
-where
-    F: FnOnce(&mut FuncMeta),
-{
-    let (name_id, function_type) = {
-        let func_meta = interner.function_meta_mut(&func_id);
-        f(func_meta);
-        (func_meta.name.id, func_meta.typ.clone())
-    };
-
-    interner.push_definition_type(name_id, function_type);
-}
-
-fn replace_func_meta_parameters(typ: &mut Type, parameter_types: Vec<Type>) {
-    match typ {
-        Type::Function(parameters, _, _) => {
-            *parameters = parameter_types;
-        }
-        Type::Forall(_, typ) => replace_func_meta_parameters(typ, parameter_types),
-        _ => {}
-    }
-}
-
-fn replace_func_meta_return_type(typ: &mut Type, return_type: Type) {
-    match typ {
-        Type::Function(_, ret, _) => {
-            *ret = Box::new(return_type);
-        }
-        Type::Forall(_, typ) => replace_func_meta_return_type(typ, return_type),
-        _ => {}
-    }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -31,11 +31,13 @@ use super::Interpreter;
 
 pub(crate) mod builtin_helpers;
 
+pub(crate) type ValueAndLocation = (Value, Location);
+
 impl<'local, 'context> Interpreter<'local, 'context> {
     pub(super) fn call_builtin(
         &mut self,
         name: &str,
-        arguments: Vec<(Value, Location)>,
+        arguments: Vec<ValueAndLocation>,
         return_type: Type,
         location: Location,
     ) -> IResult<Value> {
@@ -105,7 +107,7 @@ fn failing_constraint<T>(message: impl Into<String>, location: Location) -> IRes
 
 fn array_len(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (argument, argument_location) = check_one_argument(arguments, location)?;
@@ -123,7 +125,7 @@ fn array_len(
 
 fn as_slice(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (array, array_location) = check_one_argument(arguments, location)?;
@@ -141,7 +143,7 @@ fn as_slice(
 
 fn slice_push_back(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, (element, _)) = check_two_arguments(arguments, location)?;
@@ -154,7 +156,7 @@ fn slice_push_back(
 /// fn as_type(self) -> Type
 fn struct_def_as_type(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -173,7 +175,7 @@ fn struct_def_as_type(
 /// fn generics(self) -> [Type]
 fn struct_def_generics(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -192,7 +194,7 @@ fn struct_def_generics(
 /// Returns (name, type) pairs of each field of this StructDefinition
 fn struct_def_fields(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -217,7 +219,7 @@ fn struct_def_fields(
 
 fn slice_remove(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, index) = check_two_arguments(arguments, location)?;
@@ -243,7 +245,7 @@ fn slice_remove(
 
 fn slice_push_front(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, (element, _)) = check_two_arguments(arguments, location)?;
@@ -255,7 +257,7 @@ fn slice_push_front(
 
 fn slice_pop_front(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -269,7 +271,7 @@ fn slice_pop_front(
 
 fn slice_pop_back(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -283,7 +285,7 @@ fn slice_pop_back(
 
 fn slice_insert(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (slice, index, (element, _)) = check_three_arguments(arguments, location)?;
@@ -297,7 +299,7 @@ fn slice_insert(
 // fn as_module(quoted: Quoted) -> Option<Module>
 fn quoted_as_module(
     interpreter: &mut Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -317,7 +319,7 @@ fn quoted_as_module(
 // fn as_trait_constraint(quoted: Quoted) -> TraitConstraint
 fn quoted_as_trait_constraint(
     interpreter: &mut Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -333,7 +335,7 @@ fn quoted_as_trait_constraint(
 // fn as_type(quoted: Quoted) -> Type
 fn quoted_as_type(
     interpreter: &mut Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -345,7 +347,7 @@ fn quoted_as_type(
 
 // fn as_array(self) -> Option<(Type, Type)>
 fn type_as_array(
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -360,7 +362,7 @@ fn type_as_array(
 
 // fn as_constant(self) -> Option<u32>
 fn type_as_constant(
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -375,7 +377,7 @@ fn type_as_constant(
 
 // fn as_integer(self) -> Option<(bool, u8)>
 fn type_as_integer(
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -390,7 +392,7 @@ fn type_as_integer(
 
 // fn as_slice(self) -> Option<Type>
 fn type_as_slice(
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -405,7 +407,7 @@ fn type_as_slice(
 
 // fn as_struct(self) -> Option<(StructDefinition, [Type])>
 fn type_as_struct(
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -426,7 +428,7 @@ fn type_as_struct(
 
 // fn as_tuple(self) -> Option<[Type]>
 fn type_as_tuple(
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
@@ -447,7 +449,7 @@ fn type_as_tuple(
 
 // Helper function for implementing the `type_as_...` functions.
 fn type_as<F>(
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     return_type: Type,
     location: Location,
     f: F,
@@ -464,7 +466,7 @@ where
 }
 
 // fn type_eq(_first: Type, _second: Type) -> bool
-fn type_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+fn type_eq(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
     let (self_type, other_type) = check_two_arguments(arguments, location)?;
 
     let self_type = get_type(self_type)?;
@@ -474,7 +476,7 @@ fn type_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Val
 }
 
 // fn is_bool(self) -> bool
-fn type_is_bool(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+fn type_is_bool(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
     let value = check_one_argument(arguments, location)?;
     let typ = get_type(value)?;
 
@@ -482,7 +484,7 @@ fn type_is_bool(arguments: Vec<(Value, Location)>, location: Location) -> IResul
 }
 
 // fn is_field(self) -> bool
-fn type_is_field(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+fn type_is_field(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
     let value = check_one_argument(arguments, location)?;
     let typ = get_type(value)?;
 
@@ -490,7 +492,7 @@ fn type_is_field(arguments: Vec<(Value, Location)>, location: Location) -> IResu
 }
 
 // fn type_of<T>(x: T) -> Type
-fn type_of(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+fn type_of(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
     let (value, _) = check_one_argument(arguments, location)?;
     let typ = value.get_type().into_owned();
     Ok(Value::Type(typ))
@@ -499,7 +501,7 @@ fn type_of(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Val
 // fn constraint_hash(constraint: TraitConstraint) -> Field
 fn trait_constraint_hash(
     _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -516,7 +518,7 @@ fn trait_constraint_hash(
 // fn constraint_eq(constraint_a: TraitConstraint, constraint_b: TraitConstraint) -> bool
 fn trait_constraint_eq(
     _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (value_a, value_b) = check_two_arguments(arguments, location)?;
@@ -530,7 +532,7 @@ fn trait_constraint_eq(
 // fn trait_def_hash(def: TraitDefinition) -> Field
 fn trait_def_hash(
     _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
@@ -547,7 +549,7 @@ fn trait_def_hash(
 // fn trait_def_eq(def_a: TraitDefinition, def_b: TraitDefinition) -> bool
 fn trait_def_eq(
     _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (id_a, id_b) = check_two_arguments(arguments, location)?;
@@ -642,7 +644,7 @@ fn zeroed(return_type: Type) -> IResult<Value> {
 // fn name(self) -> Quoted
 fn function_def_name(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -655,7 +657,7 @@ fn function_def_name(
 // fn parameters(self) -> [(Quoted, Type)]
 fn function_def_parameters(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -683,7 +685,7 @@ fn function_def_parameters(
 // fn return_type(self) -> Type
 fn function_def_return_type(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -696,7 +698,7 @@ fn function_def_return_type(
 // fn set_body(self, body: Quoted)
 fn function_def_set_body(
     interpreter: &mut Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, body_argument) = check_two_arguments(arguments, location)?;
@@ -730,7 +732,7 @@ fn function_def_set_body(
 // fn set_parameters(self, parameters: [(Quoted, Type)])
 fn function_def_set_parameters(
     interpreter: &mut Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, parameters_argument) = check_two_arguments(arguments, location)?;
@@ -785,7 +787,7 @@ fn function_def_set_parameters(
 // fn set_return_type(self, return_type: Type)
 fn function_def_set_return_type(
     interpreter: &mut Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, return_type_argument) = check_two_arguments(arguments, location)?;
@@ -810,7 +812,7 @@ fn function_def_set_return_type(
 // fn functions(self) -> [FunctionDefinition]
 fn module_functions(
     interpreter: &Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -834,7 +836,7 @@ fn module_functions(
 // fn is_contract(self) -> bool
 fn module_is_contract(
     interpreter: &Interpreter,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -845,7 +847,7 @@ fn module_is_contract(
 // fn name(self) -> Quoted
 fn module_name(
     interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
@@ -857,7 +859,7 @@ fn module_name(
 
 fn modulus_be_bits(
     _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     check_argument_count(0, &arguments, location)?;
@@ -872,7 +874,7 @@ fn modulus_be_bits(
 
 fn modulus_be_bytes(
     _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     check_argument_count(0, &arguments, location)?;
@@ -887,7 +889,7 @@ fn modulus_be_bytes(
 
 fn modulus_le_bits(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let Value::Slice(bits, typ) = modulus_be_bits(interner, arguments, location)? else {
@@ -899,7 +901,7 @@ fn modulus_le_bits(
 
 fn modulus_le_bytes(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let Value::Slice(bytes, typ) = modulus_be_bytes(interner, arguments, location)? else {
@@ -911,7 +913,7 @@ fn modulus_le_bytes(
 
 fn modulus_num_bits(
     _interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     check_argument_count(0, &arguments, location)?;
@@ -920,7 +922,7 @@ fn modulus_num_bits(
 }
 
 // fn quoted_eq(_first: Quoted, _second: Quoted) -> bool
-fn quoted_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+fn quoted_eq(arguments: Vec<ValueAndLocation>, location: Location) -> IResult<Value> {
     let (self_value, other_value) = check_two_arguments(arguments, location)?;
 
     let self_quoted = get_quoted(self_value)?;
@@ -931,7 +933,7 @@ fn quoted_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<V
 
 fn trait_def_as_trait_constraint(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> Result<Value, InterpreterError> {
     let argument = check_one_argument(arguments, location)?;
@@ -988,7 +990,7 @@ fn check_function_not_yet_resolved(
 }
 
 fn parse<T>(
-    (value, location): (Value, Location),
+    (value, location): ValueAndLocation,
     parser: impl NoirParser<T>,
     rule: &'static str,
 ) -> IResult<T> {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -775,7 +775,7 @@ fn function_def_set_parameters(
         parameter_types.push(parameter_type);
     }
 
-    mutate_func_meta_type(&mut interpreter.elaborator.interner, func_id, |func_meta| {
+    mutate_func_meta_type(interpreter.elaborator.interner, func_id, |func_meta| {
         func_meta.parameters = parameters.into();
         func_meta.parameter_idents = parameter_idents;
         replace_func_meta_parameters(&mut func_meta.typ, parameter_types);
@@ -798,7 +798,7 @@ fn function_def_set_return_type(
 
     let quoted_type_id = interpreter.elaborator.interner.push_quoted_type(return_type.clone());
 
-    mutate_func_meta_type(&mut interpreter.elaborator.interner, func_id, |func_meta| {
+    mutate_func_meta_type(interpreter.elaborator.interner, func_id, |func_meta| {
         func_meta.return_type = FunctionReturnType::Ty(UnresolvedType {
             typ: UnresolvedTypeData::Resolved(quoted_type_id),
             span: Some(location.span),
@@ -984,7 +984,7 @@ fn check_function_not_yet_resolved(
     match func_meta.function_body {
         FunctionBody::Unresolved(_, _, _) => Ok(()),
         FunctionBody::Resolving | FunctionBody::Resolved => {
-            return Err(InterpreterError::FunctionAlreadyResolved { location })
+            Err(InterpreterError::FunctionAlreadyResolved { location })
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -748,12 +748,10 @@ fn function_def_set_body(
 
     let body =
         parser::block(parser::fresh_statement()).parse(body_quoted).map_err(|mut errors| {
-            let error = errors.swap_remove(0);
-            let rule = "a block";
             InterpreterError::FailedToParseMacro {
-                error,
+                error: errors.swap_remove(0),
                 tokens: body_tokens,
-                rule,
+                rule: "a block",
                 file: location.file,
             }
         })?;
@@ -803,12 +801,10 @@ fn function_def_set_parameters(
             add_token_spans(parameter_name_tokens.clone(), parameters_argument_location.span);
         let parameter_pattern =
             parser::pattern().parse(parameter_name_quoted).map_err(|mut errors| {
-                let error = errors.swap_remove(0);
-                let rule = "a pattern";
                 InterpreterError::FailedToParseMacro {
-                    error,
+                    error: errors.swap_remove(0),
                     tokens: parameter_name_tokens,
-                    rule,
+                    rule: "a pattern",
                     file: location.file,
                 }
             })?;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -973,14 +973,14 @@ pub(crate) fn extract_option_generic_type(typ: Type) -> Type {
     generics.pop().expect("Expected Option to have a T generic type")
 }
 
-fn check_function_not_yet_resolved<'a>(
-    interpreter: &'a Interpreter,
+fn check_function_not_yet_resolved(
+    interpreter: &Interpreter,
     func_id: FuncId,
     location: Location,
-) -> Result<&'a FuncMeta, InterpreterError> {
+) -> Result<(), InterpreterError> {
     let func_meta = interpreter.elaborator.interner.function_meta(&func_id);
     match func_meta.function_body {
-        FunctionBody::Unresolved(_, _, _) => Ok(func_meta),
+        FunctionBody::Unresolved(_, _, _) => Ok(()),
         FunctionBody::Resolving | FunctionBody::Resolved => {
             return Err(InterpreterError::FunctionAlreadyResolved { location })
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -703,7 +703,7 @@ fn function_def_set_body(
     let body_argument_location = body_argument.1;
 
     let func_id = get_function_def(self_argument)?;
-    check_can_mutate_function(interpreter, func_id, location)?;
+    check_function_not_yet_resolved(interpreter, func_id, location)?;
 
     let body_tokens = get_quoted(body_argument)?;
     let mut body_quoted = add_token_spans(body_tokens.clone(), body_argument_location.span);
@@ -737,7 +737,7 @@ fn function_def_set_parameters(
     let parameters_argument_location = parameters_argument.1;
 
     let func_id = get_function_def(self_argument)?;
-    check_can_mutate_function(interpreter, func_id, location)?;
+    check_function_not_yet_resolved(interpreter, func_id, location)?;
 
     let (input_parameters, _type) =
         get_slice(interpreter.elaborator.interner, parameters_argument)?;
@@ -804,7 +804,7 @@ fn function_def_set_return_type(
     let return_type = get_type(return_type_argument)?;
 
     let func_id = get_function_def(self_argument)?;
-    let func_meta = check_can_mutate_function(interpreter, func_id, location)?;
+    let func_meta = check_function_not_yet_resolved(interpreter, func_id, location)?;
 
     let parameter_types = func_meta.parameters.iter().map(|(_, typ, _)| typ.clone()).collect();
 
@@ -996,7 +996,7 @@ pub(crate) fn extract_option_generic_type(typ: Type) -> Type {
     generics.pop().expect("Expected Option to have a T generic type")
 }
 
-fn check_can_mutate_function<'a>(
+fn check_function_not_yet_resolved<'a>(
     interpreter: &'a Interpreter,
     func_id: FuncId,
     location: Location,
@@ -1005,7 +1005,7 @@ fn check_can_mutate_function<'a>(
     match func_meta.function_body {
         FunctionBody::Unresolved(_, _, _) => Ok(func_meta),
         FunctionBody::Resolving | FunctionBody::Resolved => {
-            return Err(InterpreterError::CannotMutateFunction { location })
+            return Err(InterpreterError::FunctionAlreadyResolved { location })
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -27,11 +27,9 @@ use crate::{
     QuotedType, Shared, Type,
 };
 
-use super::Interpreter;
+use super::{Interpreter, ValueAndLocation};
 
 pub(crate) mod builtin_helpers;
-
-pub(crate) type ValueAndLocation = (Value, Location);
 
 impl<'local, 'context> Interpreter<'local, 'context> {
     pub(super) fn call_builtin(

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -857,7 +857,7 @@ fn function_def_set_parameters(
                 }
             })?;
 
-        let hir_pattern = interpreter.elaborate_item(interpreter.current_function, |elaborator| {
+        let hir_pattern = interpreter.elaborate_item(Some(func_id), |elaborator| {
             elaborator.elaborate_pattern_and_store_ids(
                 parameter_pattern,
                 parameter_type.clone(),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -16,11 +16,9 @@ use crate::{
     QuotedType, Type,
 };
 
-use super::ValueAndLocation;
-
 pub(crate) fn check_argument_count(
     expected: usize,
-    arguments: &[ValueAndLocation],
+    arguments: &[(Value, Location)],
     location: Location,
 ) -> IResult<()> {
     if arguments.len() == expected {
@@ -32,18 +30,18 @@ pub(crate) fn check_argument_count(
 }
 
 pub(crate) fn check_one_argument(
-    mut arguments: Vec<ValueAndLocation>,
+    mut arguments: Vec<(Value, Location)>,
     location: Location,
-) -> IResult<ValueAndLocation> {
+) -> IResult<(Value, Location)> {
     check_argument_count(1, &arguments, location)?;
 
     Ok(arguments.pop().unwrap())
 }
 
 pub(crate) fn check_two_arguments(
-    mut arguments: Vec<ValueAndLocation>,
+    mut arguments: Vec<(Value, Location)>,
     location: Location,
-) -> IResult<(ValueAndLocation, ValueAndLocation)> {
+) -> IResult<((Value, Location), (Value, Location))> {
     check_argument_count(2, &arguments, location)?;
 
     let argument2 = arguments.pop().unwrap();
@@ -53,9 +51,9 @@ pub(crate) fn check_two_arguments(
 }
 
 pub(crate) fn check_three_arguments(
-    mut arguments: Vec<ValueAndLocation>,
+    mut arguments: Vec<(Value, Location)>,
     location: Location,
-) -> IResult<(ValueAndLocation, ValueAndLocation, ValueAndLocation)> {
+) -> IResult<((Value, Location), (Value, Location), (Value, Location))> {
     check_argument_count(3, &arguments, location)?;
 
     let argument3 = arguments.pop().unwrap();
@@ -67,7 +65,7 @@ pub(crate) fn check_three_arguments(
 
 pub(crate) fn get_array(
     interner: &NodeInterner,
-    (value, location): ValueAndLocation,
+    (value, location): (Value, Location),
 ) -> IResult<(im::Vector<Value>, Type)> {
     match value {
         Value::Array(values, typ) => Ok((values, typ)),
@@ -82,7 +80,7 @@ pub(crate) fn get_array(
 
 pub(crate) fn get_slice(
     interner: &NodeInterner,
-    (value, location): ValueAndLocation,
+    (value, location): (Value, Location),
 ) -> IResult<(im::Vector<Value>, Type)> {
     match value {
         Value::Slice(values, typ) => Ok((values, typ)),
@@ -97,7 +95,7 @@ pub(crate) fn get_slice(
 
 pub(crate) fn get_tuple(
     interner: &NodeInterner,
-    (value, location): ValueAndLocation,
+    (value, location): (Value, Location),
 ) -> IResult<Vec<Value>> {
     match value {
         Value::Tuple(values) => Ok(values),
@@ -110,7 +108,7 @@ pub(crate) fn get_tuple(
     }
 }
 
-pub(crate) fn get_field((value, location): ValueAndLocation) -> IResult<FieldElement> {
+pub(crate) fn get_field((value, location): (Value, Location)) -> IResult<FieldElement> {
     match value {
         Value::Field(value) => Ok(value),
         value => {
@@ -120,7 +118,7 @@ pub(crate) fn get_field((value, location): ValueAndLocation) -> IResult<FieldEle
     }
 }
 
-pub(crate) fn get_u8((value, location): ValueAndLocation) -> IResult<u8> {
+pub(crate) fn get_u8((value, location): (Value, Location)) -> IResult<u8> {
     match value {
         Value::U8(value) => Ok(value),
         value => {
@@ -131,7 +129,7 @@ pub(crate) fn get_u8((value, location): ValueAndLocation) -> IResult<u8> {
     }
 }
 
-pub(crate) fn get_u32((value, location): ValueAndLocation) -> IResult<u32> {
+pub(crate) fn get_u32((value, location): (Value, Location)) -> IResult<u32> {
     match value {
         Value::U32(value) => Ok(value),
         value => {
@@ -142,7 +140,7 @@ pub(crate) fn get_u32((value, location): ValueAndLocation) -> IResult<u32> {
     }
 }
 
-pub(crate) fn get_function_def((value, location): ValueAndLocation) -> IResult<FuncId> {
+pub(crate) fn get_function_def((value, location): (Value, Location)) -> IResult<FuncId> {
     match value {
         Value::FunctionDefinition(id) => Ok(id),
         value => {
@@ -153,7 +151,7 @@ pub(crate) fn get_function_def((value, location): ValueAndLocation) -> IResult<F
     }
 }
 
-pub(crate) fn get_module((value, location): ValueAndLocation) -> IResult<ModuleId> {
+pub(crate) fn get_module((value, location): (Value, Location)) -> IResult<ModuleId> {
     match value {
         Value::ModuleDefinition(module_id) => Ok(module_id),
         value => {
@@ -164,7 +162,7 @@ pub(crate) fn get_module((value, location): ValueAndLocation) -> IResult<ModuleI
     }
 }
 
-pub(crate) fn get_struct((value, location): ValueAndLocation) -> IResult<StructId> {
+pub(crate) fn get_struct((value, location): (Value, Location)) -> IResult<StructId> {
     match value {
         Value::StructDefinition(id) => Ok(id),
         _ => {
@@ -176,7 +174,7 @@ pub(crate) fn get_struct((value, location): ValueAndLocation) -> IResult<StructI
 }
 
 pub(crate) fn get_trait_constraint(
-    (value, location): ValueAndLocation,
+    (value, location): (Value, Location),
 ) -> IResult<(TraitId, Vec<Type>)> {
     match value {
         Value::TraitConstraint(trait_id, generics) => Ok((trait_id, generics)),
@@ -188,7 +186,7 @@ pub(crate) fn get_trait_constraint(
     }
 }
 
-pub(crate) fn get_trait_def((value, location): ValueAndLocation) -> IResult<TraitId> {
+pub(crate) fn get_trait_def((value, location): (Value, Location)) -> IResult<TraitId> {
     match value {
         Value::TraitDefinition(id) => Ok(id),
         value => {
@@ -199,7 +197,7 @@ pub(crate) fn get_trait_def((value, location): ValueAndLocation) -> IResult<Trai
     }
 }
 
-pub(crate) fn get_type((value, location): ValueAndLocation) -> IResult<Type> {
+pub(crate) fn get_type((value, location): (Value, Location)) -> IResult<Type> {
     match value {
         Value::Type(typ) => Ok(typ),
         value => {
@@ -210,7 +208,7 @@ pub(crate) fn get_type((value, location): ValueAndLocation) -> IResult<Type> {
     }
 }
 
-pub(crate) fn get_quoted((value, location): ValueAndLocation) -> IResult<Rc<Vec<Token>>> {
+pub(crate) fn get_quoted((value, location): (Value, Location)) -> IResult<Rc<Vec<Token>>> {
     match value {
         Value::Quoted(tokens) => Ok(tokens),
         value => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -95,6 +95,22 @@ pub(crate) fn get_slice(
     }
 }
 
+pub(crate) fn get_tuple(
+    interner: &NodeInterner,
+    value: Value,
+    location: Location,
+) -> IResult<Vec<Value>> {
+    match value {
+        Value::Tuple(values) => Ok(values),
+        value => {
+            let type_var = interner.next_type_variable();
+            let expected = Type::Tuple(vec![type_var]);
+            let actual = value.get_type().into_owned();
+            Err(InterpreterError::TypeMismatch { expected, actual, location })
+        }
+    }
+}
+
 pub(crate) fn get_field(value: Value, location: Location) -> IResult<FieldElement> {
     match value {
         Value::Field(value) => Ok(value),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -159,7 +159,7 @@ pub(crate) fn get_struct((value, location): ValueAndLocation) -> IResult<StructI
         _ => {
             let expected = Type::Quoted(QuotedType::StructDefinition);
             let actual = value.get_type().into_owned();
-            return Err(InterpreterError::TypeMismatch { expected, location, actual });
+            Err(InterpreterError::TypeMismatch { expected, location, actual })
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -32,20 +32,20 @@ pub(crate) fn check_argument_count(
 pub(crate) fn check_one_argument(
     mut arguments: Vec<(Value, Location)>,
     location: Location,
-) -> IResult<Value> {
+) -> IResult<(Value, Location)> {
     check_argument_count(1, &arguments, location)?;
 
-    Ok(arguments.pop().unwrap().0)
+    Ok(arguments.pop().unwrap())
 }
 
 pub(crate) fn check_two_arguments(
     mut arguments: Vec<(Value, Location)>,
     location: Location,
-) -> IResult<(Value, Value)> {
+) -> IResult<((Value, Location), (Value, Location))> {
     check_argument_count(2, &arguments, location)?;
 
-    let argument2 = arguments.pop().unwrap().0;
-    let argument1 = arguments.pop().unwrap().0;
+    let argument2 = arguments.pop().unwrap();
+    let argument1 = arguments.pop().unwrap();
 
     Ok((argument1, argument2))
 }
@@ -53,12 +53,12 @@ pub(crate) fn check_two_arguments(
 pub(crate) fn check_three_arguments(
     mut arguments: Vec<(Value, Location)>,
     location: Location,
-) -> IResult<(Value, Value, Value)> {
+) -> IResult<((Value, Location), (Value, Location), (Value, Location))> {
     check_argument_count(3, &arguments, location)?;
 
-    let argument3 = arguments.pop().unwrap().0;
-    let argument2 = arguments.pop().unwrap().0;
-    let argument1 = arguments.pop().unwrap().0;
+    let argument3 = arguments.pop().unwrap();
+    let argument2 = arguments.pop().unwrap();
+    let argument1 = arguments.pop().unwrap();
 
     Ok((argument1, argument2, argument3))
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -16,9 +16,11 @@ use crate::{
     QuotedType, Type,
 };
 
+use super::ValueAndLocation;
+
 pub(crate) fn check_argument_count(
     expected: usize,
-    arguments: &[(Value, Location)],
+    arguments: &[ValueAndLocation],
     location: Location,
 ) -> IResult<()> {
     if arguments.len() == expected {
@@ -30,18 +32,18 @@ pub(crate) fn check_argument_count(
 }
 
 pub(crate) fn check_one_argument(
-    mut arguments: Vec<(Value, Location)>,
+    mut arguments: Vec<ValueAndLocation>,
     location: Location,
-) -> IResult<(Value, Location)> {
+) -> IResult<ValueAndLocation> {
     check_argument_count(1, &arguments, location)?;
 
     Ok(arguments.pop().unwrap())
 }
 
 pub(crate) fn check_two_arguments(
-    mut arguments: Vec<(Value, Location)>,
+    mut arguments: Vec<ValueAndLocation>,
     location: Location,
-) -> IResult<((Value, Location), (Value, Location))> {
+) -> IResult<(ValueAndLocation, ValueAndLocation)> {
     check_argument_count(2, &arguments, location)?;
 
     let argument2 = arguments.pop().unwrap();
@@ -51,9 +53,9 @@ pub(crate) fn check_two_arguments(
 }
 
 pub(crate) fn check_three_arguments(
-    mut arguments: Vec<(Value, Location)>,
+    mut arguments: Vec<ValueAndLocation>,
     location: Location,
-) -> IResult<((Value, Location), (Value, Location), (Value, Location))> {
+) -> IResult<(ValueAndLocation, ValueAndLocation, ValueAndLocation)> {
     check_argument_count(3, &arguments, location)?;
 
     let argument3 = arguments.pop().unwrap();
@@ -65,7 +67,7 @@ pub(crate) fn check_three_arguments(
 
 pub(crate) fn get_array(
     interner: &NodeInterner,
-    (value, location): (Value, Location),
+    (value, location): ValueAndLocation,
 ) -> IResult<(im::Vector<Value>, Type)> {
     match value {
         Value::Array(values, typ) => Ok((values, typ)),
@@ -80,7 +82,7 @@ pub(crate) fn get_array(
 
 pub(crate) fn get_slice(
     interner: &NodeInterner,
-    (value, location): (Value, Location),
+    (value, location): ValueAndLocation,
 ) -> IResult<(im::Vector<Value>, Type)> {
     match value {
         Value::Slice(values, typ) => Ok((values, typ)),
@@ -95,7 +97,7 @@ pub(crate) fn get_slice(
 
 pub(crate) fn get_tuple(
     interner: &NodeInterner,
-    (value, location): (Value, Location),
+    (value, location): ValueAndLocation,
 ) -> IResult<Vec<Value>> {
     match value {
         Value::Tuple(values) => Ok(values),
@@ -108,7 +110,7 @@ pub(crate) fn get_tuple(
     }
 }
 
-pub(crate) fn get_field((value, location): (Value, Location)) -> IResult<FieldElement> {
+pub(crate) fn get_field((value, location): ValueAndLocation) -> IResult<FieldElement> {
     match value {
         Value::Field(value) => Ok(value),
         value => {
@@ -118,7 +120,7 @@ pub(crate) fn get_field((value, location): (Value, Location)) -> IResult<FieldEl
     }
 }
 
-pub(crate) fn get_u32((value, location): (Value, Location)) -> IResult<u32> {
+pub(crate) fn get_u32((value, location): ValueAndLocation) -> IResult<u32> {
     match value {
         Value::U32(value) => Ok(value),
         value => {
@@ -129,7 +131,7 @@ pub(crate) fn get_u32((value, location): (Value, Location)) -> IResult<u32> {
     }
 }
 
-pub(crate) fn get_function_def((value, location): (Value, Location)) -> IResult<FuncId> {
+pub(crate) fn get_function_def((value, location): ValueAndLocation) -> IResult<FuncId> {
     match value {
         Value::FunctionDefinition(id) => Ok(id),
         value => {
@@ -140,7 +142,7 @@ pub(crate) fn get_function_def((value, location): (Value, Location)) -> IResult<
     }
 }
 
-pub(crate) fn get_module((value, location): (Value, Location)) -> IResult<ModuleId> {
+pub(crate) fn get_module((value, location): ValueAndLocation) -> IResult<ModuleId> {
     match value {
         Value::ModuleDefinition(module_id) => Ok(module_id),
         value => {
@@ -151,7 +153,7 @@ pub(crate) fn get_module((value, location): (Value, Location)) -> IResult<Module
     }
 }
 
-pub(crate) fn get_struct((value, location): (Value, Location)) -> IResult<StructId> {
+pub(crate) fn get_struct((value, location): ValueAndLocation) -> IResult<StructId> {
     match value {
         Value::StructDefinition(id) => Ok(id),
         _ => {
@@ -163,7 +165,7 @@ pub(crate) fn get_struct((value, location): (Value, Location)) -> IResult<Struct
 }
 
 pub(crate) fn get_trait_constraint(
-    (value, location): (Value, Location),
+    (value, location): ValueAndLocation,
 ) -> IResult<(TraitId, Vec<Type>)> {
     match value {
         Value::TraitConstraint(trait_id, generics) => Ok((trait_id, generics)),
@@ -175,7 +177,7 @@ pub(crate) fn get_trait_constraint(
     }
 }
 
-pub(crate) fn get_trait_def((value, location): (Value, Location)) -> IResult<TraitId> {
+pub(crate) fn get_trait_def((value, location): ValueAndLocation) -> IResult<TraitId> {
     match value {
         Value::TraitDefinition(id) => Ok(id),
         value => {
@@ -186,7 +188,7 @@ pub(crate) fn get_trait_def((value, location): (Value, Location)) -> IResult<Tra
     }
 }
 
-pub(crate) fn get_type((value, location): (Value, Location)) -> IResult<Type> {
+pub(crate) fn get_type((value, location): ValueAndLocation) -> IResult<Type> {
     match value {
         Value::Type(typ) => Ok(typ),
         value => {
@@ -197,7 +199,7 @@ pub(crate) fn get_type((value, location): (Value, Location)) -> IResult<Type> {
     }
 }
 
-pub(crate) fn get_quoted((value, location): (Value, Location)) -> IResult<Rc<Vec<Token>>> {
+pub(crate) fn get_quoted((value, location): ValueAndLocation) -> IResult<Rc<Vec<Token>>> {
     match value {
         Value::Quoted(tokens) => Ok(tokens),
         value => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -50,6 +50,7 @@ pub(crate) fn check_two_arguments(
     Ok((argument1, argument2))
 }
 
+#[allow(clippy::type_complexity)]
 pub(crate) fn check_three_arguments(
     mut arguments: Vec<(Value, Location)>,
     location: Location,

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -10,7 +10,7 @@ use crate::{
         def_map::ModuleId,
     },
     hir_def::stmt::HirPattern,
-    macros_api::NodeInterner,
+    macros_api::{NodeInterner, StructId},
     node_interner::{FuncId, TraitId},
     token::Token,
     QuotedType, Type,
@@ -65,8 +65,7 @@ pub(crate) fn check_three_arguments(
 
 pub(crate) fn get_array(
     interner: &NodeInterner,
-    value: Value,
-    location: Location,
+    (value, location): (Value, Location),
 ) -> IResult<(im::Vector<Value>, Type)> {
     match value {
         Value::Array(values, typ) => Ok((values, typ)),
@@ -81,8 +80,7 @@ pub(crate) fn get_array(
 
 pub(crate) fn get_slice(
     interner: &NodeInterner,
-    value: Value,
-    location: Location,
+    (value, location): (Value, Location),
 ) -> IResult<(im::Vector<Value>, Type)> {
     match value {
         Value::Slice(values, typ) => Ok((values, typ)),
@@ -97,8 +95,7 @@ pub(crate) fn get_slice(
 
 pub(crate) fn get_tuple(
     interner: &NodeInterner,
-    value: Value,
-    location: Location,
+    (value, location): (Value, Location),
 ) -> IResult<Vec<Value>> {
     match value {
         Value::Tuple(values) => Ok(values),
@@ -111,7 +108,7 @@ pub(crate) fn get_tuple(
     }
 }
 
-pub(crate) fn get_field(value: Value, location: Location) -> IResult<FieldElement> {
+pub(crate) fn get_field((value, location): (Value, Location)) -> IResult<FieldElement> {
     match value {
         Value::Field(value) => Ok(value),
         value => {
@@ -121,7 +118,7 @@ pub(crate) fn get_field(value: Value, location: Location) -> IResult<FieldElemen
     }
 }
 
-pub(crate) fn get_u32(value: Value, location: Location) -> IResult<u32> {
+pub(crate) fn get_u32((value, location): (Value, Location)) -> IResult<u32> {
     match value {
         Value::U32(value) => Ok(value),
         value => {
@@ -132,7 +129,7 @@ pub(crate) fn get_u32(value: Value, location: Location) -> IResult<u32> {
     }
 }
 
-pub(crate) fn get_function_def(value: Value, location: Location) -> IResult<FuncId> {
+pub(crate) fn get_function_def((value, location): (Value, Location)) -> IResult<FuncId> {
     match value {
         Value::FunctionDefinition(id) => Ok(id),
         value => {
@@ -143,7 +140,7 @@ pub(crate) fn get_function_def(value: Value, location: Location) -> IResult<Func
     }
 }
 
-pub(crate) fn get_module(value: Value, location: Location) -> IResult<ModuleId> {
+pub(crate) fn get_module((value, location): (Value, Location)) -> IResult<ModuleId> {
     match value {
         Value::ModuleDefinition(module_id) => Ok(module_id),
         value => {
@@ -154,9 +151,19 @@ pub(crate) fn get_module(value: Value, location: Location) -> IResult<ModuleId> 
     }
 }
 
+pub(crate) fn get_struct((value, location): (Value, Location)) -> IResult<StructId> {
+    match value {
+        Value::StructDefinition(id) => Ok(id),
+        _ => {
+            let expected = Type::Quoted(QuotedType::StructDefinition);
+            let actual = value.get_type().into_owned();
+            return Err(InterpreterError::TypeMismatch { expected, location, actual });
+        }
+    }
+}
+
 pub(crate) fn get_trait_constraint(
-    value: Value,
-    location: Location,
+    (value, location): (Value, Location),
 ) -> IResult<(TraitId, Vec<Type>)> {
     match value {
         Value::TraitConstraint(trait_id, generics) => Ok((trait_id, generics)),
@@ -168,7 +175,7 @@ pub(crate) fn get_trait_constraint(
     }
 }
 
-pub(crate) fn get_trait_def(value: Value, location: Location) -> IResult<TraitId> {
+pub(crate) fn get_trait_def((value, location): (Value, Location)) -> IResult<TraitId> {
     match value {
         Value::TraitDefinition(id) => Ok(id),
         value => {
@@ -179,7 +186,7 @@ pub(crate) fn get_trait_def(value: Value, location: Location) -> IResult<TraitId
     }
 }
 
-pub(crate) fn get_type(value: Value, location: Location) -> IResult<Type> {
+pub(crate) fn get_type((value, location): (Value, Location)) -> IResult<Type> {
     match value {
         Value::Type(typ) => Ok(typ),
         value => {
@@ -190,7 +197,7 @@ pub(crate) fn get_type(value: Value, location: Location) -> IResult<Type> {
     }
 }
 
-pub(crate) fn get_quoted(value: Value, location: Location) -> IResult<Rc<Vec<Token>>> {
+pub(crate) fn get_quoted((value, location): (Value, Location)) -> IResult<Rc<Vec<Token>>> {
     match value {
         Value::Quoted(tokens) => Ok(tokens),
         value => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -8,12 +8,15 @@ use crate::{
     macros_api::NodeInterner,
 };
 
-use super::builtin::builtin_helpers::{check_two_arguments, get_array, get_field, get_u32};
+use super::{
+    builtin::builtin_helpers::{check_two_arguments, get_array, get_field, get_u32},
+    ValueAndLocation,
+};
 
 pub(super) fn call_foreign(
     interner: &mut NodeInterner,
     name: &str,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     match name {
@@ -28,7 +31,7 @@ pub(super) fn call_foreign(
 // poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32) -> [Field; N]
 fn poseidon2_permutation(
     interner: &mut NodeInterner,
-    arguments: Vec<(Value, Location)>,
+    arguments: Vec<ValueAndLocation>,
     location: Location,
 ) -> IResult<Value> {
     let (input, state_length) = check_two_arguments(arguments, location)?;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -31,10 +31,11 @@ fn poseidon2_permutation(
     arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
-    let (input, state_length) = check_two_arguments(arguments, location)?;
+    let ((input, input_location), (state_length, state_length_location)) =
+        check_two_arguments(arguments, location)?;
 
-    let (input, typ) = get_array(interner, input, location)?;
-    let state_length = get_u32(state_length, location)?;
+    let (input, typ) = get_array(interner, input, input_location)?;
+    let state_length = get_u32(state_length, state_length_location)?;
 
     let input = try_vecmap(input, |integer| get_field(integer, location))?;
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -31,13 +31,13 @@ fn poseidon2_permutation(
     arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
-    let ((input, input_location), (state_length, state_length_location)) =
-        check_two_arguments(arguments, location)?;
+    let (input, state_length) = check_two_arguments(arguments, location)?;
+    let input_location = input.1;
 
-    let (input, typ) = get_array(interner, input, input_location)?;
-    let state_length = get_u32(state_length, state_length_location)?;
+    let (input, typ) = get_array(interner, input)?;
+    let state_length = get_u32(state_length)?;
 
-    let input = try_vecmap(input, |integer| get_field(integer, location))?;
+    let input = try_vecmap(input, |integer| get_field((integer, input_location)))?;
 
     // Currently locked to only bn254!
     let fields = Bn254BlackBoxSolver

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -8,15 +8,12 @@ use crate::{
     macros_api::NodeInterner,
 };
 
-use super::{
-    builtin::builtin_helpers::{check_two_arguments, get_array, get_field, get_u32},
-    ValueAndLocation,
-};
+use super::builtin::builtin_helpers::{check_two_arguments, get_array, get_field, get_u32};
 
 pub(super) fn call_foreign(
     interner: &mut NodeInterner,
     name: &str,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     match name {
@@ -31,7 +28,7 @@ pub(super) fn call_foreign(
 // poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32) -> [Field; N]
 fn poseidon2_permutation(
     interner: &mut NodeInterner,
-    arguments: Vec<ValueAndLocation>,
+    arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
     let (input, state_length) = check_two_arguments(arguments, location)?;

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -980,6 +980,10 @@ impl NodeInterner {
         self.func_meta.get(func_id).expect("ice: all function ids should have metadata")
     }
 
+    pub fn function_meta_mut(&mut self, func_id: &FuncId) -> &mut FuncMeta {
+        self.func_meta.get_mut(func_id).expect("ice: all function ids should have metadata")
+    }
+
     pub fn try_function_meta(&self, func_id: &FuncId) -> Option<&FuncMeta> {
         self.func_meta.get(func_id)
     }

--- a/compiler/noirc_frontend/src/parser/mod.rs
+++ b/compiler/noirc_frontend/src/parser/mod.rs
@@ -24,7 +24,9 @@ pub use errors::ParserErrorReason;
 use noirc_errors::Span;
 pub use parser::path::path_no_turbofish;
 pub use parser::traits::trait_bound;
-pub use parser::{expression, parse_program, parse_type, top_level_items};
+pub use parser::{
+    block, expression, fresh_statement, parse_program, parse_type, pattern, top_level_items,
+};
 
 #[derive(Debug, Clone)]
 pub enum TopLevelStatement {

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -372,7 +372,7 @@ fn block_expr<'a>(
     block(statement).map(ExpressionKind::Block).map_with_span(Expression::new)
 }
 
-fn block<'a>(
+pub fn block<'a>(
     statement: impl NoirParser<StatementKind> + 'a,
 ) -> impl NoirParser<BlockExpression> + 'a {
     use Token::*;
@@ -474,7 +474,7 @@ where
     })
 }
 
-fn fresh_statement() -> impl NoirParser<StatementKind> {
+pub fn fresh_statement() -> impl NoirParser<StatementKind> {
     statement(expression(), expression_no_constructors(expression()))
 }
 
@@ -530,7 +530,7 @@ where
     p.map(StatementKind::new_let)
 }
 
-fn pattern() -> impl NoirParser<Pattern> {
+pub fn pattern() -> impl NoirParser<Pattern> {
     recursive(|pattern| {
         let ident_pattern = ident().map(Pattern::Identifier).map_err(|mut error| {
             if matches!(error.found(), Token::IntType(..)) {

--- a/noir_stdlib/src/meta/function_def.nr
+++ b/noir_stdlib/src/meta/function_def.nr
@@ -7,4 +7,13 @@ impl FunctionDefinition {
 
     #[builtin(function_def_return_type)]
     fn return_type(self) -> Type {}
+
+    #[builtin(function_def_set_body)]
+    fn set_body(mut self, body: Quoted) {}
+
+    #[builtin(function_def_set_parameters)]
+    fn set_parameters(mut self, parameters: [(Quoted, Type)]) {}
+
+    #[builtin(function_def_set_return_type)]
+    fn set_return_type(mut self, return_type: Type) {}
 }

--- a/noir_stdlib/src/meta/function_def.nr
+++ b/noir_stdlib/src/meta/function_def.nr
@@ -9,11 +9,11 @@ impl FunctionDefinition {
     fn return_type(self) -> Type {}
 
     #[builtin(function_def_set_body)]
-    fn set_body(mut self, body: Quoted) {}
+    fn set_body(self, body: Quoted) {}
 
     #[builtin(function_def_set_parameters)]
-    fn set_parameters(mut self, parameters: [(Quoted, Type)]) {}
+    fn set_parameters(self, parameters: [(Quoted, Type)]) {}
 
     #[builtin(function_def_set_return_type)]
-    fn set_return_type(mut self, return_type: Type) {}
+    fn set_return_type(self, return_type: Type) {}
 }

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -8,9 +8,6 @@ fn foo(w: i32, y: Field, Foo { x, field: some_field }: Foo, mut a: bool, (b, c):
     1
 }
 
-#[mutate_add_one]
-fn add_one() {}
-
 comptime fn function_attr(f: FunctionDefinition) {
     // Check FunctionDefinition::parameters
     let parameters = f.parameters();
@@ -36,6 +33,9 @@ comptime fn function_attr(f: FunctionDefinition) {
     // Check FunctionDefinition::name
     assert_eq(f.name(), quote { foo });
 }
+
+#[mutate_add_one]
+fn add_one() {}
 
 comptime fn mutate_add_one(f: FunctionDefinition) {
     // fn add_one(x: Field)

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -4,8 +4,12 @@ struct Foo { x: Field, field: Field }
 
 #[function_attr]
 fn foo(w: i32, y: Field, Foo { x, field: some_field }: Foo, mut a: bool, (b, c): (i32, i32)) -> i32 {
+    let _ = (w, y, x, some_field, a, b, c);
     1
 }
+
+#[mutate_add_one]
+fn add_one() {}
 
 comptime fn function_attr(f: FunctionDefinition) {
     // Check FunctionDefinition::parameters
@@ -33,4 +37,21 @@ comptime fn function_attr(f: FunctionDefinition) {
     assert_eq(f.name(), quote { foo });
 }
 
-fn main() {}
+comptime fn mutate_add_one(f: FunctionDefinition) {
+    // fn add_one(x: Field)
+    assert_eq(f.parameters().len(), 0);
+    f.set_parameters(&[(quote { x }, type_of(0))]);
+    assert_eq(f.parameters().len(), 1);
+
+    // fn add_one(x: Field) -> Field
+    assert_eq(f.return_type(), type_of(()));
+    f.set_return_type(type_of(0));
+    assert_eq(f.return_type(), type_of(0));
+
+    // fn add_one(x: Field) -> Field { x + 1 }
+    f.set_body(quote { x + 1 });
+}
+
+fn main() {
+    assert_eq(add_one(41), 42);
+}

--- a/tooling/nargo_fmt/src/items.rs
+++ b/tooling/nargo_fmt/src/items.rs
@@ -111,8 +111,4 @@ pub(crate) trait HasItem {
     fn start(&self) -> u32 {
         self.span().start()
     }
-
-    fn end(&self) -> u32 {
-        self.span().end()
-    }
 }


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

## Additional Context

I think we are missing a `FunctionDefinition::body`, but that could come later.

I had to get a `FuncMeta` many times in some functions because Rust wouldn't let me get two mutable borrows of interner.

Generics handling is missing... but I think right now generics can't appear in these functions, as attributes only run on top-level functions, not on impl or trait impl functions, but let me know if this is not the case.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
