### PR TITLE
fix(frontend): Do not warn when a nested struct is provided as input to main

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -846,6 +846,9 @@ impl<'context> Elaborator<'context> {
                 for generic in generics {
                     self.mark_parameter_type_as_used(generic);
                 }
+                for (_, typ) in struct_type.borrow().get_fields(generics) {
+                    self.mark_parameter_type_as_used(&typ);
+                }
             }
             Type::Alias(alias_type, generics) => {
                 self.mark_parameter_type_as_used(&alias_type.borrow().get_type(generics));
@@ -871,15 +874,6 @@ impl<'context> Elaborator<'context> {
             | Type::Function(..)
             | Type::Forall(..)
             | Type::Error => (),
-        }
-
-        if let Type::Alias(alias_type, generics) = typ {
-            self.mark_parameter_type_as_used(&alias_type.borrow().get_type(generics));
-            return;
-        }
-
-        if let Type::Struct(struct_type, _generics) = typ {
-            self.mark_struct_as_constructed(struct_type.clone());
         }
     }
 

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -210,3 +210,25 @@ fn warns_on_unused_global() {
     assert_eq!(ident.to_string(), "foo");
     assert_eq!(item.item_type(), "global");
 }
+
+#[test]
+fn no_warning_on_inner_struct_when_parent_is_used() {
+    let src = r#" 
+    struct Bar {
+        inner: [Field; 3],
+    }
+
+    struct Foo {
+        a: Field,
+        bar: Bar,
+    }
+
+    fn main(foos: [Foo; 1]) {
+        assert_eq(foos[0].a, 10);
+    }
+    "#;
+
+    let errors = get_program_errors(src);
+    println!("{errors:?}");
+    assert_eq!(errors.len(), 0);
+}

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -229,6 +229,5 @@ fn no_warning_on_inner_struct_when_parent_is_used() {
     "#;
 
     let errors = get_program_errors(src);
-    println!("{errors:?}");
     assert_eq!(errors.len(), 0);
 }


### PR DESCRIPTION
# Description

## Problem\*

No issue as found while working on other tasks.

Compile `nested_array_dynamic` and you will see a warning the `Bar` is never constructed. However, `Bar` is an internal field to the `Foo` struct which is provided as inputs and is thus constructed.

## Summary\*

When marking a parameter type as used we also go over all of the struct fields to account for any nested structs.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
