### PR TITLE
feat: optimize reading a workspace's files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,9 +2528,9 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
- "tempfile",
  "thiserror",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -100,6 +100,11 @@ impl FileManager {
         self.id_to_path.get(&file_id).map(|path| path.as_path())
     }
 
+    pub fn has_file(&self, file_name: &Path) -> bool {
+        let file_name = self.root.join(file_name);
+        self.name_to_id(file_name).is_some()
+    }
+
     // TODO: This should accept a &Path instead of a PathBuf
     pub fn name_to_id(&self, file_name: PathBuf) -> Option<FileId> {
         self.file_map.get_file_id(&PathString::from_path(file_name))

--- a/tooling/nargo/Cargo.toml
+++ b/tooling/nargo/Cargo.toml
@@ -27,15 +27,13 @@ rayon.workspace = true
 jsonrpc.workspace = true
 rand.workspace = true
 serde.workspace = true
+walkdir = "2.5.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 noir_fuzzer.workspace = true
 proptest.workspace = true
 
 [dev-dependencies]
-# TODO: This dependency is used to generate unit tests for `get_all_paths_in_dir`
-# TODO: once that method is moved to nargo_cli, we can move this dependency to nargo_cli
-tempfile.workspace = true
 jsonrpc-http-server = "18.0"
 jsonrpc-core-client = "18.0"
 jsonrpc-derive = "18.0"

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -110,7 +110,7 @@ fn insert_all_files_for_package_into_file_manager(
         file_manager.add_file_with_source(path.as_path(), source);
     }
 
-    insert_all_files_for_packages_dependencies_into_file_manager(package, file_manager);
+    insert_all_files_for_packages_dependencies_into_file_manager(package, file_manager, overrides);
 }
 
 // Inserts all files for the dependencies of the package into the file manager
@@ -118,15 +118,12 @@ fn insert_all_files_for_package_into_file_manager(
 fn insert_all_files_for_packages_dependencies_into_file_manager(
     package: &Package,
     file_manager: &mut FileManager,
+    overrides: &HashMap<&std::path::Path, &str>,
 ) {
     for (_, dep) in package.dependencies.iter() {
         match dep {
             Dependency::Local { package } | Dependency::Remote { package } => {
-                insert_all_files_for_package_into_file_manager(
-                    package,
-                    file_manager,
-                    &HashMap::new(),
-                );
+                insert_all_files_for_package_into_file_manager(package, file_manager, overrides);
             }
         }
     }

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -95,6 +95,11 @@ fn insert_all_files_for_package_into_file_manager(
 
         let path = entry.into_path();
 
+        // Avoid reading the source if the file is already there
+        if file_manager.has_file(&path) {
+            continue;
+        }
+
         let source = if let Some(src) = overrides.get(path.as_path()) {
             src.to_string()
         } else {

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -127,7 +127,6 @@ fn insert_all_files_for_packages_dependencies_into_file_manager(
                     file_manager,
                     &HashMap::new(),
                 );
-                insert_all_files_for_packages_dependencies_into_file_manager(package, file_manager);
             }
         }
     }


### PR DESCRIPTION
# Description

## Problem

Reading all workspace files is slow.

## Summary

**TL;DR: reading all `.nr` files in the noir-circuits project now takes 10ms instead of 1.5 seconds.**

Using `flamegraph` I noticed reading a workspace files was slow. For example in `noir-contracts` it was taking 1.5 seconds to do that.

The first thing in this PR is using the `walkdir` crate which brings two benefits:
- It reduces the time to 1.3 seconds (not much, but it's something)
- It removes the need for us to reproduce that code and maintain it (we had tests for walking a dir)

Still, 1.3 seconds seemed like too slow. At first I searched if there was alternatives to `std::fs::read_string` but it seems that's the most efficient thing to use. So I created a separate project that essentially did `walkdir` on `noir-contracts`, reading all files and it took around 10ms (!!). So there must be something else going on...
 
It turns out, if we have a workspace with projects A, B and C, with both A and B depending on C, C's files were read twice. So the next thing I did was to avoid reading a file's source if it was already in the file manager. That reduces the time ro 340ms. But the separate project was taking 10ms to do the same! There's still something else...

Well, we still walked C's directories twice (in the above example). So the next thing is to keep track of which packages we already added files for, and not traverse those dirs more than once. With that, now adding all the files for noir-contracts takes around 10ms.

(the difference is so big because in noir-contracts we have many projects depending on many others, resulting in some project files being read like, say, 10 times instead of 1)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
