### PR TITLE
feat: add `Expr::as_assert`

### DIFF
--- a/docs/docs/noir/standard_library/meta/expr.md
+++ b/docs/docs/noir/standard_library/meta/expr.md
@@ -12,6 +12,12 @@ title: Expr
 
 If this expression is an array, this returns a slice of each element in the array.
 
+### as_assert
+
+#include_code as_assert noir_stdlib/src/meta/expr.nr rust
+
+If this expression is an assert, this returns the assert expression and the optional message.
+
 ### as_assign
 
 #include_code as_assign noir_stdlib/src/meta/expr.nr rust

--- a/docs/docs/noir/standard_library/meta/expr.md
+++ b/docs/docs/noir/standard_library/meta/expr.md
@@ -168,16 +168,16 @@ comptime {
 
 `true` if this expression is `continue`.
 
-### mutate
+### modify
 
-#include_code mutate noir_stdlib/src/meta/expr.nr rust
+#include_code modify noir_stdlib/src/meta/expr.nr rust
 
 Applies a mapping function to this expression and to all of its sub-expressions.
 `f` will be applied to each sub-expression first, then applied to the expression itself.
 
 This happens recursively for every expression within `self`.
 
-For example, calling `mutate` on `(&[1], &[2, 3])` with an `f` that returns `Option::some`
+For example, calling `modify` on `(&[1], &[2, 3])` with an `f` that returns `Option::some`
 for expressions that are integers, doubling them, would return `(&[2], &[4, 6])`.
 
 ### quoted

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -116,27 +116,27 @@ impl Expr {
     fn is_continue(self) -> bool {}
     // docs:end:is_continue
 
-    // docs:start:mutate
-    fn mutate<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
-        // docs:end:mutate
-        let result = mutate_array(self, f);
-        let result = result.or_else(|| mutate_assert(self, f));
-        let result = result.or_else(|| mutate_assign(self, f));
-        let result = result.or_else(|| mutate_binary_op(self, f));
-        let result = result.or_else(|| mutate_block(self, f));
-        let result = result.or_else(|| mutate_cast(self, f));
-        let result = result.or_else(|| mutate_comptime(self, f));
-        let result = result.or_else(|| mutate_if(self, f));
-        let result = result.or_else(|| mutate_index(self, f));
-        let result = result.or_else(|| mutate_function_call(self, f));
-        let result = result.or_else(|| mutate_member_access(self, f));
-        let result = result.or_else(|| mutate_method_call(self, f));
-        let result = result.or_else(|| mutate_repeated_element_array(self, f));
-        let result = result.or_else(|| mutate_repeated_element_slice(self, f));
-        let result = result.or_else(|| mutate_slice(self, f));
-        let result = result.or_else(|| mutate_tuple(self, f));
-        let result = result.or_else(|| mutate_unary_op(self, f));
-        let result = result.or_else(|| mutate_unsafe(self, f));
+    // docs:start:modify
+    fn modify<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
+        // docs:end:modify
+        let result = modify_array(self, f);
+        let result = result.or_else(|| modify_assert(self, f));
+        let result = result.or_else(|| modify_assign(self, f));
+        let result = result.or_else(|| modify_binary_op(self, f));
+        let result = result.or_else(|| modify_block(self, f));
+        let result = result.or_else(|| modify_cast(self, f));
+        let result = result.or_else(|| modify_comptime(self, f));
+        let result = result.or_else(|| modify_if(self, f));
+        let result = result.or_else(|| modify_index(self, f));
+        let result = result.or_else(|| modify_function_call(self, f));
+        let result = result.or_else(|| modify_member_access(self, f));
+        let result = result.or_else(|| modify_method_call(self, f));
+        let result = result.or_else(|| modify_repeated_element_array(self, f));
+        let result = result.or_else(|| modify_repeated_element_slice(self, f));
+        let result = result.or_else(|| modify_slice(self, f));
+        let result = result.or_else(|| modify_tuple(self, f));
+        let result = result.or_else(|| modify_unary_op(self, f));
+        let result = result.or_else(|| modify_unsafe(self, f));
         if result.is_some() {
             let result = result.unwrap_unchecked();
             let modified = f(result);
@@ -153,192 +153,192 @@ impl Expr {
     }
 }
 
-fn mutate_array<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_array<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_array().map(
         |exprs: [Expr]| {
-        let exprs = mutate_expressions(exprs, f);
+        let exprs = modify_expressions(exprs, f);
         new_array(exprs)
     }
     )
 }
 
-fn mutate_assert<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_assert<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_assert().map(
         |expr: (Expr, Option<Expr>)| {
         let (predicate, msg) = expr;
-        let predicate = predicate.mutate(f);
-        let msg = msg.map(|msg: Expr| msg.mutate(f));
+        let predicate = predicate.modify(f);
+        let msg = msg.map(|msg: Expr| msg.modify(f));
         new_assert(predicate, msg)
     }
     )
 }
 
