### PR TITLE
feat: remove orphaned blocks from cfg to improve `simplify_cfg` pass.

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/cfg.rs
@@ -59,10 +59,7 @@ impl ControlFlowGraph {
 
     /// Clears out a given block's successors. This also removes the given block from
     /// being a predecessor of any of its previous successors.
-    fn invalidate_block_successors(
-        &mut self,
-        basic_block_id: BasicBlockId,
-    ) -> BTreeSet<BasicBlockId> {
+    pub(crate) fn invalidate_block_successors(&mut self, basic_block_id: BasicBlockId) {
         let node = self
             .data
             .get_mut(&basic_block_id)
@@ -70,40 +67,23 @@ impl ControlFlowGraph {
 
         let old_successors = std::mem::take(&mut node.successors);
 
-        for successor_id in &old_successors {
+        for successor_id in old_successors {
             self.data
-                .get_mut(successor_id)
+                .get_mut(&successor_id)
                 .expect("ICE: Cfg node successor doesn't exist.")
                 .predecessors
                 .remove(&basic_block_id);
         }
-
-        old_successors
     }
 
     /// Recompute the control flow graph of `block`.
     ///
     /// This is for use after modifying instructions within a specific block. It recomputes all edges
     /// from `basic_block_id` while leaving edges to `basic_block_id` intact.
-    pub(crate) fn recompute_block(
-        &mut self,
-        func: &Function,
-        basic_block_id: BasicBlockId,
-        check_for_orphans: bool,
-    ) {
-        let old_successors = self.invalidate_block_successors(basic_block_id);
+    pub(crate) fn recompute_block(&mut self, func: &Function, basic_block_id: BasicBlockId) {
+        self.invalidate_block_successors(basic_block_id);
         let basic_block = &func.dfg[basic_block_id];
         self.compute_block(basic_block_id, basic_block);
-
-        if check_for_orphans {
-            // If we've made any of the old successors unreachable, we should remove it as a predecessor from its successors.
-            for orphaned_successor in old_successors.difference(&basic_block.successors().collect())
-            {
-                if self.predecessors(*orphaned_successor).len() == 0 {
-                    self.invalidate_block_successors(*orphaned_successor);
-                }
-            }
-        }
     }
 
     /// Add a directed edge making `from` a predecessor of `to`.
@@ -261,9 +241,9 @@ mod tests {
         });
 
         // Recompute new and changed blocks
-        cfg.recompute_block(&func, block0_id, false);
-        cfg.recompute_block(&func, block2_id, false);
-        cfg.recompute_block(&func, ret_block_id, false);
+        cfg.recompute_block(&func, block0_id);
+        cfg.recompute_block(&func, block2_id);
+        cfg.recompute_block(&func, ret_block_id);
 
         #[allow(clippy::needless_collect)]
         {

--- a/compiler/noirc_evaluator/src/ssa/ir/cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/cfg.rs
@@ -85,15 +85,23 @@ impl ControlFlowGraph {
     ///
     /// This is for use after modifying instructions within a specific block. It recomputes all edges
     /// from `basic_block_id` while leaving edges to `basic_block_id` intact.
-    pub(crate) fn recompute_block(&mut self, func: &Function, basic_block_id: BasicBlockId) {
+    pub(crate) fn recompute_block(
+        &mut self,
+        func: &Function,
+        basic_block_id: BasicBlockId,
+        check_for_orphans: bool,
+    ) {
         let old_successors = self.invalidate_block_successors(basic_block_id);
         let basic_block = &func.dfg[basic_block_id];
         self.compute_block(basic_block_id, basic_block);
 
-        // If we've made any of the old successors unreachable, we should remove it as a predecessor from its successors.
-        for orphaned_successor in old_successors.difference(&basic_block.successors().collect()) {
-            if self.predecessors(*orphaned_successor).len() == 0 {
-                self.invalidate_block_successors(*orphaned_successor);
+        if check_for_orphans {
+            // If we've made any of the old successors unreachable, we should remove it as a predecessor from its successors.
+            for orphaned_successor in old_successors.difference(&basic_block.successors().collect())
+            {
+                if self.predecessors(*orphaned_successor).len() == 0 {
+                    self.invalidate_block_successors(*orphaned_successor);
+                }
             }
         }
     }
@@ -253,9 +261,9 @@ mod tests {
         });
 
         // Recompute new and changed blocks
-        cfg.recompute_block(&func, block0_id);
-        cfg.recompute_block(&func, block2_id);
-        cfg.recompute_block(&func, ret_block_id);
+        cfg.recompute_block(&func, block0_id, false);
+        cfg.recompute_block(&func, block2_id, false);
+        cfg.recompute_block(&func, ret_block_id, false);
 
         #[allow(clippy::needless_collect)]
         {

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -106,7 +106,7 @@ fn check_for_constant_jmpif(
             let call_stack = call_stack.clone();
             let jmp = TerminatorInstruction::Jmp { destination, arguments, call_stack };
             function.dfg[block].set_terminator(jmp);
-            cfg.recompute_block(function, block);
+            cfg.recompute_block(function, block, true);
         }
     }
 }
@@ -171,9 +171,9 @@ fn check_for_double_jmp(function: &mut Function, block: BasicBlockId, cfg: &mut 
         };
 
         function.dfg[predecessor_block].set_terminator(redirected_terminator_instruction);
-        cfg.recompute_block(function, predecessor_block);
+        cfg.recompute_block(function, predecessor_block, false);
     }
-    cfg.recompute_block(function, block);
+    cfg.recompute_block(function, block, false);
 }
 
 /// If the given block has block parameters, replace them with the jump arguments from the predecessor.
@@ -221,8 +221,8 @@ fn try_inline_into_predecessor(
         drop(successors);
         function.dfg.inline_block(block, predecessor);
 
-        cfg.recompute_block(function, block);
-        cfg.recompute_block(function, predecessor);
+        cfg.recompute_block(function, block, false);
+        cfg.recompute_block(function, predecessor, false);
         true
     } else {
         false

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -110,7 +110,7 @@ fn check_for_constant_jmpif(
             function.dfg[block].set_terminator(jmp);
             cfg.recompute_block(function, block);
 
-            // If `block` was the only predecessor to `unchose_destination` then it's no long reachable through the CFG,
+            // If `block` was the only predecessor to `unchosen_destination` then it's no long reachable through the CFG,
             // we can then invalidate it successors as it's an invalid predecessor.
             if cfg.predecessors(unchosen_destination).len() == 0 {
                 cfg.invalidate_block_successors(unchosen_destination);

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -51,16 +51,16 @@ impl Function {
         let mut visited = HashSet::new();
 
         while let Some(block) = stack.pop() {
-            if visited.insert(block) {
-                stack.extend(self.dfg[block].successors().filter(|block| !visited.contains(block)));
-            }
-
             // This call is before try_inline_into_predecessor so that if it succeeds in changing a
             // jmpif into a jmp, the block may then be inlined entirely into its predecessor in try_inline_into_predecessor.
             check_for_constant_jmpif(self, block, &mut cfg);
 
-            let mut predecessors = cfg.predecessors(block);
+            // We extend the stack after checking for constant jmpifs to avoid pushing an unreachable block onto the stack.
+            if visited.insert(block) {
+                stack.extend(self.dfg[block].successors().filter(|block| !visited.contains(block)));
+            }
 
+            let mut predecessors = cfg.predecessors(block);
             if predecessors.len() == 1 {
                 let predecessor =
                     predecessors.next().expect("Already checked length of predecessors");


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Inspired by https://github.com/noir-lang/noir/pull/6184, I noticed that after simplifying a constant jmpif we wouldn't inline the block following the inlined block into the first block, as an example consider the SSA

```
After Dead Instruction Elimination:
brillig fn main f0 {
  b0(v0: Field, v1: Field):
    constrain v0 == Field 1
    constrain v1 == Field 0
    jmpif u1 0 then: b2, else: b1
  b2():
    v8 = add v0, Field 1
    jmp b3(v0, v8)
  b3(v2: Field, v3: Field):
    v9 = add v0, Field 1
    constrain v2 == v9
    constrain v3 == v0
    constrain v0 == Field 1
    constrain v1 == Field 0
    return 
  b1():
    v7 = add v0, Field 1
    jmp b3(v7, v0)
}
```
Here we can see that we never enter `b2`, instead going `b0 -> b1 -> b3`. However when the simplify_cfg pass looks at the predecessors of `b3` it sees both `b1` **and `b2`** despite `b2` not being reachable anymore. It then doesn't inline `b3` into its sole predecessor.

On master we'll simplify the CFG for the SSA to give the program:
```
After Simplifying:
brillig fn main f0 {
  b0(v0: Field, v1: Field):
    constrain v0 == Field 1
    constrain v1 == Field 0
    v6 = add v0, Field 1
    jmp b1(v6, v0)
  b1(v2: Field, v3: Field):
    v7 = add v0, Field 1
    constrain v2 == v7
    constrain v3 == v0
    constrain v0 == Field 1
    constrain v1 == Field 0
    return 
}
```

This PR checks the previous successors of any block which has it's CFG recomputed to check if they've been left orphaned, if so we remove it from the CFG entirely.

We now instead fully simplify the CFG to give the program:
```
After Simplifying:
brillig fn main f0 {
  b0(v0: Field, v1: Field):
    constrain v0 == Field 1
    constrain v1 == Field 0
    v4 = add v0, Field 1
    v5 = add v0, Field 1
    constrain v4 == v5
    constrain v0 == Field 1
    constrain v1 == Field 0
    return 
}

```

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
