### PR TITLE
feat: LSP fields, functions and methods completion after "." and "::"

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -665,12 +665,12 @@ impl std::fmt::Display for Type {
             Type::Function(args, ret, env) => {
                 let closure_env_text = match **env {
                     Type::Unit => "".to_string(),
-                    _ => format!(" with env {env}"),
+                    _ => format!("[{env}]"),
                 };
 
                 let args = vecmap(args.iter(), ToString::to_string);
 
-                write!(f, "fn({}) -> {ret}{closure_env_text}", args.join(", "))
+                write!(f, "fn{closure_env_text}({}) -> {ret}", args.join(", "))
             }
             Type::MutableReference(element) => {
                 write!(f, "&mut {element}")

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1145,9 +1145,10 @@ impl NodeInterner {
                 let struct_type = struct_type.borrow();
                 self.get_struct_methods(struct_type.id)
             }
-            Type::Alias(type_alias, _) => {
+            Type::Alias(type_alias, generics) => {
                 let type_alias = type_alias.borrow();
-                self.get_type_methods(&type_alias.typ)
+                let typ = type_alias.get_type(&generics);
+                self.get_type_methods(&typ)
             }
             _ => get_type_method_key(typ).and_then(|key| self.get_primitive_methods(key)),
         }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1147,7 +1147,7 @@ impl NodeInterner {
             }
             Type::Alias(type_alias, generics) => {
                 let type_alias = type_alias.borrow();
-                let typ = type_alias.get_type(&generics);
+                let typ = type_alias.get_type(generics);
                 self.get_type_methods(&typ)
             }
             _ => get_type_method_key(typ).and_then(|key| self.get_primitive_methods(key)),

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1813,6 +1813,11 @@ impl NodeInterner {
         self.prefix_operator_traits.insert(operator, trait_id);
     }
 
+    pub fn is_operator_trait(&self, trait_id: TraitId) -> bool {
+        self.infix_operator_traits.values().any(|id| *id == trait_id)
+            || self.prefix_operator_traits.values().any(|id| *id == trait_id)
+    }
+
     /// This function is needed when creating a NodeInterner for testing so that calls
     /// to `get_operator_trait` do not panic when the stdlib isn't present.
     #[cfg(test)]

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -16,6 +16,8 @@ pub enum ParserErrorReason {
     ExpectedFieldName(Token),
     #[error("expected a pattern but found a type - {0}")]
     ExpectedPatternButFoundType(Token),
+    #[error("expected an identifier after .")]
+    ExpectedIdentifierAfterDot,
     #[error("expected an identifier after ::")]
     ExpectedIdentifierAfterColons,
     #[error("Expected a ; separating these two statements")]

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -847,6 +847,7 @@ where
         ArrayIndex(Expression),
         Cast(UnresolvedType),
         MemberAccess(UnaryRhsMemberAccess),
+        JustADot,
     }
 
     // `(arg1, ..., argN)` in `my_func(arg1, ..., argN)`
@@ -890,7 +891,10 @@ where
         })
         .labelled(ParsingRuleLabel::FieldAccess);
 
-    let rhs = choice((call_rhs, array_rhs, cast_rhs, member_rhs));
+    // TODO: error when it's just a dot
+    let just_a_dot = just(Token::Dot).map(|_| UnaryRhs::JustADot);
+
+    let rhs = choice((call_rhs, array_rhs, cast_rhs, member_rhs, just_a_dot));
 
     foldl_with_span(
         atom(expr_parser, expr_no_constructors, statement, allow_constructors),
@@ -904,6 +908,7 @@ where
             UnaryRhs::MemberAccess(field) => {
                 Expression::member_access_or_method_call(lhs, field, span)
             }
+            UnaryRhs::JustADot => lhs,
         },
     )
 }
@@ -1672,5 +1677,27 @@ mod test {
         let (block_expr, _) = parse_recover(block(fresh_statement()), src);
         let block_expr = block_expr.expect("Failed to parse module");
         assert_eq!(block_expr.statements.len(), 2);
+    }
+
+    #[test]
+    fn test_parses_member_access_without_member_name() {
+        let src = "{ foo. }";
+
+        let (Some(block_expression), _errors) = parse_recover(block(fresh_statement()), src) else {
+            panic!("Expected to be able to parse a block expression");
+        };
+
+        // TODO: assert that there's an error here
+
+        let statement = &block_expression.statements[0];
+        let StatementKind::Expression(expr) = &statement.kind else {
+            panic!("Expected an expression statement");
+        };
+
+        let ExpressionKind::Variable(var) = &expr.kind else {
+            panic!("Expected a variable expression");
+        };
+
+        assert_eq!(var.to_string(), "foo");
     }
 }

