### PR TITLE
feat: format trait impl functions

### DIFF
--- a/aztec_macros/src/transforms/events.rs
+++ b/aztec_macros/src/transforms/events.rs
@@ -1,4 +1,7 @@
-use noirc_frontend::ast::{Documented, ItemVisibility, NoirFunction, NoirTraitImpl, TraitImplItem};
+use noirc_errors::Span;
+use noirc_frontend::ast::{
+    Documented, ItemVisibility, NoirFunction, NoirTraitImpl, TraitImplItem, TraitImplItemKind,
+};
 use noirc_frontend::macros_api::{NodeInterner, StructId};
 use noirc_frontend::token::SecondaryAttribute;
 use noirc_frontend::{
@@ -67,30 +70,37 @@ pub fn generate_event_impls(
                 event_byte_len,
                 empty_spans,
             )?;
-            event_interface_trait_impl.items.push(Documented::not_documented(
-                TraitImplItem::Function(generate_fn_get_event_type_id(
+            event_interface_trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(generate_fn_get_event_type_id(
                     event_type.as_str(),
                     event_len,
                     empty_spans,
                 )?),
-            ));
-            event_interface_trait_impl.items.push(Documented::not_documented(
-                TraitImplItem::Function(generate_fn_private_to_be_bytes(
+                span: Span::default(),
+            }));
+            event_interface_trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(generate_fn_private_to_be_bytes(
                     event_type.as_str(),
                     event_byte_len,
                     empty_spans,
                 )?),
-            ));
-            event_interface_trait_impl.items.push(Documented::not_documented(
-                TraitImplItem::Function(generate_fn_to_be_bytes(
+                span: Span::default(),
+            }));
+            event_interface_trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(generate_fn_to_be_bytes(
                     event_type.as_str(),
                     event_byte_len,
                     empty_spans,
                 )?),
-            ));
-            event_interface_trait_impl.items.push(Documented::not_documented(
-                TraitImplItem::Function(generate_fn_emit(event_type.as_str(), empty_spans)?),
-            ));
+                span: Span::default(),
+            }));
+            event_interface_trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(generate_fn_emit(
+                    event_type.as_str(),
+                    empty_spans,
+                )?),
+                span: Span::default(),
+            }));
             submodule.contents.trait_impls.push(event_interface_trait_impl);
 
             let serialize_trait_impl = generate_trait_impl_serialize(

--- a/aztec_macros/src/transforms/note_interface.rs
+++ b/aztec_macros/src/transforms/note_interface.rs
@@ -1,7 +1,7 @@
 use noirc_errors::Span;
 use noirc_frontend::ast::{
     Documented, ItemVisibility, LetStatement, NoirFunction, NoirStruct, PathKind, StructField,
-    TraitImplItem, TypeImpl, UnresolvedTypeData, UnresolvedTypeExpression,
+    TraitImplItem, TraitImplItemKind, TypeImpl, UnresolvedTypeData, UnresolvedTypeExpression,
 };
 use noirc_frontend::{
     graph::CrateId,
@@ -153,9 +153,10 @@ pub fn generate_note_interface_impl(
                 note_interface_impl_span,
                 empty_spans,
             )?;
-            trait_impl.items.push(Documented::not_documented(TraitImplItem::Function(
-                note_serialize_content_fn,
-            )));
+            trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(note_serialize_content_fn),
+                span: note_interface_impl_span,
+            }));
 
             let note_deserialize_content_fn = generate_note_deserialize_content(
                 &note_type,
@@ -165,9 +166,10 @@ pub fn generate_note_interface_impl(
                 note_interface_impl_span,
                 empty_spans,
             )?;
-            trait_impl.items.push(Documented::not_documented(TraitImplItem::Function(
-                note_deserialize_content_fn,
-            )));
+            trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(note_deserialize_content_fn),
+                span: note_interface_impl_span,
+            }));
 
             let note_properties_struct = generate_note_properties_struct(
                 &note_type,
@@ -196,9 +198,10 @@ pub fn generate_note_interface_impl(
                 note_interface_impl_span,
                 empty_spans,
             )?;
-            trait_impl
-                .items
-                .push(Documented::not_documented(TraitImplItem::Function(get_header_fn)));
+            trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(get_header_fn),
+                span: note_interface_impl_span,
+            }));
         }
         if !check_trait_method_implemented(trait_impl, "set_header") {
             let set_header_fn = generate_note_set_header(
@@ -207,18 +210,20 @@ pub fn generate_note_interface_impl(
                 note_interface_impl_span,
                 empty_spans,
             )?;
-            trait_impl
-                .items
-                .push(Documented::not_documented(TraitImplItem::Function(set_header_fn)));
+            trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(set_header_fn),
+                span: note_interface_impl_span,
+            }));
         }
 
         if !check_trait_method_implemented(trait_impl, "get_note_type_id") {
             let note_type_id = compute_note_type_id(&note_type);
             let get_note_type_id_fn =
                 generate_get_note_type_id(note_type_id, note_interface_impl_span, empty_spans)?;
-            trait_impl
-                .items
-                .push(Documented::not_documented(TraitImplItem::Function(get_note_type_id_fn)));
+            trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(get_note_type_id_fn),
+                span: note_interface_impl_span,
+            }));
         }
 
         if !check_trait_method_implemented(trait_impl, "compute_note_hiding_point") {
@@ -227,9 +232,10 @@ pub fn generate_note_interface_impl(
                 note_interface_impl_span,
                 empty_spans,
             )?;
-            trait_impl.items.push(Documented::not_documented(TraitImplItem::Function(
-                compute_note_hiding_point_fn,
-            )));
+            trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(compute_note_hiding_point_fn),
+                span: note_interface_impl_span,
+            }));
         }
 
         if !check_trait_method_implemented(trait_impl, "to_be_bytes") {
@@ -240,9 +246,10 @@ pub fn generate_note_interface_impl(
                 note_interface_impl_span,
                 empty_spans,
             )?;
-            trait_impl
-                .items
-                .push(Documented::not_documented(TraitImplItem::Function(to_be_bytes_fn)));
+            trait_impl.items.push(Documented::not_documented(TraitImplItem {
+                kind: TraitImplItemKind::Function(to_be_bytes_fn),
+                span: note_interface_impl_span,
+            }));
         }
     }
 

--- a/aztec_macros/src/utils/ast_utils.rs
+++ b/aztec_macros/src/utils/ast_utils.rs
@@ -3,7 +3,7 @@ use noirc_frontend::ast::{
     BinaryOpKind, CallExpression, CastExpression, Expression, ExpressionKind, FunctionReturnType,
     Ident, IndexExpression, InfixExpression, Lambda, MemberAccessExpression, MethodCallExpression,
     NoirTraitImpl, Path, PathSegment, Pattern, PrefixExpression, Statement, StatementKind,
-    TraitImplItem, UnaryOp, UnresolvedType, UnresolvedTypeData,
+    TraitImplItemKind, UnaryOp, UnresolvedType, UnresolvedTypeData,
 };
 use noirc_frontend::token::SecondaryAttribute;
 
