### PR TITLE
feat: show test output when running via LSP

### DIFF
--- a/tooling/lsp/src/requests/code_lens_request.rs
+++ b/tooling/lsp/src/requests/code_lens_request.rs
@@ -120,7 +120,7 @@ pub(crate) fn collect_lenses_for_package(
             arguments: Some(
                 [
                     package_selection_args(workspace, package),
-                    vec!["--exact".into(), func_name.into()],
+                    vec!["--exact".into(), "--show-output".into(), func_name.into()],
                 ]
                 .concat(),
             ),

--- a/tooling/lsp/src/requests/test_run.rs
+++ b/tooling/lsp/src/requests/test_run.rs
@@ -84,7 +84,7 @@ fn on_test_run_request_inner(
                 &state.solver,
                 &mut context,
                 &test_function,
-                false,
+                true,
                 None,
                 Some(workspace.root_dir.clone()),
                 Some(package.name.to_string()),


### PR DESCRIPTION
# Description

## Problem

Alvaro told me that it would be useful to see the output of `println` statements when running tests via LSP.

## Summary

Output is now always shown when running tests via LSP. If you are running a single test it's likely you are debugging it too.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
