### PR TITLE
fix: LSP document symbol didn't work for primitive impls

### DIFF
--- a/tooling/lsp/src/requests/document_symbol.rs
+++ b/tooling/lsp/src/requests/document_symbol.rs
@@ -10,7 +10,7 @@ use noirc_errors::Span;
 use noirc_frontend::{
     ast::{
         Expression, FunctionReturnType, Ident, LetStatement, NoirFunction, NoirStruct, NoirTrait,
-        NoirTraitImpl, TypeImpl, UnresolvedType, UnresolvedTypeData, Visitor,
+        NoirTraitImpl, TypeImpl, UnresolvedType, Visitor,
     },
     parser::ParsedSubModule,
     ParsedModule,
@@ -391,13 +391,9 @@ impl<'a> Visitor for DocumentSymbolCollector<'a> {
             return false;
         };
 
-        let UnresolvedTypeData::Named(name_path, ..) = &type_impl.object_type.typ else {
-            return false;
-        };
+        let name = type_impl.object_type.typ.to_string();
 
-        let name = name_path.last_ident();
-
-        let Some(name_location) = self.to_lsp_location(name.span()) else {
+        let Some(name_location) = self.to_lsp_location(type_impl.object_type.span) else {
             return false;
         };
 
@@ -710,6 +706,23 @@ mod document_symbol_tests {
                         }
                     ]),
                 },
+                #[allow(deprecated)]
+                DocumentSymbol {
+                    name: "i32".to_string(),
+                    detail: None,
+                    kind: SymbolKind::NAMESPACE,
+                    tags: None,
+                    deprecated: None,
+                    range: Range {
+                        start: Position { line: 27, character: 0 },
+                        end: Position { line: 27, character: 11 }
+                    },
+                    selection_range: Range {
+                        start: Position { line: 27, character: 5 },
+                        end: Position { line: 27, character: 8 }
+                    },
+                    children: Some(Vec::new())
+                }
             ]
         );
     }

--- a/tooling/lsp/test_programs/document_symbol/src/main.nr
+++ b/tooling/lsp/test_programs/document_symbol/src/main.nr
@@ -24,3 +24,5 @@ impl SomeTrait<i32> for SomeStruct {
 mod submodule {
     global SOME_GLOBAL = 1;
 }
+
+impl i32 {}


### PR DESCRIPTION
# Description

## Problem

While working with the standard library I noticed Document Symbol didn't work with primitive impls.

## Summary

If you have this:

```rust
impl i32 {
  fn foo() {}
}
```

then pressing command+shift+o on VS Code didn't show `impl i32` nor `foo()`. I think when I coded this logic I didn't know you could have impls for non-named types. This PR fixes that.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
