### PR TITLE
feat: expose `derived_generators` and `pedersen_commitment_with_separator` from the stdlib

### DIFF
--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -105,7 +105,7 @@ fn __derive_generators<let N: u32, let M: u32>(
     // Same as from_field but:
     // does not assert the limbs are 128 bits
     // does not assert the decomposition does not overflow the EmbeddedCurveScalar
-    pub fn from_field_unsafe(scalar: Field) -> EmbeddedCurveScalar {
+fn from_field_unsafe(scalar: Field) -> EmbeddedCurveScalar {
     let (xlo, xhi) = unsafe {
         crate::field::bn254::decompose_hint(scalar)
     };

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -36,7 +36,7 @@ pub fn pedersen_hash_with_separator<let N: u32>(input: [Field; N], separator: u3
     __pedersen_hash_with_separator(input, separator)
 }
 
-fn pedersen_commitment_with_separator<let N: u32>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
+pub fn pedersen_commitment_with_separator<let N: u32>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
     let value = __pedersen_commitment_with_separator(input, separator);
     if (value[0] == 0) & (value[1] == 0) {
         EmbeddedCurvePoint { x: 0, y: 0, is_infinite: true }
@@ -88,7 +88,7 @@ fn __pedersen_hash_with_separator<let N: u32>(input: [Field; N], separator: u32)
 fn __pedersen_commitment_with_separator<let N: u32>(input: [Field; N], separator: u32) -> [Field; 2] {}
 
 #[field(bn254)]
-fn derive_generators<let N: u32, let M: u32>(domain_separator_bytes: [u8; M], starting_index: u32) -> [EmbeddedCurvePoint; N] {
+pub fn derive_generators<let N: u32, let M: u32>(domain_separator_bytes: [u8; M], starting_index: u32) -> [EmbeddedCurvePoint; N] {
     crate::assert_constant(domain_separator_bytes);
     // TODO(https://github.com/noir-lang/noir/issues/5672): Add back assert_constant on starting_index
     __derive_generators(domain_separator_bytes, starting_index)
@@ -105,7 +105,7 @@ fn __derive_generators<let N: u32, let M: u32>(
     // Same as from_field but:
     // does not assert the limbs are 128 bits
     // does not assert the decomposition does not overflow the EmbeddedCurveScalar
-    fn from_field_unsafe(scalar: Field) -> EmbeddedCurveScalar {
+    pub fn from_field_unsafe(scalar: Field) -> EmbeddedCurveScalar {
     let (xlo, xhi) = unsafe {
         crate::field::bn254::decompose_hint(scalar)
     };
@@ -419,4 +419,3 @@ fn assert_pedersen() {
     }
     );
 }
-

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -102,9 +102,9 @@ fn __derive_generators<let N: u32, let M: u32>(
 ) -> [EmbeddedCurvePoint; N] {}
 
 #[field(bn254)]
-    // Same as from_field but:
-    // does not assert the limbs are 128 bits
-    // does not assert the decomposition does not overflow the EmbeddedCurveScalar
+// Same as from_field but:
+// does not assert the limbs are 128 bits
+// does not assert the decomposition does not overflow the EmbeddedCurveScalar
 fn from_field_unsafe(scalar: Field) -> EmbeddedCurveScalar {
     let (xlo, xhi) = unsafe {
         crate::field::bn254::decompose_hint(scalar)


### PR DESCRIPTION
These are functions that we need to import directly in `aztec-nr`, from discussion with @vezenovm there doesn't seem to be a good reason to not export them.