### PR TITLE
feat(perf): Remove inc_rc/dec_rc instructions that follow a removed load in mem2reg

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -563,20 +563,20 @@ impl<'f> PerFunctionContext<'f> {
                 let last_instruction = instructions[instructions.len() - 2];
                 let value = self.inserter.function.dfg.resolve(*value);
                 if self.instructions_to_remove.contains(&last_instruction) {
-                    if let Instruction::Load { address } = self.inserter.function.dfg[last_instruction] {
+                    if let Instruction::Load { address } =
+                        self.inserter.function.dfg[last_instruction]
+                    {
                         let result =
                             self.inserter.function.dfg.instruction_results(last_instruction)[0];
                         let result = self.inserter.resolve(result);
-                        // We only want to remove the inc/dec rc if the removed load came from a last load
-                        if references.last_loads.get(&address).is_some() {
-                            if result == value {
-                                self.instructions_to_remove.insert(instruction);
-                            }
+                        // We only want to remove the inc/dec rc if the removed load came from a repeated load
+                        if result == value && references.last_loads.get(&address).is_some() {
+                            self.instructions_to_remove.insert(instruction);
                         }
                     }
                 }
             }
-            
+
             _ => (),
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/6088#issuecomment-2359249383

## Summary\*

If we have have an inc_rc/dec_rc instruction in mem2reg, we can check whether the previously instruction was a removed load. If it was, we can safely remove the inc_rc/dec_rc instruction.

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
