### PR TITLE
feat: visibility for globals

### DIFF
--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -500,7 +500,7 @@ impl Item {
                 noir_trait_impl.accept(self.span, visitor);
             }
             ItemKind::Impl(type_impl) => type_impl.accept(self.span, visitor),
-            ItemKind::Global(let_statement) => {
+            ItemKind::Global(let_statement, _visibility) => {
                 if visitor.visit_global(let_statement, self.span) {
                     let_statement.accept(visitor);
                 }

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -439,11 +439,12 @@ impl<'context> Elaborator<'context> {
                     resolved_trait_generics: Vec::new(),
                 });
             }
-            TopLevelStatementKind::Global(global) => {
+            TopLevelStatementKind::Global(global, visibility) => {
                 let (global, error) = dc_mod::collect_global(
                     self.interner,
                     self.def_maps.get_mut(&self.crate_id).unwrap(),
                     Documented::new(global, item.doc_comments),
+                    visibility,
                     self.file,
                     self.local_module,
                     self.crate_id,

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -96,8 +96,13 @@ impl ModuleData {
         self.definitions.remove_definition(name);
     }
 
-    pub fn declare_global(&mut self, name: Ident, id: GlobalId) -> Result<(), (Ident, Ident)> {
-        self.declare(name, ItemVisibility::Public, id.into(), None)
+    pub fn declare_global(
+        &mut self,
+        name: Ident,
+        visibility: ItemVisibility,
+        id: GlobalId,
+    ) -> Result<(), (Ident, Ident)> {
+        self.declare(name, visibility, id.into(), None)
     }
 
     pub fn declare_struct(

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1376,7 +1376,9 @@ fn ban_mutable_globals() {
     // Mutable globals are only allowed in a comptime context
     let src = r#"
         mut global FOO: Field = 0;
-        fn main() {}
+        fn main() {
+            let _ = FOO; // silence FOO never used warning
+        }
     "#;
     assert_eq!(get_program_errors(src).len(), 1);
 }

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -239,3 +239,26 @@ fn errors_if_type_alias_aliases_more_private_type_in_generic() {
     assert_eq!(typ, "Foo");
     assert_eq!(item, "Bar");
 }
+
+#[test]
+fn errors_on_unused_global() {
+    let src = r#"
+    global foo = 1;
+    global bar = 1;
+
+    fn main() {
+        let _ = bar;
+    }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ResolverError(ResolverError::UnusedItem { ident, item }) = &errors[0].0
+    else {
+        panic!("Expected an unused item error");
+    };
+
+    assert_eq!(ident.to_string(), "foo");
+    assert_eq!(item.item_type(), "global");
+}

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::{Ident, ItemVisibility},
     hir::def_map::ModuleId,
     macros_api::StructId,
-    node_interner::{FuncId, TraitId, TypeAliasId},
+    node_interner::{FuncId, GlobalId, TraitId, TypeAliasId},
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -14,6 +14,7 @@ pub enum UnusedItem {
     Struct(StructId),
     Trait(TraitId),
     TypeAlias(TypeAliasId),
+    Global(GlobalId),
 }
 
 impl UnusedItem {
@@ -24,6 +25,7 @@ impl UnusedItem {
             UnusedItem::Struct(_) => "struct",
             UnusedItem::Trait(_) => "trait",
             UnusedItem::TypeAlias(_) => "type alias",
+            UnusedItem::Global(_) => "global",
         }
     }
 }

--- a/docs/docs/noir/concepts/globals.md
+++ b/docs/docs/noir/concepts/globals.md
@@ -70,3 +70,13 @@ fn foo() -> [Field; 100] { ... }
 This is usually fine since Noir will generally optimize any function call that does not
 refer to a program input into a constant. It should be kept in mind however, if the called
 function performs side-effects like `println`, as these will still occur on each use.
+
+### Visibility
+
+By default, like functions, globals are private to the module the exist in. You can use `pub`
+to make the global public or `pub(crate)` to make it public to just its crate:
+
+```rust
+// This global is now public
+pub global N = 5;
+```

--- a/noir_stdlib/src/field/bn254.nr
+++ b/noir_stdlib/src/field/bn254.nr
@@ -4,7 +4,7 @@ use crate::runtime::is_unconstrained;
 global PLO: Field = 53438638232309528389504892708671455233;
 global PHI: Field = 64323764613183177041862057485226039389;
 
-global TWO_POW_128: Field = 0x100000000000000000000000000000000;
+pub(crate) global TWO_POW_128: Field = 0x100000000000000000000000000000000;
 
 // Decomposes a single field into two 16 byte fields.
 fn compute_decomposition(x: Field) -> (Field, Field) {

--- a/tooling/nargo_fmt/src/visitor/item.rs
+++ b/tooling/nargo_fmt/src/visitor/item.rs
@@ -276,7 +276,7 @@ impl super::FmtVisitor<'_> {
                 ItemKind::Struct(_)
                 | ItemKind::Trait(_)
                 | ItemKind::TypeAlias(_)
-                | ItemKind::Global(_)
+                | ItemKind::Global(..)
                 | ItemKind::ModuleDecl(_)
                 | ItemKind::InnerAttribute(_) => {
                     self.push_rewrite(self.slice(span).to_string(), span);


### PR DESCRIPTION
# Description

## Problem

Part of #4515

## Summary

## Additional Context

I left all of the stdlib globals as private except one which needed to be `pub(crate)` to avoid a warning. I don't know if some of these globals should actually be public.

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
