### PR TITLE
chore: single install script for cargo-binstall

### DIFF
--- a/.github/scripts/cargo-binstall-install.sh
+++ b/.github/scripts/cargo-binstall-install.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
-curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+cd $(dirname "$0")
+
+CARGO_BINSTALL_CHECK=$(./command-check.sh cargo-binstall)
+if [ $CARGO_BINSTALL_CHECK != "true" ]; then
+    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+fi

--- a/.github/scripts/command-check.sh
+++ b/.github/scripts/command-check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+
+command -v $1 >/dev/null 2>&1 && echo "true" || { echo >&2 "$1 is not installed" && echo "false"; }

--- a/compiler/wasm/scripts/install_wasm-pack.sh
+++ b/compiler/wasm/scripts/install_wasm-pack.sh
@@ -3,7 +3,7 @@ set -eu
 
 cd $(dirname "$0")/..
 
-../../../.github/scripts/cargo-binstall-install.sh
+../../.github/scripts/cargo-binstall-install.sh
 
 # Install wasm-pack 
 cargo-binstall wasm-pack@0.12.1 -y --force

--- a/compiler/wasm/scripts/install_wasm-pack.sh
+++ b/compiler/wasm/scripts/install_wasm-pack.sh
@@ -3,10 +3,7 @@ set -eu
 
 cd $(dirname "$0")/..
 
-# Install wasm-pack 
-CARGO_BINSTALL_CHECK=$(./scripts/command-check.sh cargo-binstall)
-if [ $CARGO_BINSTALL_CHECK != "true" ]; then
-    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-fi
+../../../.github/scripts/cargo-binstall-install.sh
 
+# Install wasm-pack 
 cargo-binstall wasm-pack@0.12.1 -y --force


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR just avoids us having multiple ways to install `cargo-binstall` so everything goes through `cargo-binstall-install.sh`

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
