### PR TITLE
feat: implement `to_be_radix` in the comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -174,6 +174,7 @@ impl<'local, 'context> Interpreter<'local, 'context> {
             "struct_def_module" => struct_def_module(self, arguments, location),
             "struct_def_name" => struct_def_name(interner, arguments, location),
             "struct_def_set_fields" => struct_def_set_fields(interner, arguments, location),
+            "to_be_radix" => to_be_radix(arguments, return_type, location),
             "to_le_radix" => to_le_radix(arguments, return_type, location),
             "trait_constraint_eq" => trait_constraint_eq(arguments, location),
             "trait_constraint_hash" => trait_constraint_hash(arguments, location),
@@ -754,6 +755,21 @@ fn quoted_tokens(arguments: Vec<(Value, Location)>, location: Location) -> IResu
         value.iter().map(|token| Value::Quoted(Rc::new(vec![token.clone()]))).collect(),
         Type::Slice(Box::new(Type::Quoted(QuotedType::Quoted))),
     ))
+}
+
+fn to_be_radix(
+    arguments: Vec<(Value, Location)>,
+    return_type: Type,
+    location: Location,
+) -> IResult<Value> {
+    let le_radix_limbs = to_le_radix(arguments, return_type, location)?;
+
+    let Value::Array(limbs, typ) = le_radix_limbs else {
+        unreachable!("`to_le_radix` should always return an array");
+    };
+    let be_radix_limbs = limbs.into_iter().rev().collect();
+
+    Ok(Value::Array(be_radix_limbs, typ))
 }
 
 fn to_le_radix(

--- a/test_programs/compile_success_empty/comptime_to_radix/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_to_radix/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "comptime_to_radix"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_to_radix/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_to_radix/src/main.nr
@@ -1,0 +1,10 @@
+fn main() {
+    comptime
+    {
+        let le_bytes: [u8; 3] = 257.to_le_bytes();
+        assert_eq(le_bytes, [1, 1, 0]);
+
+        let be_bytes: [u8; 3] = 257.to_be_bytes();
+        assert_eq(be_bytes, [0, 1, 1]);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6042
## Summary\*

This PR implements `to_be_radix` in the comptime interpreter by reusing our impl for `to_le_radix`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
