### PR TITLE
feat: add `Expr` methods: `as_tuple`, `as_parenthesized`, `as_index`, `as_if`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -48,6 +48,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "array_len" => array_len(interner, arguments, location),
             "as_slice" => as_slice(interner, arguments, location),
             "expr_as_function_call" => expr_as_function_call(arguments, return_type, location),
+            "expr_as_parenthesized" => expr_as_parenthesized(arguments, return_type, location),
             "expr_as_tuple" => expr_as_tuple(arguments, return_type, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
             "function_def_name" => function_def_name(interner, arguments, location),
@@ -765,6 +766,21 @@ fn expr_as_function_call(
             let arguments =
                 Value::Slice(arguments, Type::Slice(Box::new(Type::Quoted(QuotedType::Expr))));
             Some(Value::Tuple(vec![function, arguments]))
+        } else {
+            None
+        }
+    })
+}
+
+// fn as_parentehsized(self) -> Option<Expr>
+fn expr_as_parenthesized(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    expr_as(arguments, return_type, location, |expr| {
+        if let ExpressionKind::Parenthesized(expr) = expr {
+            Some(Value::Expr(expr.kind))
         } else {
             None
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -48,6 +48,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "array_len" => array_len(interner, arguments, location),
             "as_slice" => as_slice(interner, arguments, location),
             "expr_as_function_call" => expr_as_function_call(arguments, return_type, location),
+            "expr_as_index" => expr_as_index(arguments, return_type, location),
             "expr_as_parenthesized" => expr_as_parenthesized(arguments, return_type, location),
             "expr_as_tuple" => expr_as_tuple(arguments, return_type, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
@@ -766,6 +767,24 @@ fn expr_as_function_call(
             let arguments =
                 Value::Slice(arguments, Type::Slice(Box::new(Type::Quoted(QuotedType::Expr))));
             Some(Value::Tuple(vec![function, arguments]))
+        } else {
+            None
+        }
+    })
+}
+
+// fn as_index(self) -> Option<Expr>
+fn expr_as_index(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    expr_as(arguments, return_type, location, |expr| {
+        if let ExpressionKind::Index(index_expr) = expr {
+            Some(Value::Tuple(vec![
+                Value::Expr(index_expr.collection.kind),
+                Value::Expr(index_expr.index.kind),
+            ]))
         } else {
             None
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -48,6 +48,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "array_len" => array_len(interner, arguments, location),
             "as_slice" => as_slice(interner, arguments, location),
             "expr_as_function_call" => expr_as_function_call(arguments, return_type, location),
+            "expr_as_tuple" => expr_as_tuple(arguments, return_type, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
             "function_def_name" => function_def_name(interner, arguments, location),
             "function_def_parameters" => function_def_parameters(interner, arguments, location),
@@ -764,6 +765,23 @@ fn expr_as_function_call(
             let arguments =
                 Value::Slice(arguments, Type::Slice(Box::new(Type::Quoted(QuotedType::Expr))));
             Some(Value::Tuple(vec![function, arguments]))
+        } else {
+            None
+        }
+    })
+}
+
+// fn as_tuple(self) -> Option<[Expr]>
+fn expr_as_tuple(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    expr_as(arguments, return_type, location, |expr| {
+        if let ExpressionKind::Tuple(expressions) = expr {
+            let expressions = expressions.into_iter().map(|expr| Value::Expr(expr.kind)).collect();
+            let typ = Type::Slice(Box::new(Type::Quoted(QuotedType::Expr)));
+            Some(Value::Slice(expressions, typ))
         } else {
             None
         }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -4,6 +4,9 @@ impl Expr {
     #[builtin(expr_as_function_call)]
     fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 
+    #[builtin(expr_as_index)]
+    fn as_index(self) -> Option<(Expr, Expr)> {}
+
     #[builtin(expr_as_parenthesized)]
     fn as_parenthesized(self) -> Option<Expr> {}
 

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -4,6 +4,9 @@ impl Expr {
     #[builtin(expr_as_function_call)]
     fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 
+    #[builtin(expr_as_parenthesized)]
+    fn as_parenthesized(self) -> Option<Expr> {}
+
     #[builtin(expr_as_tuple)]
     fn as_tuple(self) -> Option<[Expr]> {}
 }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -3,4 +3,7 @@ use crate::option::Option;
 impl Expr {
     #[builtin(expr_as_function_call)]
     fn as_function_call(self) -> Option<(Expr, [Expr])> {}
+
+    #[builtin(expr_as_tuple)]
+    fn as_tuple(self) -> Option<[Expr]> {}
 }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -10,9 +10,6 @@ impl Expr {
     #[builtin(expr_as_index)]
     fn as_index(self) -> Option<(Expr, Expr)> {}
 
-    #[builtin(expr_as_parenthesized)]
-    fn as_parenthesized(self) -> Option<Expr> {}
-
     #[builtin(expr_as_tuple)]
     fn as_tuple(self) -> Option<[Expr]> {}
 }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -4,6 +4,9 @@ impl Expr {
     #[builtin(expr_as_function_call)]
     fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 
+    #[builtin(expr_as_if)]
+    fn as_if(self) -> Option<(Expr, Expr, Option<Expr>)> {}
+
     #[builtin(expr_as_index)]
     fn as_index(self) -> Option<(Expr, Expr)> {}
 

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -10,10 +10,6 @@ fn main() {
         let expr = quote { foo[bar] }.as_expr().unwrap();
         let _ = expr.as_index().unwrap();
 
-        // Check Expr::as_parenthesized
-        let expr = quote { (1) }.as_expr().unwrap();
-        let _ = expr.as_parenthesized().unwrap();
-
         // Check Expr::as_tuple
         let expr = quote { (1, 2) }.as_expr().unwrap();
         let tuple_exprs = expr.as_tuple().unwrap();
@@ -27,5 +23,9 @@ fn main() {
         let expr = quote { if 1 { 2 } else { 3 } }.as_expr().unwrap();
         let (_condition, _consequence, alternative) = expr.as_if().unwrap();
         assert(alternative.is_some());
+
+        // Check parenthesized expression is automatically unwrapped
+        let expr = quote { ((if 1 { 2 })) }.as_expr().unwrap();
+        assert(expr.as_if().is_some());
     }
 }

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -6,6 +6,10 @@ fn main() {
         let (_function, args) = expr.as_function_call().unwrap();
         assert_eq(args.len(), 1);
 
+        // Check Expr::as_index
+        let expr = quote { foo[bar] }.as_expr().unwrap();
+        let _ = expr.as_index().unwrap();
+
         // Check Expr::as_parenthesized
         let expr = quote { (1) }.as_expr().unwrap();
         let _ = expr.as_parenthesized().unwrap();

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -6,6 +6,10 @@ fn main() {
         let (_function, args) = expr.as_function_call().unwrap();
         assert_eq(args.len(), 1);
 
+        // Check Expr::as_parenthesized
+        let expr = quote { (1) }.as_expr().unwrap();
+        let _ = expr.as_parenthesized().unwrap();
+
         // Check Expr::as_tuple
         let expr = quote { (1, 2) }.as_expr().unwrap();
         let tuple_exprs = expr.as_tuple().unwrap();

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -18,5 +18,14 @@ fn main() {
         let expr = quote { (1, 2) }.as_expr().unwrap();
         let tuple_exprs = expr.as_tuple().unwrap();
         assert_eq(tuple_exprs.len(), 2);
+
+        // Check Expr::as_if
+        let expr = quote { if 1 { 2 } }.as_expr().unwrap();
+        let (_condition, _consequence, alternative) = expr.as_if().unwrap();
+        assert(alternative.is_none());
+
+        let expr = quote { if 1 { 2 } else { 3 } }.as_expr().unwrap();
+        let (_condition, _consequence, alternative) = expr.as_if().unwrap();
+        assert(alternative.is_some());
     }
 }

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -1,8 +1,14 @@
 fn main() {
     comptime
     {
+        // Check Expr::as_function_call
         let expr = quote { foo(bar) }.as_expr().unwrap();
         let (_function, args) = expr.as_function_call().unwrap();
         assert_eq(args.len(), 1);
+
+        // Check Expr::as_tuple
+        let expr = quote { (1, 2) }.as_expr().unwrap();
+        let tuple_exprs = expr.as_tuple().unwrap();
+        assert_eq(tuple_exprs.len(), 2);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

Just four, to keep PRs small.

## Additional Context


## Documentation

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
