### PR TITLE
feat: add `TypedExpr::get_type`

### DIFF
--- a/docs/docs/noir/standard_library/meta/typed_expr.md
+++ b/docs/docs/noir/standard_library/meta/typed_expr.md
@@ -16,4 +16,4 @@ If this expression refers to a function definitions, returns it. Otherwise retur
 
 #include_code get_type noir_stdlib/src/meta/typed_expr.nr rust
 
-Returns the type of the expression, if the expression could be resolved without errors.
+Returns the type of the expression, or `Option::none()` if there were errors when the expression was previously resolved.

--- a/docs/docs/noir/standard_library/meta/typed_expr.md
+++ b/docs/docs/noir/standard_library/meta/typed_expr.md
@@ -6,8 +6,14 @@ title: TypedExpr
 
 ## Methods
 
-### as_function_definition
+### get_type
 
 #include_code as_function_definition noir_stdlib/src/meta/typed_expr.nr rust
 
 If this expression refers to a function definitions, returns it. Otherwise returns `Option::none()`.
+
+### get_type
+
+#include_code get_type noir_stdlib/src/meta/typed_expr.nr rust
+
+Returns the type of the expression, if the expression could be resolved without errors.

--- a/noir_stdlib/src/meta/typed_expr.nr
+++ b/noir_stdlib/src/meta/typed_expr.nr
@@ -1,11 +1,14 @@
+//! Contains methods on the built-in `TypedExpr` type for resolved and type-checked expressions.
 use crate::option::Option;
 
 impl TypedExpr {
+    /// If this expression refers to a function definitions, returns it. Otherwise returns `Option::none()`.
     #[builtin(typed_expr_as_function_definition)]
     // docs:start:as_function_definition
     comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
     // docs:end:as_function_definition
 
+    /// Returns the type of the expression, if the expression could be resolved without errors.
     #[builtin(typed_expr_get_type)]
     // docs:start:get_type
     comptime fn get_type(self) -> Option<Type> {}

--- a/noir_stdlib/src/meta/typed_expr.nr
+++ b/noir_stdlib/src/meta/typed_expr.nr
@@ -5,4 +5,9 @@ impl TypedExpr {
     // docs:start:as_function_definition
     comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
     // docs:end:as_function_definition
+
+    #[builtin(typed_expr_get_type)]
+    // docs:start:get_type
+    comptime fn get_type(self) -> Option<Type> {}
+    // docs:end:get_type
 }

--- a/test_programs/compile_success_empty/comptime_typed_expr/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_typed_expr/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_typed_expr"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_typed_expr/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_typed_expr/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {
+    comptime
+    {
+        let expr = quote { [1, 3] }.as_expr().unwrap().resolve(Option::none());
+        assert_eq(expr.get_type().unwrap(), quote { [Field; 2] }.as_type());
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Part of #5668

## Summary

## Additional Context



## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
