### PR TITLE
fix: use module name as line after which we'll insert auto-import

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -882,7 +882,7 @@ impl<'a> Visitor for NodeFinder<'a> {
         false
     }
 
-    fn visit_parsed_submodule(&mut self, parsed_sub_module: &ParsedSubModule, span: Span) -> bool {
+    fn visit_parsed_submodule(&mut self, parsed_sub_module: &ParsedSubModule, _span: Span) -> bool {
         // Switch `self.module_id` to the submodule
         let previous_module_id = self.module_id;
 
@@ -897,7 +897,9 @@ impl<'a> Visitor for NodeFinder<'a> {
         let old_auto_import_line = self.auto_import_line;
         self.nesting += 1;
 
-        if let Some(lsp_location) = to_lsp_location(self.files, self.file, span) {
+        if let Some(lsp_location) =
+            to_lsp_location(self.files, self.file, parsed_sub_module.name.span())
+        {
             self.auto_import_line = (lsp_location.range.start.line + 1) as usize;
         }
 

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1395,6 +1395,7 @@ mod completion_tests {
     #[test]
     async fn test_auto_imports_when_in_nested_module_and_item_is_further_nested() {
         let src = r#"
+            #[something]
             mod foo {
                 mod bar {
                     pub fn hello_world() {}
@@ -1422,8 +1423,8 @@ mod completion_tests {
             item.additional_text_edits,
             Some(vec![TextEdit {
                 range: Range {
-                    start: Position { line: 2, character: 4 },
-                    end: Position { line: 2, character: 4 },
+                    start: Position { line: 3, character: 4 },
+                    end: Position { line: 3, character: 4 },
                 },
                 new_text: "use bar::hello_world;\n\n    ".to_string(),
             }])


### PR DESCRIPTION
# Description

## Problem

While working with attributes I found that auto-import didn't work well if a module has an attribute on it.

## Summary

Before:

![lsp-auto-import-before](https://github.com/user-attachments/assets/750c89cb-98a6-4d23-bd43-1ed1156aa2a5)

After:

![lsp-auto-import-after](https://github.com/user-attachments/assets/ab3418b5-e7ec-4eec-8625-e657163f9a0d)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
