### PR TITLE
fix: let LSP autocompletion work in more contexts

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -369,7 +369,7 @@ impl<'context> Elaborator<'context> {
                     function_args.push((typ, arg, span));
                 }
 
-                let location = Location::new(span, self.file);
+                let location = Location::new(object_span, self.file);
                 let method = method_call.method_name;
                 let turbofish_generics = generics.clone();
                 let is_macro_call = method_call.is_macro_call;

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -369,7 +369,8 @@ impl<'context> Elaborator<'context> {
                     function_args.push((typ, arg, span));
                 }
 
-                let location = Location::new(method_name_span, self.file);
+                let call_span = Span::from(object_span.start()..method_name_span.end());
+                let location = Location::new(call_span, self.file);
                 let method = method_call.method_name;
                 let turbofish_generics = generics.clone();
                 let is_macro_call = method_call.is_macro_call;

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -369,7 +369,7 @@ impl<'context> Elaborator<'context> {
                     function_args.push((typ, arg, span));
                 }
 
-                let location = Location::new(object_span, self.file);
+                let location = Location::new(method_name_span, self.file);
                 let method = method_call.method_name;
                 let turbofish_generics = generics.clone();
                 let is_macro_call = method_call.is_macro_call;

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -20,6 +20,8 @@ pub enum ParserErrorReason {
     ExpectedIdentifierAfterDot,
     #[error("expected an identifier after ::")]
     ExpectedIdentifierAfterColons,
+    #[error("expected {{ after if condition")]
+    ExpectedLeftBraceAfterIfCondition,
     #[error("Expected a ; separating these two statements")]
     MissingSeparatingSemi,
     #[error("constrain keyword is deprecated")]

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -944,10 +944,32 @@ where
 
         keyword(Keyword::If)
             .ignore_then(expr_no_constructors)
-            .then(if_block)
-            .then(keyword(Keyword::Else).ignore_then(else_block).or_not())
-            .map(|((condition, consequence), alternative)| {
-                ExpressionKind::If(Box::new(IfExpression { condition, consequence, alternative }))
+            .then(if_block.then(keyword(Keyword::Else).ignore_then(else_block).or_not()).or_not())
+            .validate(|(condition, consequence_and_alternative), span, emit_error| {
+                if let Some((consequence, alternative)) = consequence_and_alternative {
+                    ExpressionKind::If(Box::new(IfExpression {
+                        condition,
+                        consequence,
+                        alternative,
+                    }))
+                } else {
+                    // We allow `if cond` without a block mainly for LSP, so that it parses right
+                    // and autocompletion works there.
+                    emit_error(ParserError::with_reason(
+                        ParserErrorReason::ExpectedLeftBraceAfterIfCondition,
+                        span,
+                    ));
+
+                    let span_end = condition.span.end();
+                    ExpressionKind::If(Box::new(IfExpression {
+                        condition,
+                        consequence: Expression::new(
+                            ExpressionKind::Error,
+                            Span::from(span_end..span_end),
+                        ),
+                        alternative: None,
+                    }))
+                }
             })
     })
 }
@@ -1418,6 +1440,24 @@ mod test {
             if_expr(expression_no_constructors(expression()), fresh_statement()),
             vec!["if (x / a) + 1 {} else", "if foo then 1 else 2", "if true { 1 }else 3"],
         );
+    }
+
+    #[test]
+    fn parse_if_without_block() {
+        let src = "if foo";
+        let parser = if_expr(expression_no_constructors(expression()), fresh_statement());
+        let (expression_kind, errors) = parse_recover(parser, src);
+
+        let expression_kind = expression_kind.unwrap();
+        let ExpressionKind::If(if_expression) = expression_kind else {
+            panic!("Expected an if expression, got {:?}", expression_kind);
+        };
+
+        assert_eq!(if_expression.consequence.kind, ExpressionKind::Error);
+        assert_eq!(if_expression.alternative, None);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].message, "expected { after if condition");
     }
 
     #[test]

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -564,7 +564,6 @@ impl<'a> NodeFinder<'a> {
                 let typ = typ.follow_bindings();
                 let prefix = "";
                 self.complete_type_fields_and_methods(&typ, prefix);
-                return;
             }
         }
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -2877,4 +2877,22 @@ mod completion_tests {
         )
         .await;
     }
+
+    #[test]
+    async fn test_completes_in_broken_if_after_dot() {
+        let src = r#"
+            struct Some {
+                foo: i32,
+            }
+
+            fn foo(s: Some) {
+                if s.>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![simple_completion_item("foo", CompletionItemKind::FIELD, Some("i32".to_string()))],
+        )
+        .await;
+    }
 }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -2917,4 +2917,29 @@ mod completion_tests {
         )
         .await;
     }
+
+    #[test]
+    async fn test_completes_in_call_chain() {
+        let src = r#"
+            struct Foo {}
+
+            impl Foo {
+                fn foo(self) -> Foo { self }
+            }
+
+            fn foo(f: Foo) {
+                f.foo().>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![snippet_completion_item(
+                "foo()",
+                CompletionItemKind::FUNCTION,
+                "foo()",
+                Some("fn(self) -> Foo".to_string()),
+            )],
+        )
+        .await;
+    }
 }


### PR DESCRIPTION
# Description

## Problem

There were a couple of contexts where autocompletion wouldn't trigger. This PR fixes some of these.

## Summary

### Autocompletion inside if condition without following body

Before:

![lsp-autocomplete-if-before](https://github.com/user-attachments/assets/e4d96573-9c96-4ab7-b5b7-7c99a87c4b3a)

After:

![lsp-autocomplete-if-after](https://github.com/user-attachments/assets/318569b2-9556-41f1-bd63-c68eda3e7371)

### Autocompletion in nested expression

Before:

![lsp-autocomplete-nested-before](https://github.com/user-attachments/assets/ef1aa9f8-4c30-4796-9672-dc54af913b69)

The reason is that is was autocompleting for the type of `foo.bar & foo` instead of just `foo`.

After:

![lsp-autocomplete-nested-after](https://github.com/user-attachments/assets/98c28c43-029d-4305-ba41-18f2697ba58f)


### Autocompletion in call chains

Before:

![lsp-autocomplete-chain-before](https://github.com/user-attachments/assets/d2d3e4f5-3b00-4f80-bd37-25cf76288d8e)

After:

![lsp-autocomplete-chain-after](https://github.com/user-attachments/assets/bead94ba-55d2-40f1-896e-58625fd7f542)

### Autocompletion when assignment follows

Before:

![lsp-autocomplete-assignment-follows-before](https://github.com/user-attachments/assets/80a5db63-bcd3-421a-85e4-9acdfec79763)

After:

![lsp-autocomplete-assignment-follows-after](https://github.com/user-attachments/assets/328a2a83-959a-4252-b974-17f547f7fc13)

## Additional Context

I might send a follow-up PR to split `completion.rs` into several files because it's getting pretty big. For example tests could go in a separate file.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
