### PR TITLE
fix: Be more lenient with semicolons on interned expressions

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -109,6 +109,8 @@ impl StatementKind {
                     // Semicolons are optional for these expressions
                     (ExpressionKind::Block(_), semi, _)
                     | (ExpressionKind::Unsafe(..), semi, _)
+                    | (ExpressionKind::Interned(..), semi, _)
+                    | (ExpressionKind::InternedStatement(..), semi, _)
                     | (ExpressionKind::If(_), semi, _) => {
                         if semi.is_some() {
                             StatementKind::Semi(expr)
@@ -865,7 +867,11 @@ impl Display for StatementKind {
 
 impl Display for LetStatement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "let {}: {} = {}", self.pattern, self.r#type, self.expression)
+        if matches!(&self.r#type.typ, UnresolvedTypeData::Unspecified) {
+            write!(f, "let {} = {}", self.pattern, self.expression)
+        } else {
+            write!(f, "let {}: {} = {}", self.pattern, self.r#type, self.expression)
+        }
     }
 }
 

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -1621,11 +1621,11 @@ mod test {
     #[test]
     fn statement_recovery() {
         let cases = vec![
-            Case { source: "let a = 4 + 3", expect: "let a: unspecified = (4 + 3)", errors: 0 },
+            Case { source: "let a = 4 + 3", expect: "let a = (4 + 3)", errors: 0 },
             Case { source: "let a: = 4 + 3", expect: "let a: error = (4 + 3)", errors: 1 },
-            Case { source: "let = 4 + 3", expect: "let $error: unspecified = (4 + 3)", errors: 1 },
-            Case { source: "let = ", expect: "let $error: unspecified = Error", errors: 2 },
-            Case { source: "let", expect: "let $error: unspecified = Error", errors: 3 },
+            Case { source: "let = 4 + 3", expect: "let $error = (4 + 3)", errors: 1 },
+            Case { source: "let = ", expect: "let $error = Error", errors: 2 },
+            Case { source: "let", expect: "let $error = Error", errors: 3 },
             Case { source: "foo = one two three", expect: "foo = one", errors: 1 },
             Case { source: "constrain", expect: "constrain Error", errors: 2 },
             Case { source: "assert", expect: "constrain Error", errors: 1 },
@@ -1659,7 +1659,7 @@ mod test {
             },
             Case {
                 source: "{ return 123; let foo = 4 + 3; }",
-                expect: concat!("{\n", "    Error\n", "    let foo: unspecified = (4 + 3)\n", "}"),
+                expect: concat!("{\n", "    Error\n", "    let foo = (4 + 3)\n", "}"),
                 errors: 1,
             },
             Case {
@@ -1709,7 +1709,7 @@ mod test {
                 expect: concat!(
                     "{\n",
                     "    if ({\n",
-                    "        let foo: unspecified = (bar { baz: 42 })\n",
+                    "        let foo = (bar { baz: 42 })\n",
                     "        (foo == (bar { baz: 42 }))\n",
                     "    }) {\n",
                     "    }\n",


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6060

## Summary\*

We had `ExpressionKind::Interned` as always requiring a semicolon to separate two expressions, but this isn't true for all expression types (blocks, if). We can't check what is interned so I just always made the semicolon optional.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
