### PR TITLE
chore: add regression test for #5756

### DIFF
--- a/test_programs/execution_success/regression_5756/Nargo.toml
+++ b/test_programs/execution_success/regression_5756/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_5756"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/execution_success/regression_5756/src/main.nr
+++ b/test_programs/execution_success/regression_5756/src/main.nr
@@ -1,0 +1,5 @@
+fn main(x: u8) {
+    let digest1 = std::hash::keccak256([x], 1);
+    let digest2 = std::hash::keccak256([x], 1);
+    assert_eq(digest1, digest2);
+}


### PR DESCRIPTION
# Description

## Problem\*

Adds regression tests for #5756 

## Summary\*

This PR is some investigation for #5756 as I'm not sure on the underlying cause as the keccakf1600 instructions _should_
be deduplicated. I'm getting different behaviour in the constant folding pass test compared to `test_programs` which I'm a little confused by. 

Posting this so other people can investigate as well.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
