### PR TITLE
feat(perf): Remove inc_rc instructions for arrays which are never mutably borrowed

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -72,7 +72,7 @@ fn value(function: &Function, id: ValueId) -> String {
         Value::Intrinsic(intrinsic) => intrinsic.to_string(),
         Value::Array { array, .. } => {
             let elements = vecmap(array, |element| value(function, *element));
-            format!("[{}]", elements.join(", "))
+            format!("{id}=[{}]", elements.join(", "))
         }
         Value::Param { .. } | Value::Instruction { .. } | Value::ForeignFunction(_) => {
             id.to_string()

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -72,7 +72,7 @@ fn value(function: &Function, id: ValueId) -> String {
         Value::Intrinsic(intrinsic) => intrinsic.to_string(),
         Value::Array { array, .. } => {
             let elements = vecmap(array, |element| value(function, *element));
-            format!("{id}=[{}]", elements.join(", "))
+            format!("[{}]", elements.join(", "))
         }
         Value::Param { .. } | Value::Instruction { .. } | Value::ForeignFunction(_) => {
             id.to_string()

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -926,7 +926,6 @@ mod test {
         //       return v2
         //   }
         let ssa = ssa.dead_instruction_elimination();
-        println!("{}", ssa);
         let main = ssa.main();
 
         let instructions = main.dfg[main.entry_block()].instructions();

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -909,7 +909,6 @@ mod test {
 
         let zero = builder.numeric_constant(0u128, Type::unsigned(32));
         let v1 = builder.insert_array_get(v0, zero, Type::field());
-        // builder.decrement_array_reference_count(v0);
         builder.terminate_with_return(vec![v1]);
 
         let ssa = builder.finish();

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -116,7 +116,6 @@ impl Context {
         let mut rcs_with_possible_pairs: HashMap<Type, Vec<RcInstruction>> = HashMap::default();
         let mut rc_pairs_to_remove = HashSet::default();
         // We also separately track all IncrementRc instructions and all arrays which have been mutably borrowed.
-        // This is done to determine whether the array has ever been borrowed.
         // If an array has not been mutably borrowed we can then safely remove all IncrementRc instructions on that array.
         let mut inc_rcs: HashMap<ValueId, HashSet<InstructionId>> = HashMap::default();
         let mut borrowed_arrays: HashSet<ValueId> = HashSet::default();

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -912,7 +912,6 @@ mod test {
         builder.terminate_with_return(vec![v1]);
 
         let ssa = builder.finish();
-        println!("{}", ssa);
         let main = ssa.main();
 
         // The instruction count never includes the terminator instruction

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -231,7 +231,7 @@ impl Context {
             }
             Instruction::Store { value, .. } => {
                 // We are very conservative and say that any store of an array value means it has the potential
-                // to be mutated. This is due to the tracking of mutable borrows still being per block.
+                // to be mutated. This is done due to the tracking of mutable borrows still being per block.
                 let typ = function.dfg.type_of_value(*value);
                 if matches!(&typ, Type::Array(..) | Type::Slice(..)) {
                     borrowed_arrays.insert(*value);

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -157,11 +157,8 @@ impl Context {
             );
         }
 
-        for inc_rc_value in inc_rcs.keys() {
-            if !borrowed_arrays.contains(inc_rc_value) {
-                self.instructions_to_remove.extend(&inc_rcs[inc_rc_value]);
-            }
-        }
+        let unborrowed_arrays = inc_rcs.keys().filter(|id| !borrowed_arrays.contains(id));
+        self.instructions_to_remove.extend(unborrowed_arrays);
 
         self.instructions_to_remove.extend(rc_pairs_to_remove);
 


### PR DESCRIPTION
# Description

## Problem\*

Part of general effort to reduce Brillig bytecode sizes

## Summary\*

An array can be borrowed without being mutated. We code gen inc_rc instructions quite pessimistically on every borrow or reassignment of an array. If we know that the array is never mutated, it should be safe to remove these inc_rc instructions. 

During DIE we now track all inc_rc instructions in a block and if that array is never used in an array set or a store, we mark its inc_rc instruction for removal.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
