### PR TITLE
feat: Implement type paths

### DIFF
--- a/aztec_macros/src/transforms/note_interface.rs
+++ b/aztec_macros/src/transforms/note_interface.rs
@@ -776,6 +776,7 @@ pub fn inject_note_exports(
                     note.borrow().id,
                     "get_note_type_id",
                     false,
+                    true,
                 )
                 .ok_or((
                     AztecMacroError::CouldNotExportStorageLayout {

--- a/aztec_macros/src/transforms/storage.rs
+++ b/aztec_macros/src/transforms/storage.rs
@@ -360,6 +360,7 @@ pub fn assign_storage_slots(
                     storage_struct.borrow().id,
                     "init",
                     false,
+                    true,
                 )
                 .ok_or((
                     AztecMacroError::CouldNotAssignStorageSlots {

--- a/aztec_macros/src/utils/parse_utils.rs
+++ b/aztec_macros/src/utils/parse_utils.rs
@@ -295,6 +295,12 @@ fn empty_expression(expression: &mut Expression) {
             empty_unresolved_type(&mut path.typ);
             empty_path(&mut path.trait_path);
             empty_ident(&mut path.impl_item);
+            empty_type_args(&mut path.trait_generics);
+        }
+        ExpressionKind::TypePath(path) => {
+            empty_unresolved_type(&mut path.typ);
+            empty_ident(&mut path.item);
+            empty_type_args(&mut path.turbofish);
         }
         ExpressionKind::Quote(..)
         | ExpressionKind::Resolved(_)

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -14,7 +14,7 @@ use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::{Span, Spanned};
 
-use super::{AsTraitPath, UnaryRhsMemberAccess};
+use super::{AsTraitPath, TypePath, UnaryRhsMemberAccess};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ExpressionKind {
@@ -38,6 +38,7 @@ pub enum ExpressionKind {
     Comptime(BlockExpression, Span),
     Unsafe(BlockExpression, Span),
     AsTraitPath(AsTraitPath),
+    TypePath(TypePath),
 
     // This variant is only emitted when inlining the result of comptime
     // code. It is used to translate function values back into the AST while
@@ -621,6 +622,7 @@ impl Display for ExpressionKind {
                 write!(f, "quote {{ {} }}", tokens.join(" "))
             }
             AsTraitPath(path) => write!(f, "{path}"),
+            TypePath(path) => write!(f, "{path}"),
             InternedStatement(_) => write!(f, "?InternedStatement"),
         }
     }
@@ -784,6 +786,16 @@ impl Display for Lambda {
 impl Display for AsTraitPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "<{} as {}>::{}", self.typ, self.trait_path, self.impl_item)
+    }
+}
+
+impl Display for TypePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}::{}", self.typ, self.item)?;
+        if !self.turbofish.is_empty() {
+            write!(f, "::{}", self.turbofish)?;
+        }
+        Ok(())
     }
 }
 

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -389,6 +389,16 @@ pub struct AsTraitPath {
     pub impl_item: Ident,
 }
 
+/// A special kind of path in the form `Type::ident::<turbofish>`
+/// Unlike normal paths, the type here can be a primitive type or
+/// interned type.
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct TypePath {
+    pub typ: UnresolvedType,
+    pub item: Ident,
+    pub turbofish: GenericTypeArgs,
+}
+
 // Note: Path deliberately doesn't implement Recoverable.
 // No matter which default value we could give in Recoverable::error,
 // it would most likely cause further errors during name resolution

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -22,7 +22,7 @@ use crate::{
 
 use super::{
     FunctionReturnType, GenericTypeArgs, IntegerBitSize, ItemVisibility, Pattern, Signedness,
-    TraitImplItemKind, UnresolvedGenerics, UnresolvedTraitConstraint, UnresolvedType,
+    TraitImplItemKind, TypePath, UnresolvedGenerics, UnresolvedTraitConstraint, UnresolvedType,
     UnresolvedTypeData, UnresolvedTypeExpression,
 };
 
@@ -337,6 +337,10 @@ pub trait Visitor {
     }
 
     fn visit_as_trait_path(&mut self, _: &AsTraitPath, _: Span) -> bool {
+        true
+    }
+
+    fn visit_type_path(&mut self, _: &TypePath, _: Span) -> bool {
         true
     }
 
@@ -838,6 +842,7 @@ impl Expression {
             ExpressionKind::AsTraitPath(as_trait_path) => {
                 as_trait_path.accept(self.span, visitor);
             }
+            ExpressionKind::TypePath(path) => path.accept(self.span, visitor),
             ExpressionKind::Quote(tokens) => visitor.visit_quote(tokens),
             ExpressionKind::Resolved(expr_id) => visitor.visit_resolved_expression(*expr_id),
             ExpressionKind::Interned(id) => visitor.visit_interned_expression(*id),
@@ -1205,6 +1210,19 @@ impl AsTraitPath {
     pub fn accept_children(&self, visitor: &mut impl Visitor) {
         self.trait_path.accept(visitor);
         self.trait_generics.accept(visitor);
+    }
+}
+
+impl TypePath {
+    pub fn accept(&self, span: Span, visitor: &mut impl Visitor) {
+        if visitor.visit_type_path(self, span) {
+            self.accept_children(visitor);
+        }
+    }
+
+    pub fn accept_children(&self, visitor: &mut impl Visitor) {
+        self.typ.accept(visitor);
+        self.turbofish.accept(visitor);
     }
 }
 

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -3,17 +3,17 @@ use noirc_errors::{Location, Span};
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-    ast::{UnresolvedType, ERROR_IDENT},
+    ast::{TypePath, UnresolvedType, ERROR_IDENT},
     hir::{
         def_collector::dc_crate::CompilationError,
         resolution::errors::ResolverError,
         type_check::{Source, TypeCheckError},
     },
     hir_def::{
-        expr::{HirIdent, ImplKind},
+        expr::{HirIdent, HirMethodReference, ImplKind},
         stmt::HirPattern,
     },
-    macros_api::{HirExpression, Ident, Path, Pattern},
+    macros_api::{Expression, ExpressionKind, HirExpression, Ident, Path, Pattern},
     node_interner::{DefinitionId, DefinitionKind, ExprId, FuncId, GlobalId, TraitImplKind},
     ResolvedGeneric, Shared, StructType, Type, TypeBindings,
 };
@@ -696,5 +696,44 @@ impl<'context> Elaborator<'context> {
         self.push_err(error);
         let id = DefinitionId::dummy_id();
         (HirIdent::non_trait_method(id, location), 0)
+    }
+
+    pub(super) fn elaborate_type_path(&mut self, path: TypePath) -> (ExprId, Type) {
+        let span = path.item.span();
+        let typ = self.resolve_type(path.typ);
+
+        let Some(method) = self.lookup_method(&typ, &path.item.0.contents, span, false) else {
+            let error = Expression::new(ExpressionKind::Error, span);
+            return self.elaborate_expression(error);
+        };
+
+        let func_id = method
+            .func_id(self.interner)
+            .expect("Expected trait function to be a DefinitionKind::Function");
+
+        let generics = self.resolve_type_args(path.turbofish, func_id, span).0;
+        let generics = (!generics.is_empty()).then_some(generics);
+
+        let location = Location::new(span, self.file);
+        let id = self.interner.function_definition_id(func_id);
+
+        let impl_kind = match method {
+            HirMethodReference::FuncId(_) => ImplKind::NotATraitMethod,
+            HirMethodReference::TraitMethodId(method_id, generics) => {
+                let mut constraint =
+                    self.interner.get_trait(method_id.trait_id).as_constraint(span);
+                constraint.trait_generics = generics;
+                ImplKind::TraitMethod(method_id, constraint, false)
+            }
+        };
+
+        let ident = HirIdent { location, id, impl_kind };
+        let id = self.interner.push_expr(HirExpression::Ident(ident.clone(), generics.clone()));
+        self.interner.push_expr_location(id, location.span, location.file);
+
+        let typ = self.type_check_variable(ident, id, generics);
+        self.interner.push_expr_type(id, typ.clone());
+
+        (id, typ)
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1352,8 +1352,9 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 struct_def.borrow().id,
                 method_name,
                 false,
+                true,
             ),
-            _ => self.elaborator.interner.lookup_primitive_method(&typ, method_name),
+            _ => self.elaborator.interner.lookup_primitive_method(&typ, method_name, true),
         };
 
         if let Some(method) = method {

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -862,7 +862,17 @@ fn remove_interned_in_expression_kind(
                 vecmap(block.statements, |stmt| remove_interned_in_statement(interner, stmt));
             ExpressionKind::Unsafe(BlockExpression { statements }, span)
         }
-        ExpressionKind::AsTraitPath(_) => expr,
+        ExpressionKind::AsTraitPath(mut path) => {
+            path.typ = remove_interned_in_unresolved_type(interner, path.typ);
+            path.trait_generics =
+                remove_interned_in_generic_type_args(interner, path.trait_generics);
+            ExpressionKind::AsTraitPath(path)
+        }
+        ExpressionKind::TypePath(mut path) => {
+            path.typ = remove_interned_in_unresolved_type(interner, path.typ);
+            path.turbofish = remove_interned_in_generic_type_args(interner, path.turbofish);
+            ExpressionKind::TypePath(path)
+        }
         ExpressionKind::Resolved(id) => {
             let expr = interner.expression(&id);
             expr.to_display_ast(interner, Span::default()).kind

--- a/compiler/noirc_frontend/src/hir/type_check/generics.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/generics.rs
@@ -5,7 +5,7 @@ use iter_extended::vecmap;
 use crate::{
     hir_def::traits::NamedType,
     macros_api::NodeInterner,
-    node_interner::{TraitId, TypeAliasId},
+    node_interner::{FuncId, TraitId, TypeAliasId},
     ResolvedGeneric, StructType, Type,
 };
 
@@ -86,6 +86,28 @@ impl Generic for Ref<'_, StructType> {
 
     fn generics(&self, _interner: &NodeInterner) -> Vec<ResolvedGeneric> {
         self.generics.clone()
+    }
+
+    fn accepts_named_type_args(&self) -> bool {
+        false
+    }
+
+    fn named_generics(&self, _interner: &NodeInterner) -> Vec<ResolvedGeneric> {
+        Vec::new()
+    }
+}
+
+impl Generic for FuncId {
+    fn item_kind(&self) -> &'static str {
+        "function"
+    }
+
+    fn item_name(&self, interner: &NodeInterner) -> String {
+        interner.function_name(self).to_string()
+    }
+
+    fn generics(&self, interner: &NodeInterner) -> Vec<ResolvedGeneric> {
+        interner.function_meta(self).direct_generics.clone()
     }
 
     fn accepts_named_type_args(&self) -> bool {

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1680,7 +1680,7 @@ impl Type {
         if let (Type::Array(_size, element1), Type::Slice(element2)) = (&this, &target) {
             // We can only do the coercion if the `as_slice` method exists.
             // This is usually true, but some tests don't have access to the standard library.
-            if let Some(as_slice) = interner.lookup_primitive_method(&this, "as_slice") {
+            if let Some(as_slice) = interner.lookup_primitive_method(&this, "as_slice", true) {
                 // Still have to ensure the element types match.
                 // Don't need to issue an error here if not, it will be done in unify_with_coercions
                 let mut bindings = TypeBindings::new();

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -23,7 +23,7 @@
 //! prevent other parsers from being tried afterward since there is no longer an error. Thus, they should
 //! be limited to cases like the above `fn` example where it is clear we shouldn't back out of the
 //! current parser to try alternative parsers in a `choice` expression.
-use self::path::as_trait_path;
+use self::path::{as_trait_path, type_path};
 use self::primitives::{
     interned_statement, interned_statement_expr, keyword, macro_quote_marker, mutable_reference,
     variable,
@@ -1150,6 +1150,7 @@ where
         variable(),
         literal(),
         as_trait_path(parse_type()).map(ExpressionKind::AsTraitPath),
+        type_path(parse_type()),
         macro_quote_marker(),
         interned_expr(),
         interned_statement_expr(),

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -24,12 +24,7 @@ pub(super) fn parse_type_inner<'a>(
     recursive_type_parser: impl NoirParser<UnresolvedType> + 'a,
 ) -> impl NoirParser<UnresolvedType> + 'a {
     choice((
-        field_type(),
-        int_type(),
-        bool_type(),
-        string_type(),
-        comptime_type(),
-        resolved_type(),
+        primitive_type(),
         format_string_type(recursive_type_parser.clone()),
         named_type(recursive_type_parser.clone()),
         named_trait(recursive_type_parser.clone()),
@@ -40,6 +35,17 @@ pub(super) fn parse_type_inner<'a>(
         function_type(recursive_type_parser.clone()),
         mutable_reference_type(recursive_type_parser.clone()),
         as_trait_path_type(recursive_type_parser),
+    ))
+}
+
+pub(super) fn primitive_type() -> impl NoirParser<UnresolvedType> {
+    choice((
+        field_type(),
+        int_type(),
+        bool_type(),
+        string_type(),
+        comptime_type(),
+        resolved_type(),
         interned_unresolved_type(),
     ))
 }

--- a/test_programs/compile_success_empty/type_path/Nargo.toml
+++ b/test_programs/compile_success_empty/type_path/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "type_path"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/type_path/src/main.nr
+++ b/test_programs/compile_success_empty/type_path/src/main.nr
@@ -12,6 +12,5 @@ struct Foo {}
 
 impl Foo {
     fn static() {
-        println("Foo::static called");
     }
 }

--- a/test_programs/compile_success_empty/type_path/src/main.nr
+++ b/test_programs/compile_success_empty/type_path/src/main.nr
@@ -1,0 +1,16 @@
+fn main() {
+    comptime {
+        let foo = quote { Foo }.as_type();
+        quote {
+            $foo::static()
+        }
+    }
+}
+
+struct Foo {}
+
+impl Foo {
+    fn static() {
+        println("Foo::static called");
+    }
+}

--- a/test_programs/compile_success_empty/type_path/src/main.nr
+++ b/test_programs/compile_success_empty/type_path/src/main.nr
@@ -1,5 +1,6 @@
 fn main() {
-    comptime {
+    comptime
+    {
         let foo = quote { Foo }.as_type();
         quote {
             $foo::static()

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -522,6 +522,7 @@ fn get_expression_name(expression: &Expression) -> Option<String> {
         ExpressionKind::Cast(cast) => get_expression_name(&cast.lhs),
         ExpressionKind::Parenthesized(expr) => get_expression_name(expr),
         ExpressionKind::AsTraitPath(path) => Some(path.impl_item.to_string()),
+        ExpressionKind::TypePath(path) => Some(path.item.to_string()),
         ExpressionKind::Constructor(..)
         | ExpressionKind::Infix(..)
         | ExpressionKind::Index(..)

--- a/tooling/nargo_fmt/src/rewrite/expr.rs
+++ b/tooling/nargo_fmt/src/rewrite/expr.rs
@@ -192,7 +192,20 @@ pub(crate) fn rewrite(
         }
         ExpressionKind::AsTraitPath(path) => {
             let trait_path = rewrite_path(visitor, shape, path.trait_path);
-            format!("<{} as {}>::{}", path.typ, trait_path, path.impl_item)
+
+            if path.trait_generics.is_empty() {
+                format!("<{} as {}>::{}", path.typ, trait_path, path.impl_item)
+            } else {
+                let generics = path.trait_generics;
+                format!("<{} as {}::{}>::{}", path.typ, trait_path, generics, path.impl_item)
+            }
+        }
+        ExpressionKind::TypePath(path) => {
+            if path.turbofish.is_empty() {
+                format!("{}::{}", path.typ, path.item)
+            } else {
+                format!("{}::{}::{}", path.typ, path.item, path.turbofish)
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6078

## Summary\*

Adds the ability to do `Type::method` where `Type` is a primitive type or interned type. Other named types should already be supported by existing paths.

## Additional Context

I also made a small update to `lookup_method` to support looking up methods without a `self` parameter to allow for us to possibly have something like `Field::static_method()` in the future, although we have no functions like this in the stdlib currently.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
