### PR TITLE
feat!: always print Type::Constant kinds

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -163,7 +163,7 @@ impl std::fmt::Display for Kind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Kind::Normal => write!(f, "normal"),
-            Kind::Numeric(typ) => write!(f, "numeric {}", typ),
+            Kind::Numeric(typ) => write!(f, "{}", typ),
         }
     }
 }
@@ -676,7 +676,7 @@ impl std::fmt::Display for Type {
                 TypeBinding::Unbound(_) if name.is_empty() => write!(f, "_"),
                 TypeBinding::Unbound(_) => write!(f, "{name}"),
             },
-            Type::Constant(x, _kind) => write!(f, "{x}"),
+            Type::Constant(x, kind) => write!(f, "({}: {})", x, kind),
             Type::Forall(typevars, typ) => {
                 let typevars = vecmap(typevars, |var| var.id().to_string());
                 write!(f, "forall {}. {}", typevars.join(" "), typ)

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2166,7 +2166,7 @@ fn impl_stricter_than_trait_different_object_generics() {
         ..
     }) = &errors[1].0
     {
-        assert!(matches!(constraint_typ.to_string().as_str(), "[B; 8]"));
+        assert!(matches!(constraint_typ.to_string().as_str(), "[B; (8: u32)]"));
         assert!(matches!(constraint_name.as_str(), "MyTrait"));
     } else {
         panic!("Expected DefCollectorErrorKind::ImplIsStricterThanTrait but got {:?}", errors[0].0);


### PR DESCRIPTION
# Description

## Problem\*

Instead of printing:
```bash
Expected type [RootParityInput; 4)], found type [RootParityInput; 4)]
```

We print:
```bash
Expected type [RootParityInput; (4: u32)], found type [RootParityInput; (4: Field)]
```

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
