### PR TITLE
chore: regression test for #5462

### DIFF
--- a/test_programs/execution_success/regression_test_5462/Nargo.toml
+++ b/test_programs/execution_success/regression_test_5462/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_test_5462"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/execution_success/regression_test_5462/src/main.nr
+++ b/test_programs/execution_success/regression_test_5462/src/main.nr
@@ -1,10 +1,10 @@
 fn main() {
     let empty_slice: [u8] = &[];
-    
+
     if empty_slice != &[] {
         let _ = empty_slice.pop_front();
     }
-    
+
     if empty_slice.len() != 0 {
         let _ = empty_slice.pop_front();
     }

--- a/test_programs/execution_success/regression_test_5462/src/main.nr
+++ b/test_programs/execution_success/regression_test_5462/src/main.nr
@@ -1,0 +1,11 @@
+fn main() {
+    let empty_slice: [u8] = &[];
+    
+    if empty_slice != &[] {
+        let _ = empty_slice.pop_front();
+    }
+    
+    if empty_slice.len() != 0 {
+        let _ = empty_slice.pop_front();
+    }
+}

--- a/test_programs/execution_success/slice_regex/src/main.nr
+++ b/test_programs/execution_success/slice_regex/src/main.nr
@@ -208,7 +208,7 @@ fn main() {
     let result = three_ones_regex.match("1111".as_bytes().as_slice());
     println(result);
     assert_eq(result, Match { succeeded: true, match_ends: 3, leftover: &[] });
-    // TODO(https://github.com/noir-lang/noir/issues/5462): re-enable these cases and complete the test using array_regex below
+    // TODO(https://github.com/noir-lang/noir/issues/6285): re-enable these cases and complete the test using array_regex below
     // 
     // // 1*
     // let ones_regex: Star<str<1>, 5> = Star { inner: "1" };
@@ -279,7 +279,9 @@ fn main() {
     // });
 }
 
-// array_regex: use to complete test once https://github.com/noir-lang/noir/issues/5462 is resolved
+// TODO
+// array_regex execution_success test:
+// use to complete test once https://github.com/noir-lang/noir/issues/6285 is resolved
 //
 // // offset <= len <= N
 // struct Bvec<T, let N: u32> {


### PR DESCRIPTION
# Description

## Problem\*

Regression test for github.com/noir-lang/noir/issues/5462

## Summary\*

- Added the test from [5462](github.com/noir-lang/noir/issues/5462)
- Updated the issue needed to re-enable the `array_regex` execution test

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
