### PR TITLE
chore: redo typo PR by nnsW3

### DIFF
--- a/docs/docs/noir/concepts/data_types/slices.mdx
+++ b/docs/docs/noir/concepts/data_types/slices.mdx
@@ -20,7 +20,7 @@ fn main() -> pub u32 {
 }
 ```
 
-To write a slice literal, use a preceeding ampersand as in: `&[0; 2]` or
+To write a slice literal, use a preceding ampersand as in: `&[0; 2]` or
 `&[1, 2, 3]`.
 
 It is important to note that slices are not references to arrays. In Noir,


### PR DESCRIPTION
Thanks nnsW3 for https://github.com/noir-lang/noir/pull/5833. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.