### PR TITLE
fix!: Elaborate generated items as we go

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -292,22 +292,12 @@ impl<'context> Elaborator<'context> {
 
         // We have to run any comptime attributes on functions before the function is elaborated
         // since the generated items are checked beforehand as well.
-        let generated_items = self.run_attributes(
+        self.run_attributes(
             &items.traits,
             &items.types,
             &items.functions,
             &items.module_attributes,
         );
-
-        // After everything is collected, we can elaborate our generated items.
-        // It may be better to inline these within `items` entirely since elaborating them
-        // all here means any globals will not see these. Inlining them completely within `items`
-        // means we must be more careful about missing any additional items that need to be already
-        // elaborated. E.g. if a new struct is created, we've already passed the code path to
-        // elaborate them.
-        if !generated_items.is_empty() {
-            self.elaborate_items(generated_items);
-        }
 
         for functions in items.functions {
             self.elaborate_functions(functions);

--- a/test_programs/compile_success_empty/regression_6143/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_6143/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_6143"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_6143/src/main.nr
+++ b/test_programs/compile_success_empty/regression_6143/src/main.nr
@@ -1,0 +1,11 @@
+#[derive(Eq)]
+struct S {}
+
+#[attribute]
+fn main() {}
+
+comptime fn attribute(_f: FunctionDefinition) {
+    let s = quote { S }.as_type();
+    let eq = quote { Eq }.as_trait_constraint();
+    assert(s.get_trait_impl(eq).is_some());
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6143

## Summary\*

Elaborate items generated at comptime as they're generated instead of all at once later on. This is a breaking change since any code e.g. outputting functions from attributes which rely on types that are outputted later will now error and the ordering will need to be changes.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
