### PR TITLE
fix: Consider constants as used values to keep their rc ops

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -191,11 +191,15 @@ impl Context {
                 self.used_values.insert(value_id);
             }
             Value::Array { array, .. } => {
+                self.used_values.insert(value_id);
                 for elem in array {
                     self.mark_used_instruction_results(dfg, *elem);
                 }
             }
             Value::Param { .. } => {
+                self.used_values.insert(value_id);
+            }
+            Value::NumericConstant { .. } => {
                 self.used_values.insert(value_id);
             }
             _ => {

--- a/test_programs/execution_success/brillig_constant_reference_regression/Nargo.toml
+++ b/test_programs/execution_success/brillig_constant_reference_regression/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "brillig_constant_reference_regression"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/brillig_constant_reference_regression/Prover.toml
+++ b/test_programs/execution_success/brillig_constant_reference_regression/Prover.toml
@@ -1,0 +1,1 @@
+sorted_index = ["1", "0"]

--- a/test_programs/execution_success/brillig_constant_reference_regression/src/main.nr
+++ b/test_programs/execution_success/brillig_constant_reference_regression/src/main.nr
@@ -1,0 +1,16 @@
+unconstrained fn main(sorted_index: [u32; 2]) {
+    let original = [
+        55,
+        11
+    ];
+
+    let mut sorted = original; // Stores the constant "original" into the sorted reference
+
+    for i in 0..2 {
+        let index = sorted_index[i];
+        let value = original[index];
+        sorted[i] = value; // On first iteration, we should not mutate the original constant array, RC should be > 1
+    }
+
+    assert_eq(sorted[1], 55);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6121

## Summary\*

Die was not considering constants as used. As a result, the reference counter operations on constants were removed.
This created a correctness issue.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
