### PR TITLE
fix: don't crash on untyped global used as array length

### DIFF
--- a/test_programs/compile_failure/global_without_a_type_used_as_array_length/Nargo.toml
+++ b/test_programs/compile_failure/global_without_a_type_used_as_array_length/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "global_without_a_type_used_as_array_length"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_failure/global_without_a_type_used_as_array_length/src/main.nr
+++ b/test_programs/compile_failure/global_without_a_type_used_as_array_length/src/main.nr
@@ -1,0 +1,2 @@
+global BAR = OOPS;
+global X: [Field; BAR] = [];


### PR DESCRIPTION
# Description

## Problem

Resolves #6046

## Summary

Another case of an unhandled`DefinitionId::dummy()`.

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
