### PR TITLE
feat(test): Fuzz test poseidon2 hash equivalence

### DIFF
--- a/tooling/nargo_cli/tests/stdlib-props.rs
+++ b/tooling/nargo_cli/tests/stdlib-props.rs
@@ -259,14 +259,13 @@ fn fuzz_sha512_equivalence() {
 fn fuzz_poseidon2_equivalence() {
     use bn254_blackbox_solver::poseidon_hash;
 
-    for max_len in [0, 1, 4, 511, 512] {
+    for max_len in [0, 1, 3, 4, 511, 512] {
         let source = format!(
             "fn main(input: [Field; {max_len}], message_size: u32) -> pub Field {{
                 std::hash::poseidon2::Poseidon2::hash(input, message_size)
             }}"
         );
 
-        // The actual input length can be up to the maximum.
         let strategy = (0..=max_len)
             .prop_flat_map(|len: usize| {
                 // Generate Field elements from random 32 byte vectors.
@@ -277,7 +276,7 @@ fn fuzz_poseidon2_equivalence() {
             })
             .prop_map(move |mut msg| {
                 // The output hash is a single field element.
-                let output = poseidon_hash(&msg).expect("failed to hash");
+                let output = poseidon_hash(&msg, msg.len() < max_len).expect("failed to hash");
 
                 // The input has to be padded to the maximum length.
                 let msg_size = msg.len();


### PR DESCRIPTION
# Description

## Problem\*

Related to #6141 

## Summary\*

Adds a fuzz test for `poseidon2.nr` comparing the results to [bn254_blackbox_solver::poseidon_hash](https://github.com/noir-lang/noir/blob/70cbeb4322a0b11c1c167ab27bf0408d04fe7b7d/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs#L547), which says it's `"Performs a poseidon hash with a sponge construction equivalent to the one in poseidon2.nr"`

To pass the test the Rust implementation was given a new `is_variable_length` parameter to inform it whether it needs to append an extra 1 like Noir and Berratenberg do. 

## Additional Context

The test initially failed:

```console
❯ cargo test -p nargo_cli --test stdlib-props poseidon
  
test fuzz_poseidon2_equivalence ... FAILED

---- fuzz_poseidon2_equivalence stdout ----
Test failed: assertion failed: `(left == right)` 
  left: `Field(1187863985434533916290764679013201786939267142671550539990974992402592744116)`, 
 right: `Field(11250791130336988991462250958918728798886439319225016858543557054782819955502)`: max_len = 1 at tooling/nargo_cli/tests/stdlib-props.rs:106.
minimal failing input: io = SnippetInputOutput {
    description: "max_len = 1",
    inputs: {
        "input": Vec(
            [
                Field(
                    0,
                ),
            ],
        ),
        "message_size": Field(
            0,
        ),
    },
    expected_output: Field(
        11250791130336988991462250958918728798886439319225016858543557054782819955502,
    ),
}
```

So we pass in `input = [0; 1]` with `message_size=0`. It fails because the Noir code treats the case where the `message_size` is different from the maximum length differently by [appending](https://github.com/noir-lang/noir/blob/70cbeb4322a0b11c1c167ab27bf0408d04fe7b7d/noir_stdlib/src/hash/poseidon2.nr#L75-L80) an extra 1, to keep variable and fixed length hashes distinct. The Rust implementation doesn't do this, nor did the other hashes tested so far. I'm not sure if it's worth noting that the hash will not depend on how much shorter the message is than the maximum, just that it's shorter.


## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
