### PR TITLE
fix: Support debug comptime flag for attributes

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -175,6 +175,10 @@ impl<'context> Elaborator<'context> {
             .call_function(function, arguments, TypeBindings::new(), location)
             .map_err(|error| error.into_compilation_error_pair())?;
 
+        self.debug_comptime(location, |interner| {
+            value.display(interner).to_string()
+        });
+
         if value != Value::Unit {
             let items = value
                 .into_top_level_items(location, self.interner)

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -175,9 +175,7 @@ impl<'context> Elaborator<'context> {
             .call_function(function, arguments, TypeBindings::new(), location)
             .map_err(|error| error.into_compilation_error_pair())?;
 
-        self.debug_comptime(location, |interner| {
-            value.display(interner).to_string()
-        });
+        self.debug_comptime(location, |interner| value.display(interner).to_string());
 
         if value != Value::Unit {
             let items = value


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5915

## Summary\*

We were just missing a quick check after running attributes. Now their output will be shown when the `--debug-comptime-in-file` flag is used

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
