### PR TITLE
feat: suggest trait methods in LSP completion

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -5,7 +5,8 @@ use std::{
 
 use async_lsp::ResponseError;
 use completion_items::{
-    crate_completion_item, simple_completion_item, struct_field_completion_item,
+    crate_completion_item, field_completion_item, simple_completion_item,
+    struct_field_completion_item,
 };
 use fm::{FileId, PathString};
 use kinds::{FunctionCompletionKind, FunctionKind, ModuleCompletionKind, RequestedItems};
@@ -953,11 +954,7 @@ impl<'a> NodeFinder<'a> {
 
     fn complete_tuple_fields(&mut self, types: &[Type]) {
         for (index, typ) in types.iter().enumerate() {
-            self.completion_items.push(simple_completion_item(
-                index.to_string(),
-                CompletionItemKind::FIELD,
-                Some(typ.to_string()),
-            ));
+            self.completion_items.push(field_completion_item(&index.to_string(), typ.to_string()));
         }
     }
 

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -299,7 +299,11 @@ fn type_to_self_string(typ: &Type, string: &mut String) {
 }
 
 pub(super) fn struct_field_completion_item(field: &str, typ: &Type) -> CompletionItem {
-    simple_completion_item(field, CompletionItemKind::FIELD, Some(typ.to_string()))
+    field_completion_item(field, typ.to_string())
+}
+
+pub(super) fn field_completion_item(field: &str, typ: impl Into<String>) -> CompletionItem {
+    simple_completion_item(field, CompletionItemKind::FIELD, Some(typ.into()))
 }
 
 pub(super) fn simple_completion_item(

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1308,4 +1308,19 @@ mod completion_tests {
         )
         .await;
     }
+
+    #[test]
+    async fn test_completes_trait_methods() {
+        let src = r#"
+            trait One {
+                fn one() -> Self;
+            }
+
+            fn main() {
+                One::>|<
+            }
+        "#;
+        assert_completion(src, vec![function_completion_item("one()", "one()", "fn() -> Self")])
+            .await;
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -98,13 +98,12 @@ mod completion_tests {
 
     pub(super) fn function_completion_item(
         label: impl Into<String>,
-        kind: CompletionItemKind,
         insert_text: impl Into<String>,
         description: impl Into<String>,
     ) -> CompletionItem {
         completion_item_with_trigger_parameter_hints_command(snippet_completion_item(
             label,
-            kind,
+            CompletionItemKind::FUNCTION,
             insert_text,
             Some(description.into()),
         ))
@@ -426,16 +425,7 @@ mod completion_tests {
             h>|<
           }
         "#;
-        assert_completion(
-            src,
-            vec![function_completion_item(
-                "hello()",
-                CompletionItemKind::FUNCTION,
-                "hello()",
-                "fn()",
-            )],
-        )
-        .await;
+        assert_completion(src, vec![function_completion_item("hello()", "hello()", "fn()")]).await;
     }
 
     #[test]
@@ -451,7 +441,6 @@ mod completion_tests {
             src,
             vec![function_completion_item(
                 "hello(…)",
-                CompletionItemKind::FUNCTION,
                 "hello(${1:x}, ${2:y})",
                 "fn(i32, Field)".to_string(),
             )],
@@ -475,12 +464,7 @@ mod completion_tests {
                     "assert(${1:predicate})",
                     Some("fn(T)".to_string()),
                 ),
-                function_completion_item(
-                    "assert_constant(…)",
-                    CompletionItemKind::FUNCTION,
-                    "assert_constant(${1:x})",
-                    "fn(T)",
-                ),
+                function_completion_item("assert_constant(…)", "assert_constant(${1:x})", "fn(T)"),
                 snippet_completion_item(
                     "assert_eq(…)",
                     CompletionItemKind::FUNCTION,
@@ -1083,18 +1067,8 @@ mod completion_tests {
         assert_completion(
             src,
             vec![
-                function_completion_item(
-                    "foobar(…)",
-                    CompletionItemKind::FUNCTION,
-                    "foobar(${1:x})",
-                    "fn(self, i32)".to_string(),
-                ),
-                function_completion_item(
-                    "foobar2(…)",
-                    CompletionItemKind::FUNCTION,
-                    "foobar2(${1:x})",
-                    "fn(&mut self, i32)".to_string(),
-                ),
+                function_completion_item("foobar(…)", "foobar(${1:x})", "fn(self, i32)"),
+                function_completion_item("foobar2(…)", "foobar2(${1:x})", "fn(&mut self, i32)"),
             ],
         )
         .await;
@@ -1122,12 +1096,7 @@ mod completion_tests {
         "#;
         assert_completion(
             src,
-            vec![function_completion_item(
-                "foobar(…)",
-                CompletionItemKind::FUNCTION,
-                "foobar(${1:x})",
-                "fn(self, i32)",
-            )],
+            vec![function_completion_item("foobar(…)", "foobar(${1:x})", "fn(self, i32)")],
         )
         .await;
     }
@@ -1151,12 +1120,7 @@ mod completion_tests {
         "#;
         assert_completion(
             src,
-            vec![function_completion_item(
-                "foobar(…)",
-                CompletionItemKind::FUNCTION,
-                "foobar(${1:x})",
-                "fn(self, i32)".to_string(),
-            )],
+            vec![function_completion_item("foobar(…)", "foobar(${1:x})", "fn(self, i32)")],
         )
         .await;
     }
@@ -1183,7 +1147,6 @@ mod completion_tests {
                 completion_item_with_sort_text(
                     function_completion_item(
                         "foobar(…)",
-                        CompletionItemKind::FUNCTION,
                         "foobar(${1:self}, ${2:x})",
                         "fn(self, i32)",
                     ),
@@ -1192,18 +1155,12 @@ mod completion_tests {
                 completion_item_with_sort_text(
                     function_completion_item(
                         "foobar2(…)",
-                        CompletionItemKind::FUNCTION,
                         "foobar2(${1:self}, ${2:x})",
                         "fn(&mut self, i32)",
                     ),
                     self_mismatch_sort_text(),
                 ),
-                function_completion_item(
-                    "foobar3(…)",
-                    CompletionItemKind::FUNCTION,
-                    "foobar3(${1:y})",
-                    "fn(i32)",
-                ),
+                function_completion_item("foobar3(…)", "foobar3(${1:y})", "fn(i32)"),
             ],
         )
         .await;
@@ -1227,12 +1184,7 @@ mod completion_tests {
         "#;
         assert_completion(
             src,
-            vec![function_completion_item(
-                "foobar(…)",
-                CompletionItemKind::FUNCTION,
-                "foobar(${1:x})",
-                "fn(self, i32)".to_string(),
-            )],
+            vec![function_completion_item("foobar(…)", "foobar(${1:x})", "fn(self, i32)")],
         )
         .await;
     }
@@ -1261,7 +1213,6 @@ mod completion_tests {
                 completion_item_with_sort_text(
                     function_completion_item(
                         "foobar(…)",
-                        CompletionItemKind::FUNCTION,
                         "foobar(${1:self}, ${2:x})",
                         "fn(self, i32)",
                     ),
@@ -1270,18 +1221,12 @@ mod completion_tests {
                 completion_item_with_sort_text(
                     function_completion_item(
                         "foobar2(…)",
-                        CompletionItemKind::FUNCTION,
                         "foobar2(${1:self}, ${2:x})",
                         "fn(&mut self, i32)",
                     ),
                     self_mismatch_sort_text(),
                 ),
-                function_completion_item(
-                    "foobar3(…)",
-                    CompletionItemKind::FUNCTION,
-                    "foobar3(${1:y})",
-                    "fn(i32)",
-                ),
+                function_completion_item("foobar3(…)", "foobar3(${1:y})", "fn(i32)"),
             ],
         )
         .await;
@@ -1335,16 +1280,8 @@ mod completion_tests {
                 f.foo().>|<
             }
         "#;
-        assert_completion(
-            src,
-            vec![function_completion_item(
-                "foo()",
-                CompletionItemKind::FUNCTION,
-                "foo()",
-                "fn(self) -> Foo".to_string(),
-            )],
-        )
-        .await;
+        assert_completion(src, vec![function_completion_item("foo()", "foo()", "fn(self) -> Foo")])
+            .await;
     }
 
     #[test]

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -7,7 +7,8 @@ mod completion_tests {
                 completion_items::{
                     completion_item_with_sort_text,
                     completion_item_with_trigger_parameter_hints_command, crate_completion_item,
-                    module_completion_item, simple_completion_item, snippet_completion_item,
+                    field_completion_item, module_completion_item, simple_completion_item,
+                    snippet_completion_item,
                 },
                 sort_text::self_mismatch_sort_text,
             },
@@ -971,15 +972,7 @@ mod completion_tests {
                 s.p>|<
             }
         "#;
-        assert_completion(
-            src,
-            vec![simple_completion_item(
-                "property",
-                CompletionItemKind::FIELD,
-                Some("i32".to_string()),
-            )],
-        )
-        .await;
+        assert_completion(src, vec![field_completion_item("property", "i32")]).await;
     }
 
     #[test]
@@ -993,15 +986,7 @@ mod completion_tests {
                 s.p>|<
             }
         "#;
-        assert_completion(
-            src,
-            vec![simple_completion_item(
-                "property",
-                CompletionItemKind::FIELD,
-                Some("i32".to_string()),
-            )],
-        )
-        .await;
+        assert_completion(src, vec![field_completion_item("property", "i32")]).await;
     }
 
     #[test]
@@ -1015,15 +1000,7 @@ mod completion_tests {
                 s.>|<
             }
         "#;
-        assert_completion(
-            src,
-            vec![simple_completion_item(
-                "property",
-                CompletionItemKind::FIELD,
-                Some("i32".to_string()),
-            )],
-        )
-        .await;
+        assert_completion(src, vec![field_completion_item("property", "i32")]).await;
     }
 
     #[test]
@@ -1041,11 +1018,7 @@ mod completion_tests {
                 some.property.>|<
             }
         "#;
-        assert_completion(
-            src,
-            vec![simple_completion_item("bar", CompletionItemKind::FIELD, Some("i32".to_string()))],
-        )
-        .await;
+        assert_completion(src, vec![field_completion_item("bar", "i32")]).await;
     }
 
     #[test]
@@ -1243,11 +1216,7 @@ mod completion_tests {
                 if s.>|<
             }
         "#;
-        assert_completion(
-            src,
-            vec![simple_completion_item("foo", CompletionItemKind::FIELD, Some("i32".to_string()))],
-        )
-        .await;
+        assert_completion(src, vec![field_completion_item("foo", "i32")]).await;
     }
 
     #[test]
@@ -1260,11 +1229,7 @@ mod completion_tests {
                 f.bar & f.>|<
             }
         "#;
-        assert_completion(
-            src,
-            vec![simple_completion_item("bar", CompletionItemKind::FIELD, Some("Bar".to_string()))],
-        )
-        .await;
+        assert_completion(src, vec![field_completion_item("bar", "Bar")]).await;
     }
 
     #[test]
@@ -1299,11 +1264,7 @@ mod completion_tests {
                 x = 2;
             }
         "#;
-        assert_completion(
-            src,
-            vec![simple_completion_item("bar", CompletionItemKind::FIELD, Some("i32".to_string()))],
-        )
-        .await;
+        assert_completion(src, vec![field_completion_item("bar", "i32")]).await;
     }
 
     #[test]
@@ -1321,10 +1282,7 @@ mod completion_tests {
 
         assert_items_match(
             items,
-            vec![
-                simple_completion_item("0", CompletionItemKind::FIELD, Some("Field".to_string())),
-                simple_completion_item("1", CompletionItemKind::FIELD, Some("bool".to_string())),
-            ],
+            vec![field_completion_item("0", "Field"), field_completion_item("1", "bool")],
         );
     }
 
@@ -1346,10 +1304,7 @@ mod completion_tests {
         "#;
         assert_completion(
             src,
-            vec![
-                simple_completion_item("bb", CompletionItemKind::FIELD, Some("i32".to_string())),
-                simple_completion_item("bbbb", CompletionItemKind::FIELD, Some("bool".to_string())),
-            ],
+            vec![field_completion_item("bb", "i32"), field_completion_item("bbbb", "bool")],
         )
         .await;
     }


### PR DESCRIPTION
# Description

## Problem

Part of https://github.com/noir-lang/noir/issues/1577

## Summary

![lsp-complete-trait-methods](https://github.com/user-attachments/assets/2d608450-1d6d-475d-8433-9b9f6e60c357)

## Additional Context

Also includes a couple of refactors to further simplify things.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
