### PR TITLE
fix(nargo): Resolve Brillig assertion payloads

### DIFF
--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -2,8 +2,7 @@ use std::collections::BTreeMap;
 
 use acvm::{
     acir::circuit::{
-        ErrorSelector, OpcodeLocation, RawAssertionPayload, ResolvedAssertionPayload,
-        ResolvedOpcodeLocation,
+        brillig::BrilligFunctionId, ErrorSelector, OpcodeLocation, RawAssertionPayload, ResolvedAssertionPayload, ResolvedOpcodeLocation
     },
     pwg::{ErrorLocation, OpcodeResolutionError},
     AcirField, FieldElement,
@@ -66,7 +65,7 @@ impl<F: AcirField> NargoError<F> {
     ) -> Option<String> {
         match self {
             NargoError::ExecutionError(error) => match error {
-                ExecutionError::AssertionFailed(payload, _) => match payload {
+                ExecutionError::AssertionFailed(payload, _, _) => match payload {
                     ResolvedAssertionPayload::String(message) => Some(message.to_string()),
                     ResolvedAssertionPayload::Raw(raw) => {
                         let abi_type = error_types.get(&raw.selector)?;
@@ -90,7 +89,7 @@ impl<F: AcirField> NargoError<F> {
 #[derive(Debug, Error)]
 pub enum ExecutionError<F: AcirField> {
     #[error("Failed assertion")]
-    AssertionFailed(ResolvedAssertionPayload<F>, Vec<ResolvedOpcodeLocation>),
+    AssertionFailed(ResolvedAssertionPayload<F>, Vec<ResolvedOpcodeLocation>, Option<BrilligFunctionId>),
 
     #[error("Failed to solve program: '{}'", .0)]
     SolvingError(OpcodeResolutionError<F>, Option<Vec<ResolvedOpcodeLocation>>),
@@ -106,7 +105,7 @@ fn extract_locations_from_error<F: AcirField>(
             OpcodeResolutionError::BrilligFunctionFailed { .. },
             acir_call_stack,
         ) => acir_call_stack.clone(),
-        ExecutionError::AssertionFailed(_, call_stack) => Some(call_stack.clone()),
+        ExecutionError::AssertionFailed(_, call_stack, _) => Some(call_stack.clone()),
         ExecutionError::SolvingError(
             OpcodeResolutionError::IndexOutOfBounds { opcode_location: error_location, .. },
             acir_call_stack,
@@ -148,6 +147,7 @@ fn extract_locations_from_error<F: AcirField>(
             OpcodeResolutionError::BrilligFunctionFailed { function_id, .. },
             _,
         ) => Some(*function_id),
+        ExecutionError::AssertionFailed(_, _, function_id) => *function_id,
         _ => None,
     };
 
@@ -186,6 +186,7 @@ fn extract_message_from_error(
     match nargo_err {
         NargoError::ExecutionError(ExecutionError::AssertionFailed(
             ResolvedAssertionPayload::String(message),
+            _,
             _,
         )) => {
             format!("Assertion failed: '{message}'")

--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use acvm::{
     acir::circuit::{
-        brillig::BrilligFunctionId, ErrorSelector, OpcodeLocation, RawAssertionPayload, ResolvedAssertionPayload, ResolvedOpcodeLocation
+        brillig::BrilligFunctionId, ErrorSelector, OpcodeLocation, RawAssertionPayload,
+        ResolvedAssertionPayload, ResolvedOpcodeLocation,
     },
     pwg::{ErrorLocation, OpcodeResolutionError},
     AcirField, FieldElement,
@@ -89,7 +90,11 @@ impl<F: AcirField> NargoError<F> {
 #[derive(Debug, Error)]
 pub enum ExecutionError<F: AcirField> {
     #[error("Failed assertion")]
-    AssertionFailed(ResolvedAssertionPayload<F>, Vec<ResolvedOpcodeLocation>, Option<BrilligFunctionId>),
+    AssertionFailed(
+        ResolvedAssertionPayload<F>,
+        Vec<ResolvedOpcodeLocation>,
+        Option<BrilligFunctionId>,
+    ),
 
     #[error("Failed to solve program: '{}'", .0)]
     SolvingError(OpcodeResolutionError<F>, Option<Vec<ResolvedOpcodeLocation>>),

--- a/tooling/nargo/src/ops/execute.rs
+++ b/tooling/nargo/src/ops/execute.rs
@@ -117,7 +117,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>, E: ForeignCallExecutor<F>>
                         _ => None,
                     };
 
-                    let brillig_function_id =  match &error {
+                    let brillig_function_id = match &error {
                         OpcodeResolutionError::BrilligFunctionFailed { function_id, .. } => {
                             Some(*function_id)
                         }

--- a/tooling/nargo/src/ops/execute.rs
+++ b/tooling/nargo/src/ops/execute.rs
@@ -117,10 +117,18 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>, E: ForeignCallExecutor<F>>
                         _ => None,
                     };
 
+                    let brillig_function_id =  match &error {
+                        OpcodeResolutionError::BrilligFunctionFailed { function_id, .. } => {
+                            Some(*function_id)
+                        }
+                        _ => None,
+                    };
+
                     return Err(NargoError::ExecutionError(match assertion_payload {
                         Some(payload) => ExecutionError::AssertionFailed(
                             payload,
                             call_stack.expect("Should have call stack for an assertion failure"),
+                            brillig_function_id,
                         ),
                         None => ExecutionError::SolvingError(error, call_stack),
                     }));


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

Bug found while doing other work

## Summary\*

With the move to Brillig locations we fetch the brillig function id separately when resolving errors. We were not appropriately attaching a BrilligFunctionId when we had an `ExecutionError::AssertionFailed`. We now attach an `Option<BrilligFunctionId>` to an `ExecutionError::AssertionFailed` that allows us to resolve the Brillig metadata.

Testing on `execution_failure/option_expect`:
Before this PR:
<img width="434" alt="Screenshot 2024-08-30 at 2 58 34 PM" src="https://github.com/user-attachments/assets/92a7726d-1e1d-48e0-a1bc-a4c197086277">

After this PR:
<img width="729" alt="Screenshot 2024-08-30 at 2 58 46 PM" src="https://github.com/user-attachments/assets/b5f5d58c-5401-4117-8ecd-c5f3c1c87414">




## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
