### PR TITLE
chore: update git user for release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
         
       - name: Configure git
         run: |
-          git config user.name kevaundray
-          git config user.email kevtheappdev@gmail.com
+          git config user.name noirwhal
+          git config user.email tomfrench@aztecprotocol.com
 
       - name: Commit updates
         run: |
@@ -100,8 +100,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --local user.name 'kevaundray'
-          git config --local user.email 'kevtheappdev@gmail.com'
+          git config --local user.name noirwhal
+          git config --local user.email tomfrench@aztecprotocol.com
 
       - name: Commit new documentation version
         run: |


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I noticed that the commits for the release PR is still set up to be authored by Kev. I've replaced this with the noirwhal account.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
