### PR TITLE
chore: use `new_let` more widely

### DIFF
--- a/aztec_macros/src/utils/ast_utils.rs
+++ b/aztec_macros/src/utils/ast_utils.rs
@@ -1,9 +1,9 @@
 use noirc_errors::{Span, Spanned};
 use noirc_frontend::ast::{
     BinaryOpKind, CallExpression, CastExpression, Expression, ExpressionKind, FunctionReturnType,
-    Ident, IndexExpression, InfixExpression, Lambda, LetStatement, MemberAccessExpression,
-    MethodCallExpression, NoirTraitImpl, Path, PathSegment, Pattern, PrefixExpression, Statement,
-    StatementKind, TraitImplItem, UnaryOp, UnresolvedType, UnresolvedTypeData,
+    Ident, IndexExpression, InfixExpression, Lambda, MemberAccessExpression, MethodCallExpression,
+    NoirTraitImpl, Path, PathSegment, Pattern, PrefixExpression, Statement, StatementKind,
+    TraitImplItem, UnaryOp, UnresolvedType, UnresolvedTypeData,
 };
 use noirc_frontend::token::SecondaryAttribute;
 
@@ -73,13 +73,11 @@ pub fn mutable(name: &str) -> Pattern {
 }
 
 pub fn mutable_assignment(name: &str, assigned_to: Expression) -> Statement {
-    make_statement(StatementKind::Let(LetStatement {
-        pattern: mutable(name),
-        r#type: make_type(UnresolvedTypeData::Unspecified),
-        expression: assigned_to,
-        comptime: false,
-        attributes: vec![],
-    }))
+    make_statement(StatementKind::new_let(
+        mutable(name),
+        make_type(UnresolvedTypeData::Unspecified),
+        assigned_to,
+    ))
 }
 
 pub fn mutable_reference(variable_name: &str) -> Expression {
@@ -98,13 +96,7 @@ pub fn assignment_with_type(
     typ: UnresolvedTypeData,
     assigned_to: Expression,
 ) -> Statement {
-    make_statement(StatementKind::Let(LetStatement {
-        pattern: pattern(name),
-        r#type: make_type(typ),
-        expression: assigned_to,
-        comptime: false,
-        attributes: vec![],
-    }))
+    make_statement(StatementKind::new_let(pattern(name), make_type(typ), assigned_to))
 }
 
 pub fn return_type(path: Path) -> FunctionReturnType {

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -136,7 +136,9 @@ impl Recoverable for StatementKind {
 
 impl StatementKind {
     pub fn new_let(
-        ((pattern, r#type), expression): ((Pattern, UnresolvedType), Expression),
+        pattern: Pattern,
+        r#type: UnresolvedType,
+        expression: Expression,
     ) -> StatementKind {
         StatementKind::Let(LetStatement {
             pattern,
@@ -715,13 +717,11 @@ impl ForRange {
 
                 // let fresh1 = array;
                 let let_array = Statement {
-                    kind: StatementKind::Let(LetStatement {
-                        pattern: Pattern::Identifier(array_ident.clone()),
-                        r#type: UnresolvedTypeData::Unspecified.with_span(Default::default()),
-                        expression: array,
-                        comptime: false,
-                        attributes: vec![],
-                    }),
+                    kind: StatementKind::new_let(
+                        Pattern::Identifier(array_ident.clone()),
+                        UnresolvedTypeData::Unspecified.with_span(Default::default()),
+                        array,
+                    ),
                     span: array_span,
                 };
 
@@ -761,13 +761,11 @@ impl ForRange {
 
                 // let elem = array[i];
                 let let_elem = Statement {
-                    kind: StatementKind::Let(LetStatement {
-                        pattern: Pattern::Identifier(identifier),
-                        r#type: UnresolvedTypeData::Unspecified.with_span(Default::default()),
-                        expression: Expression::new(loop_element, array_span),
-                        comptime: false,
-                        attributes: vec![],
-                    }),
+                    kind: StatementKind::new_let(
+                        Pattern::Identifier(identifier),
+                        UnresolvedTypeData::Unspecified.with_span(Default::default()),
+                        Expression::new(loop_element, array_span),
+                    ),
                     span: array_span,
                 };
 

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -142,13 +142,11 @@ impl DebugInstrumenter {
             None => false,
             Some(ast::Statement { kind: ast::StatementKind::Expression(ret_expr), .. }) => {
                 let save_ret_expr = ast::Statement {
-                    kind: ast::StatementKind::Let(ast::LetStatement {
-                        pattern: ast::Pattern::Identifier(ident("__debug_expr", ret_expr.span)),
-                        r#type: ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
-                        expression: ret_expr.clone(),
-                        comptime: false,
-                        attributes: vec![],
-                    }),
+                    kind: ast::StatementKind::new_let(
+                        ast::Pattern::Identifier(ident("__debug_expr", ret_expr.span)),
+                        ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
+                        ret_expr.clone(),
+                    ),
                     span: ret_expr.span,
                 };
                 statements.push(save_ret_expr);
@@ -242,18 +240,16 @@ impl DebugInstrumenter {
         });
 
         ast::Statement {
-            kind: ast::StatementKind::Let(ast::LetStatement {
-                pattern: ast::Pattern::Tuple(vars_pattern, let_stmt.pattern.span()),
-                r#type: ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
-                comptime: false,
-                expression: ast::Expression {
+            kind: ast::StatementKind::new_let(
+                ast::Pattern::Tuple(vars_pattern, let_stmt.pattern.span()),
+                ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
+                ast::Expression {
                     kind: ast::ExpressionKind::Block(ast::BlockExpression {
                         statements: block_stmts,
                     }),
                     span: let_stmt.expression.span,
                 },
-                attributes: vec![],
-            }),
+            ),
             span: *span,
         }
     }
@@ -274,13 +270,11 @@ impl DebugInstrumenter {
         //   __debug_expr
         // };
 
-        let let_kind = ast::StatementKind::Let(ast::LetStatement {
-            pattern: ast::Pattern::Identifier(ident("__debug_expr", assign_stmt.expression.span)),
-            r#type: ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
-            expression: assign_stmt.expression.clone(),
-            comptime: false,
-            attributes: vec![],
-        });
+        let let_kind = ast::StatementKind::new_let(
+            ast::Pattern::Identifier(ident("__debug_expr", assign_stmt.expression.span)),
+            ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
+            assign_stmt.expression.clone(),
+        );
         let expression_span = assign_stmt.expression.span;
         let new_assign_stmt = match &assign_stmt.lvalue {
             ast::LValue::Ident(id) => {

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -4,7 +4,7 @@ use noirc_errors::{Span, Spanned};
 use crate::ast::{
     ArrayLiteral, AssignStatement, BlockExpression, CallExpression, CastExpression, ConstrainKind,
     ConstructorExpression, ExpressionKind, ForLoopStatement, ForRange, GenericTypeArgs, Ident,
-    IfExpression, IndexExpression, InfixExpression, LValue, Lambda, LetStatement, Literal,
+    IfExpression, IndexExpression, InfixExpression, LValue, Lambda, Literal,
     MemberAccessExpression, MethodCallExpression, Path, PathSegment, Pattern, PrefixExpression,
     UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression,
 };
@@ -29,13 +29,7 @@ impl HirStatement {
                 let pattern = let_stmt.pattern.to_display_ast(interner);
                 let r#type = interner.id_type(let_stmt.expression).to_display_ast();
                 let expression = let_stmt.expression.to_display_ast(interner);
-                StatementKind::Let(LetStatement {
-                    pattern,
-                    r#type,
-                    expression,
-                    comptime: false,
-                    attributes: Vec::new(),
-                })
+                StatementKind::new_let(pattern, r#type, expression)
             }
             HirStatement::Constrain(constrain) => {
                 let expr = constrain.0.to_display_ast(interner);

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -574,7 +574,8 @@ fn declaration<'a, P>(expr_parser: P) -> impl NoirParser<StatementKind> + 'a
 where
     P: ExprParser + 'a,
 {
-    let_statement(expr_parser).map(StatementKind::new_let)
+    let_statement(expr_parser)
+        .map(|((pattern, typ), expr)| StatementKind::new_let(pattern, typ, expr))
 }
 
 pub fn pattern() -> impl NoirParser<Pattern> {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We have this nice helper function to construct `StatementKind:Let`s in the parser but we don't use it anywhere else. This PR reworks this helper function so we can use it in more places.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