--- a/compiler/noirc_frontend/src/resolve_locations.rs
+++ b/compiler/noirc_frontend/src/resolve_locations.rs
@@ -31,6 +31,12 @@ impl NodeInterner {
         location_candidate.map(|(index, _location)| *index)
     }
 
+    /// Returns the Type of the expression that exists at the given location.
+    pub fn type_at_location(&self, location: Location) -> Option<Type> {
+        let index = self.find_location_index(location)?;
+        Some(self.id_type(index))
+    }
+
     /// Returns the [Location] of the definition of the given Ident found at [Span] of the given [FileId].
     /// Returns [None] when definition is not found.
     pub fn get_definition_location_from(

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -2472,4 +2472,65 @@ mod completion_tests {
         )
         .await;
     }
+
+    #[test]
+    async fn test_suggests_struct_trait_impl_method() {
+        let src = r#"
+            struct Some {
+            }
+
+            trait SomeTrait {
+                fn foobar(self, x: i32);
+                fn foobar2(y: i32);
+            }
+
+            impl SomeTrait for Some {
+                fn foobar(self, x: i32) {}
+                fn foobar2(y: i32) {}
+            }
+
+            fn foo(some: Some) {
+                some.f>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![snippet_completion_item(
+                "foobar(…)",
+                CompletionItemKind::FUNCTION,
+                "foobar(${1:x})",
+                Some("fn(Some, i32)".to_string()),
+            )],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_suggests_primitive_trait_impl_method() {
+        let src = r#"
+            trait SomeTrait {
+                fn foobar(self, x: i32);
+                fn foobar2(y: i32);
+            }
+
+            impl SomeTrait for Field {
+                fn foobar(self, x: i32) {}
+                fn foobar2(y: i32) {}
+            }
+
+            fn foo(field: Field) {
+                field.f>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![snippet_completion_item(
+                "foobar(…)",
+                CompletionItemKind::FUNCTION,
+                "foobar(${1:x})",
+                Some("fn(Field, i32)".to_string()),
+            )],
+        )
+        .await;
+    }
 }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -459,6 +459,17 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn find_in_expression(&mut self, expression: &Expression) {
+        // "foo." (no identifier afterwards) is parsed as the expression on the left hand-side of the dot.
+        // Here we check if there's a dot at the completion position, and if the expression
+        // ends right before the dot. If so, it means we want to complete the expression's type fields and methods.
+        if self.byte == Some(b'.') && expression.span.end() as usize == self.byte_index - 1 {
+            let location = Location::new(expression.span, self.file);
+            if let Some(typ) = self.interner.type_at_location(location) {
+                let prefix = "";
+                self.complete_type_fields_and_methods(&typ, prefix, false)
+            }
+        }
+
         match &expression.kind {
             noirc_frontend::ast::ExpressionKind::Literal(literal) => self.find_in_literal(literal),
             noirc_frontend::ast::ExpressionKind::Block(block_expression) => {
@@ -492,18 +503,7 @@ impl<'a> NodeFinder<'a> {
                 self.find_in_if_expression(if_expression);
             }
             noirc_frontend::ast::ExpressionKind::Variable(path) => {
-                // "foo." (no identifier afterwards) is parsed as a regular variable.
-                // Here we check if there's a dot at the completion position, and if the variable
-                // ends right before the dot. If so, it means we want to complete the variable's fields and methods.
-                if self.byte == Some(b'.') && path.span.end() as usize == self.byte_index - 1 {
-                    let location = Location::new(path.span, self.file);
-                    if let Some(typ) = self.interner.type_at_location(location) {
-                        let prefix = "";
-                        self.complete_type_fields_and_methods(&typ, prefix, false)
-                    }
-                } else {
-                    self.find_in_path(path, RequestedItems::AnyItems);
-                }
+                self.find_in_path(path, RequestedItems::AnyItems);
             }
             noirc_frontend::ast::ExpressionKind::Tuple(expressions) => {
                 self.find_in_expressions(expressions);
@@ -2331,6 +2331,28 @@ mod completion_tests {
                 CompletionItemKind::FIELD,
                 Some("i32".to_string()),
             )],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_suggests_struct_field_after_dot_chain() {
+        let src = r#"
+            struct Some {
+                property: Other,
+            }
+
+            struct Other {
+                bar: i32,
+            }
+
+            fn foo(some: Some) {
+                some.property.>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![simple_completion_item("bar", CompletionItemKind::FIELD, Some("i32".to_string()))],
         )
         .await;
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -186,7 +186,7 @@ impl<'a> NodeFinder<'a> {
 
             // Show items that start with underscore last in the list
             for item in items.iter_mut() {
-                if item.label.starts_with("_") {
+                if item.label.starts_with('_') {
                     item.sort_text = Some(underscore_sort_text());
                 }
             }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -182,7 +182,16 @@ impl<'a> NodeFinder<'a> {
         if self.completion_items.is_empty() {
             None
         } else {
-            Some(CompletionResponse::Array(std::mem::take(&mut self.completion_items)))
+            let mut items = std::mem::take(&mut self.completion_items);
+
+            // Show items that start with underscore last in the list
+            for item in items.iter_mut() {
+                if item.label.starts_with("_") {
+                    item.sort_text = Some(underscore_sort_text());
+                }
+            }
+
+            Some(CompletionResponse::Array(items))
         }
     }
 
@@ -1603,6 +1612,13 @@ fn self_mismatch_sort_text() -> String {
 
 /// We want to show operator methods last.
 fn operator_sort_text() -> String {
+    "8".to_string()
+}
+
+/// If a name begins with underscore it's likely something that's meant to
+/// be private (but visibility doesn't exist everywhere yet, so for now
+/// we assume that)
+fn underscore_sort_text() -> String {
     "9".to_string()
 }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -602,7 +602,8 @@ impl<'a> NodeFinder<'a> {
             if let Some(typ) = self.interner.type_at_location(location) {
                 let typ = typ.follow_bindings();
                 let prefix = ident.to_string();
-                self.complete_type_fields_and_methods(&typ, &prefix)
+                self.complete_type_fields_and_methods(&typ, &prefix);
+                return;
             }
         }
 
@@ -1045,7 +1046,7 @@ impl<'a> NodeFinder<'a> {
                     name,
                     CompletionItemKind::FIELD,
                     Some(typ.to_string()),
-                ))
+                ));
             }
         }
     }
@@ -1241,7 +1242,7 @@ impl<'a> NodeFinder<'a> {
         } else {
             false
         };
-        let description = func_meta_type_to_string(&func_meta, func_self_type.is_some());
+        let description = func_meta_type_to_string(func_meta, func_self_type.is_some());
 
         let completion_item = match function_completion_kind {
             FunctionCompletionKind::Name => {
@@ -1249,8 +1250,7 @@ impl<'a> NodeFinder<'a> {
             }
             FunctionCompletionKind::NameAndParameters => {
                 let kind = CompletionItemKind::FUNCTION;
-                let insert_text =
-                    self.compute_function_insert_text(func_meta, &name, function_kind);
+                let insert_text = self.compute_function_insert_text(func_meta, name, function_kind);
                 let label = if insert_text.ends_with("()") {
                     format!("{}()", name)
                 } else {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -476,7 +476,8 @@ impl<'a> NodeFinder<'a> {
             if let Some(typ) = self.interner.type_at_location(location) {
                 let typ = typ.follow_bindings();
                 let prefix = "";
-                self.complete_type_fields_and_methods(&typ, prefix)
+                self.complete_type_fields_and_methods(&typ, prefix);
+                return;
             }
         }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1212,15 +1212,20 @@ impl<'a> NodeFinder<'a> {
             FunctionKind::Any => (),
             FunctionKind::SelfType(mut self_type) => {
                 if let Some(func_self_type) = func_self_type {
-                    // Check that the pattern type is the same as self type.
-                    // We do this because some types (notable Field and integer types)
-                    // have their methods in the same HashMap.
-                    if let Type::MutableReference(mut_typ) = self_type {
-                        self_type = mut_typ;
-                    }
+                    if matches!(self_type, Type::Integer(..))
+                        || matches!(self_type, Type::FieldElement)
+                    {
+                        // Check that the pattern type is the same as self type.
+                        // We do this because some types (only Field and integer types)
+                        // have their methods in the same HashMap.
 
-                    if self_type != func_self_type {
-                        return None;
+                        if let Type::MutableReference(mut_typ) = self_type {
+                            self_type = mut_typ;
+                        }
+
+                        if self_type != func_self_type {
+                            return None;
+                        }
                     }
                 } else {
                     return None;

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1243,7 +1243,7 @@ impl<'a> NodeFinder<'a> {
         let description = typ.to_string();
         let description = description.strip_suffix(" -> ()").unwrap_or(&description).to_string();
 
-        let mut completion_item = match function_completion_kind {
+        let completion_item = match function_completion_kind {
             FunctionCompletionKind::Name => {
                 simple_completion_item(name, CompletionItemKind::FUNCTION, Some(description))
             }
@@ -1257,13 +1257,15 @@ impl<'a> NodeFinder<'a> {
             }
         };
 
-        if is_operator {
-            completion_item.sort_text = Some(operator_sort_text())
+        let completion_item = if is_operator {
+            completion_item_with_sort_text(completion_item, operator_sort_text())
         } else if function_kind == FunctionKind::Any && name == "new" {
-            completion_item.sort_text = Some(new_sort_text())
+            completion_item_with_sort_text(completion_item, new_sort_text())
         } else if function_kind == FunctionKind::Any && func_self_type.is_some() {
-            completion_item.sort_text = Some(self_mismatch_sort_text())
-        }
+            completion_item_with_sort_text(completion_item, self_mismatch_sort_text())
+        } else {
+            completion_item
+        };
 
         Some(completion_item)
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1248,10 +1248,14 @@ impl<'a> NodeFinder<'a> {
                 simple_completion_item(name, CompletionItemKind::FUNCTION, Some(description))
             }
             FunctionCompletionKind::NameAndParameters => {
-                let label = format!("{}(…)", name);
                 let kind = CompletionItemKind::FUNCTION;
                 let insert_text =
                     self.compute_function_insert_text(func_meta, &name, function_kind);
+                let label = if insert_text.ends_with("()") {
+                    format!("{}()", name)
+                } else {
+                    format!("{}(…)", name)
+                };
 
                 snippet_completion_item(label, kind, insert_text, Some(description))
             }
@@ -1941,6 +1945,27 @@ mod completion_tests {
                 "local",
                 CompletionItemKind::VARIABLE,
                 Some("Field".to_string()),
+            )],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_complete_function_without_arguments() {
+        let src = r#"
+          fn hello() { }
+
+          fn main() {
+            h>|<
+          }
+        "#;
+        assert_completion(
+            src,
+            vec![snippet_completion_item(
+                "hello()",
+                CompletionItemKind::FUNCTION,
+                "hello()",
+                Some("fn()".to_string()),
             )],
         )
         .await;

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -234,7 +234,7 @@ pub(crate) fn on_initialize(
                 )),
                 completion_provider: Some(lsp_types::OneOf::Right(lsp_types::CompletionOptions {
                     resolve_provider: None,
-                    trigger_characters: Some(vec![":".to_string()]),
+                    trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
                     all_commit_characters: None,
                     work_done_progress_options: WorkDoneProgressOptions {
                         work_done_progress: None,


### PR DESCRIPTION
# Description

## Problem

Part of https://github.com/noir-lang/noir/issues/1577

## Summary

Suggest struct fields and methods after you type "." or "::". 

![lsp-methods](https://github.com/user-attachments/assets/ff242c4f-6a90-4bc1-bc90-9343141f169d)

Here it's working in a project inside Aztec-Packages:

![lsp-methods-2](https://github.com/user-attachments/assets/0b3c9496-b2ea-4d6c-9e50-2fc4295420e1)


## Additional Context

Some things don't work well yet. For example if you chain some calls, like `[1, 2, 3].as_slice().` nothing is offered there. It has to do with how things are stored in `id_to_location`. Or if you type `if something.` then nothing gets offered because that doesn't parse right.

We could improve those things on later PRs, though, but at least autocompletion now is much better than before.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