-fn mutate_assign<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_assign<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_assign().map(
         |expr: (Expr, Expr)| {
         let (lhs, rhs) = expr;
-        let lhs = lhs.mutate(f);
-        let rhs = rhs.mutate(f);
+        let lhs = lhs.modify(f);
+        let rhs = rhs.modify(f);
         new_assign(lhs, rhs)
     }
     )
 }
 
-fn mutate_binary_op<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_binary_op<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_binary_op().map(
         |expr: (Expr, BinaryOp, Expr)| {
         let (lhs, op, rhs) = expr;
-        let lhs = lhs.mutate(f);
-        let rhs = rhs.mutate(f);
+        let lhs = lhs.modify(f);
+        let rhs = rhs.modify(f);
         new_binary_op(lhs, op, rhs)
     }
     )
 }
 
-fn mutate_block<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_block<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_block().map(
         |exprs: [Expr]| {
-        let exprs = mutate_expressions(exprs, f);
+        let exprs = modify_expressions(exprs, f);
         new_block(exprs)
     }
     )
 }
 
-fn mutate_cast<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_cast<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_cast().map(
         |expr: (Expr, UnresolvedType)| {
         let (expr, typ) = expr;
-        let expr = expr.mutate(f);
+        let expr = expr.modify(f);
         new_cast(expr, typ)
     }
     )
 }
 
-fn mutate_comptime<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_comptime<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_comptime().map(
         |exprs: [Expr]| {
-        let exprs = exprs.map(|expr: Expr| expr.mutate(f));
+        let exprs = exprs.map(|expr: Expr| expr.modify(f));
         new_comptime(exprs)
     }
     )
 }
 
-fn mutate_function_call<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_function_call<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_function_call().map(
         |expr: (Expr, [Expr])| {
         let (function, arguments) = expr;
-        let function = function.mutate(f);
-        let arguments = arguments.map(|arg: Expr| arg.mutate(f));
+        let function = function.modify(f);
+        let arguments = arguments.map(|arg: Expr| arg.modify(f));
         new_function_call(function, arguments)
     }
     )
 }
 
-fn mutate_if<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_if<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_if().map(
         |expr: (Expr, Expr, Option<Expr>)| {
         let (condition, consequence, alternative) = expr;
-        let condition = condition.mutate(f);
-        let consequence = consequence.mutate(f);
-        let alternative = alternative.map(|alternative: Expr| alternative.mutate(f));
+        let condition = condition.modify(f);
+        let consequence = consequence.modify(f);
+        let alternative = alternative.map(|alternative: Expr| alternative.modify(f));
         new_if(condition, consequence, alternative)
     }
     )
 }
 
-fn mutate_index<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_index<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_index().map(
         |expr: (Expr, Expr)| {
         let (object, index) = expr;
-        let object = object.mutate(f);
-        let index = index.mutate(f);
+        let object = object.modify(f);
+        let index = index.modify(f);
         new_index(object, index)
     }
     )
 }
 
-fn mutate_member_access<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_member_access<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_member_access().map(
         |expr: (Expr, Quoted)| {
         let (object, name) = expr;
-        let object = object.mutate(f);
+        let object = object.modify(f);
         new_member_access(object, name)
     }
     )
 }
 
-fn mutate_method_call<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_method_call<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_method_call().map(
         |expr: (Expr, Quoted, [UnresolvedType], [Expr])| {
         let (object, name, generics, arguments) = expr;
-        let object = object.mutate(f);
-        let arguments = arguments.map(|arg: Expr| arg.mutate(f));
+        let object = object.modify(f);
+        let arguments = arguments.map(|arg: Expr| arg.modify(f));
         new_method_call(object, name, generics, arguments)
     }
     )
 }
 
