### PR TITLE
chore(ci): Update gates diff action to not post Brillig sizes report with no changes

### DIFF
--- a/.github/workflows/gates_report.yml
+++ b/.github/workflows/gates_report.yml
@@ -80,7 +80,7 @@ jobs:
       
       - name: Compare gates reports
         id: gates_diff
-        uses: noir-lang/noir-gates-diff@1931aaaa848a1a009363d6115293f7b7fc72bb87
+        uses: noir-lang/noir-gates-diff@d88f7523b013b9edd3f31c5cfddaef87a3fe1b48
         with:
           report: gates_report.json
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)


### PR DESCRIPTION
…mment when not needed

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

No issue as found while making the public functions size report on aztec-packages.

## Summary\*

We currently repost the Brillig opcode report even when there have been no changes. This updates the noir-gates-diff to the most recent commit on the noir-gates-diff `main` branch which has the fix.


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
