### PR TITLE
chore: remove 3 unused functions warnings in the stdlib

### DIFF
--- a/noir_stdlib/src/hash/poseidon/bn254/consts.nr
+++ b/noir_stdlib/src/hash/poseidon/bn254/consts.nr
@@ -5,11 +5,6 @@
 // Consistent with https://github.com/iden3/circomlib/blob/master/circuits/poseidon.circom and https://github.com/iden3/circomlib/blob/master/circuits/poseidon_constants.circom
 use crate::hash::poseidon::PoseidonConfig;
 use crate::hash::poseidon::config;
-// Number of full rounds
-// Number of partial rounds
-fn rp() -> [u8; 16] {
-    [56, 57, 56, 60, 60, 63, 64, 63, 60, 66, 60, 65, 70, 60, 64, 68]
-}
 // S-box power
 fn alpha() -> Field {
     5

--- a/noir_stdlib/src/hash/poseidon/mod.nr
+++ b/noir_stdlib/src/hash/poseidon/mod.nr
@@ -1,5 +1,4 @@
 mod bn254; // Instantiations of Poseidon for prime field of the same order as BN254
-use crate::field::modulus_num_bits;
 use crate::hash::Hasher;
 use crate::default::Default;
 
@@ -164,13 +163,6 @@ fn sigma<let O: u32>(x: [Field; O]) -> [Field; O] {
         y[i] *= tttt;
     }
     y
-}
-
-// Check security of sponge instantiation
-fn check_security(rate: Field, width: Field, security: Field) -> bool {
-    let n = modulus_num_bits();
-
-    ((n - 1) as Field * (width - rate) / 2) as u8 > security as u8
 }
 
 struct PoseidonHasher{

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -122,6 +122,7 @@ mod tests {
         quote { 1 }
     }
 
+    #[test]
     fn returning_versus_macro_insertion() {
         comptime
         {


### PR DESCRIPTION
# Description

## Problem

Two functions were unused, another one two but it was kind of a test so I marked it as such.

## Summary


## Additional Context

After this 4 "unused" functions remain, but solving those is a bit more challenging so I'm leaving that for a separate PR.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
