### PR TITLE
fix: honor function visibility in LSP completion

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -374,9 +374,9 @@ fn resolve_external_dep(
     resolve_path_to_ns(&dep_directive, dep_module.krate, importing_crate, def_maps, path_references)
 }
 
-// Issue an error if the given private function is being called from a non-child module, or
-// if the given pub(crate) function is being called from another crate
-fn can_reference_module_id(
+// Returns false if the given private function is being called from a non-child module, or
+// if the given pub(crate) function is being called from another crate. Otherwise returns true.
+pub fn can_reference_module_id(
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
     importing_crate: CrateId,
     current_module: LocalModuleId,

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -182,7 +182,8 @@ mod completion_tests {
     async fn test_use_function() {
         let src = r#"
             mod foo {
-                fn bar(x: i32) -> u64 { 0 }
+                pub fn bar(x: i32) -> u64 { 0 }
+                fn bar_is_private(x: i32) -> u64 { 0 }
             }
             use foo::>|<
         "#;
@@ -1703,7 +1704,7 @@ mod completion_tests {
     async fn test_completes_after_colon_in_the_middle_of_an_ident_middle_segment() {
         let src = r#"
             mod foo {
-                fn bar() {}
+                pub fn bar() {}
             }
 
             fn main() {
@@ -1725,7 +1726,7 @@ mod completion_tests {
     async fn test_completes_at_function_call_name() {
         let src = r#"
             mod foo {
-                fn bar() {}
+                pub fn bar() {}
             }
 
             fn main() {


### PR DESCRIPTION
# Description

## Problem

Resolves #5808

## Summary

Reuses the same logic done when resolving a `use` or `Path` in the compiler.

## Additional Context

It's debatable whether this functionality is desired, because sometimes you add a function, want to use it and autocompletion doesn't suggest it, and it takes a while for you to realize that you forgot to add `pub`. However, a lot of the suggested functions come from the std or external crates, and it doesn't make sense to reveal these private functions. This is also how Rust Analyzer works too.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
