### PR TITLE
feat(test): Include the PoseidonHasher in the fuzzing

### DIFF
--- a/tooling/nargo_cli/tests/stdlib-props.rs
+++ b/tooling/nargo_cli/tests/stdlib-props.rs
@@ -305,7 +305,14 @@ fn fuzz_poseidon_equivalence() {
     for len in 1..light_poseidon::MAX_X5_LEN {
         let source = format!(
             "fn main(input: [Field; {len}]) -> pub Field {{
-                std::hash::poseidon::bn254::hash_{len}(input)
+                let h1 = std::hash::poseidon::bn254::hash_{len}(input);
+                let h2 = {{
+                    let mut hasher = std::hash::poseidon::PoseidonHasher::default();
+                    input.hash(&mut hasher);
+                    hasher.finish()
+                }};
+                assert_eq(h1, h2);
+                h1
             }}"
         );
 


### PR DESCRIPTION
# Description

## Problem\*

Related to #6141

## Summary\*

Assert that the `PoseidonHasher` calculates the same hash on dynamic input as the `hash_<length>` function we know it has to call.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
