### PR TITLE
fix(docs): Fix file paths for metaprogramming docs

### DIFF
--- a/docs/docs/noir/standard_library/meta/quoted.md
+++ b/docs/docs/noir/standard_library/meta/quoted.md
@@ -39,7 +39,7 @@ stream does not parse and resolve to a valid trait constraint.
 
 Example:
 
-#include_code implements_example noir_stdlib/src/meta/quoted.nr rust
+#include_code implements_example test_programs/compile_success_empty/comptime_type/src/main.nr rust
 
 ### as_type
 
@@ -48,7 +48,7 @@ Example:
 Interprets this token stream as a resolved type. Panics if the token
 stream doesn't parse to a type or if the type isn't a valid type in scope.
 
-#include_code implements_example noir_stdlib/src/meta/quoted.nr rust
+#include_code implements_example test_programs/compile_success_empty/comptime_type/src/main.nr rust
 
 ## Trait Implementations
 

--- a/docs/docs/noir/standard_library/meta/quoted.md
+++ b/docs/docs/noir/standard_library/meta/quoted.md
@@ -16,7 +16,7 @@ the expression failed to parse.
 
 Example:
 
-#include_code as_expr_example noir_stdlib/src/meta/quoted.nr rust
+#include_code as_expr_example test_programs/noir_test_success/comptime_expr/src/main.nr rust
 
 ### as_module
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

All PRs are failing the "Deploy preview for PR" CI job. This is causing a big red X on all passing PRs.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
