### PR TITLE
feat: LSP closing brace hints

### DIFF
--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -87,7 +87,7 @@ impl<'a> InlayHintCollector<'a> {
 
         match &item.kind {
             ItemKind::Function(noir_function) => {
-                self.collect_in_noir_function(noir_function, item.span)
+                self.collect_in_noir_function(noir_function, item.span);
             }
             ItemKind::Trait(noir_trait) => {
                 for item in &noir_trait.items {
@@ -153,7 +153,7 @@ impl<'a> InlayHintCollector<'a> {
     fn collect_in_trait_impl_item(&mut self, item: &TraitImplItem, span: Span) {
         match item {
             TraitImplItem::Function(noir_function) => {
-                self.collect_in_noir_function(noir_function, span)
+                self.collect_in_noir_function(noir_function, span);
             }
             TraitImplItem::Constant(_name, _typ, default_value) => {
                 self.collect_in_expression(default_value);
@@ -807,7 +807,7 @@ mod inlay_hints_tests {
         InlayHintsOptions {
             type_hints: TypeHintsOptions { enabled: false },
             parameter_hints: ParameterHintsOptions { enabled: false },
-            closing_brace_hints: ClosingBraceHintsOptions { enabled: true, min_lines: min_lines },
+            closing_brace_hints: ClosingBraceHintsOptions { enabled: true, min_lines },
         }
     }
 

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -78,6 +78,9 @@ pub(crate) struct InlayHintsOptions {
 
     #[serde(rename = "parameterHints", default = "default_parameter_hints")]
     pub(crate) parameter_hints: ParameterHintsOptions,
+
+    #[serde(rename = "closingBraceHints", default = "default_closing_brace_hints")]
+    pub(crate) closing_brace_hints: ClosingBraceHintsOptions,
 }
 
 #[derive(Debug, Deserialize, Serialize, Copy, Clone)]
@@ -92,6 +95,15 @@ pub(crate) struct ParameterHintsOptions {
     pub(crate) enabled: bool,
 }
 
+#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
+pub(crate) struct ClosingBraceHintsOptions {
+    #[serde(rename = "enabled", default = "default_closing_brace_hints_enabled")]
+    pub(crate) enabled: bool,
+
+    #[serde(rename = "minLines", default = "default_closing_brace_min_lines")]
+    pub(crate) min_lines: u32,
+}
+
 fn default_enable_code_lens() -> bool {
     true
 }
@@ -104,6 +116,7 @@ fn default_inlay_hints() -> InlayHintsOptions {
     InlayHintsOptions {
         type_hints: default_type_hints(),
         parameter_hints: default_parameter_hints(),
+        closing_brace_hints: default_closing_brace_hints(),
     }
 }
 
@@ -121,6 +134,21 @@ fn default_parameter_hints() -> ParameterHintsOptions {
 
 fn default_parameter_hints_enabled() -> bool {
     true
+}
+
+fn default_closing_brace_hints() -> ClosingBraceHintsOptions {
+    ClosingBraceHintsOptions {
+        enabled: default_closing_brace_hints_enabled(),
+        min_lines: default_closing_brace_min_lines(),
+    }
+}
+
+fn default_closing_brace_hints_enabled() -> bool {
+    true
+}
+
+fn default_closing_brace_min_lines() -> u32 {
+    25
 }
 
 impl Default for LspInitializationOptions {

--- a/tooling/lsp/test_programs/inlay_hints/src/main.nr
+++ b/tooling/lsp/test_programs/inlay_hints/src/main.nr
@@ -104,3 +104,19 @@ fn hint_on_lambda_parameter() {
     let value: i32 = 1;
     let _: i32 = some_map(value, |x| x + 1);
 }
+
+trait SomeTrait {
+
+}
+
+impl SomeTrait for SomeStruct {
+
+}
+
+mod some_module {
+
+}
+
+contract some_contract {
+
+}


### PR DESCRIPTION
# Description

## Problem

I had this code back when I was playing with inlay hints. I originally implemented all inlay hints types but then I split them into smaller PRs. This is the last one of those PRs.

## Summary


https://github.com/user-attachments/assets/6b3cf946-cbac-496f-befd-eba394cd8460



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
