### PR TITLE
chore: don't require empty `Prover.toml` for programs with zero arguments but a return value

### DIFF
--- a/tooling/nargo_cli/src/cli/fs/inputs.rs
+++ b/tooling/nargo_cli/src/cli/fs/inputs.rs
@@ -25,7 +25,13 @@ pub(crate) fn read_inputs_from_file<P: AsRef<Path>>(
 
     let file_path = path.as_ref().join(file_name).with_extension(format.ext());
     if !file_path.exists() {
-        return Err(FilesystemError::MissingTomlFile(file_name.to_owned(), file_path));
+        if abi.parameters.is_empty() {
+            // Reading a return value from the `Prover.toml` is optional,
+            // so if the ABI has no parameters we can skip reading the file if it doesn't exist.
+            return Ok((BTreeMap::new(), None));
+        } else {
+            return Err(FilesystemError::MissingTomlFile(file_name.to_owned(), file_path));
+        }
     }
 
     let input_string = std::fs::read_to_string(file_path).unwrap();


### PR DESCRIPTION
…ents but a return value

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is a small QOL change but we don't need to have a `Prover.toml` file in the case where the circuit has no inputs but potential return values. In this case we can tolerate a missing `Prover.toml` file.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
