### PR TITLE
feat: add `Quoted::as_expr` and `Expr::as_function_call`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -64,6 +64,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "modulus_le_bits" => modulus_le_bits(interner, arguments, location),
             "modulus_le_bytes" => modulus_le_bytes(interner, arguments, location),
             "modulus_num_bits" => modulus_num_bits(interner, arguments, location),
+            "quoted_as_expr" => quoted_as_expr(arguments, return_type, location),
             "quoted_as_module" => quoted_as_module(self, arguments, return_type, location),
             "quoted_as_trait_constraint" => quoted_as_trait_constraint(self, arguments, location),
             "quoted_as_type" => quoted_as_type(self, arguments, location),
@@ -310,6 +311,20 @@ fn slice_insert(
     let index = get_u32(index)? as usize;
     values.insert(index, element);
     Ok(Value::Slice(values, typ))
+}
+
+// fn as_expr(quoted: Quoted) -> Option<Expr>
+fn quoted_as_expr(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    let argument = check_one_argument(arguments, location)?;
+
+    let expr = parse(argument, parser::expression(), "an expression").ok();
+    let value = expr.map(|expr| Value::Expr(expr.kind));
+
+    option(return_type, value)
 }
 
 // fn as_module(quoted: Quoted) -> Option<Module>

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -699,7 +699,8 @@ fn expr_as_function_call(
             let function = Value::Expr(call_expression.func.kind);
             let arguments = call_expression.arguments.into_iter();
             let arguments = arguments.map(|argument| Value::Expr(argument.kind)).collect();
-            let arguments = Value::Slice(arguments, Type::Quoted(QuotedType::Expr));
+            let arguments =
+                Value::Slice(arguments, Type::Slice(Box::new(Type::Quoted(QuotedType::Expr))));
             Some(Value::Tuple(vec![function, arguments]))
         } else {
             None

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -4,7 +4,7 @@ use acvm::FieldElement;
 use noirc_errors::Location;
 
 use crate::{
-    ast::{IntegerBitSize, Signedness},
+    ast::{ExpressionKind, IntegerBitSize, Signedness},
     hir::{
         comptime::{errors::IResult, value::add_token_spans, Interpreter, InterpreterError, Value},
         def_map::ModuleId,
@@ -139,6 +139,17 @@ pub(crate) fn get_u32((value, location): (Value, Location)) -> IResult<u32> {
         Value::U32(value) => Ok(value),
         value => {
             let expected = Type::Integer(Signedness::Unsigned, IntegerBitSize::ThirtyTwo);
+            let actual = value.get_type().into_owned();
+            Err(InterpreterError::TypeMismatch { expected, actual, location })
+        }
+    }
+}
+
+pub(crate) fn get_expr((value, location): (Value, Location)) -> IResult<ExpressionKind> {
+    match value {
+        Value::Expr(expr) => Ok(expr),
+        value => {
+            let expected = Type::Quoted(QuotedType::Expr);
             let actual = value.get_type().into_owned();
             Err(InterpreterError::TypeMismatch { expected, actual, location })
         }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -57,6 +57,7 @@ pub enum Value {
     ModuleDefinition(ModuleId),
     Type(Type),
     Zeroed(Type),
+    Expr(ExpressionKind),
 }
 
 impl Value {
@@ -103,6 +104,7 @@ impl Value {
             Value::ModuleDefinition(_) => Type::Quoted(QuotedType::Module),
             Value::Type(_) => Type::Quoted(QuotedType::Type),
             Value::Zeroed(typ) => return Cow::Borrowed(typ),
+            Value::Expr(_) => Type::Quoted(QuotedType::Expr),
         })
     }
 
@@ -223,6 +225,7 @@ impl Value {
                     }
                 };
             }
+            Value::Expr(expr) => expr,
             Value::Pointer(..)
             | Value::StructDefinition(_)
             | Value::TraitConstraint(..)
@@ -345,7 +348,8 @@ impl Value {
                 HirExpression::Literal(HirLiteral::Slice(HirArrayLiteral::Standard(elements)))
             }
             Value::Quoted(tokens) => HirExpression::Unquote(add_token_spans(tokens, location.span)),
-            Value::Pointer(..)
+            Value::Expr(..)
+            | Value::Pointer(..)
             | Value::StructDefinition(_)
             | Value::TraitConstraint(..)
             | Value::TraitDefinition(_)
@@ -530,6 +534,7 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
             Value::ModuleDefinition(_) => write!(f, "(module)"),
             Value::Zeroed(typ) => write!(f, "(zeroed {typ})"),
             Value::Type(typ) => write!(f, "{}", typ),
+            Value::Expr(expr) => write!(f, "{}", expr),
         }
     }
 }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -1,0 +1,7 @@
+use crate::cmp::Eq;
+use crate::option::Option;
+
+impl Expr {
+    #[builtin(expr_as_function_call)]
+    fn as_function_call(self) -> Option<(Expr, [Expr])> {}
+}

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -1,4 +1,3 @@
-use crate::cmp::Eq;
 use crate::option::Option;
 
 impl Expr {

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -2,6 +2,7 @@ use crate::collections::umap::UHashMap;
 use crate::hash::BuildHasherDefault;
 use crate::hash::poseidon2::Poseidon2Hasher;
 
+mod expr;
 mod function_def;
 mod module;
 mod struct_def;

--- a/noir_stdlib/src/meta/quoted.nr
+++ b/noir_stdlib/src/meta/quoted.nr
@@ -2,6 +2,9 @@ use crate::cmp::Eq;
 use crate::option::Option;
 
 impl Quoted {
+    #[builtin(quoted_as_expr)]
+    fn as_expr(self) -> Option<Expr> {}
+
     #[builtin(quoted_as_module)]
     fn as_module(self) -> Option<Module> {}
 

--- a/test_programs/compile_success_empty/comptime_exp/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_exp/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_exp"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -1,6 +1,8 @@
 fn main() {
     comptime
     {
-        let _expr = quote { foo(bar) }.as_expr().unwrap();
+        let expr = quote { foo(bar) }.as_expr().unwrap();
+        let (_function, args) = expr.as_function_call().unwrap();
+        assert_eq(args.len(), 1);
     }
 }

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {
+    comptime
+    {
+        let _expr = quote { foo(bar) }.as_expr().unwrap();
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

What the title says.

## Additional Context

I didn't know how to test the exprs. I tried implementing `impl Eq for Expr` but even though two exprs looked the same (same tokens) they weren't equal... but I didn't dig deeper into why that is (I didn't know if `Eq` was desired in this case)

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
