### PR TITLE
feat: remove unnecessary copying of vector size during reversal

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
@@ -263,20 +263,14 @@ impl<F: AcirField + DebugToString> BrilligContext<F> {
         let index_at_end_of_array = self.allocate_register();
         let end_value_register = self.allocate_register();
 
+        self.mov_instruction(index_at_end_of_array, vector.size);
+
         self.codegen_loop(iteration_count, |ctx, iterator_register| {
+            // The index at the end of array is size - 1 - iterator
+            ctx.codegen_usize_op_in_place(index_at_end_of_array, BrilligBinaryOp::Sub, 1);
+
             // Load both values
             ctx.codegen_array_get(vector.pointer, iterator_register, start_value_register);
-
-            // The index at the end of array is size - 1 - iterator
-            ctx.mov_instruction(index_at_end_of_array, vector.size);
-            ctx.codegen_usize_op_in_place(index_at_end_of_array, BrilligBinaryOp::Sub, 1);
-            ctx.memory_op_instruction(
-                index_at_end_of_array,
-                iterator_register.address,
-                index_at_end_of_array,
-                BrilligBinaryOp::Sub,
-            );
-
             ctx.codegen_array_get(
                 vector.pointer,
                 SingleAddrVariable::new_usize(index_at_end_of_array),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

In order to calculate `vector_size - 1 - iterator`, rather than initialising a register to `vector_size` and then decrementing it on each loop iteration, we're currently recalculating it from scratch on each iteration. I've modified this so that we can avoid these extra ops

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
