### PR TITLE
feat: (LSP) if in runtime code, always suggest functions that return Quoted as macro calls

### DIFF
--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -232,7 +232,13 @@ impl<'a> NodeFinder<'a> {
         if modifiers.is_comptime
             && matches!(func_meta.return_type(), Type::Quoted(QuotedType::Quoted))
         {
-            vec![make_completion_item(false), make_completion_item(true)]
+            if self.in_comptime {
+                vec![make_completion_item(false), make_completion_item(true)]
+            } else {
+                // If not in a comptime block we can't operate with comptime values so the only thing
+                // we can do is call a macro.
+                vec![make_completion_item(true)]
+            }
         } else {
             vec![make_completion_item(false)]
         }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2126,7 +2126,9 @@ mod completion_tests {
         comptime fn foobar() -> Quoted {}
 
         fn main() {
-            fooba>|<
+            comptime {
+                fooba>|<
+            }
         }
         "#;
 
@@ -2136,6 +2138,24 @@ mod completion_tests {
                 function_completion_item("foobar!()", "foobar!()", "fn() -> Quoted"),
                 function_completion_item("foobar()", "foobar()", "fn() -> Quoted"),
             ],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_suggests_only_macro_call_if_comptime_function_returns_quoted_and_outside_comptime(
+    ) {
+        let src = r#"
+        comptime fn foobar() -> Quoted {}
+
+        fn main() {
+            fooba>|<
+        }
+        "#;
+
+        assert_completion_excluding_auto_import(
+            src,
+            vec![function_completion_item("foobar!()", "foobar!()", "fn() -> Quoted")],
         )
         .await;
     }


### PR DESCRIPTION

# Description

## Problem

When in non-comptime code, when suggesting a function that returns `Quoted` it should never be suggested as a non-macro call.

## Summary

![lsp-suggest-macro-call](https://github.com/user-attachments/assets/bf870da8-59fe-4993-af73-60e865d141c2)

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
