### PR TITLE
chore: bump bb version to 0.54.0

### DIFF
--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.51.1"
+VERSION="0.54.0"
 
 BBUP_PATH=~/.bb/bbup
 

--- a/tooling/noir_js_backend_barretenberg/package.json
+++ b/tooling/noir_js_backend_barretenberg/package.json
@@ -41,7 +41,7 @@
     "lint": "NODE_NO_WARNINGS=1 eslint . --ext .ts --ignore-path ./.eslintignore  --max-warnings 0"
   },
   "dependencies": {
-    "@aztec/bb.js": "0.51.1",
+    "@aztec/bb.js": "0.54.0",
     "@noir-lang/types": "workspace:*",
     "fflate": "^0.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,9 +221,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aztec/bb.js@npm:0.51.1":
-  version: 0.51.1
-  resolution: "@aztec/bb.js@npm:0.51.1"
+"@aztec/bb.js@npm:0.54.0":
+  version: 0.54.0
+  resolution: "@aztec/bb.js@npm:0.54.0"
   dependencies:
     comlink: ^4.4.1
     commander: ^10.0.1
@@ -231,7 +231,7 @@ __metadata:
     tslib: ^2.4.0
   bin:
     bb.js: dest/node/main.js
-  checksum: 246953d4d2becc86001b8e6d49ab8c0b4fa4833a9bf1d2177d0fb4e271e66f9dc65e3b02b69b00fbfcb935a11e2f90b5ac229b8c8938c34604fe54b29b3accfb
+  checksum: 0c6dce239582fcf25406c19093a5834a8050fffc81970f331d245f016ff41a02ba14043f7d8550e22f97a70a67b95fa10eb4d7a592c8b56b618c0f99527a62e1
   languageName: node
   linkType: hard
 
@@ -4161,7 +4161,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@noir-lang/backend_barretenberg@workspace:tooling/noir_js_backend_barretenberg"
   dependencies:
-    "@aztec/bb.js": 0.51.1
+    "@aztec/bb.js": 0.54.0
     "@noir-lang/types": "workspace:*"
     "@types/node": ^20.6.2
     "@types/prettier": ^3


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR bumps bb so we can take advantage of some improvements to circuit generation.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
