### PR TITLE
chore: deprecate various items in stdlib

### DIFF
--- a/noir_stdlib/src/ec/consts/te.nr
+++ b/noir_stdlib/src/ec/consts/te.nr
@@ -8,6 +8,7 @@ pub struct BabyJubjub {
 }
 
 #[field(bn254)]
+#[deprecated = "It's recommmended to use the external noir-edwards library (https://github.com/noir-lang/noir-edwards)"]
 pub fn baby_jubjub() -> BabyJubjub {
     BabyJubjub {
         // Baby Jubjub (ERC-2494) parameters in affine representation

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -27,6 +27,7 @@ mod affine {
 
     impl Point {
         // Point constructor
+        #[deprecated = "It's recommmended to use the external noir-edwards library (https://github.com/noir-lang/noir-edwards)"]
         pub fn new(x: Field, y: Field) -> Self {
             Self { x, y }
         }

--- a/noir_stdlib/src/hash/mimc.nr
+++ b/noir_stdlib/src/hash/mimc.nr
@@ -6,6 +6,7 @@ use crate::default::Default;
 // You must use constants generated for the native field
 // Rounds number should be ~ log(p)/log(exp)
 // For 254 bit primes, exponent 7 and 91 rounds seems to be recommended
+#[deprecated = "It's recommmended to use the external MiMC library (https://github.com/noir-lang/mimc)"]
 fn mimc<let N: u32>(x: Field, k: Field, constants: [Field; N], exp: Field) -> Field {
     //round 0
     let mut t = x + k;
@@ -116,6 +117,7 @@ global MIMC_BN254_CONSTANTS: [Field; MIMC_BN254_ROUNDS] = [
 
 //mimc implementation with hardcoded parameters for BN254 curve.
 #[field(bn254)]
+#[deprecated = "It's recommmended to use the external MiMC library (https://github.com/noir-lang/mimc)"]
 pub fn mimc_bn254<let N: u32>(array: [Field; N]) -> Field {
     let exponent = 7;
     let mut r = 0;

--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -8,7 +8,7 @@ use crate::runtime::is_unconstrained;
 pub fn sha256<let N: u32>(input: [u8; N]) -> [u8; 32]
 // docs:end:sha256
 {
-    crate::sha256::digest(input)
+    digest(input)
 }
 
 #[foreign(sha256_compression)]

--- a/noir_stdlib/src/schnorr.nr
+++ b/noir_stdlib/src/schnorr.nr
@@ -1,4 +1,3 @@
-use crate::collections::vec::Vec;
 use crate::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar};
 
 #[foreign(schnorr_verify)]
@@ -23,7 +22,11 @@ pub fn verify_signature_slice(
 // docs:end:schnorr_verify_slice
 {}
 
-pub fn verify_signature_noir<let N: u32>(public_key: EmbeddedCurvePoint, signature: [u8; 64], message: [u8; N]) -> bool {
+pub fn verify_signature_noir<let N: u32>(
+    public_key: EmbeddedCurvePoint,
+    signature: [u8; 64],
+    message: [u8; N]
+) -> bool {
     //scalar lo/hi from bytes
     let sig_s = EmbeddedCurveScalar::from_bytes(signature, 0);
     let sig_e = EmbeddedCurveScalar::from_bytes(signature, 32);
@@ -42,7 +45,11 @@ pub fn verify_signature_noir<let N: u32>(public_key: EmbeddedCurvePoint, signatu
     is_ok
 }
 
-pub fn assert_valid_signature<let N: u32>(public_key: EmbeddedCurvePoint, signature: [u8; 64], message: [u8; N]) {
+pub fn assert_valid_signature<let N: u32>(
+    public_key: EmbeddedCurvePoint,
+    signature: [u8; 64],
+    message: [u8; N]
+) {
     //scalar lo/hi from bytes
     let sig_s = EmbeddedCurveScalar::from_bytes(signature, 0);
     let sig_e = EmbeddedCurveScalar::from_bytes(signature, 32);

--- a/noir_stdlib/src/sha256.nr
+++ b/noir_stdlib/src/sha256.nr
@@ -1,2 +1,11 @@
 // This file is kept for backwards compatibility.
-pub use crate::hash::sha256::{digest, sha256_var};
+
+#[deprecated]
+pub fn digest<let N: u32>(msg: [u8; N]) -> [u8; 32] {
+    crate::hash::sha256::digest(msg)
+}
+
+#[deprecated]
+pub fn sha256_var<let N: u32>(msg: [u8; N], message_size: u64) -> [u8; 32] {
+    crate::hash::sha256::sha256_var(msg, message_size)
+}

--- a/noir_stdlib/src/sha256.nr
+++ b/noir_stdlib/src/sha256.nr
@@ -1,11 +1,11 @@
 // This file is kept for backwards compatibility.
 
-#[deprecated]
+#[deprecated = "replace with std::hash::sha256::digest"]
 pub fn digest<let N: u32>(msg: [u8; N]) -> [u8; 32] {
     crate::hash::sha256::digest(msg)
 }
 
-#[deprecated]
+#[deprecated = "replace with std::hash::sha256::sha256_var"]
 pub fn sha256_var<let N: u32>(msg: [u8; N], message_size: u64) -> [u8; 32] {
     crate::hash::sha256::sha256_var(msg, message_size)
 }

--- a/noir_stdlib/src/sha512.nr
+++ b/noir_stdlib/src/sha512.nr
@@ -1,2 +1,6 @@
 // This file is kept for backwards compatibility.
-pub use crate::hash::sha512::digest;
+
+#[deprecated]
+pub fn digest<let N: u32>(msg: [u8; N]) -> [u8; 64] {
+    crate::hash::sha512::digest(msg)
+}

--- a/noir_stdlib/src/sha512.nr
+++ b/noir_stdlib/src/sha512.nr
@@ -1,6 +1,6 @@
 // This file is kept for backwards compatibility.
 
-#[deprecated]
+#[deprecated = "replace with std::hash::sha512::digest"]
 pub fn digest<let N: u32>(msg: [u8; N]) -> [u8; 64] {
     crate::hash::sha512::digest(msg)
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR deprecates various items in the stdlib. Where an external library is fulfilling the role of a stdlib function we point off to that external lib.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
