### PR TITLE
fix: Parse a statement as an expression

### DIFF
--- a/aztec_macros/src/utils/parse_utils.rs
+++ b/aztec_macros/src/utils/parse_utils.rs
@@ -299,6 +299,7 @@ fn empty_expression(expression: &mut Expression) {
         ExpressionKind::Quote(..)
         | ExpressionKind::Resolved(_)
         | ExpressionKind::Interned(_)
+        | ExpressionKind::InternedStatement(_)
         | ExpressionKind::Error => (),
     }
 }

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -7,7 +7,7 @@ use crate::ast::{
 };
 use crate::hir::def_collector::errors::DefCollectorErrorKind;
 use crate::macros_api::StructId;
-use crate::node_interner::{ExprId, InternedExpressionKind, QuotedTypeId};
+use crate::node_interner::{ExprId, InternedExpressionKind, InternedStatementKind, QuotedTypeId};
 use crate::token::{Attributes, FunctionAttribute, Token, Tokens};
 use crate::{Kind, Type};
 use acvm::{acir::AcirField, FieldElement};
@@ -47,6 +47,10 @@ pub enum ExpressionKind {
     // This is an interned ExpressionKind during comptime code.
     // The actual ExpressionKind can be retrieved with a NodeInterner.
     Interned(InternedExpressionKind),
+
+    /// Interned statements are allowed to be parsed as expressions in case they resolve
+    /// to an StatementKind::Expression or StatementKind::Semi.
+    InternedStatement(InternedStatementKind),
 
     Error,
 }
@@ -617,6 +621,7 @@ impl Display for ExpressionKind {
                 write!(f, "quote {{ {} }}", tokens.join(" "))
             }
             AsTraitPath(path) => write!(f, "{path}"),
+            InternedStatement(_) => write!(f, "?InternedStatement"),
         }
     }
 }

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -841,6 +841,7 @@ impl Expression {
             ExpressionKind::Quote(tokens) => visitor.visit_quote(tokens),
             ExpressionKind::Resolved(expr_id) => visitor.visit_resolved_expression(*expr_id),
             ExpressionKind::Interned(id) => visitor.visit_interned_expression(*id),
+            ExpressionKind::InternedStatement(id) => visitor.visit_interned_statement(*id),
             ExpressionKind::Error => visitor.visit_error_expression(),
         }
     }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -536,7 +536,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
             ResolverError::InvalidInternedStatementInExpr { statement, span } => {
                 Diagnostic::simple_error(
                     format!("Failed to parse `{statement}` as an expression"),
-                    format!("The statement was used from a macro here"),
+                    "The statement was used from a macro here".to_string(),
                     *span,
                 )
             },

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -130,6 +130,8 @@ pub enum ResolverError {
     ComptimeTypeInRuntimeCode { typ: String, span: Span },
     #[error("Comptime variable `{name}` cannot be mutated in a non-comptime context")]
     MutatingComptimeInNonComptimeContext { name: String, span: Span },
+    #[error("Failed to parse `{statement}` as an expression")]
+    InvalidInternedStatementInExpr { statement: String, span: Span },
 }
 
 impl ResolverError {
@@ -528,6 +530,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 Diagnostic::simple_error(
                     format!("Comptime variable `{name}` cannot be mutated in a non-comptime context"),
                     format!("`{name}` mutated here"),
+                    *span,
+                )
+            },
+            ResolverError::InvalidInternedStatementInExpr { statement, span } => {
+                Diagnostic::simple_error(
+                    format!("Failed to parse `{statement}` as an expression"),
+                    format!("The statement was used from a macro here"),
                     *span,
                 )
             },

--- a/compiler/noirc_frontend/src/parser/parser/primitives.rs
+++ b/compiler/noirc_frontend/src/parser/parser/primitives.rs
@@ -1,7 +1,7 @@
 use chumsky::prelude::*;
 
 use crate::ast::{ExpressionKind, GenericTypeArgs, Ident, PathSegment, UnaryOp};
