### PR TITLE
feat: implement `str_as_bytes` in the `comptime` interpreter

### DIFF
--- a/test_programs/compile_success_empty/comptime_str_as_bytes/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_str_as_bytes/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_str_as_bytes"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.24.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_str_as_bytes/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_str_as_bytes/src/main.nr
@@ -1,0 +1,9 @@
+fn main() {
+    comptime
+    {
+        let hello_world_string = "hello world";
+        let hello_world_bytes: [u8; 11] = [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64];
+
+        assert_eq(hello_world_string.as_bytes(), hello_world_bytes);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR implements converting a string to a byte array in comptime, something very useful for function signatures in aztec-nr

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
