### PR TITLE
feat: swap endianness in-place in keccak implementation

### DIFF
--- a/noir_stdlib/src/hash/keccak.nr
+++ b/noir_stdlib/src/hash/keccak.nr
@@ -51,15 +51,15 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
     let mut sliced_buffer = Vec::new();
     // populate a vector of 64-bit limbs from our byte array
     for i in 0..num_limbs {
-        let word_size_times_i = i * WORD_SIZE;
-        let ws_times_i_plus_7 = word_size_times_i + 7;
+        let limb_start = WORD_SIZE * i;
+        let limb_end: u32 = limb_start + (WORD_SIZE - 1);
         let mut sliced = 0;
-        if (word_size_times_i + WORD_SIZE > max_blocks_length) {
-            let slice_size = max_blocks_length - word_size_times_i;
+        if (limb_start + WORD_SIZE > max_blocks_length) {
+            let slice_size = max_blocks_length - limb_start;
             let byte_shift = (WORD_SIZE - slice_size) * 8;
             let mut v = 1;
             for k in 0..slice_size {
-                sliced += v * (block_bytes[ws_times_i_plus_7-k] as Field);
+                sliced += v * (block_bytes[limb_end-k] as Field);
                 v *= 256;
             }
             let w = 1 << (byte_shift as u8);
@@ -67,7 +67,7 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
         } else {
             let mut v = 1;
             for k in 0..WORD_SIZE {
-                sliced += v * (block_bytes[ws_times_i_plus_7-k] as Field);
+                sliced += v * (block_bytes[limb_end-k] as Field);
                 v *= 256;
             }
         }

--- a/noir_stdlib/src/hash/keccak.nr
+++ b/noir_stdlib/src/hash/keccak.nr
@@ -40,17 +40,6 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
     // populate a vector of 64-bit limbs from our byte array
     for i in 0..num_limbs {
         let limb_start = WORD_SIZE * i;
-        let limb_end: u32 = limb_start + (WORD_SIZE - 1);
-
-        // TODO: we should be able to just remove this for-loop by indexing `block_bytes` more intelligently
-        // when constructing `sliced` below.
-        for j in 0..WORD_SIZE / 2 {
-            // keccak lanes interpret memory as little-endian integers,
-            // means we need to swap our byte ordering
-            let temp = block_bytes[limb_end - j];
-            block_bytes[limb_end - j] = block_bytes[limb_start+j];
-            block_bytes[limb_start + j] = temp;
-        }
 
         let mut sliced = 0;
         if (limb_start + WORD_SIZE > max_blocks_length) {
@@ -58,7 +47,7 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
             let byte_shift = (WORD_SIZE - slice_size) * 8;
             let mut v = 1;
             for k in 0..slice_size {
-                sliced += v * (block_bytes[limb_end-k] as Field);
+                sliced += v * (block_bytes[limb_start+k] as Field);
                 v *= 256;
             }
             let w = 1 << (byte_shift as u8);
@@ -66,7 +55,7 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
         } else {
             let mut v = 1;
             for k in 0..WORD_SIZE {
-                sliced += v * (block_bytes[limb_end-k] as Field);
+                sliced += v * (block_bytes[limb_start+k] as Field);
                 v *= 256;
             }
         }

--- a/noir_stdlib/src/hash/keccak.nr
+++ b/noir_stdlib/src/hash/keccak.nr
@@ -39,13 +39,11 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
     // means we need to swap our byte ordering
     let num_limbs = max_blocks * LIMBS_PER_BLOCK; //max_blocks_length / WORD_SIZE;
     for i in 0..num_limbs {
-        let mut temp = [0; WORD_SIZE];
         let word_size_times_i = WORD_SIZE * i;
-        for j in 0..WORD_SIZE {
-            temp[j] = block_bytes[word_size_times_i+j];
-        }
-        for j in 0..WORD_SIZE {
-            block_bytes[word_size_times_i + j] = temp[7 - j];
+        for j in 0..WORD_SIZE / 2 {
+            let temp = block_bytes[word_size_times_i + 7 - j]; 
+            block_bytes[word_size_times_i + 7 - j] = block_bytes[word_size_times_i+j];
+            block_bytes[word_size_times_i + j] = temp;
         }
     }
 

--- a/noir_stdlib/src/hash/keccak.nr
+++ b/noir_stdlib/src/hash/keccak.nr
@@ -35,24 +35,23 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
     block_bytes[message_size] = 1;
     block_bytes[real_blocks_bytes - 1] = 0x80;
 
-    // keccak lanes interpret memory as little-endian integers,
-    // means we need to swap our byte ordering
     let num_limbs = max_blocks * LIMBS_PER_BLOCK; //max_blocks_length / WORD_SIZE;
-    for i in 0..num_limbs {
-        let limb_start = WORD_SIZE * i;
-        let limb_end: u32 = limb_start + (WORD_SIZE - 1);
-        for j in 0..WORD_SIZE / 2 {
-            let temp = block_bytes[limb_end - j];
-            block_bytes[limb_end - j] = block_bytes[limb_start+j];
-            block_bytes[limb_start + j] = temp;
-        }
-    }
-
     let mut sliced_buffer = Vec::new();
     // populate a vector of 64-bit limbs from our byte array
     for i in 0..num_limbs {
         let limb_start = WORD_SIZE * i;
         let limb_end: u32 = limb_start + (WORD_SIZE - 1);
+
+        // TODO: we should be able to just remove this for-loop by indexing `block_bytes` more intelligently
+        // when constructing `sliced` below.
+        for j in 0..WORD_SIZE / 2 {
+            // keccak lanes interpret memory as little-endian integers,
+            // means we need to swap our byte ordering
+            let temp = block_bytes[limb_end - j];
+            block_bytes[limb_end - j] = block_bytes[limb_start+j];
+            block_bytes[limb_start + j] = temp;
+        }
+
         let mut sliced = 0;
         if (limb_start + WORD_SIZE > max_blocks_length) {
             let slice_size = max_blocks_length - limb_start;

--- a/noir_stdlib/src/hash/keccak.nr
+++ b/noir_stdlib/src/hash/keccak.nr
@@ -41,7 +41,7 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
     for i in 0..num_limbs {
         let word_size_times_i = WORD_SIZE * i;
         for j in 0..WORD_SIZE / 2 {
-            let temp = block_bytes[word_size_times_i + 7 - j]; 
+            let temp = block_bytes[word_size_times_i + 7 - j];
             block_bytes[word_size_times_i + 7 - j] = block_bytes[word_size_times_i+j];
             block_bytes[word_size_times_i + j] = temp;
         }

--- a/noir_stdlib/src/hash/keccak.nr
+++ b/noir_stdlib/src/hash/keccak.nr
@@ -39,11 +39,12 @@ pub(crate) fn keccak256<let N: u32>(input: [u8; N], message_size: u32) -> [u8; 3
     // means we need to swap our byte ordering
     let num_limbs = max_blocks * LIMBS_PER_BLOCK; //max_blocks_length / WORD_SIZE;
     for i in 0..num_limbs {
-        let word_size_times_i = WORD_SIZE * i;
+        let limb_start = WORD_SIZE * i;
+        let limb_end: u32 = limb_start + (WORD_SIZE - 1);
         for j in 0..WORD_SIZE / 2 {
-            let temp = block_bytes[word_size_times_i + 7 - j];
-            block_bytes[word_size_times_i + 7 - j] = block_bytes[word_size_times_i+j];
-            block_bytes[word_size_times_i + j] = temp;
+            let temp = block_bytes[limb_end - j];
+            block_bytes[limb_end - j] = block_bytes[limb_start+j];
+            block_bytes[limb_start + j] = temp;
         }
     }
 
@@ -154,4 +155,3 @@ mod tests {
         assert_eq(keccak256(input, 13), result);
     }
 }
-


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes the `temp` array created when swapping the endianness of the `block_bytes` array and just swaps the values in place. This removes some unnecessary reads/writes from brillig.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