@@ -179,8 +179,8 @@ pub fn index_array(array: Ident, index: &str) -> Expression {
 }
 
 pub fn check_trait_method_implemented(trait_impl: &NoirTraitImpl, method_name: &str) -> bool {
-    trait_impl.items.iter().any(|item| match &item.item {
-        TraitImplItem::Function(func) => func.def.name.0.contents == method_name,
+    trait_impl.items.iter().any(|item| match &item.item.kind {
+        TraitImplItemKind::Function(func) => func.def.name.0.contents == method_name,
         _ => false,
     })
 }

--- a/aztec_macros/src/utils/parse_utils.rs
+++ b/aztec_macros/src/utils/parse_utils.rs
@@ -6,9 +6,9 @@ use noirc_frontend::{
         InfixExpression, LValue, Lambda, LetStatement, Literal, MemberAccessExpression,
         MethodCallExpression, ModuleDeclaration, NoirFunction, NoirStruct, NoirTrait,
         NoirTraitImpl, NoirTypeAlias, Path, PathSegment, Pattern, PrefixExpression, Statement,
-        StatementKind, TraitImplItem, TraitItem, TypeImpl, UnresolvedGeneric, UnresolvedGenerics,
-        UnresolvedTraitConstraint, UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression,
-        UseTree, UseTreeKind,
+        StatementKind, TraitImplItem, TraitImplItemKind, TraitItem, TypeImpl, UnresolvedGeneric,
+        UnresolvedGenerics, UnresolvedTraitConstraint, UnresolvedType, UnresolvedTypeData,
+        UnresolvedTypeExpression, UseTree, UseTreeKind,
     },
     parser::{Item, ItemKind, ParsedSubModule, ParserError},
     ParsedModule,
@@ -137,14 +137,20 @@ fn empty_trait_item(trait_item: &mut TraitItem) {
 }
 
 fn empty_trait_impl_item(trait_impl_item: &mut TraitImplItem) {
+    trait_impl_item.span = Default::default();
+
+    empty_trait_impl_item_kind(&mut trait_impl_item.kind);
+}
+
+fn empty_trait_impl_item_kind(trait_impl_item: &mut TraitImplItemKind) {
     match trait_impl_item {
-        TraitImplItem::Function(noir_function) => empty_noir_function(noir_function),
-        TraitImplItem::Constant(name, typ, default_value) => {
+        TraitImplItemKind::Function(noir_function) => empty_noir_function(noir_function),
+        TraitImplItemKind::Constant(name, typ, default_value) => {
             empty_ident(name);
             empty_unresolved_type(typ);
             empty_expression(default_value);
         }
-        TraitImplItem::Type { name, alias } => {
+        TraitImplItemKind::Type { name, alias } => {
             empty_ident(name);
             empty_unresolved_type(alias);
         }

--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -95,7 +95,13 @@ pub struct TraitBound {
 }
 
 #[derive(Clone, Debug)]
-pub enum TraitImplItem {
+pub struct TraitImplItem {
+    pub kind: TraitImplItemKind,
+    pub span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub enum TraitImplItemKind {
     Function(NoirFunction),
     Constant(Ident, UnresolvedType, Expression),
     Type { name: Ident, alias: UnresolvedType },
@@ -203,10 +209,16 @@ impl Display for NoirTraitImpl {
 
 impl Display for TraitImplItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.kind.fmt(f)
+    }
+}
+
+impl Display for TraitImplItemKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TraitImplItem::Function(function) => function.fmt(f),
-            TraitImplItem::Type { name, alias } => write!(f, "type {name} = {alias};"),
-            TraitImplItem::Constant(name, typ, value) => {
+            TraitImplItemKind::Function(function) => function.fmt(f),
+            TraitImplItemKind::Type { name, alias } => write!(f, "type {name} = {alias};"),
+            TraitImplItemKind::Constant(name, typ, value) => {
                 write!(f, "let {name}: {typ} = {value};")
             }
         }

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::ast::{
     Documented, FunctionDefinition, Ident, ItemVisibility, LetStatement, ModuleDeclaration,
-    NoirFunction, NoirStruct, NoirTrait, NoirTraitImpl, NoirTypeAlias, Pattern, TraitImplItem,
+    NoirFunction, NoirStruct, NoirTrait, NoirTraitImpl, NoirTypeAlias, Pattern, TraitImplItemKind,
     TraitItem, TypeImpl,
 };
 use crate::hir::resolution::errors::ResolverError;
@@ -1124,18 +1124,18 @@ pub(crate) fn collect_trait_impl_items(
     let module = ModuleId { krate, local_id };
 
     for item in std::mem::take(&mut trait_impl.items) {
-        match item.item {
-            TraitImplItem::Function(impl_method) => {
+        match item.item.kind {
+            TraitImplItemKind::Function(impl_method) => {
                 let func_id = interner.push_empty_fn();
                 let location = Location::new(impl_method.span(), file_id);
                 interner.push_function(func_id, &impl_method.def, module, location);
                 interner.set_doc_comments(ReferenceId::Function(func_id), item.doc_comments);
                 unresolved_functions.push_fn(local_id, func_id, impl_method);
             }
-            TraitImplItem::Constant(name, typ, expr) => {
+            TraitImplItemKind::Constant(name, typ, expr) => {
                 associated_constants.push((name, typ, expr));
             }
-            TraitImplItem::Type { name, alias } => {
+            TraitImplItemKind::Type { name, alias } => {
                 associated_types.push((name, alias));
             }
         }

--- a/noir_stdlib/src/bigint.nr
+++ b/noir_stdlib/src/bigint.nr
@@ -56,19 +56,15 @@ struct Secpk1Fq {
 impl BigField for Secpk1Fq {
     fn from_le_bytes(bytes: [u8]) -> Secpk1Fq {
         assert(bytes.len() <= 32);
-        let mut array = [0;32];
+        let mut array = [0; 32];
         for i in 0..bytes.len() {
             array[i] = bytes[i];
         }
-        Secpk1Fq {
-            array: array,
-        }
+        Secpk1Fq { array }
     }
 
-    fn from_le_bytes_32(bytes: [u8;32]) -> Secpk1Fq {
-        Secpk1Fq {
-            array: bytes,
-        }
+    fn from_le_bytes_32(bytes: [u8; 32]) -> Secpk1Fq {
+        Secpk1Fq { array: bytes }
     }
 
     fn to_le_bytes(self) -> [u8] {
@@ -76,40 +72,32 @@ impl BigField for Secpk1Fq {
     }
 }
 
-impl Add for Secpk1Fq { 
+impl Add for Secpk1Fq {
     fn add(self: Self, other: Secpk1Fq) -> Secpk1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fq);
-        Secpk1Fq {
-           array: a.bigint_add(b).to_le_bytes()
-        }
+        Secpk1Fq { array: a.bigint_add(b).to_le_bytes() }
     }
 }
-impl Sub for Secpk1Fq { 
+impl Sub for Secpk1Fq {
     fn sub(self: Self, other: Secpk1Fq) -> Secpk1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fq);
-        Secpk1Fq {
-           array: a.bigint_sub(b).to_le_bytes()
-        }
+        Secpk1Fq { array: a.bigint_sub(b).to_le_bytes() }
     }
 }
-impl Mul for Secpk1Fq { 
+impl Mul for Secpk1Fq {
     fn mul(self: Self, other: Secpk1Fq) -> Secpk1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fq);
-        Secpk1Fq {
-           array: a.bigint_mul(b).to_le_bytes()
-        }
+        Secpk1Fq { array: a.bigint_mul(b).to_le_bytes() }
     }
 }
-impl Div for Secpk1Fq { 
+impl Div for Secpk1Fq {
     fn div(self: Self, other: Secpk1Fq) -> Secpk1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fq);
-        Secpk1Fq {
-           array: a.bigint_div(b).to_le_bytes()
-        }
+        Secpk1Fq { array: a.bigint_div(b).to_le_bytes() }
     }
 }
 impl Eq for Secpk1Fq {
@@ -125,60 +113,48 @@ struct Secpk1Fr {
 impl BigField for Secpk1Fr {
     fn from_le_bytes(bytes: [u8]) -> Secpk1Fr {
         assert(bytes.len() <= 32);
-        let mut array = [0;32];
+        let mut array = [0; 32];
         for i in 0..bytes.len() {
             array[i] = bytes[i];
         }
-        Secpk1Fr {
-            array: array,
-        }
+        Secpk1Fr { array }
     }
 
-    fn from_le_bytes_32(bytes: [u8;32]) -> Secpk1Fr {
-        Secpk1Fr {
-            array: bytes,
-        }
+    fn from_le_bytes_32(bytes: [u8; 32]) -> Secpk1Fr {
+        Secpk1Fr { array: bytes }
     }
-    
+
     fn to_le_bytes(self) -> [u8] {
         self.array
     }
 }
 
-impl Add for Secpk1Fr { 
+impl Add for Secpk1Fr {
     fn add(self: Self, other: Secpk1Fr) -> Secpk1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fr);
-        Secpk1Fr {
-           array: a.bigint_add(b).to_le_bytes()
-        }
+        Secpk1Fr { array: a.bigint_add(b).to_le_bytes() }
     }
 }
-impl Sub for Secpk1Fr { 
+impl Sub for Secpk1Fr {
     fn sub(self: Self, other: Secpk1Fr) -> Secpk1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fr);
-        Secpk1Fr {
-           array: a.bigint_sub(b).to_le_bytes()
-        }
+        Secpk1Fr { array: a.bigint_sub(b).to_le_bytes() }
     }
 }
-impl Mul for Secpk1Fr { 
+impl Mul for Secpk1Fr {
     fn mul(self: Self, other: Secpk1Fr) -> Secpk1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fr);
-        Secpk1Fr {
-           array: a.bigint_mul(b).to_le_bytes()
-        }
+        Secpk1Fr { array: a.bigint_mul(b).to_le_bytes() }
     }
 }
-impl Div for Secpk1Fr { 
+impl Div for Secpk1Fr {
     fn div(self: Self, other: Secpk1Fr) -> Secpk1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpk1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpk1_fr);
-        Secpk1Fr {
-           array: a.bigint_div(b).to_le_bytes()
-        }
+        Secpk1Fr { array: a.bigint_div(b).to_le_bytes() }
     }
 }
 impl Eq for Secpk1Fr {
@@ -194,19 +170,15 @@ struct Bn254Fr {
 impl BigField for Bn254Fr {
     fn from_le_bytes(bytes: [u8]) -> Bn254Fr {
         assert(bytes.len() <= 32);
-        let mut array = [0;32];
+        let mut array = [0; 32];
         for i in 0..bytes.len() {
             array[i] = bytes[i];
         }
-        Bn254Fr {
-            array: array,
-        }
+        Bn254Fr { array }
     }
 
-    fn from_le_bytes_32(bytes: [u8;32]) -> Bn254Fr {
-        Bn254Fr {
-            array: bytes,
-        }
+    fn from_le_bytes_32(bytes: [u8; 32]) -> Bn254Fr {
+        Bn254Fr { array: bytes }
     }
 
     fn to_le_bytes(self) -> [u8] {
@@ -214,40 +186,32 @@ impl BigField for Bn254Fr {
     }
 }
 
-impl Add for Bn254Fr { 
+impl Add for Bn254Fr {
     fn add(self: Self, other: Bn254Fr) -> Bn254Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fr);
-        Bn254Fr {
-           array: a.bigint_add(b).to_le_bytes()
-        }
+        Bn254Fr { array: a.bigint_add(b).to_le_bytes() }
     }
 }
-impl Sub for Bn254Fr { 
+impl Sub for Bn254Fr {
     fn sub(self: Self, other: Bn254Fr) -> Bn254Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fr);
-        Bn254Fr {
-           array: a.bigint_sub(b).to_le_bytes()
-        }
+        Bn254Fr { array: a.bigint_sub(b).to_le_bytes() }
     }
 }
-impl Mul for Bn254Fr { 
+impl Mul for Bn254Fr {
     fn mul(self: Self, other: Bn254Fr) -> Bn254Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fr);
-        Bn254Fr {
-           array: a.bigint_mul(b).to_le_bytes()
-        }
+        Bn254Fr { array: a.bigint_mul(b).to_le_bytes() }
     }
 }
-impl Div for Bn254Fr { 
+impl Div for Bn254Fr {
     fn div(self: Self, other: Bn254Fr) -> Bn254Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fr);
-        Bn254Fr {
-           array: a.bigint_div(b).to_le_bytes()
-        }
+        Bn254Fr { array: a.bigint_div(b).to_le_bytes() }
     }
 }
 impl Eq for Bn254Fr {
@@ -263,19 +227,15 @@ struct Bn254Fq {
 impl BigField for Bn254Fq {
     fn from_le_bytes(bytes: [u8]) -> Bn254Fq {
         assert(bytes.len() <= 32);
-        let mut array = [0;32];
+        let mut array = [0; 32];
         for i in 0..bytes.len() {
             array[i] = bytes[i];
         }
-        Bn254Fq {
-            array: array,
-        }
+        Bn254Fq { array }
     }
 
-    fn from_le_bytes_32(bytes: [u8;32]) -> Bn254Fq {
-        Bn254Fq {
-            array: bytes,
-        }
+    fn from_le_bytes_32(bytes: [u8; 32]) -> Bn254Fq {
+        Bn254Fq { array: bytes }
     }
 
     fn to_le_bytes(self) -> [u8] {
@@ -283,40 +243,32 @@ impl BigField for Bn254Fq {
     }
 }
 
-impl Add for Bn254Fq { 
+impl Add for Bn254Fq {
     fn add(self: Self, other: Bn254Fq) -> Bn254Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fq);
-        Bn254Fq {
-           array: a.bigint_add(b).to_le_bytes()
-        }
+        Bn254Fq { array: a.bigint_add(b).to_le_bytes() }
     }
 }
-impl Sub for Bn254Fq { 
+impl Sub for Bn254Fq {
     fn sub(self: Self, other: Bn254Fq) -> Bn254Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fq);
-        Bn254Fq {
-           array: a.bigint_sub(b).to_le_bytes()
-        }
+        Bn254Fq { array: a.bigint_sub(b).to_le_bytes() }
     }
 }
-impl Mul for Bn254Fq { 
+impl Mul for Bn254Fq {
     fn mul(self: Self, other: Bn254Fq) -> Bn254Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fq);
-        Bn254Fq {
-           array: a.bigint_mul(b).to_le_bytes()
-        }
+        Bn254Fq { array: a.bigint_mul(b).to_le_bytes() }
     }
 }
-impl Div for Bn254Fq { 
+impl Div for Bn254Fq {
     fn div(self: Self, other: Bn254Fq) -> Bn254Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), bn254_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), bn254_fq);
-        Bn254Fq {
-           array: a.bigint_div(b).to_le_bytes()
-        }
+        Bn254Fq { array: a.bigint_div(b).to_le_bytes() }
     }
 }
 impl Eq for Bn254Fq {
@@ -332,19 +284,15 @@ struct Secpr1Fq {
 impl BigField for Secpr1Fq {
     fn from_le_bytes(bytes: [u8]) -> Secpr1Fq {
         assert(bytes.len() <= 32);
-        let mut array = [0;32];
+        let mut array = [0; 32];
         for i in 0..bytes.len() {
             array[i] = bytes[i];
         }
-        Secpr1Fq {
-            array: array,
-        }
+        Secpr1Fq { array }
     }
 
-    fn from_le_bytes_32(bytes: [u8;32]) -> Secpr1Fq {
-        Secpr1Fq {
-            array: bytes,
-        }
+    fn from_le_bytes_32(bytes: [u8; 32]) -> Secpr1Fq {
+        Secpr1Fq { array: bytes }
     }
 
     fn to_le_bytes(self) -> [u8] {
@@ -352,40 +300,32 @@ impl BigField for Secpr1Fq {
     }
 }
 
-impl Add for Secpr1Fq { 
+impl Add for Secpr1Fq {
     fn add(self: Self, other: Secpr1Fq) -> Secpr1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fq);
-        Secpr1Fq {
-           array: a.bigint_add(b).to_le_bytes()
-        }
+        Secpr1Fq { array: a.bigint_add(b).to_le_bytes() }
     }
 }
-impl Sub for Secpr1Fq { 
+impl Sub for Secpr1Fq {
     fn sub(self: Self, other: Secpr1Fq) -> Secpr1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fq);
-        Secpr1Fq {
-           array: a.bigint_sub(b).to_le_bytes()
-        }
+        Secpr1Fq { array: a.bigint_sub(b).to_le_bytes() }
     }
 }
-impl Mul for Secpr1Fq { 
+impl Mul for Secpr1Fq {
     fn mul(self: Self, other: Secpr1Fq) -> Secpr1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fq);
-        Secpr1Fq {
-           array: a.bigint_mul(b).to_le_bytes()
-        }
+        Secpr1Fq { array: a.bigint_mul(b).to_le_bytes() }
     }
 }
-impl Div for Secpr1Fq { 
+impl Div for Secpr1Fq {
     fn div(self: Self, other: Secpr1Fq) -> Secpr1Fq {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fq);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fq);
-        Secpr1Fq {
-           array: a.bigint_div(b).to_le_bytes()
-        }
+        Secpr1Fq { array: a.bigint_div(b).to_le_bytes() }
     }
 }
 impl Eq for Secpr1Fq {
@@ -401,19 +341,15 @@ struct Secpr1Fr {
 impl BigField for Secpr1Fr {
     fn from_le_bytes(bytes: [u8]) -> Secpr1Fr {
         assert(bytes.len() <= 32);
-        let mut array = [0;32];
+        let mut array = [0; 32];
         for i in 0..bytes.len() {
             array[i] = bytes[i];
         }
-        Secpr1Fr {
-            array: array,
-        }
+        Secpr1Fr { array }
     }
 
-    fn from_le_bytes_32(bytes: [u8;32]) -> Secpr1Fr {
-        Secpr1Fr {
-            array: bytes,
-        }
+    fn from_le_bytes_32(bytes: [u8; 32]) -> Secpr1Fr {
+        Secpr1Fr { array: bytes }
     }
 
     fn to_le_bytes(self) -> [u8] {
@@ -421,40 +357,32 @@ impl BigField for Secpr1Fr {
     }
 }
 
-impl Add for Secpr1Fr { 
+impl Add for Secpr1Fr {
     fn add(self: Self, other: Secpr1Fr) -> Secpr1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fr);
-        Secpr1Fr {
-           array: a.bigint_add(b).to_le_bytes()
-        }
+        Secpr1Fr { array: a.bigint_add(b).to_le_bytes() }
     }
 }
-impl Sub for Secpr1Fr { 
+impl Sub for Secpr1Fr {
     fn sub(self: Self, other: Secpr1Fr) -> Secpr1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fr);
-        Secpr1Fr {
-           array: a.bigint_sub(b).to_le_bytes()
-        }
+        Secpr1Fr { array: a.bigint_sub(b).to_le_bytes() }
     }
 }
-impl Mul for Secpr1Fr { 
+impl Mul for Secpr1Fr {
     fn mul(self: Self, other: Secpr1Fr) -> Secpr1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fr);
-        Secpr1Fr {
-           array: a.bigint_mul(b).to_le_bytes()
-        }
+        Secpr1Fr { array: a.bigint_mul(b).to_le_bytes() }
     }
 }
-impl Div for Secpr1Fr { 
+impl Div for Secpr1Fr {
     fn div(self: Self, other: Secpr1Fr) -> Secpr1Fr {
         let a = BigInt::from_le_bytes(self.array.as_slice(), secpr1_fr);
         let b = BigInt::from_le_bytes(other.array.as_slice(), secpr1_fr);
-        Secpr1Fr {
-           array: a.bigint_div(b).to_le_bytes()
-        }
+        Secpr1Fr { array: a.bigint_div(b).to_le_bytes() }
     }
 }
 impl Eq for Secpr1Fr {

--- a/noir_stdlib/src/cmp.nr
+++ b/noir_stdlib/src/cmp.nr
@@ -22,26 +22,74 @@ comptime fn derive_eq(s: StructDefinition) -> Quoted {
 }
 // docs:end:derive_eq
 
-impl Eq for Field { fn eq(self, other: Field) -> bool { self == other } }
+impl Eq for Field {
+    fn eq(self, other: Field) -> bool {
+        self == other
+    }
+}
 
-impl Eq for u64 { fn eq(self, other: u64) -> bool { self == other } }
-impl Eq for u32 { fn eq(self, other: u32) -> bool { self == other } }
-impl Eq for u16 { fn eq(self, other: u16) -> bool { self == other } }
-impl Eq for u8 { fn eq(self, other: u8) -> bool { self == other } }
-impl Eq for u1 { fn eq(self, other: u1) -> bool { self == other } }
+impl Eq for u64 {
+    fn eq(self, other: u64) -> bool {
+        self == other
+    }
+}
+impl Eq for u32 {
+    fn eq(self, other: u32) -> bool {
+        self == other
+    }
+}
+impl Eq for u16 {
+    fn eq(self, other: u16) -> bool {
+        self == other
+    }
+}
+impl Eq for u8 {
+    fn eq(self, other: u8) -> bool {
+        self == other
+    }
+}
+impl Eq for u1 {
+    fn eq(self, other: u1) -> bool {
+        self == other
+    }
+}
 
-impl Eq for i8 { fn eq(self, other: i8) -> bool { self == other } }
-impl Eq for i16 { fn eq(self, other: i16) -> bool { self == other } }
-impl Eq for i32 { fn eq(self, other: i32) -> bool { self == other } }
-impl Eq for i64 { fn eq(self, other: i64) -> bool { self == other } }
+impl Eq for i8 {
+    fn eq(self, other: i8) -> bool {
+        self == other
+    }
+}
+impl Eq for i16 {
+    fn eq(self, other: i16) -> bool {
+        self == other
+    }
+}
+impl Eq for i32 {
+    fn eq(self, other: i32) -> bool {
+        self == other
+    }
+}
+impl Eq for i64 {
+    fn eq(self, other: i64) -> bool {
+        self == other
+    }
+}
 
-impl Eq for () { fn eq(_self: Self, _other: ()) -> bool { true } }
-impl Eq for bool { fn eq(self, other: bool) -> bool { self == other } }
+impl Eq for () {
+    fn eq(_self: Self, _other: ()) -> bool {
+        true
+    }
+}
+impl Eq for bool {
+    fn eq(self, other: bool) -> bool {
+        self == other
+    }
+}
 
 impl<T, let N: u32> Eq for [T; N] where T: Eq {
     fn eq(self, other: [T; N]) -> bool {
         let mut result = true;
-        for i in 0 .. self.len() {
+        for i in 0..self.len() {
             result &= self[i].eq(other[i]);
         }
         result
@@ -51,7 +99,7 @@ impl<T, let N: u32> Eq for [T; N] where T: Eq {
 impl<T> Eq for [T] where T: Eq {
     fn eq(self, other: [T]) -> bool {
         let mut result = self.len() == other.len();
-        for i in 0 .. self.len() {
+        for i in 0..self.len() {
             result &= self[i].eq(other[i]);
         }
         result
@@ -86,7 +134,11 @@ impl<A, B, C, D> Eq for (A, B, C, D) where A: Eq, B: Eq, C: Eq, D: Eq {
 
 impl<A, B, C, D, E> Eq for (A, B, C, D, E) where A: Eq, B: Eq, C: Eq, D: Eq, E: Eq {
     fn eq(self, other: (A, B, C, D, E)) -> bool {
-        self.0.eq(other.0) & self.1.eq(other.1) & self.2.eq(other.2) & self.3.eq(other.3) & self.4.eq(other.4)
+        self.0.eq(other.0)
+            & self.1.eq(other.1)
+            & self.2.eq(other.2)
+            & self.3.eq(other.3)
+            & self.4.eq(other.4)
     }
 }
 
@@ -255,12 +307,10 @@ impl Ord for bool {
             } else {
                 Ordering::greater()
             }
+        } else if other {
+            Ordering::less()
         } else {
-            if other {
-                Ordering::less()
-            } else {
-                Ordering::equal()
-            }
+            Ordering::equal()
         }
     }
 }
@@ -270,7 +320,7 @@ impl<T, let N: u32> Ord for [T; N] where T: Ord {
     // the ordering for the whole array.
     fn cmp(self, other: [T; N]) -> Ordering {
         let mut result = Ordering::equal();
-        for i in 0 .. self.len() {
+        for i in 0..self.len() {
             if result == Ordering::equal() {
                 let result_i = self[i].cmp(other[i]);
 
@@ -290,7 +340,7 @@ impl<T> Ord for [T] where T: Ord {
     // the ordering for the whole array.
     fn cmp(self, other: [T]) -> Ordering {
         let mut result = self.len().cmp(other.len());
-        for i in 0 .. self.len() {
+        for i in 0..self.len() {
             if result == Ordering::equal() {
                 let result_i = self[i].cmp(other[i]);
 

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -428,13 +428,13 @@ impl<T, let MaxLen: u32> Eq for BoundedVec<T, MaxLen> where T: Eq {
         //
         // We make the assumption that the user has used the proper interface for working with `BoundedVec`s
         // rather than directly manipulating the internal fields as this can result in an inconsistent internal state.
-        
+
         (self.len == other.len) & (self.storage == other.storage)
     }
 }
 
 impl<T, let MaxLen: u32, let Len: u32> From<[T; Len]> for BoundedVec<T, MaxLen> {
-    fn from(array: [T; Len]) -> BoundedVec<T, MaxLen>  {
+    fn from(array: [T; Len]) -> BoundedVec<T, MaxLen> {
         BoundedVec::from_array(array)
     }
 }

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -50,12 +50,9 @@ struct Slot<K, V> {
     _is_deleted: bool,
 }
 
-impl<K, V> Default for Slot<K, V>{
-    fn default() -> Self{
-        Slot{
-            _key_value: Option::none(),
-            _is_deleted: false
-        }
+impl<K, V> Default for Slot<K, V> {
+    fn default() -> Self {
+        Slot { _key_value: Option::none(), _is_deleted: false }
     }
 }
 
@@ -649,8 +646,7 @@ where
     K: Eq + Hash,
     V: Eq,
     B: BuildHasher<H>,
-    H: Hasher
-{
+    H: Hasher {
     /// Checks if two HashMaps are equal.
     /// 
     /// Example:
@@ -668,22 +664,22 @@ where
     /// assert(map1 == map2);
     /// ```
     fn eq(self, other: HashMap<K, V, N, B>) -> bool {
-// docs:end:eq
+        // docs:end:eq
         let mut equal = false;
 
-        if self.len() == other.len(){
+        if self.len() == other.len() {
             equal = true;
-            for slot in self._table{
+            for slot in self._table {
                 // Not marked as deleted and has key-value.
-                if equal & slot.is_valid(){
+                if equal & slot.is_valid() {
                     let (key, value) = slot.key_value_unchecked();
                     let other_value = other.get(key);
 
-                    if other_value.is_none(){
+                    if other_value.is_none() {
                         equal = false;
-                    }else{
+                    } else {
                         let other_value = other_value.unwrap_unchecked();
-                        if value != other_value{
+                        if value != other_value {
                             equal = false;
                         }
                     }
@@ -699,8 +695,7 @@ where
 impl<K, V, let N: u32, B, H> Default for HashMap<K, V, N, B>
 where
     B: BuildHasher<H> + Default,
-    H: Hasher + Default
-{
+    H: Hasher + Default {
     /// Constructs an empty HashMap.
     /// 
     /// Example:

--- a/noir_stdlib/src/collections/umap.nr
+++ b/noir_stdlib/src/collections/umap.nr
@@ -31,12 +31,9 @@ struct Slot<K, V> {
     _is_deleted: bool,
 }
 
-impl<K, V> Default for Slot<K, V>{
-    fn default() -> Self{
-        Slot{
-            _key_value: Option::none(),
-            _is_deleted: false
-        }
+impl<K, V> Default for Slot<K, V> {
+    fn default() -> Self {
+        Slot { _key_value: Option::none(), _is_deleted: false }
     }
 }
 
@@ -425,25 +422,26 @@ where
     K: Eq + Hash,
     V: Eq,
     B: BuildHasher<H>,
-    H: Hasher
-{
+    H: Hasher {
     fn eq(self, other: UHashMap<K, V, B>) -> bool {
-// docs:end:eq
+        // docs:end:eq
         let mut equal = false;
 
-        if self.len() == other.len(){
+        if self.len() == other.len() {
             equal = true;
-            for slot in self._table{
+            for slot in self._table {
                 // Not marked as deleted and has key-value.
-                if equal & slot.is_valid(){
+                if equal & slot.is_valid() {
                     let (key, value) = slot.key_value_unchecked();
-                    let other_value = unsafe { other.get(key) };
+                    let other_value = unsafe {
+                        other.get(key)
+                    };
 
-                    if other_value.is_none(){
+                    if other_value.is_none() {
                         equal = false;
-                    }else{
+                    } else {
                         let other_value = other_value.unwrap_unchecked();
-                        if value != other_value{
+                        if value != other_value {
                             equal = false;
                         }
                     }
@@ -459,10 +457,9 @@ where
 impl<K, V, B, H> Default for UHashMap<K, V, B>
 where
     B: BuildHasher<H> + Default,
-    H: Hasher + Default
-{
+    H: Hasher + Default {
     fn default() -> Self {
-// docs:end:default
+        // docs:end:default
         UHashMap::with_hasher(B::default())
     }
 }

--- a/noir_stdlib/src/convert.nr
+++ b/noir_stdlib/src/convert.nr
@@ -5,9 +5,9 @@ trait From<T> {
 // docs:end:from-trait
 
 impl<T> From<T> for T {
-  fn from(input: T) -> T {
-      input
-  }
+    fn from(input: T) -> T {
+        input
+    }
 }
 
 // docs:start:into-trait
@@ -16,37 +16,101 @@ trait Into<T> {
 }
 
 impl<T, U> Into<T> for U where T: From<U> {
-  fn into(self) -> T {
-      T::from(self)
-  }
+    fn into(self) -> T {
+        T::from(self)
+    }
 }
 // docs:end:into-trait
 
 // docs:start:from-impls
 // Unsigned integers
 
-impl From<u8> for u32 { fn from(value: u8) -> u32 { value as u32 } }
+impl From<u8> for u32 {
+    fn from(value: u8) -> u32 {
+        value as u32
+    }
+}
 
-impl From<u8> for u64 { fn from(value: u8) -> u64 { value as u64 } }
-impl From<u32> for u64 { fn from(value: u32) -> u64 { value as u64 } }
+impl From<u8> for u64 {
+    fn from(value: u8) -> u64 {
+        value as u64
+    }
+}
+impl From<u32> for u64 {
+    fn from(value: u32) -> u64 {
+        value as u64
+    }
+}
 
-impl From<u8> for Field { fn from(value: u8) -> Field { value as Field } }
-impl From<u32> for Field { fn from(value: u32) -> Field { value as Field } }
-impl From<u64> for Field { fn from(value: u64) -> Field { value as Field } }
+impl From<u8> for Field {
+    fn from(value: u8) -> Field {
+        value as Field
+    }
+}
+impl From<u32> for Field {
+    fn from(value: u32) -> Field {
+        value as Field
+    }
+}
+impl From<u64> for Field {
+    fn from(value: u64) -> Field {
+        value as Field
+    }
+}
 
 // Signed integers
 
-impl From<i8> for i32 { fn from(value: i8) -> i32 { value as i32 } }
+impl From<i8> for i32 {
+    fn from(value: i8) -> i32 {
+        value as i32
+    }
+}
 
-impl From<i8> for i64 { fn from(value: i8) -> i64 { value as i64 } }
-impl From<i32> for i64 { fn from(value: i32) -> i64 { value as i64 } }
+impl From<i8> for i64 {
+    fn from(value: i8) -> i64 {
+        value as i64
+    }
+}
+impl From<i32> for i64 {
+    fn from(value: i32) -> i64 {
+        value as i64
+    }
+}
 
 // Booleans
-impl From<bool> for u8 { fn from(value: bool) -> u8 { value as u8 } }
-impl From<bool> for u32 { fn from(value: bool) -> u32 { value as u32 } }
-impl From<bool> for u64 { fn from(value: bool) -> u64 { value as u64 } }
-impl From<bool> for i8 { fn from(value: bool) -> i8 { value as i8 } }
-impl From<bool> for i32 { fn from(value: bool) -> i32 { value as i32 } }
-impl From<bool> for i64 { fn from(value: bool) -> i64 { value as i64 } }
-impl From<bool> for Field { fn from(value: bool) -> Field { value as Field } }
+impl From<bool> for u8 {
+    fn from(value: bool) -> u8 {
+        value as u8
+    }
+}
+impl From<bool> for u32 {
+    fn from(value: bool) -> u32 {
+        value as u32
+    }
+}
+impl From<bool> for u64 {
+    fn from(value: bool) -> u64 {
+        value as u64
+    }
+}
+impl From<bool> for i8 {
+    fn from(value: bool) -> i8 {
+        value as i8
+    }
+}
+impl From<bool> for i32 {
+    fn from(value: bool) -> i32 {
+        value as i32
+    }
+}
+impl From<bool> for i64 {
+    fn from(value: bool) -> i64 {
+        value as i64
+    }
+}
+impl From<bool> for Field {
+    fn from(value: bool) -> Field {
+        value as Field
+    }
+}
 // docs:end:from-impls

--- a/noir_stdlib/src/default.nr
+++ b/noir_stdlib/src/default.nr
@@ -15,21 +15,69 @@ comptime fn derive_default(s: StructDefinition) -> Quoted {
     crate::meta::make_trait_impl(s, name, signature, for_each_field, quote { , }, body)
 }
 
-impl Default for Field { fn default() -> Field { 0 } }
+impl Default for Field {
+    fn default() -> Field {
+        0
+    }
+}
 
-impl Default for u1 { fn default() -> u1 { 0 } }
-impl Default for u8 { fn default() -> u8 { 0 } }
-impl Default for u16 { fn default() -> u16 { 0 } }
-impl Default for u32 { fn default() -> u32 { 0 } }
-impl Default for u64 { fn default() -> u64 { 0 } }
+impl Default for u1 {
+    fn default() -> u1 {
+        0
+    }
+}
+impl Default for u8 {
+    fn default() -> u8 {
+        0
+    }
+}
+impl Default for u16 {
+    fn default() -> u16 {
+        0
+    }
+}
+impl Default for u32 {
+    fn default() -> u32 {
+        0
+    }
+}
+impl Default for u64 {
+    fn default() -> u64 {
+        0
+    }
+}
 
-impl Default for i8 { fn default() -> i8 { 0 } }
-impl Default for i16 { fn default() -> i16 { 0 } }
-impl Default for i32 { fn default() -> i32 { 0 } }
-impl Default for i64 { fn default() -> i64 { 0 } }
+impl Default for i8 {
+    fn default() -> i8 {
+        0
+    }
+}
+impl Default for i16 {
+    fn default() -> i16 {
+        0
+    }
+}
+impl Default for i32 {
+    fn default() -> i32 {
+        0
+    }
+}
+impl Default for i64 {
+    fn default() -> i64 {
+        0
+    }
+}
 
-impl Default for () { fn default() -> () { () } }
-impl Default for bool { fn default() -> bool { false } }
+impl Default for () {
+    fn default() -> () {
+        ()
+    }
+}
+impl Default for bool {
+    fn default() -> bool {
+        false
+    }
+}
 
 impl<T, let N: u32> Default for [T; N] where T: Default {
     fn default() -> [T; N] {

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -276,7 +276,8 @@ mod curvegroup {
 
     impl Eq for Point {
         fn eq(self, p: Self) -> bool {
-             (self.z == p.z) | (((self.x * self.z) == (p.x * p.z)) & ((self.y * self.z) == (p.y * p.z)))
+            (self.z == p.z)
+                | (((self.x * self.z) == (p.x * p.z)) & ((self.y * self.z) == (p.y * p.z)))
         }
     }
 

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -60,11 +60,10 @@ mod affine {
 
     impl Eq for Point {
         fn eq(self, p: Self) -> bool {
-             let Self {x: x1, y: y1, infty: inf1} = self;
+            let Self {x: x1, y: y1, infty: inf1} = self;
             let Self {x: x2, y: y2, infty: inf2} = p;
 
-            (inf1 & inf2)
-                | (!inf1 & !inf2 & (x1 == x2) & (y1 == y2))
+            (inf1 & inf2) | (!inf1 & !inf2 & (x1 == x2) & (y1 == y2))
         }
     }
 
@@ -245,10 +244,13 @@ mod curvegroup {
 
     impl Eq for Point {
         fn eq(self, p: Self) -> bool {
-               let Self {x: x1, y: y1, z: z1} = self;
+            let Self {x: x1, y: y1, z: z1} = self;
             let Self {x: x2, y: y2, z: z2} = p;
 
-            ((z1 == 0) & (z2 == 0)) | ((z1 != 0) & (z2 != 0) & (x1*z2*z2 == x2*z1*z1) & (y1*z2*z2*z2 == y2*z1*z1*z1))
+            ((z1 == 0) & (z2 == 0)) | ((z1 != 0)
+                    & (z2 != 0)
+                    & (x1 * z2 * z2 == x2 * z1 * z1)
+                    & (y1 * z2 * z2 * z2 == y2 * z1 * z1 * z1))
         }
     }
 

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -70,7 +70,7 @@ mod affine {
 
     impl Eq for Point {
         fn eq(self, p: Self) -> bool {
-             let Self {x: x1, y: y1} = self;
+            let Self {x: x1, y: y1} = self;
             let Self {x: x2, y: y2} = p;
 
             (x1 == x2) & (y1 == y2)
@@ -261,7 +261,7 @@ mod curvegroup {
             let Self {x: x1, y: y1, t: _t1, z: z1} = self;
             let Self {x: x2, y: y2, t: _t2, z:z2} = p;
 
-            (x1*z2 == x2*z1) & (y1*z2 == y2*z1)
+            (x1 * z2 == x2 * z1) & (y1 * z2 == y2 * z1)
         }
     }
 

--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -25,14 +25,14 @@ impl EmbeddedCurvePoint {
 
 impl Add for EmbeddedCurvePoint {
     /// Adds two points P+Q, using the curve addition formula, and also handles point at infinity
-    fn add(self, other: EmbeddedCurvePoint) -> EmbeddedCurvePoint { 
+    fn add(self, other: EmbeddedCurvePoint) -> EmbeddedCurvePoint {
         embedded_curve_add(self, other)
     }
 }
 
 impl Sub for EmbeddedCurvePoint {
     /// Points subtraction operation, using addition and negation
-    fn sub(self, other: EmbeddedCurvePoint) -> EmbeddedCurvePoint { 
+    fn sub(self, other: EmbeddedCurvePoint) -> EmbeddedCurvePoint {
         self + other.neg()
     }
 }
@@ -40,19 +40,16 @@ impl Sub for EmbeddedCurvePoint {
 impl Neg for EmbeddedCurvePoint {
     /// Negates a point P, i.e returns -P, by negating the y coordinate.
     /// If the point is at infinity, then the result is also at infinity.
-    fn neg(self) -> EmbeddedCurvePoint { 
-        EmbeddedCurvePoint {
-            x: self.x,
-            y: -self.y,
-            is_infinite: self.is_infinite
-        }
+    fn neg(self) -> EmbeddedCurvePoint {
+        EmbeddedCurvePoint { x: self.x, y: -self.y, is_infinite: self.is_infinite }
     }
 }
 
 impl Eq for EmbeddedCurvePoint {
     /// Checks whether two points are equal
     fn eq(self: Self, b: EmbeddedCurvePoint) -> bool {
-        (self.is_infinite & b.is_infinite) | ((self.is_infinite == b.is_infinite) & (self.x == b.x) & (self.y == b.y))
+        (self.is_infinite & b.is_infinite)
+            | ((self.is_infinite == b.is_infinite) & (self.x == b.x) & (self.y == b.y))
     }
 }
 

--- a/noir_stdlib/src/hash/mimc.nr
+++ b/noir_stdlib/src/hash/mimc.nr
@@ -142,15 +142,13 @@ impl Hasher for MimcHasher {
         r
     }
 
-    fn write(&mut self, input: Field){
+    fn write(&mut self, input: Field) {
         self._state = self._state.push_back(input);
     }
 }
 
-impl Default for MimcHasher{
-    fn default() -> Self{
-        MimcHasher {
-            _state: &[],
-        }
+impl Default for MimcHasher {
+    fn default() -> Self {
+        MimcHasher { _state: &[] }
     }
 }

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -170,84 +170,82 @@ struct BuildHasherDefault<H>;
 
 impl<H> BuildHasher<H> for BuildHasherDefault<H>
 where 
-    H: Hasher + Default
-{
-    fn build_hasher(_self: Self) -> H{
+    H: Hasher + Default {
+    fn build_hasher(_self: Self) -> H {
         H::default()
     }
 }
 
 impl<H> Default for BuildHasherDefault<H>
 where 
-    H: Hasher + Default
-{
-    fn default() -> Self{
-        BuildHasherDefault{}
-    }    
+    H: Hasher + Default {
+    fn default() -> Self {
+        BuildHasherDefault {}
+    }
 }
 
 impl Hash for Field {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self);
     }
 }
 
 impl Hash for u1 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for u8 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for u16 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for u32 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for u64 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for i8 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for i16 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for i32 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for i64 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
 
 impl Hash for bool {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self as Field);
     }
 }
@@ -257,14 +255,14 @@ impl Hash for () {
 }
 
 impl Hash for U128 {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         H::write(state, self.lo as Field);
         H::write(state, self.hi as Field);
     }
 }
 
 impl<T, let N: u32> Hash for [T; N] where T: Hash {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         for elem in self {
             elem.hash(state);
         }
@@ -272,7 +270,7 @@ impl<T, let N: u32> Hash for [T; N] where T: Hash {
 }
 
 impl<T> Hash for [T] where T: Hash {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         self.len().hash(state);
         for elem in self {
             elem.hash(state);
@@ -281,14 +279,14 @@ impl<T> Hash for [T] where T: Hash {
 }
 
 impl<A, B> Hash for (A, B) where A: Hash, B: Hash {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         self.0.hash(state);
         self.1.hash(state);
     }
 }
 
 impl<A, B, C> Hash for (A, B, C) where A: Hash, B: Hash, C: Hash {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         self.0.hash(state);
         self.1.hash(state);
         self.2.hash(state);
@@ -296,7 +294,7 @@ impl<A, B, C> Hash for (A, B, C) where A: Hash, B: Hash, C: Hash {
 }
 
 impl<A, B, C, D> Hash for (A, B, C, D) where A: Hash, B: Hash, C: Hash, D: Hash {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         self.0.hash(state);
         self.1.hash(state);
         self.2.hash(state);
@@ -305,7 +303,7 @@ impl<A, B, C, D> Hash for (A, B, C, D) where A: Hash, B: Hash, C: Hash, D: Hash 
 }
 
 impl<A, B, C, D, E> Hash for (A, B, C, D, E) where A: Hash, B: Hash, C: Hash, D: Hash, E: Hash {
-    fn hash<H>(self, state: &mut H) where H: Hasher{
+    fn hash<H>(self, state: &mut H) where H: Hasher {
         self.0.hash(state);
         self.1.hash(state);
         self.2.hash(state);

--- a/noir_stdlib/src/hash/poseidon/mod.nr
+++ b/noir_stdlib/src/hash/poseidon/mod.nr
@@ -177,16 +177,16 @@ impl Hasher for PoseidonHasher {
         assert(len < 16);
         if len == 1 {
             result = bn254::hash_1([self._state[0]]);
-        } 
+        }
         if len == 2 {
             result = bn254::hash_2([self._state[0],self._state[1]]);
-        } 
+        }
         if len == 3 {
             result = bn254::hash_3([self._state[0],self._state[1],self._state[2]]);
-        } 
+        }
         if len == 4 {
             result = bn254::hash_4([self._state[0],self._state[1],self._state[2],self._state[3]]);
-        } 
+        }
         if len == 5 {
             result = bn254::hash_5([self._state[0],self._state[1],self._state[2],self._state[3],self._state[4]]);
         }
@@ -220,20 +220,18 @@ impl Hasher for PoseidonHasher {
         if len == 15 {
             result = bn254::hash_15([self._state[0],self._state[1],self._state[2],self._state[3],self._state[4], self._state[5], self._state[6], self._state[7], self._state[8], self._state[9], self._state[10], self._state[11], self._state[12], self._state[13], self._state[14]]);
         }
-        
+
         result
     }
 
-    fn write(&mut self, input: Field){
+    fn write(&mut self, input: Field) {
         self._state = self._state.push_back(input);
     }
 }
 
-impl Default for PoseidonHasher{
-    fn default() -> Self{
-        PoseidonHasher{
-            _state: &[],
-        }
+impl Default for PoseidonHasher {
+    fn default() -> Self {
+        PoseidonHasher { _state: &[] }
     }
 }
 

--- a/noir_stdlib/src/hash/poseidon2.nr
+++ b/noir_stdlib/src/hash/poseidon2.nr
@@ -88,7 +88,7 @@ struct Poseidon2Hasher{
 
 impl Hasher for Poseidon2Hasher {
     fn finish(self) -> Field {
-        let iv : Field = (self._state.len() as Field)*18446744073709551616;    // iv = (self._state.len() << 64)
+        let iv : Field = (self._state.len() as Field) * 18446744073709551616; // iv = (self._state.len() << 64)
         let mut sponge = Poseidon2::new(iv);
         for i in 0..self._state.len() {
             sponge.absorb(self._state[i]);
@@ -96,15 +96,13 @@ impl Hasher for Poseidon2Hasher {
         sponge.squeeze()
     }
 
-    fn write(&mut self, input: Field){
+    fn write(&mut self, input: Field) {
         self._state = self._state.push_back(input);
     }
 }
 
 impl Default for Poseidon2Hasher {
     fn default() -> Self {
-        Poseidon2Hasher {
-            _state: &[],
-        }
+        Poseidon2Hasher { _state: &[] }
     }
 }

--- a/noir_stdlib/src/ops/arith.nr
+++ b/noir_stdlib/src/ops/arith.nr
@@ -4,18 +4,58 @@ trait Add {
 }
 // docs:end:add-trait
 
-impl Add for Field { fn add(self, other: Field) -> Field { self + other } }
+impl Add for Field {
+    fn add(self, other: Field) -> Field {
+        self + other
+    }
+}
 
-impl Add for u64 { fn add(self, other: u64) -> u64 { self + other } }
-impl Add for u32 { fn add(self, other: u32) -> u32 { self + other } }
-impl Add for u16 { fn add(self, other: u16) -> u16 { self + other } }
-impl Add for u8 { fn add(self, other: u8) -> u8 { self + other } }
-impl Add for u1 { fn add(self, other: u1) -> u1 { self + other } }
+impl Add for u64 {
+    fn add(self, other: u64) -> u64 {
+        self + other
+    }
+}
+impl Add for u32 {
+    fn add(self, other: u32) -> u32 {
+        self + other
+    }
+}
+impl Add for u16 {
+    fn add(self, other: u16) -> u16 {
+        self + other
+    }
+}
+impl Add for u8 {
+    fn add(self, other: u8) -> u8 {
+        self + other
+    }
+}
+impl Add for u1 {
+    fn add(self, other: u1) -> u1 {
+        self + other
+    }
+}
 
-impl Add for i8 { fn add(self, other: i8) -> i8 { self + other } }
-impl Add for i16 { fn add(self, other: i16) -> i16 { self + other } }
-impl Add for i32 { fn add(self, other: i32) -> i32 { self + other } }
-impl Add for i64 { fn add(self, other: i64) -> i64 { self + other } }
+impl Add for i8 {
+    fn add(self, other: i8) -> i8 {
+        self + other
+    }
+}
+impl Add for i16 {
+    fn add(self, other: i16) -> i16 {
+        self + other
+    }
+}
+impl Add for i32 {
+    fn add(self, other: i32) -> i32 {
+        self + other
+    }
+}
+impl Add for i64 {
+    fn add(self, other: i64) -> i64 {
+        self + other
+    }
+}
 
 // docs:start:sub-trait
 trait Sub {
@@ -23,18 +63,58 @@ trait Sub {
 }
 // docs:end:sub-trait
 
-impl Sub for Field { fn sub(self, other: Field) -> Field { self - other } }
+impl Sub for Field {
+    fn sub(self, other: Field) -> Field {
+        self - other
+    }
+}
 
-impl Sub for u64 { fn sub(self, other: u64) -> u64 { self - other } }
-impl Sub for u32 { fn sub(self, other: u32) -> u32 { self - other } }
-impl Sub for u16 { fn sub(self, other: u16) -> u16 { self - other } }
-impl Sub for u8 { fn sub(self, other: u8) -> u8 { self - other } }
-impl Sub for u1 { fn sub(self, other: u1) -> u1 { self - other } }
+impl Sub for u64 {
+    fn sub(self, other: u64) -> u64 {
+        self - other
+    }
+}
+impl Sub for u32 {
+    fn sub(self, other: u32) -> u32 {
+        self - other
+    }
+}
+impl Sub for u16 {
+    fn sub(self, other: u16) -> u16 {
+        self - other
+    }
+}
+impl Sub for u8 {
+    fn sub(self, other: u8) -> u8 {
+        self - other
+    }
+}
+impl Sub for u1 {
+    fn sub(self, other: u1) -> u1 {
+        self - other
+    }
+}
 
-impl Sub for i8 { fn sub(self, other: i8) -> i8 { self - other } }
-impl Sub for i16 { fn sub(self, other: i16) -> i16 { self - other } }
-impl Sub for i32 { fn sub(self, other: i32) -> i32 { self - other } }
-impl Sub for i64 { fn sub(self, other: i64) -> i64 { self - other } }
+impl Sub for i8 {
+    fn sub(self, other: i8) -> i8 {
+        self - other
+    }
+}
+impl Sub for i16 {
+    fn sub(self, other: i16) -> i16 {
+        self - other
+    }
+}
+impl Sub for i32 {
+    fn sub(self, other: i32) -> i32 {
+        self - other
+    }
+}
+impl Sub for i64 {
+    fn sub(self, other: i64) -> i64 {
+        self - other
+    }
+}
 
 // docs:start:mul-trait
 trait Mul {
@@ -42,18 +122,58 @@ trait Mul {
 }
 // docs:end:mul-trait
 
-impl Mul for Field { fn mul(self, other: Field) -> Field { self * other } }
+impl Mul for Field {
+    fn mul(self, other: Field) -> Field {
+        self * other
+    }
+}
 
-impl Mul for u64 { fn mul(self, other: u64) -> u64 { self * other } }
-impl Mul for u32 { fn mul(self, other: u32) -> u32 { self * other } }
-impl Mul for u16 { fn mul(self, other: u16) -> u16 { self * other } }
-impl Mul for u8 { fn mul(self, other: u8) -> u8 { self * other } }
-impl Mul for u1 { fn mul(self, other: u1) -> u1 { self * other } }
+impl Mul for u64 {
+    fn mul(self, other: u64) -> u64 {
+        self * other
+    }
+}
+impl Mul for u32 {
+    fn mul(self, other: u32) -> u32 {
+        self * other
+    }
+}
+impl Mul for u16 {
+    fn mul(self, other: u16) -> u16 {
+        self * other
+    }
+}
+impl Mul for u8 {
+    fn mul(self, other: u8) -> u8 {
+        self * other
+    }
+}
+impl Mul for u1 {
+    fn mul(self, other: u1) -> u1 {
+        self * other
+    }
+}
 
-impl Mul for i8 { fn mul(self, other: i8) -> i8 { self * other } }
-impl Mul for i16 { fn mul(self, other: i16) -> i16 { self * other } }
-impl Mul for i32 { fn mul(self, other: i32) -> i32 { self * other } }
-impl Mul for i64 { fn mul(self, other: i64) -> i64 { self * other } }
+impl Mul for i8 {
+    fn mul(self, other: i8) -> i8 {
+        self * other
+    }
+}
+impl Mul for i16 {
+    fn mul(self, other: i16) -> i16 {
+        self * other
+    }
+}
+impl Mul for i32 {
+    fn mul(self, other: i32) -> i32 {
+        self * other
+    }
+}
+impl Mul for i64 {
+    fn mul(self, other: i64) -> i64 {
+        self * other
+    }
+}
 
 // docs:start:div-trait
 trait Div {
@@ -61,18 +181,58 @@ trait Div {
 }
 // docs:end:div-trait
 
-impl Div for Field { fn div(self, other: Field) -> Field { self / other } }
+impl Div for Field {
+    fn div(self, other: Field) -> Field {
+        self / other
+    }
+}
 
-impl Div for u64 { fn div(self, other: u64) -> u64 { self / other } }
-impl Div for u32 { fn div(self, other: u32) -> u32 { self / other } }
-impl Div for u16 { fn div(self, other: u16) -> u16 { self / other } }
-impl Div for u8 { fn div(self, other: u8) -> u8 { self / other } }
-impl Div for u1 { fn div(self, other: u1) -> u1 { self / other } }
+impl Div for u64 {
+    fn div(self, other: u64) -> u64 {
+        self / other
+    }
+}
+impl Div for u32 {
+    fn div(self, other: u32) -> u32 {
+        self / other
+    }
+}
+impl Div for u16 {
+    fn div(self, other: u16) -> u16 {
+        self / other
+    }
+}
+impl Div for u8 {
+    fn div(self, other: u8) -> u8 {
+        self / other
+    }
+}
+impl Div for u1 {
+    fn div(self, other: u1) -> u1 {
+        self / other
+    }
+}
 
-impl Div for i8 { fn div(self, other: i8) -> i8 { self / other } }
-impl Div for i16 { fn div(self, other: i16) -> i16 { self / other } }
-impl Div for i32 { fn div(self, other: i32) -> i32 { self / other } }
-impl Div for i64 { fn div(self, other: i64) -> i64 { self / other } }
+impl Div for i8 {
+    fn div(self, other: i8) -> i8 {
+        self / other
+    }
+}
+impl Div for i16 {
+    fn div(self, other: i16) -> i16 {
+        self / other
+    }
+}
+impl Div for i32 {
+    fn div(self, other: i32) -> i32 {
+        self / other
+    }
+}
+impl Div for i64 {
+    fn div(self, other: i64) -> i64 {
+        self / other
+    }
+}
 
 // docs:start:rem-trait
 trait Rem{
@@ -80,16 +240,52 @@ trait Rem{
 }
 // docs:end:rem-trait
 
-impl Rem for u64 { fn rem(self, other: u64) -> u64 { self % other } }
-impl Rem for u32 { fn rem(self, other: u32) -> u32 { self % other } }
-impl Rem for u16 { fn rem(self, other: u16) -> u16 { self % other } }
-impl Rem for u8 { fn rem(self, other: u8) -> u8 { self % other } }
-impl Rem for u1 { fn rem(self, other: u1) -> u1 { self % other } }
+impl Rem for u64 {
+    fn rem(self, other: u64) -> u64 {
+        self % other
+    }
+}
+impl Rem for u32 {
+    fn rem(self, other: u32) -> u32 {
+        self % other
+    }
+}
+impl Rem for u16 {
+    fn rem(self, other: u16) -> u16 {
+        self % other
+    }
+}
+impl Rem for u8 {
+    fn rem(self, other: u8) -> u8 {
+        self % other
+    }
+}
+impl Rem for u1 {
+    fn rem(self, other: u1) -> u1 {
+        self % other
+    }
+}
 
-impl Rem for i8 { fn rem(self, other: i8) -> i8 { self % other } }
-impl Rem for i16 { fn rem(self, other: i16) -> i16 { self % other } }
-impl Rem for i32 { fn rem(self, other: i32) -> i32 { self % other } }
-impl Rem for i64 { fn rem(self, other: i64) -> i64 { self % other } }
+impl Rem for i8 {
+    fn rem(self, other: i8) -> i8 {
+        self % other
+    }
+}
+impl Rem for i16 {
+    fn rem(self, other: i16) -> i16 {
+        self % other
+    }
+}
+impl Rem for i32 {
+    fn rem(self, other: i32) -> i32 {
+        self % other
+    }
+}
+impl Rem for i64 {
+    fn rem(self, other: i64) -> i64 {
+        self % other
+    }
+}
 
 // docs:start:neg-trait
 trait Neg {
@@ -98,11 +294,31 @@ trait Neg {
 // docs:end:neg-trait
 
 // docs:start:neg-trait-impls
-impl Neg for Field { fn neg(self) -> Field { -self } }
+impl Neg for Field {
+    fn neg(self) -> Field {
+        -self
+    }
+}
 
-impl Neg for i8 { fn neg(self) -> i8 { -self } }
-impl Neg for i16 { fn neg(self) -> i16 { -self } }
-impl Neg for i32 { fn neg(self) -> i32 { -self } }
-impl Neg for i64 { fn neg(self) -> i64 { -self } }
+impl Neg for i8 {
+    fn neg(self) -> i8 {
+        -self
+    }
+}
+impl Neg for i16 {
+    fn neg(self) -> i16 {
+        -self
+    }
+}
+impl Neg for i32 {
+    fn neg(self) -> i32 {
+        -self
+    }
+}
+impl Neg for i64 {
+    fn neg(self) -> i64 {
+        -self
+    }
+}
 // docs:end:neg-trait-impls
 

--- a/noir_stdlib/src/ops/bit.nr
+++ b/noir_stdlib/src/ops/bit.nr
@@ -5,18 +5,58 @@ trait Not {
 // docs:end:not-trait
 
 // docs:start:not-trait-impls
-impl Not for bool { fn not(self) -> bool { !self } }
+impl Not for bool {
+    fn not(self) -> bool {
+        !self
+    }
+}
 
-impl Not for u64 { fn not(self) -> u64 { !self } }
-impl Not for u32 { fn not(self) -> u32 { !self } }
-impl Not for u16 { fn not(self) -> u16 { !self } }
-impl Not for u8 { fn not(self) -> u8 { !self } }
-impl Not for u1 { fn not(self) -> u1 { !self } }
+impl Not for u64 {
+    fn not(self) -> u64 {
+        !self
+    }
+}
+impl Not for u32 {
+    fn not(self) -> u32 {
+        !self
+    }
+}
+impl Not for u16 {
+    fn not(self) -> u16 {
+        !self
+    }
+}
+impl Not for u8 {
+    fn not(self) -> u8 {
+        !self
+    }
+}
+impl Not for u1 {
+    fn not(self) -> u1 {
+        !self
+    }
+}
 
-impl Not for i8 { fn not(self) -> i8 { !self } }
-impl Not for i16 { fn not(self) -> i16 { !self } }
-impl Not for i32 { fn not(self) -> i32 { !self } }
-impl Not for i64 { fn not(self) -> i64 { !self } }
+impl Not for i8 {
+    fn not(self) -> i8 {
+        !self
+    }
+}
+impl Not for i16 {
+    fn not(self) -> i16 {
+        !self
+    }
+}
+impl Not for i32 {
+    fn not(self) -> i32 {
+        !self
+    }
+}
+impl Not for i64 {
+    fn not(self) -> i64 {
+        !self
+    }
+}
 // docs:end:not-trait-impls
 
 // docs:start:bitor-trait
@@ -25,18 +65,58 @@ trait BitOr {
 }
 // docs:end:bitor-trait
 
-impl BitOr for bool { fn bitor(self, other: bool) -> bool { self | other } }
+impl BitOr for bool {
+    fn bitor(self, other: bool) -> bool {
+        self | other
+    }
+}
 
-impl BitOr for u64 { fn bitor(self, other: u64) -> u64 { self | other } }
-impl BitOr for u32 { fn bitor(self, other: u32) -> u32 { self | other } }
-impl BitOr for u16 { fn bitor(self, other: u16) -> u16 { self | other } }
-impl BitOr for u8 { fn bitor(self, other: u8) -> u8 { self | other } }
-impl BitOr for u1 { fn bitor(self, other: u1) -> u1 { self | other } }
+impl BitOr for u64 {
+    fn bitor(self, other: u64) -> u64 {
+        self | other
+    }
+}
+impl BitOr for u32 {
+    fn bitor(self, other: u32) -> u32 {
+        self | other
+    }
+}
+impl BitOr for u16 {
+    fn bitor(self, other: u16) -> u16 {
+        self | other
+    }
+}
+impl BitOr for u8 {
+    fn bitor(self, other: u8) -> u8 {
+        self | other
+    }
+}
+impl BitOr for u1 {
+    fn bitor(self, other: u1) -> u1 {
+        self | other
+    }
+}
 
-impl BitOr for i8 { fn bitor(self, other: i8) -> i8 { self | other } }
-impl BitOr for i16 { fn bitor(self, other: i16) -> i16 { self | other } }
-impl BitOr for i32 { fn bitor(self, other: i32) -> i32 { self | other } }
-impl BitOr for i64 { fn bitor(self, other: i64) -> i64 { self | other } }
+impl BitOr for i8 {
+    fn bitor(self, other: i8) -> i8 {
+        self | other
+    }
+}
+impl BitOr for i16 {
+    fn bitor(self, other: i16) -> i16 {
+        self | other
+    }
+}
+impl BitOr for i32 {
+    fn bitor(self, other: i32) -> i32 {
+        self | other
+    }
+}
+impl BitOr for i64 {
+    fn bitor(self, other: i64) -> i64 {
+        self | other
+    }
+}
 
 // docs:start:bitand-trait
 trait BitAnd {
@@ -44,18 +124,58 @@ trait BitAnd {
 }
 // docs:end:bitand-trait
 
-impl BitAnd for bool { fn bitand(self, other: bool) -> bool { self & other } }
+impl BitAnd for bool {
+    fn bitand(self, other: bool) -> bool {
+        self & other
+    }
+}
 
-impl BitAnd for u64 { fn bitand(self, other: u64) -> u64 { self & other } }
-impl BitAnd for u32 { fn bitand(self, other: u32) -> u32 { self & other } }
-impl BitAnd for u16 { fn bitand(self, other: u16) -> u16 { self & other } }
-impl BitAnd for u8 { fn bitand(self, other: u8) -> u8 { self & other } }
-impl BitAnd for u1 { fn bitand(self, other: u1) -> u1 { self & other } }
+impl BitAnd for u64 {
+    fn bitand(self, other: u64) -> u64 {
+        self & other
+    }
+}
+impl BitAnd for u32 {
+    fn bitand(self, other: u32) -> u32 {
+        self & other
+    }
+}
+impl BitAnd for u16 {
+    fn bitand(self, other: u16) -> u16 {
+        self & other
+    }
+}
+impl BitAnd for u8 {
+    fn bitand(self, other: u8) -> u8 {
+        self & other
+    }
+}
+impl BitAnd for u1 {
+    fn bitand(self, other: u1) -> u1 {
+        self & other
+    }
+}
 
-impl BitAnd for i8 { fn bitand(self, other: i8) -> i8 { self & other } }
-impl BitAnd for i16 { fn bitand(self, other: i16) -> i16 { self & other } }
-impl BitAnd for i32 { fn bitand(self, other: i32) -> i32 { self & other } }
-impl BitAnd for i64 { fn bitand(self, other: i64) -> i64 { self & other } }
+impl BitAnd for i8 {
+    fn bitand(self, other: i8) -> i8 {
+        self & other
+    }
+}
+impl BitAnd for i16 {
+    fn bitand(self, other: i16) -> i16 {
+        self & other
+    }
+}
+impl BitAnd for i32 {
+    fn bitand(self, other: i32) -> i32 {
+        self & other
+    }
+}
+impl BitAnd for i64 {
+    fn bitand(self, other: i64) -> i64 {
+        self & other
+    }
+}
 
 // docs:start:bitxor-trait
 trait BitXor {
@@ -63,18 +183,58 @@ trait BitXor {
 }
 // docs:end:bitxor-trait
 
-impl BitXor for bool { fn bitxor(self, other: bool) -> bool { self ^ other } }
+impl BitXor for bool {
+    fn bitxor(self, other: bool) -> bool {
+        self ^ other
+    }
+}
 
-impl BitXor for u64 { fn bitxor(self, other: u64) -> u64 { self ^ other } }
-impl BitXor for u32 { fn bitxor(self, other: u32) -> u32 { self ^ other } }
-impl BitXor for u16 { fn bitxor(self, other: u16) -> u16 { self ^ other } }
-impl BitXor for u8 { fn bitxor(self, other: u8) -> u8 { self ^ other } }
-impl BitXor for u1 { fn bitxor(self, other: u1) -> u1 { self ^ other } }
+impl BitXor for u64 {
+    fn bitxor(self, other: u64) -> u64 {
+        self ^ other
+    }
+}
+impl BitXor for u32 {
+    fn bitxor(self, other: u32) -> u32 {
+        self ^ other
+    }
+}
+impl BitXor for u16 {
+    fn bitxor(self, other: u16) -> u16 {
+        self ^ other
+    }
+}
+impl BitXor for u8 {
+    fn bitxor(self, other: u8) -> u8 {
+        self ^ other
+    }
+}
+impl BitXor for u1 {
+    fn bitxor(self, other: u1) -> u1 {
+        self ^ other
+    }
+}
 
-impl BitXor for i8 { fn bitxor(self, other: i8) -> i8 { self ^ other } }
-impl BitXor for i16 { fn bitxor(self, other: i16) -> i16 { self ^ other } }
-impl BitXor for i32 { fn bitxor(self, other: i32) -> i32 { self ^ other } }
-impl BitXor for i64 { fn bitxor(self, other: i64) -> i64 { self ^ other } }
+impl BitXor for i8 {
+    fn bitxor(self, other: i8) -> i8 {
+        self ^ other
+    }
+}
+impl BitXor for i16 {
+    fn bitxor(self, other: i16) -> i16 {
+        self ^ other
+    }
+}
+impl BitXor for i32 {
+    fn bitxor(self, other: i32) -> i32 {
+        self ^ other
+    }
+}
+impl BitXor for i64 {
+    fn bitxor(self, other: i64) -> i64 {
+        self ^ other
+    }
+}
 
 // docs:start:shl-trait
 trait Shl {
@@ -82,16 +242,52 @@ trait Shl {
 }
 // docs:end:shl-trait
 
-impl Shl for u32 { fn shl(self, other: u8) -> u32 { self << other } }
-impl Shl for u64 { fn shl(self, other: u8) -> u64 { self << other } }
-impl Shl for u16 { fn shl(self, other: u8) -> u16 { self << other } }
-impl Shl for u8 { fn shl(self, other: u8) -> u8 { self << other } }
-impl Shl for u1 { fn shl(self, other: u8) -> u1 { self << other } }
+impl Shl for u32 {
+    fn shl(self, other: u8) -> u32 {
+        self << other
+    }
+}
+impl Shl for u64 {
+    fn shl(self, other: u8) -> u64 {
+        self << other
+    }
+}
+impl Shl for u16 {
+    fn shl(self, other: u8) -> u16 {
+        self << other
+    }
+}
+impl Shl for u8 {
+    fn shl(self, other: u8) -> u8 {
+        self << other
+    }
+}
+impl Shl for u1 {
+    fn shl(self, other: u8) -> u1 {
+        self << other
+    }
+}
 
-impl Shl for i8 { fn shl(self, other: u8) -> i8 { self << other } }
-impl Shl for i16 { fn shl(self, other: u8) -> i16 { self << other } }
-impl Shl for i32 { fn shl(self, other: u8) -> i32 { self << other } }
-impl Shl for i64 { fn shl(self, other: u8) -> i64 { self << other } }
+impl Shl for i8 {
+    fn shl(self, other: u8) -> i8 {
+        self << other
+    }
+}
+impl Shl for i16 {
+    fn shl(self, other: u8) -> i16 {
+        self << other
+    }
+}
+impl Shl for i32 {
+    fn shl(self, other: u8) -> i32 {
+        self << other
+    }
+}
+impl Shl for i64 {
+    fn shl(self, other: u8) -> i64 {
+        self << other
+    }
+}
 
 // docs:start:shr-trait
 trait Shr {
@@ -99,14 +295,50 @@ trait Shr {
 }
 // docs:end:shr-trait
 
-impl Shr for u64 { fn shr(self, other: u8) -> u64 { self >> other } }
-impl Shr for u32 { fn shr(self, other: u8) -> u32 { self >> other } }
-impl Shr for u16 { fn shr(self, other: u8) -> u16 { self >> other } }
-impl Shr for u8 { fn shr(self, other: u8) -> u8 { self >> other } }
-impl Shr for u1 { fn shr(self, other: u8) -> u1 { self >> other } }
+impl Shr for u64 {
+    fn shr(self, other: u8) -> u64 {
+        self >> other
+    }
+}
+impl Shr for u32 {
+    fn shr(self, other: u8) -> u32 {
+        self >> other
+    }
+}
+impl Shr for u16 {
+    fn shr(self, other: u8) -> u16 {
+        self >> other
+    }
+}
+impl Shr for u8 {
+    fn shr(self, other: u8) -> u8 {
+        self >> other
+    }
+}
+impl Shr for u1 {
+    fn shr(self, other: u8) -> u1 {
+        self >> other
+    }
+}
 
-impl Shr for i8 { fn shr(self, other: u8) -> i8 { self >> other } }
-impl Shr for i16 { fn shr(self, other: u8) -> i16 { self >> other } }
-impl Shr for i32 { fn shr(self, other: u8) -> i32 { self >> other } }
-impl Shr for i64 { fn shr(self, other: u8) -> i64 { self >> other } }
+impl Shr for i8 {
+    fn shr(self, other: u8) -> i8 {
+        self >> other
+    }
+}
+impl Shr for i16 {
+    fn shr(self, other: u8) -> i16 {
+        self >> other
+    }
+}
+impl Shr for i32 {
+    fn shr(self, other: u8) -> i32 {
+        self >> other
+    }
+}
+impl Shr for i64 {
+    fn shr(self, other: u8) -> i64 {
+        self >> other
+    }
+}
 

--- a/noir_stdlib/src/option.nr
+++ b/noir_stdlib/src/option.nr
@@ -195,12 +195,10 @@ impl<T> Ord for Option<T> where T: Ord {
             } else {
                 Ordering::greater()
             }
+        } else if other._is_some {
+            Ordering::less()
         } else {
-            if other._is_some {
-                Ordering::less()
-            } else {
-                Ordering::equal()
-            }
+            Ordering::equal()
         }
     }
 }

--- a/noir_stdlib/src/uint128.nr
+++ b/noir_stdlib/src/uint128.nr
@@ -165,14 +165,11 @@ impl Add for U128 {
     fn add(self: Self, b: U128) -> U128 {
         let low = self.lo + b.lo;
         let lo = low as u64 as Field;
-        let carry = (low - lo) / pow64;  
+        let carry = (low - lo) / pow64;
         let high = self.hi + b.hi + carry;
         let hi = high as u64 as Field;
         assert(hi == high, "attempt to add with overflow");
-        U128 {
-            lo,
-            hi,
-        }
+        U128 { lo, hi }
     }
 }
 
@@ -184,30 +181,24 @@ impl Sub for U128 {
         let high = self.hi - b.hi - borrow;
         let hi = high as u64 as Field;
         assert(hi == high, "attempt to subtract with underflow");
-        U128 {
-            lo,
-            hi,
-        }
+        U128 { lo, hi }
     }
 }
 
 impl Mul for U128 {
     fn mul(self: Self, b: U128) -> U128 {
-        assert(self.hi*b.hi == 0, "attempt to multiply with overflow");
-        let low = self.lo*b.lo;
+        assert(self.hi * b.hi == 0, "attempt to multiply with overflow");
+        let low = self.lo * b.lo;
         let lo = low as u64 as Field;
         let carry = (low - lo) / pow64;
         let high = if crate::field::modulus_num_bits() as u32 > 196 {
-            (self.lo+self.hi)*(b.lo+b.hi) - low + carry
+            (self.lo + self.hi) * (b.lo + b.hi) - low + carry
         } else {
-            self.lo*b.hi + self.hi*b.lo + carry
+            self.lo * b.hi + self.hi * b.lo + carry
         };
         let hi = high as u64 as Field;
         assert(hi == high, "attempt to multiply with overflow");
-        U128 {
-            lo,
-            hi,
-        }
+        U128 { lo, hi }
     }
 }
 
@@ -230,7 +221,7 @@ impl Rem for U128 {
             let a = b * q + r;
             assert_eq(self, a);
             assert(r < b);
-            
+
             r
         }
     }
@@ -246,7 +237,7 @@ impl Ord for U128 {
     fn cmp(self, other: Self) -> Ordering {
         let hi_ordering = (self.hi as u64).cmp((other.hi as u64));
         let lo_ordering = (self.lo as u64).cmp((other.lo as u64));
-        
+
         if hi_ordering == Ordering::equal() {
             lo_ordering
         } else {
@@ -255,16 +246,13 @@ impl Ord for U128 {
     }
 }
 
-impl Not for U128 { 
+impl Not for U128 {
     fn not(self) -> U128 {
-        U128 {
-            lo: (!(self.lo as u64)) as Field,
-            hi: (!(self.hi as u64)) as Field
-        }
+        U128 { lo: (!(self.lo as u64)) as Field, hi: (!(self.hi as u64)) as Field }
     }
 }
 
-impl BitOr for U128 { 
+impl BitOr for U128 {
     fn bitor(self, other: U128) -> U128 {
         U128 {
             lo: ((self.lo as u64) | (other.lo as u64)) as Field,
@@ -274,7 +262,7 @@ impl BitOr for U128 {
 }
 
 impl BitAnd for U128 {
-    fn bitand(self, other: U128) -> U128 { 
+    fn bitand(self, other: U128) -> U128 {
         U128 {
             lo: ((self.lo as u64) & (other.lo as u64)) as Field,
             hi: ((self.hi as u64) & (other.hi as u64)) as Field
@@ -283,7 +271,7 @@ impl BitAnd for U128 {
 }
 
 impl BitXor for U128 {
-    fn bitxor(self, other: U128) -> U128 { 
+    fn bitxor(self, other: U128) -> U128 {
         U128 {
             lo: ((self.lo as u64) ^ (other.lo as u64)) as Field,
             hi: ((self.hi as u64) ^ (other.hi as u64)) as Field
@@ -291,36 +279,36 @@ impl BitXor for U128 {
     }
 }
 
-impl Shl for U128 { 
-    fn shl(self, other: u8) -> U128 { 
+impl Shl for U128 {
+    fn shl(self, other: u8) -> U128 {
         assert(other < 128, "attempt to shift left with overflow");
         let exp_bits: [u1; 7] = (other as Field).to_be_bits();
 
         let mut r: Field = 2;
         let mut y: Field = 1;
         for i in 1..8 {
-            let bit = exp_bits[7-i] as Field;
+            let bit = exp_bits[7 - i] as Field;
             y = bit * (r * y) + (1 - bit) * y;
             r *= r;
         }
         self.wrapping_mul(U128::from_integer(y))
-    } 
+    }
 }
 
-impl Shr for U128 { 
-    fn shr(self, other: u8) -> U128 { 
+impl Shr for U128 {
+    fn shr(self, other: u8) -> U128 {
         assert(other < 128, "attempt to shift right with overflow");
         let exp_bits: [u1; 7] = (other as Field).to_be_bits();
 
         let mut r: Field = 2;
         let mut y: Field = 1;
         for i in 1..8 {
-            let bit = exp_bits[7-i] as Field;
+            let bit = exp_bits[7 - i] as Field;
             y = bit * (r * y) + (1 - bit) * y;
             r *= r;
         }
         self / U128::from_integer(y)
-    } 
+    }
 }
 
 mod tests {

--- a/test_programs/compile_success_empty/arithmetic_generics_move_constant_terms/src/main.nr
+++ b/test_programs/compile_success_empty/arithmetic_generics_move_constant_terms/src/main.nr
@@ -5,7 +5,7 @@ trait FromCallData<let N: u32, let M: u32> {
 struct Point { x: Field, y: Field }
 
 impl <let N: u32> FromCallData<N, N - 1> for Field {
-    fn from_calldata(calldata: [Field; N]) -> (Self, [Field; (N - 1)]) {
+    fn from_calldata(calldata: [Field; N]) -> (Self, [Field; N - 1]) {
         let slice = calldata.as_slice();
         let (value, slice) = slice.pop_front();
         (value, slice.as_array())
@@ -13,7 +13,7 @@ impl <let N: u32> FromCallData<N, N - 1> for Field {
 }
 
 impl <let N: u32> FromCallData<N, N - 2> for Point {
-    fn from_calldata(calldata: [Field; N]) -> (Self, [Field; (N - 2)]) {
+    fn from_calldata(calldata: [Field; N]) -> (Self, [Field; N - 2]) {
         let (x, calldata) = FromCallData::from_calldata(calldata);
         let (y, calldata) = FromCallData::from_calldata(calldata);
         (Self { x, y }, calldata)

--- a/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr
@@ -32,7 +32,7 @@ impl Hasher for TestHasher {
     fn finish(self) -> Field {
         self.result
     }
-    
+
     fn write(&mut self, input: Field) {
         self.result += input;
     }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -11,9 +11,7 @@ struct StructImplementsSomeTrait {
 
 }
 
-impl SomeTrait<i32> for StructImplementsSomeTrait {
-
-}
+impl SomeTrait<i32> for StructImplementsSomeTrait {}
 
 struct StructDoesNotImplementSomeTrait {
 

--- a/test_programs/compile_success_empty/no_duplicate_methods/src/main.nr
+++ b/test_programs/compile_success_empty/no_duplicate_methods/src/main.nr
@@ -10,11 +10,15 @@ trait ToField2 {
 struct Foo { x: Field }
 
 impl ToField for Foo {
-    fn to_field(self) -> Field { self.x }
+    fn to_field(self) -> Field {
+        self.x
+    }
 }
 
 impl ToField2 for Foo {
-    fn to_field(self) -> Field { self.x }
+    fn to_field(self) -> Field {
+        self.x
+    }
 }
 
 impl Foo {

--- a/test_programs/compile_success_empty/regression_4635/src/main.nr
+++ b/test_programs/compile_success_empty/regression_4635/src/main.nr
@@ -44,7 +44,7 @@ struct MyStruct<T> {
 
 impl<T> Deserialize<1> for MyStruct<T> where T: FromField {
     fn deserialize(fields: [Field; 1]) -> Self {
-        Self{ a: FromField::from_field(fields[0]) }
+        Self { a: FromField::from_field(fields[0]) }
     }
 }
 

--- a/test_programs/compile_success_empty/serialize/src/main.nr
+++ b/test_programs/compile_success_empty/serialize/src/main.nr
@@ -14,10 +14,10 @@ impl<A, B, let AS: u32, let BS: u32> Serialize for (A, B) where A: Serialize<Siz
         let a = self.0.serialize();
         let b = self.1.serialize();
 
-        for i in 0 .. a.len() {
+        for i in 0..a.len() {
             array[i] = a[i];
         }
-        for i in 0 .. b.len() {
+        for i in 0..b.len() {
             array[i + a.len()] = b[i];
         }
         array
@@ -35,7 +35,7 @@ impl<T, let N: u32, let TS: u32> Serialize for [T; N] where T: Serialize<Size = 
         for elem in self {
             let elem_fields = elem.serialize();
 
-            for i in 0 .. elem_fields.len() {
+            for i in 0..elem_fields.len() {
                 array[array_i] = elem_fields[i];
                 array_i += 1;
             }

--- a/test_programs/compile_success_empty/trait_default_implementation/src/main.nr
+++ b/test_programs/compile_success_empty/trait_default_implementation/src/main.nr
@@ -12,8 +12,8 @@ struct Foo {
 }
 
 impl MyDefault for Foo {
-    fn my_default(x: Field,y: Field) -> Self {
-        Self { bar: x, array: [x,y] }
+    fn my_default(x: Field, y: Field) -> Self {
+        Self { bar: x, array: [x, y] }
     }
 }
 

--- a/test_programs/compile_success_empty/trait_function_calls/src/main.nr
+++ b/test_programs/compile_success_empty/trait_function_calls/src/main.nr
@@ -30,7 +30,7 @@ trait Trait1a {
     }
 }
 struct Struct1a { vl: Field }
-impl Trait1a for Struct1a { }
+impl Trait1a for Struct1a {}
 // 1b) trait default method -> trait overriden method
 trait Trait1b {
     fn trait_method1(self) -> Field {
@@ -162,7 +162,7 @@ trait Trait2a {
     }
 }
 struct Struct2a { vl: Field }
-impl Trait2a for Struct2a { }
+impl Trait2a for Struct2a {}
 // 2b) trait default method -> trait overriden function
 trait Trait2b {
     fn trait_method1(self) -> Field {
@@ -294,7 +294,7 @@ trait Trait3a {
     }
 }
 struct Struct3a { vl: Field }
-impl Trait3a for Struct3a { }
+impl Trait3a for Struct3a {}
 // 3b) trait default function -> trait overriden method
 trait Trait3b {
     fn trait_function1(a: Field, b: Self) -> Field {
@@ -426,7 +426,7 @@ trait Trait4a {
     }
 }
 struct Struct4a { vl: Field }
-impl Trait4a for Struct4a { }
+impl Trait4a for Struct4a {}
 // 4b) trait default function -> trait overriden function
 trait Trait4b {
     fn trait_function1() -> Field {

--- a/test_programs/compile_success_empty/trait_impl_generics/src/main.nr
+++ b/test_programs/compile_success_empty/trait_impl_generics/src/main.nr
@@ -5,11 +5,15 @@ trait Foo {
 }
 
 impl Foo for Empty<u32> {
-    fn foo(_self: Self) -> u32 { 32 }
+    fn foo(_self: Self) -> u32 {
+        32
+    }
 }
 
 impl Foo for Empty<u64> {
-    fn foo(_self: Self) -> u32 { 64 }
+    fn foo(_self: Self) -> u32 {
+        64
+    }
 }
 
 fn main() {
@@ -43,7 +47,9 @@ trait T2 {
 struct S2<T> { x: T }
 
 impl<T> T2 for S2<T> {
-    fn t2(self) -> Self { self }
+    fn t2(self) -> Self {
+        self
+    }
 }
 
 fn call_impl_with_generic_function() {
@@ -55,5 +61,7 @@ trait T3 {
 }
 
 impl T3 for u32 {
-    fn t3<U>(_self: Self, y: U) -> U { y }
+    fn t3<U>(_self: Self, y: U) -> U {
+        y
+    }
 }

--- a/test_programs/compile_success_empty/trait_impl_with_where_clause/src/main.nr
+++ b/test_programs/compile_success_empty/trait_impl_with_where_clause/src/main.nr
@@ -13,7 +13,7 @@ trait MyEq {
 impl<T> MyEq for [T; 3] where T: MyEq {
     fn my_eq(self, other: Self) -> bool {
         let mut ret = true;
-        for i in 0 .. self.len() {
+        for i in 0..self.len() {
             ret &= self[i].my_eq(other[i]);
         }
         ret

--- a/test_programs/compile_success_empty/trait_multi_module_test/src/module6.nr
+++ b/test_programs/compile_success_empty/trait_multi_module_test/src/module6.nr
@@ -1,2 +1,2 @@
 // ensure we can implement traits using the Path syntax
-impl crate::module4::MyTrait4 for crate::module5::MyStruct5 { }
+impl crate::module4::MyTrait4 for crate::module5::MyStruct5 {}

--- a/test_programs/compile_success_empty/trait_override_implementation/src/main.nr
+++ b/test_programs/compile_success_empty/trait_override_implementation/src/main.nr
@@ -12,8 +12,8 @@ struct Foo {
 }
 
 impl MyDefault for Foo {
-    fn my_default(x: Field,y: Field) -> Self {
-        Self { bar: x, array: [x,y] }
+    fn my_default(x: Field, y: Field) -> Self {
+        Self { bar: x, array: [x, y] }
     }
 
     fn method2(x: Field) -> Field {
@@ -32,9 +32,15 @@ trait F {
 struct Bar {}
 
 impl F for Bar {
-    fn f5(_self: Self) -> Field { 50 }
-    fn f1(_self: Self) -> Field { 10 }
-    fn f3(_self: Self) -> Field { 30 }
+    fn f5(_self: Self) -> Field {
+        50
+    }
+    fn f1(_self: Self) -> Field {
+        10
+    }
+    fn f3(_self: Self) -> Field {
+        30
+    }
 }
 // Impls on mutable references are temporarily disabled
 // impl F for &mut Bar {

--- a/test_programs/compile_success_empty/trait_static_methods/src/main.nr
+++ b/test_programs/compile_success_empty/trait_static_methods/src/main.nr
@@ -16,7 +16,7 @@ struct Foo {
 impl ATrait for Foo {
     fn asd() -> Self {
         // This should pass as Self should be bound to Foo while typechecking this
-        Foo{x: 100}
+        Foo { x: 100 }
     }
 }
 
@@ -27,7 +27,7 @@ impl ATrait for Bar {
     // The trait method is declared as returning `Self`
     // but explicitly specifying the type in the impl should work
     fn asd() -> Bar {
-        Bar{x: 100}
+        Bar { x: 100 }
     }
 
     fn static_method_2() -> Field {

--- a/test_programs/compile_success_empty/trait_where_clause/src/main.nr
+++ b/test_programs/compile_success_empty/trait_where_clause/src/main.nr
@@ -12,9 +12,21 @@ struct Add20  { x: Field, }
 struct Add30  { x: Field, }
 struct AddXY  { x: Field, y: Field, }
 
-impl Asd for Add10 { fn asd(self) -> Field { self.x + 10 } }
-impl Asd for Add20 { fn asd(self) -> Field { self.x + 20 } }
-impl Asd for Add30 { fn asd(self) -> Field { self.x + 30 } }
+impl Asd for Add10 {
+    fn asd(self) -> Field {
+        self.x + 10
+    }
+}
+impl Asd for Add20 {
+    fn asd(self) -> Field {
+        self.x + 20
+    }
+}
+impl Asd for Add30 {
+    fn asd(self) -> Field {
+        self.x + 30
+    }
+}
 
 impl Asd for AddXY {
     fn asd(self) -> Field {
@@ -29,7 +41,9 @@ impl StaticTrait for Static100 {
 
 struct Static200 {}
 impl StaticTrait for Static200 {
-    fn static_function(slf: Self) -> Field { 200 }
+    fn static_function(slf: Self) -> Field {
+        200
+    }
 }
 
 fn assert_asd_eq_100<T>(t: T) where T: crate::the_trait::Asd {

--- a/test_programs/compile_success_empty/traits/src/main.nr
+++ b/test_programs/compile_success_empty/traits/src/main.nr
@@ -8,8 +8,8 @@ struct Foo {
 }
 
 impl MyDefault for Foo {
-    fn my_default(x: Field,y: Field) -> Self {
-        Self { bar: x, array: [x,y] }
+    fn my_default(x: Field, y: Field) -> Self {
+        Self { bar: x, array: [x, y] }
     }
 }
 

--- a/test_programs/execution_success/derive/src/main.nr
+++ b/test_programs/execution_success/derive/src/main.nr
@@ -69,7 +69,7 @@ impl std::hash::Hasher for TestHasher {
     fn finish(self) -> Field {
         self.result
     }
-    
+
     fn write(&mut self, input: Field) {
         self.result += input;
     }

--- a/test_programs/execution_success/slice_regex/src/main.nr
+++ b/test_programs/execution_success/slice_regex/src/main.nr
@@ -12,9 +12,8 @@ impl Match {
 
 impl Eq for Match {
     fn eq(self, other: Self) -> bool {
-        (self.succeeded == other.succeeded) &
-            (self.match_ends == other.match_ends)
-            // (self.leftover == other.leftover)
+        (self.succeeded == other.succeeded) & (self.match_ends == other.match_ends)
+        // (self.leftover == other.leftover)
     }
 }
 
@@ -48,17 +47,9 @@ impl<let N: u32> Regex for str<N> {
             }
         }
         if matches_input {
-            Match {
-                succeeded: true,
-                match_ends: self_as_bytes.len(),
-                leftover,
-            }
+            Match { succeeded: true, match_ends: self_as_bytes.len(), leftover }
         } else {
-            Match {
-                succeeded: false,
-                match_ends: 0,
-                leftover: input,
-            }
+            Match { succeeded: false, match_ends: 0, leftover: input }
         }
     }
 }
@@ -73,21 +64,13 @@ impl<T, U> Regex for (T, U) where T: Regex, U: Regex {
                 Match {
                     succeeded: true,
                     match_ends: lhs_result.match_ends + rhs_result.match_ends,
-                    leftover: rhs_result.leftover,
+                    leftover: rhs_result.leftover
                 }
             } else {
-                Match {
-                    succeeded: false,
-                    match_ends: 0,
-                    leftover: input,
-                }
+                Match { succeeded: false, match_ends: 0, leftover: input }
             }
         } else {
-            Match {
-                succeeded: false,
-                match_ends: 0,
-                leftover: input,
-            }
+            Match { succeeded: false, match_ends: 0, leftover: input }
         }
     }
 }
@@ -136,10 +119,7 @@ struct Question<T> {
 
 impl<T> Regex for Question<T> where T: Regex {
     fn match(self, input: [u8]) -> Match {
-        Or {
-            lhs: self.inner,
-            rhs: (),
-        }.match(input)
+        Or { lhs: self.inner, rhs: () }.match(input)
     }
 }
 
@@ -150,9 +130,7 @@ struct Star<T, let N: u32> {
 
 impl<T, let N: u32> Regex for Star<T, N> where T: Regex {
     fn match(self, input: [u8]) -> Match {
-        let regex: Repeated<_, N> = Repeated {
-            inner: Question { inner: self.inner },
-        };
+        let regex: Repeated<_, N> = Repeated { inner: Question { inner: self.inner } };
         regex.match(input)
     }
 }
@@ -166,10 +144,7 @@ impl<T, let N: u32, let N_PRED: u32> Regex for Plus<T, N, N_PRED> where T: Regex
     fn match(self, input: [u8]) -> Match {
         std::static_assert(N_PRED + 1 == N, "N - 1 != N_PRED");
         let star: Star<T, N_PRED> = Star { inner: self.inner };
-        (
-            self.inner,
-            star
-        ).match(input)
+        (self.inner, star).match(input)
     }
 }
 

--- a/test_programs/execution_success/trait_impl_base_type/src/main.nr
+++ b/test_programs/execution_success/trait_impl_base_type/src/main.nr
@@ -5,7 +5,7 @@ trait Fieldable {
 impl Fieldable for u32 {
     fn to_field(self) -> Field {
         let res = self as Field;
-        res * 3    
+        res * 3
     }
 }
 
@@ -18,21 +18,13 @@ impl Fieldable for [u32; 3] {
 
 impl Fieldable for bool {
     fn to_field(self) -> Field {
-        if self {
-            14
-        } else {
-            3
-        }
+        if self { 14 } else { 3 }
     }
 }
 
 impl Fieldable for (u32, bool) {
     fn to_field(self) -> Field {
-        if self.1 {
-            self.0 as Field
-        } else {
-            32
-        }
+        if self.1 { self.0 as Field } else { 32 }
     }
 }
 

--- a/tooling/lsp/src/requests/document_symbol.rs
+++ b/tooling/lsp/src/requests/document_symbol.rs
@@ -378,12 +378,18 @@ impl<'a> Visitor for DocumentSymbolCollector<'a> {
         name: &Ident,
         typ: &UnresolvedType,
         default_value: &Expression,
+        _span: Span,
     ) -> bool {
         self.collect_in_constant(name, typ, Some(default_value));
         false
     }
 
-    fn visit_trait_impl_item_type(&mut self, name: &Ident, alias: &UnresolvedType) -> bool {
+    fn visit_trait_impl_item_type(
+        &mut self,
+        name: &Ident,
+        alias: &UnresolvedType,
+        _span: Span,
+    ) -> bool {
         self.collect_in_type(name, Some(alias));
         false
     }

--- a/tooling/lsp/src/requests/document_symbol.rs
+++ b/tooling/lsp/src/requests/document_symbol.rs
@@ -668,7 +668,7 @@ mod document_symbol_tests {
                             tags: None,
                             deprecated: None,
                             range: Range {
-                                start: Position { line: 19, character: 7 },
+                                start: Position { line: 19, character: 4 },
                                 end: Position { line: 20, character: 5 },
                             },
                             selection_range: Range {

--- a/tooling/nargo_fmt/tests/input/impl.nr
+++ b/tooling/nargo_fmt/tests/input/impl.nr
@@ -21,7 +21,7 @@ impl MyType {
 }
 
 impl<T> MyStruct<T> where T: MyEq {
-    fn my_eq(self, other: Self) -> bool {
+fn my_eq(self, other: Self) -> bool {
         (self.a == other.a) & self.b.my_eq(other.b)
     }
 }


### PR DESCRIPTION
# Description

## Problem

Trait impl functions weren't formatted. I think it's because trait impl items don't have an associated span.

## Summary

This PR changes `TraitImplItem` to be `TraitImplItemKind`, and introduces `TraitImplItem` as the usual struct that holds `kind` and `span`.

With that, we can at least have `nargo fmt` format trait impl functions (I left the other ones unchanged, maybe they could be done later, but functions are the most common items).

## Additional Context

None.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
