### PR TITLE
feat: let `Module::functions` and `Module::structs` return them in definition order

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2458,10 +2458,12 @@ fn module_functions(
     let module_id = get_module(self_argument)?;
     let module_data = interpreter.elaborator.get_module(module_id);
     let func_ids = module_data
-        .value_definitions()
+        .definitions()
+        .definitions()
+        .iter()
         .filter_map(|module_def_id| {
             if let ModuleDefId::FunctionId(func_id) = module_def_id {
-                Some(Value::FunctionDefinition(func_id))
+                Some(Value::FunctionDefinition(*func_id))
             } else {
                 None
             }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2484,10 +2484,12 @@ fn module_structs(
     let module_id = get_module(self_argument)?;
     let module_data = interpreter.elaborator.get_module(module_id);
     let struct_ids = module_data
-        .type_definitions()
+        .definitions()
+        .definitions()
+        .iter()
         .filter_map(|module_def_id| {
             if let ModuleDefId::TypeId(id) = module_def_id {
-                Some(Value::StructDefinition(id))
+                Some(Value::StructDefinition(*id))
             } else {
                 None
             }

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -6,6 +6,8 @@ mod foo {
     pub fn z() {}
 
     pub struct Struct1 {}
+    pub struct Struct2 {}
+    pub struct Struct3 {}
 }
 
 contract bar {}
@@ -85,7 +87,11 @@ fn main() {
         assert_eq(bar.functions().len(), 0);
 
         // Check Module::structs
-        assert_eq(foo.structs().len(), 1);
+        let foo_structs = foo.structs();
+        assert_eq(foo_structs.len(), 3);
+        assert_eq(foo_structs[0].name(), quote { Struct1 });
+        assert_eq(foo_structs[1].name(), quote { Struct2 });
+        assert_eq(foo_structs[2].name(), quote { Struct3 });
         assert_eq(bar.structs().len(), 0);
 
         // Check Module::name

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -3,6 +3,7 @@ mod foo {
     #![some_attribute]
     pub fn x() {}
     pub fn y() {}
+    pub fn z() {}
 
     pub struct Struct1 {}
 }
@@ -75,7 +76,12 @@ fn main() {
         let another_module = quote { another_module }.as_module().unwrap();
 
         // Check Module::functions
-        assert_eq(foo.functions().len(), 2);
+        let foo_functions = foo.functions();
+        assert_eq(foo_functions.len(), 3);
+        assert_eq(foo_functions[0].name(), quote { x });
+        assert_eq(foo_functions[1].name(), quote { y });
+        assert_eq(foo_functions[2].name(), quote { z });
+
         assert_eq(bar.functions().len(), 0);
 
         // Check Module::structs


### PR DESCRIPTION
# Description

## Problem

The above functions would return items in different order depending on the run.

## Summary

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
