### PR TITLE
feat(perf): Simplify the cfg after DIE

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -118,6 +118,7 @@ pub(crate) fn optimize_into_acir(
     .run_pass(Ssa::remove_enable_side_effects, "After EnableSideEffectsIf removal:")
     .run_pass(Ssa::fold_constants_using_constraints, "After Constraint Folding:")
     .run_pass(Ssa::dead_instruction_elimination, "After Dead Instruction Elimination:")
+    .run_pass(Ssa::simplify_cfg, "After Simplifying:")
     .run_pass(Ssa::array_set_optimization, "After Array Set Optimizations:")
     .finish();
 


### PR DESCRIPTION
# Description

## Problem\*

Part of general effort to reduce Brillig bytecode sizes.

## Summary\*

While working other SSA opts, I noticed in a couple tests we had simplified blocks down to only their terminator, but those empty blocks still existed in our final SSA. It looks to be due to previous passes, and specifically DIE simplifying down to an empty block which was not caught in the initial CFG simplification. 

I pushed this PR wanted to see how much of a benefit simplifying at the end would be across our tests. It is a whole extra SSA pass, however, of all our passes, simplify CFG shouldn't be very heavy and wouldn't be too bad to run again if it provides decent benefits. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
