### PR TITLE
chore(ci): pin commit to install bbup from

### DIFF
--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -5,7 +5,7 @@ VERSION="0.56.0"
 BBUP_PATH=~/.bb/bbup
 
 if ! [ -f $BBUP_PATH ]; then 
-    curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/master/barretenberg/cpp/installation/install | bash
+    curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/09c3b288eb96d2fe37e7bb6dedb45f9c9f4a4044/barretenberg/cpp/installation/install | bash
 fi
 
 $BBUP_PATH -v $VERSION


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This fixes the broken CI caused by deletion of bbup in aztec-packages by fixing the commit to one in which the installation script exists.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
