### PR TITLE
feat: add `fmtstr::contents`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -586,7 +586,19 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                     consuming = false;
 
                     if let Some(value) = values.pop_front() {
-                        result.push_str(&value.display(self.elaborator.interner).to_string());
+                        // When interpolating a quoted value inside a format string, we don't include the
+                        // surrounding `quote {` ... `}` as if we are unquoting the quoted value inside the string.
+                        if let Value::Quoted(tokens) = value {
+                            for (index, token) in tokens.iter().enumerate() {
+                                if index > 0 {
+                                    result.push(' ');
+                                }
+                                result
+                                    .push_str(&token.display(self.elaborator.interner).to_string());
+                            }
+                        } else {
+                            result.push_str(&value.display(self.elaborator.interner).to_string());
+                        }
                     }
                 }
                 other if !consuming => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1577,7 +1577,7 @@ fn unwrap_expr_value(interner: &NodeInterner, mut expr_value: ExprValue) -> Expr
     expr_value
 }
 
-// fn quoted(self) -> Quoted
+// fn contents(self) -> Quoted
 fn fmtstr_contents(
     interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -7,9 +7,9 @@ use acvm::{AcirField, FieldElement};
 use builtin_helpers::{
     block_expression_to_value, check_argument_count, check_function_not_yet_resolved,
     check_one_argument, check_three_arguments, check_two_arguments, get_expr, get_field,
-    get_function_def, get_module, get_quoted, get_slice, get_struct, get_trait_constraint,
-    get_trait_def, get_trait_impl, get_tuple, get_type, get_typed_expr, get_u32,
-    get_unresolved_type, hir_pattern_to_tokens, mutate_func_meta_type, parse,
+    get_format_string, get_function_def, get_module, get_quoted, get_slice, get_struct,
+    get_trait_constraint, get_trait_def, get_trait_impl, get_tuple, get_type, get_typed_expr,
+    get_u32, get_unresolved_type, hir_pattern_to_tokens, mutate_func_meta_type, parse,
     replace_func_meta_parameters, replace_func_meta_return_type,
 };
 use chumsky::{prelude::choice, Parser};
@@ -32,6 +32,7 @@ use crate::{
         InterpreterError, Value,
     },
     hir_def::function::FunctionBody,
+    lexer::Lexer,
     macros_api::{HirExpression, HirLiteral, ModuleDefId, NodeInterner, Signedness},
     node_interner::{DefinitionKind, TraitImplKind},
     parser::{self},
@@ -95,6 +96,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "expr_is_continue" => expr_is_continue(interner, arguments, location),
             "expr_resolve" => expr_resolve(self, arguments, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
+            "fmtstr_contents" => fmtstr_contents(interner, arguments, location),
             "function_def_body" => function_def_body(interner, arguments, location),
             "function_def_has_named_attribute" => {
                 function_def_has_named_attribute(interner, arguments, location)
@@ -1573,6 +1575,23 @@ fn unwrap_expr_value(interner: &NodeInterner, mut expr_value: ExprValue) -> Expr
         }
     }
     expr_value
+}
+
+// fn quoted(self) -> Quoted
+fn fmtstr_contents(
+    interner: &NodeInterner,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    let self_argument = check_one_argument(arguments, location)?;
+    let (string, _) = get_format_string(interner, self_argument)?;
+    let (tokens, _) = Lexer::lex(&string);
+    let mut tokens: Vec<_> = tokens.0.into_iter().map(|token| token.into_token()).collect();
+    if let Some(Token::EOF) = tokens.last() {
+        tokens.pop();
+    }
+
+    Ok(Value::Quoted(Rc::new(tokens)))
 }
 
 // fn body(self) -> Expr

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -96,7 +96,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "expr_is_continue" => expr_is_continue(interner, arguments, location),
             "expr_resolve" => expr_resolve(self, arguments, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
-            "fmtstr_contents" => fmtstr_contents(interner, arguments, location),
+            "fmtstr_quoted_contents" => fmtstr_quoted_contents(interner, arguments, location),
             "function_def_body" => function_def_body(interner, arguments, location),
             "function_def_has_named_attribute" => {
                 function_def_has_named_attribute(interner, arguments, location)
@@ -1578,8 +1578,8 @@ fn unwrap_expr_value(interner: &NodeInterner, mut expr_value: ExprValue) -> Expr
     expr_value
 }
 
-// fn contents(self) -> Quoted
-fn fmtstr_contents(
+// fn quoted_contents(self) -> Quoted
+fn fmtstr_quoted_contents(
     interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,
     location: Location,

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -189,6 +189,20 @@ pub(crate) fn get_expr(
     }
 }
 
+pub(crate) fn get_format_string(
+    interner: &NodeInterner,
+    (value, location): (Value, Location),
+) -> IResult<(Rc<String>, Type)> {
+    match value {
+        Value::FormatString(value, typ) => Ok((value, typ)),
+        value => {
+            let n = Box::new(interner.next_type_variable());
+            let e = Box::new(interner.next_type_variable());
+            type_mismatch(value, Type::FmtString(n, e), location)
+        }
+    }
+}
+
 pub(crate) fn get_function_def((value, location): (Value, Location)) -> IResult<FuncId> {
     match value {
         Value::FunctionDefinition(id) => Ok(id),

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -568,33 +568,7 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
                 write!(f, "quote {{")?;
                 for token in tokens.iter() {
                     write!(f, " ")?;
-
-                    match token {
-                        Token::QuotedType(id) => {
-                            write!(f, "{}", self.interner.get_quoted_type(*id))?;
-                        }
-                        Token::InternedExpr(id) => {
-                            let value = Value::expression(ExpressionKind::Interned(*id));
-                            value.display(self.interner).fmt(f)?;
-                        }
-                        Token::InternedStatement(id) => {
-                            let value = Value::statement(StatementKind::Interned(*id));
-                            value.display(self.interner).fmt(f)?;
-                        }
-                        Token::InternedLValue(id) => {
-                            let value = Value::lvalue(LValue::Interned(*id, Span::default()));
-                            value.display(self.interner).fmt(f)?;
-                        }
-                        Token::InternedUnresolvedTypeData(id) => {
-                            let value = Value::UnresolvedType(UnresolvedTypeData::Interned(*id));
-                            value.display(self.interner).fmt(f)?;
-                        }
-                        Token::UnquoteMarker(id) => {
-                            let value = Value::TypedExpr(TypedExpr::ExprId(*id));
-                            value.display(self.interner).fmt(f)?;
-                        }
-                        other => write!(f, "{other}")?,
-                    }
+                    token.display(self.interner).fmt(f)?;
                 }
                 write!(f, " }}")
             }
@@ -672,6 +646,51 @@ impl<'value, 'interner> Display for ValuePrinter<'value, 'interner> {
                     write!(f, "{}", typ)
                 }
             }
+        }
+    }
+}
+
+impl Token {
+    pub fn display<'token, 'interner>(
+        &'token self,
+        interner: &'interner NodeInterner,
+    ) -> TokenPrinter<'token, 'interner> {
+        TokenPrinter { token: self, interner }
+    }
+}
+
+pub struct TokenPrinter<'token, 'interner> {
+    token: &'token Token,
+    interner: &'interner NodeInterner,
+}
+
+impl<'token, 'interner> Display for TokenPrinter<'token, 'interner> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.token {
+            Token::QuotedType(id) => {
+                write!(f, "{}", self.interner.get_quoted_type(*id))
+            }
+            Token::InternedExpr(id) => {
+                let value = Value::expression(ExpressionKind::Interned(*id));
+                value.display(self.interner).fmt(f)
+            }
+            Token::InternedStatement(id) => {
+                let value = Value::statement(StatementKind::Interned(*id));
+                value.display(self.interner).fmt(f)
+            }
+            Token::InternedLValue(id) => {
+                let value = Value::lvalue(LValue::Interned(*id, Span::default()));
+                value.display(self.interner).fmt(f)
+            }
+            Token::InternedUnresolvedTypeData(id) => {
+                let value = Value::UnresolvedType(UnresolvedTypeData::Interned(*id));
+                value.display(self.interner).fmt(f)
+            }
+            Token::UnquoteMarker(id) => {
+                let value = Value::TypedExpr(TypedExpr::ExprId(*id));
+                value.display(self.interner).fmt(f)
+            }
+            other => write!(f, "{other}"),
         }
     }
 }

