### PR TITLE
chore: revert mistaken stack size change

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use acvm::acir::{brillig::MemoryAddress, AcirField};
 
-pub(crate) const MAX_STACK_SIZE: usize = 32768;
+pub(crate) const MAX_STACK_SIZE: usize = 2048;
 pub(crate) const MAX_SCRATCH_SPACE: usize = 64;
 
 impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
