### PR TITLE
fix: error on `&mut x` when `x` is not mutable

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -273,14 +273,20 @@ impl<'context> Elaborator<'context> {
 
     fn check_can_mutate(&mut self, expr_id: ExprId, span: Span) {
         let expr = self.interner.expression(&expr_id);
-        if let HirExpression::Ident(hir_ident, _) = expr {
-            let definition = self.interner.definition(hir_ident.id);
-            if !definition.mutable {
-                self.push_err(TypeCheckError::CannotMutateImmutableVariable {
-                    name: definition.name.clone(),
-                    span,
-                });
+        match expr {
+            HirExpression::Ident(hir_ident, _) => {
+                let definition = self.interner.definition(hir_ident.id);
+                if !definition.mutable {
+                    self.push_err(TypeCheckError::CannotMutateImmutableVariable {
+                        name: definition.name.clone(),
+                        span,
+                    });
+                }
             }
+            HirExpression::MemberAccess(member_access) => {
+                self.check_can_mutate(member_access.lhs, span);
+            }
+            _ => (),
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -65,8 +65,10 @@ pub enum TypeCheckError {
     UnsupportedCast { span: Span },
     #[error("Index {index} is out of bounds for this tuple {lhs_type} of length {length}")]
     TupleIndexOutOfBounds { index: usize, lhs_type: Type, length: usize, span: Span },
-    #[error("Variable {name} must be mutable to be assigned to")]
+    #[error("Variable `{name}` must be mutable to be assigned to")]
     VariableMustBeMutable { name: String, span: Span },
+    #[error("Cannot mutate immutable variable `{name}`")]
+    CannotMutateImmutableVariable { name: String, span: Span },
     #[error("No method named '{method_name}' found for type '{object_type}'")]
     UnresolvedMethodCall { method_name: String, object_type: Type, span: Span },
     #[error("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?}")]
@@ -268,6 +270,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             | TypeCheckError::UnsupportedCast { span }
             | TypeCheckError::TupleIndexOutOfBounds { span, .. }
             | TypeCheckError::VariableMustBeMutable { span, .. }
+            | TypeCheckError::CannotMutateImmutableVariable { span, .. }
             | TypeCheckError::UnresolvedMethodCall { span, .. }
             | TypeCheckError::IntegerSignedness { span, .. }
             | TypeCheckError::IntegerBitWidth { span, .. }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3462,3 +3462,26 @@ fn comptime_type_in_runtime_code() {
         CompilationError::ResolverError(ResolverError::ComptimeTypeInRuntimeCode { .. })
     ));
 }
+
+#[test]
+fn cannot_mutate_immutable_variable() {
+    let src = r#"
+    fn main() {
+        let array = [1];
+        mutate(&mut array);
+    }
+
+    fn mutate(_: &mut [Field; 1]) {}
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::CannotMutateImmutableVariable { name, .. }) =
+        &errors[0].0
+    else {
+        panic!("Expected an error about passing a constrained reference to unconstrained");
+    };
+
+    assert_eq!(name, "array");
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3485,3 +3485,32 @@ fn cannot_mutate_immutable_variable() {
 
     assert_eq!(name, "array");
 }
+
+#[test]
+fn cannot_mutate_immutable_variable_on_member_access() {
+    let src = r#"
+    struct Foo {
+        x: Field
+    }
+
+    fn main() {
+        let foo = Foo { x: 0 };
+        mutate(&mut foo.x);
+    }
+
+    fn mutate(foo: &mut Field) {
+        *foo = 1;
+    }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::CannotMutateImmutableVariable { name, .. }) =
+        &errors[0].0
+    else {
+        panic!("Expected an error about passing a constrained reference to unconstrained");
+    };
+
+    assert_eq!(name, "foo");
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3480,7 +3480,7 @@ fn cannot_mutate_immutable_variable() {
     let CompilationError::TypeError(TypeCheckError::CannotMutateImmutableVariable { name, .. }) =
         &errors[0].0
     else {
-        panic!("Expected an error about passing a constrained reference to unconstrained");
+        panic!("Expected a CannotMutateImmutableVariable error");
     };
 
     assert_eq!(name, "array");
@@ -3509,7 +3509,7 @@ fn cannot_mutate_immutable_variable_on_member_access() {
     let CompilationError::TypeError(TypeCheckError::CannotMutateImmutableVariable { name, .. }) =
         &errors[0].0
     else {
-        panic!("Expected an error about passing a constrained reference to unconstrained");
+        panic!("Expected a CannotMutateImmutableVariable error");
     };
 
     assert_eq!(name, "foo");


### PR DESCRIPTION
# Description

## Problem

Resolves #5721

## Summary

Today I bumped into this bug so I thought about trying to fix it.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
