### PR TITLE
feat(perf): Simplify array get when most recent array set writes to the same index

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -761,7 +761,7 @@ impl Instruction {
 /// Simple case:
 /// v4 = array_set v1, index v2, value v3
 /// v5 = array_get v4, index v2
-/// 
+///
 /// If we could not immediately simplify the array get, we can try to follow
 /// the array set backwards in the case we have constant indices:
 ///

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -755,6 +755,16 @@ impl Instruction {
     }
 }
 
+/// If we have an array get whose array is from an array set at the same index,
+/// we can simplify that array get to the value in that array set.
+///
+/// Simple case:
+/// v4 = array_set v1, index v2, value v3
+/// v5 = array_get v4, index v2
+/// 
+/// If we could not immediately simplify the array get, we can try to follow
+/// the array set backwards in the case we have constant indices:
+///
 /// Given a chain of operations like:
 /// v1 = array_set [10, 11, 12], index 1, value: 5
 /// v2 = array_set v1, index 2, value: 6


### PR DESCRIPTION
# Description

## Problem\*

Part of general effort to reduce Brillig bytecode sizes

## Summary\*

This takes inspiration from https://github.com/noir-lang/noir/pull/6207 that the value is still known at a previous array set when the index is dynamic. 

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
