### PR TITLE
chore: Fix docs typo

### DIFF
--- a/docs/docs/noir/concepts/comptime.md
+++ b/docs/docs/noir/concepts/comptime.md
@@ -245,7 +245,7 @@ From the user's perspective it will look like this:
 
 ```rust
 // Example usage
-#[derive(Default, Eq, Cmp)]
+#[derive(Default, Eq, Ord)]
 struct MyStruct { my_field: u32 }
 ```
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Cmp is not a trait, it should be Ord.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
