### PR TITLE
feat: add a `panic` method to the stdlib

### DIFF
--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -28,6 +28,7 @@ mod runtime;
 mod meta;
 mod append;
 mod mem;
+mod panic;
 
 // Oracle calls are required to be wrapped in an unconstrained function
 // Thus, the only argument to the `println` oracle is expected to always be an ident

--- a/noir_stdlib/src/meta/op.nr
+++ b/noir_stdlib/src/meta/op.nr
@@ -40,7 +40,7 @@ impl UnaryOp {
             quote { * }
         } else {
             let op = self;
-            panic(f"Unexpected unary operator in UnaryOp::quoted: {op}")
+            std::panic::panic(f"Unexpected unary operator in UnaryOp::quoted: {op}")
         }
     }
 }
@@ -183,7 +183,7 @@ impl BinaryOp {
             quote { % }
         } else {
             let op = self;
-            panic(f"Unexpected binary operator in BinaryOp::quoted: {op}")
+            std::panic::panic(f"Unexpected binary operator in BinaryOp::quoted: {op}")
         }
     }
 }

--- a/noir_stdlib/src/meta/op.nr
+++ b/noir_stdlib/src/meta/op.nr
@@ -40,7 +40,7 @@ impl UnaryOp {
             quote { * }
         } else {
             let op = self;
-            std::panic::panic(f"Unexpected unary operator in UnaryOp::quoted: {op}")
+            crate::panic::panic(f"Unexpected unary operator in UnaryOp::quoted: {op}")
         }
     }
 }
@@ -183,7 +183,7 @@ impl BinaryOp {
             quote { % }
         } else {
             let op = self;
-            std::panic::panic(f"Unexpected binary operator in BinaryOp::quoted: {op}")
+            crate::panic::panic(f"Unexpected binary operator in BinaryOp::quoted: {op}")
         }
     }
 }

--- a/noir_stdlib/src/meta/op.nr
+++ b/noir_stdlib/src/meta/op.nr
@@ -39,7 +39,8 @@ impl UnaryOp {
         } else if self.is_dereference() {
             quote { * }
         } else {
-            crate::mem::zeroed()
+            let op = self;
+            panic(f"Unexpected unary operator in UnaryOp::quoted: {op}")
         }
     }
 }
@@ -181,7 +182,8 @@ impl BinaryOp {
         } else if self.is_modulo() {
             quote { % }
         } else {
-            crate::mem::zeroed()
+            let op = self;
+            panic(f"Unexpected binary operator in BinaryOp::quoted: {op}")
         }
     }
 }

--- a/noir_stdlib/src/panic.nr
+++ b/noir_stdlib/src/panic.nr
@@ -1,4 +1,4 @@
 pub fn panic<T, U, let N: u32>(message: fmtstr<N, T>) -> U {
     assert(false, message);
-    std::mem::zeroed()
+    crate::mem::zeroed()
 }

--- a/noir_stdlib/src/panic.nr
+++ b/noir_stdlib/src/panic.nr
@@ -1,0 +1,4 @@
+pub fn panic<T, U, let N: u32>(message: fmtstr<N, T>) -> U {
+    assert(false, message);
+    std::mem::zeroed()
+}

--- a/noir_stdlib/src/prelude.nr
+++ b/noir_stdlib/src/prelude.nr
@@ -7,3 +7,4 @@ pub use crate::cmp::{Eq, Ord};
 pub use crate::default::Default;
 pub use crate::convert::{From, Into};
 pub use crate::meta::{derive, derive_via};
+pub use crate::panic::panic;


### PR DESCRIPTION
# Description

## Problem

Resolves #5849

## Summary

Adds a `panic` method exactly as proposed in #5849 , and uses it in a couple of places where `panic` would have been useful to have.

## Additional Context

Is it okay in `std::panic::panic`? Where should we document this? (maybe in a new `panic.md` file, or somewhere else?)

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
