### PR TITLE
feat: Allow inserting new structs and into programs from attributes

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -339,6 +339,10 @@ impl<'context> Elaborator<'context> {
                     generated_items.types.insert(type_id, the_struct);
                 }
             }
+            TopLevelStatement::Impl(r#impl) => {
+                let module = self.module_id();
+                dc_mod::collect_impl(self.interner, generated_items, r#impl, self.file, module);
+            }
 
             // Assume that an error has already been issued
             TopLevelStatement::Error => (),
@@ -346,7 +350,6 @@ impl<'context> Elaborator<'context> {
             TopLevelStatement::Module(_)
             | TopLevelStatement::Import(..)
             | TopLevelStatement::Trait(_)
-            | TopLevelStatement::Impl(_)
             | TopLevelStatement::TypeAlias(_)
             | TopLevelStatement::SubModule(_) => {
                 let item = item.to_string();

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -326,12 +326,25 @@ impl<'context> Elaborator<'context> {
                     self.errors.push(error);
                 }
             }
+            TopLevelStatement::Struct(struct_def) => {
+                if let Some((type_id, the_struct)) = dc_mod::collect_struct(
+                    self.interner,
+                    self.def_maps.get_mut(&self.crate_id).unwrap(),
+                    struct_def,
+                    self.file,
+                    self.local_module,
+                    self.crate_id,
+                    &mut self.errors,
+                ) {
+                    generated_items.types.insert(type_id, the_struct);
+                }
+            }
+
             // Assume that an error has already been issued
             TopLevelStatement::Error => (),
 
             TopLevelStatement::Module(_)
             | TopLevelStatement::Import(..)
-            | TopLevelStatement::Struct(_)
             | TopLevelStatement::Trait(_)
             | TopLevelStatement::Impl(_)
             | TopLevelStatement::TypeAlias(_)

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -488,7 +488,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             InterpreterError::UnsupportedTopLevelItemUnquote { item, location } => {
                 let msg = "Unsupported statement type to unquote".into();
                 let secondary =
-                    "Only functions, globals, and trait impls can be unquoted here".into();
+                    "Only functions, structs, globals, and trait impls can be unquoted here".into();
                 let mut error = CustomDiagnostic::simple_error(msg, secondary, location.span);
                 error.add_note(format!("Unquoted item was:\n{item}"));
                 error

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -488,7 +488,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             InterpreterError::UnsupportedTopLevelItemUnquote { item, location } => {
                 let msg = "Unsupported statement type to unquote".into();
                 let secondary =
-                    "Only functions, structs, globals, and trait impls can be unquoted here".into();
+                    "Only functions, structs, globals, and impls can be unquoted here".into();
                 let mut error = CustomDiagnostic::simple_error(msg, secondary, location.span);
                 error.add_note(format!("Unquoted item was:\n{item}"));
                 error

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -15,7 +15,7 @@ use crate::ast::{
     TypeImpl,
 };
 use crate::hir::resolution::errors::ResolverError;
-use crate::macros_api::{Expression, NodeInterner, UnresolvedType, UnresolvedTypeData};
+use crate::macros_api::{Expression, NodeInterner, StructId, UnresolvedType, UnresolvedTypeData};
 use crate::node_interner::ModuleAttributes;
 use crate::{
     graph::CrateId,
@@ -280,88 +280,19 @@ impl<'a> ModCollector<'a> {
     ) -> Vec<(CompilationError, FileId)> {
         let mut definition_errors = vec![];
         for struct_definition in types {
-            self.check_duplicate_field_names(&struct_definition, &mut definition_errors);
-
-            let name = struct_definition.name.clone();
-
-            let unresolved = UnresolvedStruct {
-                file_id: self.file_id,
-                module_id: self.module_id,
-                struct_def: struct_definition,
-            };
-
-            let resolved_generics = context.resolve_generics(
-                &unresolved.struct_def.generics,
-                &mut definition_errors,
+            if let Some((id, the_struct)) = collect_struct(
+                &mut context.def_interner,
+                &mut self.def_collector.def_map,
+                struct_definition,
                 self.file_id,
-            );
-
-            // Create the corresponding module for the struct namespace
-            let id = match self.push_child_module(
-                context,
-                &name,
-                Location::new(name.span(), self.file_id),
-                false,
-                false,
+                self.module_id,
+                krate,
+                &mut definition_errors,
             ) {
-                Ok(module_id) => context.def_interner.new_struct(
-                    &unresolved,
-                    resolved_generics,
-                    krate,
-                    module_id.local_id,
-                    self.file_id,
-                ),
-                Err(error) => {
-                    definition_errors.push((error.into(), self.file_id));
-                    continue;
-                }
-            };
-
-            // Add the struct to scope so its path can be looked up later
-            let result = self.def_collector.def_map.modules[self.module_id.0]
-                .declare_struct(name.clone(), id);
-
-            if let Err((first_def, second_def)) = result {
-                let error = DefCollectorErrorKind::Duplicate {
-                    typ: DuplicateType::TypeDefinition,
-                    first_def,
-                    second_def,
-                };
-                definition_errors.push((error.into(), self.file_id));
-            }
-
-            // And store the TypeId -> StructType mapping somewhere it is reachable
-            self.def_collector.items.types.insert(id, unresolved);
-
-            if context.def_interner.is_in_lsp_mode() {
-                let parent_module_id = ModuleId { krate, local_id: self.module_id };
-                context.def_interner.register_struct(id, name.to_string(), parent_module_id);
+                self.def_collector.items.types.insert(id, the_struct);
             }
         }
         definition_errors
-    }
-
-    fn check_duplicate_field_names(
-        &self,
-        struct_definition: &NoirStruct,
-        definition_errors: &mut Vec<(CompilationError, FileId)>,
-    ) {
-        let mut seen_field_names = std::collections::HashSet::new();
-        for (field_name, _) in &struct_definition.fields {
-            if seen_field_names.insert(field_name) {
-                continue;
-            }
-
-            let previous_field_name = *seen_field_names.get(field_name).unwrap();
-            definition_errors.push((
-                DefCollectorErrorKind::DuplicateField {
-                    first_def: previous_field_name.clone(),
-                    second_def: field_name.clone(),
-                }
-                .into(),
-                self.file_id,
-            ));
-        }
     }
 
     /// Collect any type aliases definitions declared within the ast.
@@ -383,7 +314,8 @@ impl<'a> ModCollector<'a> {
                 type_alias_def: type_alias,
             };
 
-            let resolved_generics = context.resolve_generics(
+            let resolved_generics = Context::resolve_generics(
+                &context.def_interner,
                 &unresolved.type_alias_def.generics,
                 &mut errors,
                 self.file_id,
@@ -584,8 +516,12 @@ impl<'a> ModCollector<'a> {
                 }
             }
 
-            let resolved_generics =
-                context.resolve_generics(&trait_definition.generics, &mut errors, self.file_id);
+            let resolved_generics = Context::resolve_generics(
+                &context.def_interner,
+                &trait_definition.generics,
+                &mut errors,
+                self.file_id,
+            );
 
             let unresolved = UnresolvedTrait {
                 file_id: self.file_id,
@@ -741,75 +677,6 @@ impl<'a> ModCollector<'a> {
         errors
     }
 
-    /// Add a child module to the current def_map.
-    /// On error this returns None and pushes to `errors`
-    fn push_child_module(
-        &mut self,
-        context: &mut Context,
-        mod_name: &Ident,
-        mod_location: Location,
-        add_to_parent_scope: bool,
-        is_contract: bool,
-    ) -> Result<ModuleId, DefCollectorErrorKind> {
-        let parent = Some(self.module_id);
-
-        // Note: the difference between `location` and `mod_location` is:
-        // - `mod_location` will point to either the token "foo" in `mod foo { ... }`
-        //   if it's an inline module, or the first char of a the file if it's an external module.
-        // - `location` will always point to the token "foo" in `mod foo` regardless of whether
-        //   it's inline or external.
-        // Eventually the location put in `ModuleData` is used for codelenses about `contract`s,
-        // so we keep using `location` so that it continues to work as usual.
-        let location = Location::new(mod_name.span(), mod_location.file);
-        let new_module = ModuleData::new(parent, location, is_contract);
-        let module_id = self.def_collector.def_map.modules.insert(new_module);
-
-        let modules = &mut self.def_collector.def_map.modules;
-
-        // Update the parent module to reference the child
-        modules[self.module_id.0].children.insert(mod_name.clone(), LocalModuleId(module_id));
-
-        let mod_id = ModuleId {
-            krate: self.def_collector.def_map.krate,
-            local_id: LocalModuleId(module_id),
-        };
-
-        // Add this child module into the scope of the parent module as a module definition
-        // module definitions are definitions which can only exist at the module level.
-        // ModuleDefinitionIds can be used across crates since they contain the CrateId
-        //
-        // We do not want to do this in the case of struct modules (each struct type corresponds
-        // to a child module containing its methods) since the module name should not shadow
-        // the struct name.
-        if add_to_parent_scope {
-            if let Err((first_def, second_def)) =
-                modules[self.module_id.0].declare_child_module(mod_name.to_owned(), mod_id)
-            {
-                let err = DefCollectorErrorKind::Duplicate {
-                    typ: DuplicateType::Module,
-                    first_def,
-                    second_def,
-                };
-                return Err(err);
-            }
-
-            context.def_interner.add_module_attributes(
-                mod_id,
-                ModuleAttributes {
-                    name: mod_name.0.contents.clone(),
-                    location: mod_location,
-                    parent: Some(self.module_id),
-                },
-            );
-
-            if context.def_interner.is_in_lsp_mode() {
-                context.def_interner.register_module(mod_id, mod_name.0.contents.clone());
-            }
-        }
-
-        Ok(mod_id)
-    }
-
     fn resolve_associated_constant_type(
         &self,
         typ: &UnresolvedType,
@@ -826,6 +693,146 @@ impl<'a> ModCollector<'a> {
             }
         }
     }
+
+    /// Add a child module to the current def_map.
+    /// On error this returns None and pushes to `errors`
+    fn push_child_module(
+        &mut self,
+        context: &mut Context,
+        mod_name: &Ident,
+        mod_location: Location,
+        add_to_parent_scope: bool,
+        is_contract: bool,
+    ) -> Result<ModuleId, DefCollectorErrorKind> {
+        push_child_module(
+            &mut context.def_interner,
+            &mut self.def_collector.def_map,
+            self.module_id,
+            mod_name,
+            mod_location,
+            add_to_parent_scope,
+            is_contract,
+        )
+    }
+}
+
+/// Add a child module to the current def_map.
+/// On error this returns None and pushes to `errors`
+fn push_child_module(
+    interner: &mut NodeInterner,
+    def_map: &mut CrateDefMap,
+    parent: LocalModuleId,
+    mod_name: &Ident,
+    mod_location: Location,
+    add_to_parent_scope: bool,
+    is_contract: bool,
+) -> Result<ModuleId, DefCollectorErrorKind> {
+    // Note: the difference between `location` and `mod_location` is:
+    // - `mod_location` will point to either the token "foo" in `mod foo { ... }`
+    //   if it's an inline module, or the first char of a the file if it's an external module.
+    // - `location` will always point to the token "foo" in `mod foo` regardless of whether
+    //   it's inline or external.
+    // Eventually the location put in `ModuleData` is used for codelenses about `contract`s,
+    // so we keep using `location` so that it continues to work as usual.
+    let location = Location::new(mod_name.span(), mod_location.file);
+    let new_module = ModuleData::new(Some(parent), location, is_contract);
+    let module_id = def_map.modules.insert(new_module);
+
+    let modules = &mut def_map.modules;
+
+    // Update the parent module to reference the child
+    modules[parent.0].children.insert(mod_name.clone(), LocalModuleId(module_id));
+
+    let mod_id = ModuleId { krate: def_map.krate, local_id: LocalModuleId(module_id) };
+
+    // Add this child module into the scope of the parent module as a module definition
+    // module definitions are definitions which can only exist at the module level.
+    // ModuleDefinitionIds can be used across crates since they contain the CrateId
+    //
+    // We do not want to do this in the case of struct modules (each struct type corresponds
+    // to a child module containing its methods) since the module name should not shadow
+    // the struct name.
+    if add_to_parent_scope {
+        if let Err((first_def, second_def)) =
+            modules[parent.0].declare_child_module(mod_name.to_owned(), mod_id)
+        {
+            let err = DefCollectorErrorKind::Duplicate {
+                typ: DuplicateType::Module,
+                first_def,
+                second_def,
+            };
+            return Err(err);
+        }
+
+        interner.add_module_attributes(
+            mod_id,
+            ModuleAttributes {
+                name: mod_name.0.contents.clone(),
+                location: mod_location,
+                parent: Some(parent),
+            },
+        );
+
+        if interner.is_in_lsp_mode() {
+            interner.register_module(mod_id, mod_name.0.contents.clone());
+        }
+    }
+
+    Ok(mod_id)
+}
+
+pub fn collect_struct(
+    interner: &mut NodeInterner,
+    def_map: &mut CrateDefMap,
+    struct_definition: NoirStruct,
+    file_id: FileId,
+    module_id: LocalModuleId,
+    krate: CrateId,
+    definition_errors: &mut Vec<(CompilationError, FileId)>,
+) -> Option<(StructId, UnresolvedStruct)> {
+    check_duplicate_field_names(&struct_definition, file_id, definition_errors);
+
+    let name = struct_definition.name.clone();
+
+    let unresolved = UnresolvedStruct { file_id, module_id, struct_def: struct_definition };
+
+    let resolved_generics = Context::resolve_generics(
+        interner,
+        &unresolved.struct_def.generics,
+        definition_errors,
+        file_id,
+    );
+
+    // Create the corresponding module for the struct namespace
+    let location = Location::new(name.span(), file_id);
+    let id = match push_child_module(interner, def_map, module_id, &name, location, false, false) {
+        Ok(module_id) => {
+            interner.new_struct(&unresolved, resolved_generics, krate, module_id.local_id, file_id)
+        }
+        Err(error) => {
+            definition_errors.push((error.into(), file_id));
+            return None;
+        }
+    };
+
+    // Add the struct to scope so its path can be looked up later
+    let result = def_map.modules[module_id.0].declare_struct(name.clone(), id);
+
+    if let Err((first_def, second_def)) = result {
+        let error = DefCollectorErrorKind::Duplicate {
+            typ: DuplicateType::TypeDefinition,
+            first_def,
+            second_def,
+        };
+        definition_errors.push((error.into(), file_id));
+    }
+
+    if interner.is_in_lsp_mode() {
+        let parent_module_id = ModuleId { krate, local_id: module_id };
+        interner.register_struct(id, name.to_string(), parent_module_id);
+    }
+
+    Some((id, unresolved))
 }
 
 fn find_module(
@@ -984,6 +991,29 @@ pub(crate) fn collect_global(
 
     let global = UnresolvedGlobal { file_id, module_id, global_id, stmt_def: global };
     (global, error)
+}
+
+fn check_duplicate_field_names(
+    struct_definition: &NoirStruct,
+    file: FileId,
+    definition_errors: &mut Vec<(CompilationError, FileId)>,
+) {
+    let mut seen_field_names = std::collections::HashSet::new();
+    for (field_name, _) in &struct_definition.fields {
+        if seen_field_names.insert(field_name) {
+            continue;
+        }
+
+        let previous_field_name = *seen_field_names.get(field_name).unwrap();
+        definition_errors.push((
+            DefCollectorErrorKind::DuplicateField {
+                first_def: previous_field_name.clone(),
+                second_def: field_name.clone(),
+            }
+            .into(),
+            file,
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -775,6 +775,7 @@ impl<'a> ModCollector<'a> {
 
 /// Add a child module to the current def_map.
 /// On error this returns None and pushes to `errors`
+#[allow(clippy::too_many_arguments)]
 fn push_child_module(
     interner: &mut NodeInterner,
     def_map: &mut CrateDefMap,

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -272,14 +272,14 @@ impl Context<'_, '_> {
     /// Each result is returned in a list rather than returned as a single result as to allow
     /// definition collection to provide an error for each ill-formed numeric generic.
     pub(crate) fn resolve_generics(
-        &mut self,
+        interner: &NodeInterner,
         generics: &UnresolvedGenerics,
         errors: &mut Vec<(CompilationError, FileId)>,
         file_id: FileId,
     ) -> Generics {
         vecmap(generics, |generic| {
             // Map the generic to a fresh type variable
-            let id = self.def_interner.next_type_variable_id();
+            let id = interner.next_type_variable_id();
             let type_var = TypeVariable::unbound(id);
             let ident = generic.ident();
             let span = ident.0.span();

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3361,6 +3361,7 @@ fn warns_on_re_export_of_item_with_less_visibility() {
     ));
 }
 
+#[test]
 fn unoquted_integer_as_integer_token() {
     let src = r#"
     trait Serialize<let N: u32> {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3341,3 +3341,21 @@ fn warns_on_re_export_of_item_with_less_visibility() {
         )
     ));
 }
+
+#[test]
+fn can_unquote_struct() {
+    let src = r#"
+    mod foo {
+        mod bar {
+            pub fn baz() {}
+        }
+
+        pub use bar::baz;
+    }
+
+    fn main() {
+        foo::baz();
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/docs/docs/noir/concepts/comptime.md
+++ b/docs/docs/noir/concepts/comptime.md
@@ -183,7 +183,7 @@ comptime fn my_function_annotation(f: FunctionDefinition) {
 
 Anything returned from one of these functions will be inserted at top-level along with the original item.
 Note that expressions are not valid at top-level so you'll get an error trying to return `3` or similar just as if you tried to write a program containing `3; struct Foo {}`.
-You can insert other top-level items such as traits, structs, or functions this way though.
+You can insert other top-level items such as trait impls, structs, or functions this way though.
 For example, this is the mechanism used to insert additional trait implementations into the program when deriving a trait impl from a struct:
 
 #include_code derive-field-count-example noir_stdlib/src/meta/mod.nr rust

--- a/test_programs/compile_success_empty/unquote_struct/Nargo.toml
+++ b/test_programs/compile_success_empty/unquote_struct/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "unquote_struct"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/unquote_struct/src/main.nr
+++ b/test_programs/compile_success_empty/unquote_struct/src/main.nr
@@ -1,0 +1,22 @@
+fn main() {
+    let foo = Foo { x: 4, y: 5 };
+    assert_eq(foo.x, 4);
+}
+
+#[output_struct]
+fn foo(x: Field, y: u32) -> u32 {
+    x as u32 + y
+}
+
+// Given a function, wrap its parameters in a struct definition
+comptime fn output_struct(f: FunctionDefinition) -> Quoted {
+    let fields = f.parameters().map(|param: (Quoted, Type)| {
+        let name = param.0;
+        let typ = param.1;
+        quote { $name: $typ, }
+    }).join(quote {});
+
+    quote {
+        struct Foo { $fields }
+    }
+}

--- a/test_programs/compile_success_empty/unquote_struct/src/main.nr
+++ b/test_programs/compile_success_empty/unquote_struct/src/main.nr
@@ -1,6 +1,6 @@
 fn main() {
-    let foo = Foo { x: 4, y: 5 };
-    assert_eq(foo.x, 4);
+    let foo = Foo { x: 4, y: 4 };
+    foo.assert_equal();
 }
 
 #[output_struct]
@@ -18,5 +18,11 @@ comptime fn output_struct(f: FunctionDefinition) -> Quoted {
 
     quote {
         struct Foo { $fields }
+
+        impl Foo {
+            fn assert_equal(self) {
+                assert_eq(self.x as u32, self.y);
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5913

## Summary\*

Allows inserting new structs and impls into the program from comptime attributes.

## Additional Context

Inserting new structs wasn't allowed originally since functions wouldn't be able to refer to them in their signature. This use case isn't needed for aztec currently so I'm adding this feature now and we can look into expanding it later. See https://github.com/noir-lang/noir/issues/5926

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
