### PR TITLE
feat: check argument count and types on attribute function callback

### DIFF
--- a/aztec_macros/src/utils/ast_utils.rs
+++ b/aztec_macros/src/utils/ast_utils.rs
@@ -187,7 +187,7 @@ pub fn check_trait_method_implemented(trait_impl: &NoirTraitImpl, method_name: &
 
 /// Checks if an attribute is a custom attribute with a specific name
 pub fn is_custom_attribute(attr: &SecondaryAttribute, attribute_name: &str) -> bool {
-    if let SecondaryAttribute::Custom(custom_attr) = attr {
+    if let SecondaryAttribute::Custom(custom_attr, _) = attr {
         custom_attr.as_str() == attribute_name
     } else {
         false

--- a/aztec_macros/src/utils/ast_utils.rs
+++ b/aztec_macros/src/utils/ast_utils.rs
@@ -187,8 +187,8 @@ pub fn check_trait_method_implemented(trait_impl: &NoirTraitImpl, method_name: &
 
 /// Checks if an attribute is a custom attribute with a specific name
 pub fn is_custom_attribute(attr: &SecondaryAttribute, attribute_name: &str) -> bool {
-    if let SecondaryAttribute::Custom(custom_attr, _) = attr {
-        custom_attr.as_str() == attribute_name
+    if let SecondaryAttribute::Custom(custom_attribute) = attr {
+        custom_attribute.contents.as_str() == attribute_name
     } else {
         false
     }

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -453,8 +453,8 @@ fn compile_contract_inner(
             .secondary
             .iter()
             .filter_map(|attr| {
-                if let SecondaryAttribute::Custom(tag, _span) = attr {
-                    Some(tag)
+                if let SecondaryAttribute::Custom(attribute) = attr {
+                    Some(&attribute.contents)
                 } else {
                     None
                 }

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -452,9 +452,13 @@ fn compile_contract_inner(
             .attributes
             .secondary
             .iter()
-            .filter_map(
-                |attr| if let SecondaryAttribute::Custom(tag) = attr { Some(tag) } else { None },
-            )
+            .filter_map(|attr| {
+                if let SecondaryAttribute::Custom(tag, _span) = attr {
+                    Some(tag)
+                } else {
+                    None
+                }
+            })
             .cloned()
             .collect();
 

--- a/compiler/noirc_errors/src/position.rs
+++ b/compiler/noirc_errors/src/position.rs
@@ -103,6 +103,10 @@ impl Span {
         let other_distance = other.end() - other.start();
         self_distance < other_distance
     }
+
+    pub fn shift_by(&self, offset: u32) -> Span {
+        Self::from(self.start() + offset..self.end() + offset)
+    }
 }
 
 impl From<Span> for Range<usize> {

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -97,12 +97,11 @@ impl<'context> Elaborator<'context> {
     ) {
         for attribute in attributes {
             if let SecondaryAttribute::Custom(attribute) = attribute {
-                let attribute_span = Span::from(attribute.name_start..attribute.span.end());
                 if let Err(error) = self.run_comptime_attribute_on_item(
                     &attribute.contents,
                     item.clone(),
                     span,
-                    attribute_span,
+                    attribute.contents_span,
                     generated_items,
                 ) {
                     self.errors.push(error);

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -287,19 +287,12 @@ impl<'context> Elaborator<'context> {
                 expr_type
             };
 
-            let mut bindings = TypeBindings::new();
-            match arg_type.try_unify(param_type, &mut bindings) {
-                Ok(()) => {
-                    // Commit any type bindings on success
-                    Type::apply_type_bindings(bindings);
-                }
-                Err(UnificationError) => {
-                    return Err(InterpreterError::TypeMismatch {
-                        expected: param_type.clone(),
-                        actual: arg_type,
-                        location: arg_location,
-                    });
-                }
+            if let Err(UnificationError) = arg_type.unify(param_type) {
+                return Err(InterpreterError::TypeMismatch {
+                    expected: param_type.clone(),
+                    actual: arg_type,
+                    location: arg_location,
+                });
             }
         }
 

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -97,12 +97,13 @@ impl<'context> Elaborator<'context> {
         generated_items: &mut CollectedItems,
     ) {
         for attribute in attributes {
-            if let SecondaryAttribute::Custom(name, attribute_span) = attribute {
+            if let SecondaryAttribute::Custom(attribute) = attribute {
+                let attribute_span = Span::from(attribute.name_start..attribute.span.end());
                 if let Err(error) = self.run_comptime_attribute_on_item(
-                    name,
+                    &attribute.contents,
                     item.clone(),
                     span,
-                    *attribute_span,
+                    attribute_span,
                     generated_items,
                 ) {
                     self.errors.push(error);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -28,6 +28,7 @@ use crate::{
     node_interner::{
         DefinitionKind, DependencyId, ExprId, FuncId, GlobalId, ReferenceId, TraitId, TypeAliasId,
     },
+    token::CustomAtrribute,
     Shared, Type, TypeVariable,
 };
 use crate::{
@@ -819,8 +820,7 @@ impl<'context> Elaborator<'context> {
         let attributes = func.secondary_attributes().iter();
         let attributes =
             attributes.filter_map(|secondary_attribute| secondary_attribute.as_custom());
-        let attributes: Vec<(String, Span)> =
-            attributes.map(|(str, span)| (str.to_string(), span)).collect();
+        let attributes: Vec<CustomAtrribute> = attributes.cloned().collect();
 
         let meta = FuncMeta {
             name: name_ident,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -819,7 +819,8 @@ impl<'context> Elaborator<'context> {
         let attributes = func.secondary_attributes().iter();
         let attributes =
             attributes.filter_map(|secondary_attribute| secondary_attribute.as_custom());
-        let attributes = attributes.map(|str| str.to_string()).collect();
+        let attributes: Vec<(String, Span)> =
+            attributes.map(|(str, span)| (str.to_string(), span)).collect();
 
         let meta = FuncMeta {
             name: name_ident,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -36,7 +36,7 @@ use crate::{
         TraitImplKind, TraitMethodId,
     },
     Generics, Kind, ResolvedGeneric, Type, TypeBinding, TypeBindings, TypeVariable,
-    TypeVariableKind,
+    TypeVariableKind, UnificationError,
 };
 
 use super::{lints, Elaborator};
@@ -713,9 +713,9 @@ impl<'context> Elaborator<'context> {
         expected: &Type,
         make_error: impl FnOnce() -> TypeCheckError,
     ) {
-        let mut errors = Vec::new();
-        actual.unify(expected, &mut errors, make_error);
-        self.errors.extend(errors.into_iter().map(|error| (error.into(), self.file)));
+        if let Err(UnificationError) = actual.unify(expected) {
+            self.errors.push((make_error().into(), self.file));
+        }
     }
 
     /// Wrapper of Type::unify_with_coercions using self.errors

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1609,7 +1609,7 @@ fn function_def_has_named_attribute(
     let name = name.iter().map(|token| token.to_string()).collect::<Vec<_>>().join("");
 
     for (attribute, _) in attributes {
-        let parse_result = Elaborator::parse_attribute(attribute, location.file);
+        let parse_result = Elaborator::parse_attribute(attribute, location);
         let Ok(Some((function, _arguments))) = parse_result else {
             continue;
         };

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1608,8 +1608,8 @@ fn function_def_has_named_attribute(
 
     let name = name.iter().map(|token| token.to_string()).collect::<Vec<_>>().join("");
 
-    for (attribute, _) in attributes {
-        let parse_result = Elaborator::parse_attribute(attribute, location);
+    for attribute in attributes {
+        let parse_result = Elaborator::parse_attribute(&attribute.contents, location);
         let Ok(Some((function, _arguments))) = parse_result else {
             continue;
         };

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1608,7 +1608,7 @@ fn function_def_has_named_attribute(
 
     let name = name.iter().map(|token| token.to_string()).collect::<Vec<_>>().join("");
 
-    for attribute in attributes {
+    for (attribute, _) in attributes {
         let parse_result = Elaborator::parse_attribute(attribute, location.file);
         let Ok(Some((function, _arguments))) = parse_result else {
             continue;

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -166,7 +166,7 @@ pub struct FuncMeta {
     pub self_type: Option<Type>,
 
     /// Custom attributes attached to this function.
-    pub custom_attributes: Vec<String>,
+    pub custom_attributes: Vec<(String, Span)>,
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -10,6 +10,7 @@ use crate::graph::CrateId;
 use crate::hir::def_map::LocalModuleId;
 use crate::macros_api::{BlockExpression, StructId};
 use crate::node_interner::{ExprId, NodeInterner, TraitId, TraitImplId};
+use crate::token::CustomAtrribute;
 use crate::{ResolvedGeneric, Type};
 
 /// A Hir function is a block expression with a list of statements.
@@ -166,7 +167,7 @@ pub struct FuncMeta {
     pub self_type: Option<Type>,
 
     /// Custom attributes attached to this function.
-    pub custom_attributes: Vec<(String, Span)>,
+    pub custom_attributes: Vec<CustomAtrribute>,
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1467,21 +1467,13 @@ impl Type {
     /// equal to the other type in the process. When comparing types, unification
     /// (including try_unify) are almost always preferred over Type::eq as unification
     /// will correctly handle generic types.
-    pub fn unify(
-        &self,
-        expected: &Type,
-        errors: &mut Vec<TypeCheckError>,
-        make_error: impl FnOnce() -> TypeCheckError,
-    ) {
+    pub fn unify(&self, expected: &Type) -> Result<(), UnificationError> {
         let mut bindings = TypeBindings::new();
 
-        match self.try_unify(expected, &mut bindings) {
-            Ok(()) => {
-                // Commit any type bindings on success
-                Self::apply_type_bindings(bindings);
-            }
-            Err(UnificationError) => errors.push(make_error()),
-        }
+        self.try_unify(expected, &mut bindings).map(|()| {
+            // Commit any type bindings on success
+            Self::apply_type_bindings(bindings);
+        })
     }
 
     /// `try_unify` is a bit of a misnomer since although errors are not committed,

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -820,7 +820,7 @@ mod tests {
             &Token::Attribute(Attribute::Secondary(SecondaryAttribute::Custom(CustomAtrribute {
                 contents: "custom(hello)".to_string(),
                 span: Span::from(0..16),
-                contents_span: Span::from(2..14)
+                contents_span: Span::from(2..15)
             })))
         );
     }

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -295,9 +295,11 @@ impl<'a> Lexer<'a> {
         }
         self.next_char();
 
-        let name_start = self.position;
+        let contents_start = self.position + 1;
 
         let word = self.eat_while(None, |ch| ch != ']');
+
+        let contents_end = self.position;
 
         if !self.peek_char_is(']') {
             return Err(LexerErrorKind::UnexpectedCharacter {
@@ -310,8 +312,10 @@ impl<'a> Lexer<'a> {
 
         let end = self.position;
 
-        let attribute =
-            Attribute::lookup_attribute(&word, Span::inclusive(start, end), name_start)?;
+        let span = Span::inclusive(start, end);
+        let contents_span = Span::inclusive(contents_start, contents_end);
+
+        let attribute = Attribute::lookup_attribute(&word, span, contents_span)?;
 
         Ok(attribute.into_span(start, end))
     }
@@ -815,8 +819,8 @@ mod tests {
             token.token(),
             &Token::Attribute(Attribute::Secondary(SecondaryAttribute::Custom(CustomAtrribute {
                 contents: "custom(hello)".to_string(),
-                span: Span::from(0..14),
-                name_start: 2,
+                span: Span::from(0..16),
+                contents_span: Span::from(2..14)
             })))
         );
     }

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -770,7 +770,7 @@ impl Attribute {
             ["varargs"] => Attribute::Secondary(SecondaryAttribute::Varargs),
             tokens => {
                 tokens.iter().try_for_each(|token| validate(token))?;
-                Attribute::Secondary(SecondaryAttribute::Custom(word.to_owned()))
+                Attribute::Secondary(SecondaryAttribute::Custom(word.to_owned(), span))
             }
         };
 
@@ -863,7 +863,7 @@ pub enum SecondaryAttribute {
     ContractLibraryMethod,
     Export,
     Field(String),
-    Custom(String),
+    Custom(String, Span),
     Abi(String),
 
     /// A variable-argument comptime function.
@@ -871,9 +871,9 @@ pub enum SecondaryAttribute {
 }
 
 impl SecondaryAttribute {
-    pub(crate) fn as_custom(&self) -> Option<&str> {
-        if let Self::Custom(str) = self {
-            Some(str)
+    pub(crate) fn as_custom(&self) -> Option<(&str, Span)> {
+        if let Self::Custom(str, span) = self {
+            Some((str, *span))
         } else {
             None
         }
@@ -887,7 +887,7 @@ impl fmt::Display for SecondaryAttribute {
             SecondaryAttribute::Deprecated(Some(ref note)) => {
                 write!(f, r#"#[deprecated("{note}")]"#)
             }
-            SecondaryAttribute::Custom(ref k) => write!(f, "#[{k}]"),
+            SecondaryAttribute::Custom(ref k, _) => write!(f, "#[{k}]"),
             SecondaryAttribute::ContractLibraryMethod => write!(f, "#[contract_library_method]"),
             SecondaryAttribute::Export => write!(f, "#[export]"),
             SecondaryAttribute::Field(ref k) => write!(f, "#[field({k})]"),
@@ -916,7 +916,7 @@ impl AsRef<str> for SecondaryAttribute {
         match self {
             SecondaryAttribute::Deprecated(Some(string)) => string,
             SecondaryAttribute::Deprecated(None) => "",
-            SecondaryAttribute::Custom(string)
+            SecondaryAttribute::Custom(string, _)
             | SecondaryAttribute::Field(string)
             | SecondaryAttribute::Abi(string) => string,
             SecondaryAttribute::ContractLibraryMethod => "",

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -697,7 +697,11 @@ impl fmt::Display for Attribute {
 impl Attribute {
     /// If the string is a fixed attribute return that, else
     /// return the custom attribute
-    pub(crate) fn lookup_attribute(word: &str, span: Span) -> Result<Token, LexerErrorKind> {
+    pub(crate) fn lookup_attribute(
+        word: &str,
+        span: Span,
+        name_start: u32,
+    ) -> Result<Token, LexerErrorKind> {
         let word_segments: Vec<&str> = word
             .split(|c| c == '(' || c == ')')
             .filter(|string_segment| !string_segment.is_empty())
@@ -770,7 +774,11 @@ impl Attribute {
             ["varargs"] => Attribute::Secondary(SecondaryAttribute::Varargs),
             tokens => {
                 tokens.iter().try_for_each(|token| validate(token))?;
-                Attribute::Secondary(SecondaryAttribute::Custom(word.to_owned(), span))
+                Attribute::Secondary(SecondaryAttribute::Custom(CustomAtrribute {
+                    contents: word.to_owned(),
+                    span,
+                    name_start,
+                }))
             }
         };
 
@@ -863,17 +871,27 @@ pub enum SecondaryAttribute {
     ContractLibraryMethod,
     Export,
     Field(String),
-    Custom(String, Span),
+    Custom(CustomAtrribute),
     Abi(String),
 
     /// A variable-argument comptime function.
     Varargs,
 }
 
+#[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
+pub struct CustomAtrribute {
+    pub contents: String,
+
+    // The span of the entire attribute, including leading `#[` and trailing `]`
+    pub span: Span,
+    // The byte position where the attribute name starts
+    pub name_start: u32,
+}
+
 impl SecondaryAttribute {
-    pub(crate) fn as_custom(&self) -> Option<(&str, Span)> {
-        if let Self::Custom(str, span) = self {
-            Some((str, *span))
+    pub(crate) fn as_custom(&self) -> Option<&CustomAtrribute> {
+        if let Self::Custom(attribute) = self {
+            Some(attribute)
         } else {
             None
         }
@@ -887,7 +905,7 @@ impl fmt::Display for SecondaryAttribute {
             SecondaryAttribute::Deprecated(Some(ref note)) => {
                 write!(f, r#"#[deprecated("{note}")]"#)
             }
-            SecondaryAttribute::Custom(ref k, _) => write!(f, "#[{k}]"),
+            SecondaryAttribute::Custom(ref attribute) => write!(f, "#[{}]", attribute.contents),
             SecondaryAttribute::ContractLibraryMethod => write!(f, "#[contract_library_method]"),
             SecondaryAttribute::Export => write!(f, "#[export]"),
             SecondaryAttribute::Field(ref k) => write!(f, "#[field({k})]"),
@@ -916,9 +934,8 @@ impl AsRef<str> for SecondaryAttribute {
         match self {
             SecondaryAttribute::Deprecated(Some(string)) => string,
             SecondaryAttribute::Deprecated(None) => "",
-            SecondaryAttribute::Custom(string, _)
-            | SecondaryAttribute::Field(string)
-            | SecondaryAttribute::Abi(string) => string,
+            SecondaryAttribute::Custom(attribute) => &attribute.contents,
+            SecondaryAttribute::Field(string) | SecondaryAttribute::Abi(string) => string,
             SecondaryAttribute::ContractLibraryMethod => "",
             SecondaryAttribute::Export => "",
             SecondaryAttribute::Varargs => "",

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -700,7 +700,7 @@ impl Attribute {
     pub(crate) fn lookup_attribute(
         word: &str,
         span: Span,
-        name_start: u32,
+        contents_span: Span,
     ) -> Result<Token, LexerErrorKind> {
         let word_segments: Vec<&str> = word
             .split(|c| c == '(' || c == ')')
@@ -777,7 +777,7 @@ impl Attribute {
                 Attribute::Secondary(SecondaryAttribute::Custom(CustomAtrribute {
                     contents: word.to_owned(),
                     span,
-                    name_start,
+                    contents_span,
                 }))
             }
         };
@@ -881,11 +881,10 @@ pub enum SecondaryAttribute {
 #[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
 pub struct CustomAtrribute {
     pub contents: String,
-
     // The span of the entire attribute, including leading `#[` and trailing `]`
     pub span: Span,
-    // The byte position where the attribute name starts
-    pub name_start: u32,
+    // The span for the attribute contents (what's inside `#[...]`)
+    pub contents_span: Span,
 }
 
 impl SecondaryAttribute {


### PR DESCRIPTION
# Description

## Problem

Resolves #5903

## Summary

Now the compiler will check that attribute function callbacks have at least one argument, that that argument's type matches the corresponding type, and that remaining arguments also match the types given.

Also previously errors on these callbacks were shown on the function that had the attribute, instead of on the attribute, likely because attributes didn't have a Span attached to them: this PR adds that too.

## Additional Context

The error message is still a bit strange because if you have code like this:

```rust
#[attr]
fn foo() {}

fn attr() {}

fn main() {}
```

You get this:

```
error: Expected 0 arguments, but 1 was provided
  ┌─ src/main.nr:1:3
  │
1 │ #[attr]
  │   ---- Too many arguments
```

which kind of makes sense, because 1 implicit argument was provided but 0 are expected in the callback, but maybe the error should point out that the callback actually needs one argument. Let me know if you think we should improve the error message here... but at least it doesn't error anymore.

Oh, I remember why I didn't improve that error message: the error should likely be on the callback function, but it should point out that the error happens because of a given attribute, so we need two different locations for the error, which I think we currently doesn't support.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
