### PR TITLE
fix: Error when mutating comptime variables in non-comptime code

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -249,6 +249,15 @@ impl<'context> Elaborator<'context> {
                 } else {
                     if let Some(definition) = self.interner.try_definition(ident.id) {
                         mutable = definition.mutable;
+
+                        if definition.comptime && !self.in_comptime_context() {
+                            let span = ident.location.span;
+                            let name = definition.name.clone();
+                            self.push_err(ResolverError::MutatingComptimeInNonComptimeContext {
+                                name,
+                                span,
+                            });
+                        }
                     }
 
                     let typ = self.interner.definition_type(ident.id).instantiate(self.interner).0;

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -251,11 +251,9 @@ impl<'context> Elaborator<'context> {
                         mutable = definition.mutable;
 
                         if definition.comptime && !self.in_comptime_context() {
-                            let span = ident.location.span;
-                            let name = definition.name.clone();
                             self.push_err(ResolverError::MutatingComptimeInNonComptimeContext {
-                                name,
-                                span,
+                                name: definition.name.clone(),
+                                span: ident.location.span,
                             });
                         }
                     }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -128,6 +128,8 @@ pub enum ResolverError {
     QuoteInRuntimeCode { span: Span },
     #[error("Comptime-only type `{typ}` cannot be used in runtime code")]
     ComptimeTypeInRuntimeCode { typ: String, span: Span },
+    #[error("Comptime variable `{name}` cannot be mutated in a non-comptime context")]
+    MutatingComptimeInNonComptimeContext { name: String, span: Span },
 }
 
 impl ResolverError {
@@ -519,6 +521,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 Diagnostic::simple_error(
                     format!("Comptime-only type `{typ}` cannot be used in runtime code"),
                     "Comptime-only type used here".to_string(),
+                    *span,
+                )
+            },
+            ResolverError::MutatingComptimeInNonComptimeContext { name, span } => {
+                Diagnostic::simple_error(
+                    format!("Comptime variable `{name}` cannot be mutated in a non-comptime context"),
+                    format!("`{name}` mutated here"),
                     *span,
                 )
             },


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5982

## Summary\*

Issues an error when mutating comptime globals in a non-comptime context. Previously we either allowed the code if the method is unused, or panicked during monomorphization.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
