### PR TITLE
fix: Allow comptime code to use break without also being `unconstrained`

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1458,9 +1458,12 @@ impl<'context> Elaborator<'context> {
     /// True if we're currently within a constrained function.
     /// Defaults to `true` if the current function is unknown.
     fn in_constrained_function(&self) -> bool {
-        self.current_item.map_or(true, |id| match id {
-            DependencyId::Function(id) => !self.interner.function_modifiers(&id).is_unconstrained,
-            _ => true,
-        })
+        !self.in_comptime_context()
+            && self.current_item.map_or(true, |id| match id {
+                DependencyId::Function(id) => {
+                    !self.interner.function_modifiers(&id).is_unconstrained
+                }
+                _ => true,
+            })
     }
 }

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -45,7 +45,7 @@ pub comptime fn derive(s: StructDefinition, traits: [TraitDefinition]) -> Quoted
     result
 }
 
-unconstrained pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
+pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
     HANDLERS.insert(t, f);
 }
 

--- a/test_programs/compile_success_empty/macros_in_comptime/src/main.nr
+++ b/test_programs/compile_success_empty/macros_in_comptime/src/main.nr
@@ -13,7 +13,7 @@ fn main() {
 
 // Call a different function from the interpreter, then have the
 // elaborator switch to the middle of foo from its previous scope in main
-unconstrained comptime fn foo<let N: Field>(x: Field) {
+comptime fn foo<let N: Field>(x: Field) {
     assert(modulus_num_bits() != 0);
 
     let cond = quote { modulus_num_bits() != 0 };


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Allows `comptime` code to use `break` and `continue` without also marking the functions `unconstrained`. This is more important with the `unsafe { }` change since we don't want to have to wrap comptime code in unsafe blocks, nor do we want to mark unconstrained functions used in a comptime block as requiring `unsafe { }`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
