### PR TITLE
fix: preserve generic kind on trait methods

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -288,10 +288,10 @@ pub(crate) fn check_trait_impl_method_matches_declaration(
         // Substitute each generic on the trait function with the corresponding generic on the impl function
         for (
             ResolvedGeneric { type_var: trait_fn_generic, .. },
-            ResolvedGeneric { name, type_var: impl_fn_generic, .. },
+            ResolvedGeneric { name, type_var: impl_fn_generic, kind, .. },
         ) in trait_fn_meta.direct_generics.iter().zip(&meta.direct_generics)
         {
-            let arg = Type::NamedGeneric(impl_fn_generic.clone(), name.clone(), Kind::Normal);
+            let arg = Type::NamedGeneric(impl_fn_generic.clone(), name.clone(), kind.clone());
             bindings.insert(trait_fn_generic.id(), (trait_fn_generic.clone(), arg));
         }
 
@@ -334,6 +334,7 @@ fn check_function_type_matches_expected_type(
         if params_a.len() == params_b.len() {
             for (i, (a, b)) in params_a.iter().zip(params_b.iter()).enumerate() {
                 if a.try_unify(b, &mut bindings).is_err() {
+                    println!("{a:?} != {b:?}");
                     errors.push(TypeCheckError::TraitMethodParameterTypeMismatch {
                         method_name: method_name.to_string(),
                         expected_typ: a.to_string(),

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -334,7 +334,6 @@ fn check_function_type_matches_expected_type(
         if params_a.len() == params_b.len() {
             for (i, (a, b)) in params_a.iter().zip(params_b.iter()).enumerate() {
                 if a.try_unify(b, &mut bindings).is_err() {
-                    println!("{a:?} != {b:?}");
                     errors.push(TypeCheckError::TraitMethodParameterTypeMismatch {
                         method_name: method_name.to_string(),
                         expected_typ: a.to_string(),

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3701,7 +3701,6 @@ fn use_non_u32_generic_in_struct() {
     assert_eq!(errors.len(), 0);
 }
 
-
 #[test]
 fn use_numeric_generic_in_trait_method() {
     let src = r#"

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3700,3 +3700,29 @@ fn use_non_u32_generic_in_struct() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 0);
 }
+
+
+#[test]
+fn use_numeric_generic_in_trait_method() {
+    let src = r#"
+        trait Foo  {
+            fn foo<let N: u32>(self, x: [u8; N]) -> Self;
+        }
+
+        struct Bar;
+
+        impl Foo for Bar {
+            fn foo<let N: u32>(self, _x: [u8; N]) -> Self {
+                self
+            }
+        }
+
+        fn main() {
+            let _ = Bar{}.foo([1,2,3]);
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    println!("{errors:?}");
+    assert_eq!(errors.len(), 0);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6100 

## Summary\*

It seems that #5156 has resulted in problems in unifying numeric generics in trait impl methods.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
