### PR TITLE
feat: LSP autocompletion for attributes

### DIFF
--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -12,6 +12,7 @@ mod traits;
 mod type_alias;
 mod visitor;
 
+pub use visitor::AttributeTarget;
 pub use visitor::Visitor;
 
 pub use expression::*;

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -134,9 +134,7 @@ pub trait Visitor {
         true
     }
 
-    fn visit_module_declaration(&mut self, _: &ModuleDeclaration, _: Span) -> bool {
-        true
-    }
+    fn visit_module_declaration(&mut self, _: &ModuleDeclaration, _: Span) {}
 
     fn visit_expression(&mut self, _: &Expression) -> bool {
         true
@@ -509,16 +507,16 @@ impl Item {
 
 impl ParsedSubModule {
     pub fn accept(&self, span: Span, visitor: &mut impl Visitor) {
+        for attribute in &self.outer_attributes {
+            attribute.accept(AttributeTarget::Module, visitor);
+        }
+
         if visitor.visit_parsed_submodule(self, span) {
             self.accept_children(visitor);
         }
     }
 
     pub fn accept_children(&self, visitor: &mut impl Visitor) {
-        for attribute in &self.outer_attributes {
-            attribute.accept(AttributeTarget::Module, visitor);
-        }
-
         self.contents.accept(visitor);
     }
 }
@@ -723,11 +721,11 @@ impl NoirTypeAlias {
 
 impl ModuleDeclaration {
     pub fn accept(&self, span: Span, visitor: &mut impl Visitor) {
-        if visitor.visit_module_declaration(self, span) {
-            for attribute in &self.outer_attributes {
-                attribute.accept(AttributeTarget::Module, visitor);
-            }
+        for attribute in &self.outer_attributes {
+            attribute.accept(AttributeTarget::Module, visitor);
         }
+
+        visitor.visit_module_declaration(self, span);
     }
 }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -791,37 +791,7 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn suggest_attributes(&mut self, prefix: &str, target: AttributeTarget) {
-        match target {
-            AttributeTarget::Module => (),
-            AttributeTarget::Struct => {
-                self.suggest_one_argument_attributes(prefix, &["abi"]);
-            }
-            AttributeTarget::Function => {
-                let no_arguments_attributes = &[
-                    "contract_library_method",
-                    "deprecated",
-                    "export",
-                    "fold",
-                    "no_predicates",
-                    "recursive",
-                    "test",
-                    "varargs",
-                ];
-                self.suggest_no_arguments_attributes(prefix, no_arguments_attributes);
-
-                let one_argument_attributes = &["abi", "field", "foreign", "oracle"];
-                self.suggest_one_argument_attributes(prefix, one_argument_attributes);
-
-                if name_matches("test", prefix) || name_matches("should_fail_with", prefix) {
-                    self.completion_items.push(snippet_completion_item(
-                        "test(should_fail_with=\"...\")",
-                        CompletionItemKind::METHOD,
-                        "test(should_fail_with=\"${1:message}\")",
-                        None,
-                    ));
-                }
-            }
-        }
+        self.suggest_builtin_attributes(prefix, target);
 
         let function_completion_kind = FunctionCompletionKind::NameAndParameters;
         let requested_items = RequestedItems::OnlyAttributeFunctions(target);

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -802,7 +802,7 @@ impl<'a> NodeFinder<'a> {
                     "deprecated",
                     "export",
                     "fold",
-                    "no_predicated",
+                    "no_predicates",
                     "recursive",
                     "test",
                     "varargs",
@@ -812,7 +812,7 @@ impl<'a> NodeFinder<'a> {
                 let one_argument_attributes = &["abi", "field", "foreign", "oracle"];
                 self.suggest_one_argument_attributes(prefix, one_argument_attributes);
 
-                if "test".starts_with(prefix) {
+                if name_matches("test", prefix) || name_matches("should_fail_with", prefix) {
                     self.completion_items.push(snippet_completion_item(
                         "test(should_fail_with=\"...\")",
                         CompletionItemKind::METHOD,
@@ -840,7 +840,7 @@ impl<'a> NodeFinder<'a> {
 
     fn suggest_no_arguments_attributes(&mut self, prefix: &str, attributes: &[&str]) {
         for name in attributes {
-            if name.starts_with(prefix) {
+            if name_matches(name, prefix) {
                 self.completion_items.push(simple_completion_item(
                     *name,
                     CompletionItemKind::METHOD,
@@ -852,7 +852,7 @@ impl<'a> NodeFinder<'a> {
 
     fn suggest_one_argument_attributes(&mut self, prefix: &str, attributes: &[&str]) {
         for name in attributes {
-            if name.starts_with(prefix) {
+            if name_matches(name, prefix) {
                 self.completion_items.push(snippet_completion_item(
                     format!("{}(…)", name),
                     CompletionItemKind::METHOD,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -360,6 +360,7 @@ impl<'a> NodeFinder<'a> {
                     self.builtin_types_completion(&prefix);
                     self.type_parameters_completion(&prefix);
                 }
+                RequestedItems::OnlyAttributeFunctions(..) => (),
             }
             self.complete_auto_imports(&prefix, requested_items, function_completion_kind);
         }
@@ -607,6 +608,7 @@ impl<'a> NodeFinder<'a> {
                         func_id,
                         function_completion_kind,
                         function_kind,
+                        None, // attribute first type
                         self_prefix,
                     ) {
                         self.completion_items.push(completion_item);
@@ -633,6 +635,7 @@ impl<'a> NodeFinder<'a> {
                     *func_id,
                     function_completion_kind,
                     function_kind,
+                    None, // attribute first type
                     self_prefix,
                 ) {
                     self.completion_items.push(completion_item);
@@ -819,6 +822,20 @@ impl<'a> NodeFinder<'a> {
                 }
             }
         }
+
+        let function_completion_kind = FunctionCompletionKind::NameAndParameters;
+        let requested_items = RequestedItems::OnlyAttributeFunctions(target);
+
+        self.complete_in_module(
+            self.module_id,
+            prefix,
+            PathKind::Plain,
+            true,
+            function_completion_kind,
+            requested_items,
+        );
+
+        self.complete_auto_imports(prefix, requested_items, function_completion_kind);
     }
 
     fn suggest_no_arguments_attributes(&mut self, prefix: &str, attributes: &[&str]) {

--- a/tooling/lsp/src/requests/completion/kinds.rs
+++ b/tooling/lsp/src/requests/completion/kinds.rs
@@ -1,4 +1,4 @@
-use noirc_frontend::Type;
+use noirc_frontend::{ast::AttributeTarget, Type};
 
 /// When suggest a function as a result of completion, whether to autocomplete its name or its name and parameters.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -27,4 +27,6 @@ pub(super) enum RequestedItems {
     AnyItems,
     // Only suggest types.
     OnlyTypes,
+    // Only attribute functions
+    OnlyAttributeFunctions(AttributeTarget),
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1919,7 +1919,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_suggests_function_attribute() {
+    async fn test_suggests_built_in_function_attribute() {
         let src = r#"
             #[dep>|<]
             fn foo() {}
@@ -1928,6 +1928,27 @@ mod completion_tests {
         assert_completion_excluding_auto_import(
             src,
             vec![simple_completion_item("deprecated", CompletionItemKind::METHOD, None)],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_suggests_function_attribute() {
+        let src = r#"
+            #[some>|<]
+            fn foo() {}
+
+            fn some_attr(f: FunctionDefinition, x: Field) {}
+            fn some_other_function(x: Field) {}
+        "#;
+
+        assert_completion_excluding_auto_import(
+            src,
+            vec![function_completion_item(
+                "some_attr(…)",
+                "some_attr(${1:x})",
+                "fn(FunctionDefinition, Field)",
+            )],
         )
         .await;
     }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1917,4 +1917,18 @@ mod completion_tests {
         )
         .await;
     }
+
+    #[test]
+    async fn test_suggests_function_attribute() {
+        let src = r#"
+            #[dep>|<]
+            fn foo() {}
+        "#;
+
+        assert_completion_excluding_auto_import(
+            src,
+            vec![simple_completion_item("deprecated", CompletionItemKind::METHOD, None)],
+        )
+        .await;
+    }
 }


### PR DESCRIPTION
# Description

## Problem

While working a lot with attributes lately I thought it would be nice if we had autocompletion there too.

## Summary

Built-in attributes are suggested (I don't know if I got them all right, I don't know which attributes are allowed on structs) and also "function attributes" (we need to give this a name) are suggested if their first argument type matches that of the item the annotation is on (and with auto-import, we effectively get all annotations available to be placed on a function/struct/module).

![lsp-complete-attribute](https://github.com/user-attachments/assets/ab918a88-203d-42e1-88a8-412e5c67029c)

## Additional Context

If we add new attributes we'll have to remember to update the LSP code. But... I think this might be rare, so it might be fine to have to remember this. Also eventually if would be nice if all attributes had an associated function (even if it's a built-in one) and then we wouldn't need special code for that.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
