### PR TITLE
fix!: Infer globals to be u32 when used in a type

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -215,7 +215,7 @@ impl<'context> Elaborator<'context> {
                         UnresolvedTypeExpression::Constant(0, span)
                     });
 
-                let length = self.convert_expression_type(length, span);
+                let length = self.convert_expression_type(length, &Kind::u32(), span);
                 let (repeated_element, elem_type) = self.elaborate_expression(*repeated_element);
 
                 let length_clone = length.clone();

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -77,22 +77,22 @@ impl<'context> Elaborator<'context> {
             FieldElement => Type::FieldElement,
             Array(size, elem) => {
                 let elem = Box::new(self.resolve_type_inner(*elem, kind));
-                let size = self.convert_expression_type(size, span);
+                let size = self.convert_expression_type(size, &Kind::u32(), span);
                 Type::Array(Box::new(size), elem)
             }
             Slice(elem) => {
                 let elem = Box::new(self.resolve_type_inner(*elem, kind));
                 Type::Slice(elem)
             }
-            Expression(expr) => self.convert_expression_type(expr, span),
+            Expression(expr) => self.convert_expression_type(expr, kind, span),
             Integer(sign, bits) => Type::Integer(sign, bits),
             Bool => Type::Bool,
             String(size) => {
-                let resolved_size = self.convert_expression_type(size, span);
+                let resolved_size = self.convert_expression_type(size, &Kind::u32(), span);
                 Type::String(Box::new(resolved_size))
             }
             FormatString(size, fields) => {
-                let resolved_size = self.convert_expression_type(size, span);
+                let resolved_size = self.convert_expression_type(size, &Kind::u32(), span);
                 let fields = self.resolve_type_inner(*fields, kind);
                 Type::FmtString(Box::new(resolved_size), Box::new(fields))
             }
@@ -423,23 +423,22 @@ impl<'context> Elaborator<'context> {
         }
     }
 
