### PR TITLE
feat: show LSP diagnostic related information

### DIFF
--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -10,7 +10,7 @@ use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 pub struct CustomDiagnostic {
     pub message: String,
     pub secondaries: Vec<CustomLabel>,
-    notes: Vec<String>,
+    pub notes: Vec<String>,
     pub kind: DiagnosticKind,
     pub deprecated: bool,
     pub unnecessary: bool,

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -292,6 +292,23 @@ fn file_diagnostic_to_diagnostic(
         });
     }
 
+    for frame in diagnostic.call_stack.into_iter().rev() {
+        let Some(path) = fm.path(frame.file) else {
+            continue;
+        };
+        let Ok(uri) = Url::from_file_path(path) else {
+            continue;
+        };
+        let Some(range) = byte_span_to_range(files, file_id, frame.span.into()) else {
+            continue;
+        };
+
+        related_information.push(DiagnosticRelatedInformation {
+            location: lsp_types::Location { uri, range },
+            message: "Error originated here".to_string(),
+        });
+    }
+
     Some(Diagnostic {
         range,
         severity: Some(severity),


### PR DESCRIPTION
# Description

## Problem

Errors shown in LSP didn't show the "secondaries" we capture, nor the notes.

Resolves #6272

## Summary

Now secondaries and notes are shown as details to the primary error, like in Rust Analyzer:

![lsp-related-information-1](https://github.com/user-attachments/assets/bc307cb0-e314-4e40-97a2-a5a57abed717)

![lsp-related-information-2](https://github.com/user-attachments/assets/a79e379e-dc06-4f74-ab51-8c4b4f868899)

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
