### PR TITLE
feat: Add `StructDefinition::add_generic`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -601,19 +601,31 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 CustomDiagnostic::simple_error(msg, secondary, location.span)
             }
             InterpreterError::GenericNameShouldBeAnIdent { name, location } => {
-                let msg = format!("Generic name needs to be a valid identifer (one word beginning with a letter)");
+                let msg =
+                    "Generic name needs to be a valid identifer (one word beginning with a letter)"
+                        .to_string();
                 let secondary = format!("`{name}` is not a valid identifier");
                 CustomDiagnostic::simple_error(msg, secondary, location.span)
-            },
-            InterpreterError::DuplicateGeneric { name, struct_name, duplicate_location, existing_location } => {
+            }
+            InterpreterError::DuplicateGeneric {
+                name,
+                struct_name,
+                duplicate_location,
+                existing_location,
+            } => {
                 let msg = format!("`{struct_name}` already has a generic named `{name}`");
                 let secondary = format!("`{name}` added here a second time");
-                let mut error = CustomDiagnostic::simple_error(msg, secondary, duplicate_location.span);
+                let mut error =
+                    CustomDiagnostic::simple_error(msg, secondary, duplicate_location.span);
 
                 let existing_msg = format!("`{name}` was previously defined here");
-                error.add_secondary_with_file(existing_msg, existing_location.span, existing_location.file);
+                error.add_secondary_with_file(
+                    existing_msg,
+                    existing_location.span,
+                    existing_location.file,
+                );
                 error
-            },
+            }
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -194,7 +194,6 @@ pub enum InterpreterError {
         candidates: Vec<String>,
         location: Location,
     },