--- a/docs/docs/noir/standard_library/fmtstr.md
+++ b/docs/docs/noir/standard_library/fmtstr.md
@@ -2,7 +2,7 @@
 title: fmtstr
 ---
 
-`std::meta::format_string` contains comptime methods on the `fmtstr` type for format strings.
+`fmtstr<N, T>` is the type resulting from using format string (`f"..."`).
 
 ## Methods
 

--- a/docs/docs/noir/standard_library/fmtstr.md
+++ b/docs/docs/noir/standard_library/fmtstr.md
@@ -6,8 +6,8 @@ title: fmtstr
 
 ## Methods
 
-### contents
+### quoted_contents
 
-#include_code contents noir_stdlib/src/meta/format_string.nr rust
+#include_code quoted_contents noir_stdlib/src/meta/format_string.nr rust
 
 Returns the format string contents (that is, without the leading and trailing double quotes) as a `Quoted` value.

--- a/docs/docs/noir/standard_library/meta/fmtstr.md
+++ b/docs/docs/noir/standard_library/meta/fmtstr.md
@@ -1,0 +1,13 @@
+---
+title: fmtstr
+---
+
+`std::meta::format_string` contains comptime methods on the `fmtstr` type for format strings.
+
+## Methods
+
+### contents
+
+#include_code quoted noir_stdlib/src/meta/format_string.nr rust
+
+Returns the format string contents (that is, without the leading and trailing double quotes) as a `Quoted` value.

