### PR TITLE
chore: add a span to track timing of brillig gen

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -52,6 +52,7 @@ impl std::ops::Index<FunctionId> for Brillig {
 
 impl Ssa {
     /// Compile to brillig brillig functions and ACIR functions reachable from them
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn to_brillig(&self, enable_debug_trace: bool) -> Brillig {
         // Collect all the function ids that are reachable from brillig
         // That means all the functions marked as brillig and ACIR functions called by them

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -127,11 +127,12 @@ pub(crate) fn optimize_into_acir(
             ssa.check_for_underconstrained_values()
         })
     };
+
+    drop(ssa_gen_span_guard);
+
     let brillig = time("SSA to Brillig", options.print_codegen_timings, || {
         ssa.to_brillig(options.enable_brillig_logging)
     });
-
-    drop(ssa_gen_span_guard);
 
     let artifacts = time("SSA to ACIR", options.print_codegen_timings, || {
         ssa.into_acir(&brillig, options.expression_width)


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Small change which adds tracking for how long brillig gen takes to the debug logs.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
