### PR TITLE
feat(optimization): Avoid merging identical (by ID) arrays

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -733,11 +733,15 @@ impl Instruction {
                     }
                 }
 
+                let then_value = dfg.resolve(*then_value);
+                let else_value = dfg.resolve(*else_value);
+                if then_value == else_value {
+                    return SimplifiedTo(then_value);
+                }
+
                 if matches!(&typ, Type::Numeric(_)) {
                     let then_condition = *then_condition;
-                    let then_value = *then_value;
                     let else_condition = *else_condition;
-                    let else_value = *else_value;
 
                     let result = ValueMerger::merge_numeric_values(
                         dfg,

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -58,6 +58,13 @@ impl<'a> ValueMerger<'a> {
         then_value: ValueId,
         else_value: ValueId,
     ) -> ValueId {
+        let then_value = self.dfg.resolve(then_value);
+        let else_value = self.dfg.resolve(else_value);
+
+        if then_value == else_value {
+            return then_value;
+        }
+
         match self.dfg.type_of_value(then_value) {
             Type::Numeric(_) => Self::merge_numeric_values(
                 self.dfg,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Found while I was working on Jan's bug. There were a number of arrays we merged where we'd get `vN = if ... then vM else vM` which we had to go through the long merge for without this.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
