### PR TITLE
feat: (LSP) show global value on hover

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -622,7 +622,7 @@ impl<'context> Elaborator<'context> {
 
         let length = stmt.expression;
         let span = self.interner.expr_span(&length);
-        let result = self.try_eval_array_length_id(length, span);
+        let result = try_eval_array_length_id(self.interner, length, span);
 
         match result.map(|length| length.try_into()) {
             Ok(Ok(length_value)) => return length_value,
@@ -631,88 +631,6 @@ impl<'context> Elaborator<'context> {
             Err(None) => (),
         }
         0
-    }
-
-    fn try_eval_array_length_id(
-        &self,
-        rhs: ExprId,
-        span: Span,
-    ) -> Result<u128, Option<ResolverError>> {
-        // Arbitrary amount of recursive calls to try before giving up
-        let fuel = 100;
-        self.try_eval_array_length_id_with_fuel(rhs, span, fuel)
-    }
-
-    fn try_eval_array_length_id_with_fuel(
-        &self,
-        rhs: ExprId,
-        span: Span,
-        fuel: u32,
-    ) -> Result<u128, Option<ResolverError>> {
-        if fuel == 0 {
-            // If we reach here, it is likely from evaluating cyclic globals. We expect an error to
-            // be issued for them after name resolution so issue no error now.
-            return Err(None);
-        }
-
-        match self.interner.expression(&rhs) {
-            HirExpression::Literal(HirLiteral::Integer(int, false)) => {
-                int.try_into_u128().ok_or(Some(ResolverError::IntegerTooLarge { span }))
-            }
-            HirExpression::Ident(ident, _) => {
-                if let Some(definition) = self.interner.try_definition(ident.id) {
-                    match definition.kind {
-                        DefinitionKind::Global(global_id) => {
-                            let let_statement = self.interner.get_global_let_statement(global_id);
-                            if let Some(let_statement) = let_statement {
-                                let expression = let_statement.expression;
-                                self.try_eval_array_length_id_with_fuel(expression, span, fuel - 1)
-                            } else {
-                                Err(Some(ResolverError::InvalidArrayLengthExpr { span }))
-                            }
-                        }
-                        _ => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
-                    }
-                } else {
-                    Err(Some(ResolverError::InvalidArrayLengthExpr { span }))
-                }
-            }
-            HirExpression::Infix(infix) => {
-                let lhs = self.try_eval_array_length_id_with_fuel(infix.lhs, span, fuel - 1)?;
-                let rhs = self.try_eval_array_length_id_with_fuel(infix.rhs, span, fuel - 1)?;
-
-                match infix.operator.kind {
-                    BinaryOpKind::Add => Ok(lhs + rhs),
-                    BinaryOpKind::Subtract => Ok(lhs - rhs),
-                    BinaryOpKind::Multiply => Ok(lhs * rhs),
-                    BinaryOpKind::Divide => Ok(lhs / rhs),
-                    BinaryOpKind::Equal => Ok((lhs == rhs) as u128),
-                    BinaryOpKind::NotEqual => Ok((lhs != rhs) as u128),
-                    BinaryOpKind::Less => Ok((lhs < rhs) as u128),
-                    BinaryOpKind::LessEqual => Ok((lhs <= rhs) as u128),
-                    BinaryOpKind::Greater => Ok((lhs > rhs) as u128),
-                    BinaryOpKind::GreaterEqual => Ok((lhs >= rhs) as u128),
-                    BinaryOpKind::And => Ok(lhs & rhs),
-                    BinaryOpKind::Or => Ok(lhs | rhs),
-                    BinaryOpKind::Xor => Ok(lhs ^ rhs),
-                    BinaryOpKind::ShiftRight => Ok(lhs >> rhs),
-                    BinaryOpKind::ShiftLeft => Ok(lhs << rhs),
-                    BinaryOpKind::Modulo => Ok(lhs % rhs),
-                }
-            }
-            HirExpression::Cast(cast) => {
-                let lhs = self.try_eval_array_length_id_with_fuel(cast.lhs, span, fuel - 1)?;
-                let lhs_value = Value::Field(lhs.into());
-                let evaluated_value =
-                    Interpreter::evaluate_cast_one_step(&cast, rhs, lhs_value, self.interner)
-                        .map_err(|error| Some(ResolverError::ArrayLengthInterpreter { error }))?;
-
-                evaluated_value
-                    .to_u128()
-                    .ok_or_else(|| Some(ResolverError::InvalidArrayLengthExpr { span }))
-            }
-            _other => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
-        }
     }
 
     pub fn unify(
@@ -1845,6 +1763,88 @@ impl<'context> Elaborator<'context> {
             let self_type = the_trait.self_type_typevar.clone();
             bindings.insert(self_type.id(), (self_type, constraint.typ.clone()));
         }
+    }
+}
+
+pub fn try_eval_array_length_id(
+    interner: &NodeInterner,
+    rhs: ExprId,
+    span: Span,
+) -> Result<u128, Option<ResolverError>> {
+    // Arbitrary amount of recursive calls to try before giving up
+    let fuel = 100;
+    try_eval_array_length_id_with_fuel(interner, rhs, span, fuel)
+}
+
+fn try_eval_array_length_id_with_fuel(
+    interner: &NodeInterner,
+    rhs: ExprId,
+    span: Span,
+    fuel: u32,
+) -> Result<u128, Option<ResolverError>> {
+    if fuel == 0 {
+        // If we reach here, it is likely from evaluating cyclic globals. We expect an error to
+        // be issued for them after name resolution so issue no error now.
+        return Err(None);
+    }
+
+    match interner.expression(&rhs) {
+        HirExpression::Literal(HirLiteral::Integer(int, false)) => {
+            int.try_into_u128().ok_or(Some(ResolverError::IntegerTooLarge { span }))
+        }
+        HirExpression::Ident(ident, _) => {
+            if let Some(definition) = interner.try_definition(ident.id) {
+                match definition.kind {
+                    DefinitionKind::Global(global_id) => {
+                        let let_statement = interner.get_global_let_statement(global_id);
+                        if let Some(let_statement) = let_statement {
+                            let expression = let_statement.expression;
+                            try_eval_array_length_id_with_fuel(interner, expression, span, fuel - 1)
+                        } else {
+                            Err(Some(ResolverError::InvalidArrayLengthExpr { span }))
+                        }
+                    }
+                    _ => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
+                }
+            } else {
+                Err(Some(ResolverError::InvalidArrayLengthExpr { span }))
+            }
+        }
+        HirExpression::Infix(infix) => {
+            let lhs = try_eval_array_length_id_with_fuel(interner, infix.lhs, span, fuel - 1)?;
+            let rhs = try_eval_array_length_id_with_fuel(interner, infix.rhs, span, fuel - 1)?;
+
+            match infix.operator.kind {
+                BinaryOpKind::Add => Ok(lhs + rhs),
+                BinaryOpKind::Subtract => Ok(lhs - rhs),
+                BinaryOpKind::Multiply => Ok(lhs * rhs),
+                BinaryOpKind::Divide => Ok(lhs / rhs),
+                BinaryOpKind::Equal => Ok((lhs == rhs) as u128),
+                BinaryOpKind::NotEqual => Ok((lhs != rhs) as u128),
+                BinaryOpKind::Less => Ok((lhs < rhs) as u128),
+                BinaryOpKind::LessEqual => Ok((lhs <= rhs) as u128),
+                BinaryOpKind::Greater => Ok((lhs > rhs) as u128),
+                BinaryOpKind::GreaterEqual => Ok((lhs >= rhs) as u128),
+                BinaryOpKind::And => Ok(lhs & rhs),
+                BinaryOpKind::Or => Ok(lhs | rhs),
+                BinaryOpKind::Xor => Ok(lhs ^ rhs),
+                BinaryOpKind::ShiftRight => Ok(lhs >> rhs),
+                BinaryOpKind::ShiftLeft => Ok(lhs << rhs),
+                BinaryOpKind::Modulo => Ok(lhs % rhs),
+            }
+        }
+        HirExpression::Cast(cast) => {
+            let lhs = try_eval_array_length_id_with_fuel(interner, cast.lhs, span, fuel - 1)?;
+            let lhs_value = Value::Field(lhs.into());
+            let evaluated_value =
+                Interpreter::evaluate_cast_one_step(&cast, rhs, lhs_value, interner)
+                    .map_err(|error| Some(ResolverError::ArrayLengthInterpreter { error }))?;
+
+            evaluated_value
+                .to_u128()
+                .ok_or_else(|| Some(ResolverError::InvalidArrayLengthExpr { span }))
+        }
+        _other => Err(Some(ResolverError::InvalidArrayLengthExpr { span })),
     }
 }
 

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -347,6 +347,10 @@ fn format_alias(id: TypeAliasId, args: &ProcessRequestCallbackArgs) -> String {
 
 fn format_local(id: DefinitionId, args: &ProcessRequestCallbackArgs) -> String {
     let definition_info = args.interner.definition(id);
+    if let DefinitionKind::Global(global_id) = &definition_info.kind {
+        return format_global(*global_id, args);
+    }
+
     let DefinitionKind::Local(expr_id) = definition_info.kind else {
         panic!("Expected a local reference to reference a local definition")
     };

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -167,14 +167,21 @@ fn format_trait(id: TraitId, args: &ProcessRequestCallbackArgs) -> String {
 fn format_global(id: GlobalId, args: &ProcessRequestCallbackArgs) -> String {
     let global_info = args.interner.get_global(id);
     let definition_id = global_info.definition_id;
+    let definition = args.interner.definition(definition_id);
     let typ = args.interner.definition_type(definition_id);
-    dbg!(&global_info.value);
 
     let mut string = String::new();
     if format_parent_module(ReferenceId::Global(id), args, &mut string) {
         string.push('\n');
     }
+
     string.push_str("    ");
+    if definition.comptime {
+        string.push_str("comptime ");
+    }
+    if definition.mutable {
+        string.push_str("mut ");
+    }
     string.push_str("global ");
     string.push_str(&global_info.ident.0.contents);
     string.push_str(": ");

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -218,13 +218,7 @@ fn get_global_value(interner: &NodeInterner, expr: ExprId) -> Option<String> {
             HirLiteral::Unit => Some("()".to_string()),
         },
         HirExpression::Tuple(values) => {
-            let strings: Vec<String> =
-                values.iter().filter_map(|value| get_global_value(interner, *value)).collect();
-            if strings.len() == values.len() {
-                Some(format!("({})", strings.join(", ")))
-            } else {
-                None
-            }
+            get_exprs_global_value(interner, &values).map(|value| format!("({})", value))
         }
         _ => None,
     }
@@ -237,29 +231,33 @@ fn get_global_array_value(
 ) -> Option<String> {
     match literal {
         HirArrayLiteral::Standard(values) => {
-            let strings: Vec<String> =
-                values.iter().filter_map(|value| get_global_value(interner, *value)).collect();
-            if strings.len() == values.len() {
+            get_exprs_global_value(interner, &values).map(|value| {
                 if is_slice {
-                    Some(format!("&[{}]", strings.join(", ")))
+                    format!("&[{}]", value)
                 } else {
-                    Some(format!("[{}]", strings.join(", ")))
+                    format!("[{}]", value)
                 }
-            } else {
-                None
-            }
+            })
         }
         HirArrayLiteral::Repeated { repeated_element, length } => {
-            if let Some(value) = get_global_value(interner, repeated_element) {
+            get_global_value(interner, repeated_element).map(|value| {
                 if is_slice {
-                    Some(format!("&[{}; {}]", value, length))
+                    format!("&[{}; {}]", value, length)
                 } else {
-                    Some(format!("[{}; {}]", value, length))
+                    format!("[{}; {}]", value, length)
                 }
-            } else {
-                None
-            }
+            })
         }
+    }
+}
+
+fn get_exprs_global_value(interner: &NodeInterner, exprs: &[ExprId]) -> Option<String> {
+    let strings: Vec<String> =
+        exprs.iter().filter_map(|value| get_global_value(interner, *value)).collect();
+    if strings.len() == exprs.len() {
+        Some(strings.join(", "))
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
# Description

## Problem

I noticed Rust Analyzer shows a `const` value, so I figured we could do the same thing with simple globals.

## Summary

This is only done for globals with "simple" types (bools, strings, integers, arrays, tuples). It can be useful to avoid having to go to the global definition to check the value, in case it's needed.

![lsp-globals](https://github.com/user-attachments/assets/8886e78d-f18c-4b2a-939b-c3f98c242044)

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
