### PR TITLE
fix: help link was outdated

### DIFF
--- a/aztec_macros/src/utils/errors.rs
+++ b/aztec_macros/src/utils/errors.rs
@@ -29,7 +29,7 @@ impl From<AztecMacroError> for MacroError {
     fn from(err: AztecMacroError) -> Self {
         match err {
             AztecMacroError::AztecDepNotFound {} => MacroError {
-                primary_message: "Aztec dependency not found. Please add aztec as a dependency in your Nargo.toml. For more information go to https://docs.aztec.network/developers/debugging/aztecnr-errors#aztec-dependency-not-found-please-add-aztec-as-a-dependency-in-your-nargotoml".to_owned(),
+                primary_message: "Aztec dependency not found. Please add aztec as a dependency in your Nargo.toml. For more information go to https://docs.aztec.network/reference/developer_references/common_errors/aztecnr-errors#aztec-dependency-not-found-please-add-aztec-as-a-dependency-in-your-nargotoml".to_owned(),
                 secondary_message: None,
                 span: None,
             },


### PR DESCRIPTION
# Description

## Problem

I wrote `contract { ... }` in a file and it told me to go somewhere that doesn't exist (it redirects me to the main docs page).

## Summary

Updates the link to one that I think is correct.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
