### PR TITLE
feat: fault-tolerant parsing of `fn` and `impl`

### DIFF
--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -28,6 +28,8 @@ pub enum ParserErrorReason {
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitName,
     #[error("expected <, where or {{ after impl name")]
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterImplName,
+    #[error("expected <, where or {{ after trait impl for type")]
+    ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitImplForType,
     #[error("Expected a ; separating these two statements")]
     MissingSeparatingSemi,
     #[error("constrain keyword is deprecated")]

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -26,8 +26,8 @@ pub enum ParserErrorReason {
     ExpectedLeftBraceAfterIfCondition,
     #[error("expected <, where or {{ after trait name")]
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitName,
-    #[error("expected <, where or {{ after impl name")]
-    ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterImplName,
+    #[error("expected <, where or {{ after impl typw")]
+    ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterImplType,
     #[error("expected <, where or {{ after trait impl for type")]
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitImplForType,
     #[error("Expected a ; separating these two statements")]

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -24,6 +24,8 @@ pub enum ParserErrorReason {
     ExpectedLeftBraceOrArrowAfterFunctionParameters,
     #[error("expected {{ after if condition")]
     ExpectedLeftBraceAfterIfCondition,
+    #[error("expected <, where or {{ after trait name")]
+    ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitName,
     #[error("Expected a ; separating these two statements")]
     MissingSeparatingSemi,
     #[error("constrain keyword is deprecated")]

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -26,7 +26,7 @@ pub enum ParserErrorReason {
     ExpectedLeftBraceAfterIfCondition,
     #[error("expected <, where or {{ after trait name")]
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitName,
-    #[error("expected <, where or {{ after impl typw")]
+    #[error("expected <, where or {{ after impl type")]
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterImplType,
     #[error("expected <, where or {{ after trait impl for type")]
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitImplForType,

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -26,6 +26,8 @@ pub enum ParserErrorReason {
     ExpectedLeftBraceAfterIfCondition,
     #[error("expected <, where or {{ after trait name")]
     ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitName,
+    #[error("expected <, where or {{ after impl name")]
+    ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterImplName,
     #[error("Expected a ; separating these two statements")]
     MissingSeparatingSemi,
     #[error("constrain keyword is deprecated")]

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -20,6 +20,8 @@ pub enum ParserErrorReason {
     ExpectedIdentifierAfterDot,
     #[error("expected an identifier after ::")]
     ExpectedIdentifierAfterColons,
+    #[error("expected {{ or -> after function parameters")]
+    ExpectedLeftBraceOrArrowAfterFunctionParameters,
     #[error("expected {{ after if condition")]
     ExpectedLeftBraceAfterIfCondition,
     #[error("Expected a ; separating these two statements")]

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -237,7 +237,7 @@ fn implementation() -> impl NoirParser<TopLevelStatement> {
                 methods
             } else {
                 emit(ParserError::with_reason(
-                    ParserErrorReason::ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterImplName,
+                    ParserErrorReason::ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterImplType,
                     span,
                 ));
                 vec![]
@@ -1781,7 +1781,7 @@ mod test {
 
         let (top_level_statement, errors) = parse_recover(implementation(), src);
         assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].message, "expected <, where or { after impl name");
+        assert_eq!(errors[0].message, "expected <, where or { after impl type");
 
         let top_level_statement = top_level_statement.unwrap();
         let TopLevelStatement::Impl(impl_) = top_level_statement else {

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -243,7 +243,6 @@ fn implementation() -> impl NoirParser<TopLevelStatement> {
         .map(|args| {
             let ((other_args, where_clause), methods) = args;
             let (generics, (object_type, type_span)) = other_args;
-
             TopLevelStatement::Impl(TypeImpl {
                 generics,
                 object_type,

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -6,7 +6,10 @@ use super::{
     self_parameter, where_clause, NoirParser,
 };
 use crate::token::{Keyword, Token, TokenKind};
-use crate::{ast::IntegerBitSize, parser::spanned};
+use crate::{
+    ast::{BlockExpression, IntegerBitSize},
+    parser::spanned,
+};
 use crate::{
     ast::{
         FunctionDefinition, FunctionReturnType, ItemVisibility, NoirFunction, Param, Visibility,
@@ -20,6 +23,7 @@ use crate::{
 };
 
 use chumsky::prelude::*;
+use noirc_errors::Span;
 
 /// function_definition: attribute function_modifiers 'fn' ident generics '(' function_parameters ')' function_return_type block
 ///                      function_modifiers 'fn' ident generics '(' function_parameters ')' function_return_type block
@@ -32,12 +36,23 @@ pub(super) fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunct
         .then(parenthesized(function_parameters(allow_self)))
         .then(function_return_type())
         .then(where_clause())
-        .then(spanned(block(fresh_statement())))
+        .then(spanned(block(fresh_statement()).or_not()))
         .validate(|(((args, ret), where_clause), (body, body_span)), span, emit| {
             let ((((attributes, modifiers), name), generics), parameters) = args;
 
             // Validate collected attributes, filtering them into function and secondary variants
             let attributes = validate_attributes(attributes, span, emit);
+
+            let (body, body_span) = if let Some(body) = body {
+                (body, body_span)
+            } else {
+                emit(ParserError::with_reason(
+                    ParserErrorReason::ExpectedLeftBraceOrArrowAfterFunctionParameters,
+                    span,
+                ));
+                (BlockExpression { statements: vec![] }, Span::from(span.end()..span.end()))
+            };
+
             FunctionDefinition {
                 span: body_span,
                 name,
@@ -267,5 +282,19 @@ mod test {
                 "fn func_name<let N: u64>(x: [Field; N]) {}",
             ],
         );
+    }
+
+    #[test]
+    fn parse_recover_function_without_body() {
+        let src = "fn foo(x: i32)";
+
+        let (noir_function, errors) = parse_recover(function_definition(false), src);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].message, "expected { or -> after function parameters");
+
+        let noir_function = noir_function.unwrap();
+        assert_eq!(noir_function.name(), "foo");
+        assert_eq!(noir_function.parameters().len(), 1);
+        assert!(noir_function.def.body.statements.is_empty());
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -55,7 +55,6 @@ pub(super) fn function_definition(allow_self: bool) -> impl NoirParser<NoirFunct
 
             // Validate collected attributes, filtering them into function and secondary variants
             let attributes = validate_attributes(attributes, span, emit);
-
             FunctionDefinition {
                 span: body_span,
                 name,

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -128,23 +128,23 @@ fn trait_type_declaration() -> impl NoirParser<TraitItem> {
 ///
 /// trait_implementation: 'impl' generics ident generic_args for type '{' trait_implementation_body '}'
 pub(super) fn trait_implementation() -> impl NoirParser<TopLevelStatement> {
-    let body_or_error = 
-    just(Token::LeftBrace)
-                .ignore_then(trait_implementation_body())
-                .then_ignore(just(Token::RightBrace))
-                .or_not()
-                .validate(|items, span, emit| {
-                    if let Some(items) = items {
-                        items
-                    } else {
-                        emit(ParserError::with_reason(
-                            ParserErrorReason::ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitImplForType,
-                            span,
-                        ));
-        
-                        vec![]
-                    }
-                });
+    let body_or_error =
+        just(Token::LeftBrace)
+            .ignore_then(trait_implementation_body())
+            .then_ignore(just(Token::RightBrace))
+            .or_not()
+            .validate(|items, span, emit| {
+                if let Some(items) = items {
+                    items
+                } else {
+                    emit(ParserError::with_reason(
+                        ParserErrorReason::ExpectedLeftBracketOrWhereOrLeftBraceOrArrowAfterTraitImplForType,
+                        span,
+                    ));
+
+                    vec![]
+                }
+            });
 
     keyword(Keyword::Impl)
         .ignore_then(function::generics())

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -47,7 +47,6 @@ pub(super) fn trait_definition() -> impl NoirParser<TopLevelStatement> {
         .then(trait_body_or_error)
         .validate(|((((attributes, name), generics), where_clause), items), span, emit| {
             let attributes = validate_secondary_attributes(attributes, span, emit);
-
             TopLevelStatement::Trait(NoirTrait {
                 name,
                 generics,
@@ -158,7 +157,6 @@ pub(super) fn trait_implementation() -> impl NoirParser<TopLevelStatement> {
         .map(|args| {
             let (((other_args, object_type), where_clause), items) = args;
             let ((impl_generics, trait_name), trait_generics) = other_args;
-
             TopLevelStatement::TraitImpl(NoirTraitImpl {
                 impl_generics,
                 trait_name,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -251,6 +251,9 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn find_in_noir_trait_impl(&mut self, noir_trait_impl: &NoirTraitImpl) {
+        self.find_in_path(&noir_trait_impl.trait_name, RequestedItems::OnlyTypes);
+        self.find_in_unresolved_type(&noir_trait_impl.object_type);
+
         self.type_parameters.clear();
         self.collect_type_parameters_in_generics(&noir_trait_impl.impl_generics);
 
@@ -262,6 +265,8 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn find_in_type_impl(&mut self, type_impl: &TypeImpl) {
+        self.find_in_unresolved_type(&type_impl.object_type);
+
         self.type_parameters.clear();
         self.collect_type_parameters_in_generics(&type_impl.generics);
 

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1556,4 +1556,44 @@ mod completion_tests {
             })
         );
     }
+
+    #[test]
+    async fn test_completes_in_impl_type() {
+        let src = r#"
+            struct FooBar {
+            }
+
+            impl FooB>|<
+        "#;
+
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "FooBar",
+                CompletionItemKind::STRUCT,
+                Some("FooBar".to_string()),
+            )],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_completes_in_impl_for_type() {
+        let src = r#"
+            struct FooBar {
+            }
+
+            impl Default for FooB>|<
+        "#;
+
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "FooBar",
+                CompletionItemKind::STRUCT,
+                Some("FooBar".to_string()),
+            )],
+        )
+        .await;
+    }
 }


### PR DESCRIPTION
# Description

## Problem

Part of https://github.com/noir-lang/noir/issues/1577

## Summary

Autocompletion wasn't triggering in function parameter types, or in impl names. The reason is that when you start writing them the body will still be missing, and that discarded the entire fn or impl. In this PR we make that parse well, but produce an error (and create a fake empty body).

Now autocompletion works fine in these scenarios:

![lsp-recover-fn](https://github.com/user-attachments/assets/e2358d49-c2e3-473b-bd4c-bfc6c0ff43e9)

![lsp-recover-impl](https://github.com/user-attachments/assets/a8fb1d44-86ce-4514-b167-f1ff6eb4b9b7)

## Additional Context

I'm not sure about the many new "parser error" introduced, maybe there should be a generic "expected these tokens"? I think chumsky has one of those errors but it's kind of tied to the parsing logic. On the other hand adding new errors is simple, so maybe it's fine.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
