### PR TITLE
feat: user `super::` in LSP autocompletion if possible

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1226,13 +1226,13 @@ mod completion_name_matches_tests {
 
     #[test]
     fn test_name_matches() {
-        // assert!(name_matches("foo", "foo"));
-        // assert!(name_matches("foo_bar", "bar"));
-        // assert!(name_matches("FooBar", "foo"));
-        // assert!(name_matches("FooBar", "bar"));
-        // assert!(name_matches("FooBar", "foo_bar"));
+        assert!(name_matches("foo", "foo"));
+        assert!(name_matches("foo_bar", "bar"));
+        assert!(name_matches("FooBar", "foo"));
+        assert!(name_matches("FooBar", "bar"));
+        assert!(name_matches("FooBar", "foo_bar"));
         assert!(name_matches("bar_baz", "bar_b"));
 
-        // assert!(!name_matches("foo_bar", "o_b"));
+        assert!(!name_matches("foo_bar", "o_b"));
     }
 }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1185,18 +1185,14 @@ fn name_matches(name: &str, prefix: &str) -> bool {
 
     let mut last_index: i32 = -1;
     for prefix_part in prefix.split('_') {
-        if let Some(mut name_part_index) = name_parts
-            .iter()
-            .skip(
-                // Look past parts we already matched
-                if last_index >= 0 { last_index as usize + 1 } else { 0 },
-            )
-            .position(|name_part| name_part.starts_with(prefix_part))
+        // Look past parts we already matched
+        let offset = if last_index >= 0 { last_index as usize + 1 } else { 0 };
+
+        if let Some(mut name_part_index) =
+            name_parts.iter().skip(offset).position(|name_part| name_part.starts_with(prefix_part))
         {
-            if last_index >= 0 {
-                // Need to adjust the index if we skipped some segments
-                name_part_index += last_index as usize + 1;
-            }
+            // Need to adjust the index if we skipped some segments
+            name_part_index += offset;
 
             if last_index >= name_part_index as i32 {
                 return false;

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1185,9 +1185,19 @@ fn name_matches(name: &str, prefix: &str) -> bool {
 
     let mut last_index: i32 = -1;
     for prefix_part in prefix.split('_') {
-        if let Some(name_part_index) =
-            name_parts.iter().position(|name_part| name_part.starts_with(prefix_part))
+        if let Some(mut name_part_index) = name_parts
+            .iter()
+            .skip(
+                // Look past parts we already matched
+                if last_index >= 0 { last_index as usize + 1 } else { 0 },
+            )
+            .position(|name_part| name_part.starts_with(prefix_part))
         {
+            if last_index >= 0 {
+                // Need to adjust the index if we skipped some segments
+                name_part_index += last_index as usize + 1;
+            }
+
             if last_index >= name_part_index as i32 {
                 return false;
             }
@@ -1220,12 +1230,13 @@ mod completion_name_matches_tests {
 
     #[test]
     fn test_name_matches() {
-        assert!(name_matches("foo", "foo"));
-        assert!(name_matches("foo_bar", "bar"));
-        assert!(name_matches("FooBar", "foo"));
-        assert!(name_matches("FooBar", "bar"));
-        assert!(name_matches("FooBar", "foo_bar"));
+        // assert!(name_matches("foo", "foo"));
+        // assert!(name_matches("foo_bar", "bar"));
+        // assert!(name_matches("FooBar", "foo"));
+        // assert!(name_matches("FooBar", "bar"));
+        // assert!(name_matches("FooBar", "foo_bar"));
+        assert!(name_matches("bar_baz", "bar_b"));
 
-        assert!(!name_matches("foo_bar", "o_b"));
+        // assert!(!name_matches("foo_bar", "o_b"));
     }
 }

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -1,8 +1,10 @@
+use std::collections::BTreeMap;
+
 use lsp_types::{Position, Range, TextEdit};
 use noirc_frontend::{
     ast::ItemVisibility,
     graph::{CrateId, Dependency},
-    hir::def_map::ModuleId,
+    hir::def_map::{CrateDefMap, ModuleId},
     macros_api::{ModuleDefId, NodeInterner},
     node_interner::ReferenceId,
 };
@@ -16,6 +18,8 @@ use super::{
 
 impl<'a> NodeFinder<'a> {
     pub(super) fn complete_auto_imports(&mut self, prefix: &str, requested_items: RequestedItems) {
+        let current_module_parent_id = get_parent_module_id(&self.def_maps, self.module_id);
+
         for (name, entries) in self.interner.get_auto_import_names() {
             if !name_matches(name, prefix) {
                 continue;
@@ -39,13 +43,15 @@ impl<'a> NodeFinder<'a> {
                 let module_full_path;
                 if let ModuleDefId::ModuleId(module_id) = module_def_id {
                     module_full_path = module_id_path(
-                        module_id,
+                        *module_id,
                         &self.module_id,
+                        current_module_parent_id,
                         self.interner,
                         self.dependencies,
                     );
                 } else {
-                    let Some(parent_module) = get_parent_module(self.interner, *module_def_id)
+                    let Some(parent_module) =
+                        get_parent_module(self.interner, self.def_maps, *module_def_id)
                     else {
                         continue;
                     };
@@ -67,6 +73,7 @@ impl<'a> NodeFinder<'a> {
                     module_full_path = module_id_path(
                         parent_module,
                         &self.module_id,
+                        current_module_parent_id,
                         self.interner,
                         self.dependencies,
                     );
@@ -111,9 +118,30 @@ impl<'a> NodeFinder<'a> {
     }
 }
 
-fn get_parent_module(interner: &NodeInterner, module_def_id: ModuleDefId) -> Option<&ModuleId> {
-    let reference_id = module_def_id_to_reference_id(module_def_id);
-    interner.reference_module(reference_id)
+fn get_parent_module(
+    interner: &NodeInterner,
+    def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    module_def_id: ModuleDefId,
+) -> Option<ModuleId> {
+    if let ModuleDefId::ModuleId(module_id) = module_def_id {
+        get_parent_module_id(def_maps, module_id)
+    } else {
+        let reference_id = module_def_id_to_reference_id(module_def_id);
+        interner.reference_module(reference_id).map(|id| *id)
+    }
+}
+
+fn get_parent_module_id(
+    def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    module_id: ModuleId,
+) -> Option<ModuleId> {
+    let crate_def_map = &def_maps[&module_id.krate];
+    let module_data = &crate_def_map.modules()[module_id.local_id.0];
+    if let Some(parent) = module_data.parent {
+        Some(ModuleId { krate: module_id.krate, local_id: parent })
+    } else {
+        None
+    }
 }
 
 fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> ReferenceId {
@@ -130,8 +158,9 @@ fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> ReferenceId {
 /// Computes the path of `module_id` relative to `current_module_id`.
 /// If it's not relative, the full path is returned.
 fn module_id_path(
-    module_id: &ModuleId,
+    module_id: ModuleId,
     current_module_id: &ModuleId,
+    current_module_parent_id: Option<ModuleId>,
     interner: &NodeInterner,
     dependencies: &[Dependency],
 ) -> String {
@@ -139,7 +168,14 @@ fn module_id_path(
 
     let crate_id = module_id.krate;
     let crate_name = match crate_id {
-        CrateId::Root(_) => Some("crate".to_string()),
+        CrateId::Root(_) => {
+            if Some(module_id) == current_module_parent_id {
+                Some("super".to_string())
+            } else {
+                Some("crate".to_string())
+            }
+        }
+
         CrateId::Crate(_) => dependencies
             .iter()
             .find(|dep| dep.crate_id == crate_id)
@@ -155,7 +191,7 @@ fn module_id_path(
         false
     };
 
-    let Some(module_attributes) = interner.try_module_attributes(module_id) else {
+    let Some(module_attributes) = interner.try_module_attributes(&module_id) else {
         return string;
     };
 
@@ -173,6 +209,12 @@ fn module_id_path(
         if current_module_id == parent_module_id {
             // When the path is relative we don't want the "crate::" prefix anymore
             string = string.strip_prefix("crate::").unwrap_or(&string).to_string();
+            break;
+        }
+
+        if current_module_parent_id == Some(*parent_module_id) {
+            string = string.strip_prefix("crate::").unwrap_or(&string).to_string();
+            string.insert_str(0, "super::");
             break;
         }
 

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -18,7 +18,7 @@ use super::{
 
 impl<'a> NodeFinder<'a> {
     pub(super) fn complete_auto_imports(&mut self, prefix: &str, requested_items: RequestedItems) {
-        let current_module_parent_id = get_parent_module_id(&self.def_maps, self.module_id);
+        let current_module_parent_id = get_parent_module_id(self.def_maps, self.module_id);
 
         for (name, entries) in self.interner.get_auto_import_names() {
             if !name_matches(name, prefix) {
@@ -127,7 +127,7 @@ fn get_parent_module(
         get_parent_module_id(def_maps, module_id)
     } else {
         let reference_id = module_def_id_to_reference_id(module_def_id);
-        interner.reference_module(reference_id).map(|id| *id)
+        interner.reference_module(reference_id).copied()
     }
 }
 
@@ -137,11 +137,7 @@ fn get_parent_module_id(
 ) -> Option<ModuleId> {
     let crate_def_map = &def_maps[&module_id.krate];
     let module_data = &crate_def_map.modules()[module_id.local_id.0];
-    if let Some(parent) = module_data.parent {
-        Some(ModuleId { krate: module_id.krate, local_id: parent })
-    } else {
-        None
-    }
+    module_data.parent.map(|parent| ModuleId { krate: module_id.krate, local_id: parent })
 }
 
 fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> ReferenceId {

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -197,7 +197,7 @@ fn module_id_path(
                 .iter()
                 .find(|dep| dep.crate_id == crate_id)
                 .map(|dep| format!("{}", dep.name)),
-            CrateId::Dummy => None,
+            CrateId::Dummy => unreachable!("ICE: A dummy CrateId should not be accessible"),
         }
     };
 

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -142,10 +142,10 @@ fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> ReferenceId {
     }
 }
 
-/// Returns the path to reach an item inside `module_id` from inside `current_module_id`.
+/// Returns the path to reach an item inside `target_module_id` from inside `current_module_id`.
 /// Returns a relative path if possible.
 fn module_id_path(
-    module_id: ModuleId,
+    target_module_id: ModuleId,
     current_module_id: &ModuleId,
     current_module_parent_id: Option<ModuleId>,
     interner: &NodeInterner,
@@ -154,13 +154,13 @@ fn module_id_path(
     let mut segments: Vec<&str> = Vec::new();
     let mut is_relative = false;
 
-    if let Some(module_attributes) = interner.try_module_attributes(&module_id) {
+    if let Some(module_attributes) = interner.try_module_attributes(&target_module_id) {
         segments.push(&module_attributes.name);
 
         let mut current_attributes = module_attributes;
         loop {
             let parent_module_id =
-                &ModuleId { krate: module_id.krate, local_id: current_attributes.parent };
+                &ModuleId { krate: target_module_id.krate, local_id: current_attributes.parent };
 
             if current_module_id == parent_module_id {
                 is_relative = true;
@@ -182,13 +182,13 @@ fn module_id_path(
         }
     }
 
-    let crate_id = module_id.krate;
+    let crate_id = target_module_id.krate;
     let crate_name = if is_relative {
         None
     } else {
         match crate_id {
             CrateId::Root(_) => {
-                if Some(module_id) == current_module_parent_id {
+                if Some(target_module_id) == current_module_parent_id {
                     // This can happen if the item to import is inside the parent module
                     Some("super".to_string())
                 } else {

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -151,6 +151,10 @@ fn module_id_path(
     interner: &NodeInterner,
     dependencies: &[Dependency],
 ) -> String {
+    if Some(target_module_id) == current_module_parent_id {
+        return "super".to_string();
+    }
+
     let mut segments: Vec<&str> = Vec::new();
     let mut is_relative = false;
 
@@ -187,20 +191,12 @@ fn module_id_path(
         None
     } else {
         match crate_id {
-            CrateId::Root(_) => {
-                if Some(target_module_id) == current_module_parent_id {
-                    // This can happen if the item to import is inside the parent module
-                    Some("super".to_string())
-                } else {
-                    Some("crate".to_string())
-                }
-            }
-
+            CrateId::Root(_) => Some("crate".to_string()),
+            CrateId::Stdlib(_) => Some("std".to_string()),
             CrateId::Crate(_) => dependencies
                 .iter()
                 .find(|dep| dep.crate_id == crate_id)
                 .map(|dep| format!("{}", dep.name)),
-            CrateId::Stdlib(_) => Some("std".to_string()),
             CrateId::Dummy => None,
         }
     };

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -124,6 +124,8 @@ fn get_parent_module(
     module_def_id: ModuleDefId,
 ) -> Option<ModuleId> {
     if let ModuleDefId::ModuleId(module_id) = module_def_id {
+        // ModuleDefId::ModuelId isn't tracked in interner's reference modules,
+        // so we find the parent in def maps.
         get_parent_module_id(def_maps, module_id)
     } else {
         let reference_id = module_def_id_to_reference_id(module_def_id);

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -50,8 +50,7 @@ impl<'a> NodeFinder<'a> {
                         self.dependencies,
                     );
                 } else {
-                    let Some(parent_module) =
-                        get_parent_module(self.interner, self.def_maps, *module_def_id)
+                    let Some(parent_module) = get_parent_module(self.interner, *module_def_id)
                     else {
                         continue;
                     };
@@ -118,19 +117,9 @@ impl<'a> NodeFinder<'a> {
     }
 }
 
-fn get_parent_module(
-    interner: &NodeInterner,
-    def_maps: &BTreeMap<CrateId, CrateDefMap>,
-    module_def_id: ModuleDefId,
-) -> Option<ModuleId> {
-    if let ModuleDefId::ModuleId(module_id) = module_def_id {
-        // ModuleDefId::ModuelId isn't tracked in interner's reference modules,
-        // so we find the parent in def maps.
-        get_parent_module_id(def_maps, module_id)
-    } else {
-        let reference_id = module_def_id_to_reference_id(module_def_id);
-        interner.reference_module(reference_id).copied()
-    }
+fn get_parent_module(interner: &NodeInterner, module_def_id: ModuleDefId) -> Option<ModuleId> {
+    let reference_id = module_def_id_to_reference_id(module_def_id);
+    interner.reference_module(reference_id).copied()
 }
 
 fn get_parent_module_id(

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -196,7 +196,7 @@ fn module_id_path(
             CrateId::Crate(_) => dependencies
                 .iter()
                 .find(|dep| dep.crate_id == crate_id)
-                .map(|dep| format!("{}", dep.name)),
+                .map(|dep| dep.name.to_string()),
             CrateId::Dummy => unreachable!("ICE: A dummy CrateId should not be accessible"),
         }
     };

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -153,8 +153,8 @@ fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> ReferenceId {
     }
 }
 
-/// Computes the path of `module_id` relative to `current_module_id`.
-/// If it's not relative, the full path is returned.
+/// Returns the path to reach an item inside `module_id` from inside `current_module_id`.
+/// Returns a relative path if possible.
 fn module_id_path(
     module_id: ModuleId,
     current_module_id: &ModuleId,
@@ -200,6 +200,7 @@ fn module_id_path(
         match crate_id {
             CrateId::Root(_) => {
                 if Some(module_id) == current_module_parent_id {
+                    // This can happen if the item to import is inside the parent module
                     Some("super".to_string())
                 } else {
                     Some("crate".to_string())

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1443,7 +1443,7 @@ mod completion_tests {
         assert_eq!(
             item.label_details,
             Some(CompletionItemLabelDetails {
-                detail: Some("(use crate::foo::bar::hello_world)".to_string()),
+                detail: Some("(use super::bar::hello_world)".to_string()),
                 description: Some("fn()".to_string())
             })
         );
@@ -1455,7 +1455,7 @@ mod completion_tests {
                     start: Position { line: 7, character: 8 },
                     end: Position { line: 7, character: 8 },
                 },
-                new_text: "use crate::foo::bar::hello_world;\n\n        ".to_string(),
+                new_text: "use super::bar::hello_world;\n\n        ".to_string(),
             }])
         );
     }
@@ -1553,6 +1553,31 @@ mod completion_tests {
             Some(CompletionItemLabelDetails {
                 detail: Some("(use foo::barbaz)".to_string()),
                 description: None
+            })
+        );
+    }
+
+    #[test]
+    async fn test_auto_import_with_super() {
+        let src = r#"
+            pub fn barbaz() {}
+
+            mod tests {
+                fn foo() {
+                    barb>|<
+                }
+            }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(item.label, "barbaz()");
+        assert_eq!(
+            item.label_details,
+            Some(CompletionItemLabelDetails {
+                detail: Some("(use super::barbaz)".to_string()),
+                description: Some("fn()".to_string())
             })
         );
     }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1577,11 +1577,11 @@ mod completion_tests {
     #[test]
     async fn test_auto_import_with_super() {
         let src = r#"
-            pub fn barbaz() {}
+            pub fn bar_baz() {}
 
             mod tests {
                 fn foo() {
-                    barb>|<
+                    bar_b>|<
                 }
             }
         "#;
@@ -1589,11 +1589,11 @@ mod completion_tests {
         assert_eq!(items.len(), 1);
 
         let item = &items[0];
-        assert_eq!(item.label, "barbaz()");
+        assert_eq!(item.label, "bar_baz()");
         assert_eq!(
             item.label_details,
             Some(CompletionItemLabelDetails {
-                detail: Some("(use super::barbaz)".to_string()),
+                detail: Some("(use super::bar_baz)".to_string()),
                 description: Some("fn()".to_string())
             })
         );

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -343,7 +343,7 @@ fn format_parent_module_from_module_id(
             .find(|dep| dep.crate_id == crate_id)
             .map(|dep| format!("{}", dep.name)),
         CrateId::Stdlib(_) => Some("std".to_string()),
-        CrateId::Dummy => None,
+        CrateId::Dummy => unreachable!("ICE: A dummy CrateId should not be accessible"),
     };
 
     if let Some(crate_name) = &crate_name {

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -319,6 +319,21 @@ fn format_parent_module_from_module_id(
     args: &ProcessRequestCallbackArgs,
     string: &mut String,
 ) -> bool {
+    let mut segments: Vec<&str> = Vec::new();
+
+    if let Some(module_attributes) = args.interner.try_module_attributes(module) {
+        segments.push(&module_attributes.name);
+
+        let mut current_attributes = module_attributes;
+        while let Some(parent_attributes) = args.interner.try_module_attributes(&ModuleId {
+            krate: module.krate,
+            local_id: current_attributes.parent,
+        }) {
+            segments.push(&parent_attributes.name);
+            current_attributes = parent_attributes;
+        }
+    }
+
     let crate_id = module.krate;
     let crate_name = match crate_id {
         CrateId::Root(_) => Some(args.crate_name.clone()),
@@ -331,41 +346,18 @@ fn format_parent_module_from_module_id(
         CrateId::Dummy => None,
     };
 
-    let wrote_crate = if let Some(crate_name) = crate_name {
-        string.push_str("    ");
-        string.push_str(&crate_name);
-        true
-    } else {
-        false
+    if let Some(crate_name) = &crate_name {
+        segments.push(crate_name);
     };
 
-    let Some(module_attributes) = args.interner.try_module_attributes(module) else {
-        return wrote_crate;
-    };
-
-    if wrote_crate {
-        string.push_str("::");
-    } else {
-        string.push_str("    ");
+    if segments.is_empty() {
+        return false;
     }
 
-    let mut segments = Vec::new();
-    let mut current_attributes = module_attributes;
-    while let Some(parent_attributes) = args.interner.try_module_attributes(&ModuleId {
-        krate: module.krate,
-        local_id: current_attributes.parent,
-    }) {
-        segments.push(&parent_attributes.name);
-        current_attributes = parent_attributes;
-    }
+    segments.reverse();
 
-    for segment in segments.iter().rev() {
-        string.push_str(segment);
-        string.push_str("::");
-    }
-
-    string.push_str(&module_attributes.name);
-
+    string.push_str("    ");
+    string.push_str(&segments.join("::"));
     true
 }
 


### PR DESCRIPTION
# Description

## Problem

Part of #1577

## Summary

We recently added `super::` to `use` so I thought it would be nice if the auto-importer used that if possible.

![lsp-use-super](https://github.com/user-attachments/assets/4f8cbf37-f844-4293-832e-bc9685295837)

## Additional Context

This PR also includes a small refactor in the hover code because the code to format a module path exists there too (but the two are different enough that I didn't reuse them).

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
