### PR TITLE
feat: add `Expr::as_bool`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -897,6 +897,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs == rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs == rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs == rhs)),
+                (Value::Bool(lhs), Value::Bool(rhs)) => Ok(Value::Bool(lhs == rhs)),
                 (lhs, rhs) => make_error(self, lhs, rhs, "=="),
             },
             BinaryOpKind::NotEqual => match (lhs, rhs) {
@@ -909,6 +910,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 (Value::U16(lhs), Value::U16(rhs)) => Ok(Value::Bool(lhs != rhs)),
                 (Value::U32(lhs), Value::U32(rhs)) => Ok(Value::Bool(lhs != rhs)),
                 (Value::U64(lhs), Value::U64(rhs)) => Ok(Value::Bool(lhs != rhs)),
+                (Value::Bool(lhs), Value::Bool(rhs)) => Ok(Value::Bool(lhs != rhs)),
                 (lhs, rhs) => make_error(self, lhs, rhs, "!="),
             },
             BinaryOpKind::Less => match (lhs, rhs) {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -17,7 +17,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     ast::{
-        ExpressionKind, FunctionKind, FunctionReturnType, IntegerBitSize, UnresolvedType,
+        ExpressionKind, FunctionKind, FunctionReturnType, IntegerBitSize, Literal, UnresolvedType,
         UnresolvedTypeData, Visibility,
     },
     hir::comptime::{errors::IResult, value::add_token_spans, InterpreterError, Value},
@@ -47,6 +47,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "array_as_str_unchecked" => array_as_str_unchecked(interner, arguments, location),
             "array_len" => array_len(interner, arguments, location),
             "as_slice" => as_slice(interner, arguments, location),
+            "expr_as_bool" => expr_as_bool(arguments, return_type, location),
             "expr_as_function_call" => expr_as_function_call(arguments, return_type, location),
             "expr_as_if" => expr_as_if(arguments, return_type, location),
             "expr_as_index" => expr_as_index(arguments, return_type, location),
@@ -751,6 +752,21 @@ fn zeroed(return_type: Type) -> IResult<Value> {
         | Type::TraitAsType(_, _, _)
         | Type::NamedGeneric(_, _, _) => Ok(Value::Zeroed(return_type)),
     }
+}
+
+// fn as_bool(self) -> Option<bool>
+fn expr_as_bool(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    expr_as(arguments, return_type, location, |expr| {
+        if let ExpressionKind::Literal(Literal::Bool(bool)) = expr {
+            Some(Value::Bool(bool))
+        } else {
+            None
+        }
+    })
 }
 
 // fn as_function_call(self) -> Option<(Expr, [Expr])>

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -1,6 +1,9 @@
 use crate::option::Option;
 
 impl Expr {
+    #[builtin(expr_as_bool)]
+    fn as_bool(self) -> Option<bool> {}
+
     #[builtin(expr_as_function_call)]
     fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 

--- a/test_programs/compile_success_empty/comptime_exp/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_exp/src/main.nr
@@ -27,5 +27,12 @@ fn main() {
         // Check parenthesized expression is automatically unwrapped
         let expr = quote { ((if 1 { 2 })) }.as_expr().unwrap();
         assert(expr.as_if().is_some());
+
+        // Check Expr::as_bool
+        let expr = quote { false }.as_expr().unwrap();
+        assert(expr.as_bool().unwrap() == false);
+
+        let expr = quote { true }.as_expr().unwrap();
+        assert_eq(expr.as_bool().unwrap(), true);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

Just one method because while doing it I got an error trying to compare two bools at comptime, and I found that that case was missing.

## Additional Context

## Documentation

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