--- a/docs/docs/noir/standard_library/meta/fmtstr.md
+++ b/docs/docs/noir/standard_library/meta/fmtstr.md
@@ -8,6 +8,6 @@ title: fmtstr
 
 ### contents
 
-#include_code quoted noir_stdlib/src/meta/format_string.nr rust
+#include_code contents noir_stdlib/src/meta/format_string.nr rust
 
 Returns the format string contents (that is, without the leading and trailing double quotes) as a `Quoted` value.

--- a/noir_stdlib/src/meta/format_string.nr
+++ b/noir_stdlib/src/meta/format_string.nr
@@ -1,7 +1,6 @@
-use crate::option::Option;
-
 impl <let N: u32, T> fmtstr<N, T> {
-    fn as_identifier(self) -> Option<Quoted> {
-        Option::none()
-    }
+    #[builtin(fmtstr_contents)]
+    // docs:start:contents
+    fn contents(self) -> Quoted {}
+    // docs:end:contents
 }

--- a/noir_stdlib/src/meta/format_string.nr
+++ b/noir_stdlib/src/meta/format_string.nr
@@ -1,0 +1,7 @@
+use crate::option::Option;
+
+impl <let N: u32, T> fmtstr<N, T> {
+    fn as_identifier(self) -> Option<Quoted> {
+        Option::none()
+    }
+}

--- a/noir_stdlib/src/meta/format_string.nr
+++ b/noir_stdlib/src/meta/format_string.nr
@@ -1,6 +1,6 @@
 impl <let N: u32, T> fmtstr<N, T> {
-    #[builtin(fmtstr_contents)]
-    // docs:start:contents
-    fn contents(self) -> Quoted {}
-    // docs:end:contents
+    #[builtin(fmtstr_quoted_contents)]
+    // docs:start:quoted_contents
+    fn quoted_contents(self) -> Quoted {}
+    // docs:end:quoted_contents
 }

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -1,4 +1,5 @@
 mod expr;
+mod format_string;
 mod function_def;
 mod module;
 mod op;

--- a/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
@@ -12,4 +12,18 @@ fn main() {
     };
     assert_eq(s1, "x is 4, fake interpolation: {y}, y is 5");
     assert_eq(s2, "\0\0\0\0");
+
+    // Mainly test fmtstr::contents
+    call!(glue(quote { hello }, quote { world }));
 }
+
+fn glue(x: Quoted, y: Quoted) -> Quoted {
+    f"{x}_{y}".contents()
+}
+
+fn hello_world() {}
+
+comptime fn call(x: Quoted) -> Quoted {
+    quote { $x() }
+}
+

--- a/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
@@ -13,12 +13,12 @@ fn main() {
     assert_eq(s1, "x is 4, fake interpolation: {y}, y is 5");
     assert_eq(s2, "\0\0\0\0");
 
-    // Mainly test fmtstr::contents
+    // Mainly test fmtstr::quoted_contents
     call!(glue(quote { hello }, quote { world }));
 }
 
 fn glue(x: Quoted, y: Quoted) -> Quoted {
-    f"{x}_{y}".contents()
+    f"{x}_{y}".quoted_contents()
 }
 
 fn hello_world() {}

--- a/test_programs/compile_success_empty/unquote_struct/src/main.nr
+++ b/test_programs/compile_success_empty/unquote_struct/src/main.nr
@@ -10,11 +10,13 @@ fn foo(x: Field, y: u32) -> u32 {
 
 // Given a function, wrap its parameters in a struct definition
 comptime fn output_struct(f: FunctionDefinition) -> Quoted {
-    let fields = f.parameters().map(|param: (Quoted, Type)| {
+    let fields = f.parameters().map(
+        |param: (Quoted, Type)| {
         let name = param.0;
         let typ = param.1;
         quote { $name: $typ, }
-    }).join(quote {});
+    }
+    ).join(quote {});
 
     quote {
         struct Foo { $fields }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -336,7 +336,7 @@ mod completion_tests {
             fo>|<
           }
         "#;
-        assert_completion(src, vec![module_completion_item("foobar")]).await;
+        assert_completion_excluding_auto_import(src, vec![module_completion_item("foobar")]).await;
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

Resolves #5899
Resolves #5914

## Summary

Two things here:
1. When interpolating quotes values inside a format string, we do that without producing the `quote {` and `}` parts, which is likely what a user would expect (similar to unquoting those values).
2. In order to create identifiers (or any piece of code in general) by joining severa quoted values you can use format strings together with the new `fmtstr::contents` method, which returns a `Quoted` value with the string contents (that is, without the leading and trailing double quotes).

## Additional Context

I originally thought about a method like `fmtstr::as_identifier` that would try to parse the string contents as an identifier (maybe an `Ident`, or maybe a `Path`), returning `Option<Quoted>` and `None` in case it couldn't be parsed to that. But I think in general it could be more useful to just get the string contents as a `Quoted` value. After all, if it isn't an identifier you'll learn it later on once the value is unquoted or interpolated.

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
