### PR TITLE
feat: visibility for impl functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1134,7 +1134,7 @@ impl<'context> Elaborator<'context> {
                 // object types in each method overlap or not. If they do, we issue an error.
                 // If not, that is specialization which is allowed.
                 let name = method.name_ident().clone();
-                if module.declare_function(name, ItemVisibility::Public, *method_id).is_err() {
+                if module.declare_function(name, method.def.visibility, *method_id).is_err() {
                     let existing = module.find_func_with_name(method.name_ident()).expect(
                         "declare_function should only error if there is an existing function",
                     );


### PR DESCRIPTION
# Description

## Problem

Part of #4515

## Summary

After searching for a while I found that to make this work we only needed to change one line 😊 

## Additional Context

I didn't include tests for now, but I'll add them later because we first need to figure out which `impl` functions should be marked as `pub` or `pub(crate)` in the stdlib. I'm not familiar with the stdlib though I probably can't do it. That said, if you open the standard library with a nargo compiled from this PR you already get some warnings, so those functions should at least not be private.


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
