### PR TITLE
feat: LSP path completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum",
  "thiserror",
  "tokio",
  "tower",

--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -32,12 +32,12 @@ tracing.workspace = true
 petgraph = "0.6"
 rangemap = "1.4.0"
 lalrpop-util = { version = "0.20.2", features = ["lexer"] }
+strum = "0.24"
+strum_macros = "0.24"
 
 
 [dev-dependencies]
 base64.workspace = true
-strum = "0.24"
-strum_macros = "0.24"
 
 [build-dependencies]
 lalrpop = "0.20.2"

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -38,7 +38,7 @@ impl ModuleData {
         }
     }
 
-    pub(crate) fn scope(&self) -> &ItemScope {
+    pub fn scope(&self) -> &ItemScope {
         &self.scope
     }
 

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -530,6 +530,11 @@ impl IntType {
             Ok(Some(Token::IntType(IntType::Unsigned(str_as_u32))))
         }
     }
+
+    // Returns all the names of built-in integer types
+    pub fn builtin_types() -> [&'static str; 8] {
+        ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"]
+    }
 }
 
 /// TestScope is used to specify additional annotations for test functions
@@ -883,8 +888,7 @@ impl AsRef<str> for SecondaryAttribute {
 
 /// Note that `self` is not present - it is a contextual keyword rather than a true one as it is
 /// only special within `impl`s. Otherwise `self` functions as a normal identifier.
-#[derive(PartialEq, Eq, Hash, Debug, Copy, Clone, PartialOrd, Ord)]
-#[cfg_attr(test, derive(strum_macros::EnumIter))]
+#[derive(PartialEq, Eq, Hash, Debug, Copy, Clone, PartialOrd, Ord, strum_macros::EnumIter)]
 pub enum Keyword {
     As,
     Assert,
@@ -1047,6 +1051,60 @@ impl Keyword {
         };
 
         Some(Token::Keyword(keyword))
+    }
+
+    /// If this keyword corresponds to a built-in type, returns that type's name.
+    pub fn builtin_type(&self) -> Option<&'static str> {
+        match self {
+            Keyword::Bool => Some("bool"),
+            Keyword::Expr => Some("Expr"),
+            Keyword::Field => Some("Field"),
+            Keyword::FunctionDefinition => Some("FunctionDefinition"),
+            Keyword::StructDefinition => Some("StructDefinition"),
+            Keyword::TraitConstraint => Some("TraitConstraint"),
+            Keyword::TraitDefinition => Some("TraitDefinition"),
+            Keyword::TypeType => Some("Type"),
+
+            Keyword::As
+            | Keyword::Assert
+            | Keyword::AssertEq
+            | Keyword::Break
+            | Keyword::CallData
+            | Keyword::Char
+            | Keyword::Comptime
+            | Keyword::Constrain
+            | Keyword::Continue
+            | Keyword::Contract
+            | Keyword::Crate
+            | Keyword::Dep
+            | Keyword::Else
+            | Keyword::Fn
+            | Keyword::For
+            | Keyword::FormatString
+            | Keyword::Global
+            | Keyword::If
+            | Keyword::Impl
+            | Keyword::In
+            | Keyword::Let
+            | Keyword::Mod
+            | Keyword::Module
+            | Keyword::Mut
+            | Keyword::Pub
+            | Keyword::Quoted
+            | Keyword::Return
+            | Keyword::ReturnData
+            | Keyword::String
+            | Keyword::Struct
+            | Keyword::Super
+            | Keyword::TopLevelItem
+            | Keyword::Trait
+            | Keyword::Type
+            | Keyword::Unchecked
+            | Keyword::Unconstrained
+            | Keyword::Use
+            | Keyword::Where
+            | Keyword::While => None,
+        }
     }
 }
 

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -530,11 +530,6 @@ impl IntType {
             Ok(Some(Token::IntType(IntType::Unsigned(str_as_u32))))
         }
     }
-
-    // Returns all the names of built-in integer types
-    pub fn builtin_types() -> [&'static str; 8] {
-        ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"]
-    }
 }
 
 /// TestScope is used to specify additional annotations for test functions
@@ -1051,60 +1046,6 @@ impl Keyword {
         };
 
         Some(Token::Keyword(keyword))
