### PR TITLE
fix: Error when comptime functions are used in runtime code

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -48,7 +48,7 @@ impl MonomorphizationError {
             MonomorphizationError::ComptimeFnInRuntimeCode { name, location } => {
                 let message = format!("Comptime function {name} used in runtime code");
                 let secondary =
-                    format!("Comptime functions must be in a comptime block to be called");
+                    "Comptime functions must be in a comptime block to be called".into();
                 return CustomDiagnostic::simple_error(message, secondary, location.span);
             }
         };

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -8,6 +8,7 @@ pub enum MonomorphizationError {
     NoDefaultType { location: Location },
     InternalError { message: &'static str, location: Location },
     InterpreterError(InterpreterError),
+    ComptimeFnInRuntimeCode { name: String, location: Location },
 }
 
 impl MonomorphizationError {
@@ -15,6 +16,7 @@ impl MonomorphizationError {
         match self {
             MonomorphizationError::UnknownArrayLength { location, .. }
             | MonomorphizationError::InternalError { location, .. }
+            | MonomorphizationError::ComptimeFnInRuntimeCode { location, .. }
             | MonomorphizationError::NoDefaultType { location, .. } => *location,
             MonomorphizationError::InterpreterError(error) => error.get_location(),
         }
@@ -43,6 +45,12 @@ impl MonomorphizationError {
             }
             MonomorphizationError::InterpreterError(error) => return error.into(),
             MonomorphizationError::InternalError { message, .. } => message.to_string(),
+            MonomorphizationError::ComptimeFnInRuntimeCode { name, location } => {
+                let message = format!("Comptime function {name} used in runtime code");
+                let secondary =
+                    format!("Comptime functions must be in a comptime block to be called");
+                return CustomDiagnostic::simple_error(message, secondary, location.span);
+            }
         };
 
         let location = self.location();


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Adds an error during monomorphization if any comptime functions fall through the cracks and aren't executed at compile-time.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