-use crate::macros_api::UnresolvedType;
+use crate::macros_api::{StatementKind, UnresolvedType};
 use crate::parser::ParserErrorReason;
 use crate::{
     parser::{labels::ParsingRuleLabel, ExprParser, NoirParser, ParserError},
@@ -123,6 +123,26 @@ pub(super) fn interned_expr() -> impl NoirParser<ExpressionKind> {
     token_kind(TokenKind::InternedExpr).map(|token| match token {
         Token::InternedExpr(id) => ExpressionKind::Interned(id),
         _ => unreachable!("token_kind(InternedExpr) guarantees we parse an interned expr"),
+    })
+}
+
+pub(super) fn interned_statement() -> impl NoirParser<StatementKind> {
+    token_kind(TokenKind::InternedStatement).map(|token| match token {
+        Token::InternedStatement(id) => StatementKind::Interned(id),
+        _ => {
+            unreachable!("token_kind(InternedStatement) guarantees we parse an interned statement")
+        }
+    })
+}
+
+// This rule is so that we can re-parse StatementKind::Expression and Semi in
+// an expression position (ignoring the semicolon) if needed.
+pub(super) fn interned_statement_expr() -> impl NoirParser<ExpressionKind> {
+    token_kind(TokenKind::InternedStatement).map(|token| match token {
+        Token::InternedStatement(id) => ExpressionKind::InternedStatement(id),
+        _ => {
+            unreachable!("token_kind(InternedStatement) guarantees we parse an interned statement")
+        }
     })
 }
 

--- a/test_programs/compile_success_empty/comptime_parse_statement_as_expression/'
+++ b/test_programs/compile_success_empty/comptime_parse_statement_as_expression/'
@@ -1,0 +1,4 @@
+struct ArrData<let N: u32> {
+    a: [Field; N],
+    b: [Field; N + N - 1],
+}

--- a/test_programs/compile_success_empty/comptime_parse_statement_as_expression/'
+++ b/test_programs/compile_success_empty/comptime_parse_statement_as_expression/'
@@ -1,4 +1,0 @@
-struct ArrData<let N: u32> {
-    a: [Field; N],
-    b: [Field; N + N - 1],
-}

--- a/test_programs/compile_success_empty/comptime_parse_statement_as_expression/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_parse_statement_as_expression/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_parse_statement_as_expression"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_parse_statement_as_expression/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_parse_statement_as_expression/src/main.nr
@@ -1,0 +1,27 @@
+fn main() {
+    comptime
+    {
+        let block = quote[{
+            1;
+            2;
+            3
+        }];
+        let statements = block.as_expr().unwrap().as_block().unwrap();
+        let last = statements.pop_back().1;
+
+        // `3` should  fit in an expression position even though it is
+        // originally a StatementKind::Expression
+        let regression1 = quote[{
+            let _ = $last;
+        }];
+        assert(regression1.as_expr().is_some());
+
+        // `1;` should  fit in an expression position even though it is
+        // originally a StatementKind::Semi
+        let first = statements.pop_front().0;
+        let regression2 = quote[{
+            let _ = $first;
+        }];
+        assert(regression2.as_expr().is_some());
+    }
+}

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -542,6 +542,7 @@ fn get_expression_name(expression: &Expression) -> Option<String> {
         | ExpressionKind::Comptime(..)
         | ExpressionKind::Resolved(..)
         | ExpressionKind::Interned(..)
+        | ExpressionKind::InternedStatement(..)
         | ExpressionKind::Literal(..)
         | ExpressionKind::Unsafe(..)
         | ExpressionKind::Error => None,

--- a/tooling/nargo_fmt/src/rewrite/expr.rs
+++ b/tooling/nargo_fmt/src/rewrite/expr.rs
@@ -178,6 +178,11 @@ pub(crate) fn rewrite(
         ExpressionKind::Interned(_) => {
             unreachable!("ExpressionKind::Interned should only emitted by the comptime interpreter")
         }
+        ExpressionKind::InternedStatement(_) => {
+            unreachable!(
+                "ExpressionKind::InternedStatement should only emitted by the comptime interpreter"
+            )
+        }
         ExpressionKind::Unquote(expr) => {
             if matches!(&expr.kind, ExpressionKind::Variable(..)) {
                 format!("${expr}")


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6036

## Summary\*

Grego was having an issue from some macros where some code was taken from a block and later put in the rhs of a `let` statement: `let _ = $former_block_statement`. Since this expression originated from a block statement though, it is a `Token::InternedStatement` and not a valid expression.

I've updated the parser to accept interned statements in an expression position, and we just later validate that they're either `StatementKind::Expression` or `StatementKind::Semi` nodes.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
