### PR TITLE
feat: LSP signature help for assert and assert_eq

### DIFF
--- a/tooling/lsp/src/requests/completion/builtins.rs
+++ b/tooling/lsp/src/requests/completion/builtins.rs
@@ -3,7 +3,10 @@ use noirc_frontend::token::Keyword;
 use strum::IntoEnumIterator;
 
 use super::{
-    completion_items::{simple_completion_item, snippet_completion_item},
+    completion_items::{
+        completion_item_with_trigger_parameter_hints_command, simple_completion_item,
+        snippet_completion_item,
+    },
     kinds::FunctionCompletionKind,
     name_matches, NodeFinder,
 };
@@ -31,12 +34,16 @@ impl<'a> NodeFinder<'a> {
                         }
                     }
 
-                    self.completion_items.push(snippet_completion_item(
-                        label,
-                        CompletionItemKind::FUNCTION,
-                        insert_text,
-                        description,
-                    ));
+                    self.completion_items.push(
+                        completion_item_with_trigger_parameter_hints_command(
+                            snippet_completion_item(
+                                label,
+                                CompletionItemKind::FUNCTION,
+                                insert_text,
+                                description,
+                            ),
+                        ),
+                    );
                 }
             }
         }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -470,19 +470,19 @@ mod completion_tests {
         assert_completion_excluding_auto_import(
             src,
             vec![
-                snippet_completion_item(
+                completion_item_with_trigger_parameter_hints_command(snippet_completion_item(
                     "assert(…)",
                     CompletionItemKind::FUNCTION,
                     "assert(${1:predicate})",
                     Some("fn(T)".to_string()),
-                ),
+                )),
                 function_completion_item("assert_constant(…)", "assert_constant(${1:x})", "fn(T)"),
-                snippet_completion_item(
+                completion_item_with_trigger_parameter_hints_command(snippet_completion_item(
                     "assert_eq(…)",
                     CompletionItemKind::FUNCTION,
                     "assert_eq(${1:lhs}, ${2:rhs})",
                     Some("fn(T, T)".to_string()),
-                ),
+                )),
             ],
         )
         .await;

--- a/tooling/lsp/src/requests/signature_help/tests.rs
+++ b/tooling/lsp/src/requests/signature_help/tests.rs
@@ -193,4 +193,27 @@ mod signature_help_tests {
 
         assert_eq!(signature.active_parameter, Some(0));
     }
+
+    #[test]
+    async fn test_signature_help_for_assert() {
+        let src = r#"
+            fn bar() {
+                assert(>|<1, "hello");
+            }
+        "#;
+
+        let signature_help = get_signature_help(src).await;
+        assert_eq!(signature_help.signatures.len(), 1);
+
+        let signature = &signature_help.signatures[0];
+        assert_eq!(signature.label, "assert(predicate: bool, [failure_message: str<N>])");
+
+        let params = signature.parameters.as_ref().unwrap();
+        assert_eq!(params.len(), 2);
+
+        check_label(&signature.label, &params[0].label, "predicate: bool");
+        check_label(&signature.label, &params[1].label, "[failure_message: str<N>]");
+
+        assert_eq!(signature.active_parameter, Some(0));
+    }
 }

--- a/tooling/lsp/src/requests/signature_help/tests.rs
+++ b/tooling/lsp/src/requests/signature_help/tests.rs
@@ -216,4 +216,28 @@ mod signature_help_tests {
 
         assert_eq!(signature.active_parameter, Some(0));
     }
+
+    #[test]
+    async fn test_signature_help_for_assert_eq() {
+        let src = r#"
+            fn bar() {
+                assert_eq(>|<true, false, "oops");
+            }
+        "#;
+
+        let signature_help = get_signature_help(src).await;
+        assert_eq!(signature_help.signatures.len(), 1);
+
+        let signature = &signature_help.signatures[0];
+        assert_eq!(signature.label, "assert_eq(lhs: T, rhs: T, [failure_message: str<N>])");
+
+        let params = signature.parameters.as_ref().unwrap();
+        assert_eq!(params.len(), 3);
+
+        check_label(&signature.label, &params[0].label, "lhs: T");
+        check_label(&signature.label, &params[1].label, "rhs: T");
+        check_label(&signature.label, &params[2].label, "[failure_message: str<N>]");
+
+        assert_eq!(signature.active_parameter, Some(0));
+    }
 }

--- a/tooling/lsp/src/requests/signature_help/traversal.rs
+++ b/tooling/lsp/src/requests/signature_help/traversal.rs
@@ -4,11 +4,11 @@ use super::SignatureFinder;
 
 use noirc_frontend::{
     ast::{
-        ArrayLiteral, AssignStatement, BlockExpression, CastExpression, ConstrainStatement,
-        ConstructorExpression, Expression, ExpressionKind, ForLoopStatement, ForRange,
-        IfExpression, IndexExpression, InfixExpression, LValue, Lambda, LetStatement, Literal,
-        MemberAccessExpression, NoirFunction, NoirTrait, NoirTraitImpl, Statement, StatementKind,
-        TraitImplItem, TraitItem, TypeImpl,
+        ArrayLiteral, AssignStatement, BlockExpression, CastExpression, ConstructorExpression,
+        Expression, ExpressionKind, ForLoopStatement, ForRange, IfExpression, IndexExpression,
+        InfixExpression, LValue, Lambda, LetStatement, Literal, MemberAccessExpression,
+        NoirFunction, NoirTrait, NoirTraitImpl, Statement, StatementKind, TraitImplItem, TraitItem,
+        TypeImpl,
     },
     parser::{Item, ItemKind},
     ParsedModule,
@@ -134,14 +134,6 @@ impl<'a> SignatureFinder<'a> {
 
     pub(super) fn find_in_let_statement(&mut self, let_statement: &LetStatement) {
         self.find_in_expression(&let_statement.expression);
-    }
-
-    pub(super) fn find_in_constrain_statement(&mut self, constrain_statement: &ConstrainStatement) {
-        self.find_in_expression(&constrain_statement.0);
-
-        if let Some(exp) = &constrain_statement.1 {
-            self.find_in_expression(exp);
-        }
     }
 
     pub(super) fn find_in_assign_statement(&mut self, assign_statement: &AssignStatement) {


### PR DESCRIPTION
# Description

## Problem

This is something minor, but it's good for completeness and also for users to easily learn that there's an optional failure message you can use in these built-in functions.

## Summary

![lsp-signature-help-assert](https://github.com/user-attachments/assets/77d621fb-360f-47df-92da-f51af00298db)

![lsp-signature-help-assert_eq](https://github.com/user-attachments/assets/6d23a051-9440-4a86-b970-e060b60ab5a1)

## Additional Context

I don't know if the syntax is clear for showing that the last argument is optional, so if you have another syntax in mind let me know!

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