-
     Unimplemented {
         item: String,
         location: Location,
@@ -210,6 +209,16 @@ pub enum InterpreterError {
     InvalidAttribute {
         attribute: String,
         location: Location,
+    },
+    GenericNameShouldBeAnIdent {
+        name: Rc<String>,
+        location: Location,
+    },
+    DuplicateGeneric {
+        name: Rc<String>,
+        struct_name: String,
+        duplicate_location: Location,
+        existing_location: Location,
     },
 
     // These cases are not errors, they are just used to prevent us from running more code
@@ -279,8 +288,10 @@ impl InterpreterError {
             | InterpreterError::FunctionAlreadyResolved { location, .. }
             | InterpreterError::MultipleMatchingImpls { location, .. }
             | InterpreterError::ExpectedIdentForStructField { location, .. }
+            | InterpreterError::InvalidAttribute { location, .. }
+            | InterpreterError::GenericNameShouldBeAnIdent { location, .. }
+            | InterpreterError::DuplicateGeneric { duplicate_location: location, .. }
             | InterpreterError::TypeAnnotationsNeededForMethodCall { location } => *location,
-            InterpreterError::InvalidAttribute { location, .. } => *location,
 
             InterpreterError::FailedToParseMacro { error, file, .. } => {
                 Location::new(error.span(), *file)
@@ -589,6 +600,20 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 let secondary = "Note that this method expects attribute contents, without the leading `#[` or trailing `]`".to_string();
                 CustomDiagnostic::simple_error(msg, secondary, location.span)
             }
+            InterpreterError::GenericNameShouldBeAnIdent { name, location } => {
+                let msg = format!("Generic name needs to be a valid identifer (one word beginning with a letter)");
+                let secondary = format!("`{name}` is not a valid identifier");
+                CustomDiagnostic::simple_error(msg, secondary, location.span)
+            },
+            InterpreterError::DuplicateGeneric { name, struct_name, duplicate_location, existing_location } => {
+                let msg = format!("`{struct_name}` already has a generic named `{name}`");
+                let secondary = format!("`{name}` added here a second time");
+                let mut error = CustomDiagnostic::simple_error(msg, secondary, duplicate_location.span);
+
+                let existing_msg = format!("`{name}` was previously defined here");
+                error.add_secondary_with_file(existing_msg, existing_location.span, existing_location.file);
+                error
+            },
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -332,7 +332,7 @@ fn struct_def_add_generic(
     let generic_location = generic.1;
     let generic = get_str(interner, generic)?;
 
-    let mut tokens = Lexer::lex(&generic).0.0;
+    let mut tokens = Lexer::lex(&generic).0 .0;
     if let Some(Token::EOF) = tokens.last().map(|token| token.token()) {
         tokens.pop();
     }

--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -24,7 +24,7 @@ the struct already has a generic with the same name.
 This method should be used carefully, if there is existing code referring
 to the struct type it may be checked before this function is called and
 see the struct with the original number of generics. This method should
-thus be prefered to use on code generated from other macros and structs
+thus be preferred to use on code generated from other macros and structs
 that are not used in function signatures.
 
 Example:

--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -13,6 +13,24 @@ This type corresponds to `struct Name { field1: Type1, ... }` items in the sourc
 
 Adds an attribute to the struct.
 
+### add_generic
+
+#include_code add_generic noir_stdlib/src/meta/struct_def.nr rust
+
+Adds an generic to the struct. Returns the new generic type.
+Errors if the given generic name isn't a single identifier or if
+the struct already has a generic with the same name.
+
+This method should be used carefully, if there is existing code referring
+to the struct type it may be checked before this function is called and
+see the struct with the original number of generics. This method should
+thus be prefered to use on code generated from other macros and structs
+that are not used in function signatures.
+
+Example:
+
+#include_code add-generic-example test_programs/compile_success_empty/comptime_struct_definition/src/main.nr rust
+
 ### as_type
 
 #include_code as_type noir_stdlib/src/meta/struct_def.nr rust

--- a/noir_stdlib/src/meta/struct_def.nr
+++ b/noir_stdlib/src/meta/struct_def.nr
@@ -4,10 +4,15 @@ impl StructDefinition {
     fn add_attribute<let N: u32>(self, attribute: str<N>) {}
     // docs:end:add_attribute
 
+    #[builtin(struct_def_add_generic)]
+    // docs:start:add_generic
+    fn add_generic<let N: u32>(self, generic_name: str<N>) -> Type {}
+    // docs:end:add_generic
+
     /// Return a syntactic version of this struct definition as a type.
     /// For example, `as_type(quote { type Foo<A, B> { ... } })` would return `Foo<A, B>`
     #[builtin(struct_def_as_type)]
-// docs:start:as_type
+    // docs:start:as_type
     fn as_type(self) -> Type {}
     // docs:end:as_type
 
@@ -18,14 +23,14 @@ impl StructDefinition {
 
     /// Return each generic on this struct.
     #[builtin(struct_def_generics)]
-// docs:start:generics
+    // docs:start:generics
     fn generics(self) -> [Type] {}
     // docs:end:generics
 
     /// Returns (name, type) pairs of each field in this struct. Each type is as-is
     /// with any generic arguments unchanged.
     #[builtin(struct_def_fields)]
-// docs:start:fields
+    // docs:start:fields
     fn fields(self) -> [(Quoted, Type)] {}
     // docs:end:fields
 

--- a/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
@@ -27,10 +27,23 @@ mod foo {
     #[attr]
     struct Foo {}
 
-    fn attr(s: StructDefinition) {
+    comptime fn attr(s: StructDefinition) {
         assert_eq(s.module().name(), quote { foo });
     }
+
+    #[add_generic]
+    struct Bar {}
+
+    // docs:start:add-generic-example
+    comptime fn add_generic(s: StructDefinition) {
+        assert_eq(s.generics().len(), 0);
+        let new_generic = s.add_generic("T");
+
+        let generics = s.generics();
+        assert_eq(generics.len(), 1);
+        assert_eq(generics[0], new_generic);
+    }
+    // docs:end:add-generic-example
 }
 
 fn main() {}
-


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5957

## Summary\*

Adds a generic to an existing struct.

## Additional Context

Due to the same reasoning in https://github.com/noir-lang/noir/issues/5926, existing code referring to these structs won't see the generics on them. For now I've documented to try to avoid this use case.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
