### PR TITLE
feat: (LSP) suggest $vars inside `quote { ... }`

### DIFF
--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2174,4 +2174,52 @@ mod completion_tests {
         assert_eq!(completions.len(), 1);
         assert_eq!(completions[0].label, "unquote!(…)");
     }
+
+    #[test]
+    async fn test_suggests_variable_in_quoted_after_dollar() {
+        let src = r#"
+        fn main() {
+            comptime {
+                let some_var = 1;
+                quote {
+                    $>|<
+                }
+            }
+        }
+        "#;
+
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "some_var",
+                CompletionItemKind::VARIABLE,
+                Some("Field".to_string()),
+            )],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn test_suggests_variable_in_quoted_after_dollar_and_letters() {
+        let src = r#"
+        fn main() {
+            comptime {
+                let some_var = 1;
+                quote {
+                    $s>|<
+                }
+            }
+        }
+        "#;
+
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "some_var",
+                CompletionItemKind::VARIABLE,
+                Some("Field".to_string()),
+            )],
+        )
+        .await;
+    }
 }

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -238,7 +238,11 @@ pub(crate) fn on_initialize(
                 )),
                 completion_provider: Some(lsp_types::OneOf::Right(lsp_types::CompletionOptions {
                     resolve_provider: None,
-                    trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
+                    trigger_characters: Some(vec![
+                        ".".to_string(), // For method calls
+                        ":".to_string(), // For paths
+                        "$".to_string(), // For $var inside `quote { ... }`
+                    ]),
                     all_commit_characters: None,
                     work_done_progress_options: WorkDoneProgressOptions {
                         work_done_progress: None,


### PR DESCRIPTION
# Description

## Problem

`$var` should be suggested inside `quote { ... }`: only local variables should be suggested.

## Summary

![lsp-complete-dollar](https://github.com/user-attachments/assets/745494ac-2cac-4dcb-bc5e-03c2209456d5)

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
