### PR TITLE
fix: don't warn on unuse global if it has an abi annotation

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1203,6 +1203,7 @@ pub(crate) fn collect_global(
     let global = global.item;
 
     let name = global.pattern.name_ident().clone();
+    let is_abi = global.attributes.iter().any(|attribute| attribute.is_abi());
 
     let global_id = interner.push_empty_global(
         name.clone(),
@@ -1217,13 +1218,15 @@ pub(crate) fn collect_global(
     // Add the statement to the scope so its path can be looked up later
     let result = def_map.modules[module_id.0].declare_global(name.clone(), visibility, global_id);
 
-    let parent_module_id = ModuleId { krate: crate_id, local_id: module_id };
-    interner.usage_tracker.add_unused_item(
-        parent_module_id,
-        name,
-        UnusedItem::Global(global_id),
-        visibility,
-    );
+    if !is_abi {
+        let parent_module_id = ModuleId { krate: crate_id, local_id: module_id };
+        interner.usage_tracker.add_unused_item(
+            parent_module_id,
+            name,
+            UnusedItem::Global(global_id),
+            visibility,
+        );
+    }
 
     let error = result.err().map(|(first_def, second_def)| {
         let err =

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -212,6 +212,19 @@ fn warns_on_unused_global() {
 }
 
 #[test]
+fn does_not_warn_on_unused_global_if_it_has_an_abi_attribute() {
+    let src = r#"
+    contract foo {
+        #[abi(notes)]
+        global bar = 1;
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn no_warning_on_inner_struct_when_parent_is_used() {
     let src = r#" 
     struct Bar {


### PR DESCRIPTION
# Description

## Problem

Resolves #6250

## Summary

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
