### PR TITLE
feat: let `has_named_attribute` work for built-in attributes

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -8,7 +8,6 @@ use crate::{
         BlockExpression, ExpressionKind, IntegerBitSize, LValue, Pattern, Signedness,
         StatementKind, UnresolvedTypeData,
     },
-    elaborator::Elaborator,
     hir::{
         comptime::{
             errors::IResult,
@@ -25,7 +24,7 @@ use crate::{
     macros_api::{NodeInterner, StructId},
     node_interner::{FuncId, TraitId, TraitImplId},
     parser::NoirParser,
-    token::{Token, Tokens},
+    token::{SecondaryAttribute, Token, Tokens},
     QuotedType, Type,
 };
 
@@ -449,23 +448,12 @@ pub(super) fn block_expression_to_value(block_expr: BlockExpression) -> Value {
     Value::Slice(statements, typ)
 }
 
-pub(super) fn has_named_attribute<'a>(
-    name: &'a str,
-    attributes: impl Iterator<Item = &'a String>,
-    location: Location,
-) -> bool {
+pub(super) fn has_named_attribute(name: &str, attributes: &[SecondaryAttribute]) -> bool {
     for attribute in attributes {
-        let parse_result = Elaborator::parse_attribute(attribute, location);
-        let Ok(Some((function, _arguments))) = parse_result else {
-            continue;
-        };
-
-        let ExpressionKind::Variable(path) = function.kind else {
-            continue;
-        };
-
-        if path.last_name() == name {
-            return true;
+        if let Some(attribute_name) = attribute.name() {
+            if name == attribute_name {
+                return true;
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -26,8 +26,7 @@ pub struct ModuleData {
     /// True if this module is a `contract Foo { ... }` module containing contract functions
     pub is_contract: bool,
 
-    pub outer_attributes: Vec<String>,
-    pub inner_attributes: Vec<String>,
+    pub attributes: Vec<SecondaryAttribute>,
 }
 
 impl ModuleData {
@@ -38,11 +37,8 @@ impl ModuleData {
         inner_attributes: Vec<SecondaryAttribute>,
         is_contract: bool,
     ) -> ModuleData {
-        let outer_attributes = outer_attributes.iter().filter_map(|attr| attr.as_custom());
-        let outer_attributes = outer_attributes.map(|attr| attr.contents.to_string()).collect();
-
-        let inner_attributes = inner_attributes.iter().filter_map(|attr| attr.as_custom());
-        let inner_attributes = inner_attributes.map(|attr| attr.contents.to_string()).collect();
+        let mut attributes = outer_attributes;
+        attributes.extend(inner_attributes);
 
         ModuleData {
             parent,
@@ -51,8 +47,7 @@ impl ModuleData {
             definitions: ItemScope::default(),
             location,
             is_contract,
-            outer_attributes,
-            inner_attributes,
+            attributes,
         }
     }
 

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -10,6 +10,8 @@ use crate::{
     },
 };
 
+use super::Lexer;
+
 /// Represents a token in noir's grammar - a word, number,
 /// or symbol that can be used in noir's syntax. This is the
 /// smallest unit of grammar. A parser may (will) decide to parse
@@ -868,6 +870,18 @@ impl FunctionAttribute {
     pub fn is_no_predicates(&self) -> bool {
         matches!(self, FunctionAttribute::NoPredicates)
     }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            FunctionAttribute::Foreign(_) => "foreign",
+            FunctionAttribute::Builtin(_) => "builtin",
+            FunctionAttribute::Oracle(_) => "oracle",
+            FunctionAttribute::Test(_) => "test",
+            FunctionAttribute::Recursive => "recursive",
+            FunctionAttribute::Fold => "fold",
+            FunctionAttribute::NoPredicates => "no_predicates",
+        }
+    }
 }
 
 impl fmt::Display for FunctionAttribute {
@@ -911,6 +925,20 @@ impl SecondaryAttribute {
             None
         }
     }
+
+    pub(crate) fn name(&self) -> Option<String> {
+        match self {
+            SecondaryAttribute::Deprecated(_) => Some("deprecated".to_string()),
+            SecondaryAttribute::ContractLibraryMethod => {
+                Some("contract_library_method".to_string())
+            }
+            SecondaryAttribute::Export => Some("export".to_string()),
+            SecondaryAttribute::Field(_) => Some("field".to_string()),
+            SecondaryAttribute::Custom(custom) => custom.name(),
+            SecondaryAttribute::Abi(_) => Some("abi".to_string()),
+            SecondaryAttribute::Varargs => Some("varargs".to_string()),
+        }
+    }
 }
 
 impl fmt::Display for SecondaryAttribute {
@@ -937,6 +965,18 @@ pub struct CustomAtrribute {
     pub span: Span,
     // The span for the attribute contents (what's inside `#[...]`)
     pub contents_span: Span,
+}
+
+impl CustomAtrribute {
+    fn name(&self) -> Option<String> {
+        let mut lexer = Lexer::new(&self.contents);
+        let token = lexer.next()?.ok()?;
+        if let Token::Ident(ident) = token.into_token() {
+            Some(ident)
+        } else {
+            None
+        }
+    }
 }
 
 impl AsRef<str> for FunctionAttribute {

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -903,15 +903,6 @@ pub enum SecondaryAttribute {
     Varargs,
 }
 
-#[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
-pub struct CustomAtrribute {
-    pub contents: String,
-    // The span of the entire attribute, including leading `#[` and trailing `]`
-    pub span: Span,
-    // The span for the attribute contents (what's inside `#[...]`)
-    pub contents_span: Span,
-}
-
 impl SecondaryAttribute {
     pub(crate) fn as_custom(&self) -> Option<&CustomAtrribute> {
         if let Self::Custom(attribute) = self {
@@ -937,6 +928,15 @@ impl fmt::Display for SecondaryAttribute {
             SecondaryAttribute::Varargs => write!(f, "#[varargs]"),
         }
     }
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
+pub struct CustomAtrribute {
+    pub contents: String,
+    // The span of the entire attribute, including leading `#[` and trailing `]`
+    pub span: Span,
+    // The span for the attribute contents (what's inside `#[...]`)
+    pub contents_span: Span,
 }
 
 impl AsRef<str> for FunctionAttribute {

--- a/noir_stdlib/src/meta/function_def.nr
+++ b/noir_stdlib/src/meta/function_def.nr
@@ -11,7 +11,7 @@ impl FunctionDefinition {
 
     #[builtin(function_def_has_named_attribute)]
     // docs:start:has_named_attribute
-    comptime fn has_named_attribute(self, name: Quoted) -> bool {}
+    comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
     // docs:end:has_named_attribute
 
     #[builtin(function_def_is_unconstrained)]

--- a/noir_stdlib/src/meta/module.nr
+++ b/noir_stdlib/src/meta/module.nr
@@ -6,7 +6,7 @@ impl Module {
 
     #[builtin(module_has_named_attribute)]
     // docs:start:has_named_attribute
-    comptime fn has_named_attribute(self, name: Quoted) -> bool {}
+    comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
     // docs:end:has_named_attribute
 
     #[builtin(module_is_contract)]

--- a/noir_stdlib/src/meta/struct_def.nr
+++ b/noir_stdlib/src/meta/struct_def.nr
@@ -18,7 +18,7 @@ impl StructDefinition {
 
     #[builtin(struct_def_has_named_attribute)]
     // docs:start:has_named_attribute
-    comptime fn has_named_attribute(self, name: Quoted) -> bool {}
+    comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
     // docs:end:has_named_attribute
 
     /// Return each generic on this struct.

--- a/test_programs/compile_success_empty/attributes_struct/src/main.nr
+++ b/test_programs/compile_success_empty/attributes_struct/src/main.nr
@@ -16,9 +16,9 @@ struct Foo {
 }
 
 comptime fn add_attribute(s: StructDefinition) {
-    assert(!s.has_named_attribute(quote { foo }));
+    assert(!s.has_named_attribute("foo"));
     s.add_attribute("foo");
-    assert(s.has_named_attribute(quote { foo }));
+    assert(s.has_named_attribute("foo"));
 
-    assert(s.has_named_attribute(quote { abi }));
+    assert(s.has_named_attribute("abi"));
 }

--- a/test_programs/compile_success_empty/attributes_struct/src/main.nr
+++ b/test_programs/compile_success_empty/attributes_struct/src/main.nr
@@ -9,6 +9,7 @@ fn main() {}
 
 // Check that add_attribute and has_named_attribute work well
 
+#[abi(something)]
 #[add_attribute]
 struct Foo {
 
@@ -18,4 +19,6 @@ comptime fn add_attribute(s: StructDefinition) {
     assert(!s.has_named_attribute(quote { foo }));
     s.add_attribute("foo");
     assert(s.has_named_attribute(quote { foo }));
+
+    assert(s.has_named_attribute(quote { abi }));
 }

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -38,12 +38,12 @@ comptime fn function_attr(f: FunctionDefinition) {
     // Check FunctionDefinition::name
     assert_eq(f.name(), quote { foo });
 
-    assert(f.has_named_attribute(quote { function_attr }));
+    assert(f.has_named_attribute("function_attr"));
 }
 
 comptime fn check_named_attribute(f: FunctionDefinition) {
-    assert(f.has_named_attribute(quote { test }));
-    assert(f.has_named_attribute(quote { deprecated }));
+    assert(f.has_named_attribute("test"));
+    assert(f.has_named_attribute("deprecated"));
 }
 
 #[mutate_add_one]

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -8,6 +8,11 @@ pub fn foo(w: i32, y: Field, Foo { x, field: some_field }: Foo, mut a: bool, (b,
     1
 }
 
+#[test]
+#[deprecated]
+#[check_named_attribute]
+fn some_test() {}
+
 comptime fn function_attr(f: FunctionDefinition) {
     // Check FunctionDefinition::parameters
     let parameters = f.parameters();
@@ -34,6 +39,11 @@ comptime fn function_attr(f: FunctionDefinition) {
     assert_eq(f.name(), quote { foo });
 
     assert(f.has_named_attribute(quote { function_attr }));
+}
+
+comptime fn check_named_attribute(f: FunctionDefinition) {
+    assert(f.has_named_attribute(quote { test }));
+    assert(f.has_named_attribute(quote { deprecated }));
 }
 
 #[mutate_add_one]

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -85,10 +85,10 @@ fn main() {
         assert_eq(bar.name(), quote { bar });
 
         // Check Module::has_named_attribute
-        assert(foo.has_named_attribute(quote { some_attribute }));
-        assert(foo.has_named_attribute(quote { outer_attribute }));
-        assert(!bar.has_named_attribute(quote { some_attribute }));
-        assert(another_module.has_named_attribute(quote { some_attribute }));
+        assert(foo.has_named_attribute("some_attribute"));
+        assert(foo.has_named_attribute("outer_attribute"));
+        assert(!bar.has_named_attribute("some_attribute"));
+        assert(another_module.has_named_attribute("some_attribute"));
     }
 
     assert_eq(counter, 4);

--- a/test_programs/compile_success_empty/inject_context_attribute/src/main.nr
+++ b/test_programs/compile_success_empty/inject_context_attribute/src/main.nr
@@ -45,7 +45,7 @@ comptime fn mapping_function(expr: Expr, f: FunctionDefinition) -> Option<Expr> 
         let (name, arguments) = func_call;
         name.resolve(Option::some(f)).as_function_definition().and_then(
             |function_definition: FunctionDefinition| {
-            if function_definition.has_named_attribute(quote { inject_context }) {
+            if function_definition.has_named_attribute("inject_context") {
                 let arguments = arguments.push_front(quote { _context }.as_expr().unwrap());
                 let arguments = arguments.map(|arg: Expr| arg.quoted()).join(quote { , });
                 Option::some(quote { $name($arguments) }.as_expr().unwrap())


### PR DESCRIPTION
# Description

## Problem

Resolves #6009

## Summary

Also made it a bit more efficient.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
