### PR TITLE
fix: add missing trait impls for integer types to stdlib

### DIFF
--- a/noir_stdlib/src/cmp.nr
+++ b/noir_stdlib/src/cmp.nr
@@ -159,7 +159,6 @@ impl Ord for u32 {
     }
 }
 
-
 impl Ord for u16 {
     fn cmp(self, other: u16) -> Ordering {
         if self < other {

--- a/noir_stdlib/src/cmp.nr
+++ b/noir_stdlib/src/cmp.nr
@@ -18,10 +18,12 @@ impl Eq for Field { fn eq(self, other: Field) -> bool { self == other } }
 
 impl Eq for u64 { fn eq(self, other: u64) -> bool { self == other } }
 impl Eq for u32 { fn eq(self, other: u32) -> bool { self == other } }
+impl Eq for u16 { fn eq(self, other: u16) -> bool { self == other } }
 impl Eq for u8 { fn eq(self, other: u8) -> bool { self == other } }
 impl Eq for u1 { fn eq(self, other: u1) -> bool { self == other } }
 
 impl Eq for i8 { fn eq(self, other: i8) -> bool { self == other } }
+impl Eq for i16 { fn eq(self, other: i16) -> bool { self == other } }
 impl Eq for i32 { fn eq(self, other: i32) -> bool { self == other } }
 impl Eq for i64 { fn eq(self, other: i64) -> bool { self == other } }
 
@@ -157,6 +159,19 @@ impl Ord for u32 {
     }
 }
 
+
+impl Ord for u16 {
+    fn cmp(self, other: u16) -> Ordering {
+        if self < other {
+            Ordering::less()
+        } else if self > other {
+            Ordering::greater()
+        } else {
+            Ordering::equal()
+        }
+    }
+}
+
 impl Ord for u8 {
     fn cmp(self, other: u8) -> Ordering {
         if self < other {
@@ -171,6 +186,18 @@ impl Ord for u8 {
 
 impl Ord for i8 {
     fn cmp(self, other: i8) -> Ordering {
+        if self < other {
+            Ordering::less()
+        } else if self > other {
+            Ordering::greater()
+        } else {
+            Ordering::equal()
+        }
+    }
+}
+
+impl Ord for i16 {
+    fn cmp(self, other: i16) -> Ordering {
         if self < other {
             Ordering::less()
         } else if self > other {

--- a/noir_stdlib/src/default.nr
+++ b/noir_stdlib/src/default.nr
@@ -24,6 +24,7 @@ impl Default for u32 { fn default() -> u32 { 0 } }
 impl Default for u64 { fn default() -> u64 { 0 } }
 
 impl Default for i8 { fn default() -> i8 { 0 } }
+impl Default for i16 { fn default() -> i16 { 0 } }
 impl Default for i32 { fn default() -> i32 { 0 } }
 impl Default for i64 { fn default() -> i64 { 0 } }
 

--- a/noir_stdlib/src/default.nr
+++ b/noir_stdlib/src/default.nr
@@ -17,7 +17,9 @@ comptime fn derive_default(s: StructDefinition) -> Quoted {
 
 impl Default for Field { fn default() -> Field { 0 } }
 
+impl Default for u1 { fn default() -> u1 { 0 } }
 impl Default for u8 { fn default() -> u8 { 0 } }
+impl Default for u16 { fn default() -> u16 { 0 } }
 impl Default for u32 { fn default() -> u32 { 0 } }
 impl Default for u64 { fn default() -> u64 { 0 } }
 

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -195,7 +195,19 @@ impl Hash for Field {
     }
 }
 
+impl Hash for u1 {
+    fn hash<H>(self, state: &mut H) where H: Hasher{
+        H::write(state, self as Field);
+    }
+}
+
 impl Hash for u8 {
+    fn hash<H>(self, state: &mut H) where H: Hasher{
+        H::write(state, self as Field);
+    }
+}
+
+impl Hash for u16 {
     fn hash<H>(self, state: &mut H) where H: Hasher{
         H::write(state, self as Field);
     }

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -231,6 +231,12 @@ impl Hash for i8 {
     }
 }
 
+impl Hash for i16 {
+    fn hash<H>(self, state: &mut H) where H: Hasher{
+        H::write(state, self as Field);
+    }
+}
+
 impl Hash for i32 {
     fn hash<H>(self, state: &mut H) where H: Hasher{
         H::write(state, self as Field);

--- a/noir_stdlib/src/ops/arith.nr
+++ b/noir_stdlib/src/ops/arith.nr
@@ -10,6 +10,7 @@ impl Add for u64 { fn add(self, other: u64) -> u64 { self + other } }
 impl Add for u32 { fn add(self, other: u32) -> u32 { self + other } }
 impl Add for u16 { fn add(self, other: u16) -> u16 { self + other } }
 impl Add for u8 { fn add(self, other: u8) -> u8 { self + other } }
+impl Add for u1 { fn add(self, other: u1) -> u1 { self + other } }
 
 impl Add for i8 { fn add(self, other: i8) -> i8 { self + other } }
 impl Add for i16 { fn add(self, other: i16) -> i16 { self + other } }
@@ -28,6 +29,7 @@ impl Sub for u64 { fn sub(self, other: u64) -> u64 { self - other } }
 impl Sub for u32 { fn sub(self, other: u32) -> u32 { self - other } }
 impl Sub for u16 { fn sub(self, other: u16) -> u16 { self - other } }
 impl Sub for u8 { fn sub(self, other: u8) -> u8 { self - other } }
+impl Sub for u1 { fn sub(self, other: u1) -> u1 { self - other } }
 
 impl Sub for i8 { fn sub(self, other: i8) -> i8 { self - other } }
 impl Sub for i16 { fn sub(self, other: i16) -> i16 { self - other } }
@@ -46,6 +48,7 @@ impl Mul for u64 { fn mul(self, other: u64) -> u64 { self * other } }
 impl Mul for u32 { fn mul(self, other: u32) -> u32 { self * other } }
 impl Mul for u16 { fn mul(self, other: u16) -> u16 { self * other } }
 impl Mul for u8 { fn mul(self, other: u8) -> u8 { self * other } }
+impl Mul for u1 { fn mul(self, other: u1) -> u1 { self * other } }
 
 impl Mul for i8 { fn mul(self, other: i8) -> i8 { self * other } }
 impl Mul for i16 { fn mul(self, other: i16) -> i16 { self * other } }
@@ -64,6 +67,7 @@ impl Div for u64 { fn div(self, other: u64) -> u64 { self / other } }
 impl Div for u32 { fn div(self, other: u32) -> u32 { self / other } }
 impl Div for u16 { fn div(self, other: u16) -> u16 { self / other } }
 impl Div for u8 { fn div(self, other: u8) -> u8 { self / other } }
+impl Div for u1 { fn div(self, other: u1) -> u1 { self / other } }
 
 impl Div for i8 { fn div(self, other: i8) -> i8 { self / other } }
 impl Div for i16 { fn div(self, other: i16) -> i16 { self / other } }
@@ -80,6 +84,7 @@ impl Rem for u64 { fn rem(self, other: u64) -> u64 { self % other } }
 impl Rem for u32 { fn rem(self, other: u32) -> u32 { self % other } }
 impl Rem for u16 { fn rem(self, other: u16) -> u16 { self % other } }
 impl Rem for u8 { fn rem(self, other: u8) -> u8 { self % other } }
+impl Rem for u1 { fn rem(self, other: u1) -> u1 { self % other } }
 
 impl Rem for i8 { fn rem(self, other: i8) -> i8 { self % other } }
 impl Rem for i16 { fn rem(self, other: i16) -> i16 { self % other } }

--- a/noir_stdlib/src/ops/bit.nr
+++ b/noir_stdlib/src/ops/bit.nr
@@ -31,6 +31,7 @@ impl BitOr for u64 { fn bitor(self, other: u64) -> u64 { self | other } }
 impl BitOr for u32 { fn bitor(self, other: u32) -> u32 { self | other } }
 impl BitOr for u16 { fn bitor(self, other: u16) -> u16 { self | other } }
 impl BitOr for u8 { fn bitor(self, other: u8) -> u8 { self | other } }
+impl BitOr for u1 { fn bitor(self, other: u1) -> u1 { self | other } }
 
 impl BitOr for i8 { fn bitor(self, other: i8) -> i8 { self | other } }
 impl BitOr for i16 { fn bitor(self, other: i16) -> i16 { self | other } }
@@ -49,6 +50,7 @@ impl BitAnd for u64 { fn bitand(self, other: u64) -> u64 { self & other } }
 impl BitAnd for u32 { fn bitand(self, other: u32) -> u32 { self & other } }
 impl BitAnd for u16 { fn bitand(self, other: u16) -> u16 { self & other } }
 impl BitAnd for u8 { fn bitand(self, other: u8) -> u8 { self & other } }
+impl BitAnd for u1 { fn bitand(self, other: u1) -> u1 { self & other } }
 
 impl BitAnd for i8 { fn bitand(self, other: i8) -> i8 { self & other } }
 impl BitAnd for i16 { fn bitand(self, other: i16) -> i16 { self & other } }
@@ -67,6 +69,7 @@ impl BitXor for u64 { fn bitxor(self, other: u64) -> u64 { self ^ other } }
 impl BitXor for u32 { fn bitxor(self, other: u32) -> u32 { self ^ other } }
 impl BitXor for u16 { fn bitxor(self, other: u16) -> u16 { self ^ other } }
 impl BitXor for u8 { fn bitxor(self, other: u8) -> u8 { self ^ other } }
+impl BitXor for u1 { fn bitxor(self, other: u1) -> u1 { self ^ other } }
 
 impl BitXor for i8 { fn bitxor(self, other: i8) -> i8 { self ^ other } }
 impl BitXor for i16 { fn bitxor(self, other: i16) -> i16 { self ^ other } }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5733 

## Summary\*

This PR implements some missing trait implementations for numeric types. This covers `u16` as mentioned in the issue but also `u1`s

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
