### PR TITLE
feat: suggest tuple fields in LSP completion

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -11,13 +11,10 @@ use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, Completion
 use noirc_errors::{Location, Span};
 use noirc_frontend::{
     ast::{
-        ArrayLiteral, AsTraitPath, BlockExpression, CallExpression, CastExpression,
-        ConstrainStatement, ConstructorExpression, Expression, ForLoopStatement, ForRange,
-        FunctionReturnType, Ident, IfExpression, IndexExpression, InfixExpression, LValue, Lambda,
-        LetStatement, Literal, MemberAccessExpression, MethodCallExpression, NoirFunction,
-        NoirStruct, NoirTrait, NoirTraitImpl, NoirTypeAlias, Path, PathKind, PathSegment, Pattern,
-        Statement, TraitImplItem, TraitItem, TypeImpl, UnresolvedGeneric, UnresolvedGenerics,
-        UnresolvedType, UseTree, UseTreeKind,
+        AsTraitPath, BlockExpression, ConstructorExpression, Expression, ForLoopStatement, Ident,
+        IfExpression, LValue, Lambda, LetStatement, MemberAccessExpression, NoirFunction,
+        NoirStruct, NoirTraitImpl, Path, PathKind, PathSegment, Pattern, Statement, TraitItem,
+        TypeImpl, UnresolvedGeneric, UnresolvedGenerics, UnresolvedType, UseTree, UseTreeKind,
     },
     graph::{CrateId, Dependency},
     hir::{
@@ -40,6 +37,7 @@ mod completion_items;
 mod kinds;
 mod sort_text;
 mod tests;
+mod traversal;
 
 pub(crate) fn on_completion_request(
     state: &mut LspState,
@@ -154,12 +152,6 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
-    fn find_in_parsed_module(&mut self, parsed_module: &ParsedModule) {
-        for item in &parsed_module.items {
-            self.find_in_item(item);
-        }
-    }
-
     fn find_in_item(&mut self, item: &Item) {
         if !self.includes_span(item.span) {
             return;
@@ -230,14 +222,6 @@ impl<'a> NodeFinder<'a> {
         self.type_parameters.clear();
     }
 
-    fn find_in_trait_impl_item(&mut self, item: &TraitImplItem) {
-        match item {
-            TraitImplItem::Function(noir_function) => self.find_in_noir_function(noir_function),
-            TraitImplItem::Constant(_, _, _) => (),
-            TraitImplItem::Type { .. } => (),
-        }
-    }
-
     fn find_in_type_impl(&mut self, type_impl: &TypeImpl) {
         self.type_parameters.clear();
         self.collect_type_parameters_in_generics(&type_impl.generics);
@@ -254,10 +238,6 @@ impl<'a> NodeFinder<'a> {
         self.type_parameters.clear();
     }
 
-    fn find_in_noir_type_alias(&mut self, noir_type_alias: &NoirTypeAlias) {
-        self.find_in_unresolved_type(&noir_type_alias.typ);
-    }
-
     fn find_in_noir_struct(&mut self, noir_struct: &NoirStruct) {
         self.type_parameters.clear();
         self.collect_type_parameters_in_generics(&noir_struct.generics);
@@ -267,12 +247,6 @@ impl<'a> NodeFinder<'a> {
         }
 
         self.type_parameters.clear();
-    }
-
-    fn find_in_noir_trait(&mut self, noir_trait: &NoirTrait) {
-        for item in &noir_trait.items {
-            self.find_in_trait_item(item);
-        }
     }
 
     fn find_in_trait_item(&mut self, trait_item: &TraitItem) {
@@ -380,22 +354,6 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
-    fn find_in_constrain_statement(&mut self, constrain_statement: &ConstrainStatement) {
-        self.find_in_expression(&constrain_statement.0);
-
-        if let Some(exp) = &constrain_statement.1 {
-            self.find_in_expression(exp);
-        }
-    }
-
-    fn find_in_assign_statement(
-        &mut self,
-        assign_statement: &noirc_frontend::ast::AssignStatement,
-    ) {
-        self.find_in_lvalue(&assign_statement.lvalue);
-        self.find_in_expression(&assign_statement.expression);
-    }
-
     fn find_in_for_loop_statement(&mut self, for_loop_statement: &ForLoopStatement) {
         let old_local_variables = self.local_variables.clone();
         let ident = &for_loop_statement.identifier;
@@ -427,22 +385,6 @@ impl<'a> NodeFinder<'a> {
                 self.find_in_expression(index);
             }
             LValue::Dereference(lvalue, _) => self.find_in_lvalue(lvalue),
-        }
-    }
-
-    fn find_in_for_range(&mut self, for_range: &ForRange) {
-        match for_range {
-            ForRange::Range(start, end) => {
-                self.find_in_expression(start);
-                self.find_in_expression(end);
-            }
-            ForRange::Array(expression) => self.find_in_expression(expression),
-        }
-    }
-
-    fn find_in_expressions(&mut self, expressions: &[Expression]) {
-        for expression in expressions {
-            self.find_in_expression(expression);
         }
     }
 
@@ -530,44 +472,6 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
-    fn find_in_literal(&mut self, literal: &Literal) {
-        match literal {
-            Literal::Array(array_literal) => self.find_in_array_literal(array_literal),
-            Literal::Slice(array_literal) => self.find_in_array_literal(array_literal),
-            Literal::Bool(_)
-            | Literal::Integer(_, _)
-            | Literal::Str(_)
-            | Literal::RawStr(_, _)
-            | Literal::FmtStr(_)
-            | Literal::Unit => (),
-        }
-    }
-
-    fn find_in_array_literal(&mut self, array_literal: &ArrayLiteral) {
-        match array_literal {
-            ArrayLiteral::Standard(expressions) => self.find_in_expressions(expressions),
-            ArrayLiteral::Repeated { repeated_element, length } => {
-                self.find_in_expression(repeated_element);
-                self.find_in_expression(length);
-            }
-        }
-    }
-
-    fn find_in_index_expression(&mut self, index_expression: &IndexExpression) {
-        self.find_in_expression(&index_expression.collection);
-        self.find_in_expression(&index_expression.index);
-    }
-
-    fn find_in_call_expression(&mut self, call_expression: &CallExpression) {
-        self.find_in_expression(&call_expression.func);
-        self.find_in_expressions(&call_expression.arguments);
-    }
-
-    fn find_in_method_call_expression(&mut self, method_call_expression: &MethodCallExpression) {
-        self.find_in_expression(&method_call_expression.object);
-        self.find_in_expressions(&method_call_expression.arguments);
-    }
-
     fn find_in_constructor_expression(&mut self, constructor_expression: &ConstructorExpression) {
         self.find_in_path(&constructor_expression.type_name, RequestedItems::OnlyTypes);
 
@@ -594,15 +498,6 @@ impl<'a> NodeFinder<'a> {
         }
 
         self.find_in_expression(&member_access_expression.lhs);
-    }
-
-    fn find_in_cast_expression(&mut self, cast_expression: &CastExpression) {
-        self.find_in_expression(&cast_expression.lhs);
-    }
-
-    fn find_in_infix_expression(&mut self, infix_expression: &InfixExpression) {
-        self.find_in_expression(&infix_expression.lhs);
-        self.find_in_expression(&infix_expression.rhs);
     }
 
     fn find_in_if_expression(&mut self, if_expression: &IfExpression) {
@@ -636,21 +531,6 @@ impl<'a> NodeFinder<'a> {
 
     fn find_in_as_trait_path(&mut self, as_trait_path: &AsTraitPath) {
         self.find_in_path(&as_trait_path.trait_path, RequestedItems::OnlyTypes);
-    }
-
-    fn find_in_function_return_type(&mut self, return_type: &FunctionReturnType) {
-        match return_type {
-            noirc_frontend::ast::FunctionReturnType::Default(_) => (),
-            noirc_frontend::ast::FunctionReturnType::Ty(unresolved_type) => {
-                self.find_in_unresolved_type(unresolved_type);
-            }
-        }
-    }
-
-    fn find_in_unresolved_types(&mut self, unresolved_type: &[UnresolvedType]) {
-        for unresolved_type in unresolved_type {
-            self.find_in_unresolved_type(unresolved_type);
-        }
     }
 
     fn find_in_unresolved_type(&mut self, unresolved_type: &UnresolvedType) {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -922,7 +922,7 @@ impl<'a> NodeFinder<'a> {
                 index.to_string(),
                 CompletionItemKind::FIELD,
                 Some(typ.to_string()),
-            ))
+            ));
         }
     }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -854,6 +854,9 @@ impl<'a> NodeFinder<'a> {
                 let type_alias = type_alias.borrow();
                 return self.complete_type_fields_and_methods(&type_alias.typ, prefix);
             }
+            Type::Tuple(types) => {
+                self.complete_tuple_fields(types);
+            }
             Type::FieldElement
             | Type::Array(_, _)
             | Type::Slice(_)
@@ -862,7 +865,6 @@ impl<'a> NodeFinder<'a> {
             | Type::String(_)
             | Type::FmtString(_, _)
             | Type::Unit
-            | Type::Tuple(_)
             | Type::TypeVariable(_, _)
             | Type::TraitAsType(_, _, _)
             | Type::NamedGeneric(_, _, _)
@@ -911,6 +913,16 @@ impl<'a> NodeFinder<'a> {
                     Some(typ.to_string()),
                 ));
             }
+        }
+    }
+
+    fn complete_tuple_fields(&mut self, types: &[Type]) {
+        for (index, typ) in types.iter().enumerate() {
+            self.completion_items.push(simple_completion_item(
+                index.to_string(),
+                CompletionItemKind::FIELD,
+                Some(typ.to_string()),
+            ))
         }
     }
 

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -90,7 +90,7 @@ impl<'a> NodeFinder<'a> {
         let func_meta = self.interner.function_meta(&func_id);
         let name = &self.interner.function_name(&func_id).to_string();
 
-        let func_self_type = if let Some((pattern, typ, _)) = func_meta.parameters.0.get(0) {
+        let func_self_type = if let Some((pattern, typ, _)) = func_meta.parameters.0.first() {
             if self.hir_pattern_is_self_type(pattern) {
                 if let Type::MutableReference(mut_typ) = typ {
                     let typ: &Type = mut_typ;

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -123,6 +123,14 @@ impl<'a> NodeFinder<'a> {
                         if self_type != func_self_type {
                             return None;
                         }
+                    } else if let Type::Tuple(self_tuple_types) = self_type {
+                        // Tuple types of different lengths seem to also have methods defined on all of them,
+                        // so here we reject methods for tuples where the length doesn't match.
+                        if let Type::Tuple(func_self_tuple_types) = func_self_type {
+                            if self_tuple_types.len() != func_self_tuple_types.len() {
+                                return None;
+                            }
+                        }
                     }
                 } else {
                     return None;

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1388,6 +1388,6 @@ mod completion_tests {
                 simple_completion_item("0", CompletionItemKind::FIELD, Some("Field".to_string())),
                 simple_completion_item("1", CompletionItemKind::FIELD, Some("bool".to_string())),
             ],
-        )
+        );
     }
 }

--- a/tooling/lsp/src/requests/completion/traversal.rs
+++ b/tooling/lsp/src/requests/completion/traversal.rs
@@ -1,0 +1,132 @@
+/// This file includes the completion logic that's just about
+/// traversing the AST without any additional logic.
+use noirc_frontend::{
+    ast::{
+        ArrayLiteral, AssignStatement, CallExpression, CastExpression, ConstrainStatement,
+        Expression, ForRange, FunctionReturnType, IndexExpression, InfixExpression, Literal,
+        MethodCallExpression, NoirTrait, NoirTypeAlias, TraitImplItem, UnresolvedType,
+    },
+    ParsedModule,
+};
+
+use super::NodeFinder;
+
+impl<'a> NodeFinder<'a> {
+    pub(super) fn find_in_parsed_module(&mut self, parsed_module: &ParsedModule) {
+        for item in &parsed_module.items {
+            self.find_in_item(item);
+        }
+    }
+
+    pub(super) fn find_in_trait_impl_item(&mut self, item: &TraitImplItem) {
+        match item {
+            TraitImplItem::Function(noir_function) => self.find_in_noir_function(noir_function),
+            TraitImplItem::Constant(_, _, _) => (),
+            TraitImplItem::Type { .. } => (),
+        }
+    }
+
+    pub(super) fn find_in_noir_trait(&mut self, noir_trait: &NoirTrait) {
+        for item in &noir_trait.items {
+            self.find_in_trait_item(item);
+        }
+    }
+
+    pub(super) fn find_in_constrain_statement(&mut self, constrain_statement: &ConstrainStatement) {
+        self.find_in_expression(&constrain_statement.0);
+
+        if let Some(exp) = &constrain_statement.1 {
+            self.find_in_expression(exp);
+        }
+    }
+
+    pub(super) fn find_in_assign_statement(&mut self, assign_statement: &AssignStatement) {
+        self.find_in_lvalue(&assign_statement.lvalue);
+        self.find_in_expression(&assign_statement.expression);
+    }
+
+    pub(super) fn find_in_for_range(&mut self, for_range: &ForRange) {
+        match for_range {
+            ForRange::Range(start, end) => {
+                self.find_in_expression(start);
+                self.find_in_expression(end);
+            }
+            ForRange::Array(expression) => self.find_in_expression(expression),
+        }
+    }
+
+    pub(super) fn find_in_expressions(&mut self, expressions: &[Expression]) {
+        for expression in expressions {
+            self.find_in_expression(expression);
+        }
+    }
+
+    pub(super) fn find_in_literal(&mut self, literal: &Literal) {
+        match literal {
+            Literal::Array(array_literal) => self.find_in_array_literal(array_literal),
+            Literal::Slice(array_literal) => self.find_in_array_literal(array_literal),
+            Literal::Bool(_)
+            | Literal::Integer(_, _)
+            | Literal::Str(_)
+            | Literal::RawStr(_, _)
+            | Literal::FmtStr(_)
+            | Literal::Unit => (),
+        }
+    }
+
+    pub(super) fn find_in_array_literal(&mut self, array_literal: &ArrayLiteral) {
+        match array_literal {
+            ArrayLiteral::Standard(expressions) => self.find_in_expressions(expressions),
+            ArrayLiteral::Repeated { repeated_element, length } => {
+                self.find_in_expression(repeated_element);
+                self.find_in_expression(length);
+            }
+        }
+    }
+
+    pub(super) fn find_in_index_expression(&mut self, index_expression: &IndexExpression) {
+        self.find_in_expression(&index_expression.collection);
+        self.find_in_expression(&index_expression.index);
+    }
+
+    pub(super) fn find_in_call_expression(&mut self, call_expression: &CallExpression) {
+        self.find_in_expression(&call_expression.func);
+        self.find_in_expressions(&call_expression.arguments);
+    }
+
+    pub(super) fn find_in_method_call_expression(
+        &mut self,
+        method_call_expression: &MethodCallExpression,
+    ) {
+        self.find_in_expression(&method_call_expression.object);
+        self.find_in_expressions(&method_call_expression.arguments);
+    }
+
+    pub(super) fn find_in_cast_expression(&mut self, cast_expression: &CastExpression) {
+        self.find_in_expression(&cast_expression.lhs);
+    }
+
+    pub(super) fn find_in_infix_expression(&mut self, infix_expression: &InfixExpression) {
+        self.find_in_expression(&infix_expression.lhs);
+        self.find_in_expression(&infix_expression.rhs);
+    }
+
+    pub(super) fn find_in_unresolved_types(&mut self, unresolved_type: &[UnresolvedType]) {
+        for unresolved_type in unresolved_type {
+            self.find_in_unresolved_type(unresolved_type);
+        }
+    }
+
+    pub(super) fn find_in_function_return_type(&mut self, return_type: &FunctionReturnType) {
+        match return_type {
+            noirc_frontend::ast::FunctionReturnType::Default(_) => (),
+            noirc_frontend::ast::FunctionReturnType::Ty(unresolved_type) => {
+                self.find_in_unresolved_type(unresolved_type);
+            }
+        }
+    }
+
+    pub(super) fn find_in_noir_type_alias(&mut self, noir_type_alias: &NoirTypeAlias) {
+        self.find_in_unresolved_type(&noir_type_alias.typ);
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Part of #1577

(there are many more completions we could support and it's hard to list all of them upfront, so I'll just link to that issue from now on)

## Summary

Suggest tuple fields (0, 1) in autocompletion, which is useful if you don't know the type you are handling with (maybe it's a result of another expression that's not in a variable).

Also I noticed tuple methods showed up duplicate, so that's fixed too.

Before:

![lsp-complete-tuple-before](https://github.com/user-attachments/assets/9dc36a32-9017-4b3d-a16c-091ea6ab5a42)

After:

![lsp-complete-tuple-after](https://github.com/user-attachments/assets/70b6d9fd-4f4f-4d57-ab45-55a270fa64cb)

## Additional Context

The two first commits are just refactors, so I'd suggest going commit by commit.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