-    /// Resolves a constant expression for an array or string.
-    /// Note that the kind of this expression is always expected to be u32 (unlike struct args)
     pub(super) fn convert_expression_type(
         &mut self,
         length: UnresolvedTypeExpression,
+        expected_kind: &Kind,
         span: Span,
     ) -> Type {
         match length {
             UnresolvedTypeExpression::Variable(path) => {
                 let typ = self.resolve_named_type(path, GenericTypeArgs::default());
-                self.check_u32_kind(typ, span)
+                self.check_kind(typ, expected_kind, span)
             }
             UnresolvedTypeExpression::Constant(int, _span) => Type::Constant(int, Kind::u32()),
             UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, span) => {
                 let (lhs_span, rhs_span) = (lhs.span(), rhs.span());
-                let lhs = self.convert_expression_type(*lhs, lhs_span);
-                let rhs = self.convert_expression_type(*rhs, rhs_span);
+                let lhs = self.convert_expression_type(*lhs, expected_kind, lhs_span);
+                let rhs = self.convert_expression_type(*rhs, expected_kind, rhs_span);
 
                 match (lhs, rhs) {
                     (Type::Constant(lhs, lhs_kind), Type::Constant(rhs, rhs_kind)) => {
@@ -463,16 +462,16 @@ impl<'context> Elaborator<'context> {
             }
             UnresolvedTypeExpression::AsTraitPath(path) => {
                 let typ = self.resolve_as_trait_path(*path);
-                self.check_u32_kind(typ, span)
+                self.check_kind(typ, expected_kind, span)
             }
         }
     }
 
-    fn check_u32_kind(&mut self, typ: Type, span: Span) -> Type {
+    fn check_kind(&mut self, typ: Type, expected_kind: &Kind, span: Span) -> Type {
         if let Some(kind) = typ.kind() {
-            if !kind.unifies(&Kind::u32()) {
+            if !kind.unifies(expected_kind) {
                 self.push_err(TypeCheckError::TypeKindMismatch {
-                    expected_kind: Kind::u32().to_string(),
+                    expected_kind: expected_kind.to_string(),
                     expr_kind: kind.to_string(),
                     expr_span: span,
                 });

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -434,7 +434,9 @@ impl<'context> Elaborator<'context> {
                 let typ = self.resolve_named_type(path, GenericTypeArgs::default());
                 self.check_kind(typ, expected_kind, span)
             }
-            UnresolvedTypeExpression::Constant(int, _span) => Type::Constant(int, Kind::u32()),
+            UnresolvedTypeExpression::Constant(int, _span) => {
+                Type::Constant(int, expected_kind.clone())
+            }
             UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, span) => {
                 let (lhs_span, rhs_span) = (lhs.span(), rhs.span());
                 let lhs = self.convert_expression_type(*lhs, expected_kind, lhs_span);

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -61,8 +61,6 @@ impl<'context> Elaborator<'context> {
     pub fn resolve_type_inner(&mut self, typ: UnresolvedType, kind: &Kind) -> Type {
         use crate::ast::UnresolvedTypeData::*;
 
-        eprintln!("Resolving {typ}");
-
         let span = typ.span;
         let (named_path_span, is_self_type_name, is_synthetic) =
             if let Named(ref named_path, _, synthetic) = typ.typ {
@@ -80,7 +78,6 @@ impl<'context> Elaborator<'context> {
             Array(size, elem) => {
                 let elem = Box::new(self.resolve_type_inner(*elem, kind));
                 let size = self.convert_expression_type(size, span);
-                dbg!(&size);
                 Type::Array(Box::new(size), elem)
             }
             Slice(elem) => {
@@ -420,7 +417,6 @@ impl<'context> Elaborator<'context> {
                     .map(|let_statement| Kind::Numeric(Box::new(let_statement.r#type)))
                     .unwrap_or(Kind::u32());
 
-                dbg!(&kind);
                 Some(Type::Constant(self.eval_global_as_array_length(id, path), kind))
             }
             _ => None,

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1616,25 +1616,30 @@ fn numeric_generic_binary_operation_type_mismatch() {
 #[test]
 fn bool_generic_as_loop_bound() {
     let src = r#"
-    pub fn read<let N: bool>() {
-        let mut fields = [0; N];
-        for i in 0..N {
+    pub fn read<let N: bool>() { // error here
+        let mut fields = [0; N]; // error here
+        for i in 0..N {  // error here
             fields[i] = i + 1;
         }
         assert(fields[0] == 1);
     }
     "#;
     let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 2);
+    assert_eq!(errors.len(), 3);
 
     assert!(matches!(
         errors[0].0,
         CompilationError::ResolverError(ResolverError::UnsupportedNumericGenericType { .. }),
     ));
 
+    assert!(matches!(
+        errors[1].0,
+        CompilationError::TypeError(TypeCheckError::TypeKindMismatch { .. }),
+    ));
+
     let CompilationError::TypeError(TypeCheckError::TypeMismatch {
         expected_typ, expr_typ, ..
-    }) = &errors[1].0
+    }) = &errors[2].0
     else {
         panic!("Got an error other than a type mismatch");
     };
@@ -1646,7 +1651,7 @@ fn bool_generic_as_loop_bound() {
 #[test]
 fn numeric_generic_in_function_signature() {
     let src = r#"
-    pub fn foo<let N: u8>(arr: [Field; N]) -> [Field; N] { arr }
+    pub fn foo<let N: u32>(arr: [Field; N]) -> [Field; N] { arr }
     "#;
     assert_no_errors(src);
 }
@@ -3643,4 +3648,41 @@ fn does_not_crash_when_passing_mutable_undefined_variable() {
     };
 
     assert_eq!(name, "undefined");
+}
+
+#[test]
+fn infer_globals_to_u32_from_type_use() {
+    let src = r#"
+        global ARRAY_LEN = 3;
+        global STR_LEN = 2;
+        global FMT_STR_LEN = 2;
+
+        fn main() {
+            let _a: [u32; ARRAY_LEN] = [1, 2, 3];
+            let _b: str<STR_LEN> = "hi";
+            let _c: fmtstr<FMT_STR_LEN, _> = f"hi";
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn non_u32_in_array_length() {
+    let src = r#"
+        global ARRAY_LEN: u8 = 3;
+
+        fn main() {
+            let _a: [u32; ARRAY_LEN] = [1, 2, 3];
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(
+        errors[0].0,
+        CompilationError::TypeError(TypeCheckError::TypeKindMismatch { .. })
+    ));
 }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3686,3 +3686,17 @@ fn non_u32_in_array_length() {
         CompilationError::TypeError(TypeCheckError::TypeKindMismatch { .. })
     ));
 }
+
+#[test]
+fn use_non_u32_generic_in_struct() {
+    let src = r#"
+        struct S<let N: u8> {}
+
+        fn main() {
+            let _: S<3> = S {};
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 0);
+}

--- a/test_programs/compile_success_empty/numeric_generics_explicit/src/main.nr
+++ b/test_programs/compile_success_empty/numeric_generics_explicit/src/main.nr
@@ -28,7 +28,7 @@ fn main() {
 }
 
 // Used in the signature of a function
-fn id<let I: Field>(x: [Field; I]) -> [Field; I] {
+fn id<let I: u32>(x: [Field; I]) -> [Field; I] {
     x
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6081
Resolves https://github.com/noir-lang/noir/issues/6082

## Summary\*

Now that we check kinds explicitly we were erroring if globals weren't already `u32` yet leading to a lot of existing code needing to be changed.

If we change the exact equality to a unification check we can instead infer the globals need to be a `u32` without requiring user code to be changed.

This PR is still breaking since there were causes we didn't catch before of invalid kinds being used in array lengths, e.g. `fn foo<let N: u8>(a: [Field; N])` in one of our unit tests.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
