### PR TITLE
fix: Unify macro result type with actual type

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -97,7 +97,7 @@ pub struct Elaborator<'context> {
 
     def_maps: &'context mut DefMaps,
 
-    file: FileId,
+    pub(crate) file: FileId,
 
     in_unsafe_block: bool,
     nested_loops: usize,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -710,7 +710,7 @@ impl<'context> Elaborator<'context> {
         }
     }
 
-    pub(super) fn unify(
+    pub fn unify(
         &mut self,
         actual: &Type,
         expected: &Type,

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1305,7 +1305,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                     // are inconsistencies or the type needs to be known.
                     let expected_type = self.elaborator.interner.id_type(id);
                     let actual_type = result.get_type();
-                    self.unify(&actual_type, &expected_type, location)
+                    self.unify(&actual_type, &expected_type, location);
                 }
                 Ok(result)
             }
@@ -1323,12 +1323,10 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         // We need to swap out the elaborator's file since we may be
         // in a different one currently, and it uses that for the error location.
         let old_file = std::mem::replace(&mut self.elaborator.file, location.file);
-        self.elaborator.unify(actual, expected, || {
-            TypeCheckError::TypeMismatch {
-                expected_typ: expected.to_string(),
-                expr_typ: actual.to_string(),
-                expr_span: location.span,
-            }
+        self.elaborator.unify(actual, expected, || TypeCheckError::TypeMismatch {
+            expected_typ: expected.to_string(),
+            expr_typ: actual.to_string(),
+            expr_span: location.span,
         });
         self.elaborator.file = old_file;
     }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -12,6 +12,7 @@ use crate::ast::{BinaryOpKind, FunctionKind, IntegerBitSize, Signedness};
 use crate::elaborator::Elaborator;
 use crate::graph::CrateId;
 use crate::hir::def_map::ModuleId;
+use crate::hir::type_check::TypeCheckError;
 use crate::hir_def::expr::ImplKind;
 use crate::hir_def::function::FunctionBody;
 use crate::macros_api::UnaryOp;
@@ -1298,6 +1299,13 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                         elaborator.elaborate_expression(expr).0
                     });
                     result = self.evaluate(expr)?;
+
+                    // Macro calls are typed as type variables during type checking.
+                    // Now that we know the type we need to further unify it in case there
+                    // are inconsistencies or the type needs to be known.
+                    let expected_type = self.elaborator.interner.id_type(id);
+                    let actual_type = result.get_type();
+                    self.unify(&actual_type, &expected_type, location)
                 }
                 Ok(result)
             }
@@ -1309,6 +1317,20 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 Err(InterpreterError::NonFunctionCalled { typ, location })
             }
         }
+    }
+
+    fn unify(&mut self, actual: &Type, expected: &Type, location: Location) {
+        // We need to swap out the elaborator's file since we may be
+        // in a different one currently, and it uses that for the error location.
+        let old_file = std::mem::replace(&mut self.elaborator.file, location.file);
+        self.elaborator.unify(actual, expected, || {
+            TypeCheckError::TypeMismatch {
+                expected_typ: expected.to_string(),
+                expr_typ: actual.to_string(),
+                expr_span: location.span,
+            }
+        });
+        self.elaborator.file = old_file;
     }
 
     fn evaluate_method_call(

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -130,8 +130,13 @@ mod tests {
             // let _a: Quoted = quote { 1 };
             let _a: Quoted = quote_one();
 
-            // let _b: i32 = 1;
-            let _b: i32 = quote_one!();
+            // let _b: Field = 1;
+            let _b: Field = quote_one!();
+
+            // Since integers default to fields, if we
+            // want a different type we have to explicitly cast
+            // let _c: i32 = 1 as i32;
+            let _c: i32 = quote_one!() as i32;
         }
     }
     // docs:end:quote-example

--- a/test_programs/compile_success_empty/macro_result_type/Nargo.toml
+++ b/test_programs/compile_success_empty/macro_result_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "macro_result_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/macro_result_type/src/main.nr
+++ b/test_programs/compile_success_empty/macro_result_type/src/main.nr
@@ -1,0 +1,13 @@
+fn main() {
+    comptime
+    {
+        let signature = "hello".as_ctstring();
+        let string = signature.as_quoted_str!();
+        let result = half(string);
+        assert_eq(result, 2);
+    }
+}
+
+comptime fn half<let N: u32>(_s: str<N>) -> u32 {
+    N / 2
+}

--- a/test_programs/compile_success_empty/macro_result_type/t.rs
+++ b/test_programs/compile_success_empty/macro_result_type/t.rs
@@ -1,0 +1,12 @@
+
+trait Foo<const N: u32> {
+    fn foo() {}
+}
+
+impl Foo<3> for () {
+    fn foo() {}
+}
+
+fn main() {
+    let _ = Foo::foo();
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue from @asterite on slack

## Summary\*

When we type check a macro call we don't know the actual type so we return a fresh type variable.

When we later execute this code at comptime we do know the type, so we should unify the type variable then, potentially catching any inconsistencies. This also makes the value of the type variable known (during evaluation, not type checking!) as in the new test case.

## Additional Context

Also fixed an issue where you couldn't call a method as a macro directly and needed an extra `unquote!` call.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
