### PR TITLE
feat: LSP autocomplete constructor fields

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use async_lsp::ResponseError;
-use completion_items::{crate_completion_item, simple_completion_item};
+use completion_items::{
+    crate_completion_item, simple_completion_item, struct_field_completion_item,
+};
 use fm::{FileId, PathString};
 use kinds::{FunctionCompletionKind, FunctionKind, ModuleCompletionKind, RequestedItems};
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse};
@@ -509,11 +511,7 @@ impl<'a> NodeFinder<'a> {
         }
 
         for (field, typ) in fields {
-            self.completion_items.push(simple_completion_item(
-                field,
-                CompletionItemKind::FIELD,
-                Some(typ.to_string()),
-            ));
+            self.completion_items.push(struct_field_completion_item(field, typ));
         }
     }
 
@@ -945,13 +943,9 @@ impl<'a> NodeFinder<'a> {
         generics: &[Type],
         prefix: &str,
     ) {
-        for (name, typ) in struct_type.get_fields(generics) {
-            if name_matches(&name, prefix) {
-                self.completion_items.push(simple_completion_item(
-                    name,
-                    CompletionItemKind::FIELD,
-                    Some(typ.to_string()),
-                ));
+        for (name, typ) in &struct_type.get_fields(generics) {
+            if name_matches(name, prefix) {
+                self.completion_items.push(struct_field_completion_item(name, typ));
             }
         }
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -490,7 +490,8 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn complete_constructor_field_name(&mut self, constructor_expression: &ConstructorExpression) {
-        let location = Location::new(constructor_expression.type_name.span, self.file);
+        let location =
+            Location::new(constructor_expression.type_name.last_ident().span(), self.file);
         let Some(ReferenceId::Struct(struct_id)) = self.interner.find_referenced(location) else {
             return;
         };

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -298,6 +298,10 @@ fn type_to_self_string(typ: &Type, string: &mut String) {
     }
 }
 
+pub(super) fn struct_field_completion_item(field: &str, typ: &Type) -> CompletionItem {
+    simple_completion_item(field, CompletionItemKind::FIELD, Some(typ.to_string()))
+}
+
 pub(super) fn simple_completion_item(
     label: impl Into<String>,
     kind: CompletionItemKind,

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1390,4 +1390,28 @@ mod completion_tests {
             ],
         );
     }
+
+    #[test]
+    async fn test_completes_constructor_fields() {
+        let src = r#"
+            struct Foo {
+                bb: i32,
+                bbb: Field,
+                bbbb: bool,
+                bbbbb: str<6>,
+            }
+
+            fn main() {
+                Foo { bbb: 1, b>|<, bbbbb }
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![
+                simple_completion_item("bb", CompletionItemKind::FIELD, Some("i32".to_string())),
+                simple_completion_item("bbbb", CompletionItemKind::FIELD, Some("bool".to_string())),
+            ],
+        )
+        .await;
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1394,15 +1394,17 @@ mod completion_tests {
     #[test]
     async fn test_completes_constructor_fields() {
         let src = r#"
-            struct Foo {
-                bb: i32,
-                bbb: Field,
-                bbbb: bool,
-                bbbbb: str<6>,
+            mod foobar {
+                struct Foo {
+                    bb: i32,
+                    bbb: Field,
+                    bbbb: bool,
+                    bbbbb: str<6>,
+                }
             }
 
             fn main() {
-                Foo { bbb: 1, b>|<, bbbbb }
+                foobar::Foo { bbb: 1, b>|<, bbbbb }
             }
         "#;
         assert_completion(


### PR DESCRIPTION
# Description

## Problem

Part of https://github.com/noir-lang/noir/issues/1577

## Summary

![lsp-complete-constructor-fields](https://github.com/user-attachments/assets/7b822fd8-1852-492f-9d7f-48ae45e171a9)

^ The above is just an example of it working, I'm not encouraging using constructors of std types 😄 

## Additional Context

This is the last autocompletion I had in mind while implementing autocompletion, so I'll likely won't send any other LSP PRs for a while...

That said, if you think of other autocompletions (that don't involve auto-importing, because that's a big thing) let me know (or capture an issue) and we can work on it.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
