### PR TITLE
chore: Add docs tip about filenames between commands

### DIFF
--- a/docs/docs/getting_started/hello_noir/index.md
+++ b/docs/docs/getting_started/hello_noir/index.md
@@ -129,6 +129,11 @@ bb prove -b ./target/hello_world.json -w ./target/witness-name.gz -o ./target/pr
 
 The proof generated will then be written to the file `./target/proof`.
 
+:::tip
+Since the params for `nargo` and `bb` often specify multiple filenames to read from or write to, remember to check each command is referring to the desired filenames.
+Or for greater certainty, delete the target folder and go through each step again (compile, witness, prove, ...) to ensure files generated in past commands are being referenced in future ones.
+:::
+
 ### 6. Verify the execution proof
 
 Once a proof is generated, we can verify correct execution of our Noir program by verifying the proof file.


### PR DESCRIPTION
# Description

## Problem\*

Since nargo/bb split, a few people accidentally mix up filenames used between the commands (compile, witness, prove, verify)

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
