### PR TITLE
fix: handle parenthesized expressions in array length

### DIFF
--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -460,6 +460,7 @@ impl UnresolvedTypeExpression {
             ExpressionKind::AsTraitPath(path) => {
                 Ok(UnresolvedTypeExpression::AsTraitPath(Box::new(path)))
             }
+            ExpressionKind::Parenthesized(expr) => Self::from_expr_helper(*expr),
             _ => Err(expr),
         }
     }

--- a/test_programs/compile_success_empty/parenthesized_expression_in_array_length/Nargo.toml
+++ b/test_programs/compile_success_empty/parenthesized_expression_in_array_length/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "parenthesized_expression_in_array_length"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.32.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/parenthesized_expression_in_array_length/src/main.nr
+++ b/test_programs/compile_success_empty/parenthesized_expression_in_array_length/src/main.nr
@@ -1,0 +1,6 @@
+global N = 100;
+global BLOCK_SIZE = 10;
+
+fn main() {
+    let _: [Field; 110] = [0; ((N + BLOCK_SIZE) * BLOCK_SIZE) / BLOCK_SIZE];
+}


### PR DESCRIPTION
# Description

## Problem

We were missing handling parenthesized expressions in `UnresolvedTypeExpression::from_expr_helper`

## Summary

Fixes the above issue.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
