### PR TITLE
fix: let LSP suggest fields and methods in LValue chains

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1556,10 +1556,10 @@ fn get_field_type(typ: &Type, name: &str) -> Option<Type> {
 }
 
 fn get_array_element_type(typ: Type) -> Option<Type> {
-    match typ {
+    match typ.follow_bindings() {
         Type::Array(_, typ) | Type::Slice(typ) => Some(*typ),
         Type::Alias(alias_type, generics) => {
-            let typ = alias_type.borrow().get_type(&generics).follow_bindings();
+            let typ = alias_type.borrow().get_type(&generics);
             get_array_element_type(typ)
         }
         _ => None,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1559,7 +1559,7 @@ fn get_array_element_type(typ: Type) -> Option<Type> {
     match typ {
         Type::Array(_, typ) | Type::Slice(typ) => Some(*typ),
         Type::Alias(alias_type, generics) => {
-            let typ = alias_type.borrow().get_type(&generics);
+            let typ = alias_type.borrow().get_type(&generics).follow_bindings();
             get_array_element_type(typ)
         }
         _ => None,

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2015,4 +2015,108 @@ mod completion_tests {
         )
         .await;
     }
+
+    #[test]
+    async fn test_suggests_when_assignment_follows_in_chain_1() {
+        let src = r#"
+        struct Foo {
+            bar: Bar
+        }
+
+        struct Bar {
+            baz: Field
+        }
+
+        fn f(foo: Foo) {
+            let mut x = 1;
+
+            foo.bar.>|<
+
+            x = 2;
+        }"#;
+
+        assert_completion(src, vec![field_completion_item("baz", "Field")]).await;
+    }
+
+    #[test]
+    async fn test_suggests_when_assignment_follows_in_chain_2() {
+        let src = r#"
+        struct Foo {
+            bar: Bar
+        }
+
+        struct Bar {
+            baz: Baz
+        }
+
+        struct Baz {
+            qux: Field
+        }
+
+        fn f(foo: Foo) {
+            let mut x = 1;
+
+            foo.bar.baz.>|<
+
+            x = 2;
+        }"#;
+
+        assert_completion(src, vec![field_completion_item("qux", "Field")]).await;
+    }
+
+    #[test]
+    async fn test_suggests_when_assignment_follows_in_chain_3() {
+        let src = r#"
+        struct Foo {
+            foo: Field
+        }
+
+        fn execute() {
+            let a = Foo { foo: 1 };
+            a.>|<
+
+            x = 1;
+        }"#;
+
+        assert_completion(src, vec![field_completion_item("foo", "Field")]).await;
+    }
+
+    #[test]
+    async fn test_suggests_when_assignment_follows_in_chain_4() {
+        let src = r#"
+        struct Foo {
+            bar: Bar
+        }
+
+        struct Bar {
+            baz: Field
+        }
+
+        fn execute() {
+            let foo = Foo { foo: 1 };
+            foo.bar.>|<
+
+            x = 1;
+        }"#;
+
+        assert_completion(src, vec![field_completion_item("baz", "Field")]).await;
+    }
+
+    #[test]
+    async fn test_suggests_when_assignment_follows_in_chain_with_index() {
+        let src = r#"
+        struct Foo {
+            bar: Field
+        }
+
+        fn f(foos: [Foo; 3]) {
+            let mut x = 1;
+
+            foos[0].>|<
+
+            x = 2;
+        }"#;
+
+        assert_completion(src, vec![field_completion_item("bar", "Field")]).await;
+    }
 }


### PR DESCRIPTION
# Description

## Problem

LSP autocompletion didn't trigger in some cases.

## Summary

Makes LSP autocompletion work when typing a dot but in the next line an l-value assignment follows. In that case the current line and the line that follows are parsed as a single assignment to an l-value and we must complete in the middle of that entire expression.

## Additional Context

Also adds a missing `follow_bindings()` that caused some of these cases to not work.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
