### PR TITLE
feat: faster LSP by caching file managers

### DIFF
--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -35,7 +35,7 @@ use nargo::{
 use nargo_toml::{find_file_manifest, resolve_workspace_from_toml, PackageSelection};
 use noirc_driver::{file_manager_with_stdlib, prepare_crate, NOIR_ARTIFACT_VERSION_STRING};
 use noirc_frontend::{
-    graph::{CrateId, CrateName},
+    graph::{CrateGraph, CrateId, CrateName},
     hir::{
         def_map::{parse_file, CrateDefMap},
         Context, FunctionNameMatch, ParsedFiles,
@@ -92,13 +92,24 @@ pub struct LspState {
     open_documents_count: usize,
     input_files: HashMap<String, String>,
     cached_lenses: HashMap<String, Vec<CodeLens>>,
-    cached_definitions: HashMap<PathBuf, NodeInterner>,
     cached_parsed_files: HashMap<PathBuf, (usize, (ParsedModule, Vec<ParserError>))>,
-    cached_def_maps: HashMap<PathBuf, BTreeMap<CrateId, CrateDefMap>>,
+    workspace_cache: HashMap<PathBuf, WorkspaceCacheData>,
+    package_cache: HashMap<PathBuf, PackageCacheData>,
     options: LspInitializationOptions,
 
     // Tracks files that currently have errors, by package root.
     files_with_errors: HashMap<PathBuf, HashSet<Url>>,
+}
+
+struct WorkspaceCacheData {
+    file_manager: FileManager,
+}
+
+struct PackageCacheData {
+    crate_id: CrateId,
+    crate_graph: CrateGraph,
+    node_interner: NodeInterner,
+    def_maps: BTreeMap<CrateId, CrateDefMap>,
 }
 
 impl LspState {
@@ -112,12 +123,11 @@ impl LspState {
             solver: WrapperSolver(Box::new(solver)),
             input_files: HashMap::new(),
             cached_lenses: HashMap::new(),
-            cached_definitions: HashMap::new(),
-            open_documents_count: 0,
             cached_parsed_files: HashMap::new(),
-            cached_def_maps: HashMap::new(),
+            workspace_cache: HashMap::new(),
+            package_cache: HashMap::new(),
+            open_documents_count: 0,
             options: Default::default(),
-
             files_with_errors: HashMap::new(),
         }
     }

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 
-use crate::insert_all_files_for_workspace_into_file_manager;
+use crate::{
+    insert_all_files_for_workspace_into_file_manager, PackageCacheData, WorkspaceCacheData,
+};
 use async_lsp::{ErrorCode, LanguageClient, ResponseError};
 use fm::{FileManager, FileMap};
 use fxhash::FxHashMap as HashMap;
@@ -79,7 +81,8 @@ pub(super) fn on_did_close_text_document(
     state.open_documents_count -= 1;
 
     if state.open_documents_count == 0 {
-        state.cached_definitions.clear();
+        state.package_cache.clear();
+        state.workspace_cache.clear();
     }
 
     let document_uri = params.text_document.uri;
@@ -155,8 +158,15 @@ pub(crate) fn process_workspace_for_noir_document(
             Some(&file_path),
         );
         state.cached_lenses.insert(document_uri.to_string(), collected_lenses);
-        state.cached_definitions.insert(package.root_dir.clone(), context.def_interner);
-        state.cached_def_maps.insert(package.root_dir.clone(), context.def_maps);
+        state.package_cache.insert(
+            package.root_dir.clone(),
+            PackageCacheData {
+                crate_id,
+                crate_graph: context.crate_graph,
+                node_interner: context.def_interner,
+                def_maps: context.def_maps,
+            },
+        );
 
         let fm = &context.file_manager;
         let files = fm.as_file_map();
@@ -165,6 +175,11 @@ pub(crate) fn process_workspace_for_noir_document(
             publish_diagnostics(state, &package.root_dir, files, fm, file_diagnostics);
         }
     }
+
+    state.workspace_cache.insert(
+        workspace.root_dir.clone(),
+        WorkspaceCacheData { file_manager: workspace_file_manager },
+    );
 
     Ok(())
 }

--- a/tooling/lsp/src/requests/references.rs
+++ b/tooling/lsp/src/requests/references.rs
@@ -16,7 +16,7 @@ pub(crate) fn on_references_request(
         find_all_references_in_workspace(
             args.location,
             args.interner,
-            args.interners,
+            args.package_cache,
             args.files,
             include_declaration,
             true,

--- a/tooling/lsp/src/requests/rename.rs
+++ b/tooling/lsp/src/requests/rename.rs
@@ -38,7 +38,7 @@ pub(crate) fn on_rename_request(
         let rename_changes = find_all_references_in_workspace(
             args.location,
             args.interner,
-            args.interners,
+            args.package_cache,
             args.files,
             true,
             false,


### PR DESCRIPTION
# Description

## Problem

LSP is still relatively slow and there are many optimization opportunities we can use.

## Summary

This is just the second commit of #6045

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
