### PR TITLE
feat: add `Expr` methods: as_comptime, as_unsafe, is_break, is_continue

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -5,11 +5,11 @@ use std::{
 
 use acvm::{AcirField, FieldElement};
 use builtin_helpers::{
-    check_argument_count, check_function_not_yet_resolved, check_one_argument,
-    check_three_arguments, check_two_arguments, get_expr, get_function_def, get_module, get_quoted,
-    get_slice, get_struct, get_trait_constraint, get_trait_def, get_trait_impl, get_tuple,
-    get_type, get_u32, hir_pattern_to_tokens, mutate_func_meta_type, parse, parse_tokens,
-    replace_func_meta_parameters, replace_func_meta_return_type,
+    block_expression_to_value, check_argument_count, check_function_not_yet_resolved,
+    check_one_argument, check_three_arguments, check_two_arguments, get_expr, get_function_def,
+    get_module, get_quoted, get_slice, get_struct, get_trait_constraint, get_trait_def,
+    get_trait_impl, get_tuple, get_type, get_u32, hir_pattern_to_tokens, mutate_func_meta_type,
+    parse, parse_tokens, replace_func_meta_parameters, replace_func_meta_return_type,
 };
 use iter_extended::{try_vecmap, vecmap};
 use noirc_errors::Location;
@@ -835,11 +835,7 @@ fn expr_as_block(
 ) -> IResult<Value> {
     expr_as(arguments, return_type, location, |expr| {
         if let ExprValue::Expression(ExpressionKind::Block(block_expr)) = expr {
-            let typ = Type::Slice(Box::new(Type::Quoted(QuotedType::Expr)));
-            let statements = block_expr.statements.into_iter();
-            let statements = statements.map(|statement| Value::statement(statement.kind)).collect();
-
-            Some(Value::Slice(statements, typ))
+            Some(block_expression_to_value(block_expr))
         } else {
             None
         }
@@ -869,11 +865,7 @@ fn expr_as_comptime(
 ) -> IResult<Value> {
     expr_as(arguments, return_type, location, |expr| {
         if let ExprValue::Expression(ExpressionKind::Comptime(block_expr, _)) = expr {
-            let typ = Type::Slice(Box::new(Type::Quoted(QuotedType::Expr)));
-            let statements = block_expr.statements.into_iter();
-            let statements = statements.map(|statement| Value::statement(statement.kind)).collect();
-
-            Some(Value::Slice(statements, typ))
+            Some(block_expression_to_value(block_expr))
         } else {
             None
         }
@@ -1110,11 +1102,7 @@ fn expr_as_unsafe(
 ) -> IResult<Value> {
     expr_as(arguments, return_type, location, |expr| {
         if let ExprValue::Expression(ExpressionKind::Unsafe(block_expr, _)) = expr {
-            let typ = Type::Slice(Box::new(Type::Quoted(QuotedType::Expr)));
-            let statements = block_expr.statements.into_iter();
-            let statements = statements.map(|statement| Value::statement(statement.kind)).collect();
-
-            Some(Value::Slice(statements, typ))
+            Some(block_expression_to_value(block_expr))
         } else {
             None
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -73,6 +73,8 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "expr_as_unary_op" => expr_as_unary_op(arguments, return_type, location),
             "expr_as_unsafe" => expr_as_unsafe(arguments, return_type, location),
             "expr_has_semicolon" => expr_has_semicolon(arguments, location),
+            "expr_is_break" => expr_is_break(arguments, location),
+            "expr_is_continue" => expr_is_continue(arguments, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
             "function_def_name" => function_def_name(interner, arguments, location),
             "function_def_parameters" => function_def_parameters(interner, arguments, location),
@@ -1133,6 +1135,20 @@ fn expr_has_semicolon(arguments: Vec<(Value, Location)>, location: Location) -> 
     let self_argument = check_one_argument(arguments, location)?;
     let expr_value = get_expr(self_argument)?;
     Ok(Value::Bool(matches!(expr_value, ExprValue::Statement(StatementKind::Semi(..)))))
+}
+
+// fn is_break(self) -> bool
+fn expr_is_break(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+    let self_argument = check_one_argument(arguments, location)?;
+    let expr_value = get_expr(self_argument)?;
+    Ok(Value::Bool(matches!(expr_value, ExprValue::Statement(StatementKind::Break))))
+}
+
+// fn is_continue(self) -> bool
+fn expr_is_continue(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
+    let self_argument = check_one_argument(arguments, location)?;
+    let expr_value = get_expr(self_argument)?;
+    Ok(Value::Bool(matches!(expr_value, ExprValue::Statement(StatementKind::Continue))))
 }
 
 // Helper function for implementing the `expr_as_...` functions.

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -866,6 +866,8 @@ fn expr_as_comptime(
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
+    use ExpressionKind::Block;
+
     expr_as(arguments, return_type, location, |expr| {
         if let ExprValue::Expression(ExpressionKind::Comptime(block_expr, _)) = expr {
             Some(block_expression_to_value(block_expr))
@@ -876,12 +878,9 @@ fn expr_as_comptime(
             // and in that case we return the block expression statements
             // (comptime as a statement can also be comptime for, but in that case we'll
             // return the for statement as a single expression)
-            if let StatementKind::Expression(Expression {
-                kind: ExpressionKind::Block(block_expr),
-                ..
-            }) = statement.kind
+            if let StatementKind::Expression(Expression { kind: Block(block), .. }) = statement.kind
             {
-                Some(block_expression_to_value(block_expr))
+                Some(block_expression_to_value(block))
             } else {
                 let mut elements = Vector::new();
                 elements.push_back(Value::statement(statement.kind));

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -4,7 +4,7 @@ use acvm::FieldElement;
 use noirc_errors::Location;
 
 use crate::{
-    ast::{IntegerBitSize, Signedness},
+    ast::{BlockExpression, IntegerBitSize, Signedness},
     hir::{
         comptime::{
             errors::IResult,
@@ -349,4 +349,12 @@ pub(super) fn replace_func_meta_return_type(typ: &mut Type, return_type: Type) {
         Type::Forall(_, typ) => replace_func_meta_return_type(typ, return_type),
         _ => {}
     }
+}
+
+pub(super) fn block_expression_to_value(block_expr: BlockExpression) -> Value {
+    let typ = Type::Slice(Box::new(Type::Quoted(QuotedType::Expr)));
+    let statements = block_expr.statements.into_iter();
+    let statements = statements.map(|statement| Value::statement(statement.kind)).collect();
+
+    Value::Slice(statements, typ)
 }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -53,6 +53,12 @@ impl Expr {
 
     #[builtin(expr_has_semicolon)]
     fn has_semicolon(self) -> bool {}
+
+    #[builtin(expr_is_break)]
+    fn is_break(self) -> bool {}
+
+    #[builtin(expr_is_continue)]
+    fn is_continue(self) -> bool {}
 }
 
 mod tests {
@@ -264,6 +270,26 @@ mod tests {
             let expr = quote { unsafe { 1; 4; 23 } }.as_expr().unwrap();
             let exprs = expr.as_unsafe().unwrap();
             assert_eq(exprs.len(), 3);
+        }
+    }
+
+    #[test]
+    fn test_expr_is_break() {
+        comptime
+        {
+            let expr = quote { { break; } }.as_expr().unwrap();
+            let exprs = expr.as_block().unwrap();
+            assert(exprs[0].is_break());
+        }
+    }
+
+    #[test]
+    fn test_expr_is_continue() {
+        comptime
+        {
+            let expr = quote { { continue; } }.as_expr().unwrap();
+            let exprs = expr.as_block().unwrap();
+            assert(exprs[0].is_continue());
         }
     }
 

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -145,6 +145,19 @@ mod tests {
     }
 
     #[test]
+    fn test_expr_as_comptime_as_statement() {
+        comptime
+        {
+            let expr = quote { { comptime { 1; 4; 23 } } }.as_expr().unwrap();
+            let exprs = expr.as_block().unwrap();
+            assert_eq(exprs.len(), 1);
+
+            let exprs = exprs[0].as_comptime().unwrap();
+            assert_eq(exprs.len(), 3);
+        }
+    }
+
+    #[test]
     fn test_expr_as_function_call() {
         comptime
         {

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -18,6 +18,9 @@ impl Expr {
     #[builtin(expr_as_bool)]
     fn as_bool(self) -> Option<bool> {}
 
+    #[builtin(expr_as_comptime)]
+    fn as_comptime(self) -> Option<[Expr]> {}
+
     #[builtin(expr_as_function_call)]
     fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 
@@ -44,6 +47,9 @@ impl Expr {
 
     #[builtin(expr_as_unary_op)]
     fn as_unary_op(self) -> Option<(UnaryOp, Expr)> {}
+
+    #[builtin(expr_as_unsafe)]
+    fn as_unsafe(self) -> Option<[Expr]> {}
 
     #[builtin(expr_has_semicolon)]
     fn has_semicolon(self) -> bool {}
@@ -125,6 +131,16 @@ mod tests {
 
             let expr = quote { true }.as_expr().unwrap();
             assert_eq(expr.as_bool().unwrap(), true);
+        }
+    }
+
+    #[test]
+    fn test_expr_as_comptime() {
+        comptime
+        {
+            let expr = quote { comptime { 1; 4; 23 } }.as_expr().unwrap();
+            let exprs = expr.as_comptime().unwrap();
+            assert_eq(exprs.len(), 3);
         }
     }
 
@@ -225,6 +241,16 @@ mod tests {
             assert(get_unary_op(quote { !x }).is_not());
             assert(get_unary_op(quote { &mut x }).is_mutable_reference());
             assert(get_unary_op(quote { *x }).is_dereference());
+        }
+    }
+
+    #[test]
+    fn test_expr_as_unsafe() {
+        comptime
+        {
+            let expr = quote { unsafe { 1; 4; 23 } }.as_expr().unwrap();
+            let exprs = expr.as_unsafe().unwrap();
+            assert_eq(exprs.len(), 3);
         }
     }
 


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

Continuing with the least hardest ones...

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
