### PR TITLE
chore: sanitize url's to only allow github

### DIFF
--- a/compiler/wasm/src/noir/dependencies/github-dependency-resolver.ts
+++ b/compiler/wasm/src/noir/dependencies/github-dependency-resolver.ts
@@ -45,7 +45,8 @@ export class GithubDependencyResolver implements DependencyResolver {
   }
 
   async #fetchZipFromGithub(dependency: Pick<GitDependencyConfig, 'git' | 'tag'>): Promise<string> {
-    if (!dependency.git.startsWith('https://github.com')) {
+    const git_host = new URL(dependency.git);
+    if (git_host !== null && git_host.host != 'github.com') {
       throw new Error('Only github dependencies are supported');
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5737

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
