### PR TITLE
feat: LSP auto-import completion

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -479,6 +479,10 @@ pub struct FunctionDefinition {
 }
 
 impl FunctionDefinition {
+    pub fn is_private(&self) -> bool {
+        self.visibility == ItemVisibility::Private
+    }
+
     pub fn is_test(&self) -> bool {
         if let Some(attribute) = &self.attributes.function {
             matches!(attribute, FunctionAttribute::Test(..))

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -8,7 +8,7 @@ use crate::ast::{
 use crate::hir::def_collector::errors::DefCollectorErrorKind;
 use crate::macros_api::StructId;
 use crate::node_interner::{ExprId, QuotedTypeId};
-use crate::token::{Attributes, Token, Tokens};
+use crate::token::{Attributes, FunctionAttribute, Token, Tokens};
 use crate::{Kind, Type};
 use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
@@ -476,6 +476,16 @@ pub struct FunctionDefinition {
     pub where_clause: Vec<UnresolvedTraitConstraint>,
     pub return_type: FunctionReturnType,
     pub return_visibility: Visibility,
+}
+
+impl FunctionDefinition {
+    pub fn is_test(&self) -> bool {
+        if let Some(attribute) = &self.attributes.function {
+            matches!(attribute, FunctionAttribute::Test(..))
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -270,7 +270,7 @@ impl<'context> Elaborator<'context> {
                 self.interner.push_function(id, &function.def, module, location);
 
                 if self.is_in_lsp_mode() && !function.def.is_test() && !function.def.is_private() {
-                    self.interner.register_name_for_autoimport(
+                    self.interner.register_name_for_auto_import(
                         function.def.name.0.contents.clone(),
                         ModuleDefId::FunctionId(id),
                         function.def.visibility,

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -269,10 +269,11 @@ impl<'context> Elaborator<'context> {
                 let module = self.module_id();
                 self.interner.push_function(id, &function.def, module, location);
 
-                if self.is_in_lsp_mode() && !function.def.is_test() {
+                if self.is_in_lsp_mode() && !function.def.is_test() && !function.def.is_private() {
                     self.interner.register_name_for_autoimport(
                         function.def.name.0.contents.clone(),
                         ModuleDefId::FunctionId(id),
+                        function.def.visibility,
                     );
                 }
 

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -20,8 +20,7 @@ use crate::{
     hir_def::expr::HirIdent,
     lexer::Lexer,
     macros_api::{
-        Expression, ExpressionKind, HirExpression, ModuleDefId, NodeInterner, SecondaryAttribute,
-        StructId,
+        Expression, ExpressionKind, HirExpression, NodeInterner, SecondaryAttribute, StructId,
     },
     node_interner::{DefinitionKind, DependencyId, FuncId, TraitId},
     parser::{self, TopLevelStatement},
@@ -273,11 +272,7 @@ impl<'context> Elaborator<'context> {
                     && !function.def.is_test()
                     && !function.def.is_private()
                 {
-                    self.interner.register_name_for_auto_import(
-                        function.def.name.0.contents.clone(),
-                        ModuleDefId::FunctionId(id),
-                        function.def.visibility,
-                    );
+                    self.interner.register_function(id, &function.def);
                 }
 
                 let functions = vec![(self.local_module, id, function)];

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -269,7 +269,7 @@ impl<'context> Elaborator<'context> {
                 let module = self.module_id();
                 self.interner.push_function(id, &function.def, module, location);
 
-                if self.is_in_lsp_mode() {
+                if self.is_in_lsp_mode() && !function.def.is_test() {
                     self.interner.register_name_for_autoimport(
                         function.def.name.0.contents.clone(),
                         ModuleDefId::FunctionId(id),

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -269,7 +269,10 @@ impl<'context> Elaborator<'context> {
                 let module = self.module_id();
                 self.interner.push_function(id, &function.def, module, location);
 
-                if self.is_in_lsp_mode() && !function.def.is_test() && !function.def.is_private() {
+                if self.interner.is_in_lsp_mode()
+                    && !function.def.is_test()
+                    && !function.def.is_private()
+                {
                     self.interner.register_name_for_auto_import(
                         function.def.name.0.contents.clone(),
                         ModuleDefId::FunctionId(id),

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -20,7 +20,8 @@ use crate::{
     hir_def::expr::HirIdent,
     lexer::Lexer,
     macros_api::{
-        Expression, ExpressionKind, HirExpression, NodeInterner, SecondaryAttribute, StructId,
+        Expression, ExpressionKind, HirExpression, ModuleDefId, NodeInterner, SecondaryAttribute,
+        StructId,
     },
     node_interner::{DefinitionKind, DependencyId, FuncId, TraitId},
     parser::{self, TopLevelStatement},
@@ -267,6 +268,14 @@ impl<'context> Elaborator<'context> {
                 let id = self.interner.push_empty_fn();
                 let module = self.module_id();
                 self.interner.push_function(id, &function.def, module, location);
+
+                if self.is_in_lsp_mode() {
+                    self.interner.register_name_for_autoimport(
+                        function.def.name.0.contents.clone(),
+                        ModuleDefId::FunctionId(id),
+                    );
+                }
+
                 let functions = vec![(self.local_module, id, function)];
                 generated_items.functions.push(UnresolvedFunctions {
                     file_id: self.file,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1333,7 +1333,7 @@ impl<'context> Elaborator<'context> {
             .add_definition_location(ReferenceId::Global(global_id), Some(self.module_id()));
 
         if let Some(name) = name {
-            self.interner.register_name_for_autoimport(
+            self.interner.register_name_for_auto_import(
                 name,
                 ModuleDefId::GlobalId(global_id),
                 ItemVisibility::Public,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1333,7 +1333,11 @@ impl<'context> Elaborator<'context> {
             .add_definition_location(ReferenceId::Global(global_id), Some(self.module_id()));
 
         if let Some(name) = name {
-            self.interner.register_name_for_autoimport(name, ModuleDefId::GlobalId(global_id));
+            self.interner.register_name_for_autoimport(
+                name,
+                ModuleDefId::GlobalId(global_id),
+                ItemVisibility::Public,
+            );
         }
 
         self.local_module = old_module;

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1297,7 +1297,7 @@ impl<'context> Elaborator<'context> {
         self.current_item = Some(DependencyId::Global(global_id));
         let let_stmt = global.stmt_def;
 
-        let name = if self.is_in_lsp_mode() {
+        let name = if self.interner.is_in_lsp_mode() {
             if let Pattern::Identifier(ident) = &let_stmt.pattern {
                 Some(ident.to_string())
             } else {
@@ -1480,9 +1480,5 @@ impl<'context> Elaborator<'context> {
             DependencyId::Function(id) => !self.interner.function_modifiers(&id).is_unconstrained,
             _ => true,
         })
-    }
-
-    fn is_in_lsp_mode(&self) -> bool {
-        self.interner.is_in_lsp_mode()
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1298,11 +1298,7 @@ impl<'context> Elaborator<'context> {
         let let_stmt = global.stmt_def;
 
         let name = if self.interner.is_in_lsp_mode() {
-            if let Pattern::Identifier(ident) = &let_stmt.pattern {
-                Some(ident.to_string())
-            } else {
-                None
-            }
+            Some(let_stmt.pattern.name_ident().to_string())
         } else {
             None
         };

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1325,15 +1325,8 @@ impl<'context> Elaborator<'context> {
             self.elaborate_comptime_global(global_id);
         }
 
-        self.interner
-            .add_definition_location(ReferenceId::Global(global_id), Some(self.module_id()));
-
         if let Some(name) = name {
-            self.interner.register_name_for_auto_import(
-                name,
-                ModuleDefId::GlobalId(global_id),
-                ItemVisibility::Public,
-            );
+            self.interner.register_global(global_id, name, self.module_id());
         }
 
         self.local_module = old_module;

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -232,10 +232,14 @@ impl<'a> ModCollector<'a> {
             let location = Location::new(function.span(), self.file_id);
             context.def_interner.push_function(func_id, &function.def, module, location);
 
-            if context.def_interner.is_in_lsp_mode() && !function.def.is_test() {
+            if context.def_interner.is_in_lsp_mode()
+                && !function.def.is_test()
+                && !function.def.is_private()
+            {
                 context.def_interner.register_name_for_autoimport(
                     function.def.name.0.contents.clone(),
                     ModuleDefId::FunctionId(func_id),
+                    function.def.visibility,
                 );
             }
 
@@ -335,9 +339,11 @@ impl<'a> ModCollector<'a> {
                     Some(ModuleId { krate, local_id: self.module_id }),
                 );
 
-                context
-                    .def_interner
-                    .register_name_for_autoimport(name.to_string(), ModuleDefId::TypeId(id));
+                context.def_interner.register_name_for_autoimport(
+                    name.to_string(),
+                    ModuleDefId::TypeId(id),
+                    ItemVisibility::Public,
+                );
             }
         }
         definition_errors
@@ -418,6 +424,7 @@ impl<'a> ModCollector<'a> {
                 context.def_interner.register_name_for_autoimport(
                     name.to_string(),
                     ModuleDefId::TypeAliasId(type_alias_id),
+                    ItemVisibility::Public,
                 );
             }
         }
@@ -593,9 +600,11 @@ impl<'a> ModCollector<'a> {
                     Some(ModuleId { krate, local_id: self.module_id }),
                 );
 
-                context
-                    .def_interner
-                    .register_name_for_autoimport(name.to_string(), ModuleDefId::TraitId(trait_id));
+                context.def_interner.register_name_for_autoimport(
+                    name.to_string(),
+                    ModuleDefId::TraitId(trait_id),
+                    ItemVisibility::Public,
+                );
             }
 
             self.def_collector.items.traits.insert(trait_id, unresolved);

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -236,7 +236,7 @@ impl<'a> ModCollector<'a> {
                 && !function.def.is_test()
                 && !function.def.is_private()
             {
-                context.def_interner.register_name_for_autoimport(
+                context.def_interner.register_name_for_auto_import(
                     function.def.name.0.contents.clone(),
                     ModuleDefId::FunctionId(func_id),
                     function.def.visibility,
@@ -339,7 +339,7 @@ impl<'a> ModCollector<'a> {
                     Some(ModuleId { krate, local_id: self.module_id }),
                 );
 
-                context.def_interner.register_name_for_autoimport(
+                context.def_interner.register_name_for_auto_import(
                     name.to_string(),
                     ModuleDefId::TypeId(id),
                     ItemVisibility::Public,
@@ -421,7 +421,7 @@ impl<'a> ModCollector<'a> {
                     Some(ModuleId { krate, local_id: self.module_id }),
                 );
 
-                context.def_interner.register_name_for_autoimport(
+                context.def_interner.register_name_for_auto_import(
                     name.to_string(),
                     ModuleDefId::TypeAliasId(type_alias_id),
                     ItemVisibility::Public,
@@ -600,7 +600,7 @@ impl<'a> ModCollector<'a> {
                     Some(ModuleId { krate, local_id: self.module_id }),
                 );
 
-                context.def_interner.register_name_for_autoimport(
+                context.def_interner.register_name_for_auto_import(
                     name.to_string(),
                     ModuleDefId::TraitId(trait_id),
                     ItemVisibility::Public,
@@ -803,7 +803,7 @@ impl<'a> ModCollector<'a> {
             );
 
             if context.def_interner.is_in_lsp_mode() {
-                context.def_interner.register_name_for_autoimport(
+                context.def_interner.register_name_for_auto_import(
                     mod_name.0.contents.clone(),
                     ModuleDefId::ModuleId(mod_id),
                     ItemVisibility::Public,

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -232,7 +232,7 @@ impl<'a> ModCollector<'a> {
             let location = Location::new(function.span(), self.file_id);
             context.def_interner.push_function(func_id, &function.def, module, location);
 
-            if context.def_interner.is_in_lsp_mode() {
+            if context.def_interner.is_in_lsp_mode() && !function.def.is_test() {
                 context.def_interner.register_name_for_autoimport(
                     function.def.name.0.contents.clone(),
                     ModuleDefId::FunctionId(func_id),

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -801,6 +801,14 @@ impl<'a> ModCollector<'a> {
                     parent: self.module_id,
                 },
             );
+
+            if context.def_interner.is_in_lsp_mode() {
+                context.def_interner.register_name_for_autoimport(
+                    mod_name.0.contents.clone(),
+                    ModuleDefId::ModuleId(mod_id),
+                    ItemVisibility::Public,
+                );
+            }
         }
 
         Ok(mod_id)

--- a/compiler/noirc_frontend/src/hir/def_map/module_def.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_def.rs
@@ -3,7 +3,7 @@ use crate::node_interner::{FuncId, GlobalId, StructId, TraitId, TypeAliasId};
 use super::ModuleId;
 
 /// A generic ID that references either a module, function, type, interface or global
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ModuleDefId {
     ModuleId(ModuleId),
     FunctionId(FuncId),

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -1,7 +1,7 @@
 use fm::FileId;
 use noirc_errors::Location;
 use rangemap::RangeMap;
-use rustc_hash::FxHashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     hir::def_map::{ModuleDefId, ModuleId},
@@ -12,7 +12,7 @@ use petgraph::prelude::NodeIndex as PetGraphIndex;
 
 #[derive(Debug, Default)]
 pub(crate) struct LocationIndices {
-    map_file_to_range: FxHashMap<FileId, RangeMap<u32, PetGraphIndex>>,
+    map_file_to_range: HashMap<FileId, RangeMap<u32, PetGraphIndex>>,
 }
 
 impl LocationIndices {
@@ -274,5 +274,21 @@ impl NodeInterner {
         self.reference_graph
             .neighbors_directed(reference_index, petgraph::Direction::Outgoing)
             .next()
+    }
+
+    pub(crate) fn register_name_for_autoimport(
+        &mut self,
+        name: String,
+        module_def_id: ModuleDefId,
+    ) {
+        if !self.lsp_mode {
+            return;
+        }
+
+        self.autoimport_names.entry(name).or_default().push(module_def_id);
+    }
+
+    pub fn get_autoimport_names(&self) -> &HashMap<String, Vec<ModuleDefId>> {
+        &self.autoimport_names
     }
 }

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -277,7 +277,7 @@ impl NodeInterner {
             .next()
     }
 
-    pub(crate) fn register_name_for_autoimport(
+    pub(crate) fn register_name_for_auto_import(
         &mut self,
         name: String,
         module_def_id: ModuleDefId,
@@ -287,10 +287,10 @@ impl NodeInterner {
             return;
         }
 
-        self.autoimport_names.entry(name).or_default().push((module_def_id, visibility));
+        self.auto_import_names.entry(name).or_default().push((module_def_id, visibility));
     }
 
-    pub fn get_autoimport_names(&self) -> &HashMap<String, Vec<(ModuleDefId, ItemVisibility)>> {
-        &self.autoimport_names
+    pub fn get_auto_import_names(&self) -> &HashMap<String, Vec<(ModuleDefId, ItemVisibility)>> {
+        &self.auto_import_names
     }
 }

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -4,6 +4,7 @@ use rangemap::RangeMap;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
+    ast::ItemVisibility,
     hir::def_map::{ModuleDefId, ModuleId},
     macros_api::{NodeInterner, StructId},
     node_interner::{DefinitionId, FuncId, GlobalId, ReferenceId, TraitId, TypeAliasId},
@@ -280,15 +281,16 @@ impl NodeInterner {
         &mut self,
         name: String,
         module_def_id: ModuleDefId,
+        visibility: ItemVisibility,
     ) {
         if !self.lsp_mode {
             return;
         }
 
-        self.autoimport_names.entry(name).or_default().push(module_def_id);
+        self.autoimport_names.entry(name).or_default().push((module_def_id, visibility));
     }
 
-    pub fn get_autoimport_names(&self) -> &HashMap<String, Vec<ModuleDefId>> {
+    pub fn get_autoimport_names(&self) -> &HashMap<String, Vec<(ModuleDefId, ItemVisibility)>> {
         &self.autoimport_names
     }
 }

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -4,7 +4,7 @@ use rangemap::RangeMap;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-    ast::ItemVisibility,
+    ast::{FunctionDefinition, ItemVisibility},
     hir::def_map::{ModuleDefId, ModuleId},
     macros_api::{NodeInterner, StructId},
     node_interner::{DefinitionId, FuncId, GlobalId, ReferenceId, TraitId, TypeAliasId},
@@ -277,7 +277,61 @@ impl NodeInterner {
             .next()
     }
 
-    pub(crate) fn register_name_for_auto_import(
+    pub(crate) fn register_module(&mut self, id: ModuleId, name: String) {
+        self.register_name_for_auto_import(name, ModuleDefId::ModuleId(id), ItemVisibility::Public);
+    }
+
+    pub(crate) fn register_global(
+        &mut self,
+        id: GlobalId,
+        name: String,
+        parent_module_id: ModuleId,
+    ) {
+        self.add_definition_location(ReferenceId::Global(id), Some(parent_module_id));
+
+        let visibility = ItemVisibility::Public;
+        self.register_name_for_auto_import(name, ModuleDefId::GlobalId(id), visibility);
+    }
+
+    pub(crate) fn register_struct(
+        &mut self,
+        id: StructId,
+        name: String,
+        parent_module_id: ModuleId,
+    ) {
+        self.add_definition_location(ReferenceId::Struct(id), Some(parent_module_id));
+
+        let visibility = ItemVisibility::Public;
+        self.register_name_for_auto_import(name, ModuleDefId::TypeId(id), visibility);
+    }
+
+    pub(crate) fn register_trait(&mut self, id: TraitId, name: String, parent_module_id: ModuleId) {
+        self.add_definition_location(ReferenceId::Trait(id), Some(parent_module_id));
+
+        self.register_name_for_auto_import(name, ModuleDefId::TraitId(id), ItemVisibility::Public);
+    }
+
+    pub(crate) fn register_type_alias(
+        &mut self,
+        id: TypeAliasId,
+        name: String,
+        parent_module_id: ModuleId,
+    ) {
+        self.add_definition_location(ReferenceId::Alias(id), Some(parent_module_id));
+
+        let visibility = ItemVisibility::Public;
+        self.register_name_for_auto_import(name, ModuleDefId::TypeAliasId(id), visibility);
+    }
+
+    pub(crate) fn register_function(&mut self, id: FuncId, func_def: &FunctionDefinition) {
+        self.register_name_for_auto_import(
+            func_def.name.0.contents.clone(),
+            ModuleDefId::FunctionId(id),
+            func_def.visibility,
+        );
+    }
+
+    fn register_name_for_auto_import(
         &mut self,
         name: String,
         module_def_id: ModuleDefId,

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -235,7 +235,7 @@ pub struct NodeInterner {
     // All names (and their definitions) that can be offered for autoimport.
     // These include top-level functions, global variables and types, but excludes
     // impl and trait-impl methods.
-    pub(crate) autoimport_names: HashMap<String, Vec<ModuleDefId>>,
+    pub(crate) autoimport_names: HashMap<String, Vec<(ModuleDefId, ItemVisibility)>>,
 
     /// Each value currently in scope in the comptime interpreter.
     /// Each element of the Vec represents a scope with every scope together making

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -232,10 +232,10 @@ pub struct NodeInterner {
     // (ReferenceId::Reference and ReferenceId::Local aren't included here)
     pub(crate) reference_modules: HashMap<ReferenceId, ModuleId>,
 
-    // All names (and their definitions) that can be offered for autoimport.
+    // All names (and their definitions) that can be offered for auto_import.
     // These include top-level functions, global variables and types, but excludes
     // impl and trait-impl methods.
-    pub(crate) autoimport_names: HashMap<String, Vec<(ModuleDefId, ItemVisibility)>>,
+    pub(crate) auto_import_names: HashMap<String, Vec<(ModuleDefId, ItemVisibility)>>,
 
     /// Each value currently in scope in the comptime interpreter.
     /// Each element of the Vec represents a scope with every scope together making
@@ -608,7 +608,7 @@ impl Default for NodeInterner {
             reference_graph: petgraph::graph::DiGraph::new(),
             reference_graph_indices: HashMap::default(),
             reference_modules: HashMap::default(),
-            autoimport_names: HashMap::default(),
+            auto_import_names: HashMap::default(),
             comptime_scopes: vec![HashMap::default()],
         }
     }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -19,6 +19,7 @@ use crate::hir::comptime;
 use crate::hir::def_collector::dc_crate::CompilationError;
 use crate::hir::def_collector::dc_crate::{UnresolvedStruct, UnresolvedTrait, UnresolvedTypeAlias};
 use crate::hir::def_map::{LocalModuleId, ModuleId};
+use crate::macros_api::ModuleDefId;
 use crate::macros_api::UnaryOp;
 use crate::QuotedType;
 
@@ -230,6 +231,11 @@ pub struct NodeInterner {
     // The module where each reference is
     // (ReferenceId::Reference and ReferenceId::Local aren't included here)
     pub(crate) reference_modules: HashMap<ReferenceId, ModuleId>,
+
+    // All names (and their definitions) that can be offered for autoimport.
+    // These include top-level functions, global variables and types, but excludes
+    // impl and trait-impl methods.
+    pub(crate) autoimport_names: HashMap<String, Vec<ModuleDefId>>,
 
     /// Each value currently in scope in the comptime interpreter.
     /// Each element of the Vec represents a scope with every scope together making
@@ -602,6 +608,7 @@ impl Default for NodeInterner {
             reference_graph: petgraph::graph::DiGraph::new(),
             reference_graph_indices: HashMap::default(),
             reference_modules: HashMap::default(),
+            autoimport_names: HashMap::default(),
             comptime_scopes: vec![HashMap::default()],
         }
     }
@@ -910,6 +917,7 @@ impl NodeInterner {
         // This needs to be done after pushing the definition since it will reference the
         // location that was stored
         self.add_definition_location(ReferenceId::Function(id), Some(module));
+
         definition_id
     }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -68,6 +68,7 @@ pub(crate) fn on_completion_request(
                 let mut finder = NodeFinder::new(
                     args.files,
                     file_id,
+                    source,
                     byte_index,
                     byte,
                     args.crate_id,
@@ -85,6 +86,7 @@ pub(crate) fn on_completion_request(
 struct NodeFinder<'a> {
     files: &'a FileMap,
     file: FileId,
+    lines: Vec<&'a str>,
     byte_index: usize,
     byte: Option<u8>,
     /// The module ID of the current file.
@@ -116,6 +118,7 @@ impl<'a> NodeFinder<'a> {
     fn new(
         files: &'a FileMap,
         file: FileId,
+        source: &'a str,
         byte_index: usize,
         byte: Option<u8>,
         krate: CrateId,
@@ -137,6 +140,7 @@ impl<'a> NodeFinder<'a> {
         Self {
             files,
             file,
+            lines: source.lines().collect(),
             byte_index,
             byte,
             root_module_id,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -172,6 +172,12 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn find_in_item(&mut self, item: &Item) {
+        if let ItemKind::Import(..) = &item.kind {
+            if let Some(lsp_location) = to_lsp_location(self.files, self.file, item.span) {
+                self.autoimport_line = (lsp_location.range.end.line + 1) as usize;
+            }
+        }
+
         if !self.includes_span(item.span) {
             return;
         }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -112,6 +112,7 @@ struct NodeFinder<'a> {
 }
 
 impl<'a> NodeFinder<'a> {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         files: &'a FileMap,
         file: FileId,

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -123,7 +123,7 @@ fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> ReferenceId {
     }
 }
 
-/// Computes the path of `module_id` reltive to `current_module_id`.
+/// Computes the path of `module_id` relative to `current_module_id`.
 /// If it's not relative, the full path is returned.
 fn module_id_path(
     module_id: &ModuleId,

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -9,7 +9,9 @@ use noirc_frontend::{
 
 use super::{
     kinds::{FunctionCompletionKind, FunctionKind, RequestedItems},
-    name_matches, NodeFinder,
+    name_matches,
+    sort_text::auto_import_sort_text,
+    NodeFinder,
 };
 
 impl<'a> NodeFinder<'a> {
@@ -99,6 +101,8 @@ impl<'a> NodeFinder<'a> {
                     },
                     new_text: format!("use {};{}{}", full_path, newlines, indent),
                 }]);
+
+                completion_item.sort_text = Some(auto_import_sort_text());
 
                 self.completion_items.push(completion_item);
                 self.suggested_module_def_ids.insert(*module_def_id);

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -13,8 +13,8 @@ use super::{
 };
 
 impl<'a> NodeFinder<'a> {
-    pub(super) fn complete_autoimports(&mut self, prefix: &str, requested_items: RequestedItems) {
-        for (name, entries) in self.interner.get_autoimport_names() {
+    pub(super) fn complete_auto_imports(&mut self, prefix: &str, requested_items: RequestedItems) {
+        for (name, entries) in self.interner.get_auto_import_names() {
             if !name_matches(name, prefix) {
                 continue;
             }
@@ -80,7 +80,7 @@ impl<'a> NodeFinder<'a> {
                 label_details.detail = Some(format!("(use {})", full_path));
                 completion_item.label_details = Some(label_details);
 
-                let line = self.autoimport_line as u32;
+                let line = self.auto_import_line as u32;
                 let character = (self.nesting * 4) as u32;
                 let indent = " ".repeat(self.nesting * 4);
                 let mut newlines = "\n";

--- a/tooling/lsp/src/requests/completion/autoimport.rs
+++ b/tooling/lsp/src/requests/completion/autoimport.rs
@@ -83,13 +83,21 @@ impl<'a> NodeFinder<'a> {
                 let line = self.autoimport_line as u32;
                 let character = (self.nesting * 4) as u32;
                 let indent = " ".repeat(self.nesting * 4);
+                let mut newlines = "\n";
+
+                // If the line we are inserting into is not an empty line, insert an extra line to make some room
+                if let Some(line_text) = self.lines.get(line as usize) {
+                    if !line_text.trim().is_empty() {
+                        newlines = "\n\n";
+                    }
+                }
 
                 completion_item.additional_text_edits = Some(vec![TextEdit {
                     range: Range {
                         start: Position { line, character },
                         end: Position { line, character },
                     },
-                    new_text: format!("use {};\n{}", full_path, indent),
+                    new_text: format!("use {};{}{}", full_path, newlines, indent),
                 }]);
 
                 self.completion_items.push(completion_item);

--- a/tooling/lsp/src/requests/completion/autoimport.rs
+++ b/tooling/lsp/src/requests/completion/autoimport.rs
@@ -1,0 +1,129 @@
+use lsp_types::{Position, Range, TextEdit};
+use noirc_frontend::{
+    graph::{CrateId, Dependency},
+    hir::def_map::ModuleId,
+    macros_api::{ModuleDefId, NodeInterner},
+    node_interner::ReferenceId,
+};
+
+use super::{
+    kinds::{FunctionCompletionKind, FunctionKind, RequestedItems},
+    name_matches, NodeFinder,
+};
+
+impl<'a> NodeFinder<'a> {
+    pub(super) fn complete_autoimports(&mut self, prefix: &str, requested_items: RequestedItems) {
+        for (name, module_def_ids) in self.interner.get_autoimport_names() {
+            if !name_matches(name, prefix) {
+                continue;
+            }
+
+            for module_def_id in module_def_ids {
+                if self.suggested_module_def_ids.contains(module_def_id) {
+                    continue;
+                }
+
+                let Some(mut completion_item) = self.module_def_id_completion_item(
+                    *module_def_id,
+                    name.clone(),
+                    FunctionCompletionKind::NameAndParameters,
+                    FunctionKind::Any,
+                    requested_items,
+                ) else {
+                    continue;
+                };
+
+                let Some(parent_module) = get_parent_module(&self.interner, *module_def_id) else {
+                    continue;
+                };
+
+                let module_full_path =
+                    module_id_full_path(parent_module, self.interner, &self.dependencies);
+
+                let mut label_details = completion_item.label_details.unwrap();
+                label_details.detail = Some(format!("(use {}::{})", module_full_path, name));
+                completion_item.label_details = Some(label_details);
+
+                completion_item.additional_text_edits = Some(vec![TextEdit {
+                    range: Range {
+                        start: Position { line: 0, character: 0 },
+                        end: Position { line: 0, character: 0 },
+                    },
+                    new_text: format!("use {}::{};\n", module_full_path, name),
+                }]);
+
+                self.completion_items.push(completion_item);
+                self.suggested_module_def_ids.insert(*module_def_id);
+            }
+        }
+    }
+}
+
+fn get_parent_module(interner: &NodeInterner, module_def_id: ModuleDefId) -> Option<&ModuleId> {
+    let reference_id = module_def_id_to_reference_id(module_def_id);
+    interner.reference_module(reference_id)
+}
+
+fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> ReferenceId {
+    match module_def_id {
+        ModuleDefId::ModuleId(id) => ReferenceId::Module(id),
+        ModuleDefId::FunctionId(id) => ReferenceId::Function(id),
+        ModuleDefId::TypeId(id) => ReferenceId::Struct(id),
+        ModuleDefId::TypeAliasId(id) => ReferenceId::Alias(id),
+        ModuleDefId::TraitId(id) => ReferenceId::Trait(id),
+        ModuleDefId::GlobalId(id) => ReferenceId::Global(id),
+    }
+}
+
+fn module_id_full_path(
+    module: &ModuleId,
+    interner: &NodeInterner,
+    dependencies: &[Dependency],
+) -> String {
+    let mut string = String::new();
+
+    let crate_id = module.krate;
+    let crate_name = match crate_id {
+        CrateId::Root(_) => None,
+        CrateId::Crate(_) => dependencies
+            .iter()
+            .find(|dep| dep.crate_id == crate_id)
+            .map(|dep| format!("{}", dep.name)),
+        CrateId::Stdlib(_) => Some("std".to_string()),
+        CrateId::Dummy => None,
+    };
+
+    let wrote_crate = if let Some(crate_name) = crate_name {
+        string.push_str(&crate_name);
+        true
+    } else {
+        false
+    };
+
+    let Some(module_attributes) = interner.try_module_attributes(module) else {
+        return string;
+    };
+
+    if wrote_crate {
+        string.push_str("::");
+    }
+
+    let mut segments = Vec::new();
+    let mut current_attributes = module_attributes;
+    while let Some(parent_attributes) = interner.try_module_attributes(&ModuleId {
+        krate: module.krate,
+        local_id: current_attributes.parent,
+    }) {
+        segments.push(&parent_attributes.name);
+        current_attributes = parent_attributes;
+    }
+
+    for segment in segments.iter().rev() {
+        string.push_str(segment);
+        string.push_str("::");
+    }
+
+    string.push_str(&module_attributes.name);
+
+    string
+}

--- a/tooling/lsp/src/requests/completion/autoimport.rs
+++ b/tooling/lsp/src/requests/completion/autoimport.rs
@@ -13,12 +13,12 @@ use super::{
 
 impl<'a> NodeFinder<'a> {
     pub(super) fn complete_autoimports(&mut self, prefix: &str, requested_items: RequestedItems) {
-        for (name, module_def_ids) in self.interner.get_autoimport_names() {
+        for (name, entries) in self.interner.get_autoimport_names() {
             if !name_matches(name, prefix) {
                 continue;
             }
 
-            for module_def_id in module_def_ids {
+            for (module_def_id, visibility) in entries {
                 if self.suggested_module_def_ids.contains(module_def_id) {
                     continue;
                 }

--- a/tooling/lsp/src/requests/completion/autoimport.rs
+++ b/tooling/lsp/src/requests/completion/autoimport.rs
@@ -48,12 +48,16 @@ impl<'a> NodeFinder<'a> {
                 label_details.detail = Some(format!("(use {}::{})", module_full_path, name));
                 completion_item.label_details = Some(label_details);
 
+                let line = self.autoimport_line as u32;
+                let character = (self.nesting * 4) as u32;
+                let indent = " ".repeat(self.nesting * 4);
+
                 completion_item.additional_text_edits = Some(vec![TextEdit {
                     range: Range {
-                        start: Position { line: 0, character: 0 },
-                        end: Position { line: 0, character: 0 },
+                        start: Position { line, character },
+                        end: Position { line, character },
                     },
-                    new_text: format!("use {}::{};\n", module_full_path, name),
+                    new_text: format!("use {}::{};\n{}", module_full_path, name, indent),
                 }]);
 
                 self.completion_items.push(completion_item);

--- a/tooling/lsp/src/requests/completion/autoimport.rs
+++ b/tooling/lsp/src/requests/completion/autoimport.rs
@@ -34,7 +34,7 @@ impl<'a> NodeFinder<'a> {
                     continue;
                 };
 
-                let Some(parent_module) = get_parent_module(&self.interner, *module_def_id) else {
+                let Some(parent_module) = get_parent_module(self.interner, *module_def_id) else {
                     continue;
                 };
 
@@ -56,7 +56,7 @@ impl<'a> NodeFinder<'a> {
                     parent_module,
                     &self.module_id,
                     self.interner,
-                    &self.dependencies,
+                    self.dependencies,
                 );
 
                 let mut label_details = completion_item.label_details.unwrap();

--- a/tooling/lsp/src/requests/completion/sort_text.rs
+++ b/tooling/lsp/src/requests/completion/sort_text.rs
@@ -9,6 +9,11 @@ pub(super) fn default_sort_text() -> String {
     "5".to_string()
 }
 
+/// Sort text for auto-import items. We want these to show up after local definitions.
+pub(super) fn auto_import_sort_text() -> String {
+    "6".to_string()
+}
+
 /// When completing something like `Foo::`, we want to show methods that take
 /// self after the other ones.
 pub(super) fn self_mismatch_sort_text() -> String {

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1527,4 +1527,31 @@ mod completion_tests {
         let items = get_completions(src).await;
         assert!(items.is_empty());
     }
+
+    #[test]
+    async fn test_autoimport_suggests_modules_too() {
+        let src = r#"
+            mod foo {
+                mod barbaz {
+                    fn hello_world() {}
+                }
+            }
+
+            fn main() {
+                barb>|<
+            }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(item.label, "barbaz");
+        assert_eq!(
+            item.label_details,
+            Some(CompletionItemLabelDetails {
+                detail: Some("(use foo::barbaz)".to_string()),
+                description: None
+            })
+        );
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1335,7 +1335,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_autoimports() {
+    async fn test_autoimports_x() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1413,7 +1413,7 @@ mod completion_tests {
                     start: Position { line: 2, character: 4 },
                     end: Position { line: 2, character: 4 },
                 },
-                new_text: "use bar::hello_world;\n    ".to_string(),
+                new_text: "use bar::hello_world;\n\n    ".to_string(),
             }])
         );
     }
@@ -1453,7 +1453,7 @@ mod completion_tests {
                     start: Position { line: 7, character: 8 },
                     end: Position { line: 7, character: 8 },
                 },
-                new_text: "use crate::foo::bar::hello_world;\n        ".to_string(),
+                new_text: "use crate::foo::bar::hello_world;\n\n        ".to_string(),
             }])
         );
     }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1407,16 +1407,16 @@ mod completion_tests {
             })
         );
 
-        // assert_eq!(
-        //     item.additional_text_edits,
-        //     Some(vec![TextEdit {
-        //         range: Range {
-        //             start: Position { line: 0, character: 0 },
-        //             end: Position { line: 0, character: 0 },
-        //         },
-        //         new_text: "use foo::bar::hello_world;\n".to_string(),
-        //     }])
-        // );
+        assert_eq!(
+            item.additional_text_edits,
+            Some(vec![TextEdit {
+                range: Range {
+                    start: Position { line: 2, character: 4 },
+                    end: Position { line: 2, character: 4 },
+                },
+                new_text: "use bar::hello_world;\n    ".to_string(),
+            }])
+        );
     }
 
     #[test]
@@ -1447,15 +1447,15 @@ mod completion_tests {
             })
         );
 
-        // assert_eq!(
-        //     item.additional_text_edits,
-        //     Some(vec![TextEdit {
-        //         range: Range {
-        //             start: Position { line: 0, character: 0 },
-        //             end: Position { line: 0, character: 0 },
-        //         },
-        //         new_text: "use foo::bar::hello_world;\n".to_string(),
-        //     }])
-        // );
+        assert_eq!(
+            item.additional_text_edits,
+            Some(vec![TextEdit {
+                range: Range {
+                    start: Position { line: 7, character: 8 },
+                    end: Position { line: 7, character: 8 },
+                },
+                new_text: "use crate::foo::bar::hello_world;\n        ".to_string(),
+            }])
+        );
     }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1458,4 +1458,35 @@ mod completion_tests {
             }])
         );
     }
+
+    #[test]
+    async fn test_autoimport_inserts_after_last_use() {
+        let src = r#"
+            mod foo {
+                mod bar {
+                    pub fn hello_world() {}
+                }
+            }
+
+            use foo::bar;
+
+            fn main() {
+                hel>|<
+            }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(
+            item.additional_text_edits,
+            Some(vec![TextEdit {
+                range: Range {
+                    start: Position { line: 8, character: 0 },
+                    end: Position { line: 8, character: 0 },
+                },
+                new_text: "use foo::bar::hello_world;\n".to_string(),
+            }])
+        );
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -97,7 +97,7 @@ mod completion_tests {
         assert_items_match(items, expected);
     }
 
-    async fn assert_completion_excluding_autoimport(src: &str, expected: Vec<CompletionItem>) {
+    async fn assert_completion_excluding_auto_import(src: &str, expected: Vec<CompletionItem>) {
         let items = get_completions(src).await;
         let items = items.into_iter().filter(|item| item.additional_text_edits.is_none()).collect();
         assert_items_match(items, expected);
@@ -374,7 +374,7 @@ mod completion_tests {
             l>|<
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "local",
@@ -394,7 +394,7 @@ mod completion_tests {
             l>|<
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "local",
@@ -412,7 +412,7 @@ mod completion_tests {
             l>|<
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "local",
@@ -432,7 +432,7 @@ mod completion_tests {
             h>|<
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![function_completion_item("hello()", "hello()", "fn()")],
         )
@@ -448,7 +448,7 @@ mod completion_tests {
             h>|<
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![function_completion_item(
                 "hello(…)",
@@ -466,7 +466,7 @@ mod completion_tests {
             a>|<
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![
                 snippet_completion_item(
@@ -498,7 +498,7 @@ mod completion_tests {
             }
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "SomeStruct",
@@ -521,7 +521,7 @@ mod completion_tests {
             }
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "SomeStruct",
@@ -541,7 +541,7 @@ mod completion_tests {
             }
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "index",
@@ -561,7 +561,7 @@ mod completion_tests {
             lambda(|var| v>|<)
           }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "var",
@@ -752,7 +752,7 @@ mod completion_tests {
                 let x = t>|<
             }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "true",
@@ -776,7 +776,7 @@ mod completion_tests {
                 }
             }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![
                 simple_completion_item(
@@ -804,7 +804,7 @@ mod completion_tests {
                 }
             }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![
                 simple_completion_item(
@@ -832,7 +832,7 @@ mod completion_tests {
                 g>|<
             }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "good",
@@ -854,7 +854,7 @@ mod completion_tests {
                 }
             }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![
                 simple_completion_item(
@@ -880,7 +880,7 @@ mod completion_tests {
                 g>|<
             }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item(
                 "good",
@@ -898,7 +898,7 @@ mod completion_tests {
                 context: C>|<
             }
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item("Context", CompletionItemKind::TYPE_PARAMETER, None)],
         )
@@ -964,7 +964,7 @@ mod completion_tests {
         let src = r#"
             fn foo<Context>(x: C>|<) {}
         "#;
-        assert_completion_excluding_autoimport(
+        assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item("Context", CompletionItemKind::TYPE_PARAMETER, None)],
         )
@@ -1335,7 +1335,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_autoimports_x() {
+    async fn test_auto_imports_x() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1381,7 +1381,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_autoimports_when_in_nested_module_and_item_is_further_nested() {
+    async fn test_auto_imports_when_in_nested_module_and_item_is_further_nested() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1419,7 +1419,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_autoimports_when_in_nested_module_and_item_is_not_further_nested() {
+    async fn test_auto_imports_when_in_nested_module_and_item_is_not_further_nested() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1459,7 +1459,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_autoimport_inserts_after_last_use() {
+    async fn test_auto_import_inserts_after_last_use() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1490,7 +1490,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_does_not_autoimport_test_functions() {
+    async fn test_does_not_auto_import_test_functions() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1510,7 +1510,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_does_not_autoimport_private_functions() {
+    async fn test_does_not_auto_import_private_functions() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1529,7 +1529,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_autoimport_suggests_modules_too() {
+    async fn test_auto_import_suggests_modules_too() {
         let src = r#"
             mod foo {
                 mod barbaz {

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1380,4 +1380,82 @@ mod completion_tests {
             }])
         );
     }
+
+    #[test]
+    async fn test_autoimports_when_in_nested_module_and_item_is_further_nested() {
+        let src = r#"
+            mod foo {
+                mod bar {
+                    pub fn hello_world() {}
+                }
+
+                fn foo() {
+                    hel>|<
+                }
+            }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(item.label, "hello_world()");
+        assert_eq!(
+            item.label_details,
+            Some(CompletionItemLabelDetails {
+                detail: Some("(use bar::hello_world)".to_string()),
+                description: Some("fn()".to_string())
+            })
+        );
+
+        // assert_eq!(
+        //     item.additional_text_edits,
+        //     Some(vec![TextEdit {
+        //         range: Range {
+        //             start: Position { line: 0, character: 0 },
+        //             end: Position { line: 0, character: 0 },
+        //         },
+        //         new_text: "use foo::bar::hello_world;\n".to_string(),
+        //     }])
+        // );
+    }
+
+    #[test]
+    async fn test_autoimports_when_in_nested_module_and_item_is_not_further_nested() {
+        let src = r#"
+            mod foo {
+                mod bar {
+                    pub fn hello_world() {}
+                }
+
+                mod baz {
+                    fn foo() {
+                        hel>|<
+                    }
+                }
+            }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(item.label, "hello_world()");
+        assert_eq!(
+            item.label_details,
+            Some(CompletionItemLabelDetails {
+                detail: Some("(use crate::foo::bar::hello_world)".to_string()),
+                description: Some("fn()".to_string())
+            })
+        );
+
+        // assert_eq!(
+        //     item.additional_text_edits,
+        //     Some(vec![TextEdit {
+        //         range: Range {
+        //             start: Position { line: 0, character: 0 },
+        //             end: Position { line: 0, character: 0 },
+        //         },
+        //         new_text: "use foo::bar::hello_world;\n".to_string(),
+        //     }])
+        // );
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1508,4 +1508,23 @@ mod completion_tests {
         let items = get_completions(src).await;
         assert!(items.is_empty());
     }
+
+    #[test]
+    async fn test_does_not_autoimport_private_functions() {
+        let src = r#"
+            mod foo {
+                mod bar {
+                    fn hello_world() {}
+                }
+            }
+
+            use foo::bar;
+
+            fn main() {
+                hel>|<
+            }
+        "#;
+        let items = get_completions(src).await;
+        assert!(items.is_empty());
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -10,7 +10,7 @@ mod completion_tests {
                     field_completion_item, module_completion_item, simple_completion_item,
                     snippet_completion_item,
                 },
-                sort_text::self_mismatch_sort_text,
+                sort_text::{auto_import_sort_text, self_mismatch_sort_text},
             },
             on_completion_request,
         },
@@ -1335,7 +1335,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_auto_imports_x() {
+    async fn test_auto_imports() {
         let src = r#"
             mod foo {
                 mod bar {
@@ -1378,6 +1378,8 @@ mod completion_tests {
                 new_text: "use foo::bar::hello_world;\n".to_string(),
             }])
         );
+
+        assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

Part of https://github.com/noir-lang/noir/issues/1577

## Summary

I said I wasn't going to send any more LSP features, but I had this one in the back of my head since I started working on autocompletion. I had the idea of how to do it in my head, but I wanted to first work on the easier stuff (regular autocompletion). It turns out auto-import wasn't that hard to implement after all!

![lsp-autoimport](https://github.com/user-attachments/assets/9d2268fb-5caf-4b42-9bb3-b01f6ca40a9b)

![lsp-autoimport-nested](https://github.com/user-attachments/assets/ac4cd18a-d87d-4311-82d0-61f6d5a8dd19)

## Additional Context

In this PR every new imported item is added as a full path. Ideally, like in Rust Analyzer, we'd group common use prefixes, add to existing ones, etc. We can do that! But maybe it could be part of a follow-up PR, or maybe we could do it much later. Or maybe `nargo fmt` could handle this, so the auto-import doesn't do it, but once you save the file it's done. That's why I didn't spend time on that in this PR.

There's another thing I noticed while working on this PR: Rust Analyzer will offer matches that match **any** part of the name, not just the beginning. So, in Noir, if you type `merkle` it should probably offer `compute_merkle_root` as an auto-import completion, which is nice because maybe you are looking for stuff related to "merkle" but don't know the full name... but I didn't want to introduce that change in this PR (it also works for every other autocompletion). But, as always, this could be done later on.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