-    }
-
-    /// If this keyword corresponds to a built-in type, returns that type's name.
-    pub fn builtin_type(&self) -> Option<&'static str> {
-        match self {
-            Keyword::Bool => Some("bool"),
-            Keyword::Expr => Some("Expr"),
-            Keyword::Field => Some("Field"),
-            Keyword::FunctionDefinition => Some("FunctionDefinition"),
-            Keyword::StructDefinition => Some("StructDefinition"),
-            Keyword::TraitConstraint => Some("TraitConstraint"),
-            Keyword::TraitDefinition => Some("TraitDefinition"),
-            Keyword::TypeType => Some("Type"),
-
-            Keyword::As
-            | Keyword::Assert
-            | Keyword::AssertEq
-            | Keyword::Break
-            | Keyword::CallData
-            | Keyword::Char
-            | Keyword::Comptime
-            | Keyword::Constrain
-            | Keyword::Continue
-            | Keyword::Contract
-            | Keyword::Crate
-            | Keyword::Dep
-            | Keyword::Else
-            | Keyword::Fn
-            | Keyword::For
-            | Keyword::FormatString
-            | Keyword::Global
-            | Keyword::If
-            | Keyword::Impl
-            | Keyword::In
-            | Keyword::Let
-            | Keyword::Mod
-            | Keyword::Module
-            | Keyword::Mut
-            | Keyword::Pub
-            | Keyword::Quoted
-            | Keyword::Return
-            | Keyword::ReturnData
-            | Keyword::String
-            | Keyword::Struct
-            | Keyword::Super
-            | Keyword::TopLevelItem
-            | Keyword::Trait
-            | Keyword::Type
-            | Keyword::Unchecked
-            | Keyword::Unconstrained
-            | Keyword::Use
-            | Keyword::Where
-            | Keyword::While => None,
-        }
     }
 }
 

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -22,6 +22,7 @@ noirc_frontend.workspace = true
 noirc_artifacts.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+strum = "0.24"
 tower.workspace = true
 async-lsp = { workspace = true, features = ["omni-trait"] }
 serde_with = "3.2.0"

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -260,8 +260,13 @@ impl<'a> NodeFinder<'a> {
         self.type_parameters.clear();
         self.collect_type_parameters_in_generics(&type_impl.generics);
 
-        for (method, _) in &type_impl.methods {
+        for (method, span) in &type_impl.methods {
             self.find_in_noir_function(method);
+
+            // Optimization: stop looking in functions past the completion cursor
+            if span.end() as usize > self.byte_index {
+                break;
+            }
         }
 
         self.type_parameters.clear();
@@ -336,6 +341,11 @@ impl<'a> NodeFinder<'a> {
         let old_local_variables = self.local_variables.clone();
         for statement in &block_expression.statements {
             self.find_in_statement(statement);
+
+            // Optimization: stop looking in statements past the completion cursor
+            if statement.span.end() as usize > self.byte_index {
+                break;
+            }
         }
         self.local_variables = old_local_variables;
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -733,6 +733,7 @@ impl<'a> NodeFinder<'a> {
                 RequestedItems::AnyItems => {
                     self.local_variables_completion(&prefix);
                     self.builtin_functions_completion(&prefix);
+                    self.builtin_values_completion(&prefix);
                 }
                 RequestedItems::OnlyTypes => {
                     self.builtin_types_completion(&prefix);
@@ -1181,7 +1182,9 @@ impl<'a> NodeFinder<'a> {
                 Some("fn(T, T, str)".to_string()),
             ));
         }
+    }
 
+    fn builtin_values_completion(&mut self, prefix: &str) {
         for keyword in ["false", "true"] {
             if name_matches(keyword, prefix) {
                 self.completion_items.push(simple_completion_item(

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -219,7 +219,7 @@ impl<'a> NodeFinder<'a> {
         &mut self,
         noir_function: &NoirFunction,
     ) -> Option<CompletionResponse> {
-        self.type_parameters.clear();
+        let old_type_parameters = self.type_parameters.clone();
         self.collect_type_parameters_in_generics(&noir_function.def.generics);
 
         let mut response = None;
@@ -231,12 +231,12 @@ impl<'a> NodeFinder<'a> {
         }
 
         if let Some(response) = response {
-            self.type_parameters.clear();
+            self.type_parameters = old_type_parameters;
             return Some(response);
         }
 
         if let Some(response) = self.find_in_function_return_type(&noir_function.def.return_type) {
-            self.type_parameters.clear();
+            self.type_parameters = old_type_parameters;
             return Some(response);
         }
 
@@ -247,7 +247,7 @@ impl<'a> NodeFinder<'a> {
 
         let response = self.find_in_block_expression(&noir_function.def.body);
 
-        self.type_parameters.clear();
+        self.type_parameters = old_type_parameters;
 
         response
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1273,6 +1273,16 @@ fn predefined_functions_completion(prefix: &String) -> Option<CompletionResponse
         ));
     }
 
+    for keyword in ["false", "true"] {
+        if name_matches(keyword, prefix) {
+            completion_items.push(simple_completion_item(
+                keyword,
+                CompletionItemKind::KEYWORD,
+                Some("bool".to_string()),
+            ));
+        }
+    }
+
     if completion_items.is_empty() {
         None
     } else {
@@ -2090,6 +2100,24 @@ mod completion_tests {
                 simple_completion_item("i32", CompletionItemKind::STRUCT, Some("i32".to_string())),
                 simple_completion_item("i64", CompletionItemKind::STRUCT, Some("i64".to_string())),
             ],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_suggest_true() {
+        let src = r#"
+            fn main() {
+                let x = t>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "true",
+                CompletionItemKind::KEYWORD,
+                Some("bool".to_string()),
+            )],
         )
         .await;
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -855,8 +855,7 @@ impl<'a> NodeFinder<'a> {
                     function_completion_kind,
                     requested_items,
                 );
-            }
-            if let Some(module_id) = self.resolve_module(segments) {
+            } else if let Some(module_id) = self.resolve_module(segments) {
                 let at_root = false;
                 self.complete_in_module(
                     module_id,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -29,8 +29,10 @@ use noirc_frontend::{
     macros_api::{ModuleDefId, NodeInterner, StructId},
     node_interner::{FuncId, GlobalId, ReferenceId, TraitId, TypeAliasId},
     parser::{Item, ItemKind},
+    token::{IntType, Keyword},
     ParsedModule, Type,
 };
+use strum::IntoEnumIterator;
 
 use crate::{utils, LspState};
 
@@ -1192,26 +1194,19 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn builtin_types_completion(&mut self, prefix: &str) {
-        for typ in [
-            "bool",
-            "i8",
-            "i16",
-            "i32",
-            "i64",
-            "u8",
-            "u16",
-            "u32",
-            "u64",
-            "str",
-            "Expr",
-            "Field",
-            "FunctionDefinition",
-            "Quoted",
-            "StructDefinition",
-            "TraitConstraint",
-            "TraitDefinition",
-            "Type",
-        ] {
+        for keyword in Keyword::iter() {
+            if let Some(typ) = keyword.builtin_type() {
+                if name_matches(typ, prefix) {
+                    self.completion_items.push(simple_completion_item(
+                        typ,
+                        CompletionItemKind::STRUCT,
+                        Some(typ.to_string()),
+                    ));
+                }
+            }
+        }
+
+        for typ in IntType::builtin_types() {
             if name_matches(typ, prefix) {
                 self.completion_items.push(simple_completion_item(
                     typ,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1807,13 +1807,13 @@ mod completion_tests {
     #[test]
     async fn test_complete_path_shows_module() {
         let src = r#"
-          mod foo {}
+          mod foobar {}
 
           fn main() {
-            f>|<
+            fo>|<
           }
         "#;
-        assert_completion(src, vec![module_completion_item("foo")]).await;
+        assert_completion(src, vec![module_completion_item("foobar")]).await;
     }
 
     #[test]
@@ -2048,7 +2048,7 @@ mod completion_tests {
           fn SomeFunction() {}
 
           struct Another {
-            some: S>|<
+            some: So>|<
           }
         "#;
         assert_completion(
@@ -2067,7 +2067,7 @@ mod completion_tests {
         let src = r#"
           struct Something {}
 
-          fn foo(x: S>|<) {}
+          fn foo(x: So>|<) {}
         "#;
         assert_completion(
             src,
@@ -2085,7 +2085,7 @@ mod completion_tests {
         let src = r#"
           struct Something {}
 
-          fn foo() -> S>|< {}
+          fn foo() -> So>|< {}
         "#;
         assert_completion(
             src,
@@ -2103,7 +2103,7 @@ mod completion_tests {
         let src = r#"
           struct Something {}
 
-          type Foo = S>|<
+          type Foo = So>|<
         "#;
         assert_completion(
             src,
@@ -2122,7 +2122,7 @@ mod completion_tests {
           struct Something {}
 
           trait Trait {
-            fn foo(s: S>|<);
+            fn foo(s: So>|<);
           }
         "#;
         assert_completion(
@@ -2142,7 +2142,7 @@ mod completion_tests {
           struct Something {}
 
           trait Trait {
-            fn foo() -> S>|<;
+            fn foo() -> So>|<;
           }
         "#;
         assert_completion(
@@ -2162,7 +2162,7 @@ mod completion_tests {
           struct Something {}
 
           fn main() {
-            let x: S>|<
+            let x: So>|<
           }
         "#;
         assert_completion(
@@ -2182,7 +2182,7 @@ mod completion_tests {
           struct Something {}
 
           fn main() {
-            foo(|s: S>|<| s)
+            foo(|s: So>|<| s)
           }
         "#;
         assert_completion(

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -177,6 +177,10 @@ impl<'a> NodeFinder<'a> {
         noir_function: &NoirFunction,
     ) -> Option<CompletionResponse> {
         self.local_variables.clear();
+        for param in &noir_function.def.parameters {
+            self.collect_local_variables(&param.pattern);
+        }
+
         self.find_in_block_expression(&noir_function.def.body)
     }
 
@@ -1106,6 +1110,24 @@ mod completion_tests {
                 "local",
                 CompletionItemKind::VARIABLE,
                 Some("bool".to_string()),
+            )],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_complete_path_with_function_argument() {
+        let src = r#"
+          fn main(local: Field) {
+            l>|<
+          }
+        "#;
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "local",
+                CompletionItemKind::VARIABLE,
+                Some("Field".to_string()),
             )],
         )
         .await;

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1157,6 +1157,12 @@ impl<'a> NodeFinder<'a> {
                 "assert(${1:predicate})",
                 Some("fn(T)".to_string()),
             ));
+            self.completion_items.push(snippet_completion_item(
+                "assert(…)",
+                CompletionItemKind::FUNCTION,
+                "assert(${1:predicate}, ${2:message})",
+                Some("fn(T, str)".to_string()),
+            ));
         }
 
         if name_matches("assert_eq", prefix) {
@@ -1165,6 +1171,12 @@ impl<'a> NodeFinder<'a> {
                 CompletionItemKind::FUNCTION,
                 "assert_eq(${1:lhs}, ${2:rhs})",
                 Some("fn(T, T)".to_string()),
+            ));
+            self.completion_items.push(snippet_completion_item(
+                "assert_eq(…)",
+                CompletionItemKind::FUNCTION,
+                "assert_eq(${1:lhs}, ${2:rhs}, ${3:message})",
+                Some("fn(T, T, str)".to_string()),
             ));
         }
 
@@ -1706,6 +1718,12 @@ mod completion_tests {
                     Some("fn(T)".to_string()),
                 ),
                 snippet_completion_item(
+                    "assert(…)",
+                    CompletionItemKind::FUNCTION,
+                    "assert(${1:predicate}, ${2:message})",
+                    Some("fn(T, str)".to_string()),
+                ),
+                snippet_completion_item(
                     "assert_constant(…)",
                     CompletionItemKind::FUNCTION,
                     "assert_constant(${1:x})",
@@ -1716,6 +1734,12 @@ mod completion_tests {
                     CompletionItemKind::FUNCTION,
                     "assert_eq(${1:lhs}, ${2:rhs})",
                     Some("fn(T, T)".to_string()),
+                ),
+                snippet_completion_item(
+                    "assert_eq(…)",
+                    CompletionItemKind::FUNCTION,
+                    "assert_eq(${1:lhs}, ${2:rhs}, ${3:message})",
+                    Some("fn(T, T, str)".to_string()),
                 ),
             ],
         )

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -273,7 +273,7 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn find_in_noir_type_alias(&mut self, noir_type_alias: &NoirTypeAlias) {
-        self.find_in_unresolved_type(&noir_type_alias.typ)
+        self.find_in_unresolved_type(&noir_type_alias.typ);
     }
 
     fn find_in_noir_struct(&mut self, noir_struct: &NoirStruct) {
@@ -321,7 +321,7 @@ impl<'a> NodeFinder<'a> {
                     for (name, _) in parameters {
                         self.local_variables.insert(name.to_string(), name.span());
                     }
-                    self.find_in_block_expression(body)
+                    self.find_in_block_expression(body);
                 };
 
                 self.type_parameters = old_type_parameters;
@@ -330,7 +330,7 @@ impl<'a> NodeFinder<'a> {
                 self.find_in_unresolved_type(typ);
 
                 if let Some(default_value) = default_value {
-                    self.find_in_expression(default_value)
+                    self.find_in_expression(default_value);
                 }
             }
             TraitItem::Type { name: _ } => (),
@@ -855,19 +855,18 @@ impl<'a> NodeFinder<'a> {
                     function_completion_kind,
                     requested_items,
                 );
-            } else {
-                if let Some(module_id) = self.resolve_module(segments) {
-                    let at_root = false;
-                    self.complete_in_module(
-                        module_id,
-                        &prefix,
-                        path_kind,
-                        at_root,
-                        module_completion_kind,
-                        function_completion_kind,
-                        requested_items,
-                    );
-                };
+            }
+            if let Some(module_id) = self.resolve_module(segments) {
+                let at_root = false;
+                self.complete_in_module(
+                    module_id,
+                    &prefix,
+                    path_kind,
+                    at_root,
+                    module_completion_kind,
+                    function_completion_kind,
+                    requested_items,
+                );
             }
         }
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -186,7 +186,7 @@ impl<'a> NodeFinder<'a> {
         match &item.kind {
             ItemKind::Import(use_tree) => {
                 let mut prefixes = Vec::new();
-                self.find_in_use_tree(use_tree, &mut prefixes)
+                self.find_in_use_tree(use_tree, &mut prefixes);
             }
             ItemKind::Submodules(parsed_sub_module) => {
                 // Switch `self.module_id` to the submodule
@@ -353,19 +353,19 @@ impl<'a> NodeFinder<'a> {
     fn find_in_statement(&mut self, statement: &Statement) {
         match &statement.kind {
             noirc_frontend::ast::StatementKind::Let(let_statement) => {
-                self.find_in_let_statement(let_statement, true)
+                self.find_in_let_statement(let_statement, true);
             }
             noirc_frontend::ast::StatementKind::Constrain(constrain_statement) => {
-                self.find_in_constrain_statement(constrain_statement)
+                self.find_in_constrain_statement(constrain_statement);
             }
             noirc_frontend::ast::StatementKind::Expression(expression) => {
-                self.find_in_expression(expression)
+                self.find_in_expression(expression);
             }
             noirc_frontend::ast::StatementKind::Assign(assign_statement) => {
-                self.find_in_assign_statement(assign_statement)
+                self.find_in_assign_statement(assign_statement);
             }
             noirc_frontend::ast::StatementKind::For(for_loop_statement) => {
-                self.find_in_for_loop_statement(for_loop_statement)
+                self.find_in_for_loop_statement(for_loop_statement);
             }
             noirc_frontend::ast::StatementKind::Comptime(statement) => {
                 // When entering a comptime block, regular local variables shouldn't be offered anymore
@@ -377,7 +377,7 @@ impl<'a> NodeFinder<'a> {
                 self.local_variables = old_local_variables;
             }
             noirc_frontend::ast::StatementKind::Semi(expression) => {
-                self.find_in_expression(expression)
+                self.find_in_expression(expression);
             }
             noirc_frontend::ast::StatementKind::Break
             | noirc_frontend::ast::StatementKind::Continue
@@ -402,7 +402,7 @@ impl<'a> NodeFinder<'a> {
         self.find_in_expression(&constrain_statement.0);
 
         if let Some(exp) = &constrain_statement.1 {
-            self.find_in_expression(exp)
+            self.find_in_expression(exp);
         }
     }
 
@@ -411,7 +411,7 @@ impl<'a> NodeFinder<'a> {
         assign_statement: &noirc_frontend::ast::AssignStatement,
     ) {
         self.find_in_lvalue(&assign_statement.lvalue);
-        self.find_in_expression(&assign_statement.expression)
+        self.find_in_expression(&assign_statement.expression);
     }
 
     fn find_in_for_loop_statement(&mut self, for_loop_statement: &ForLoopStatement) {
@@ -457,47 +457,47 @@ impl<'a> NodeFinder<'a> {
         match &expression.kind {
             noirc_frontend::ast::ExpressionKind::Literal(literal) => self.find_in_literal(literal),
             noirc_frontend::ast::ExpressionKind::Block(block_expression) => {
-                self.find_in_block_expression(block_expression)
+                self.find_in_block_expression(block_expression);
             }
             noirc_frontend::ast::ExpressionKind::Prefix(prefix_expression) => {
-                self.find_in_expression(&prefix_expression.rhs)
+                self.find_in_expression(&prefix_expression.rhs);
             }
             noirc_frontend::ast::ExpressionKind::Index(index_expression) => {
-                self.find_in_index_expression(index_expression)
+                self.find_in_index_expression(index_expression);
             }
             noirc_frontend::ast::ExpressionKind::Call(call_expression) => {
-                self.find_in_call_expression(call_expression)
+                self.find_in_call_expression(call_expression);
             }
             noirc_frontend::ast::ExpressionKind::MethodCall(method_call_expression) => {
-                self.find_in_method_call_expression(method_call_expression)
+                self.find_in_method_call_expression(method_call_expression);
             }
             noirc_frontend::ast::ExpressionKind::Constructor(constructor_expression) => {
-                self.find_in_constructor_expression(constructor_expression)
+                self.find_in_constructor_expression(constructor_expression);
             }
             noirc_frontend::ast::ExpressionKind::MemberAccess(member_access_expression) => {
-                self.find_in_member_access_expression(member_access_expression)
+                self.find_in_member_access_expression(member_access_expression);
             }
             noirc_frontend::ast::ExpressionKind::Cast(cast_expression) => {
-                self.find_in_cast_expression(cast_expression)
+                self.find_in_cast_expression(cast_expression);
             }
             noirc_frontend::ast::ExpressionKind::Infix(infix_expression) => {
-                self.find_in_infix_expression(infix_expression)
+                self.find_in_infix_expression(infix_expression);
             }
             noirc_frontend::ast::ExpressionKind::If(if_expression) => {
-                self.find_in_if_expression(if_expression)
+                self.find_in_if_expression(if_expression);
             }
             noirc_frontend::ast::ExpressionKind::Variable(path) => {
-                self.find_in_path(path, RequestedItems::AnyItems)
+                self.find_in_path(path, RequestedItems::AnyItems);
             }
             noirc_frontend::ast::ExpressionKind::Tuple(expressions) => {
-                self.find_in_expressions(expressions)
+                self.find_in_expressions(expressions);
             }
             noirc_frontend::ast::ExpressionKind::Lambda(lambda) => self.find_in_lambda(lambda),
             noirc_frontend::ast::ExpressionKind::Parenthesized(expression) => {
-                self.find_in_expression(expression)
+                self.find_in_expression(expression);
             }
             noirc_frontend::ast::ExpressionKind::Unquote(expression) => {
-                self.find_in_expression(expression)
+                self.find_in_expression(expression);
             }
             noirc_frontend::ast::ExpressionKind::Comptime(block_expression, _) => {
                 // When entering a comptime block, regular local variables shouldn't be offered anymore
@@ -509,7 +509,7 @@ impl<'a> NodeFinder<'a> {
                 self.local_variables = old_local_variables;
             }
             noirc_frontend::ast::ExpressionKind::AsTraitPath(as_trait_path) => {
-                self.find_in_as_trait_path(as_trait_path)
+                self.find_in_as_trait_path(as_trait_path);
             }
             noirc_frontend::ast::ExpressionKind::Quote(_)
             | noirc_frontend::ast::ExpressionKind::Resolved(_)
@@ -567,16 +567,16 @@ impl<'a> NodeFinder<'a> {
         &mut self,
         member_access_expression: &MemberAccessExpression,
     ) {
-        self.find_in_expression(&member_access_expression.lhs)
+        self.find_in_expression(&member_access_expression.lhs);
     }
 
     fn find_in_cast_expression(&mut self, cast_expression: &CastExpression) {
-        self.find_in_expression(&cast_expression.lhs)
+        self.find_in_expression(&cast_expression.lhs);
     }
 
     fn find_in_infix_expression(&mut self, infix_expression: &InfixExpression) {
         self.find_in_expression(&infix_expression.lhs);
-        self.find_in_expression(&infix_expression.rhs)
+        self.find_in_expression(&infix_expression.rhs);
     }
 
     fn find_in_if_expression(&mut self, if_expression: &IfExpression) {
@@ -609,14 +609,14 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn find_in_as_trait_path(&mut self, as_trait_path: &AsTraitPath) {
-        self.find_in_path(&as_trait_path.trait_path, RequestedItems::OnlyTypes)
+        self.find_in_path(&as_trait_path.trait_path, RequestedItems::OnlyTypes);
     }
 
     fn find_in_function_return_type(&mut self, return_type: &FunctionReturnType) {
         match return_type {
             noirc_frontend::ast::FunctionReturnType::Default(_) => (),
             noirc_frontend::ast::FunctionReturnType::Ty(unresolved_type) => {
-                self.find_in_unresolved_type(unresolved_type)
+                self.find_in_unresolved_type(unresolved_type);
             }
         }
     }
@@ -636,35 +636,35 @@ impl<'a> NodeFinder<'a> {
 
         match &unresolved_type.typ {
             noirc_frontend::ast::UnresolvedTypeData::Array(_, unresolved_type) => {
-                self.find_in_unresolved_type(unresolved_type)
+                self.find_in_unresolved_type(unresolved_type);
             }
             noirc_frontend::ast::UnresolvedTypeData::Slice(unresolved_type) => {
-                self.find_in_unresolved_type(unresolved_type)
+                self.find_in_unresolved_type(unresolved_type);
             }
             noirc_frontend::ast::UnresolvedTypeData::Parenthesized(unresolved_type) => {
-                self.find_in_unresolved_type(unresolved_type)
+                self.find_in_unresolved_type(unresolved_type);
             }
             noirc_frontend::ast::UnresolvedTypeData::Named(path, unresolved_types, _) => {
                 self.find_in_path(path, RequestedItems::OnlyTypes);
-                self.find_in_unresolved_types(unresolved_types)
+                self.find_in_unresolved_types(unresolved_types);
             }
             noirc_frontend::ast::UnresolvedTypeData::TraitAsType(path, unresolved_types) => {
                 self.find_in_path(path, RequestedItems::OnlyTypes);
-                self.find_in_unresolved_types(unresolved_types)
+                self.find_in_unresolved_types(unresolved_types);
             }
             noirc_frontend::ast::UnresolvedTypeData::MutableReference(unresolved_type) => {
-                self.find_in_unresolved_type(unresolved_type)
+                self.find_in_unresolved_type(unresolved_type);
             }
             noirc_frontend::ast::UnresolvedTypeData::Tuple(unresolved_types) => {
-                self.find_in_unresolved_types(unresolved_types)
+                self.find_in_unresolved_types(unresolved_types);
             }
             noirc_frontend::ast::UnresolvedTypeData::Function(args, ret, env) => {
                 self.find_in_unresolved_types(args);
                 self.find_in_unresolved_type(ret);
-                self.find_in_unresolved_type(env)
+                self.find_in_unresolved_type(env);
             }
             noirc_frontend::ast::UnresolvedTypeData::AsTraitPath(as_trait_path) => {
-                self.find_in_as_trait_path(as_trait_path)
+                self.find_in_as_trait_path(as_trait_path);
             }
             noirc_frontend::ast::UnresolvedTypeData::Expression(_)
             | noirc_frontend::ast::UnresolvedTypeData::FormatString(_, _)
@@ -778,9 +778,8 @@ impl<'a> NodeFinder<'a> {
         match &use_tree.kind {
             UseTreeKind::Path(ident, alias) => {
                 prefixes.push(use_tree.prefix.clone());
-                let response = self.find_in_use_tree_path(prefixes, ident, alias);
+                self.find_in_use_tree_path(prefixes, ident, alias);
                 prefixes.pop();
-                response
             }
             UseTreeKind::List(use_trees) => {
                 prefixes.push(use_tree.prefix.clone());

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -794,7 +794,7 @@ fn predefined_functions_completion(prefix: &String) -> Option<CompletionResponse
             "assert(…)",
             CompletionItemKind::FUNCTION,
             "assert(${1:predicate})",
-            None,
+            Some("fn(T)".to_string()),
         ));
     }
 
@@ -803,7 +803,7 @@ fn predefined_functions_completion(prefix: &String) -> Option<CompletionResponse
             "assert_eq(…)",
             CompletionItemKind::FUNCTION,
             "assert_eq(${1:lhs}, ${2:rhs})",
-            None,
+            Some("fn(T, T)".to_string()),
         ));
     }
 
@@ -1312,7 +1312,7 @@ mod completion_tests {
                     "assert(…)",
                     CompletionItemKind::FUNCTION,
                     "assert(${1:predicate})",
-                    None,
+                    Some("fn(T)".to_string()),
                 ),
                 snippet_completion_item(
                     "assert_constant(…)",
@@ -1324,7 +1324,7 @@ mod completion_tests {
                     "assert_eq(…)",
                     CompletionItemKind::FUNCTION,
                     "assert_eq(${1:lhs}, ${2:rhs})",
-                    None,
+                    Some("fn(T, T)".to_string()),
                 ),
             ],
         )

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -904,8 +904,8 @@ impl<'a> NodeFinder<'a> {
                     let local_vars_response = self.local_variables_completion(&prefix);
                     let response = merge_completion_responses(response, local_vars_response);
 
-                    let predefined_response = predefined_functions_completion(&prefix);
-                    let response = merge_completion_responses(response, predefined_response);
+                    let builtin_response = builtin_functions_completion(&prefix);
+                    let response = merge_completion_responses(response, builtin_response);
 
                     response
                 }
@@ -1364,7 +1364,7 @@ fn name_matches(name: &str, prefix: &str) -> bool {
     name.starts_with(prefix)
 }
 
-fn predefined_functions_completion(prefix: &String) -> Option<CompletionResponse> {
+fn builtin_functions_completion(prefix: &String) -> Option<CompletionResponse> {
     let mut completion_items = Vec::new();
 
     if name_matches("assert", prefix) {
@@ -1926,7 +1926,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_complete_predefined_functions() {
+    async fn test_complete_builtin_functions() {
         let src = r#"
           fn main() {
             a>|<

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -29,7 +29,7 @@ use noirc_frontend::{
     macros_api::{ModuleDefId, NodeInterner, StructId},
     node_interner::{FuncId, GlobalId, ReferenceId, TraitId, TypeAliasId},
     parser::{Item, ItemKind},
-    token::{IntType, Keyword},
+    token::Keyword,
     ParsedModule, Type,
 };
 use strum::IntoEnumIterator;
@@ -1195,7 +1195,7 @@ impl<'a> NodeFinder<'a> {
 
     fn builtin_types_completion(&mut self, prefix: &str) {
         for keyword in Keyword::iter() {
-            if let Some(typ) = keyword.builtin_type() {
+            if let Some(typ) = keyword_builtin_type(&keyword) {
                 if name_matches(typ, prefix) {
                     self.completion_items.push(simple_completion_item(
                         typ,
@@ -1206,7 +1206,7 @@ impl<'a> NodeFinder<'a> {
             }
         }
 
-        for typ in IntType::builtin_types() {
+        for typ in builtin_integer_types() {
             if name_matches(typ, prefix) {
                 self.completion_items.push(simple_completion_item(
                     typ,
@@ -1224,6 +1224,64 @@ impl<'a> NodeFinder<'a> {
 
 fn name_matches(name: &str, prefix: &str) -> bool {
     name.starts_with(prefix)
+}
+
+fn builtin_integer_types() -> [&'static str; 8] {
+    ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"]
+}
+
+/// If this keyword corresponds to a built-in type, returns that type's name.
+fn keyword_builtin_type(keyword: &Keyword) -> Option<&'static str> {
+    match keyword {
+        Keyword::Bool => Some("bool"),
+        Keyword::Expr => Some("Expr"),
+        Keyword::Field => Some("Field"),
+        Keyword::FunctionDefinition => Some("FunctionDefinition"),
+        Keyword::StructDefinition => Some("StructDefinition"),
+        Keyword::TraitConstraint => Some("TraitConstraint"),
+        Keyword::TraitDefinition => Some("TraitDefinition"),
+        Keyword::TypeType => Some("Type"),
+
+        Keyword::As
+        | Keyword::Assert
+        | Keyword::AssertEq
+        | Keyword::Break
+        | Keyword::CallData
+        | Keyword::Char
+        | Keyword::Comptime
+        | Keyword::Constrain
+        | Keyword::Continue
+        | Keyword::Contract
+        | Keyword::Crate
+        | Keyword::Dep
+        | Keyword::Else
+        | Keyword::Fn
+        | Keyword::For
+        | Keyword::FormatString
+        | Keyword::Global
+        | Keyword::If
+        | Keyword::Impl
+        | Keyword::In
+        | Keyword::Let
+        | Keyword::Mod
+        | Keyword::Module
+        | Keyword::Mut
+        | Keyword::Pub
+        | Keyword::Quoted
+        | Keyword::Return
+        | Keyword::ReturnData
+        | Keyword::String
+        | Keyword::Struct
+        | Keyword::Super
+        | Keyword::TopLevelItem
+        | Keyword::Trait
+        | Keyword::Type
+        | Keyword::Unchecked
+        | Keyword::Unconstrained
+        | Keyword::Use
+        | Keyword::Where
+        | Keyword::While => None,
+    }
 }
 
 fn module_completion_item(name: impl Into<String>) -> CompletionItem {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -522,9 +522,17 @@ impl<'a> NodeFinder<'a> {
             Pattern::Identifier(ident) => {
                 self.local_variables.insert(ident.to_string(), ident.span());
             }
-            Pattern::Mutable(_, _, _) => todo!(),
-            Pattern::Tuple(_, _) => todo!(),
-            Pattern::Struct(_, _, _) => todo!(),
+            Pattern::Mutable(pattern, _, _) => self.collect_local_variables(pattern),
+            Pattern::Tuple(patterns, _) => {
+                for pattern in patterns {
+                    self.collect_local_variables(pattern);
+                }
+            }
+            Pattern::Struct(_, patterns, _) => {
+                for (_, pattern) in patterns {
+                    self.collect_local_variables(pattern);
+                }
+            }
         }
     }
 

--- a/tooling/lsp/src/requests/completion/builtins.rs
+++ b/tooling/lsp/src/requests/completion/builtins.rs
@@ -1,0 +1,127 @@
+use noirc_frontend::token::Keyword;
+
+pub(super) fn builtin_integer_types() -> [&'static str; 8] {
+    ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"]
+}
+
+/// If a keyword corresponds to a built-in type, returns that type's name.
+pub(super) fn keyword_builtin_type(keyword: &Keyword) -> Option<&'static str> {
+    match keyword {
+        Keyword::Bool => Some("bool"),
+        Keyword::Expr => Some("Expr"),
+        Keyword::Field => Some("Field"),
+        Keyword::FunctionDefinition => Some("FunctionDefinition"),
+        Keyword::StructDefinition => Some("StructDefinition"),
+        Keyword::TraitConstraint => Some("TraitConstraint"),
+        Keyword::TraitDefinition => Some("TraitDefinition"),
+        Keyword::TypeType => Some("Type"),
+
+        Keyword::As
+        | Keyword::Assert
+        | Keyword::AssertEq
+        | Keyword::Break
+        | Keyword::CallData
+        | Keyword::Char
+        | Keyword::Comptime
+        | Keyword::Constrain
+        | Keyword::Continue
+        | Keyword::Contract
+        | Keyword::Crate
+        | Keyword::Dep
+        | Keyword::Else
+        | Keyword::Fn
+        | Keyword::For
+        | Keyword::FormatString
+        | Keyword::Global
+        | Keyword::If
+        | Keyword::Impl
+        | Keyword::In
+        | Keyword::Let
+        | Keyword::Mod
+        | Keyword::Module
+        | Keyword::Mut
+        | Keyword::Pub
+        | Keyword::Quoted
+        | Keyword::Return
+        | Keyword::ReturnData
+        | Keyword::String
+        | Keyword::Struct
+        | Keyword::Super
+        | Keyword::TopLevelItem
+        | Keyword::Trait
+        | Keyword::Type
+        | Keyword::Unchecked
+        | Keyword::Unconstrained
+        | Keyword::Use
+        | Keyword::Where
+        | Keyword::While => None,
+    }
+}
+
+pub(super) struct BuiltInFunction {
+    pub(super) name: &'static str,
+    pub(super) parameters: &'static str,
+    pub(super) description: &'static str,
+}
+
+/// If a keyword corresponds to a built-in function, returns info about it
+pub(super) fn keyword_builtin_function(keyword: &Keyword) -> Option<BuiltInFunction> {
+    match keyword {
+        Keyword::Assert => Some(BuiltInFunction {
+            name: "assert",
+            parameters: "${1:predicate}",
+            description: "fn(T)",
+        }),
+        Keyword::AssertEq => Some(BuiltInFunction {
+            name: "assert_eq",
+            parameters: "${1:lhs}, ${2:rhs}",
+            description: "fn(T, T)",
+        }),
+
+        Keyword::As
+        | Keyword::Bool
+        | Keyword::Break
+        | Keyword::CallData
+        | Keyword::Char
+        | Keyword::Comptime
+        | Keyword::Constrain
+        | Keyword::Continue
+        | Keyword::Contract
+        | Keyword::Crate
+        | Keyword::Dep
+        | Keyword::Else
+        | Keyword::Expr
+        | Keyword::Field
+        | Keyword::Fn
+        | Keyword::For
+        | Keyword::FormatString
+        | Keyword::FunctionDefinition
+        | Keyword::Global
+        | Keyword::If
+        | Keyword::Impl
+        | Keyword::In
+        | Keyword::Let
+        | Keyword::Mod
+        | Keyword::Module
+        | Keyword::Mut
+        | Keyword::Pub
+        | Keyword::Quoted
+        | Keyword::Return
+        | Keyword::ReturnData
+        | Keyword::String
+        | Keyword::Struct
+        | Keyword::StructDefinition
+        | Keyword::Super
+        | Keyword::TopLevelItem
+        | Keyword::Trait
+        | Keyword::TraitConstraint
+        | Keyword::TraitDefinition
+        | Keyword::Type
+        | Keyword::TypeType
+        | Keyword::Unchecked
+        | Keyword::Unconstrained
+        | Keyword::Use
+        | Keyword::Where
+        | Keyword::While => None,
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Part of #1577

## Summary

LSP will now suggest completions anywhere there's a Path. Here are some scenarios:

### Autocomplete functions in full paths, with parameters

![lsp-complete-function](https://github.com/user-attachments/assets/48f1bc08-50e6-4c10-b22a-8c99dd67736d)

### Autocomplete functions when they exist in a use statement

![lsp-complete-function-after-use](https://github.com/user-attachments/assets/74f27049-ec4d-4722-972b-586e1f834969)

### Built-in functions are also suggested

![lsp-builtin-functions](https://github.com/user-attachments/assets/17ecd98b-7001-4981-a1ba-f54ec4aa8ca3)

### Autocomplete local variables

![lsp-local-var](https://github.com/user-attachments/assets/671efe94-4a4d-4cd8-a66b-982d67276383)

### Autocomplete types in several type positions

![lsp-suggest-type](https://github.com/user-attachments/assets/e52a965a-59b1-47a9-aff2-c5c7cbce8e37)

### Built-in types are also suggested

![lsp-builtin-type](https://github.com/user-attachments/assets/9b3c0bb6-b429-447a-9b13-7d1d939127dc)

### Autocomplete type parameters

![lsp-type-parameter](https://github.com/user-attachments/assets/e8bd3e8d-ac20-48f9-b416-426d9ddfcd4e)

## Additional Context

Sorry for the large diff, the bulk of it is traversing the AST. I thought about using something like the Visitor pattern, but I'm not exactly sure how it would look in Rust and whether it would greatly reduce the amount of code. It could be a separate refactor, though! (and we have tons of tests now, so it should be safe to do too).

Another big chunk of code is tests... So the actual logic isn't that large. 

Some more things could be done on top of this, like suggesting `Self` if it's available, but I wanted to stop making this PR bigger 😊 

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