-fn mutate_repeated_element_array<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_repeated_element_array<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_repeated_element_array().map(
         |expr: (Expr, Expr)| {
         let (expr, length) = expr;
-        let expr = expr.mutate(f);
-        let length = length.mutate(f);
+        let expr = expr.modify(f);
+        let length = length.modify(f);
         new_repeated_element_array(expr, length)
     }
     )
 }
 
-fn mutate_repeated_element_slice<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_repeated_element_slice<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_repeated_element_slice().map(
         |expr: (Expr, Expr)| {
         let (expr, length) = expr;
-        let expr = expr.mutate(f);
-        let length = length.mutate(f);
+        let expr = expr.modify(f);
+        let length = length.modify(f);
         new_repeated_element_slice(expr, length)
     }
     )
 }
 
-fn mutate_slice<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_slice<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_slice().map(
         |exprs: [Expr]| {
-        let exprs = mutate_expressions(exprs, f);
+        let exprs = modify_expressions(exprs, f);
         new_slice(exprs)
     }
     )
 }
 
-fn mutate_tuple<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_tuple<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_tuple().map(
         |exprs: [Expr]| {
-        let exprs = mutate_expressions(exprs, f);
+        let exprs = modify_expressions(exprs, f);
         new_tuple(exprs)
     }
     )
 }
 
-fn mutate_unary_op<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_unary_op<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_unary_op().map(
         |expr: (UnaryOp, Expr)| {
         let (op, rhs) = expr;
-        let rhs = rhs.mutate(f);
+        let rhs = rhs.modify(f);
         new_unary_op(op, rhs)
     }
     )
 }
 
-fn mutate_unsafe<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+fn modify_unsafe<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
     expr.as_unsafe().map(
         |exprs: [Expr]| {
-        let exprs = exprs.map(|expr: Expr| expr.mutate(f));
+        let exprs = exprs.map(|expr: Expr| expr.modify(f));
         new_unsafe(exprs)
     }
     )
 }
 
