### PR TITLE
feat: LSP autocompletion for use statement

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -137,8 +137,4 @@ impl ModuleData {
     pub fn value_definitions(&self) -> impl Iterator<Item = ModuleDefId> + '_ {
         self.definitions.values().values().flat_map(|a| a.values().map(|(id, _, _)| *id))
     }
-
-    pub fn value_idents(&self) -> impl Iterator<Item = &Ident> + '_ {
-        self.definitions.values().keys()
-    }
 }

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -133,4 +133,8 @@ impl ModuleData {
     pub fn value_definitions(&self) -> impl Iterator<Item = ModuleDefId> + '_ {
         self.definitions.values().values().flat_map(|a| a.values().map(|(id, _, _)| *id))
     }
+
+    pub fn value_idents(&self) -> impl Iterator<Item = &Ident> + '_ {
+        self.definitions.values().keys()
+    }
 }

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -38,8 +38,12 @@ impl ModuleData {
         }
     }
 
-    pub fn scope(&self) -> &ItemScope {
+    pub(crate) fn scope(&self) -> &ItemScope {
         &self.scope
+    }
+
+    pub fn definitions(&self) -> &ItemScope {
+        &self.definitions
     }
 
     fn declare(

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -38,7 +38,7 @@ impl ModuleData {
         }
     }
 
-    pub(crate) fn scope(&self) -> &ItemScope {
+    pub fn scope(&self) -> &ItemScope {
         &self.scope
     }
 

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -84,18 +84,3 @@ pub mod macros_api {
         ) -> Result<(), (MacroError, FileId)>;
     }
 }
-
-pub fn log(contents: &str) {
-    use std::fs::OpenOptions;
-    use std::io::prelude::*;
-
-    let mut file = OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open("/Users/asterite/Sandbox/output/lsp.txt")
-        .unwrap();
-
-    if let Err(e) = writeln!(file, "{}", contents) {
-        eprintln!("Couldn't write to file: {}", e);
-    }
-}

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -84,3 +84,18 @@ pub mod macros_api {
         ) -> Result<(), (MacroError, FileId)>;
     }
 }
+
+pub fn log(contents: &str) {
+    use std::fs::OpenOptions;
+    use std::io::prelude::*;
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open("/Users/asterite/Sandbox/output/lsp.txt")
+        .unwrap();
+
+    if let Err(e) = writeln!(file, "{}", contents) {
+        eprintln!("Couldn't write to file: {}", e);
+    }
+}

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -16,6 +16,8 @@ pub enum ParserErrorReason {
     ExpectedFieldName(Token),
     #[error("expected a pattern but found a type - {0}")]
     ExpectedPatternButFoundType(Token),
+    #[error("expected an identifier after ::")]
+    ExpectedIdentifierAfterColons,
     #[error("Expected a ; separating these two statements")]
     MissingSeparatingSemi,
     #[error("constrain keyword is deprecated")]

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -28,7 +28,7 @@ fn path_inner<'a>(segment: impl NoirParser<PathSegment> + 'a) -> impl NoirParser
                 emit_error(ParserError::with_reason(
                     ParserErrorReason::ExpectedIdentifierAfterColons,
                     span,
-                ))
+                ));
             }
             path_segments
         });

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -153,8 +153,8 @@ pub(crate) fn process_workspace_for_noir_document(
                 Some(&file_path),
             );
             state.cached_lenses.insert(document_uri.to_string(), collected_lenses);
-
-            state.cached_definitions.insert(package_root_dir, context.def_interner);
+            state.cached_definitions.insert(package_root_dir.clone(), context.def_interner);
+            state.cached_def_maps.insert(package_root_dir.clone(), context.def_maps);
 
             let fm = &context.file_manager;
             let files = fm.as_file_map();

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -30,7 +30,7 @@ pub(super) fn on_did_change_configuration(
     ControlFlow::Continue(())
 }
 
