### PR TITLE
chore: make nested slice error more clear for `[[T]; N]` case

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -44,7 +44,7 @@ pub enum RuntimeError {
     StaticAssertDynamicPredicate { call_stack: CallStack },
     #[error("Argument is false")]
     StaticAssertFailed { call_stack: CallStack },
-    #[error("Nested slices are not supported")]
+    #[error("Nested slices, i.e. slices within an array or slice, are not supported")]
     NestedSlice { call_stack: CallStack },
     #[error("Big Integer modulus do no match")]
     BigIntModulus { call_stack: CallStack },

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -72,7 +72,7 @@ pub enum ResolverError {
     NumericConstantInFormatString { name: String, span: Span },
     #[error("Closure environment must be a tuple or unit type")]
     InvalidClosureEnvironment { typ: Type, span: Span },
-    #[error("Nested slices are not supported")]
+    #[error("Nested slices, i.e. slices within an array or slice, are not supported")]
     NestedSlices { span: Span },
     #[error("#[recursive] attribute is only allowed on entry points to a program")]
     MisplacedRecursiveAttribute { ident: Ident },
@@ -323,8 +323,8 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 format!("{typ} is not a valid closure environment type"),
                 "Closure environment must be a tuple or unit type".to_string(), *span),
             ResolverError::NestedSlices { span } => Diagnostic::simple_error(
-                "Nested slices are not supported".into(),
-                "Try to use a constant sized array instead".into(),
+                "Nested slices, i.e. slices within an array or slice, are not supported".into(),
+                "Try to use a constant sized array or BoundedVec instead".into(),
                 *span,
             ),
             ResolverError::MisplacedRecursiveAttribute { ident } => {


### PR DESCRIPTION
# Description

## Problem\*

The `NestedSlice` error is unclear when there is only one slice:

```bash
error: Nested slices are not supported
   ┌─ /Users/michaelklein/Coding/noir/two_tag/src/main.nr:31:12
   │
31 │     rules: [[Field]; N],
   │            ------------ Try to use a constant sized array instead
```

## Summary\*

Rephrases the `NestedSlice` error message to make it more clear that slices within arrays or other slices are disallowed.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