-fn mutate_expressions<Env>(exprs: [Expr], f: fn[Env](Expr) -> Option<Expr>) -> [Expr] {
-    exprs.map(|expr: Expr| expr.mutate(f))
+fn modify_expressions<Env>(exprs: [Expr], f: fn[Env](Expr) -> Option<Expr>) -> [Expr] {
+    exprs.map(|expr: Expr| expr.modify(f))
 }
 
 fn new_array(exprs: [Expr]) -> Expr {

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -8,6 +8,11 @@ impl Expr {
     fn as_array(self) -> Option<[Expr]> {}
     // docs:end:as_array
 
+    #[builtin(expr_as_assert)]
+    // docs:start:as_assert
+    fn as_assert(self) -> Option<(Expr, Option<Expr>)> {}
+    // docs:end:as_assert
+
     #[builtin(expr_as_assign)]
     // docs:start:as_assign
     fn as_assign(self) -> Option<(Expr, Expr)> {}
@@ -115,6 +120,7 @@ impl Expr {
     fn mutate<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
         // docs:end:mutate
         let result = mutate_array(self, f);
+        let result = result.or_else(|| mutate_assert(self, f));
         let result = result.or_else(|| mutate_assign(self, f));
         let result = result.or_else(|| mutate_binary_op(self, f));
         let result = result.or_else(|| mutate_block(self, f));
@@ -152,6 +158,17 @@ fn mutate_array<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Exp
         |exprs: [Expr]| {
         let exprs = mutate_expressions(exprs, f);
         new_array(exprs)
+    }
+    )
+}
+
+fn mutate_assert<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
+    expr.as_assert().map(
+        |expr: (Expr, Option<Expr>)| {
+        let (predicate, msg) = expr;
+        let predicate = predicate.mutate(f);
+        let msg = msg.map(|msg: Expr| msg.mutate(f));
+        new_assert(predicate, msg)
     }
     )
 }
@@ -327,6 +344,15 @@ fn mutate_expressions<Env>(exprs: [Expr], f: fn[Env](Expr) -> Option<Expr>) -> [
 fn new_array(exprs: [Expr]) -> Expr {
     let exprs = join_expressions(exprs, quote { , });
     quote { [$exprs]}.as_expr().unwrap()
+}
+
+fn new_assert(predicate: Expr, msg: Option<Expr>) -> Expr {
+    if msg.is_some() {
+        let msg = msg.unwrap();
+        quote { assert($predicate, $msg) }.as_expr().unwrap()
+    } else {
+        quote { assert($predicate) }.as_expr().unwrap()
+    }
 }
 
 fn new_assign(lhs: Expr, rhs: Expr) -> Expr {

--- a/test_programs/compile_success_empty/inject_context_attribute/src/main.nr
+++ b/test_programs/compile_success_empty/inject_context_attribute/src/main.nr
@@ -31,7 +31,7 @@ fn inject_context(f: FunctionDefinition) {
     f.set_parameters(parameters);
 
     // Create a new body where every function call has `_context` added to the list of arguments.
-    let body = f.body().mutate(mapping_function);
+    let body = f.body().modify(mapping_function);
     f.set_body(body);
 }
 

--- a/test_programs/noir_test_success/comptime_expr/src/main.nr
+++ b/test_programs/noir_test_success/comptime_expr/src/main.nr
@@ -20,7 +20,7 @@ mod tests {
         comptime
         {
             let expr = quote { [1, 2, 4] }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let elems = expr.as_array().unwrap();
             assert_eq(elems.len(), 3);
             assert_eq(elems[0].as_integer().unwrap(), (2, false));
@@ -50,13 +50,13 @@ mod tests {
         comptime
         {
             let expr = quote { assert(1) }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (predicate, msg) = expr.as_assert().unwrap();
             assert_eq(predicate.as_integer().unwrap(), (2, false));
             assert(msg.is_none());
 
             let expr = quote { assert(1, 2) }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (predicate, msg) = expr.as_assert().unwrap();
             assert_eq(predicate.as_integer().unwrap(), (2, false));
             assert_eq(msg.unwrap().as_integer().unwrap(), (4, false));
@@ -79,7 +79,7 @@ mod tests {
         comptime
         {
             let expr = quote { { a = 1; } }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let exprs = expr.as_block().unwrap();
             let (_lhs, rhs) = exprs[0].as_assign().unwrap();
             assert_eq(rhs.as_integer().unwrap(), (2, false));
@@ -108,7 +108,7 @@ mod tests {
         comptime
         {
             let expr = quote { { 1; 4; 23 } }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let exprs = expr.as_block().unwrap();
             assert_eq(exprs.len(), 3);
             assert_eq(exprs[0].as_integer().unwrap(), (2, false));
@@ -144,7 +144,7 @@ mod tests {
         comptime
         {
             let expr = quote { foo.bar(3, 4) }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
 
             let (_object, name, generics, arguments) = expr.as_method_call().unwrap();
 
@@ -175,7 +175,7 @@ mod tests {
         comptime
         {
             let expr = quote { 1 }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
 
             assert_eq((2, false), expr.as_integer().unwrap());
         }
@@ -209,7 +209,7 @@ mod tests {
         comptime
         {
             let expr = quote { 3 + 4 }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
 
             let (lhs, op, rhs) = expr.as_binary_op().unwrap();
             assert_eq(lhs.as_integer().unwrap(), (6, false));
@@ -246,7 +246,7 @@ mod tests {
         comptime
         {
             let expr = quote { 1 as Field }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (expr, typ) = expr.as_cast().unwrap();
             assert_eq(expr.as_integer().unwrap(), (2, false));
             assert(typ.is_field());
@@ -268,7 +268,7 @@ mod tests {
         comptime
         {
             let expr = quote { comptime { 1; 4; 23 } }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let exprs = expr.as_comptime().unwrap();
             assert_eq(exprs.len(), 3);
             assert_eq(exprs[0].as_integer().unwrap(), (2, false));
@@ -308,7 +308,7 @@ mod tests {
         comptime
         {
             let expr = quote { foo(42) }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (_function, args) = expr.as_function_call().unwrap();
             assert_eq(args.len(), 1);
             assert_eq(args[0].as_integer().unwrap(), (84, false));
@@ -334,7 +334,7 @@ mod tests {
         comptime
         {
             let expr = quote { if 1 { 2 } }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (condition, consequence, alternative) = expr.as_if().unwrap();
             assert_eq(condition.as_integer().unwrap(), (2, false));
             let consequence = consequence.as_block().unwrap()[0].as_block().unwrap()[0];
@@ -342,7 +342,7 @@ mod tests {
             assert(alternative.is_none());
 
             let expr = quote { if 1 { 2 } else { 3 } }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (condition, consequence, alternative) = expr.as_if().unwrap();
             assert_eq(condition.as_integer().unwrap(), (2, false));
             let consequence = consequence.as_block().unwrap()[0].as_block().unwrap()[0];
@@ -366,7 +366,7 @@ mod tests {
         comptime
         {
             let expr = quote { 1[2] }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (object, index) = expr.as_index().unwrap();
             assert_eq(object.as_integer().unwrap(), (2, false));
             assert_eq(index.as_integer().unwrap(), (4, false));
@@ -388,7 +388,7 @@ mod tests {
         comptime
         {
             let expr = quote { 1.bar }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (expr, name) = expr.as_member_access().unwrap();
             assert_eq(name, quote { bar });
             assert_eq(expr.as_integer().unwrap(), (2, false));
@@ -423,7 +423,7 @@ mod tests {
         comptime
         {
             let expr = quote { [1; 3] }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (expr, length) = expr.as_repeated_element_array().unwrap();
             assert_eq(expr.as_integer().unwrap(), (2, false));
             assert_eq(length.as_integer().unwrap(), (6, false));
@@ -446,7 +446,7 @@ mod tests {
         comptime
         {
             let expr = quote { &[1; 3] }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (expr, length) = expr.as_repeated_element_slice().unwrap();
             assert_eq(expr.as_integer().unwrap(), (2, false));
             assert_eq(length.as_integer().unwrap(), (6, false));
@@ -471,7 +471,7 @@ mod tests {
         comptime
         {
             let expr = quote { &[1, 3, 5] }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let elems = expr.as_slice().unwrap();
             assert_eq(elems.len(), 3);
             assert_eq(elems[0].as_integer().unwrap(), (2, false));
@@ -495,7 +495,7 @@ mod tests {
         comptime
         {
             let expr = quote { (1, 2) }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let tuple_exprs = expr.as_tuple().unwrap();
             assert_eq(tuple_exprs.len(), 2);
             assert_eq(tuple_exprs[0].as_integer().unwrap(), (2, false));
@@ -519,7 +519,7 @@ mod tests {
         comptime
         {
             let expr = quote { -(1) }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let (op, expr) = expr.as_unary_op().unwrap();
             assert(op.is_minus());
             assert_eq(expr.as_integer().unwrap(), (2, false));
@@ -541,7 +541,7 @@ mod tests {
         comptime
         {
             let expr = quote { unsafe { 1; 4; 23 } }.as_expr().unwrap();
-            let expr = expr.mutate(times_two);
+            let expr = expr.modify(times_two);
             let exprs = expr.as_unsafe().unwrap();
             assert_eq(exprs.len(), 3);
             assert_eq(exprs[0].as_integer().unwrap(), (2, false));

--- a/test_programs/noir_test_success/comptime_expr/src/main.nr
+++ b/test_programs/noir_test_success/comptime_expr/src/main.nr
@@ -30,6 +30,40 @@ mod tests {
     }
 
     #[test]
+    fn test_expr_as_assert() {
+        comptime
+        {
+            let expr = quote { assert(true) }.as_expr().unwrap();
+            let (predicate, msg) = expr.as_assert().unwrap();
+            assert_eq(predicate.as_bool().unwrap(), true);
+            assert(msg.is_none());
+
+            let expr = quote { assert(false, "oops") }.as_expr().unwrap();
+            let (predicate, msg) = expr.as_assert().unwrap();
+            assert_eq(predicate.as_bool().unwrap(), false);
+            assert(msg.is_some());
+        }
+    }
+
+    #[test]
+    fn test_expr_mutate_for_assert() {
+        comptime
+        {
+            let expr = quote { assert(1) }.as_expr().unwrap();
+            let expr = expr.mutate(times_two);
+            let (predicate, msg) = expr.as_assert().unwrap();
+            assert_eq(predicate.as_integer().unwrap(), (2, false));
+            assert(msg.is_none());
+
+            let expr = quote { assert(1, 2) }.as_expr().unwrap();
+            let expr = expr.mutate(times_two);
+            let (predicate, msg) = expr.as_assert().unwrap();
+            assert_eq(predicate.as_integer().unwrap(), (2, false));
+            assert_eq(msg.unwrap().as_integer().unwrap(), (4, false));
+        }
+    }
+
+    #[test]
     fn test_expr_as_assign() {
         comptime
         {


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

Adds `Expr::as_assert` and handles it in `Expr::mutate`.

## Additional Context

None.

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
