### PR TITLE
feat: faster LSP

### DIFF
--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -35,7 +35,7 @@ use nargo::{
 use nargo_toml::{find_file_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{file_manager_with_stdlib, prepare_crate, NOIR_ARTIFACT_VERSION_STRING};
 use noirc_frontend::{
-    graph::{CrateId, CrateName},
+    graph::{CrateGraph, CrateId, CrateName},
     hir::{
         def_map::{parse_file, CrateDefMap},
         Context, FunctionNameMatch, ParsedFiles,
@@ -92,13 +92,24 @@ pub struct LspState {
     open_documents_count: usize,
     input_files: HashMap<String, String>,
     cached_lenses: HashMap<String, Vec<CodeLens>>,
-    cached_definitions: HashMap<PathBuf, NodeInterner>,
     cached_parsed_files: HashMap<PathBuf, (usize, (ParsedModule, Vec<ParserError>))>,
-    cached_def_maps: HashMap<PathBuf, BTreeMap<CrateId, CrateDefMap>>,
+    workspace_cache: HashMap<PathBuf, WorkspaceCacheData>,
+    package_cache: HashMap<PathBuf, PackageCacheData>,
     options: LspInitializationOptions,
 
     // Tracks files that currently have errors, by package root.
     files_with_errors: HashMap<PathBuf, HashSet<Url>>,
+}
+
+struct WorkspaceCacheData {
+    file_manager: FileManager,
+}
+
+struct PackageCacheData {
+    crate_id: CrateId,
+    crate_graph: CrateGraph,
+    node_interner: NodeInterner,
+    def_maps: BTreeMap<CrateId, CrateDefMap>,
 }
 
 impl LspState {
@@ -112,12 +123,11 @@ impl LspState {
             solver: WrapperSolver(Box::new(solver)),
             input_files: HashMap::new(),
             cached_lenses: HashMap::new(),
-            cached_definitions: HashMap::new(),
-            open_documents_count: 0,
             cached_parsed_files: HashMap::new(),
-            cached_def_maps: HashMap::new(),
+            workspace_cache: HashMap::new(),
+            package_cache: HashMap::new(),
+            open_documents_count: 0,
             options: Default::default(),
-
             files_with_errors: HashMap::new(),
         }
     }

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -326,11 +326,11 @@ fn empty_parsed_module_function_bodies(parsed_module: &mut ParsedModule) {
         match &mut item.kind {
             ItemKind::Function(noir_function) => empty_noir_function_body(noir_function),
             ItemKind::TraitImpl(noir_trait_impl) => {
-                empty_noir_trait_impl_function_bodies(noir_trait_impl)
+                empty_noir_trait_impl_function_bodies(noir_trait_impl);
             }
             ItemKind::Impl(noir_impl) => empty_noir_impl_function_bodies(noir_impl),
             ItemKind::Submodules(parsed_sub_module) => {
-                empty_parsed_module_function_bodies(&mut parsed_sub_module.contents)
+                empty_parsed_module_function_bodies(&mut parsed_sub_module.contents);
             }
             ItemKind::Import(_, _)
             | ItemKind::Struct(_)
@@ -354,12 +354,12 @@ fn empty_noir_trait_impl_function_bodies(noir_trait_impl: &mut NoirTraitImpl) {
 
 fn empty_noir_impl_function_bodies(noir_impl: &mut TypeImpl) {
     for (noir_function, _span) in &mut noir_impl.methods {
-        empty_noir_function_body(&mut noir_function.item)
+        empty_noir_function_body(&mut noir_function.item);
     }
 }
 
 fn empty_noir_function_body(noir_function: &mut NoirFunction) {
-    noir_function.def.body.statements.clear()
+    noir_function.def.body.statements.clear();
 }
 
 #[cfg(test)]

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 
-use crate::insert_all_files_for_workspace_into_file_manager;
+use crate::{
+    insert_all_files_for_workspace_into_file_manager, PackageCacheData, WorkspaceCacheData,
+};
 use async_lsp::{ErrorCode, LanguageClient, ResponseError};
 use fm::{FileId, FileManager, FileMap};
 use fxhash::FxHashMap as HashMap;
@@ -94,7 +96,8 @@ pub(super) fn on_did_close_text_document(
     state.open_documents_count -= 1;
 
     if state.open_documents_count == 0 {
-        state.cached_definitions.clear();
+        state.package_cache.clear();
+        state.workspace_cache.clear();
     }
 
     let document_uri = params.text_document.uri;
@@ -205,8 +208,15 @@ pub(crate) fn process_workspace_for_noir_document(
         );
 
         state.cached_lenses.insert(document_uri.to_string(), collected_lenses);
-        state.cached_definitions.insert(package.root_dir.clone(), context.def_interner);
-        state.cached_def_maps.insert(package.root_dir.clone(), context.def_maps);
+        state.package_cache.insert(
+            package.root_dir.clone(),
+            PackageCacheData {
+                crate_id,
+                crate_graph: context.crate_graph,
+                node_interner: context.def_interner,
+                def_maps: context.def_maps,
+            },
+        );
 
         let fm = &context.file_manager;
         let files = fm.as_file_map();
@@ -215,6 +225,11 @@ pub(crate) fn process_workspace_for_noir_document(
             publish_diagnostics(state, &package.root_dir, files, fm, file_diagnostics);
         }
     }
+
+    state.workspace_cache.insert(
+        workspace.root_dir.clone(),
+        WorkspaceCacheData { file_manager: workspace_file_manager },
+    );
 
     Ok(())
 }

--- a/tooling/lsp/src/requests/references.rs
+++ b/tooling/lsp/src/requests/references.rs
@@ -16,7 +16,7 @@ pub(crate) fn on_references_request(
         find_all_references_in_workspace(
             args.location,
             args.interner,
-            args.interners,
+            args.package_cache,
             args.files,
             include_declaration,
             true,

--- a/tooling/lsp/src/requests/references.rs
+++ b/tooling/lsp/src/requests/references.rs
@@ -113,11 +113,13 @@ mod references_tests {
 
         // We call this to open the document, so that the entire workspace is analyzed
         let output_diagnostics = true;
+        let only_check_open_files = false;
 
         notifications::process_workspace_for_noir_document(
             &mut state,
             one_lib.clone(),
             output_diagnostics,
+            only_check_open_files,
         )
         .unwrap();
 

--- a/tooling/lsp/src/requests/rename.rs
+++ b/tooling/lsp/src/requests/rename.rs
@@ -38,7 +38,7 @@ pub(crate) fn on_rename_request(
         let rename_changes = find_all_references_in_workspace(
             args.location,
             args.interner,
-            args.interners,
+            args.package_cache,
             args.files,
             true,
             false,


### PR DESCRIPTION
# Description

## Problem

LSP is still relatively slow and there are many optimization opportunities we can use.

## Summary

Whenever a user opens a document, types something in it, saves it or closes it, we type-check the package they are in. However, we push errors from the server to the client in all of these cases except when the user types something (similar to Rust Analyzer and likely every other LSP server).

So, there's an idea: if we don't show type errors when a user types something (and doesn't save) we can maybe speed-up the type-checking. The idea here is this: if function bodies in non-open files are empty (instead of their actual content) then users of those functions would still type-check well. The only "problem" is that the function body will give an error like "the body type doesn't match the return type" but given that we don't show errors, it's not a problem. Type-checking a function body is much slower than emptying that function body.

That's the first thing this PR does: it empties function bodies in files that are not visible to the user (again, only when the user types something, when it saves the file we type-check everything as usual).

Another thing that's done in our LSP server is that on every LSP request (hover, completion, document symbol, etc.) we re-read all the package's files. That takes a fair amount of time. Coupled with the fact that whenever you type something many (like 4 or 5) LSP requests are triggered, and they are all sequential, until we get to the request we are interested in (say, completion) it might take a while.

So, the second optimization here is that we now cache a package's files, and use that cache on every request. The cache is updated when a user types, or when it saves a file, etc. It might sound like we are caching too much data, but we are already caching parsed modules, node interners, def maps... and checking Mac's Activity Manager I never saw it go above 300MB... while Rust Analyzer can reach gigabytes of memory. So for now I think this is not an issue (and computers have plenty of memory).

With these optimizations, LSP feels a lot more responsive now.

That said, contract projects in Aztec-Packages still appear to be slow, regarding LSP, but that's because running macros there takes about 600ms. That could be optimized later on, or maybe it will go away alone once we use Noir macros, so for now I didn't do anything about that (and likely won't).

## Additional Context

Instead of emptying function bodies I initially thought of another way of doing this: pass a set of FileIDs we want to type-check. Then in `Elaborator::elaborate_function` we'd check if the FileID is in that set, and if it's not then type-check the body as if it is an empty block. Doing this might also be faster than emptying function bodies. However, that requires a change to the compiler that's specific to LSP, and maybe it feels a bit more hacky. In this PR only the "lsp" directory was changed so maybe it's better.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
