### PR TITLE
feat: LSP autocompletion for `TypePath`

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -628,7 +628,15 @@ impl<'a> NodeFinder<'a> {
         };
 
         for (name, methods) in methods_by_name {
-            for (func_id, _method_type) in methods.iter() {
+            for (func_id, method_type) in methods.iter() {
+                if function_kind == FunctionKind::Any {
+                    if let Some(method_type) = method_type {
+                        if method_type.unify(typ).is_err() {
+                            continue;
+                        }
+                    }
+                }
+
                 if name_matches(name, prefix) {
                     let completion_items = self.function_completion_items(
                         name,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -17,10 +17,11 @@ use noirc_frontend::{
     ast::{
         AsTraitPath, AttributeTarget, BlockExpression, CallExpression, ConstructorExpression,
         Expression, ExpressionKind, ForLoopStatement, GenericTypeArgs, Ident, IfExpression,
-        ItemVisibility, LValue, Lambda, LetStatement, MemberAccessExpression, MethodCallExpression,
-        NoirFunction, NoirStruct, NoirTraitImpl, Path, PathKind, Pattern, Statement,
-        TraitImplItemKind, TypeImpl, UnresolvedGeneric, UnresolvedGenerics, UnresolvedType,
-        UnresolvedTypeData, UseTree, UseTreeKind, Visitor,
+        IntegerBitSize, ItemVisibility, LValue, Lambda, LetStatement, MemberAccessExpression,
+        MethodCallExpression, NoirFunction, NoirStruct, NoirTraitImpl, Path, PathKind, Pattern,
+        Signedness, Statement, TraitImplItemKind, TypeImpl, TypePath, UnresolvedGeneric,
+        UnresolvedGenerics, UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression, UseTree,
+        UseTreeKind, Visitor,
     },
     graph::{CrateId, Dependency},
     hir::def_map::{CrateDefMap, LocalModuleId, ModuleId},
@@ -29,7 +30,7 @@ use noirc_frontend::{
     node_interner::ReferenceId,
     parser::{Item, ItemKind, ParsedSubModule},
     token::{CustomAttribute, Token, Tokens},
-    ParsedModule, StructType, Type, TypeBinding,
+    Kind, ParsedModule, StructType, Type, TypeBinding,
 };
 use sort_text::underscore_sort_text;
 
@@ -1550,6 +1551,44 @@ impl<'a> Visitor for NodeFinder<'a> {
     ) -> bool {
         self.find_in_path(path, RequestedItems::OnlyTypes);
         unresolved_types.accept(self);
+        false
+    }
+
+    fn visit_type_path(&mut self, type_path: &TypePath, _: Span) -> bool {
+        if type_path.item.span().end() as usize != self.byte_index {
+            return true;
+        }
+
+        let typ = match &type_path.typ.typ {
+            UnresolvedTypeData::FieldElement => Some(Type::FieldElement),
+            UnresolvedTypeData::Integer(signedness, integer_bit_size) => {
+                Some(Type::Integer(*signedness, *integer_bit_size))
+            }
+            UnresolvedTypeData::Bool => Some(Type::Bool),
+            UnresolvedTypeData::String(UnresolvedTypeExpression::Constant(value, _)) => {
+                Some(Type::String(Box::new(Type::Constant(
+                    *value,
+                    Kind::Numeric(Box::new(Type::Integer(
+                        Signedness::Unsigned,
+                        IntegerBitSize::ThirtyTwo,
+                    ))),
+                ))))
+            }
+            UnresolvedTypeData::Quoted(quoted_type) => Some(Type::Quoted(*quoted_type)),
+            _ => None,
+        };
+
+        if let Some(typ) = typ {
+            let prefix = &type_path.item.0.contents;
+            self.complete_type_methods(
+                &typ,
+                prefix,
+                FunctionKind::Any,
+                FunctionCompletionKind::NameAndParameters,
+                false, // self_prefix
+            );
+        }
+
         false
     }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -363,6 +363,8 @@ impl<'a> NodeFinder<'a> {
                     self.local_variables_completion(&prefix);
                     self.builtin_functions_completion(&prefix, function_completion_kind);
                     self.builtin_values_completion(&prefix);
+                    self.builtin_types_completion(&prefix);
+                    self.type_parameters_completion(&prefix);
                     if let Some(self_type) = &self.self_type {
                         let self_prefix = true;
                         self.complete_type_fields_and_methods(

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -432,6 +432,27 @@ mod completion_tests {
     }
 
     #[test]
+    async fn test_complete_type_path_with_non_empty_name() {
+        let src = r#"
+          trait One {
+              fn one() -> Self;
+          }
+
+          impl One for Field {
+              fn one() -> Self {
+                  1
+              }
+          }
+
+          fn main() {
+            Field::o>|<
+          }
+        "#;
+        assert_completion(src, vec![function_completion_item("one()", "one()", "fn() -> Field")])
+            .await;
+    }
+
+    #[test]
     async fn test_complete_function_without_arguments() {
         let src = r#"
           fn hello() { }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -778,21 +778,29 @@ mod completion_tests {
     }
 
     #[test]
+    async fn test_suggest_builtin_types_in_any_position() {
+        let src = r#"
+            fn foo() {
+                i>|<
+            }
+        "#;
+
+        let items = get_completions(src).await;
+        assert!(items.iter().any(|item| item.label == "i8"));
+    }
+
+    #[test]
     async fn test_suggest_true() {
         let src = r#"
             fn main() {
                 let x = t>|<
             }
         "#;
-        assert_completion_excluding_auto_import(
-            src,
-            vec![simple_completion_item(
-                "true",
-                CompletionItemKind::KEYWORD,
-                Some("bool".to_string()),
-            )],
-        )
-        .await;
+
+        let items = get_completions(src).await;
+        assert!(items
+            .iter()
+            .any(|item| item.label == "true" && item.kind == Some(CompletionItemKind::KEYWORD)));
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

Autocompletion for `TypePath` didn't exist because it's a recently added feature.

## Summary

Offers suggestions when you type, for example, `u32::`. For this I had to allow parsing a `TypePath` without any ident following it (like we do for paths), still producing a parsing error.

![lsp-complete-type-path](https://github.com/user-attachments/assets/8126f181-aad1-4e57-b94b-53b7b668e083)

Also fixes the issue that built-in types weren't suggest in any position (only where types are expected, like function argument types, but now that you can call static methods on these types it makes sense to always offer them):

![lsp-suggest-type](https://github.com/user-attachments/assets/76748dcb-20ea-485c-92cf-aab6487d6ab4)


## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
