### PR TITLE
feat: allow silencing an unused variable defined via `let`

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -141,13 +141,14 @@ impl StatementKind {
         pattern: Pattern,
         r#type: UnresolvedType,
         expression: Expression,
+        attributes: Vec<SecondaryAttribute>,
     ) -> StatementKind {
         StatementKind::Let(LetStatement {
             pattern,
             r#type,
             expression,
             comptime: false,
-            attributes: vec![],
+            attributes,
         })
     }
 
@@ -814,6 +815,7 @@ impl ForRange {
                         Pattern::Identifier(array_ident.clone()),
                         UnresolvedTypeData::Unspecified.with_span(Default::default()),
                         array,
+                        vec![],
                     ),
                     span: array_span,
                 };
@@ -858,6 +860,7 @@ impl ForRange {
                         Pattern::Identifier(identifier),
                         UnresolvedTypeData::Unspecified.with_span(Default::default()),
                         Expression::new(loop_element, array_span),
+                        vec![],
                     ),
                     span: array_span,
                 };

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -32,6 +32,7 @@ pub enum AttributeTarget {
     Struct,
     Trait,
     Function,
+    Let,
 }
 
 /// Implements the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) for Noir's AST.
@@ -1097,6 +1098,10 @@ impl Statement {
 
 impl LetStatement {
     pub fn accept(&self, visitor: &mut impl Visitor) {
+        for attribute in &self.attributes {
+            attribute.accept(AttributeTarget::Let, visitor);
+        }
+
         if visitor.visit_let_statement(self) {
             self.accept_children(visitor);
         }

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -146,6 +146,7 @@ impl DebugInstrumenter {
                         ast::Pattern::Identifier(ident("__debug_expr", ret_expr.span)),
                         ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
                         ret_expr.clone(),
+                        vec![],
                     ),
                     span: ret_expr.span,
                 };
@@ -249,6 +250,7 @@ impl DebugInstrumenter {
                     }),
                     span: let_stmt.expression.span,
                 },
+                vec![],
             ),
             span: *span,
         }
@@ -274,6 +276,7 @@ impl DebugInstrumenter {
             ast::Pattern::Identifier(ident("__debug_expr", assign_stmt.expression.span)),
             ast::UnresolvedTypeData::Unspecified.with_span(Default::default()),
             assign_stmt.expression.clone(),
+            vec![],
         );
         let expression_span = assign_stmt.expression.span;
         let new_assign_stmt = match &assign_stmt.lvalue {

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -790,7 +790,7 @@ impl<'context> Elaborator<'context> {
             let parameter = DefinitionKind::Local(None);
             let typ = self.resolve_inferred_type(typ);
             arg_types.push(typ.clone());
-            (self.elaborate_pattern(pattern, typ.clone(), parameter), typ)
+            (self.elaborate_pattern(pattern, typ.clone(), parameter, true), typ)
         });
 
         let return_type = self.resolve_inferred_type(lambda.return_type);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -362,7 +362,12 @@ impl<'context> Elaborator<'context> {
             if let Kind::Numeric(typ) = &generic.kind {
                 let definition = DefinitionKind::GenericType(generic.type_var.clone());
                 let ident = Ident::new(generic.name.to_string(), generic.span);
-                let hir_ident = self.add_variable_decl(ident, false, false, false, definition);
+                let hir_ident = self.add_variable_decl(
+                    ident, false, // mutable
+                    false, // allow_shadowing
+                    false, // warn_if_unused
+                    definition,
+                );
                 self.interner.push_definition_type(hir_ident.id, *typ.clone());
             }
         }
@@ -759,7 +764,7 @@ impl<'context> Elaborator<'context> {
                 typ.clone(),
                 DefinitionKind::Local(None),
                 &mut parameter_idents,
-                true,
+                true, // warn_if_unused
                 None,
             );
 

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -362,8 +362,7 @@ impl<'context> Elaborator<'context> {
             if let Kind::Numeric(typ) = &generic.kind {
                 let definition = DefinitionKind::GenericType(generic.type_var.clone());
                 let ident = Ident::new(generic.name.to_string(), generic.span);
-                let hir_ident =
-                    self.add_variable_decl_inner(ident, false, false, false, definition);
+                let hir_ident = self.add_variable_decl(ident, false, false, false, definition);
                 self.interner.push_definition_type(hir_ident.id, *typ.clone());
             }
         }
