### PR TITLE
fix: Pass radix directly to the blackbox

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -553,14 +553,7 @@ impl<'block> BrilligBlock<'block> {
                     let results = dfg.instruction_results(instruction_id);
 
                     let source = self.convert_ssa_single_addr_value(arguments[0], dfg);
-
-                    let radix: u32 = dfg
-                        .get_numeric_constant(arguments[1])
-                        .expect("Radix should be known")
-                        .try_to_u64()
-                        .expect("Radix should fit in u64")
-                        .try_into()
-                        .expect("Radix should be u32");
+                    let radix = self.convert_ssa_single_addr_value(arguments[1], dfg);
 
                     let target_array = self
                         .variables
@@ -595,13 +588,17 @@ impl<'block> BrilligBlock<'block> {
                         )
                         .extract_array();
 
+                    let two = self.brillig_context.make_usize_constant_instruction(2_usize.into());
+
                     self.brillig_context.codegen_to_radix(
                         source,
                         target_array,
-                        2,
+                        two,
                         matches!(endianness, Endian::Big),
                         true,
                     );
+
+                    self.brillig_context.deallocate_single_addr(two);
                 }
 
                 // `Intrinsic::AsWitness` is used to provide hints to acir-gen on optimal expression splitting.

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
@@ -68,21 +68,20 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         &mut self,
         source_field: SingleAddrVariable,
         target_array: BrilligArray,
-        radix: u32,
+        radix: SingleAddrVariable,
         big_endian: bool,
         output_bits: bool, // If true will generate bit limbs, if false will generate byte limbs
     ) {
         assert!(source_field.bit_size == F::max_num_bits());
+        assert!(radix.bit_size == 32);
 
         self.codegen_initialize_array(target_array);
 
         let heap_array = self.codegen_brillig_array_to_heap_array(target_array);
 
-        let radix_var = self.make_constant_instruction(F::from(radix as u128), 32);
-
         self.black_box_op_instruction(BlackBoxOp::ToRadix {
             input: source_field.address,
-            radix: radix_var.address,
+            radix: radix.address,
             output: heap_array,
             output_bits,
         });
@@ -93,6 +92,5 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
             self.deallocate_single_addr(items_len);
         }
         self.deallocate_register(heap_array.pointer);
-        self.deallocate_register(radix_var.address);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Avoids creating an extra constant for to radix when we already have a variable for it.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
