### PR TITLE
fix: Do not duplicate constant arrays in brillig

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
@@ -5,7 +5,7 @@ use crate::ssa::ir::types::Type;
 use super::{
     basic_block::BasicBlockId,
     dfg::{CallStack, InsertInstructionResult},
-    function::{Function, RuntimeType},
+    function::Function,
     instruction::{Instruction, InstructionId},
     value::ValueId,
 };
@@ -46,14 +46,7 @@ impl<'f> FunctionInserter<'f> {
                     if let Some(fetched_value) =
                         self.const_arrays.get(&(new_array.clone(), typ.clone()))
                     {
-                        // Arrays in ACIR are immutable, but in Brillig arrays are copy-on-write
-                        // so for function's with a Brillig runtime we make sure to check that value
-                        // in our constants array map matches the resolved array value id.
-                        if matches!(self.function.runtime(), RuntimeType::Acir(_)) {
-                            return *fetched_value;
-                        } else if *fetched_value == value {
-                            return value;
-                        }
+                        return *fetched_value;
                     };
 
                     let new_array_clone = new_array.clone();


### PR DESCRIPTION
# Description

## Problem\*

Avoids array duplication in inserter for brillig runtimes.

## Summary\*

After https://github.com/noir-lang/noir/pull/6122 the inhibitor in the deduplication process for brillig should not be necessary anymore.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
