### PR TITLE
chore: Toggle underconstrained check

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -126,7 +126,7 @@ pub struct CompileOptions {
 
     /// Flag to turn off the compiler check for under constrained values.
     /// Warning: This can improve compilation speed but can also lead to correctness errors.
-    /// This check should always be run on production code. 
+    /// This check should always be run on production code.
     #[arg(long)]
     pub skip_underconstrained_check: bool,
 }

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -123,6 +123,12 @@ pub struct CompileOptions {
     /// Temporary flag to enable the experimental arithmetic generics feature
     #[arg(long, hide = true)]
     pub arithmetic_generics: bool,
+
+    /// Flag to turn off the compiler check for under constrained values.
+    /// Warning: This can improve compilation speed but can also lead to correctness errors.
+    /// This check should always be run on production code. 
+    #[arg(long)]
+    pub skip_underconstrained_check: bool,
 }
 
 pub fn parse_expression_width(input: &str) -> Result<ExpressionWidth, std::io::Error> {
@@ -576,6 +582,7 @@ pub fn compile_no_check(
             ExpressionWidth::default()
         },
         emit_ssa: if options.emit_ssa { Some(context.package_build_path.clone()) } else { None },
+        skip_underconstrained_check: options.skip_underconstrained_check,
     };
 
     let SsaProgramArtifact { program, debug, warnings, names, error_types, .. } =

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -64,6 +64,9 @@ pub struct SsaEvaluatorOptions {
 
     /// Dump the unoptimized SSA to the supplied path if it exists
     pub emit_ssa: Option<PathBuf>,
+
+    /// Skip the check for under constrained values
+    pub skip_underconstrained_check: bool,
 }
 
 pub(crate) struct ArtifactsAndWarnings(Artifacts, Vec<SsaReport>);
@@ -117,7 +120,11 @@ pub(crate) fn optimize_into_acir(
     .run_pass(Ssa::array_set_optimization, "After Array Set Optimizations:")
     .finish();
 
-    let ssa_level_warnings = ssa.check_for_underconstrained_values();
+    let ssa_level_warnings = if options.skip_underconstrained_check {
+        vec![]
+    } else {
+        time("After Check for Underconstrained Values", options.print_codegen_timings, || ssa.check_for_underconstrained_values())
+    };
     let brillig = time("SSA to Brillig", options.print_codegen_timings, || {
         ssa.to_brillig(options.enable_brillig_logging)
     });

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -123,7 +123,9 @@ pub(crate) fn optimize_into_acir(
     let ssa_level_warnings = if options.skip_underconstrained_check {
         vec![]
     } else {
-        time("After Check for Underconstrained Values", options.print_codegen_timings, || ssa.check_for_underconstrained_values())
+        time("After Check for Underconstrained Values", options.print_codegen_timings, || {
+            ssa.check_for_underconstrained_values()
+        })
     };
     let brillig = time("SSA to Brillig", options.print_codegen_timings, || {
         ssa.to_brillig(options.enable_brillig_logging)

--- a/cspell.json
+++ b/cspell.json
@@ -204,6 +204,7 @@
         "typevar",
         "typevars",
         "udiv",
+        "underconstrained",
         "uninstantiated",
         "unnormalized",
         "unoptimized",


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

No issue as discovered when experimenting with https://github.com/iAmMichaelConnor/blob-lib/tree/domain-size-4096. 

When compiling the circuit on the branch linked above using Noir master this was the result of timing `nargo compile`:
```
nargo compile --force --benchmark-codegen --silence-warnings  383.30s user 148.34s system 131% cpu 6:44.03 total
```
with under constrained check taking 200ms (about half the compilation time). 

The check returned no bugs. If the developer wants to iterate more quickly and knows they are not changing unconstrained code or simply wishes to check for under constrained bugs later they should have the ability.

## Summary\*

This PR simply adds a flag `--skip-underconstrained-check` that skips calling `ssa.check_for_underconstrained_values()`.

The blob-lib linked above compiled in half the time with the underconstrained check off:
```
nargo compile --force --skip-underconstrained-check --benchmark-codegen  192.15s user 295.27s system 220% cpu 3:41.33 total
``` 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
