### PR TITLE
feat(ci): Brillig opcode report workflow 

### DIFF
--- a/.github/workflows/gates_report_brillig.yml
+++ b/.github/workflows/gates_report_brillig.yml
@@ -68,12 +68,13 @@ jobs:
       - name: Generate Brillig opcodes report
         working-directory: ./test_programs
         run: |
+          chmod +x gates_report_brillig.sh
           ./gates_report_brillig.sh
           mv gates_report_brillig.json ../gates_report_brillig.json
 
       - name: Compare Brillig opcode reports
         id: gates_diff
-        uses: noir-lang/noir-gates-diff@6523ebb2b1eda8efef9cfc2fefada821ead948b7
+        uses: noir-lang/noir-gates-diff@93e4cae1229d669de61f0ac76d32e47cefe4adcc
         with:
           report: gates_report_brillig.json
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)

--- a/.github/workflows/gates_report_brillig.yml
+++ b/.github/workflows/gates_report_brillig.yml
@@ -74,11 +74,11 @@ jobs:
 
       - name: Compare Brillig bytecode size reports
         id: brillig_bytecode_diff
-        uses: noir-lang/noir-gates-diff@93e4cae1229d669de61f0ac76d32e47cefe4adcc
+        uses: noir-lang/noir-gates-diff@cd8721ebe0ad9a67889c601063cccc33a8ca7f32
         with:
           report: gates_report_brillig.json
           header: |
-            # Changes to Brillig byte code sizes
+            # Changes to Brillig bytecode sizes
           summaryQuantile: 0.9 # only display the 10% most significant bytecode size diffs in the summary (defaults to 20%)
 
       - name: Add bytecode size diff to sticky comment

--- a/.github/workflows/gates_report_brillig.yml
+++ b/.github/workflows/gates_report_brillig.yml
@@ -1,4 +1,4 @@
-name: Report Brillig opcodes diff
+name: Report Brillig bytecode size diff
 
 on:
   push:
