### PR TITLE
fix: bit shifting type checking

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1041,9 +1041,6 @@ impl<'context> Elaborator<'context> {
             // Matches on TypeVariable must be first so that we follow any type
             // bindings.
             (TypeVariable(int, _), other) | (other, TypeVariable(int, _)) => {
-                if let TypeBinding::Bound(binding) = &*int.borrow() {
-                    return self.infix_operand_type_rules(binding, op, other, span);
-                }
                 if op.kind == BinaryOpKind::ShiftLeft || op.kind == BinaryOpKind::ShiftRight {
                     self.unify(
                         rhs_type,
@@ -1057,6 +1054,9 @@ impl<'context> Elaborator<'context> {
                         true
                     };
                     return Ok((lhs_type.clone(), use_impl));
+                }
+                if let TypeBinding::Bound(binding) = &*int.borrow() {
+                    return self.infix_operand_type_rules(binding, op, other, span);
                 }
                 let use_impl = self.bind_type_variables_for_infix(lhs_type, op, rhs_type, span);
                 Ok((other.clone(), use_impl))

--- a/test_programs/compile_success_empty/regression_5823/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_5823/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_5823"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_5823/src/main.nr
+++ b/test_programs/compile_success_empty/regression_5823/src/main.nr
@@ -1,0 +1,5 @@
+fn main() {
+    let x = 1 as u64;
+    let y = 2 as u8;
+    assert_eq(x << y, 4);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5823

## Summary\*

We check `rhs` differently than `lhs` in left and right bit shifts in a series of hacky checks.
In the case of type variables, `lhs` and `rhs` may be swapped causing the unification to be placed on lhs instead of rhs. I've reordered the cases to prevent this.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
