### PR TITLE
feat: Add `Module::structs`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -130,6 +130,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "module_has_named_attribute" => module_has_named_attribute(self, arguments, location),
             "module_is_contract" => module_is_contract(self, arguments, location),
             "module_name" => module_name(interner, arguments, location),
+            "module_structs" => module_structs(self, arguments, location),
             "modulus_be_bits" => modulus_be_bits(interner, arguments, location),
             "modulus_be_bytes" => modulus_be_bytes(interner, arguments, location),
             "modulus_le_bits" => modulus_le_bits(interner, arguments, location),
@@ -2292,6 +2293,30 @@ fn module_functions(
 
     let slice_type = Type::Slice(Box::new(Type::Quoted(QuotedType::FunctionDefinition)));
     Ok(Value::Slice(func_ids, slice_type))
+}
+
+// fn structs(self) -> [StructDefinition]
+fn module_structs(
+    interpreter: &Interpreter,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    let self_argument = check_one_argument(arguments, location)?;
+    let module_id = get_module(self_argument)?;
+    let module_data = interpreter.elaborator.get_module(module_id);
+    let struct_ids = module_data
+        .type_definitions()
+        .filter_map(|module_def_id| {
+            if let ModuleDefId::TypeId(id) = module_def_id {
+                Some(Value::StructDefinition(id))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let slice_type = Type::Slice(Box::new(Type::Quoted(QuotedType::StructDefinition)));
+    Ok(Value::Slice(struct_ids, slice_type))
 }
 
 // fn has_named_attribute(self, name: Quoted) -> bool

--- a/docs/docs/noir/standard_library/meta/module.md
+++ b/docs/docs/noir/standard_library/meta/module.md
@@ -16,17 +16,11 @@ Adds a top-level item (a function, a struct, a global, etc.) to the module.
 Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.  
 Note that the items are type-checked as if they are inside the module they are being added to.
 
-### name
-
-#include_code name noir_stdlib/src/meta/module.nr rust
-
-Returns the name of the module.
-
 ### functions
 
 #include_code functions noir_stdlib/src/meta/module.nr rust
 
-Returns each function in the module.
+Returns each function defined in the module.
 
 ### has_named_attribute
 
@@ -39,3 +33,15 @@ Returns true if this module has a custom attribute with the given name.
 #include_code is_contract noir_stdlib/src/meta/module.nr rust
 
 `true` if this module is a contract module (was declared via `contract foo { ... }`).
+
+### name
+
+#include_code name noir_stdlib/src/meta/module.nr rust
+
+Returns the name of the module.
+
+### structs
+
+#include_code structs noir_stdlib/src/meta/module.nr rust
+
+Returns each struct defined in the module.

--- a/noir_stdlib/src/meta/module.nr
+++ b/noir_stdlib/src/meta/module.nr
@@ -10,17 +10,22 @@ impl Module {
     // docs:end:has_named_attribute
 
     #[builtin(module_is_contract)]
-// docs:start:is_contract
+    // docs:start:is_contract
     comptime fn is_contract(self) -> bool {}
     // docs:end:is_contract
 
     #[builtin(module_functions)]
-// docs:start:functions
+    // docs:start:functions
     comptime fn functions(self) -> [FunctionDefinition] {}
     // docs:end:functions
 
+    #[builtin(module_structs)]
+    // docs:start:structs
+    comptime fn structs(self) -> [StructDefinition] {}
+    // docs:end:structs
+
     #[builtin(module_name)]
-// docs:start:name
+    // docs:start:name
     comptime fn name(self) -> Quoted {}
     // docs:end:name
 }

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -3,6 +3,8 @@ mod foo {
     #![some_attribute]
     pub fn x() {}
     pub fn y() {}
+
+    struct Struct1 {}
 }
 
 contract bar {}
@@ -73,6 +75,10 @@ fn main() {
         // Check Module::functions
         assert_eq(foo.functions().len(), 2);
         assert_eq(bar.functions().len(), 0);
+
+        // Check Module::structs
+        assert_eq(foo.structs().len(), 1);
+        assert_eq(bar.structs().len(), 0);
 
         // Check Module::name
         assert_eq(foo.name(), quote { foo });


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6015

## Summary\*

Adds a method to `Module` to retrieve each struct defined in the module

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
