### PR TITLE
chore: remove `DefCollectorErrorKind::MacroError`

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -71,8 +71,6 @@ pub enum DefCollectorErrorKind {
         "Either the type or the trait must be from the same crate as the trait implementation"
     )]
     TraitImplOrphaned { span: Span },
-    #[error("macro error : {0:?}")]
-    MacroError(MacroError),
     #[error("The only supported types of numeric generics are integers, fields, and booleans")]
     UnsupportedNumericGenericType { ident: Ident, typ: UnresolvedTypeData },
     #[error("impl has stricter requirements than trait")]
@@ -84,14 +82,6 @@ pub enum DefCollectorErrorKind {
         trait_method_name: String,
         trait_method_span: Span,
     },
-}
-
-/// An error struct that macro processors can return.
-#[derive(Debug, Clone)]
-pub struct MacroError {
-    pub primary_message: String,
-    pub secondary_message: Option<String>,
-    pub span: Option<Span>,
 }
 
 impl DefCollectorErrorKind {
@@ -276,9 +266,6 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
                 "Either the type or the trait must be from the same crate as the trait implementation".into(),
                 *span,
             ),
-            DefCollectorErrorKind::MacroError(macro_error) => {
-                Diagnostic::simple_error(macro_error.primary_message.clone(), macro_error.secondary_message.clone().unwrap_or_default(), macro_error.span.unwrap_or_default())
-            },
             DefCollectorErrorKind::UnsupportedNumericGenericType { ident, typ } => {
                 let name = &ident.0.contents;
 

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -45,7 +45,6 @@ pub mod macros_api {
     pub use noirc_errors::Span;
 
     pub use crate::graph::CrateId;
-    pub use crate::hir::def_collector::errors::MacroError;
     pub use crate::hir_def::expr::{HirExpression, HirLiteral};
     pub use crate::hir_def::stmt::HirStatement;
     pub use crate::node_interner::{NodeInterner, StructId};


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR follows up on #6087 by removing the error variant which is provided for `aztec_macros` to return.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
