### PR TITLE
fix: Fix using lazily elaborated comptime globals

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -513,15 +513,6 @@ impl<'context> Elaborator<'context> {
         let typ = self.type_check_variable(expr, id, generics);
         self.interner.push_expr_type(id, typ.clone());
 
-        // Comptime variables must be replaced with their values
-        if let Some(definition) = self.interner.try_definition(definition_id) {
-            if definition.comptime && !self.in_comptime_context() {
-                let mut interpreter = self.setup_interpreter();
-                let value = interpreter.evaluate(id);
-                return self.inline_comptime_value(value, span);
-            }
-        }
-
         (id, typ)
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -405,6 +405,11 @@ impl Value {
             }
             Value::Quoted(tokens) => HirExpression::Unquote(add_token_spans(tokens, location.span)),
             Value::TypedExpr(TypedExpr::ExprId(expr_id)) => interner.expression(&expr_id),
+            // Only convert pointers with auto_deref = true. These are mutable variables
+            // and we don't need to wrap them in `&mut`.
+            Value::Pointer(element, true) => {
+                return element.unwrap_or_clone().into_hir_expression(interner, location);
+            }
             Value::TypedExpr(TypedExpr::StmtId(..))
             | Value::Expr(..)
             | Value::Pointer(..)

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -471,6 +471,16 @@ impl<T> Shared<T> {
     pub fn borrow_mut(&self) -> std::cell::RefMut<T> {
         self.0.borrow_mut()
     }
+
+    pub fn unwrap_or_clone(self) -> T
+    where
+        T: Clone,
+    {
+        match Rc::try_unwrap(self.0) {
+            Ok(elem) => elem.into_inner(),
+            Err(rc) => rc.as_ref().clone().into_inner(),
+        }
+    }
 }
 
 /// A restricted subset of binary operators useable on

--- a/test_programs/compile_success_empty/comptime_globals_regression/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_globals_regression/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_globals_regression"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_globals_regression/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_globals_regression/src/main.nr
@@ -1,0 +1,23 @@
+comptime mut global COUNTER = 0;
+
+fn main() {
+    comptime
+    {
+        increment()
+    };
+    comptime
+    {
+        increment()
+    };
+
+    assert_eq(get_counter(), 2);
+}
+
+fn get_counter() -> Field {
+    COUNTER
+}
+
+comptime fn increment() {
+    COUNTER += 1;
+    assert_eq(get_counter(), COUNTER);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5991

## Summary\*

Fixes two issues:
1. The original linked issue where elaborating a function early would cause any globals to be "locked in" in a sense.
2. The fact that we were never actually mutating underlying values in the interpreter.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
