### PR TITLE
chore: Add missing cases to arithmetic generics

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -445,14 +445,19 @@ impl<'context> Elaborator<'context> {
                 })
             }
             UnresolvedTypeExpression::Constant(int, _) => Type::Constant(int),
-            UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, _) => {
+            UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, span) => {
                 let (lhs_span, rhs_span) = (lhs.span(), rhs.span());
                 let lhs = self.convert_expression_type(*lhs);
                 let rhs = self.convert_expression_type(*rhs);
 
                 match (lhs, rhs) {
                     (Type::Constant(lhs), Type::Constant(rhs)) => {
-                        Type::Constant(op.function(lhs, rhs))
+                        if let Some(result) = op.function(lhs, rhs) {
+                            Type::Constant(result)
+                        } else {
+                            self.push_err(ResolverError::OverflowInType { lhs, op, rhs, span });
+                            Type::Error
+                        }
                     }
                     (lhs, rhs) => {
                         if !self.enable_arithmetic_generics {

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -120,6 +120,8 @@ pub enum ResolverError {
     NamedTypeArgs { span: Span, item_kind: &'static str },
     #[error("Associated constants may only be a field or integer type")]
     AssociatedConstantsMustBeNumeric { span: Span },
+    #[error("Overflow in `{lhs} {op} {rhs}`")]
+    OverflowInType { lhs: u32, op: crate::BinaryTypeOperator, rhs: u32, span: Span },
 }
 
 impl ResolverError {
@@ -477,6 +479,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 Diagnostic::simple_error(
                     "Associated constants may only be a field or integer type".to_string(),
                     "Only numeric constants are allowed".to_string(),
+                    *span,
+                )
+            }
+            ResolverError::OverflowInType { lhs, op, rhs, span } => {
+                Diagnostic::simple_error(
+                    format!("Overflow in `{lhs} {op} {rhs}`"),
+                    "Overflow here".to_string(),
                     *span,
                 )
             }

--- a/compiler/noirc_frontend/src/hir/type_check/generics.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/generics.rs
@@ -160,6 +160,7 @@ fn fmt_trait_generics(
                 write!(f, "{} = {}", named.name, named.typ)?;
             }
         }
+        write!(f, ">")?;
     }
     Ok(())
 }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1806,7 +1806,7 @@ impl Type {
                 Some(Type::InfixExpr(l_type, l_op, Box::new(Type::Constant(result))))
             }
             (Multiplication | Division, Multiplication | Division) => {
-                // If l_op is a subtraction we want to inverse the rhs operator.
+                // If l_op is a division we want to inverse the rhs operator.
                 if l_op == Division {
                     op = op.inverse()?;
                 }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1811,7 +1811,7 @@ impl Type {
                     op = op.inverse()?;
                 }
                 // If op is a division we need to ensure it divides evenly
-                if op == Division && l_const % r_const != 0 {
+                if op == Division && &&(r_const == 0 || l_const % r_const != 0) {
                     None
                 } else {
                     let result = op.function(l_const, r_const)?;

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1811,7 +1811,7 @@ impl Type {
                     op = op.inverse()?;
                 }
                 // If op is a division we need to ensure it divides evenly
-                if op == Division && &&(r_const == 0 || l_const % r_const != 0) {
+                if op == Division && (r_const == 0 || l_const % r_const != 0) {
                     None
                 } else {
                     let result = op.function(l_const, r_const)?;

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -1,0 +1,215 @@
+use std::collections::BTreeSet;
+
+use crate::{BinaryTypeOperator, Type};
+
+impl Type {
+    /// Try to canonicalize the representation of this type.
+    /// Currently the only type with a canonical representation is
+    /// `Type::Infix` where for each consecutive commutative operator
+    /// we sort the non-constant operands by `Type: Ord` and place all constant
+    /// operands at the end, constant folded.
+    ///
+    /// For example:
+    /// - `canonicalize[((1 + N) + M) + 2] = (M + N) + 3`
+    /// - `canonicalize[A + 2 * B + 3 - 2] = A + (B * 2) + 3 - 2`
+    pub fn canonicalize(&self) -> Type {
+        match self.follow_bindings() {
+            Type::InfixExpr(lhs, op, rhs) => {
+                // evaluate_to_u32 also calls canonicalize so if we just called
+                // `self.evaluate_to_u32()` we'd get infinite recursion.
+                if let (Some(lhs), Some(rhs)) = (lhs.evaluate_to_u32(), rhs.evaluate_to_u32()) {
+                    if let Some(result) = op.function(lhs, rhs) {
+                        return Type::Constant(result);
+                    }
+                }
+
+                let lhs = lhs.canonicalize();
+                let rhs = rhs.canonicalize();
+                if let Some(result) = Self::try_simplify_non_constants_in_lhs(&lhs, op, &rhs) {
+                    return result.canonicalize();
+                }
+
+                if let Some(result) = Self::try_simplify_non_constants_in_rhs(&lhs, op, &rhs) {
+                    return result.canonicalize();
+                }
+
+                // Try to simplify partially constant expressions in the form `(N op1 C1) op2 C2`
+                // where C1 and C2 are constants that can be combined (e.g. N + 5 - 3 = N + 2)
+                if let Some(result) = Self::try_simplify_partial_constants(&lhs, op, &rhs) {
+                    return result.canonicalize();
+                }
+
+                if op.is_commutative() {
+                    return Self::sort_commutative(&lhs, op, &rhs);
+                }
+
+                Type::InfixExpr(Box::new(lhs), op, Box::new(rhs))
+            }
+            other => other,
+        }
+    }
+
+    fn sort_commutative(lhs: &Type, op: BinaryTypeOperator, rhs: &Type) -> Type {
+        let mut queue = vec![lhs.clone(), rhs.clone()];
+
+        let mut sorted = BTreeSet::new();
+
+        let zero_value = if op == BinaryTypeOperator::Addition { 0 } else { 1 };
+        let mut constant = zero_value;
+
+        // Push each non-constant term to `sorted` to sort them. Recur on InfixExprs with the same operator.
+        while let Some(item) = queue.pop() {
+            match item.canonicalize() {
+                Type::InfixExpr(lhs, new_op, rhs) if new_op == op => {
+                    queue.push(*lhs);
+                    queue.push(*rhs);
+                }
+                Type::Constant(new_constant) => {
+                    if let Some(result) = op.function(constant, new_constant) {
+                        constant = result;
+                    } else {
+                        sorted.insert(Type::Constant(new_constant));
+                    }
+                }
+                other => {
+                    sorted.insert(other);
+                }
+            }
+        }
+
+        if let Some(first) = sorted.pop_first() {
+            let mut typ = first.clone();
+
+            for rhs in sorted {
+                typ = Type::InfixExpr(Box::new(typ), op, Box::new(rhs.clone()));
+            }
+
+            if constant != zero_value {
+                typ = Type::InfixExpr(Box::new(typ), op, Box::new(Type::Constant(constant)));
+            }
+
+            typ
+        } else {
+            // Every type must have been a constant
+            Type::Constant(constant)
+        }
+    }
+
+    /// Try to simplify non-constant expressions in the form `(N op1 M) op2 M`
+    /// where the two `M` terms are expected to cancel out.
+    /// Precondition: `lhs & rhs are in canonical form`
+    ///
+    /// - Simplifies `(N +/- M) -/+ M` to `N`
+    /// - Simplifies `(N */÷ M) ÷/* M` to `N`
+    fn try_simplify_non_constants_in_lhs(
+        lhs: &Type,
+        op: BinaryTypeOperator,
+        rhs: &Type,
+    ) -> Option<Type> {
+        let Type::InfixExpr(l_lhs, l_op, l_rhs) = lhs.follow_bindings() else {
+            return None;
+        };
+
+        // Note that this is exact, syntactic equality, not unification.
+        // `rhs` is expected to already be in canonical form.
+        if l_op.inverse() != Some(op) || l_rhs.canonicalize() != *rhs {
+            return None;
+        }
+
+        Some(*l_lhs)
+    }
+
+    /// Try to simplify non-constant expressions in the form `N op1 (M op1 N)`
+    /// where the two `M` terms are expected to cancel out.
+    /// Precondition: `lhs & rhs are in canonical form`
+    ///
+    /// Unlike `try_simplify_non_constants_in_lhs` we can't simplify `N / (M * N)`
+    /// Since that should simplify to `1 / M` instead of `M`.
+    ///
+    /// - Simplifies `N +/- (M -/+ N)` to `M`
+    /// - Simplifies `N * (M ÷ N)` to `M`
+    fn try_simplify_non_constants_in_rhs(
+        lhs: &Type,
+        op: BinaryTypeOperator,
+        rhs: &Type,
+    ) -> Option<Type> {
+        let Type::InfixExpr(r_lhs, r_op, r_rhs) = rhs.follow_bindings() else {
+            return None;
+        };
+
+        // `N / (M * N)` should be simplified to `1 / M`, but we only handle
+        // simplifying to `M` in this function.
+        if op == BinaryTypeOperator::Division && r_op == BinaryTypeOperator::Multiplication {
+            return None;
+        }
+
+        // Note that this is exact, syntactic equality, not unification.
+        // `lhs` is expected to already be in canonical form.
+        if r_op.inverse() != Some(op) || *lhs != r_rhs.canonicalize() {
+            return None;
+        }
+
+        Some(*r_lhs)
+    }
+
+    /// Given:
+    ///   lhs = `N op C1`
+    ///   rhs = C2
+    /// Returns: `(N, op, C1, C2)` if C1 and C2 are constants.
+    ///   Note that the operator here is within the `lhs` term, the operator
+    ///   separating lhs and rhs is not needed.
+    /// Precondition: `lhs & rhs are in canonical form`
+    fn parse_partial_constant_expr(
+        lhs: &Type,
+        rhs: &Type,
+    ) -> Option<(Box<Type>, BinaryTypeOperator, u32, u32)> {
+        let rhs = rhs.evaluate_to_u32()?;
+
+        let Type::InfixExpr(l_type, l_op, l_rhs) = lhs.follow_bindings() else {
+            return None;
+        };
+
+        let l_rhs = l_rhs.evaluate_to_u32()?;
+        Some((l_type, l_op, l_rhs, rhs))
+    }
+
+    /// Try to simplify partially constant expressions in the form `(N op1 C1) op2 C2`
+    /// where C1 and C2 are constants that can be combined (e.g. N + 5 - 3 = N + 2)
+    /// Precondition: `lhs & rhs are in canonical form`
+    ///
+    /// - Simplifies `(N +/- C1) +/- C2` to `N +/- (C1 +/- C2)` if C1 and C2 are constants.
+    /// - Simplifies `(N */÷ C1) */÷ C2` to `N */÷ (C1 */÷ C2)` if C1 and C2 are constants.
+    fn try_simplify_partial_constants(
+        lhs: &Type,
+        mut op: BinaryTypeOperator,
+        rhs: &Type,
+    ) -> Option<Type> {
+        use BinaryTypeOperator::*;
+        let (l_type, l_op, l_const, r_const) = Type::parse_partial_constant_expr(lhs, rhs)?;
+
+        match (l_op, op) {
+            (Addition | Subtraction, Addition | Subtraction) => {
+                // If l_op is a subtraction we want to inverse the rhs operator.
+                if l_op == Subtraction {
+                    op = op.inverse()?;
+                }
+                let result = op.function(l_const, r_const)?;
+                Some(Type::InfixExpr(l_type, l_op, Box::new(Type::Constant(result))))
+            }
+            (Multiplication | Division, Multiplication | Division) => {
+                // If l_op is a division we want to inverse the rhs operator.
+                if l_op == Division {
+                    op = op.inverse()?;
+                }
+                // If op is a division we need to ensure it divides evenly
+                if op == Division && (r_const == 0 || l_const % r_const != 0) {
+                    None
+                } else {
+                    let result = op.function(l_const, r_const)?;
+                    Some(Type::InfixExpr(l_type, l_op, Box::new(Type::Constant(result))))
+                }
+            }
+            _ => None,
+        }
+    }
+}

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -34,7 +34,7 @@ impl MonomorphizationError {
     fn into_diagnostic(self) -> CustomDiagnostic {
         let message = match &self {
             MonomorphizationError::UnknownArrayLength { length, .. } => {
-                format!("ICE: Could not determine array length `{length}`")
+                format!("Could not determine array length `{length}`")
             }
             MonomorphizationError::NoDefaultType { location } => {
                 let message = "Type annotation needed".into();

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -858,6 +858,7 @@ impl<'interner> Monomorphizer<'interner> {
                     generics.unwrap_or_default(),
                     None,
                 );
+                eprintln!("Converting type of function: {typ:?}");
                 let typ = Self::convert_type(&typ, ident.location)?;
                 let ident = ast::Ident { location, mutable, definition, name, typ: typ.clone() };
                 let ident_expression = ast::Expression::Ident(ident);

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -858,7 +858,6 @@ impl<'interner> Monomorphizer<'interner> {
                     generics.unwrap_or_default(),
                     None,
                 );
-                eprintln!("Converting type of function: {typ:?}");
                 let typ = Self::convert_type(&typ, ident.location)?;
                 let ident = ast::Ident { location, mutable, definition, name, typ: typ.clone() };
                 let ident_expression = ast::Expression::Ident(ident);

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -301,6 +301,7 @@ impl<'interner> Monomorphizer<'interner> {
         }
 
         let meta = self.interner.function_meta(&f).clone();
+
         let mut func_sig = meta.function_signature();
         // Follow the bindings of the function signature for entry points
         // which are not `main` such as foldable functions.
@@ -1950,6 +1951,7 @@ pub fn resolve_trait_method(
         TraitImplKind::Normal(impl_id) => impl_id,
         TraitImplKind::Assumed { object_type, trait_generics } => {
             let location = interner.expr_location(&expr_id);
+
             match interner.lookup_trait_implementation(
                 &object_type,
                 method.trait_id,

--- a/test_programs/compile_success_empty/arithmetic_generics/src/main.nr
+++ b/test_programs/compile_success_empty/arithmetic_generics/src/main.nr
@@ -7,6 +7,9 @@ fn main() {
     let _ = split_first([1, 2, 3]);
 
     let _ = push_multiple([1, 2, 3]);
+
+    test_constant_folding();
+    test_non_constant_folding();
 }
 
 fn split_first<T, let N: u32>(array: [T; N]) -> (T, [T; N - 1]) {
@@ -100,4 +103,27 @@ fn demo_proof<let N: u32>() -> Equiv<W<(N * (N + 1))>, (Equiv<W<N>, (), W<N>, ()
     let p3_sub: Equiv<W<N>, (), W<N>, ()> = mul_one_r();
     let p3: Equiv<W<N * N + N>, (), W<N * N + N>, ()> = add_equiv_r::<N * N, N, N, _, _>(p3_sub);
     equiv_trans(equiv_trans(p1, p2), p3)
+}
+
+// Helper function as a quick way to make a particular numeric generic
+fn value<let N: u32>() -> W<N> {
+    W {}
+}
+
+fn test_constant_folding<let N: u32>() {
+    // N + C1 - C2 = N + (C1 - C2)
+    let _: W<N + 5 - 2> = value::<N + 3>();
+
+    // N - C1 + C2 = N - (C1 - C2)
+    let _: W<N - 3 + 2> = value::<N - 1>();
+
+    // N * C1 / C2 = N * (C1 / C2)
+    let _: W<N * 10 / 2> = value::<N * 5>();
+
+    // N / C1 * C2 = N / (C1 / C2)
+    let _: W<N / 10 * 2> = value::<N / 5>();
+}
+
+fn test_non_constant_folding<let N: u32>() {
+    // TODO
 }

--- a/test_programs/compile_success_empty/arithmetic_generics/src/main.nr
+++ b/test_programs/compile_success_empty/arithmetic_generics/src/main.nr
@@ -8,8 +8,8 @@ fn main() {
 
     let _ = push_multiple([1, 2, 3]);
 
-    test_constant_folding();
-    test_non_constant_folding();
+    test_constant_folding::<10>();
+    test_non_constant_folding::<10, 20>();
 }
 
 fn split_first<T, let N: u32>(array: [T; N]) -> (T, [T; N - 1]) {
@@ -105,25 +105,30 @@ fn demo_proof<let N: u32>() -> Equiv<W<(N * (N + 1))>, (Equiv<W<N>, (), W<N>, ()
     equiv_trans(equiv_trans(p1, p2), p3)
 }
 
-// Helper function as a quick way to make a particular numeric generic
-fn value<let N: u32>() -> W<N> {
-    W {}
-}
-
 fn test_constant_folding<let N: u32>() {
     // N + C1 - C2 = N + (C1 - C2)
-    let _: W<N + 5 - 2> = value::<N + 3>();
+    let _: W<N + 5 - 2> = W::<N + 3> {};
 
     // N - C1 + C2 = N - (C1 - C2)
-    let _: W<N - 3 + 2> = value::<N - 1>();
+    let _: W<N - 3 + 2> = W::<N - 1> {};
 
     // N * C1 / C2 = N * (C1 / C2)
-    let _: W<N * 10 / 2> = value::<N * 5>();
+    let _: W<N * 10 / 2> = W::<N * 5> {};
 
     // N / C1 * C2 = N / (C1 / C2)
-    let _: W<N / 10 * 2> = value::<N / 5>();
+    let _: W<N / 10 * 2> = W::<N / 5> {};
 }
 
-fn test_non_constant_folding<let N: u32>() {
-    // TODO
+fn test_non_constant_folding<let N: u32, let M: u32>() {
+    // N + M - M = N
+    let _: W<N + M - M> = W::<N> {};
+
+    // N - M + M = N
+    let _: W<N - M + M> = W::<N> {};
+
+    // N * M / M = N
+    let _: W<N * M / M> = W::<N> {};
+
+    // N / M * M = N
+    let _: W<N / M * M> = W::<N> {};
 }


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

In the initial arithmetic generics PR we only added the one specific case for simplifying `(N + C1) - C2`.

Later in the associated types PR we added another case to simplify the non-constant `(N + M) - M`

This PR fills in the missing cases for each other operator. It also has somewhat better overflow handling by returning an `Option` in the operator function and removing the wrapping operations.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
