### PR TITLE
chore: rename CustomAtrribute to CustomAttribute

### DIFF
--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -16,7 +16,7 @@ use crate::{
         InternedUnresolvedTypeData, QuotedTypeId,
     },
     parser::{Item, ItemKind, ParsedSubModule},
-    token::{CustomAtrribute, SecondaryAttribute, Tokens},
+    token::{CustomAttribute, SecondaryAttribute, Tokens},
     ParsedModule, QuotedType,
 };
 
@@ -461,7 +461,7 @@ pub trait Visitor {
         true
     }
 
-    fn visit_custom_attribute(&mut self, _: &CustomAtrribute, _target: AttributeTarget) {}
+    fn visit_custom_attribute(&mut self, _: &CustomAttribute, _target: AttributeTarget) {}
 }
 
 impl ParsedModule {
@@ -1377,7 +1377,7 @@ impl SecondaryAttribute {
     }
 }
 
-impl CustomAtrribute {
+impl CustomAttribute {
     pub fn accept(&self, target: AttributeTarget, visitor: &mut impl Visitor) {
         visitor.visit_custom_attribute(self, target);
     }

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         DefinitionKind, DependencyId, ExprId, FuncId, FunctionModifiers, GlobalId, ReferenceId,
         TraitId, TypeAliasId,
     },
-    token::CustomAtrribute,
+    token::CustomAttribute,
     Shared, Type, TypeVariable,
 };
 use crate::{
@@ -800,7 +800,7 @@ impl<'context> Elaborator<'context> {
         let attributes = func.secondary_attributes().iter();
         let attributes =
             attributes.filter_map(|secondary_attribute| secondary_attribute.as_custom());
-        let attributes: Vec<CustomAtrribute> = attributes.cloned().collect();
+        let attributes: Vec<CustomAttribute> = attributes.cloned().collect();
 
         let meta = FuncMeta {
             name: name_ident,

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -10,7 +10,7 @@ use crate::graph::CrateId;
 use crate::hir::def_map::LocalModuleId;
 use crate::macros_api::{BlockExpression, StructId};
 use crate::node_interner::{ExprId, NodeInterner, TraitId, TraitImplId};
-use crate::token::CustomAtrribute;
+use crate::token::CustomAttribute;
 use crate::{ResolvedGeneric, Type};
 
 /// A Hir function is a block expression with a list of statements.
@@ -167,7 +167,7 @@ pub struct FuncMeta {
     pub self_type: Option<Type>,
 
     /// Custom attributes attached to this function.
-    pub custom_attributes: Vec<CustomAtrribute>,
+    pub custom_attributes: Vec<CustomAttribute>,
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -690,7 +690,7 @@ mod tests {
     use iter_extended::vecmap;
 
     use super::*;
-    use crate::token::{CustomAtrribute, FunctionAttribute, SecondaryAttribute, TestScope};
+    use crate::token::{CustomAttribute, FunctionAttribute, SecondaryAttribute, TestScope};
 
     #[test]
     fn test_single_double_char() {
@@ -818,7 +818,7 @@ mod tests {
         let token = lexer.next_token().unwrap();
         assert_eq!(
             token.token(),
-            &Token::Attribute(Attribute::Secondary(SecondaryAttribute::Custom(CustomAtrribute {
+            &Token::Attribute(Attribute::Secondary(SecondaryAttribute::Custom(CustomAttribute {
                 contents: "custom(hello)".to_string(),
                 span: Span::from(0..16),
                 contents_span: Span::from(2..15)
@@ -916,7 +916,7 @@ mod tests {
         let token = lexer.next_token().unwrap();
         assert_eq!(
             token.token(),
-            &Token::InnerAttribute(SecondaryAttribute::Custom(CustomAtrribute {
+            &Token::InnerAttribute(SecondaryAttribute::Custom(CustomAttribute {
                 contents: "something".to_string(),
                 span: Span::from(0..13),
                 contents_span: Span::from(3..12),

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -801,7 +801,7 @@ impl Attribute {
             ["varargs"] => Attribute::Secondary(SecondaryAttribute::Varargs),
             tokens => {
                 tokens.iter().try_for_each(|token| validate(token))?;
-                Attribute::Secondary(SecondaryAttribute::Custom(CustomAtrribute {
+                Attribute::Secondary(SecondaryAttribute::Custom(CustomAttribute {
                     contents: word.to_owned(),
                     span,
                     contents_span,
@@ -910,7 +910,7 @@ pub enum SecondaryAttribute {
     ContractLibraryMethod,
     Export,
     Field(String),
-    Custom(CustomAtrribute),
+    Custom(CustomAttribute),
     Abi(String),
 
     /// A variable-argument comptime function.
@@ -918,7 +918,7 @@ pub enum SecondaryAttribute {
 }
 
 impl SecondaryAttribute {
-    pub(crate) fn as_custom(&self) -> Option<&CustomAtrribute> {
+    pub(crate) fn as_custom(&self) -> Option<&CustomAttribute> {
         if let Self::Custom(attribute) = self {
             Some(attribute)
         } else {
@@ -959,7 +959,7 @@ impl fmt::Display for SecondaryAttribute {
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
-pub struct CustomAtrribute {
+pub struct CustomAttribute {
     pub contents: String,
     // The span of the entire attribute, including leading `#[` and trailing `]`
     pub span: Span,
@@ -967,7 +967,7 @@ pub struct CustomAtrribute {
     pub contents_span: Span,
 }
 
-impl CustomAtrribute {
+impl CustomAttribute {
     fn name(&self) -> Option<String> {
         let mut lexer = Lexer::new(&self.contents);
         let token = lexer.next()?.ok()?;

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -28,7 +28,7 @@ use noirc_frontend::{
     macros_api::{ModuleDefId, NodeInterner},
     node_interner::ReferenceId,
     parser::{Item, ItemKind, ParsedSubModule},
-    token::CustomAtrribute,
+    token::CustomAttribute,
     ParsedModule, StructType, Type,
 };
 use sort_text::underscore_sort_text;
@@ -1434,7 +1434,7 @@ impl<'a> Visitor for NodeFinder<'a> {
         false
     }
 
-    fn visit_custom_attribute(&mut self, attribute: &CustomAtrribute, target: AttributeTarget) {
+    fn visit_custom_attribute(&mut self, attribute: &CustomAttribute, target: AttributeTarget) {
         if self.byte_index != attribute.contents_span.end() as usize {
             return;
         }


### PR DESCRIPTION
# Description

## Problem

I saw spellcheck complain about this. Until that I didn't realize there was a typo 😄 

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