@@ -760,6 +759,7 @@ impl<'context> Elaborator<'context> {
                 typ.clone(),
                 DefinitionKind::Local(None),
                 &mut parameter_idents,
+                true,
                 None,
             );
 

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -26,6 +26,7 @@ impl<'context> Elaborator<'context> {
         pattern: Pattern,
         expected_type: Type,
         definition_kind: DefinitionKind,
+        warn_if_unused: bool,
     ) -> HirPattern {
         self.elaborate_pattern_mut(
             pattern,
@@ -33,6 +34,7 @@ impl<'context> Elaborator<'context> {
             definition_kind,
             None,
             &mut Vec::new(),
+            warn_if_unused,
             None,
         )
     }
@@ -45,6 +47,7 @@ impl<'context> Elaborator<'context> {
         expected_type: Type,
         definition_kind: DefinitionKind,
         created_ids: &mut Vec<HirIdent>,
+        warn_if_unused: bool,
         global_id: Option<GlobalId>,
     ) -> HirPattern {
         self.elaborate_pattern_mut(
@@ -53,10 +56,12 @@ impl<'context> Elaborator<'context> {
             definition_kind,
             None,
             created_ids,
+            warn_if_unused,
             global_id,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn elaborate_pattern_mut(
         &mut self,
         pattern: Pattern,
@@ -64,6 +69,7 @@ impl<'context> Elaborator<'context> {
         definition: DefinitionKind,
         mutable: Option<Span>,
         new_definitions: &mut Vec<HirIdent>,
+        warn_if_unused: bool,
         global_id: Option<GlobalId>,
     ) -> HirPattern {
         match pattern {
@@ -80,7 +86,13 @@ impl<'context> Elaborator<'context> {
                     let location = Location::new(name.span(), self.file);
                     HirIdent::non_trait_method(id, location)
                 } else {
-                    self.add_variable_decl(name, mutable.is_some(), true, definition)
+                    self.add_variable_decl(
+                        name,
+                        mutable.is_some(),
+                        true,
+                        warn_if_unused,
+                        definition,
+                    )
                 };
                 self.interner.push_definition_type(ident.id, expected_type);
                 new_definitions.push(ident.clone());
@@ -97,6 +109,7 @@ impl<'context> Elaborator<'context> {
                     definition,
                     Some(span),
                     new_definitions,
+                    warn_if_unused,
                     global_id,
                 );
                 let location = Location::new(span, self.file);
@@ -128,6 +141,7 @@ impl<'context> Elaborator<'context> {
                         definition.clone(),
                         mutable,
                         new_definitions,
+                        warn_if_unused,
                         global_id,
                     )
                 });
@@ -151,6 +165,7 @@ impl<'context> Elaborator<'context> {
                     definition,
                     mutable,
                     new_definitions,
+                    warn_if_unused,
                     global_id,
                 )
             }
@@ -180,7 +195,7 @@ impl<'context> Elaborator<'context> {
             // shadowing here lets us avoid further errors if we define ERROR_IDENT
             // multiple times.
             let name = ERROR_IDENT.into();
-            let identifier = this.add_variable_decl(name, false, true, definition.clone());
+            let identifier = this.add_variable_decl(name, false, true, true, definition.clone());
             HirPattern::Identifier(identifier)
         };
 
@@ -263,6 +278,7 @@ impl<'context> Elaborator<'context> {
                 definition.clone(),
                 mutable,
                 new_definitions,
+                true,
                 None,
             );
 
@@ -295,16 +311,6 @@ impl<'context> Elaborator<'context> {
     }
 
     pub(super) fn add_variable_decl(
-        &mut self,
-        name: Ident,
-        mutable: bool,
-        allow_shadowing: bool,
-        definition: DefinitionKind,
-    ) -> HirIdent {
-        self.add_variable_decl_inner(name, mutable, allow_shadowing, true, definition)
-    }
-
-    pub fn add_variable_decl_inner(
         &mut self,
         name: Ident,
         mutable: bool,

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -89,7 +89,7 @@ impl<'context> Elaborator<'context> {
                     self.add_variable_decl(
                         name,
                         mutable.is_some(),
-                        true,
+                        true, // allow_shadowing
                         warn_if_unused,
                         definition,
                     )
@@ -278,7 +278,7 @@ impl<'context> Elaborator<'context> {
                 definition.clone(),
                 mutable,
                 new_definitions,
-                true,
+                true, // warn_if_unused
                 None,
             );
 

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -98,12 +98,16 @@ impl<'context> Elaborator<'context> {
             }
         }
 
+        let warn_if_unused =
+            !let_stmt.attributes.iter().any(|attr| attr.is_allow_unused_variables());
+
         let r#type = annotated_type;
         let pattern = self.elaborate_pattern_and_store_ids(
             let_stmt.pattern,
             r#type.clone(),
             definition,
             &mut Vec::new(),
+            warn_if_unused,
             global_id,
         );
 
@@ -215,7 +219,7 @@ impl<'context> Elaborator<'context> {
         // TODO: For loop variables are currently mutable by default since we haven't
         //       yet implemented syntax for them to be optionally mutable.
         let kind = DefinitionKind::Local(None);
-        let identifier = self.add_variable_decl(identifier, false, true, kind);
+        let identifier = self.add_variable_decl(identifier, false, true, true, kind);
 
         // Check that start range and end range have the same types
         let range_span = start_span.merge(end_span);

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -219,7 +219,12 @@ impl<'context> Elaborator<'context> {
         // TODO: For loop variables are currently mutable by default since we haven't
         //       yet implemented syntax for them to be optionally mutable.
         let kind = DefinitionKind::Local(None);
-        let identifier = self.add_variable_decl(identifier, false, true, true, kind);
+        let identifier = self.add_variable_decl(
+            identifier, false, // mutable
+            true,  // allow_shadowing
+            true,  // warn_if_unused
+            kind,
+        );
 
         // Check that start range and end range have the same types
         let range_span = start_span.merge(end_span);

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -29,7 +29,7 @@ impl HirStatement {
                 let pattern = let_stmt.pattern.to_display_ast(interner);
                 let r#type = interner.id_type(let_stmt.expression).to_display_ast();
                 let expression = let_stmt.expression.to_display_ast(interner);
-                StatementKind::new_let(pattern, r#type, expression)
+                StatementKind::new_let(pattern, r#type, expression, let_stmt.attributes.clone())
             }
             HirStatement::Constrain(constrain) => {
                 let expr = constrain.0.to_display_ast(interner);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2338,7 +2338,7 @@ fn function_def_set_parameters(
                 parameter_type.clone(),
                 DefinitionKind::Local(None),
                 &mut parameter_idents,
-                true,
+                true, // warn_if_unused
                 None,
             )
         });

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2338,6 +2338,7 @@ fn function_def_set_parameters(
                 parameter_type.clone(),
                 DefinitionKind::Local(None),
                 &mut parameter_idents,
+                true,
                 None,
             )
         });

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -955,6 +955,13 @@ impl SecondaryAttribute {
             SecondaryAttribute::Allow(_) => Some("allow".to_string()),
         }
     }
+
+    pub(crate) fn is_allow_unused_variables(&self) -> bool {
+        match self {
+            SecondaryAttribute::Allow(string) => string == "unused_variables",
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for SecondaryAttribute {

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -804,6 +804,7 @@ impl Attribute {
             }
             ["varargs"] => Attribute::Secondary(SecondaryAttribute::Varargs),
             ["use_callers_scope"] => Attribute::Secondary(SecondaryAttribute::UseCallersScope),
+            ["allow", tag] => Attribute::Secondary(SecondaryAttribute::Allow(tag.to_string())),
             tokens => {
                 tokens.iter().try_for_each(|token| validate(token))?;
                 Attribute::Secondary(SecondaryAttribute::Custom(CustomAttribute {
@@ -925,6 +926,9 @@ pub enum SecondaryAttribute {
     /// within the scope of the calling function/module rather than this one.
     /// This affects functions such as `Expression::resolve` or `Quoted::as_type`.
     UseCallersScope,
+
+    /// Allow chosen warnings to happen so they are silenced.
+    Allow(String),
 }
 
 impl SecondaryAttribute {
@@ -948,6 +952,7 @@ impl SecondaryAttribute {
             SecondaryAttribute::Abi(_) => Some("abi".to_string()),
             SecondaryAttribute::Varargs => Some("varargs".to_string()),
             SecondaryAttribute::UseCallersScope => Some("use_callers_scope".to_string()),
+            SecondaryAttribute::Allow(_) => Some("allow".to_string()),
         }
     }
 }
@@ -966,6 +971,7 @@ impl fmt::Display for SecondaryAttribute {
             SecondaryAttribute::Abi(ref k) => write!(f, "#[abi({k})]"),
             SecondaryAttribute::Varargs => write!(f, "#[varargs]"),
             SecondaryAttribute::UseCallersScope => write!(f, "#[use_callers_scope]"),
+            SecondaryAttribute::Allow(ref k) => write!(f, "#[allow(#{k})]"),
         }
     }
 }
@@ -1011,7 +1017,9 @@ impl AsRef<str> for SecondaryAttribute {
             SecondaryAttribute::Deprecated(Some(string)) => string,
             SecondaryAttribute::Deprecated(None) => "",
             SecondaryAttribute::Custom(attribute) => &attribute.contents,
-            SecondaryAttribute::Field(string) | SecondaryAttribute::Abi(string) => string,
+            SecondaryAttribute::Field(string)
+            | SecondaryAttribute::Abi(string)
+            | SecondaryAttribute::Allow(string) => string,
             SecondaryAttribute::ContractLibraryMethod => "",
             SecondaryAttribute::Export => "",
             SecondaryAttribute::Varargs => "",

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -54,7 +54,7 @@ use crate::ast::{
 };
 use crate::lexer::Lexer;
 use crate::parser::{force, ignore_then_commit, statement_recovery};
-use crate::token::{Keyword, Token, TokenKind};
+use crate::token::{Keyword, SecondaryAttribute, Token, TokenKind};
 use acvm::AcirField;
 
 use chumsky::prelude::*;
@@ -535,23 +535,30 @@ where
 
 fn let_statement<'a, P>(
     expr_parser: P,
-) -> impl NoirParser<((Pattern, UnresolvedType), Expression)> + 'a
+) -> impl NoirParser<(Vec<SecondaryAttribute>, Pattern, UnresolvedType, Expression)> + 'a
 where
     P: ExprParser + 'a,
 {
-    let p =
-        ignore_then_commit(keyword(Keyword::Let).labelled(ParsingRuleLabel::Statement), pattern());
+    let p = attributes();
+    let p = p.then_ignore(keyword(Keyword::Let).labelled(ParsingRuleLabel::Statement));
+    let p = then_commit(p, pattern());
     let p = p.then(optional_type_annotation());
     let p = then_commit_ignore(p, just(Token::Assign));
-    then_commit(p, expr_parser)
+    let p = then_commit(p, expr_parser);
+    p.validate(|(((attributes, pattern), typ), expr), span, emit| {
+        let attributes = attributes::validate_secondary_attributes(attributes, span, emit);
+
+        (attributes, pattern, typ, expr)
+    })
 }
 
 fn declaration<'a, P>(expr_parser: P) -> impl NoirParser<StatementKind> + 'a
 where
     P: ExprParser + 'a,
 {
-    let_statement(expr_parser)
-        .map(|((pattern, typ), expr)| StatementKind::new_let(pattern, typ, expr))
+    let_statement(expr_parser).map(|(attributes, pattern, typ, expr)| {
+        StatementKind::new_let(pattern, typ, expr, attributes)
+    })
 }
 
 pub fn pattern() -> impl NoirParser<Pattern> {

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -203,7 +203,7 @@ fn trait_implementation_body() -> impl NoirParser<Vec<Documented<TraitImplItem>>
         .map(|(name, alias)| TraitImplItemKind::Type { name, alias });
 
     let let_statement = let_statement(expression()).then_ignore(just(Token::Semicolon)).try_map(
-        |(_attributes, pattern, typ, expr), span| match pattern {
+        |((pattern, typ), expr), span| match pattern {
             Pattern::Identifier(ident) => Ok(TraitImplItemKind::Constant(ident, typ, expr)),
             _ => Err(ParserError::with_reason(
                 ParserErrorReason::PatternInTraitFunctionParameter,

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -203,7 +203,7 @@ fn trait_implementation_body() -> impl NoirParser<Vec<Documented<TraitImplItem>>
         .map(|(name, alias)| TraitImplItemKind::Type { name, alias });
 
     let let_statement = let_statement(expression()).then_ignore(just(Token::Semicolon)).try_map(
-        |((pattern, typ), expr), span| match pattern {
+        |(_attributes, pattern, typ, expr), span| match pattern {
             Pattern::Identifier(ident) => Ok(TraitImplItemKind::Constant(ident, typ, expr)),
             _ => Err(ParserError::with_reason(
                 ParserErrorReason::PatternInTraitFunctionParameter,

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -1,4 +1,7 @@
-use crate::hir::{def_collector::dc_crate::CompilationError, resolution::errors::ResolverError};
+use crate::{
+    hir::{def_collector::dc_crate::CompilationError, resolution::errors::ResolverError},
+    tests::assert_no_errors,
+};
 
 use super::get_program_errors;
 
@@ -156,4 +159,15 @@ fn errors_on_unused_trait() {
 
     assert_eq!(ident.to_string(), "Foo");
     assert_eq!(*item_type, "trait");
+}
+
+#[test]
+fn silences_unused_variable_warning() {
+    let src = r#"
+    fn main() {
+        #[allow(unused_variables)]
+        let x = 1;
+    }
+    "#;
+    assert_no_errors(src);
 }

--- a/tooling/lsp/src/requests/completion/builtins.rs
+++ b/tooling/lsp/src/requests/completion/builtins.rs
@@ -116,6 +116,15 @@ impl<'a> NodeFinder<'a> {
                     ));
                 }
             }
+            AttributeTarget::Let => {
+                if name_matches("allow", prefix) || name_matches("unused_variables", prefix) {
+                    self.completion_items.push(simple_completion_item(
+                        "allow(unused_variables)",
+                        CompletionItemKind::METHOD,
+                        None,
+                    ));
+                }
+            }
         }
     }
 }

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -51,6 +51,10 @@ impl<'a> NodeFinder<'a> {
                     AttributeTarget::Struct => Some(Type::Quoted(QuotedType::StructDefinition)),
                     AttributeTarget::Trait => Some(Type::Quoted(QuotedType::TraitDefinition)),
                     AttributeTarget::Function => Some(Type::Quoted(QuotedType::FunctionDefinition)),
+                    AttributeTarget::Let => {
+                        // No item can be suggested for a let statement attribute
+                        return Vec::new();
+                    }
                 }
             } else {
                 None

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1943,6 +1943,26 @@ mod completion_tests {
     }
 
     #[test]
+    async fn test_suggests_built_in_let_attribute() {
+        let src = r#"
+            fn foo() {
+                #[allo>|<]
+                let x = 1;
+            }
+        "#;
+
+        assert_completion_excluding_auto_import(
+            src,
+            vec![simple_completion_item(
+                "allow(unused_variables)",
+                CompletionItemKind::METHOD,
+                None,
+            )],
+        )
+        .await;
+    }
+
+    #[test]
     async fn test_suggests_function_attribute() {
         let src = r#"
             #[some>|<]


### PR DESCRIPTION
# Description

## Problem

Resolves #6148

## Summary

![lsp-allow-unused](https://github.com/user-attachments/assets/738168ab-cfd6-468e-8abc-fbb0e30e60b6)

## Additional Context

This is only for `let`, which is what we currently need.

Should this be documented? I guess so, but I couldn't find where in our docs we explain `let`. (on the other hand we have `deprecated` but it seems to also be undocumented)

## Documentation

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
