### PR TITLE
feat: allow visibility modifiers in struct definitions

### DIFF
--- a/compiler/noirc_frontend/src/ast/structure.rs
+++ b/compiler/noirc_frontend/src/ast/structure.rs
@@ -6,13 +6,14 @@ use crate::token::SecondaryAttribute;
 use iter_extended::vecmap;
 use noirc_errors::Span;
 
-use super::Documented;
+use super::{Documented, ItemVisibility};
 
 /// Ast node for a struct
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NoirStruct {
     pub name: Ident,
     pub attributes: Vec<SecondaryAttribute>,
+    pub visibility: ItemVisibility,
     pub generics: UnresolvedGenerics,
     pub fields: Vec<Documented<StructField>>,
     pub span: Span,

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -998,7 +998,7 @@ pub fn collect_struct(
     }
 
     if interner.is_in_lsp_mode() {
-        interner.register_struct(id, name.to_string(), parent_module_id);
+        interner.register_struct(id, name.to_string(), visibility, parent_module_id);
     }
 
     Some((id, unresolved))

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -979,6 +979,15 @@ pub fn collect_struct(
     let visibility = unresolved.struct_def.visibility;
     let result = def_map.modules[module_id.0].declare_struct(name.clone(), visibility, id);
 
+    let parent_module_id = ModuleId { krate, local_id: module_id };
+
+    interner.usage_tracker.add_unused_item(
+        parent_module_id,
+        name.clone(),
+        UnusedItem::Struct(id),
+        visibility,
+    );
+
     if let Err((first_def, second_def)) = result {
         let error = DefCollectorErrorKind::Duplicate {
             typ: DuplicateType::TypeDefinition,
@@ -989,7 +998,6 @@ pub fn collect_struct(
     }
 
     if interner.is_in_lsp_mode() {
-        let parent_module_id = ModuleId { krate, local_id: module_id };
         interner.register_struct(id, name.to_string(), parent_module_id);
     }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -976,7 +976,8 @@ pub fn collect_struct(
     }
 
     // Add the struct to scope so its path can be looked up later
-    let result = def_map.modules[module_id.0].declare_struct(name.clone(), id);
+    let visibility = unresolved.struct_def.visibility;
+    let result = def_map.modules[module_id.0].declare_struct(name.clone(), visibility, id);
 
     if let Err((first_def, second_def)) = result {
         let error = DefCollectorErrorKind::Duplicate {

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -100,8 +100,13 @@ impl ModuleData {
         self.declare(name, ItemVisibility::Public, id.into(), None)
     }
 
-    pub fn declare_struct(&mut self, name: Ident, id: StructId) -> Result<(), (Ident, Ident)> {
-        self.declare(name, ItemVisibility::Public, ModuleDefId::TypeId(id), None)
+    pub fn declare_struct(
+        &mut self,
+        name: Ident,
+        visibility: ItemVisibility,
+        id: StructId,
+    ) -> Result<(), (Ident, Ident)> {
+        self.declare(name, visibility, ModuleDefId::TypeId(id), None)
     }
 
     pub fn declare_type_alias(

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -298,11 +298,10 @@ impl NodeInterner {
         &mut self,
         id: StructId,
         name: String,
+        visibility: ItemVisibility,
         parent_module_id: ModuleId,
     ) {
         self.add_definition_location(ReferenceId::Struct(id), Some(parent_module_id));
-
-        let visibility = ItemVisibility::Public;
         self.register_name_for_auto_import(name, ModuleDefId::TypeId(id), visibility, None);
     }
 

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -1,6 +1,7 @@
 use chumsky::prelude::*;
 
 use crate::ast::{Documented, NoirStruct, StructField};
+use crate::parser::parser::visibility::item_visibility;
 use crate::{
     parser::{
         parser::{
@@ -30,13 +31,21 @@ pub(super) fn struct_definition() -> impl NoirParser<TopLevelStatementKind> {
         .or(just(Semicolon).to(Vec::new()));
 
     attributes()
+        .then(item_visibility())
         .then_ignore(keyword(Struct))
         .then(ident())
         .then(function::generics())
         .then(fields)
-        .validate(|(((attributes, name), generics), fields), span, emit| {
+        .validate(|((((attributes, visibility), name), generics), fields), span, emit| {
             let attributes = validate_secondary_attributes(attributes, span, emit);
-            TopLevelStatementKind::Struct(NoirStruct { name, attributes, generics, fields, span })
+            TopLevelStatementKind::Struct(NoirStruct {
+                name,
+                attributes,
+                visibility,
+                generics,
+                fields,
+                span,
+            })
         })
 }
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3424,6 +3424,30 @@ fn errors_on_unused_function() {
 }
 
 #[test]
+fn errors_on_unused_struct() {
+    let src = r#"
+    struct Foo {}
+    struct Bar {}
+
+    fn main() {
+        let _ = Bar {};
+    }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ResolverError(ResolverError::UnusedItem { ident, item_type }) =
+        &errors[0].0
+    else {
+        panic!("Expected an unused item error");
+    };
+
+    assert_eq!(ident.to_string(), "Foo");
+    assert_eq!(*item_type, "struct");
+}
+
+#[test]
 fn constrained_reference_to_unconstrained() {
     let src = r#"
     fn main(mut x: u32, y: pub u32) {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2742,8 +2742,8 @@ fn duplicate_struct_field() {
     assert_eq!(first_def.to_string(), "x");
     assert_eq!(second_def.to_string(), "x");
 
-    assert_eq!(first_def.span().start(), 26);
-    assert_eq!(second_def.span().start(), 42);
+    assert_eq!(first_def.span().start(), 30);
+    assert_eq!(second_def.span().start(), 46);
 }
 
 #[test]

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1565,11 +1565,11 @@ fn struct_numeric_generic_in_function() {
 #[test]
 fn struct_numeric_generic_in_struct() {
     let src = r#"
-    struct Foo {
+    pub struct Foo {
         inner: u64
     }
 
-    struct Bar<let N: Foo> { }
+    pub struct Bar<let N: Foo> { }
     "#;
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 1);
@@ -1658,7 +1658,7 @@ fn numeric_generic_in_function_signature() {
 #[test]
 fn numeric_generic_as_struct_field_type() {
     let src = r#"
-    struct Foo<let N: u32> {
+    pub struct Foo<let N: u32> {
         a: Field,
         b: N,
     }
@@ -1674,7 +1674,7 @@ fn numeric_generic_as_struct_field_type() {
 #[test]
 fn normal_generic_as_array_length() {
     let src = r#"
-    struct Foo<N> {
+    pub struct Foo<N> {
         a: Field,
         b: [Field; N],
     }
@@ -1719,11 +1719,11 @@ fn numeric_generic_as_param_type() {
 #[test]
 fn numeric_generic_used_in_nested_type_fail() {
     let src = r#"
-    struct Foo<let N: u32> {
+    pub struct Foo<let N: u32> {
         a: Field,
         b: Bar<N>,
     }
-    struct Bar<N> {
+    pub struct Bar<N> {
         inner: N
     }
     "#;
@@ -1738,11 +1738,11 @@ fn numeric_generic_used_in_nested_type_fail() {
 #[test]
 fn normal_generic_used_in_nested_array_length_fail() {
     let src = r#"
-    struct Foo<N> {
+    pub struct Foo<N> {
         a: Field,
         b: Bar<N>,
     }
-    struct Bar<let N: u32> {
+    pub struct Bar<let N: u32> {
         inner: [Field; N]
     }
     "#;
@@ -1756,11 +1756,11 @@ fn numeric_generic_used_in_nested_type_pass() {
     // The order of these structs should not be changed to make sure
     // that we are accurately resolving all struct generics before struct fields
     let src = r#"
-    struct NestedNumeric<let N: u32> {
+    pub struct NestedNumeric<let N: u32> {
         a: Field,
         b: InnerNumeric<N>
     }
-    struct InnerNumeric<let N: u32> {
+    pub struct InnerNumeric<let N: u32> {
         inner: [u64; N],
     }    
     "#;
@@ -2721,7 +2721,7 @@ fn bit_not_on_untyped_integer() {
 #[test]
 fn duplicate_struct_field() {
     let src = r#"
-    struct Foo {
+    pub struct Foo {
         x: i32,
         x: i32,
     }

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::{
     ast::{Ident, ItemVisibility},
     hir::def_map::ModuleId,
+    macros_api::StructId,
     node_interner::FuncId,
 };
 
@@ -10,6 +11,7 @@ use crate::{
 pub enum UnusedItem {
     Import,
     Function(FuncId),
+    Struct(StructId),
 }
 
 impl UnusedItem {
@@ -17,6 +19,7 @@ impl UnusedItem {
         match self {
             UnusedItem::Import => "import",
             UnusedItem::Function(_) => "function",
+            UnusedItem::Struct(_) => "struct",
         }
     }
 }

--- a/docs/docs/noir/concepts/data_types/structs.md
+++ b/docs/docs/noir/concepts/data_types/structs.md
@@ -68,3 +68,15 @@ fn get_octopus() -> Animal {
 
 The new variables can be bound with names different from the original struct field names, as
 showcased in the `legs --> feet` binding in the example above.
+
+By default, like functions, structs are private to the module the exist in. You can use `pub`
+to make the struct public or `pub(crate)` to make it public to just its crate:
+
+```rust
+// This struct is now public
+pub struct Animal {
+    hands: Field,
+    legs: Field,
+    eyes: u8,
+}
+```

--- a/noir_stdlib/src/bigint.nr
+++ b/noir_stdlib/src/bigint.nr
@@ -12,7 +12,7 @@ global secpr1_fq = &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF];
 global secpr1_fr = &[81, 37, 99, 252, 194, 202, 185, 243, 132, 158, 23, 167, 173, 250, 230, 188, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 255, 255, 255, 255];
 // docs:start:big_int_definition
-struct BigInt {
+pub struct BigInt {
     pointer: u32,
     modulus: u32,
 }
@@ -49,7 +49,7 @@ trait BigField {
     fn to_le_bytes(self) -> [u8];
 }
 
-struct Secpk1Fq {
+pub struct Secpk1Fq {
    array: [u8;32],
 }
 
@@ -106,7 +106,7 @@ impl Eq for Secpk1Fq {
     }
 }
 
-struct Secpk1Fr {
+pub struct Secpk1Fr {
     array: [u8;32],
 }
 
@@ -163,7 +163,7 @@ impl Eq for Secpk1Fr {
     }
 }
 
-struct Bn254Fr {
+pub struct Bn254Fr {
     array: [u8;32],
 }
 
@@ -220,7 +220,7 @@ impl Eq for Bn254Fr {
     }
 }
 
-struct Bn254Fq {
+pub struct Bn254Fq {
     array: [u8;32],
 }
 
@@ -277,7 +277,7 @@ impl Eq for Bn254Fq {
     }
 }
 
-struct Secpr1Fq {
+pub struct Secpr1Fq {
     array: [u8;32],
 }
 
@@ -334,7 +334,7 @@ impl Eq for Secpr1Fq {
     }
 }
 
-struct Secpr1Fr {
+pub struct Secpr1Fr {
     array: [u8;32],
 }
 

--- a/noir_stdlib/src/cmp.nr
+++ b/noir_stdlib/src/cmp.nr
@@ -150,7 +150,7 @@ impl Eq for Ordering {
 
 // Noir doesn't have enums yet so we emulate (Lt | Eq | Gt) with a struct
 // that has 3 public functions for constructing the struct.
-struct Ordering {
+pub struct Ordering {
     result: Field,
 }
 

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -22,7 +22,7 @@ use crate::{cmp::Eq, convert::From};
 /// assert(vector.len() == 5);
 /// assert(vector.max_len() == 10);
 /// ```
-struct BoundedVec<T, let MaxLen: u32> {
+pub struct BoundedVec<T, let MaxLen: u32> {
     storage: [T; MaxLen],
     len: u32,
 }

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -30,7 +30,7 @@ global MAX_LOAD_FACTOR_DEN0MINATOR = 4;
 /// 
 /// let two = map.get(1).unwrap();
 /// ```
-struct HashMap<K, V, let N: u32, B> {
+pub struct HashMap<K, V, let N: u32, B> {
     _table: [Slot<K, V>; N],
 
     /// Amount of valid elements in the map.

--- a/noir_stdlib/src/collections/umap.nr
+++ b/noir_stdlib/src/collections/umap.nr
@@ -11,7 +11,7 @@ use crate::hash::{Hash, Hasher, BuildHasher};
 //
 // Compared to the constrained HashMap type, UHashMap can grow automatically
 // as needed and is more efficient since it can break out of loops early.
-struct UHashMap<K, V, B> {
+pub struct UHashMap<K, V, B> {
     _table: [Slot<K, V>],
 
     // Amount of valid elements in the map.

--- a/noir_stdlib/src/collections/vec.nr
+++ b/noir_stdlib/src/collections/vec.nr
@@ -1,4 +1,4 @@
-struct Vec<T> { 
+pub struct Vec<T> { 
     slice: [T]
 }
 // A mutable vector type implemented as a wrapper around immutable slices.

--- a/noir_stdlib/src/ec/consts/te.nr
+++ b/noir_stdlib/src/ec/consts/te.nr
@@ -1,7 +1,7 @@
 use crate::ec::tecurve::affine::Point as TEPoint;
 use crate::ec::tecurve::affine::Curve as TECurve;
 
-struct BabyJubjub {
+pub struct BabyJubjub {
     curve: TECurve,
     base8: TEPoint,
     suborder: Field,

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -15,14 +15,14 @@ mod affine {
     use crate::cmp::Eq;
 
     // Curve specification
-    struct Curve { // Montgomery Curve configuration (ky^2 = x^3 + j*x^2 + x)
+    pub struct Curve { // Montgomery Curve configuration (ky^2 = x^3 + j*x^2 + x)
         j: Field,
         k: Field,
         // Generator as point in Cartesian coordinates
         gen: Point
     }
     // Point in Cartesian coordinates
-    struct Point {
+    pub struct Point {
         x: Field,
         y: Field,
         infty: bool // Indicator for point at infinity
@@ -222,14 +222,14 @@ mod curvegroup {
     use crate::ec::tecurve::curvegroup::Point as TEPoint;
     use crate::cmp::Eq;
 
-    struct Curve { // Montgomery Curve configuration (ky^2 z = x*(x^2 + j*x*z + z*z))
+    pub struct Curve { // Montgomery Curve configuration (ky^2 z = x*(x^2 + j*x*z + z*z))
         j: Field,
         k: Field,
         // Generator as point in projective coordinates
         gen: Point
     }
     // Point in projective coordinates
-    struct Point {
+    pub struct Point {
         x: Field,
         y: Field,
         z: Field

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -10,7 +10,7 @@ mod affine {
     use crate::cmp::Eq;
 
     // Curve specification
-    struct Curve { // Short Weierstraß curve
+    pub struct Curve { // Short Weierstraß curve
         // Coefficients in defining equation y^2 = x^3 + ax + b
         a: Field,
         b: Field,
@@ -18,7 +18,7 @@ mod affine {
         gen: Point
     }
     // Point in Cartesian coordinates
-    struct Point {
+    pub struct Point {
         x: Field,
         y: Field,
         infty: bool // Indicator for point at infinity
@@ -194,7 +194,7 @@ mod curvegroup {
     use crate::cmp::Eq;
 
     // Curve specification
-    struct Curve { // Short Weierstraß curve
+    pub struct Curve { // Short Weierstraß curve
         // Coefficients in defining equation y^2 = x^3 + axz^4 + bz^6
         a: Field,
         b: Field,
@@ -202,7 +202,7 @@ mod curvegroup {
         gen: Point
     }
     // Point in three-dimensional Jacobian coordinates
-    struct Point {
+    pub struct Point {
         x: Field,
         y: Field,
         z: Field // z = 0 corresponds to point at infinity.

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -12,7 +12,7 @@ mod affine {
     use crate::cmp::Eq;
 
     // Curve specification
-    struct Curve { // Twisted Edwards curve
+    pub struct Curve { // Twisted Edwards curve
         // Coefficients in defining equation ax^2 + y^2 = 1 + dx^2y^2
         a: Field,
         d: Field,
@@ -20,7 +20,7 @@ mod affine {
         gen: Point
     }
     // Point in Cartesian coordinates
-    struct Point {
+    pub struct Point {
         x: Field,
         y: Field
     }
@@ -204,7 +204,7 @@ mod curvegroup {
     use crate::cmp::Eq;
 
     // Curve specification
-    struct Curve { // Twisted Edwards curve
+    pub struct Curve { // Twisted Edwards curve
         // Coefficients in defining equation a(x^2 + y^2)z^2 = z^4 + dx^2y^2
         a: Field,
         d: Field,
@@ -212,7 +212,7 @@ mod curvegroup {
         gen: Point
     }
     // Point in extended twisted Edwards coordinates
-    struct Point {
+    pub struct Point {
         x: Field,
         y: Field,
         t: Field,

--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -4,7 +4,7 @@ use crate::cmp::Eq;
 /// A point on the embedded elliptic curve
 /// By definition, the base field of the embedded curve is the scalar field of the proof system curve, i.e the Noir Field.
 /// x and y denotes the Weierstrass coordinates of the point, if is_infinite is false.
-struct EmbeddedCurvePoint {
+pub struct EmbeddedCurvePoint {
     x: Field,
     y: Field,
     is_infinite: bool
@@ -56,7 +56,7 @@ impl Eq for EmbeddedCurvePoint {
 /// Scalar for the embedded curve represented as low and high limbs
 /// By definition, the scalar field of the embedded curve is base field of the proving system curve.
 /// It may not fit into a Field element, so it is represented with two Field elements; its low and high limbs.
-struct EmbeddedCurveScalar {
+pub struct EmbeddedCurveScalar {
     lo: Field,
     hi: Field,
 }

--- a/noir_stdlib/src/hash/mimc.nr
+++ b/noir_stdlib/src/hash/mimc.nr
@@ -126,7 +126,7 @@ pub fn mimc_bn254<let N: u32>(array: [Field; N]) -> Field {
     r
 }
 
-struct MimcHasher {
+pub struct MimcHasher {
     _state: [Field],
 }
 

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -166,7 +166,7 @@ trait BuildHasher<H> where H: Hasher{
     fn build_hasher(self) -> H;
 }
 
-struct BuildHasherDefault<H>;
+pub struct BuildHasherDefault<H>;
 
 impl<H> BuildHasher<H> for BuildHasherDefault<H>
 where 

--- a/noir_stdlib/src/hash/poseidon/mod.nr
+++ b/noir_stdlib/src/hash/poseidon/mod.nr
@@ -5,7 +5,7 @@ use crate::default::Default;
 // A config struct defining the parameters of the Poseidon instance to use.
 //
 // A thorough writeup of this method (along with an unoptimized method) can be found at: https://spec.filecoin.io/algorithms/crypto/poseidon/
-struct PoseidonConfig<let T: u32, let N: u32, let X: u32> { 
+pub struct PoseidonConfig<let T: u32, let N: u32, let X: u32> { 
     // State width, should be equal to `T`
     t: Field,
     // Number of full rounds. should be even
@@ -165,7 +165,7 @@ fn sigma<let O: u32>(x: [Field; O]) -> [Field; O] {
     y
 }
 
-struct PoseidonHasher{
+pub struct PoseidonHasher{
     _state: [Field],
 }
 

--- a/noir_stdlib/src/hash/poseidon2.nr
+++ b/noir_stdlib/src/hash/poseidon2.nr
@@ -3,7 +3,7 @@ use crate::default::Default;
 
 comptime global RATE: u32 = 3;
 
-struct Poseidon2 {
+pub struct Poseidon2 {
     cache: [Field;3],
     state: [Field;4],
     cache_size: u32,
@@ -82,7 +82,7 @@ impl Poseidon2 {
     }
 }
 
-struct Poseidon2Hasher{
+pub struct Poseidon2Hasher{
     _state: [Field],
 }
 

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -237,4 +237,14 @@ mod tests {
         )
     }
     // docs:end:big-derive-usage-example
+
+    // This function is just to remove unused warnings
+    fn remove_unused_warnings() {
+        let _: Bar = crate::panic::panic(f"");
+        let _: MyStruct = crate::panic::panic(f"");
+        let _: MyOtherStruct = crate::panic::panic(f"");
+        let _ = derive_do_nothing(crate::panic::panic(f""));
+        let _ = derive_do_nothing_alt(crate::panic::panic(f""));
+        remove_unused_warnings();
+    }
 }

--- a/noir_stdlib/src/meta/op.nr
+++ b/noir_stdlib/src/meta/op.nr
@@ -1,5 +1,5 @@
 #[derive(Eq, Hash)]
-struct UnaryOp {
+pub struct UnaryOp {
     op: Field
 }
 
@@ -47,7 +47,7 @@ impl UnaryOp {
 }
 
 #[derive(Eq, Hash)]
-struct BinaryOp {
+pub struct BinaryOp {
     op: Field
 }
 

--- a/noir_stdlib/src/option.nr
+++ b/noir_stdlib/src/option.nr
@@ -2,7 +2,7 @@ use crate::hash::{Hash, Hasher};
 use crate::cmp::{Ordering, Ord, Eq};
 use crate::default::Default;
 
-struct Option<T> {
+pub struct Option<T> {
     _is_some: bool,
     _value: T,
 }

--- a/noir_stdlib/src/test.nr
+++ b/noir_stdlib/src/test.nr
@@ -16,7 +16,7 @@ unconstrained fn set_mock_times_oracle(id: Field, times: u64) {}
 #[oracle(clear_mock)]
 unconstrained fn clear_mock_oracle(id: Field) {}
 
-struct OracleMock {
+pub struct OracleMock {
     id: Field,
 }
 

--- a/noir_stdlib/src/uint128.nr
+++ b/noir_stdlib/src/uint128.nr
@@ -3,7 +3,7 @@ use crate::cmp::{Eq, Ord, Ordering};
 
 global pow64 : Field = 18446744073709551616; //2^64;
 global pow63 : Field = 9223372036854775808; // 2^63;
-struct U128 {
+pub struct U128 {
     lo: Field,
     hi: Field,
 }

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -134,7 +134,7 @@ mod tests {
         let src = r#"
         mod foo {
             mod bar {
-                struct SomeTypeInBar {}
+                pub struct SomeTypeInBar {}
             }
         }
 
@@ -144,7 +144,7 @@ mod tests {
         let expected = r#"
         mod foo {
             mod bar {
-                struct SomeTypeInBar {}
+                pub struct SomeTypeInBar {}
             }
         }
 

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -160,7 +160,7 @@ mod tests {
 
         let src = r#"mod foo {
     mod bar {
-        struct SomeTypeInBar {}
+        pub struct SomeTypeInBar {}
     }
 }
 
@@ -170,7 +170,7 @@ fn foo(x: SomeType>|<InBar) {}"#;
 
 mod foo {
     mod bar {
-        struct SomeTypeInBar {}
+        pub struct SomeTypeInBar {}
     }
 }
 

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -176,7 +176,7 @@ mod completion_tests {
     async fn test_use_struct() {
         let src = r#"
             mod foo {
-                struct Foo {}
+                pub struct Foo {}
             }
             use foo::>|<
         "#;


### PR DESCRIPTION
# Description

## Problem

Part of #4515
Part of #4775

## Summary

Allows marking structs as pub or pub(crate). Also will now report unused structs.

## Additional Context

Let me know if some of the structs I marked as `pub` shouldn't actually be `pub`. I didn't mark some as pub, I think only the ones used for tests.

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
