### PR TITLE
fix: (LSP) only add cached files relevant to workspace

### DIFF
--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -387,11 +387,19 @@ pub fn insert_all_files_for_workspace_into_file_manager(
     workspace: &Workspace,
     file_manager: &mut FileManager,
 ) {
+    let root_dir: String = workspace.root_dir.as_os_str().to_string_lossy().into();
+
     // First add files we cached: these have the source code of files that are modified
     // but not saved to disk yet, and we want to make sure all LSP features work well
     // according to these unsaved buffers, not what's saved on disk.
     for (path, source) in &state.input_files {
         let path = path.strip_prefix("file://").unwrap();
+
+        // Only add files relevant to the workspace
+        if !path.starts_with(&root_dir) {
+            continue;
+        }
+
         file_manager.add_file_with_source_canonical_path(Path::new(path), source.clone());
     }
 

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -387,23 +387,18 @@ pub fn insert_all_files_for_workspace_into_file_manager(
     workspace: &Workspace,
     file_manager: &mut FileManager,
 ) {
-    let root_dir: String = workspace.root_dir.as_os_str().to_string_lossy().into();
-
-    // First add files we cached: these have the source code of files that are modified
-    // but not saved to disk yet, and we want to make sure all LSP features work well
-    // according to these unsaved buffers, not what's saved on disk.
+    // Source code for files we cached override those that are read from disk.
+    let mut overrides: HashMap<&Path, &str> = HashMap::new();
     for (path, source) in &state.input_files {
         let path = path.strip_prefix("file://").unwrap();
-
-        // Only add files relevant to the workspace
-        if !path.starts_with(&root_dir) {
-            continue;
-        }
-
-        file_manager.add_file_with_source_canonical_path(Path::new(path), source.clone());
+        overrides.insert(Path::new(path), source);
     }
 
-    nargo::insert_all_files_for_workspace_into_file_manager(workspace, file_manager);
+    nargo::insert_all_files_for_workspace_into_file_manager_with_overrides(
+        workspace,
+        file_manager,
+        &overrides,
+    );
 }
 
 #[test]

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -13,7 +13,10 @@ pub mod ops;
 pub mod package;
 pub mod workspace;
 
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::Path,
+};
 
 use fm::{FileManager, FILE_EXTENSION};
 use noirc_driver::{add_dep, prepare_crate, prepare_dependency};
@@ -46,8 +49,20 @@ pub fn insert_all_files_for_workspace_into_file_manager(
     workspace: &workspace::Workspace,
     file_manager: &mut FileManager,
 ) {
+    insert_all_files_for_workspace_into_file_manager_with_overrides(
+        workspace,
+        file_manager,
+        &HashMap::new(),
+    )
+}
+
+pub fn insert_all_files_for_workspace_into_file_manager_with_overrides(
+    workspace: &workspace::Workspace,
+    file_manager: &mut FileManager,
+    overrides: &HashMap<&Path, &str>,
+) {
     for package in workspace.clone().into_iter() {
-        insert_all_files_for_package_into_file_manager(package, file_manager);
+        insert_all_files_for_package_into_file_manager(package, file_manager, overrides);
     }
 }
 // We will pre-populate the file manager with all the files in the package
@@ -59,6 +74,7 @@ pub fn insert_all_files_for_workspace_into_file_manager(
 fn insert_all_files_for_package_into_file_manager(
     package: &Package,
     file_manager: &mut FileManager,
+    overrides: &HashMap<&Path, &str>,
 ) {
     // Start off at the entry path and read all files in the parent directory.
     let entry_path_parent = package
@@ -70,8 +86,12 @@ fn insert_all_files_for_package_into_file_manager(
     let paths = get_all_noir_source_in_dir(entry_path_parent)
         .expect("could not get all paths in the package");
     for path in paths {
-        let source = std::fs::read_to_string(path.as_path())
-            .unwrap_or_else(|_| panic!("could not read file {:?} into string", path));
+        let source = if let Some(src) = overrides.get(path.as_path()) {
+            src.to_string()
+        } else {
+            std::fs::read_to_string(path.as_path())
+                .unwrap_or_else(|_| panic!("could not read file {:?} into string", path))
+        };
         file_manager.add_file_with_source(path.as_path(), source);
     }
 
@@ -87,7 +107,11 @@ fn insert_all_files_for_packages_dependencies_into_file_manager(
     for (_, dep) in package.dependencies.iter() {
         match dep {
             Dependency::Local { package } | Dependency::Remote { package } => {
-                insert_all_files_for_package_into_file_manager(package, file_manager);
+                insert_all_files_for_package_into_file_manager(
+                    package,
+                    file_manager,
+                    &HashMap::new(),
+                );
                 insert_all_files_for_packages_dependencies_into_file_manager(package, file_manager);
             }
         }

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -13,10 +13,7 @@ pub mod ops;
 pub mod package;
 pub mod workspace;
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::Path,
-};
+use std::collections::{BTreeMap, HashMap};
 
 use fm::{FileManager, FILE_EXTENSION};
 use noirc_driver::{add_dep, prepare_crate, prepare_dependency};
@@ -53,13 +50,13 @@ pub fn insert_all_files_for_workspace_into_file_manager(
         workspace,
         file_manager,
         &HashMap::new(),
-    )
+    );
 }
 
 pub fn insert_all_files_for_workspace_into_file_manager_with_overrides(
     workspace: &workspace::Workspace,
     file_manager: &mut FileManager,
-    overrides: &HashMap<&Path, &str>,
+    overrides: &HashMap<&std::path::Path, &str>,
 ) {
     for package in workspace.clone().into_iter() {
         insert_all_files_for_package_into_file_manager(package, file_manager, overrides);
@@ -74,7 +71,7 @@ pub fn insert_all_files_for_workspace_into_file_manager_with_overrides(
 fn insert_all_files_for_package_into_file_manager(
     package: &Package,
     file_manager: &mut FileManager,
-    overrides: &HashMap<&Path, &str>,
+    overrides: &HashMap<&std::path::Path, &str>,
 ) {
     // Start off at the entry path and read all files in the parent directory.
     let entry_path_parent = package


### PR DESCRIPTION
# Description

## Problem

Resolves #5774

## Summary

LSP caches open files so that features work relative to open, potentially unsaved, file buffers. Before analyzing a crate or processing a package, we add these open files to a FileManager. The problem was that we were adding all open files, regardless of whether they belonged to a package. Because we don't always call `check_crate` on LSP features (for example when you hover we collect a packages files but don't call `check_crate`) a packages file FileIDs would change if we added new files that didn't exist before in that package.

It's... kind of hard to explain. But it also makes sense to not add files that are not relevant to the package. I debugged it for hours until I found the reason. With this fix LSP should work really well now (it wasn't working that well in Aztec-Packages).

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