-pub(super) fn on_did_open_text_document(
+pub(crate) fn on_did_open_text_document(
     state: &mut LspState,
     params: DidOpenTextDocumentParams,
 ) -> ControlFlow<Result<(), async_lsp::Error>> {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -176,7 +176,7 @@ impl<'a> NodeFinder<'a> {
         let module_data = def_map.modules().get(module_id.local_id.0)?;
         let mut completion_items = Vec::new();
 
-        for ident in module_data.scope().names() {
+        for ident in module_data.definitions().names() {
             let name = &ident.0.contents;
 
             if name_matches(name, &prefix) {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -205,6 +205,14 @@ impl<'a> NodeFinder<'a> {
                     completion_items.push(crate_completion_item(dependency_name));
                 }
             }
+
+            if name_matches("crate::", &prefix) {
+                completion_items.push(simple_completion_item(
+                    "crate::",
+                    CompletionItemKind::KEYWORD,
+                    None,
+                ));
+            }
         }
 
         Some(CompletionResponse::Array(completion_items))
@@ -493,5 +501,18 @@ mod completion_tests {
         "#;
 
         assert_completion(src, vec![module_completion_item("foo")]).await;
+    }
+
+    #[test]
+    async fn test_use_suggests_hardcoded_crate() {
+        let src = r#"
+            use c>|<
+        "#;
+
+        assert_completion(
+            src,
+            vec![simple_completion_item("crate::", CompletionItemKind::KEYWORD, None)],
+        )
+        .await;
     }
 }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -176,14 +176,7 @@ impl<'a> NodeFinder<'a> {
         let module_data = def_map.modules().get(module_id.local_id.0)?;
         let mut completion_items = Vec::new();
 
-        // module_data.value_definitions()
-
-        // Find in the target module types and values
-        let type_idents = module_data.children.keys();
-        let value_idents = module_data.value_idents();
-        let all_idents = type_idents.chain(value_idents);
-
-        for ident in all_idents {
+        for ident in module_data.scope().names() {
             let name = &ident.0.contents;
 
             if name_matches(name, &prefix) {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -572,12 +572,18 @@ mod completion_tests {
 
     #[test]
     async fn test_use_after_crate_and_letter() {
+        // Prove that "std" shows up
         let src = r#"
-            mod foo {}
-            use crate::f>|<
+            use s>|<
         "#;
+        assert_completion(src, vec![module_completion_item("std")]).await;
 
-        assert_completion(src, vec![module_completion_item("foo")]).await;
+        // "std" doesn't show up anymore because of the "crate::" prefix
+        let src = r#"
+            mod something {}
+            use crate::s>|<
+        "#;
+        assert_completion(src, vec![module_completion_item("something")]).await;
     }
 
     #[test]

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -205,7 +205,7 @@ impl<'a> NodeFinder<'a> {
         }
 
         if after_colons {
-            // We are after the colon
+            // We are right after "::"
             segments.push(ident.clone());
 
             self.resolve_module(segments).and_then(|module_id| {
@@ -214,9 +214,8 @@ impl<'a> NodeFinder<'a> {
                 self.complete_in_module(module_id, prefix, is_super, suggest_crates)
             })
         } else {
+            // We are right after the last segment
             let prefix = ident.to_string();
-
-            // Otherwise we must complete the last segment
             if segments.is_empty() {
                 // We are at the start of the use segment and completing the first segment
                 let suggest_crates = prefixes.first().unwrap().kind != PathKind::Crate;
@@ -264,7 +263,6 @@ impl<'a> NodeFinder<'a> {
             }
         }
 
-        // If this is the first segment, also find in all crates
         if suggest_crates {
             for dependency in self.dependencies {
                 let dependency_name = dependency.as_name();

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -384,10 +384,10 @@ fn name_matches(name: &str, prefix: &str) -> bool {
 }
 
 fn module_completion_item(name: impl Into<String>) -> CompletionItem {
-    simple_completion_item(name.into(), CompletionItemKind::MODULE, None)
+    simple_completion_item(name, CompletionItemKind::MODULE, None)
 }
 
-fn crate_completion_item(name: String) -> CompletionItem {
+fn crate_completion_item(name: impl Into<String>) -> CompletionItem {
     simple_completion_item(name, CompletionItemKind::MODULE, None)
 }
 
@@ -585,7 +585,7 @@ mod completion_tests {
         let src = r#"
             use s>|<
         "#;
-        assert_completion(src, vec![module_completion_item("std")]).await;
+        assert_completion(src, vec![crate_completion_item("std")]).await;
 
         // "std" doesn't show up anymore because of the "crate::" prefix
         let src = r#"
@@ -661,7 +661,7 @@ mod completion_tests {
             src,
             vec![
                 module_completion_item("something"),
-                module_completion_item("std"),
+                crate_completion_item("std"),
                 simple_completion_item("super::", CompletionItemKind::KEYWORD, None),
             ],
         )

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -394,8 +394,11 @@ mod completion_tests {
             panic!("Expected response to be CompletionResponse::Array");
         };
 
-        let items = items.clone().sort_by_key(|item| item.label.clone());
-        let expected = expected.clone().sort_by_key(|item| item.label.clone());
+        let mut items = items.clone();
+        items.sort_by_key(|item| item.label.clone());
+
+        let mut expected = expected.clone();
+        expected.sort_by_key(|item| item.label.clone());
 
         assert_eq!(items, expected);
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1,0 +1,218 @@
+use std::{
+    collections::BTreeMap,
+    future::{self, Future},
+};
+
+use async_lsp::ResponseError;
+use fm::PathString;
+use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse};
+use noirc_errors::Span;
+use noirc_frontend::{
+    ast::{UseTree, UseTreeKind},
+    graph::{CrateId, Dependency},
+    hir::def_map::{CrateDefMap, ModuleId},
+    parser::{Item, ItemKind},
+    ParsedModule,
+};
+
+use crate::{utils, LspState};
+
+use super::process_request;
+
+pub(crate) fn on_completion_request(
+    state: &mut LspState,
+    params: CompletionParams,
+) -> impl Future<Output = Result<Option<CompletionResponse>, ResponseError>> {
+    noirc_frontend::log("Completion Request");
+
+    let uri = params.text_document_position.clone().text_document.uri;
+
+    let result = process_request(state, params.text_document_position.clone(), |args| {
+        let path = PathString::from_path(uri.to_file_path().unwrap());
+        args.files.get_file_id(&path).and_then(|file_id| {
+            utils::position_to_byte_index(
+                args.files,
+                file_id,
+                &params.text_document_position.position,
+            )
+            .and_then(|byte_index| {
+                let file = args.files.get_file(file_id).unwrap();
+                let source = file.source();
+                let byte = source.bytes().nth(byte_index - 1);
+                let (parsed_module, _errors) = noirc_frontend::parse_program(source);
+
+                let finder = NodeFinder::new(
+                    byte_index,
+                    byte,
+                    args.root_crate_id,
+                    args.def_maps,
+                    args.root_crate_dependencies,
+                );
+                finder.find(&parsed_module)
+            })
+        })
+    });
+    future::ready(result)
+}
+
+struct NodeFinder<'a> {
+    byte_index: usize,
+    byte: Option<u8>,
+    krate: CrateId,
+    current_module_id: ModuleId,
+    def_maps: &'a BTreeMap<CrateId, CrateDefMap>,
+    dependencies: &'a Vec<Dependency>,
+}
+
+impl<'a> NodeFinder<'a> {
+    fn new(
+        byte_index: usize,
+        byte: Option<u8>,
+        krate: CrateId,
+        def_maps: &'a BTreeMap<CrateId, CrateDefMap>,
+        dependencies: &'a Vec<Dependency>,
+    ) -> Self {
+        let def_map = &def_maps[&krate];
+        let current_module_id = ModuleId { krate: krate, local_id: def_map.root() };
+        Self { byte_index, byte, krate, current_module_id, def_maps, dependencies }
+    }
+
+    fn find(&self, parsed_module: &ParsedModule) -> Option<CompletionResponse> {
+        for item in &parsed_module.items {
+            if let Some(response) = self.find_in_item(item) {
+                return Some(response);
+            }
+        }
+
+        None
+    }
+
+    fn find_in_item(&self, item: &Item) -> Option<CompletionResponse> {
+        if !self.includes_span(item.span) {
+            return None;
+        }
+
+        match &item.kind {
+            ItemKind::Import(use_tree) => {
+                if let Some(completion) = self.find_in_use_tree(use_tree, item.span) {
+                    return Some(completion);
+                }
+            }
+            _ => (),
+        }
+
+        None
+    }
+
+    fn find_in_use_tree(&self, use_tree: &UseTree, span: Span) -> Option<CompletionResponse> {
+        match &use_tree.kind {
+            UseTreeKind::Path(ident, alias) => {
+                if let Some(_alias) = alias {
+                    // TODO: handle
+                    None
+                } else {
+                    // If we are at the end of the use statement (likely the most common scenario)...
+                    if self.byte_index == span.end() as usize {
+                        if let Some(b':') = self.byte {
+                            let mut segments: Vec<_> = use_tree
+                                .prefix
+                                .segments
+                                .iter()
+                                .map(|segment| &segment.ident)
+                                .collect();
+                            segments.push(ident);
+
+                            // If we are after a colon, find inside the last segment
+                            // TODO: handle
+                            None
+                        } else {
+                            // Otherwise we must complete the last segment
+                            if use_tree.prefix.segments.is_empty() {
+                                // We are at the start of the use segment and completing the first segment,
+                                // let's start here.
+                                return self.complete_in_module(
+                                    self.current_module_id,
+                                    ident.to_string(),
+                                    true,
+                                );
+                            }
+                            None
+                        }
+                    } else {
+                        // TODO: handle
+                        None
+                    }
+                }
+            }
+            UseTreeKind::List(..) => {
+                // TODO: handle
+                None
+            }
+        }
+    }
+
+    fn complete_in_module(
+        &self,
+        module_id: ModuleId,
+        prefix: String,
+        first_segment: bool,
+    ) -> Option<CompletionResponse> {
+        let def_map = &self.def_maps[&module_id.krate];
+        let module_data = def_map.modules().get(module_id.local_id.0)?;
+        let mut completion_items = Vec::new();
+
+        // Find in the target module
+        for child in module_data.children.keys() {
+            if name_matches(&child.0.contents, &prefix) {
+                completion_items.push(module_completion_item(child.0.contents.clone()));
+            }
+        }
+
+        // If this is the first segment, also find in all crates
+        if first_segment {
+            for dependency in self.dependencies {
+                let dependency_name = dependency.as_name();
+                if name_matches(&dependency_name, &prefix) {
+                    completion_items.push(crate_completion_item(dependency_name));
+                }
+            }
+        }
+
+        Some(CompletionResponse::Array(completion_items))
+    }
+
+    fn includes_span(&self, span: Span) -> bool {
+        span.start() as usize <= self.byte_index && self.byte_index <= span.end() as usize
+    }
+}
+
+fn name_matches(name: &str, prefix: &str) -> bool {
+    name.starts_with(prefix)
+}
+
+fn module_completion_item(name: String) -> CompletionItem {
+    CompletionItem {
+        label: name,
+        label_details: None,
+        kind: Some(CompletionItemKind::MODULE),
+        detail: None,
+        documentation: None,
+        deprecated: None,
+        preselect: None,
+        sort_text: None,
+        filter_text: None,
+        insert_text: None,
+        insert_text_format: None,
+        insert_text_mode: None,
+        text_edit: None,
+        additional_text_edits: None,
+        command: None,
+        commit_characters: None,
+        data: None,
+        tags: None,
+    }
+}
+
+fn crate_completion_item(name: String) -> CompletionItem {
+    module_completion_item(name)
+}

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -20,7 +20,7 @@ use noirc_frontend::{
     macros_api::{ModuleDefId, NodeInterner, StructId},
     node_interner::{FuncId, GlobalId, TraitId, TypeAliasId},
     parser::{Item, ItemKind},
-    ParsedModule,
+    ParsedModule, Type,
 };
 
 use crate::{utils, LspState};
@@ -225,7 +225,11 @@ impl<'a> NodeFinder<'a> {
 
     fn function_completion_item(&self, func_id: FuncId) -> CompletionItem {
         let name = self.interner.function_name(&func_id).to_string();
-        let description = self.interner.function_meta(&func_id).typ.to_string();
+        let mut typ = &self.interner.function_meta(&func_id).typ;
+        if let Type::Forall(_, typ_) = typ {
+            typ = typ_;
+        }
+        let description = typ.to_string();
 
         simple_completion_item(name, CompletionItemKind::FUNCTION, Some(description))
     }

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -321,9 +321,9 @@ fn format_parent_module_from_module_id(
 ) -> bool {
     let crate_id = module.krate;
     let crate_name = match crate_id {
-        CrateId::Root(_) => Some(args.root_crate_name.clone()),
+        CrateId::Root(_) => Some(args.crate_name.clone()),
         CrateId::Crate(_) => args
-            .root_crate_dependencies
+            .dependencies
             .iter()
             .find(|dep| dep.crate_id == crate_id)
             .map(|dep| format!("{}", dep.name)),

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -1,4 +1,3 @@
-use fm::codespan_files::Files;
 use std::future::{self, Future};
 
 use async_lsp::ResponseError;
@@ -21,7 +20,7 @@ use noirc_frontend::{
     ParsedModule, Type, TypeBinding, TypeVariable, TypeVariableKind,
 };
 
-use crate::LspState;
+use crate::{utils, LspState};
 
 use super::{process_request, to_lsp_location, InlayHintsOptions};
 
@@ -43,7 +42,7 @@ pub(crate) fn on_inlay_hint_request(
             let source = file.source();
             let (parsed_moduled, _errors) = noirc_frontend::parse_program(source);
 
-            let span = range_to_byte_span(args.files, file_id, &params.range)
+            let span = utils::range_to_byte_span(args.files, file_id, &params.range)
                 .map(|range| Span::from(range.start as u32..range.end as u32));
 
             let mut collector =
@@ -684,63 +683,6 @@ fn get_expression_name(expression: &Expression) -> Option<String> {
         | ExpressionKind::Resolved(..)
         | ExpressionKind::Literal(..)
         | ExpressionKind::Error => None,
-    }
-}
-
-// These functions are copied from the codespan_lsp crate, except that they never panic
-// (the library will sometimes panic, so functions returning Result are not always accurate)
-
-fn range_to_byte_span(
-    files: &FileMap,
-    file_id: FileId,
-    range: &lsp_types::Range,
-) -> Option<std::ops::Range<usize>> {
-    Some(
-        position_to_byte_index(files, file_id, &range.start)?
-            ..position_to_byte_index(files, file_id, &range.end)?,
-    )
-}
-
-fn position_to_byte_index(
-    files: &FileMap,
-    file_id: FileId,
-    position: &lsp_types::Position,
-) -> Option<usize> {
-    let Ok(source) = files.source(file_id) else {
-        return None;
-    };
-
-    let Ok(line_span) = files.line_range(file_id, position.line as usize) else {
-        return None;
-    };
-    let line_str = source.get(line_span.clone())?;
-
-    let byte_offset = character_to_line_offset(line_str, position.character)?;
-
-    Some(line_span.start + byte_offset)
-}
-
-fn character_to_line_offset(line: &str, character: u32) -> Option<usize> {
-    let line_len = line.len();
-    let mut character_offset = 0;
-
-    let mut chars = line.chars();
-    while let Some(ch) = chars.next() {
-        if character_offset == character {
-            let chars_off = chars.as_str().len();
-            let ch_off = ch.len_utf8();
-
-            return Some(line_len - chars_off - ch_off);
-        }
-
-        character_offset += ch.len_utf16() as u32;
-    }
-
-    // Handle positions after the last character on the line
-    if character_offset == character {
-        Some(line_len)
-    } else {
-        None
     }
 }
 

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -388,9 +388,9 @@ pub(crate) struct ProcessRequestCallbackArgs<'a> {
     files: &'a FileMap,
     interner: &'a NodeInterner,
     interners: &'a HashMap<String, NodeInterner>,
-    root_crate_id: CrateId,
-    root_crate_name: String,
-    root_crate_dependencies: &'a Vec<Dependency>,
+    crate_id: CrateId,
+    crate_name: String,
+    dependencies: &'a Vec<Dependency>,
     def_maps: &'a BTreeMap<CrateId, CrateDefMap>,
 }
 
@@ -450,9 +450,9 @@ where
         files,
         interner,
         interners: &state.cached_definitions,
-        root_crate_id: crate_id,
-        root_crate_name: package.name.to_string(),
-        root_crate_dependencies: &context.crate_graph[context.root_crate_id()].dependencies,
+        crate_id,
+        crate_name: package.name.to_string(),
+        dependencies: &context.crate_graph[context.root_crate_id()].dependencies,
         def_maps,
     }))
 }

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::{collections::HashMap, future::Future};
 
@@ -15,6 +16,8 @@ use lsp_types::{
 };
 use nargo_fmt::Config;
 use noirc_driver::file_manager_with_stdlib;
+use noirc_frontend::graph::CrateId;
+use noirc_frontend::hir::def_map::CrateDefMap;
 use noirc_frontend::{graph::Dependency, macros_api::NodeInterner};
 use serde::{Deserialize, Serialize};
 
@@ -34,6 +37,7 @@ use crate::{
 // and params passed in.
 
 mod code_lens_request;
+mod completion;
 mod document_symbol;
 mod goto_declaration;
 mod goto_definition;
@@ -47,12 +51,12 @@ mod tests;
 
 pub(crate) use {
     code_lens_request::collect_lenses_for_package, code_lens_request::on_code_lens_request,
-    document_symbol::on_document_symbol_request, goto_declaration::on_goto_declaration_request,
-    goto_definition::on_goto_definition_request, goto_definition::on_goto_type_definition_request,
-    hover::on_hover_request, inlay_hint::on_inlay_hint_request,
-    profile_run::on_profile_run_request, references::on_references_request,
-    rename::on_prepare_rename_request, rename::on_rename_request, test_run::on_test_run_request,
-    tests::on_tests_request,
+    completion::on_completion_request, document_symbol::on_document_symbol_request,
+    goto_declaration::on_goto_declaration_request, goto_definition::on_goto_definition_request,
+    goto_definition::on_goto_type_definition_request, hover::on_hover_request,
+    inlay_hint::on_inlay_hint_request, profile_run::on_profile_run_request,
+    references::on_references_request, rename::on_prepare_rename_request,
+    rename::on_rename_request, test_run::on_test_run_request, tests::on_tests_request,
 };
 
 /// LSP client will send initialization request after the server has started.
@@ -228,6 +232,15 @@ pub(crate) fn on_initialize(
                         label: Some("Noir".to_string()),
                     },
                 )),
+                completion_provider: Some(lsp_types::OneOf::Right(lsp_types::CompletionOptions {
+                    resolve_provider: None,
+                    trigger_characters: Some(vec![":".to_string()]),
+                    all_commit_characters: None,
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
+                    completion_item: None,
+                })),
             },
             server_info: None,
         })
@@ -375,8 +388,10 @@ pub(crate) struct ProcessRequestCallbackArgs<'a> {
     files: &'a FileMap,
     interner: &'a NodeInterner,
     interners: &'a HashMap<String, NodeInterner>,
+    root_crate_id: CrateId,
     root_crate_name: String,
     root_crate_dependencies: &'a Vec<Dependency>,
+    def_maps: &'a BTreeMap<CrateId, CrateDefMap>,
 }
 
 pub(crate) fn process_request<F, T>(
@@ -411,12 +426,15 @@ where
         crate::prepare_package(&workspace_file_manager, &parsed_files, package);
 
     let interner;
+    let def_maps;
     if let Some(def_interner) = state.cached_definitions.get(&package_root_path) {
         interner = def_interner;
+        def_maps = state.cached_def_maps.get(&package_root_path).unwrap();
     } else {
         // We ignore the warnings and errors produced by compilation while resolving the definition
         let _ = noirc_driver::check_crate(&mut context, crate_id, &Default::default());
         interner = &context.def_interner;
+        def_maps = &context.def_maps;
     }
 
     let files = context.file_manager.as_file_map();
@@ -432,8 +450,10 @@ where
         files,
         interner,
         interners: &state.cached_definitions,
+        root_crate_id: crate_id,
         root_crate_name: package.name.to_string(),
         root_crate_dependencies: &context.crate_graph[context.root_crate_id()].dependencies,
+        def_maps,
     }))
 }
 pub(crate) fn find_all_references_in_workspace(

--- a/tooling/lsp/src/types.rs
+++ b/tooling/lsp/src/types.rs
@@ -1,7 +1,8 @@
 use fm::FileId;
 use lsp_types::{
-    DeclarationCapability, DefinitionOptions, DocumentSymbolOptions, HoverOptions,
-    InlayHintOptions, OneOf, ReferencesOptions, RenameOptions, TypeDefinitionProviderCapability,
+    CompletionOptions, DeclarationCapability, DefinitionOptions, DocumentSymbolOptions,
+    HoverOptions, InlayHintOptions, OneOf, ReferencesOptions, RenameOptions,
+    TypeDefinitionProviderCapability,
 };
 use noirc_driver::DebugFile;
 use noirc_errors::{debug_info::OpCodesCount, Location};
@@ -156,6 +157,10 @@ pub(crate) struct ServerCapabilities {
     /// The server provides document symbol support.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) document_symbol_provider: Option<OneOf<bool, DocumentSymbolOptions>>,
+
+    /// The server provides completion support.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_provider: Option<OneOf<bool, CompletionOptions>>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/tooling/lsp/src/utils.rs
+++ b/tooling/lsp/src/utils.rs
@@ -1,0 +1,59 @@
+// These functions are copied from the codespan_lsp crate, except that they never panic
+// (the library will sometimes panic, so functions returning Result are not always accurate)
+
+use fm::codespan_files::Files;
+use fm::{FileId, FileMap};
+
+pub(crate) fn range_to_byte_span(
+    files: &FileMap,
+    file_id: FileId,
+    range: &lsp_types::Range,
+) -> Option<std::ops::Range<usize>> {
+    Some(
+        position_to_byte_index(files, file_id, &range.start)?
+            ..position_to_byte_index(files, file_id, &range.end)?,
+    )
+}
+
+pub(crate) fn position_to_byte_index(
+    files: &FileMap,
+    file_id: FileId,
+    position: &lsp_types::Position,
+) -> Option<usize> {
+    let Ok(source) = files.source(file_id) else {
+        return None;
+    };
+
+    let Ok(line_span) = files.line_range(file_id, position.line as usize) else {
+        return None;
+    };
+    let line_str = source.get(line_span.clone())?;
+
+    let byte_offset = character_to_line_offset(line_str, position.character)?;
+
+    Some(line_span.start + byte_offset)
+}
+
+pub(crate) fn character_to_line_offset(line: &str, character: u32) -> Option<usize> {
+    let line_len = line.len();
+    let mut character_offset = 0;
+
+    let mut chars = line.chars();
+    while let Some(ch) = chars.next() {
+        if character_offset == character {
+            let chars_off = chars.as_str().len();
+            let ch_off = ch.len_utf8();
+
+            return Some(line_len - chars_off - ch_off);
+        }
+
+        character_offset += ch.len_utf16() as u32;
+    }
+
+    // Handle positions after the last character on the line
+    if character_offset == character {
+        Some(line_len)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Part of #1577

## Summary

Implements autocompletion for use statements, so typing anything after `use`.

https://github.com/user-attachments/assets/a9ecd738-30c2-41fc-8ea0-3ea93d5d99ab

Note: the gray hints are probably coming from copilot, I should have turned it off before recording 😅 

## Additional Context

To begin implementing autocompletion I thought starting with `use` would be the easiest thing, but also not having to look up the std (or your project) module hierarchy could be useful.

To implement this I had to allow parsing `use foo::`, that is, allowing trailing colons, because otherwise that wouldn't parse to a use statement and we wouldn't have any information to do the autocompletion.

There are still some cases that don't work. For example if you write `use ` and explicitly ask for autocompletion, you don't get anything. The reason is that `use ` gives a parse error so no AST is produced. We could tackle those in later PRs (I didn't want to continue making this PR bigger).

This PR also introduces a simple way to test autocompletions, so next autocompletion PRs should be much smaller.

Another thought: at first I was worried that caching `def_maps` in the LSP state would increase the memory usage by a lot, but in retrospective I think that's not a heavy data structure, or at least `NodeInterner`, which was already cached, is probably much larger in memory footprint. I tried this PR in a few projects and the memory usage was fine.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
