### PR TITLE
fix: visibility for impl methods

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     hir::{
         resolution::{
-            errors::ResolverError, import::PathResolutionError, visibility::struct_field_is_visible,
+            errors::ResolverError, import::PathResolutionError, visibility::struct_member_is_visible,
         },
         type_check::{Source, TypeCheckError},
     },
@@ -508,7 +508,7 @@ impl<'context> Elaborator<'context> {
         visibility: ItemVisibility,
         span: Span,
     ) {
-        if !struct_field_is_visible(struct_type, visibility, self.module_id(), self.def_maps) {
+        if !struct_member_is_visible(struct_type.id, visibility, self.module_id(), self.def_maps) {
             self.push_err(ResolverError::PathResolutionError(PathResolutionError::Private(
                 Ident::new(field_name.to_string(), span),
             )));

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -8,7 +8,8 @@ use crate::{
     },
     hir::{
         resolution::{
-            errors::ResolverError, import::PathResolutionError, visibility::struct_member_is_visible,
+            errors::ResolverError, import::PathResolutionError,
+            visibility::struct_member_is_visible,
         },
         type_check::{Source, TypeCheckError},
     },

--- a/compiler/noirc_frontend/src/hir/resolution/visibility.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/visibility.rs
@@ -1,10 +1,11 @@
 use crate::graph::CrateId;
-use crate::node_interner::StructId;
+use crate::node_interner::{FuncId, NodeInterner, StructId};
+use crate::Type;
 
 use std::collections::BTreeMap;
 
 use crate::ast::ItemVisibility;
-use crate::hir::def_map::{CrateDefMap, LocalModuleId, ModuleId};
+use crate::hir::def_map::{CrateDefMap, DefMaps, LocalModuleId, ModuleId};
 
 // Returns false if the given private function is being called from a non-child module, or
 // if the given pub(crate) function is being called from another crate. Otherwise returns true.
@@ -91,6 +92,50 @@ pub fn struct_member_is_visible(
                 struct_parent_module_id.local_id,
                 current_module_id.local_id,
             )
+        }
+    }
+}
+
+pub fn method_call_is_visible(
+    object_type: &Type,
+    func_id: FuncId,
+    current_module: ModuleId,
+    interner: &NodeInterner,
+    def_maps: &DefMaps,
+) -> bool {
+    let modifiers = interner.function_modifiers(&func_id);
+    match modifiers.visibility {
+        ItemVisibility::Public => true,
+        ItemVisibility::PublicCrate => {
+            if object_type.is_primitive() {
+                current_module.krate.is_stdlib()
+            } else {
+                interner.function_module(func_id).krate == current_module.krate
+            }
+        }
+        ItemVisibility::Private => {
+            if object_type.is_primitive() {
+                let func_module = interner.function_module(func_id);
+                can_reference_module_id(
+                    def_maps,
+                    current_module.krate,
+                    current_module.local_id,
+                    func_module,
+                    modifiers.visibility,
+                )
+            } else {
+                let func_meta = interner.function_meta(&func_id);
+                if let Some(struct_id) = func_meta.struct_id {
+                    struct_member_is_visible(
+                        struct_id,
+                        modifiers.visibility,
+                        current_module,
+                        def_maps,
+                    )
+                } else {
+                    true
+                }
+            }
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/resolution/visibility.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/visibility.rs
@@ -1,5 +1,5 @@
 use crate::graph::CrateId;
-use crate::StructType;
+use crate::node_interner::StructId;
 
 use std::collections::BTreeMap;
 
@@ -64,8 +64,8 @@ fn module_is_parent_of_struct_module(
     module_data.is_struct && module_data.parent == Some(current)
 }
 
-pub fn struct_field_is_visible(
-    struct_type: &StructType,
+pub fn struct_member_is_visible(
+    struct_id: StructId,
     visibility: ItemVisibility,
     current_module_id: ModuleId,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
@@ -73,10 +73,10 @@ pub fn struct_field_is_visible(
     match visibility {
         ItemVisibility::Public => true,
         ItemVisibility::PublicCrate => {
-            struct_type.id.parent_module_id(def_maps).krate == current_module_id.krate
+            struct_id.parent_module_id(def_maps).krate == current_module_id.krate
         }
         ItemVisibility::Private => {
-            let struct_parent_module_id = struct_type.id.parent_module_id(def_maps);
+            let struct_parent_module_id = struct_id.parent_module_id(def_maps);
             if struct_parent_module_id.krate != current_module_id.krate {
                 return false;
             }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -983,6 +983,34 @@ impl Type {
         }
     }
 
+    pub fn is_primitive(&self) -> bool {
+        match self.follow_bindings() {
+            Type::FieldElement
+            | Type::Array(_, _)
+            | Type::Slice(_)
+            | Type::Integer(..)
+            | Type::Bool
+            | Type::String(_)
+            | Type::FmtString(_, _)
+            | Type::Unit
+            | Type::Function(..)
+            | Type::Tuple(..) => true,
+            Type::Alias(alias_type, generics) => {
+                alias_type.borrow().get_type(&generics).is_primitive()
+            }
+            Type::MutableReference(typ) => typ.is_primitive(),
+            Type::Struct(..)
+            | Type::TypeVariable(..)
+            | Type::TraitAsType(..)
+            | Type::NamedGeneric(..)
+            | Type::Forall(..)
+            | Type::Constant(..)
+            | Type::Quoted(..)
+            | Type::InfixExpr(..)
+            | Type::Error => false,
+        }
+    }
+
     pub fn find_numeric_type_vars(&self, found_names: &mut Vec<String>) {
         // Return whether the named generic has a Kind::Numeric and save its name
         let named_generic_is_numeric = |typ: &Type, found_names: &mut Vec<String>| {

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -40,7 +40,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        fn into_group(self) -> curvegroup::Point {
+        pub(crate) fn into_group(self) -> curvegroup::Point {
             if self.is_zero() {
                 curvegroup::Point::zero()
             } else {
@@ -62,7 +62,7 @@ pub mod affine {
         }
 
         // Map into equivalent Twisted Edwards curve
-        fn into_tecurve(self) -> TEPoint {
+        pub(crate) fn into_tecurve(self) -> TEPoint {
             let Self {x, y, infty} = self;
 
             if infty | (y * (x + 1) == 0) {
@@ -95,7 +95,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        fn into_group(self) -> curvegroup::Curve {
+        pub(crate) fn into_group(self) -> curvegroup::Curve {
             curvegroup::Curve::new(self.j, self.k, self.gen.into_group())
         }
 
@@ -165,7 +165,7 @@ pub mod affine {
         }
 
         // Point mapping from equivalent Short Weierstrass curve
-        fn map_from_swcurve(self, p: SWPoint) -> Point {
+        pub(crate) fn map_from_swcurve(self, p: SWPoint) -> Point {
             let SWPoint {x, y, infty} = p;
             let j = self.j;
             let k = self.k;
@@ -174,7 +174,7 @@ pub mod affine {
         }
 
         // Elligator 2 map-to-curve method; see <https://datatracker.ietf.org/doc/id/draft-irtf-cfrg-hash-to-curve-06.html#name-elligator-2-method>.
-        fn elligator2_map(self, u: Field) -> Point {
+        pub(crate) fn elligator2_map(self, u: Field) -> Point {
             let j = self.j;
             let k = self.k;
             let z = ZETA; // Non-square Field element required for map
@@ -205,7 +205,7 @@ pub mod affine {
         }
 
         // SWU map-to-curve method (via rational map)
-        fn swu_map(self, z: Field, u: Field) -> Point {
+        pub(crate) fn swu_map(self, z: Field, u: Field) -> Point {
             self.map_from_swcurve(self.into_swcurve().swu_map(z, u))
         }
     }
@@ -269,7 +269,7 @@ pub mod curvegroup {
         }
 
         // Map into equivalent Twisted Edwards curve
-        fn into_tecurve(self) -> TEPoint {
+        pub(crate) fn into_tecurve(self) -> TEPoint {
             self.into_affine().into_tecurve().into_group()
         }
     }
@@ -348,7 +348,7 @@ pub mod curvegroup {
         }
 
         // Conversion to equivalent Short Weierstrass curve
-        fn into_swcurve(self) -> SWCurve {
+        pub(crate) fn into_swcurve(self) -> SWCurve {
             let j = self.j;
             let k = self.k;
             let a0 = (3 - j * j) / (3 * k * k);
@@ -363,17 +363,17 @@ pub mod curvegroup {
         }
 
         // Point mapping from equivalent Short Weierstrass curve
-        fn map_from_swcurve(self, p: SWPoint) -> Point {
+        pub(crate) fn map_from_swcurve(self, p: SWPoint) -> Point {
             self.into_affine().map_from_swcurve(p.into_affine()).into_group()
         }
 
         // Elligator 2 map-to-curve method
-        fn elligator2_map(self, u: Field) -> Point {
+        pub(crate) fn elligator2_map(self, u: Field) -> Point {
             self.into_affine().elligator2_map(u).into_group()
         }
 
         // SWU map-to-curve method (via rational map)
-        fn swu_map(self, z: Field, u: Field) -> Point {
+        pub(crate) fn swu_map(self, z: Field, u: Field) -> Point {
             self.into_affine().swu_map(z, u).into_group()
         }
     }

--- a/noir_stdlib/src/ec/montcurve.nr
+++ b/noir_stdlib/src/ec/montcurve.nr
@@ -40,7 +40,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        pub(crate) fn into_group(self) -> curvegroup::Point {
+        pub fn into_group(self) -> curvegroup::Point {
             if self.is_zero() {
                 curvegroup::Point::zero()
             } else {
@@ -55,14 +55,14 @@ pub mod affine {
         }
 
         // Negation
-        fn negate(self) -> Self {
+        pub fn negate(self) -> Self {
             let Self {x, y, infty} = self;
 
             Self { x, y: 0 - y, infty }
         }
 
         // Map into equivalent Twisted Edwards curve
-        pub(crate) fn into_tecurve(self) -> TEPoint {
+        pub fn into_tecurve(self) -> TEPoint {
             let Self {x, y, infty} = self;
 
             if infty | (y * (x + 1) == 0) {
@@ -95,7 +95,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        pub(crate) fn into_group(self) -> curvegroup::Curve {
+        pub fn into_group(self) -> curvegroup::Curve {
             curvegroup::Curve::new(self.j, self.k, self.gen.into_group())
         }
 
@@ -114,17 +114,17 @@ pub mod affine {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             self.into_tecurve().bit_mul(bits, p.into_tecurve()).into_montcurve()
         }
 
         // Scalar multiplication (p + ... + p n times)
-        fn mul(self, n: Field, p: Point) -> Point {
+        pub fn mul(self, n: Field, p: Point) -> Point {
             self.into_tecurve().mul(n, p.into_tecurve()).into_montcurve()
         }
 
         // Multi-scalar multiplication (n[0]*p[0] + ... + n[N]*p[N], where * denotes scalar multiplication)
-        fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
+        pub fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -135,12 +135,12 @@ pub mod affine {
         }
 
         // Point subtraction
-        fn subtract(self, p1: Point, p2: Point) -> Point {
+        pub fn subtract(self, p1: Point, p2: Point) -> Point {
             self.add(p1, p2.negate())
         }
 
         // Conversion to equivalent Twisted Edwards curve
-        fn into_tecurve(self) -> TECurve {
+        pub fn into_tecurve(self) -> TECurve {
             let Self {j, k, gen} = self;
             TECurve::new((j + 2) / k, (j - 2) / k, gen.into_tecurve())
         }
@@ -165,7 +165,7 @@ pub mod affine {
         }
 
         // Point mapping from equivalent Short Weierstrass curve
-        pub(crate) fn map_from_swcurve(self, p: SWPoint) -> Point {
+        pub fn map_from_swcurve(self, p: SWPoint) -> Point {
             let SWPoint {x, y, infty} = p;
             let j = self.j;
             let k = self.k;
@@ -174,7 +174,7 @@ pub mod affine {
         }
 
         // Elligator 2 map-to-curve method; see <https://datatracker.ietf.org/doc/id/draft-irtf-cfrg-hash-to-curve-06.html#name-elligator-2-method>.
-        pub(crate) fn elligator2_map(self, u: Field) -> Point {
+        pub fn elligator2_map(self, u: Field) -> Point {
             let j = self.j;
             let k = self.k;
             let z = ZETA; // Non-square Field element required for map
@@ -205,7 +205,7 @@ pub mod affine {
         }
 
         // SWU map-to-curve method (via rational map)
-        pub(crate) fn swu_map(self, z: Field, u: Field) -> Point {
+        pub fn swu_map(self, z: Field, u: Field) -> Point {
             self.map_from_swcurve(self.into_swcurve().swu_map(z, u))
         }
     }
@@ -247,7 +247,7 @@ pub mod curvegroup {
         }
 
         // Conversion to affine coordinates
-        fn into_affine(self) -> affine::Point {
+        pub fn into_affine(self) -> affine::Point {
             if self.is_zero() {
                 affine::Point::zero()
             } else {
@@ -262,14 +262,14 @@ pub mod curvegroup {
         }
 
         // Negation
-        fn negate(self) -> Self {
+        pub fn negate(self) -> Self {
             let Self {x, y, z} = self;
 
             Point::new(x, 0 - y, z)
         }
 
         // Map into equivalent Twisted Edwards curve
-        pub(crate) fn into_tecurve(self) -> TEPoint {
+        pub fn into_tecurve(self) -> TEPoint {
             self.into_affine().into_tecurve().into_group()
         }
     }
@@ -297,7 +297,7 @@ pub mod curvegroup {
         }
 
         // Conversion to affine coordinates
-        fn into_affine(self) -> affine::Curve {
+        pub fn into_affine(self) -> affine::Curve {
             affine::Curve::new(self.j, self.k, self.gen.into_affine())
         }
 
@@ -316,7 +316,7 @@ pub mod curvegroup {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             self.into_tecurve().bit_mul(bits, p.into_tecurve()).into_montcurve()
         }
 
@@ -326,7 +326,7 @@ pub mod curvegroup {
         }
 
         // Multi-scalar multiplication (n[0]*p[0] + ... + n[N]*p[N], where * denotes scalar multiplication)
-        fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
+        pub fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -342,13 +342,13 @@ pub mod curvegroup {
         }
 
         // Conversion to equivalent Twisted Edwards curve
-        fn into_tecurve(self) -> TECurve {
+        pub fn into_tecurve(self) -> TECurve {
             let Self {j, k, gen} = self;
             TECurve::new((j + 2) / k, (j - 2) / k, gen.into_tecurve())
         }
 
         // Conversion to equivalent Short Weierstrass curve
-        pub(crate) fn into_swcurve(self) -> SWCurve {
+        pub fn into_swcurve(self) -> SWCurve {
             let j = self.j;
             let k = self.k;
             let a0 = (3 - j * j) / (3 * k * k);
@@ -363,17 +363,17 @@ pub mod curvegroup {
         }
 
         // Point mapping from equivalent Short Weierstrass curve
-        pub(crate) fn map_from_swcurve(self, p: SWPoint) -> Point {
+        pub fn map_from_swcurve(self, p: SWPoint) -> Point {
             self.into_affine().map_from_swcurve(p.into_affine()).into_group()
         }
 
         // Elligator 2 map-to-curve method
-        pub(crate) fn elligator2_map(self, u: Field) -> Point {
+        pub fn elligator2_map(self, u: Field) -> Point {
             self.into_affine().elligator2_map(u).into_group()
         }
 
         // SWU map-to-curve method (via rational map)
-        pub(crate) fn swu_map(self, z: Field, u: Field) -> Point {
+        pub fn swu_map(self, z: Field, u: Field) -> Point {
             self.into_affine().swu_map(z, u).into_group()
         }
     }

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -36,7 +36,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        fn into_group(self) -> curvegroup::Point {
+        pub(crate) fn into_group(self) -> curvegroup::Point {
             let Self {x, y, infty} = self;
 
             if infty {
@@ -161,7 +161,7 @@ pub mod affine {
         // Simplified Shallue-van de Woestijne-Ulas map-to-curve method; see <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-shallue-van-de-w>.
         // First determine non-square z != -1 in Field s.t. g(x) - z irreducible over Field and g(b/(z*a)) is square,
         // where g(x) = x^3 + a*x + b. swu_map(c,z,.) then maps a Field element to a point on curve c.
-        fn swu_map(self, z: Field, u: Field) -> Point {
+        pub(crate) fn swu_map(self, z: Field, u: Field) -> Point {
             // Check whether curve is admissible
             assert(self.a * self.b != 0);
 
@@ -338,7 +338,7 @@ pub mod curvegroup {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub(crate) fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {

--- a/noir_stdlib/src/ec/swcurve.nr
+++ b/noir_stdlib/src/ec/swcurve.nr
@@ -36,7 +36,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        pub(crate) fn into_group(self) -> curvegroup::Point {
+        pub fn into_group(self) -> curvegroup::Point {
             let Self {x, y, infty} = self;
 
             if infty {
@@ -52,7 +52,7 @@ pub mod affine {
         }
 
         // Negation
-        fn negate(self) -> Self {
+        pub fn negate(self) -> Self {
             let Self {x, y, infty} = self;
             Self { x, y: 0 - y, infty }
         }
@@ -82,7 +82,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        fn into_group(self) -> curvegroup::Curve {
+        pub fn into_group(self) -> curvegroup::Curve {
             let Curve{a, b, gen} = self;
 
             curvegroup::Curve { a, b, gen: gen.into_group() }
@@ -100,7 +100,7 @@ pub mod affine {
         }
 
         // Mixed point addition, i.e. first argument in affine, second in CurveGroup coordinates.
-        fn mixed_add(self, p1: Point, p2: curvegroup::Point) -> curvegroup::Point {
+        pub fn mixed_add(self, p1: Point, p2: curvegroup::Point) -> curvegroup::Point {
             if p1.is_zero() {
                 p2
             } else if p2.is_zero() {
@@ -133,7 +133,7 @@ pub mod affine {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             self.into_group().bit_mul(bits, p.into_group()).into_affine()
         }
 
@@ -161,7 +161,7 @@ pub mod affine {
         // Simplified Shallue-van de Woestijne-Ulas map-to-curve method; see <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-simplified-shallue-van-de-w>.
         // First determine non-square z != -1 in Field s.t. g(x) - z irreducible over Field and g(b/(z*a)) is square,
         // where g(x) = x^3 + a*x + b. swu_map(c,z,.) then maps a Field element to a point on curve c.
-        pub(crate) fn swu_map(self, z: Field, u: Field) -> Point {
+        pub fn swu_map(self, z: Field, u: Field) -> Point {
             // Check whether curve is admissible
             assert(self.a * self.b != 0);
 
@@ -236,7 +236,7 @@ pub mod curvegroup {
         }
 
         // Negation
-        fn negate(self) -> Self {
+        pub fn negate(self) -> Self {
             let Self {x, y, z} = self;
             Self { x, y: 0 - y, z }
         }
@@ -338,7 +338,7 @@ pub mod curvegroup {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        pub(crate) fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -363,7 +363,7 @@ pub mod curvegroup {
         }
 
         // Multi-scalar multiplication (n[0]*p[0] + ... + n[N]*p[N], where * denotes scalar multiplication)
-        fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
+        pub fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -379,7 +379,7 @@ pub mod curvegroup {
         }
 
         // Simplified SWU map-to-curve method
-        fn swu_map(self, z: Field, u: Field) -> Point {
+        pub fn swu_map(self, z: Field, u: Field) -> Point {
             self.into_affine().swu_map(z, u).into_group()
         }
     }

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -38,7 +38,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        pub(crate) fn into_group(self) -> curvegroup::Point {
+        pub fn into_group(self) -> curvegroup::Point {
             let Self {x, y} = self;
 
             curvegroup::Point::new(x, y, x * y, 1)
@@ -50,13 +50,13 @@ pub mod affine {
         }
 
         // Negation
-        fn negate(self) -> Self {
+        pub fn negate(self) -> Self {
             let Self {x, y} = self;
             Point::new(0 - x, y)
         }
 
         // Map into prime-order subgroup of equivalent Montgomery curve
-        pub(crate) fn into_montcurve(self) -> MPoint {
+        pub fn into_montcurve(self) -> MPoint {
             if self.is_zero() {
                 MPoint::zero()
             } else {
@@ -93,7 +93,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        fn into_group(self) -> curvegroup::Curve {
+        pub fn into_group(self) -> curvegroup::Curve {
             let Curve{a, d, gen} = self;
 
             curvegroup::Curve { a, d, gen: gen.into_group() }
@@ -111,7 +111,7 @@ pub mod affine {
         }
 
         // Mixed point addition, i.e. first argument in affine, second in CurveGroup coordinates.
-        fn mixed_add(self, p1: Point, p2: curvegroup::Point) -> curvegroup::Point {
+        pub fn mixed_add(self, p1: Point, p2: curvegroup::Point) -> curvegroup::Point {
             let Point{x: x1, y: y1} = p1;
             let curvegroup::Point{x: x2, y: y2, t: t2, z: z2} = p2;
 
@@ -133,17 +133,17 @@ pub mod affine {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        pub(crate) fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             self.into_group().bit_mul(bits, p.into_group()).into_affine()
         }
 
         // Scalar multiplication (p + ... + p n times)
-        pub(crate) fn mul(self, n: Field, p: Point) -> Point {
+        pub fn mul(self, n: Field, p: Point) -> Point {
             self.into_group().mul(n, p.into_group()).into_affine()
         }
 
         // Multi-scalar multiplication (n[0]*p[0] + ... + n[N]*p[N], where * denotes scalar multiplication)
-        fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
+        pub fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -154,7 +154,7 @@ pub mod affine {
         }
 
         // Point subtraction
-        fn subtract(self, p1: Point, p2: Point) -> Point {
+        pub fn subtract(self, p1: Point, p2: Point) -> Point {
             self.add(p1, p2.negate())
         }
 
@@ -178,17 +178,17 @@ pub mod affine {
         }
 
         // Point mapping from equivalent Short Weierstrass curve
-        fn map_from_swcurve(self, p: SWPoint) -> Point {
+        pub fn map_from_swcurve(self, p: SWPoint) -> Point {
             self.into_montcurve().map_from_swcurve(p).into_tecurve()
         }
 
         // Elligator 2 map-to-curve method (via rational map)
-        fn elligator2_map(self, u: Field) -> Point {
+        pub fn elligator2_map(self, u: Field) -> Point {
             self.into_montcurve().elligator2_map(u).into_tecurve()
         }
 
         // Simplified SWU map-to-curve method (via rational map)
-        fn swu_map(self, z: Field, u: Field) -> Point {
+        pub fn swu_map(self, z: Field, u: Field) -> Point {
             self.into_montcurve().swu_map(z, u).into_tecurve()
         }
     }
@@ -245,14 +245,14 @@ pub mod curvegroup {
         }
 
         // Negation
-        fn negate(self) -> Self {
+        pub fn negate(self) -> Self {
             let Self {x, y, t, z} = self;
 
             Point::new(0 - x, y, 0 - t, z)
         }
 
         // Map into prime-order subgroup of equivalent Montgomery curve
-        pub(crate) fn into_montcurve(self) -> MPoint {
+        pub fn into_montcurve(self) -> MPoint {
             self.into_affine().into_montcurve().into_group()
         }
     }
@@ -341,7 +341,7 @@ pub mod curvegroup {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        pub(crate) fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -366,7 +366,7 @@ pub mod curvegroup {
         }
 
         // Multi-scalar multiplication (n[0]*p[0] + ... + n[N]*p[N], where * denotes scalar multiplication)
-        fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
+        pub fn msm<let N: u32>(self, n: [Field; N], p: [Point; N]) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {
@@ -377,17 +377,17 @@ pub mod curvegroup {
         }
 
         // Point subtraction
-        fn subtract(self, p1: Point, p2: Point) -> Point {
+        pub fn subtract(self, p1: Point, p2: Point) -> Point {
             self.add(p1, p2.negate())
         }
 
         // Conversion to equivalent Montgomery curve
-        fn into_montcurve(self) -> MCurve {
+        pub fn into_montcurve(self) -> MCurve {
             self.into_affine().into_montcurve().into_group()
         }
 
         // Conversion to equivalent Short Weierstrass curve
-        fn into_swcurve(self) -> SWCurve {
+        pub fn into_swcurve(self) -> SWCurve {
             self.into_montcurve().into_swcurve()
         }
 
@@ -397,17 +397,17 @@ pub mod curvegroup {
         }
 
         // Point mapping from equivalent short Weierstrass curve
-        fn map_from_swcurve(self, p: SWPoint) -> Point {
+        pub fn map_from_swcurve(self, p: SWPoint) -> Point {
             self.into_montcurve().map_from_swcurve(p).into_tecurve()
         }
 
         // Elligator 2 map-to-curve method (via rational maps)
-        fn elligator2_map(self, u: Field) -> Point {
+        pub fn elligator2_map(self, u: Field) -> Point {
             self.into_montcurve().elligator2_map(u).into_tecurve()
         }
 
         // Simplified SWU map-to-curve method (via rational map)
-        fn swu_map(self, z: Field, u: Field) -> Point {
+        pub fn swu_map(self, z: Field, u: Field) -> Point {
             self.into_montcurve().swu_map(z, u).into_tecurve()
         }
     }

--- a/noir_stdlib/src/ec/tecurve.nr
+++ b/noir_stdlib/src/ec/tecurve.nr
@@ -38,7 +38,7 @@ pub mod affine {
         }
 
         // Conversion to CurveGroup coordinates
-        fn into_group(self) -> curvegroup::Point {
+        pub(crate) fn into_group(self) -> curvegroup::Point {
             let Self {x, y} = self;
 
             curvegroup::Point::new(x, y, x * y, 1)
@@ -56,7 +56,7 @@ pub mod affine {
         }
 
         // Map into prime-order subgroup of equivalent Montgomery curve
-        fn into_montcurve(self) -> MPoint {
+        pub(crate) fn into_montcurve(self) -> MPoint {
             if self.is_zero() {
                 MPoint::zero()
             } else {
@@ -133,12 +133,12 @@ pub mod affine {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub(crate) fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             self.into_group().bit_mul(bits, p.into_group()).into_affine()
         }
 
         // Scalar multiplication (p + ... + p n times)
-        fn mul(self, n: Field, p: Point) -> Point {
+        pub(crate) fn mul(self, n: Field, p: Point) -> Point {
             self.into_group().mul(n, p.into_group()).into_affine()
         }
 
@@ -252,7 +252,7 @@ pub mod curvegroup {
         }
 
         // Map into prime-order subgroup of equivalent Montgomery curve
-        fn into_montcurve(self) -> MPoint {
+        pub(crate) fn into_montcurve(self) -> MPoint {
             self.into_affine().into_montcurve().into_group()
         }
     }
@@ -341,7 +341,7 @@ pub mod curvegroup {
 
         // Scalar multiplication with scalar represented by a bit array (little-endian convention).
         // If k is the natural number represented by `bits`, then this computes p + ... + p k times.
-        fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
+        pub(crate) fn bit_mul<let N: u32>(self, bits: [u1; N], p: Point) -> Point {
             let mut out = Point::zero();
 
             for i in 0..N {

--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -79,7 +79,6 @@ fn verify_msg_block<let N: u32>(
 }
 
 global BLOCK_SIZE = 64;
-global ZERO = 0;
 
 // Variable size SHA-256 hash
 pub fn sha256_var<let N: u32>(msg: [u8; N], message_size: u64) -> [u8; 32] {

--- a/noir_stdlib/src/option.nr
+++ b/noir_stdlib/src/option.nr
@@ -57,7 +57,7 @@ impl<T> Option<T> {
     }
 
     /// Asserts `self.is_some()` with a provided custom message and returns the contained `Some` value
-    fn expect<let N: u32, MessageTypes>(self, message: fmtstr<N, MessageTypes>) -> T {
+    pub fn expect<let N: u32, MessageTypes>(self, message: fmtstr<N, MessageTypes>) -> T {
         assert(self.is_some(), message);
         self._value
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -26,7 +26,7 @@ use noirc_frontend::{
     graph::{CrateId, Dependency},
     hir::{
         def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId},
-        resolution::visibility::struct_member_is_visible,
+        resolution::visibility::{method_call_is_visible, struct_member_is_visible},
     },
     hir_def::traits::Trait,
     node_interner::{NodeInterner, ReferenceId, StructId},
@@ -632,6 +632,7 @@ impl<'a> NodeFinder<'a> {
         };
 
         let struct_id = get_type_struct_id(typ);
+        let is_primitive = typ.is_primitive();
 
         for (name, methods) in methods_by_name {
             for (func_id, method_type) in methods.iter() {
@@ -654,6 +655,18 @@ impl<'a> NodeFinder<'a> {
                     ) {
                         continue;
                     }
+                }
+
+                if is_primitive
+                    && !method_call_is_visible(
+                        typ,
+                        func_id,
+                        self.module_id,
+                        self.interner,
+                        self.def_maps,
+                    )
+                {
+                    continue;
                 }
 
                 if name_matches(name, prefix) {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -26,10 +26,10 @@ use noirc_frontend::{
     graph::{CrateId, Dependency},
     hir::{
         def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId},
-        resolution::visibility::struct_field_is_visible,
+        resolution::visibility::struct_member_is_visible,
     },
     hir_def::traits::Trait,
-    node_interner::{NodeInterner, ReferenceId},
+    node_interner::{NodeInterner, ReferenceId, StructId},
     parser::{Item, ItemKind, ParsedSubModule},
     token::{CustomAttribute, Token, Tokens},
     Kind, ParsedModule, StructType, Type, TypeBinding,
@@ -631,6 +631,8 @@ impl<'a> NodeFinder<'a> {
             return;
         };
 
+        let struct_id = get_type_struct_id(typ);
+
         for (name, methods) in methods_by_name {
             for (func_id, method_type) in methods.iter() {
                 if function_kind == FunctionKind::Any {
@@ -638,6 +640,19 @@ impl<'a> NodeFinder<'a> {
                         if method_type.unify(typ).is_err() {
                             continue;
                         }
+                    }
+                }
+
+                if let Some(struct_id) = struct_id {
+                    let modifiers = self.interner.function_modifiers(&func_id);
+                    let visibility = modifiers.visibility;
+                    if !struct_member_is_visible(
+                        struct_id,
+                        visibility,
+                        self.module_id,
+                        self.def_maps,
+                    ) {
+                        continue;
                     }
                 }
 
@@ -696,7 +711,8 @@ impl<'a> NodeFinder<'a> {
         for (field_index, (name, visibility, typ)) in
             struct_type.get_fields_with_visibility(generics).iter().enumerate()
         {
-            if !struct_field_is_visible(struct_type, *visibility, self.module_id, self.def_maps) {
+            if !struct_member_is_visible(struct_type.id, *visibility, self.module_id, self.def_maps)
+            {
                 continue;
             }
 
@@ -1696,6 +1712,18 @@ fn get_array_element_type(typ: Type) -> Option<Type> {
             } else {
                 None
             }
+        }
+        _ => None,
+    }
+}
+
+fn get_type_struct_id(typ: &Type) -> Option<StructId> {
+    match typ {
+        Type::Struct(struct_type, _) => Some(struct_type.borrow().id),
+        Type::Alias(type_alias, generics) => {
+            let type_alias = type_alias.borrow();
+            let typ = type_alias.get_type(generics);
+            get_type_struct_id(&typ)
         }
         _ => None,
     }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1822,7 +1822,7 @@ mod completion_tests {
     }
 
     #[test]
-    async fn test_does_not_suggest_private_methods() {
+    async fn test_does_not_suggest_private_struct_methods() {
         let src = r#"
             mod moo {
                 pub struct Foo {}
@@ -1836,7 +1836,20 @@ mod completion_tests {
                 f.>|<()
             }
         "#;
-        assert_completion_excluding_auto_import(src, vec![]).await;
+        assert_completion(src, vec![]).await;
+    }
+
+    #[test]
+    async fn test_does_not_suggest_private_primitive_methods() {
+        let src = r#"
+            fn foo(x: Field) {
+                x.>|<
+            }
+        "#;
+        let items = get_completions(src).await;
+        if items.iter().any(|item| item.label == "__assert_max_bit_size") {
+            panic!("Private method __assert_max_bit_size was suggested");
+        }
     }
 
     #[test]

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1822,6 +1822,24 @@ mod completion_tests {
     }
 
     #[test]
+    async fn test_does_not_suggest_private_methods() {
+        let src = r#"
+            mod moo {
+                pub struct Foo {}
+
+                impl Foo {
+                    fn bar(self) {}
+                }
+            }
+
+            fn x(f: moo::Foo) {
+                f.>|<()
+            }
+        "#;
+        assert_completion_excluding_auto_import(src, vec![]).await;
+    }
+
+    #[test]
     async fn test_suggests_pub_use() {
         let src = r#"
             mod bar {


### PR DESCRIPTION
# Description

## Problem

Part of #4515

Apparently in #6179 I only made it work for calls like `foo::Bar::baz()` but no checks were done for method calls (where `self` is involved).

## Summary

This PR now warns when calling private or `pub(crate)` methods, either on structs or primitive types, when they are not accessible from the current module.

We also now don't suggest non-accessible methods from LSP.

## Additional Context


I also removed an unused global that was introduced some time ago.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
