### PR TITLE
feat: add `fmtstr::quoted`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -100,7 +100,6 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "expr_is_continue" => expr_is_continue(interner, arguments, location),
             "expr_resolve" => expr_resolve(self, arguments, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
-            "fmtstr_quoted" => fmtstr_quoted(interner, arguments, location),
             "fmtstr_quoted_contents" => fmtstr_quoted_contents(interner, arguments, location),
             "fresh_type_variable" => fresh_type_variable(interner),
             "function_def_add_attribute" => function_def_add_attribute(self, arguments, location),
@@ -1896,18 +1895,6 @@ fn unwrap_expr_value(interner: &NodeInterner, mut expr_value: ExprValue) -> Expr
         }
     }
     expr_value
-}
-
-// fn quoted(self) -> Quoted
-fn fmtstr_quoted(
-    interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    location: Location,
-) -> IResult<Value> {
-    let self_argument = check_one_argument(arguments, location)?;
-    let (string, _) = get_format_string(interner, self_argument)?;
-    let token = Token::Str((*string).clone());
-    Ok(Value::Quoted(Rc::new(vec![token])))
 }
 
 // fn quoted_contents(self) -> Quoted

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -100,6 +100,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "expr_is_continue" => expr_is_continue(interner, arguments, location),
             "expr_resolve" => expr_resolve(self, arguments, location),
             "is_unconstrained" => Ok(Value::Bool(true)),
+            "fmtstr_quoted" => fmtstr_quoted(interner, arguments, location),
             "fmtstr_quoted_contents" => fmtstr_quoted_contents(interner, arguments, location),
             "fresh_type_variable" => fresh_type_variable(interner),
             "function_def_add_attribute" => function_def_add_attribute(self, arguments, location),
@@ -1895,6 +1896,18 @@ fn unwrap_expr_value(interner: &NodeInterner, mut expr_value: ExprValue) -> Expr
         }
     }
     expr_value
+}
+
+// fn quoted(self) -> Quoted
+fn fmtstr_quoted(
+    interner: &NodeInterner,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    let self_argument = check_one_argument(arguments, location)?;
+    let (string, _) = get_format_string(interner, self_argument)?;
+    let token = Token::Str((*string).clone());
+    Ok(Value::Quoted(Rc::new(vec![token])))
 }
 
 // fn quoted_contents(self) -> Quoted

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -362,11 +362,11 @@ impl fmt::Display for Token {
             Token::Ident(ref s) => write!(f, "{s}"),
             Token::Int(n) => write!(f, "{}", n.to_u128()),
             Token::Bool(b) => write!(f, "{b}"),
-            Token::Str(ref b) => write!(f, "{b}"),
-            Token::FmtStr(ref b) => write!(f, "f{b}"),
+            Token::Str(ref b) => write!(f, "{b:?}"),
+            Token::FmtStr(ref b) => write!(f, "f{b:?}"),
             Token::RawStr(ref b, hashes) => {
                 let h: String = std::iter::once('#').cycle().take(hashes as usize).collect();
-                write!(f, "r{h}\"{b}\"{h}")
+                write!(f, "r{h}{b:?}{h}")
             }
             Token::Keyword(k) => write!(f, "{k}"),
             Token::Attribute(ref a) => write!(f, "{a}"),

--- a/docs/docs/noir/standard_library/fmtstr.md
+++ b/docs/docs/noir/standard_library/fmtstr.md
@@ -6,6 +6,12 @@ title: fmtstr
 
 ## Methods
 
+### quoted
+
+#include_code quoted noir_stdlib/src/meta/format_string.nr rust
+
+Returns the string literal as a `Quoted` value (this includes the leading and trailing double quoted).
+
 ### quoted_contents
 
 #include_code quoted_contents noir_stdlib/src/meta/format_string.nr rust

--- a/noir_stdlib/src/meta/format_string.nr
+++ b/noir_stdlib/src/meta/format_string.nr
@@ -1,7 +1,8 @@
 impl <let N: u32, T> fmtstr<N, T> {
-    #[builtin(fmtstr_quoted)]
     // docs:start:quoted
-    comptime fn quoted(self) -> Quoted {}
+    comptime fn quoted(self) -> Quoted {
+        crate::meta::unquote!(quote { $self })
+    }
     // docs:end:quoted
 
     #[builtin(fmtstr_quoted_contents)]

--- a/noir_stdlib/src/meta/format_string.nr
+++ b/noir_stdlib/src/meta/format_string.nr
@@ -1,8 +1,7 @@
 impl <let N: u32, T> fmtstr<N, T> {
+    #[builtin(fmtstr_quoted)]
     // docs:start:quoted
-    comptime fn quoted(self) -> Quoted {
-        crate::meta::unquote!(quote { $self })
-    }
+    comptime fn quoted(self) -> Quoted {}
     // docs:end:quoted
 
     #[builtin(fmtstr_quoted_contents)]

--- a/noir_stdlib/src/meta/format_string.nr
+++ b/noir_stdlib/src/meta/format_string.nr
@@ -1,4 +1,9 @@
 impl <let N: u32, T> fmtstr<N, T> {
+    #[builtin(fmtstr_quoted)]
+    // docs:start:quoted
+    comptime fn quoted(self) -> Quoted {}
+    // docs:end:quoted
+
     #[builtin(fmtstr_quoted_contents)]
     // docs:start:quoted_contents
     comptime fn quoted_contents(self) -> Quoted {}

--- a/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
@@ -18,7 +18,7 @@ fn main() {
 
     comptime
     {
-        let x = "world";
+        let x = "world\n\t\"";
         let s = f"Hello {x}".quoted();
         let code = quote { check_hello_world($s) };
         std::meta::unquote!(code);
@@ -35,6 +35,6 @@ comptime fn call(x: Quoted) -> Quoted {
     quote { $x() }
 }
 fn check_hello_world<let N: u32>(s: str<N>) {
-    assert_eq(s.as_bytes().len(), "Hello world".as_bytes().len());
+    assert_eq(s.as_bytes().len(), "Hello world\n\t\"".as_bytes().len());
 }
 

--- a/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr
@@ -15,6 +15,14 @@ fn main() {
 
     // Mainly test fmtstr::quoted_contents
     call!(glue(quote { hello }, quote { world }));
+
+    comptime
+    {
+        let x = "world";
+        let s = f"Hello {x}".quoted();
+        let code = quote { check_hello_world($s) };
+        std::meta::unquote!(code);
+    }
 }
 
 comptime fn glue(x: Quoted, y: Quoted) -> Quoted {
@@ -25,5 +33,8 @@ fn hello_world() {}
 
 comptime fn call(x: Quoted) -> Quoted {
     quote { $x() }
+}
+fn check_hello_world<let N: u32>(s: str<N>) {
+    assert_eq(s.as_bytes().len(), "Hello world".as_bytes().len());
 }
 


### PR DESCRIPTION
# Description

## Problem

Reviving the first commit in #5942

## Summary

This adds a way to turn a `fmtstr` into a `Quoted` value that holds a string token. Otherwise there's no way to create string tokens by interpolating dymamic (well, at compile-time) values.

This PR also fixes an issue with how string tokens are displayed. Previously they wouldn't include the double quotes, and special characters weren't escaped.

## Additional Context

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
