### PR TITLE
fix: don't warn twice when referring to private item

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -544,8 +544,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             InterpreterError::VariableNotInScope { location }
         })?;
 
-        if let ImplKind::TraitMethod(method, _, _) = ident.impl_kind {
-            let method_id = resolve_trait_method(self.elaborator.interner, method, id)?;
+        if let ImplKind::TraitMethod(method) = ident.impl_kind {
+            let method_id = resolve_trait_method(self.elaborator.interner, method.method_id, id)?;
             let typ = self.elaborator.interner.id_type(id).follow_bindings();
             let bindings = self.elaborator.interner.get_instantiation_bindings(id).clone();
             return Ok(Value::Function(method_id, typ, Rc::new(bindings)));

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -70,7 +70,14 @@ pub enum ImplKind {
     /// and eventually linked to this id. The boolean indicates whether the impl
     /// is already assumed to exist - e.g. when resolving a path such as `T::default`
     /// when there is a corresponding `T: Default` constraint in scope.
-    TraitMethod(TraitMethodId, TraitConstraint, bool),
+    TraitMethod(TraitMethod),
+}
+
+#[derive(Debug, Clone)]
+pub struct TraitMethod {
+    pub method_id: TraitMethodId,
+    pub constraint: TraitConstraint,
+    pub assumed: bool,
 }
 
 impl Eq for HirIdent {}
@@ -247,7 +254,7 @@ impl HirMethodCallExpression {
                     trait_generics,
                     span: location.span,
                 };
-                (id, ImplKind::TraitMethod(method_id, constraint, false))
+                (id, ImplKind::TraitMethod(TraitMethod { method_id, constraint, assumed: false }))
             }
         };
         let func_var = HirIdent { location, id, impl_kind };

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -850,8 +850,8 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> Result<ast::Expression, MonomorphizationError> {
         let typ = self.interner.id_type(expr_id);
 
-        if let ImplKind::TraitMethod(method, _, _) = ident.impl_kind {
-            return self.resolve_trait_method_expr(expr_id, typ, method);
+        if let ImplKind::TraitMethod(method) = ident.impl_kind {
+            return self.resolve_trait_method_expr(expr_id, typ, method.method_id);
         }
 
         // Ensure all instantiation bindings are bound.

--- a/compiler/noirc_frontend/src/tests/imports.rs
+++ b/compiler/noirc_frontend/src/tests/imports.rs
@@ -73,7 +73,7 @@ fn warns_on_use_of_private_exported_item() {
     "#;
 
     let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 2); // An existing bug causes this error to be duplicated
+    assert_eq!(errors.len(), 1);
 
     assert!(matches!(
         &errors[0].0,

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -94,7 +94,7 @@ fn errors_if_trying_to_access_public_function_inside_private_module() {
     "#;
 
     let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 2); // There's a bug that duplicates this error
+    assert_eq!(errors.len(), 1);
 
     let CompilationError::ResolverError(ResolverError::PathResolutionError(
         PathResolutionError::Private(ident),


### PR DESCRIPTION
# Description

## Problem

We were producing "this item is private" errors twice.

## Summary

The problem was that the code looked up a path twice, and errored each time it found an error in that lookup.

Now the code still looks up the path twice, but only errors once (if the first lookup succeeds, we report the optional error of that lookup, otherwise we do the same with the second one).

## Additional Context

Also applied some refactors (made a tuple return value its own struct, and made an enum variant use a struct instead of a tuple too).

This fixes the issue but we are still doing two Path lookups here, which means there's an optimization opportunity to only do the lookup once. But this can be done in a separate PR.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