@@ -42,7 +42,7 @@ jobs:
           path: ./dist/*
           retention-days: 3
 
-  compare_brillig_opcode_reports:
+  compare_brillig_bytecode_size_reports:
     needs: [build-nargo]
     runs-on: ubuntu-latest
     permissions:
@@ -65,26 +65,26 @@ jobs:
           export PATH="$PATH:$(dirname $nargo_binary)"
           nargo -V
 
-      - name: Generate Brillig opcodes report
+      - name: Generate Brillig bytecode size report
         working-directory: ./test_programs
         run: |
           chmod +x gates_report_brillig.sh
           ./gates_report_brillig.sh
           mv gates_report_brillig.json ../gates_report_brillig.json
 
-      - name: Compare Brillig opcode reports
-        id: gates_diff
+      - name: Compare Brillig bytecode size reports
+        id: brillig_bytecode_diff
         uses: noir-lang/noir-gates-diff@93e4cae1229d669de61f0ac76d32e47cefe4adcc
         with:
           report: gates_report_brillig.json
           header: |
             # Changes to Brillig byte code sizes
-          summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)
+          summaryQuantile: 0.9 # only display the 10% most significant bytecode size diffs in the summary (defaults to 20%)
 
-      - name: Add gates diff to sticky comment
+      - name: Add bytecode size diff to sticky comment
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          # delete the comment in case changes no longer impact circuit sizes
-          delete: ${{ !steps.gates_diff.outputs.markdown }}
-          message: ${{ steps.gates_diff.outputs.markdown }}
+          # delete the comment in case changes no longer impact brillig bytecode sizes
+          delete: ${{ !steps.brillig_bytecode_diff.outputs.markdown }}
+          message: ${{ steps.brillig_bytecode_diff.outputs.markdown }}

--- a/.github/workflows/gates_report_brillig.yml
+++ b/.github/workflows/gates_report_brillig.yml
@@ -77,6 +77,8 @@ jobs:
         uses: noir-lang/noir-gates-diff@93e4cae1229d669de61f0ac76d32e47cefe4adcc
         with:
           report: gates_report_brillig.json
+          header: |
+            # Changes to Brillig byte code sizes
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)
 
       - name: Add gates diff to sticky comment

--- a/.github/workflows/gates_report_brillig.yml
+++ b/.github/workflows/gates_report_brillig.yml
@@ -1,4 +1,4 @@
-name: Report gates diff
+name: Report Brillig opcodes diff
 
 on:
   push:
@@ -42,8 +42,7 @@ jobs:
           path: ./dist/*
           retention-days: 3
 
-
-  compare_gates_reports:
+  compare_brillig_opcode_reports:
     needs: [build-nargo]
     runs-on: ubuntu-latest
     permissions:
@@ -51,11 +50,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install `bb`
-        run: |
-          ./scripts/install_bb.sh
-          echo "$HOME/.bb/" >> $GITHUB_PATH
 
       - name: Download nargo binary
         uses: actions/download-artifact@v4
@@ -71,18 +65,17 @@ jobs:
           export PATH="$PATH:$(dirname $nargo_binary)"
           nargo -V
 
-      - name: Generate gates report
+      - name: Generate Brillig opcodes report
         working-directory: ./test_programs
         run: |
-          ./rebuild.sh
-          ./gates_report.sh
-          mv gates_report.json ../gates_report.json
-      
-      - name: Compare gates reports
+          ./gates_report_brillig.sh
+          mv gates_report_brillig.json ../gates_report_brillig.json
+
+      - name: Compare Brillig opcode reports
         id: gates_diff
-        uses: noir-lang/noir-gates-diff@1931aaaa848a1a009363d6115293f7b7fc72bb87
+        uses: noir-lang/noir-gates-diff@6523ebb2b1eda8efef9cfc2fefada821ead948b7
         with:
-          report: gates_report.json
+          report: gates_report_brillig.json
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)
 
       - name: Add gates diff to sticky comment

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ tooling/noir_js/lib
 !compiler/wasm/noir-script/target
 
 gates_report.json
+gates_report_brillig.json
 
 # Github Actions scratch space
 # This gives a location to download artifacts into the repository in CI without making git dirty.

--- a/test_programs/gates_report_brillig.sh
+++ b/test_programs/gates_report_brillig.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+# These tests are incompatible with gas reporting
+excluded_dirs=("workspace" "workspace_default_member" "double_verify_nested_proof" "overlapping_dep_and_mod" "comptime_println")
+
+current_dir=$(pwd)
+base_path="$current_dir/execution_success"
+test_dirs=$(ls $base_path)
+
+# We generate a Noir workspace which contains all of the test cases
+# This allows us to generate a gates report using `nargo info` for all of them at once.
+
+echo "[workspace]" > Nargo.toml
+echo "members = [" >> Nargo.toml
+
+for dir in $test_dirs; do
+    if [[ " ${excluded_dirs[@]} " =~ " ${dir} " ]]; then
+      continue
+    fi
+
+    if [[ ${CI-false} = "true" ]] && [[ " ${ci_excluded_dirs[@]} " =~ " ${dir} " ]]; then
+      continue
+    fi
+
+    echo "  \"execution_success/$dir\"," >> Nargo.toml
+done
+
+echo "]" >> Nargo.toml
+
+nargo info --force-brillig --json > gates_report_brillig.json
+
+rm Nargo.toml

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -207,7 +207,7 @@ fn generate_compile_success_empty_tests(test_file: &mut File, test_data_dir: &Pa
         let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {{
             panic!("JSON was not well-formatted {:?}\n\n{:?}", e, std::str::from_utf8(&output.stdout))
         }});
-        let num_opcodes = &json["programs"][0]["functions"][0]["acir_opcodes"];
+        let num_opcodes = &json["programs"][0]["functions"][0]["opcodes"];
         assert_eq!(num_opcodes.as_u64().expect("number of opcodes should fit in a u64"), 0);
         "#;
 

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -175,6 +175,7 @@ struct ProgramInfo {
     #[serde(skip)]
     expression_width: ExpressionWidth,
     functions: Vec<FunctionInfo>,
+    #[serde(skip)]
     unconstrained_functions_opcodes: usize,
     unconstrained_functions: Vec<FunctionInfo>,
 }
@@ -186,7 +187,7 @@ impl From<ProgramInfo> for Vec<Row> {
                 Fm->format!("{}", program_info.package_name),
                 Fc->format!("{}", function.name),
                 format!("{:?}", program_info.expression_width),
-                Fc->format!("{}", function.acir_opcodes),
+                Fc->format!("{}", function.opcodes),
                 Fc->format!("{}", program_info.unconstrained_functions_opcodes),
             ]
         });
@@ -196,7 +197,7 @@ impl From<ProgramInfo> for Vec<Row> {
                 Fc->format!("{}", function.name),
                 format!("N/A", ),
                 Fc->format!("N/A"),
-                Fc->format!("{}", function.acir_opcodes),
+                Fc->format!("{}", function.opcodes),
             ]
         }));
         main
@@ -215,7 +216,7 @@ struct ContractInfo {
 #[derive(Debug, Serialize)]
 struct FunctionInfo {
     name: String,
-    acir_opcodes: usize,
+    opcodes: usize,
 }
 
 impl From<ContractInfo> for Vec<Row> {
@@ -225,7 +226,7 @@ impl From<ContractInfo> for Vec<Row> {
                 Fm->format!("{}", contract_info.name),
                 Fc->format!("{}", function.name),
                 format!("{:?}", contract_info.expression_width),
-                Fc->format!("{}", function.acir_opcodes),
+                Fc->format!("{}", function.opcodes),
             ]
         })
     }
@@ -243,7 +244,7 @@ fn count_opcodes_and_gates_in_program(
         .enumerate()
         .map(|(i, function)| FunctionInfo {
             name: compiled_program.names[i].clone(),
-            acir_opcodes: function.opcodes.len(),
+            opcodes: function.opcodes.len(),
         })
         .collect();
 
@@ -264,7 +265,7 @@ fn count_opcodes_and_gates_in_program(
         .clone()
         .iter()
         .zip(opcodes_len)
-        .map(|(name, len)| FunctionInfo { name: name.clone(), acir_opcodes: len })
+        .map(|(name, len)| FunctionInfo { name: name.clone(), opcodes: len })
         .collect();
 
     ProgramInfo {


### PR DESCRIPTION
# Description

## Problem\*

Related to https://github.com/noir-lang/noir/issues/5101. Just that this is not a benchmark for execution speed and instead byte code size. This will be useful as we look to make more optimizations in the SSA to reduce the byte code size of unconstrained Noir code.

## Summary\*

Similar to the "Report gates diff" we now have a "Report Brillig opcodes diff" action. This will compile all of the tests under `execution_success` with `--force-brillig`. The report produced by `gates_report_brillig.sh` will be sent to a noir-gates-diff action that has been updated to handled the "unconstrained_functions" field of an `InfoReport` produced by `nargo info`. 

## Additional Context

The relevant noir-gates-diff updates can be found here: https://github.com/noir-lang/noir-gates-diff/pull/5.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
