### PR TITLE
docs: Fix example for `aes128_encrypt`

### DIFF
--- a/docs/docs/noir/standard_library/cryptographic_primitives/ciphers.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/ciphers.mdx
@@ -17,10 +17,10 @@ Given a plaintext as an array of bytes, returns the corresponding aes128 ciphert
 
 ```rust
 fn main() {
-    let input: [u8; 4] = [0, 12, 3, 15] // Random bytes, will be padded to 16 bytes.
+    let input: [u8; 4] = [0, 12, 3, 15]; // Random bytes, will be padded to 16 bytes.
     let iv: [u8; 16] = [0; 16]; // Initialisation vector
-    let key: [u8; 16] = [0; 16] // AES key
-    let ciphertext = std::aes128::aes128_encrypt(inputs.as_bytes(), iv.as_bytes(), key.as_bytes()); // In this case, the output length will be 16 bytes.
+    let key: [u8; 16] = [0; 16]; // AES key
+    let ciphertext = std::aes128::aes128_encrypt(input, iv, key); // In this case, the output length will be 16 bytes.
 }
 ```
 


### PR DESCRIPTION
# Description

## Problem\*

Docs: https://noir-lang.org/docs/noir/standard_library/cryptographic_primitives/ciphers#aes128

The example for `aes128_encrypt` is incorrect. The parameters are different (now?), there are missing semicolons and there's a typo: `inputs` should be `input`.

## Summary\*

Updated example for `aes128_encrypt`.

## Additional Context

```console
$ nargo --version
nargo version = 0.31.0
noirc version = 0.31.0+540bef3597bd3e5775c83ec2ee3c0d4463084b4c
(git version hash: 540bef3597bd3e5775c83ec2ee3c0d4463084b4c, is dirty: false)
$ bb --version
0.41.0
```

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
