### PR TITLE
feat: add `StructDefinition::add_attribute` and `has_named_attribute`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1773,7 +1773,7 @@ fn function_def_add_attribute(
         });
     }
 
-    let token = tokens[0].token();
+    let token = tokens.into_iter().next().unwrap().into_token();
     let Token::Attribute(attribute) = token else {
         return Err(InterpreterError::InvalidAttribute {
             attribute: attribute.to_string(),
@@ -1786,7 +1786,7 @@ fn function_def_add_attribute(
 
     let function_modifiers = interpreter.elaborator.interner.function_modifiers_mut(&func_id);
 
-    match attribute {
+    match &attribute {
         Attribute::Function(attribute) => {
             function_modifiers.attributes.function = Some(attribute.clone());
         }
@@ -1797,7 +1797,7 @@ fn function_def_add_attribute(
 
     if let Attribute::Secondary(SecondaryAttribute::Custom(attribute)) = attribute {
         let func_meta = interpreter.elaborator.interner.function_meta_mut(&func_id);
-        func_meta.custom_attributes.push(attribute.clone());
+        func_meta.custom_attributes.push(attribute);
     }
 
     Ok(Value::Unit)

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -8,6 +8,7 @@ use crate::{
         BlockExpression, ExpressionKind, IntegerBitSize, LValue, Signedness, StatementKind,
         UnresolvedTypeData,
     },
+    elaborator::Elaborator,
     hir::{
         comptime::{
             errors::IResult,
@@ -436,4 +437,27 @@ pub(super) fn block_expression_to_value(block_expr: BlockExpression) -> Value {
     let statements = statements.map(|statement| Value::statement(statement.kind)).collect();
 
     Value::Slice(statements, typ)
+}
+
+pub(super) fn has_named_attribute<'a>(
+    name: &'a str,
+    attributes: impl Iterator<Item = &'a String>,
+    location: Location,
+) -> bool {
+    for attribute in attributes {
+        let parse_result = Elaborator::parse_attribute(attribute, location);
+        let Ok(Some((function, _arguments))) = parse_result else {
+            continue;
+        };
+
+        let ExpressionKind::Variable(path) = function.kind else {
+            continue;
+        };
+
+        if path.last_name() == name {
+            return true;
+        }
+    }
+
+    false
 }

--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -7,6 +7,12 @@ This type corresponds to `struct Name { field1: Type1, ... }` items in the sourc
 
 ## Methods
 
+### add_attribute
+
+#include_code add_attribute noir_stdlib/src/meta/struct_def.nr rust
+
+Adds an attribute to the struct.
+
 ### as_type
 
 #include_code as_type noir_stdlib/src/meta/struct_def.nr rust
@@ -43,6 +49,12 @@ comptime fn example(foo: StructDefinition) {
 #include_code fields noir_stdlib/src/meta/struct_def.nr rust
 
 Returns each field of this struct as a pair of (field name, field type).
+
+### has_named_attribute
+
+#include_code has_named_attribute noir_stdlib/src/meta/struct_def.nr rust
+
+Returns true if this struct has a custom attribute with the given name.
 
 ### set_fields
 

--- a/noir_stdlib/src/meta/struct_def.nr
+++ b/noir_stdlib/src/meta/struct_def.nr
@@ -1,10 +1,20 @@
 impl StructDefinition {
+    #[builtin(struct_def_add_attribute)]
+    // docs:start:add_attribute
+    fn add_attribute<let N: u32>(self, attribute: str<N>) {}
+    // docs:end:add_attribute
+
     /// Return a syntactic version of this struct definition as a type.
     /// For example, `as_type(quote { type Foo<A, B> { ... } })` would return `Foo<A, B>`
     #[builtin(struct_def_as_type)]
 // docs:start:as_type
     fn as_type(self) -> Type {}
     // docs:end:as_type
+
+    #[builtin(struct_def_has_named_attribute)]
+    // docs:start:has_named_attribute
+    fn has_named_attribute(self, name: Quoted) -> bool {}
+    // docs:end:has_named_attribute
 
     /// Return each generic on this struct.
     #[builtin(struct_def_generics)]

--- a/test_programs/compile_success_empty/attributes_struct/src/main.nr
+++ b/test_programs/compile_success_empty/attributes_struct/src/main.nr
@@ -6,3 +6,16 @@ struct SomeStruct {
 }
 
 fn main() {}
+
+// Check that add_attribute and has_named_attribute work well
+
+#[add_attribute]
+struct Foo {
+
+}
+
+fn add_attribute(s: StructDefinition) {
+    assert(!s.has_named_attribute(quote { foo }));
+    s.add_attribute("foo");
+    assert(s.has_named_attribute(quote { foo }));
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #5874

## Summary

## Additional Context

I originally wanted to test this by adding `abi(...)` to a struct and seeing that it errors if that struct appears in a signature but is outside of a contract, but... function parameters are type-checked before that (I think). So another way to test this is to also have `has_named_attribute`, so I added that too.

Side note: maybe adding an attribute to a function/struct should eventually invoke the associated function, if there's any, but we can probably try to do that in a separate PR, and only if really needed.

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
