### PR TITLE
fix: let `derive(Eq)` work for empty structs

### DIFF
--- a/noir_stdlib/src/cmp.nr
+++ b/noir_stdlib/src/cmp.nr
@@ -11,7 +11,13 @@ trait Eq {
 comptime fn derive_eq(s: StructDefinition) -> Quoted {
     let signature = quote { fn eq(_self: Self, _other: Self) -> bool };
     let for_each_field = |name| quote { (_self.$name == _other.$name) };
-    let body = |fields| fields;
+    let body = |fields| {
+        if s.fields().len() == 0 {
+            quote { true }
+        } else {
+            fields
+        }
+    };
     crate::meta::make_trait_impl(s, quote { Eq }, signature, for_each_field, quote { & }, body)
 }
 // docs:end:derive_eq

--- a/test_programs/execution_success/derive/src/main.nr
+++ b/test_programs/execution_success/derive/src/main.nr
@@ -35,6 +35,9 @@ struct MyOtherOtherStruct<T> {
     x: T,
 }
 
+#[derive(Eq, Default, Hash, Ord)]
+struct EmptyStruct { }
+
 fn main() {
     let s = MyStruct { my_field: 1 };
     s.do_nothing();
@@ -53,6 +56,9 @@ fn main() {
     let mut hasher = TestHasher { result: 0 };
     o1.hash(&mut hasher);
     assert_eq(hasher.finish(), 12 + 24 + 54);
+
+    let empty = EmptyStruct {};
+    assert_eq(empty, empty);
 }
 
 struct TestHasher {


### PR DESCRIPTION
# Description

## Problem

While playing around with the derive attribute I noticed `derive(Eq)` fails to compile for an empty struct.

## Summary

Fixes the above.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
