### PR TITLE
feat: better println for Quoted

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -567,37 +567,33 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
             Value::Quoted(tokens) => {
                 write!(f, "quote {{")?;
                 for token in tokens.iter() {
+                    write!(f, " ")?;
+
                     match token {
                         Token::QuotedType(id) => {
-                            write!(f, " {}", self.interner.get_quoted_type(*id))?;
+                            write!(f, "{}", self.interner.get_quoted_type(*id))?;
                         }
                         Token::InternedExpr(id) => {
-                            let expr = self.interner.get_expression_kind(*id);
-                            let expr =
-                                remove_interned_in_expression_kind(self.interner, expr.clone());
-                            write!(f, " {}", expr)?;
+                            let value = Value::expression(ExpressionKind::Interned(*id));
+                            value.display(self.interner).fmt(f)?;
                         }
                         Token::InternedStatement(id) => {
-                            let stmt = self.interner.get_statement_kind(*id);
-                            let stmt =
-                                remove_interned_in_statement_kind(self.interner, stmt.clone());
-                            write!(f, " {}", stmt)?;
+                            let value = Value::statement(StatementKind::Interned(*id));
+                            value.display(self.interner).fmt(f)?;
                         }
                         Token::InternedLValue(id) => {
-                            let lvalue = self.interner.get_lvalue(*id, Span::default());
-                            let lvalue = remove_interned_in_lvalue(self.interner, lvalue.clone());
-                            write!(f, " {}", lvalue)?;
+                            let value = Value::lvalue(LValue::Interned(*id, Span::default()));
+                            value.display(self.interner).fmt(f)?;
                         }
                         Token::InternedUnresolvedTypeData(id) => {
-                            let typ = self.interner.get_unresolved_type_data(*id);
-                            write!(f, " {}", typ)?;
+                            let value = Value::UnresolvedType(UnresolvedTypeData::Interned(*id));
+                            value.display(self.interner).fmt(f)?;
                         }
                         Token::UnquoteMarker(id) => {
-                            let hir_expr = self.interner.expression(id);
-                            let expr = hir_expr.to_display_ast(self.interner, Span::default());
-                            write!(f, " {}", expr.kind)?;
+                            let value = Value::TypedExpr(TypedExpr::ExprId(*id));
+                            value.display(self.interner).fmt(f)?;
                         }
-                        other => write!(f, " {other}")?,
+                        other => write!(f, "{other}")?,
                     }
                 }
                 write!(f, " }}")
@@ -658,7 +654,16 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
             Value::Expr(ExprValue::LValue(lvalue)) => {
                 write!(f, "{}", remove_interned_in_lvalue(self.interner, lvalue.clone()))
             }
-            Value::TypedExpr(_) => write!(f, "(typed expr)"),
+            Value::TypedExpr(TypedExpr::ExprId(id)) => {
+                let hir_expr = self.interner.expression(id);
+                let expr = hir_expr.to_display_ast(self.interner, Span::default());
+                write!(f, "{}", expr.kind)
+            }
+            Value::TypedExpr(TypedExpr::StmtId(id)) => {
+                let hir_statement = self.interner.statement(id);
+                let stmt = hir_statement.to_display_ast(self.interner, Span::default());
+                write!(f, "{}", stmt.kind)
+            }
             Value::UnresolvedType(typ) => {
                 if let UnresolvedTypeData::Interned(id) = typ {
                     let typ = self.interner.get_unresolved_type_data(*id);

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -571,6 +571,27 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
                         Token::QuotedType(id) => {
                             write!(f, " {}", self.interner.get_quoted_type(*id))?;
                         }
+                        Token::InternedExpr(id) => {
+                            let expr = self.interner.get_expression_kind(*id);
+                            let expr =
+                                remove_interned_in_expression_kind(self.interner, expr.clone());
+                            write!(f, "{}", expr)?;
+                        }
+                        Token::InternedStatement(id) => {
+                            let stmt = self.interner.get_statement_kind(*id);
+                            let stmt =
+                                remove_interned_in_statement_kind(self.interner, stmt.clone());
+                            write!(f, "{}", stmt)?;
+                        }
+                        Token::InternedLValue(id) => {
+                            let lvalue = self.interner.get_lvalue(*id, Span::default());
+                            let lvalue = remove_interned_in_lvalue(self.interner, lvalue.clone());
+                            write!(f, "{}", lvalue)?;
+                        }
+                        Token::InternedUnresolvedTypeData(id) => {
+                            let typ = self.interner.get_unresolved_type_data(*id);
+                            write!(f, "{}", typ)?;
+                        }
                         other => write!(f, " {other}")?,
                     }
                 }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -592,6 +592,11 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
                             let typ = self.interner.get_unresolved_type_data(*id);
                             write!(f, " {}", typ)?;
                         }
+                        Token::UnquoteMarker(id) => {
+                            let hir_expr = self.interner.expression(id);
+                            let expr = hir_expr.to_display_ast(self.interner, Span::default());
+                            write!(f, " {}", expr.kind)?;
+                        }
                         other => write!(f, " {other}")?,
                     }
                 }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -575,22 +575,22 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
                             let expr = self.interner.get_expression_kind(*id);
                             let expr =
                                 remove_interned_in_expression_kind(self.interner, expr.clone());
-                            write!(f, "{}", expr)?;
+                            write!(f, " {}", expr)?;
                         }
                         Token::InternedStatement(id) => {
                             let stmt = self.interner.get_statement_kind(*id);
                             let stmt =
                                 remove_interned_in_statement_kind(self.interner, stmt.clone());
-                            write!(f, "{}", stmt)?;
+                            write!(f, " {}", stmt)?;
                         }
                         Token::InternedLValue(id) => {
                             let lvalue = self.interner.get_lvalue(*id, Span::default());
                             let lvalue = remove_interned_in_lvalue(self.interner, lvalue.clone());
-                            write!(f, "{}", lvalue)?;
+                            write!(f, " {}", lvalue)?;
                         }
                         Token::InternedUnresolvedTypeData(id) => {
                             let typ = self.interner.get_unresolved_type_data(*id);
-                            write!(f, "{}", typ)?;
+                            write!(f, " {}", typ)?;
                         }
                         other => write!(f, " {other}")?,
                     }


### PR DESCRIPTION
# Description

## Problem

Resolves #5899

For debugging purposes, when you `println` a quoted value, some token values aren't expanded, making it a bit harder to understand what's going on.

## Summary

Now interned expressions are shown in `Quoted` values.

This program:

```rust
fn main() {
    comptime
    {
        let n = quote { [1, 2, 3] }.as_expr().unwrap();
        let q = quote { $n };
        println(q);
    }
}
```

Used to print:

```
quote { (expr) }
```

Now it prints: 

```
quote { [1, 2, 3] }
```

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
