### PR TITLE
fix: don't warn on unused struct that has an abi annotation

### DIFF
--- a/compiler/noirc_frontend/src/ast/structure.rs
+++ b/compiler/noirc_frontend/src/ast/structure.rs
@@ -19,6 +19,12 @@ pub struct NoirStruct {
     pub span: Span,
 }
 
+impl NoirStruct {
+    pub fn is_abi(&self) -> bool {
+        self.attributes.iter().any(|attr| attr.is_abi())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StructField {
     pub name: Ident,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1277,6 +1277,13 @@ impl<'context> Elaborator<'context> {
             self.local_module = typ.module_id;
 
             let fields = self.resolve_struct_fields(&typ.struct_def, *type_id);
+
+            if typ.struct_def.is_abi() {
+                for (_field_name, field_type) in &fields {
+                    self.mark_parameter_type_as_used(field_type);
+                }
+            }
+
             let fields_len = fields.len();
             self.interner.update_struct(*type_id, |struct_def| {
                 struct_def.set_fields(fields);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -751,7 +751,7 @@ impl<'context> Elaborator<'context> {
             );
 
             if is_entry_point {
-                self.mark_parameter_type_as_used(&typ);
+                self.mark_type_as_used(&typ);
             }
 
             let pattern = self.elaborate_pattern_and_store_ids(
@@ -832,33 +832,33 @@ impl<'context> Elaborator<'context> {
         self.current_item = None;
     }
 
-    fn mark_parameter_type_as_used(&mut self, typ: &Type) {
+    fn mark_type_as_used(&mut self, typ: &Type) {
         match typ {
-            Type::Array(_n, typ) => self.mark_parameter_type_as_used(typ),
-            Type::Slice(typ) => self.mark_parameter_type_as_used(typ),
+            Type::Array(_n, typ) => self.mark_type_as_used(typ),
+            Type::Slice(typ) => self.mark_type_as_used(typ),
             Type::Tuple(types) => {
                 for typ in types {
-                    self.mark_parameter_type_as_used(typ);
+                    self.mark_type_as_used(typ);
                 }
             }
             Type::Struct(struct_type, generics) => {
                 self.mark_struct_as_constructed(struct_type.clone());
                 for generic in generics {
-                    self.mark_parameter_type_as_used(generic);
+                    self.mark_type_as_used(generic);
                 }
                 for (_, typ) in struct_type.borrow().get_fields(generics) {
-                    self.mark_parameter_type_as_used(&typ);
+                    self.mark_type_as_used(&typ);
                 }
             }
             Type::Alias(alias_type, generics) => {
-                self.mark_parameter_type_as_used(&alias_type.borrow().get_type(generics));
+                self.mark_type_as_used(&alias_type.borrow().get_type(generics));
             }
             Type::MutableReference(typ) => {
-                self.mark_parameter_type_as_used(typ);
+                self.mark_type_as_used(typ);
             }
             Type::InfixExpr(left, _op, right) => {
-                self.mark_parameter_type_as_used(left);
-                self.mark_parameter_type_as_used(right);
+                self.mark_type_as_used(left);
+                self.mark_type_as_used(right);
             }
             Type::FieldElement
             | Type::Integer(..)
@@ -1280,7 +1280,7 @@ impl<'context> Elaborator<'context> {
 
             if typ.struct_def.is_abi() {
                 for (_field_name, field_type) in &fields {
-                    self.mark_parameter_type_as_used(field_type);
+                    self.mark_type_as_used(field_type);
                 }
             }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1012,13 +1012,16 @@ pub fn collect_struct(
     let result = def_map.modules[module_id.0].declare_struct(name.clone(), visibility, id);
 
     let parent_module_id = ModuleId { krate, local_id: module_id };
+    let is_abi = unresolved.struct_def.attributes.iter().any(|attribute| attribute.is_abi());
 
-    interner.usage_tracker.add_unused_item(
-        parent_module_id,
-        name.clone(),
-        UnusedItem::Struct(id),
-        visibility,
-    );
+    if !is_abi {
+        interner.usage_tracker.add_unused_item(
+            parent_module_id,
+            name.clone(),
+            UnusedItem::Struct(id),
+            visibility,
+        );
+    }
 
     if let Err((first_def, second_def)) = result {
         let error = DefCollectorErrorKind::Duplicate {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1012,9 +1012,8 @@ pub fn collect_struct(
     let result = def_map.modules[module_id.0].declare_struct(name.clone(), visibility, id);
 
     let parent_module_id = ModuleId { krate, local_id: module_id };
-    let is_abi = unresolved.struct_def.attributes.iter().any(|attribute| attribute.is_abi());
 
-    if !is_abi {
+    if !unresolved.struct_def.is_abi() {
         interner.usage_tracker.add_unused_item(
             parent_module_id,
             name.clone(),

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -995,6 +995,10 @@ impl SecondaryAttribute {
             _ => false,
         }
     }
+
+    pub(crate) fn is_abi(&self) -> bool {
+        matches!(self, SecondaryAttribute::Abi(_))
+    }
 }
 
 impl fmt::Display for SecondaryAttribute {

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -245,3 +245,21 @@ fn no_warning_on_struct_if_it_has_an_abi_attribute() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn no_warning_on_indirect_struct_if_it_has_an_abi_attribute() {
+    let src = r#" 
+    struct Bar {
+        field: Field,
+    }
+
+    #[abi(functions)]
+    struct Foo {
+        bar: Bar,
+    }
+
+    fn main() {
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -231,3 +231,17 @@ fn no_warning_on_inner_struct_when_parent_is_used() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 0);
 }
+
+#[test]
+fn no_warning_on_struct_if_it_has_an_abi_attribute() {
+    let src = r#" 
+    #[abi(functions)]
+    struct Foo {
+        a: Field,
+    }
+
+    fn main() {
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #6250

## Summary

Also renames a method to have a clearer name.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
