### PR TITLE
feat: Add `Expr::as_block` and `Expr::has_semicolon`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1084,24 +1084,8 @@ fn expr_as_unary_op(
 // fn as_has_semicolon(self) -> bool
 fn expr_has_semicolon(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
-    let mut expr_value = get_expr(self_argument)?;
-
-    loop {
-        match expr_value {
-            ExprValue::Expression(ExpressionKind::Parenthesized(expression)) => {
-                expr_value = ExprValue::Expression(expression.kind);
-            }
-            ExprValue::Statement(StatementKind::Expression(expression)) => {
-                expr_value = ExprValue::Expression(expression.kind);
-            }
-            ExprValue::Statement(StatementKind::Semi(..)) => {
-                return Ok(Value::Bool(true));
-            }
-            _ => break,
-        }
-    }
-
-    Ok(Value::Bool(false))
+    let expr_value = get_expr(self_argument)?;
+    Ok(Value::Bool(matches!(expr_value, ExprValue::Statement(StatementKind::Semi(..)))))
 }
 
 // Helper function for implementing the `expr_as_...` functions.

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -4,9 +4,13 @@ use acvm::FieldElement;
 use noirc_errors::Location;
 
 use crate::{
-    ast::{ExpressionKind, IntegerBitSize, Signedness},
+    ast::{IntegerBitSize, Signedness},
     hir::{
-        comptime::{errors::IResult, value::add_token_spans, Interpreter, InterpreterError, Value},
+        comptime::{
+            errors::IResult,
+            value::{add_token_spans, ExprValue},
+            Interpreter, InterpreterError, Value,
+        },
         def_map::ModuleId,
     },
     hir_def::{
@@ -137,7 +141,7 @@ pub(crate) fn get_u32((value, location): (Value, Location)) -> IResult<u32> {
     }
 }
 
-pub(crate) fn get_expr((value, location): (Value, Location)) -> IResult<ExpressionKind> {
+pub(crate) fn get_expr((value, location): (Value, Location)) -> IResult<ExprValue> {
     match value {
         Value::Expr(expr) => Ok(expr),
         value => type_mismatch(value, Type::Quoted(QuotedType::Expr), location),

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -8,7 +8,10 @@ use noirc_errors::{Location, Span};
 use strum_macros::Display;
 
 use crate::{
-    ast::{ArrayLiteral, ConstructorExpression, Ident, IntegerBitSize, Signedness, StatementKind},
+    ast::{
+        ArrayLiteral, BlockExpression, ConstructorExpression, Ident, IntegerBitSize, Signedness,
+        Statement, StatementKind,
+    },
     hir::def_map::ModuleId,
     hir_def::{
         expr::{HirArrayLiteral, HirConstructorExpression, HirIdent, HirLambda, ImplKind},
@@ -246,8 +249,12 @@ impl Value {
                 };
             }
             Value::Expr(ExprValue::Expression(expr)) => expr,
-            Value::Expr(_)
-            | Value::Pointer(..)
+            Value::Expr(ExprValue::Statement(statement)) => {
+                ExpressionKind::Block(BlockExpression {
+                    statements: vec![Statement { kind: statement, span: location.span }],
+                })
+            }
+            Value::Pointer(..)
             | Value::StructDefinition(_)
             | Value::TraitConstraint(..)
             | Value::TraitDefinition(_)

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -12,6 +12,9 @@ impl Expr {
     #[builtin(expr_as_binary_op)]
     fn as_binary_op(self) -> Option<(Expr, BinaryOp, Expr)> {}
 
+    #[builtin(expr_as_block)]
+    fn as_block(self) -> Option<[Expr]> {}
+
     #[builtin(expr_as_bool)]
     fn as_bool(self) -> Option<bool> {}
 
@@ -41,6 +44,9 @@ impl Expr {
 
     #[builtin(expr_as_unary_op)]
     fn as_unary_op(self) -> Option<(UnaryOp, Expr)> {}
+
+    #[builtin(expr_has_semicolon)]
+    fn has_semicolon(self) -> bool {}
 }
 
 mod tests {
@@ -57,6 +63,23 @@ mod tests {
             assert_eq(elems[0].as_integer().unwrap(), (1, false));
             assert_eq(elems[1].as_integer().unwrap(), (2, false));
             assert_eq(elems[2].as_integer().unwrap(), (4, false));
+        }
+    }
+
+    #[test]
+    fn test_expr_as_block() {
+        comptime
+        {
+            let expr = quote { { 1; 4; 23 } }.as_expr().unwrap();
+            let exprs = expr.as_block().unwrap();
+            assert_eq(exprs.len(), 3);
+            assert_eq(exprs[0].as_integer().unwrap(), (1, false));
+            assert_eq(exprs[1].as_integer().unwrap(), (4, false));
+            assert_eq(exprs[2].as_integer().unwrap(), (23, false));
+
+            assert(exprs[0].has_semicolon());
+            assert(exprs[1].has_semicolon());
+            assert(!exprs[2].has_semicolon());
         }
     }
 


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

Both ExpressionKind and StatementKind will be exposed as `Expr` (as discussed with Jake). So `Expr::as_block` will return the block statements as a list of expressions. There's also the thing that some of these statements might be `Semi` (well, all except maybe the last one) and having to explicitly unwrap that with `as_semi` might be tedious or bug-prone, so instead that's unwrapped automatically when you call any of the `as_...` methods, but then there's an `has_semicolon` on `Expr` to know if it has a semicolon.

## Additional Context

There's just those two methods in this PR because I wanted to validate this approach. Next I'll add more `as_...` methods but for StatementKind.

## Documentation

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
