### PR TITLE
feat: optimize constraints in sha256

### DIFF
--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -186,11 +186,9 @@ pub fn sha256_var<let N: u32>(msg: [u8; N], message_size: u64) -> [u8; 32] {
 
     if !crate::runtime::is_unconstrained() {
         for i in 0..56 {
-            if i < msg_byte_ptr {
-                assert_eq(msg_block[i], last_block[i]);
-            } else {
-                assert_eq(msg_block[i], zero);
-            }
+            let predicate = (i < msg_byte_ptr) as u8;
+            let expected_byte = predicate * last_block[i];
+            assert_eq(msg_block[i], expected_byte);
         }
 
         let len = 8 * message_size;

--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -195,7 +195,7 @@ pub fn sha256_var<let N: u32>(msg: [u8; N], message_size: u64) -> [u8; 32] {
         let len = 8 * message_size;
         let mut reconstructed_len: Field = 0;
         for i in 0..8 {
-            reconstructed_len += msg_block[63 - i] as Field * (1 << (i as u8)) as Field;
+            reconstructed_len =  256 * reconstructed_len + msg_block[56 + i] as Field;
         }
         assert_eq(reconstructed_len, len as Field);
     }
@@ -254,4 +254,3 @@ fn hash_final_block(msg_block: [u8; 64], mut state: [u32; 8]) -> [u8; 32] {
 
     out_h
 }
-

--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -194,8 +194,8 @@ pub fn sha256_var<let N: u32>(msg: [u8; N], message_size: u64) -> [u8; 32] {
         // We verify the message length was inserted correctly by reversing the byte decomposition.
         let len = 8 * message_size;
         let mut reconstructed_len: Field = 0;
-        for i in 0..8 {
-            reconstructed_len =  256 * reconstructed_len + msg_block[56 + i] as Field;
+        for i in 56..64 {
+            reconstructed_len = 256 * reconstructed_len + msg_block[i] as Field;
         }
         assert_eq(reconstructed_len, len as Field);
     }

--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -191,11 +191,13 @@ pub fn sha256_var<let N: u32>(msg: [u8; N], message_size: u64) -> [u8; 32] {
             assert_eq(msg_block[i], expected_byte);
         }
 
+        // We verify the message length was inserted correctly by reversing the byte decomposition.
         let len = 8 * message_size;
-        let len_bytes: [u8; 8] = (len as Field).to_be_bytes();
-        for i in 56..64 {
-            assert_eq(msg_block[i], len_bytes[i - 56]);
+        let mut reconstructed_len: Field = 0;
+        for i in 0..8 {
+            reconstructed_len += msg_block[63 - i] as Field * (1 << (i as u8)) as Field;
         }
+        assert_eq(reconstructed_len, len as Field);
     }
 
     hash_final_block(msg_block, h)


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We can optimize the sha256 implementation rolling the if-statement condition into the values being constrained manually. This allows us to have a single constraint rather than 2 with opposite predicates.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
