### PR TITLE
feat: remove equality operation on boolean constraints against constants

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -255,7 +255,7 @@ impl<'block> BrilligBlock<'block> {
                 self.convert_ssa_binary(binary, dfg, result_var);
             }
             Instruction::Constrain(lhs, rhs, assert_message) => {
-                let condition = match (
+                let (condition, deallocate) = match (
                     dfg.get_numeric_constant_with_type(*lhs),
                     dfg.get_numeric_constant_with_type(*rhs),
                 ) {
@@ -264,13 +264,13 @@ impl<'block> BrilligBlock<'block> {
                         Some((constant, Type::Numeric(NumericType::Unsigned { bit_size: 1 }))),
                         None,
                     ) if constant == FieldElement::one() => {
-                        self.convert_ssa_single_addr_value(*rhs, dfg)
+                        (self.convert_ssa_single_addr_value(*rhs, dfg), false)
                     }
                     (
                         None,
                         Some((constant, Type::Numeric(NumericType::Unsigned { bit_size: 1 }))),
                     ) if constant == FieldElement::one() => {
-                        self.convert_ssa_single_addr_value(*lhs, dfg)
+                        (self.convert_ssa_single_addr_value(*lhs, dfg), false)
                     }
 
                     // Otherwise we need to perform the equality explicitly.
@@ -285,7 +285,7 @@ impl<'block> BrilligBlock<'block> {
                             condition,
                         );
 
-                        condition
+                        (condition, true)
                     }
                 };
 
@@ -311,7 +311,9 @@ impl<'block> BrilligBlock<'block> {
                         self.brillig_context.codegen_constrain(condition, None);
                     }
                 }
-                self.brillig_context.deallocate_single_addr(condition);
+                if deallocate {
+                    self.brillig_context.deallocate_single_addr(condition);
+                }
             }
             Instruction::Allocate => {
                 let result_value = dfg.instruction_results(instruction_id)[0];

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -255,16 +255,40 @@ impl<'block> BrilligBlock<'block> {
                 self.convert_ssa_binary(binary, dfg, result_var);
             }
             Instruction::Constrain(lhs, rhs, assert_message) => {
-                let condition = SingleAddrVariable {
-                    address: self.brillig_context.allocate_register(),
-                    bit_size: 1,
+                let condition = match (
+                    dfg.get_numeric_constant_with_type(*lhs),
+                    dfg.get_numeric_constant_with_type(*rhs),
+                ) {
+                    // If the constraint is of the form `x == u1 1` then we can simply constrain `x` directly
+                    (
+                        Some((constant, Type::Numeric(NumericType::Unsigned { bit_size: 1 }))),
+                        None,
+                    ) if constant == FieldElement::one() => {
+                        self.convert_ssa_single_addr_value(*rhs, dfg)
+                    }
+                    (
+                        None,
+                        Some((constant, Type::Numeric(NumericType::Unsigned { bit_size: 1 }))),
+                    ) if constant == FieldElement::one() => {
+                        self.convert_ssa_single_addr_value(*lhs, dfg)
+                    }
+
+                    // Otherwise we need to perform the equality explicitly.
+                    _ => {
+                        let condition = SingleAddrVariable {
+                            address: self.brillig_context.allocate_register(),
+                            bit_size: 1,
+                        };
+                        self.convert_ssa_binary(
+                            &Binary { lhs: *lhs, rhs: *rhs, operator: BinaryOp::Eq },
+                            dfg,
+                            condition,
+                        );
+
+                        condition
+                    }
                 };
 
-                self.convert_ssa_binary(
-                    &Binary { lhs: *lhs, rhs: *rhs, operator: BinaryOp::Eq },
-                    dfg,
-                    condition,
-                );
                 match assert_message {
                     Some(ConstrainError::Dynamic(selector, values)) => {
                         let payload_values =


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently performing a `x == 1` equality and then constraining the result to be `1` when dealing with boolean values in brillig. This PR updates the codegen to just act on `x` directly.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
