### PR TITLE
fix: Reject invalid expression with in CLI parser

### DIFF
--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -11,8 +11,8 @@ mod transformers;
 
 pub use optimizers::optimize;
 use optimizers::optimize_internal;
-pub use transformers::transform;
 use transformers::transform_internal;
+pub use transformers::{transform, MIN_EXPRESSION_WIDTH};
 
 /// This module moves and decomposes acir opcodes. The transformation map allows consumers of this module to map
 /// metadata they had about the opcodes to the new opcode structure generated after the transformation.

--- a/acvm-repo/acvm/src/compiler/transformers/csat.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/csat.rs
@@ -6,6 +6,9 @@ use acir::{
 };
 use indexmap::IndexMap;
 
+/// Minimum width accepted by the `CSatTransformer`.
+pub const MIN_EXPRESSION_WIDTH: usize = 3;
+
 /// A transformer which processes any [`Expression`]s to break them up such that they
 /// fit within the [`ProofSystemCompiler`][crate::ProofSystemCompiler]'s width.
 ///
@@ -22,9 +25,11 @@ pub(crate) struct CSatTransformer {
 }
 
 impl CSatTransformer {
-    // Configure the width for the optimizer
+    /// Create an optimizer with a given width.
+    ///
+    /// Panics if `width` is less than `MIN_EXPRESSION_WIDTH`.
     pub(crate) fn new(width: usize) -> CSatTransformer {
-        assert!(width > 2);
+        assert!(width >= MIN_EXPRESSION_WIDTH, "width has to be at least {MIN_EXPRESSION_WIDTH}");
 
         CSatTransformer { width, solvable_witness: HashSet::new() }
     }

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap;
 mod csat;
 
 pub(crate) use csat::CSatTransformer;
+pub use csat::MIN_EXPRESSION_WIDTH;
 
 use super::{transform_assert_messages, AcirTransformationMap};
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -5,6 +5,7 @@
 
 use abi_gen::{abi_type_from_hir_type, value_from_hir_expression};
 use acvm::acir::circuit::ExpressionWidth;
+use acvm::compiler::MIN_EXPRESSION_WIDTH;
 use clap::Args;
 use fm::{FileId, FileManager};
 use iter_extended::vecmap;
@@ -134,7 +135,11 @@ pub fn parse_expression_width(input: &str) -> Result<ExpressionWidth, std::io::E
 
     match width {
         0 => Ok(ExpressionWidth::Unbounded),
-        _ => Ok(ExpressionWidth::Bounded { width }),
+        w if w >= MIN_EXPRESSION_WIDTH => Ok(ExpressionWidth::Bounded { width }),
+        _ => Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("minimum value is {MIN_EXPRESSION_WIDTH}"),
+        )),
     }
 }
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -138,7 +138,7 @@ pub fn parse_expression_width(input: &str) -> Result<ExpressionWidth, std::io::E
         w if w >= MIN_EXPRESSION_WIDTH => Ok(ExpressionWidth::Bounded { width }),
         _ => Err(Error::new(
             ErrorKind::InvalidInput,
-            format!("minimum value is {MIN_EXPRESSION_WIDTH}"),
+            format!("has to be 0 or at least {MIN_EXPRESSION_WIDTH}"),
         )),
     }
 }

--- a/tooling/nargo_cli/benches/criterion.rs
+++ b/tooling/nargo_cli/benches/criterion.rs
@@ -23,6 +23,8 @@ fn compile_program(test_program_dir: &Path) {
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("compile");
     cmd.arg("--force");
+    cmd.arg("--expression-width");
+    cmd.arg("1");
     cmd.assert().success();
 }
 

--- a/tooling/nargo_cli/benches/criterion.rs
+++ b/tooling/nargo_cli/benches/criterion.rs
@@ -23,8 +23,6 @@ fn compile_program(test_program_dir: &Path) {
     cmd.arg("--program-dir").arg(test_program_dir);
     cmd.arg("compile");
     cmd.arg("--force");
-    cmd.arg("--expression-width");
-    cmd.arg("1");
     cmd.assert().success();
 }
 

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -112,3 +112,20 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
     println!("{markdown}");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    /// Test that parsing an invalid option doesn't
+    #[test]
+    fn test_parse_invalid_expression_width() {
+        let cmd = "nargo --program-dir . compile --expression-width 1";
+        let res = super::NargoCli::try_parse_from(cmd.split_ascii_whitespace());
+
+        let err = res.expect_err("should fail because of invalid width");
+        assert!(err.to_string().contains("expression-width"));
+        assert!(err
+            .to_string()
+            .contains(acvm::compiler::MIN_EXPRESSION_WIDTH.to_string().as_str()));
+    }
+}

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -116,7 +116,6 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
-    /// Test that parsing an invalid option doesn't
     #[test]
     fn test_parse_invalid_expression_width() {
         let cmd = "nargo --program-dir . compile --expression-width 1";


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5560

## Summary\*

Rejects an invalid `--expression-value` in the CLI, which would later cause a panic in `acvm::compiler::transformers::csat`. 

An example error message looks like:

```text
error: invalid value '1' for '--expression-width <EXPRESSION_WIDTH>': minimum value is 3
```

## Additional Context

The issue suggests that [CSatTransformer::new](https://github.com/noir-lang/noir/blob/ae87d287ab1fae0f999dfd0d1166fbddb927ba97/acvm-repo/acvm/src/compiler/transformers/csat.rs#L24-L27) should return a `Result` explaining the problem it has with `width`, rather than doing an `assert!` (without any message) and crashing the program. I agree, however looking at the chain of calls, none of the half-dozen functions we go through to reach this use `Result`, and the `CSatTransformer` is the only option we have. This suggests to me that this limitation is perhaps supposed to be well-known to the user, ie. it's not the case that one transformer has X limit and another has Y limit. 

For this reason I added a `pub const MIN_EXPRESSION_WIDTH: usize = 3;` to the `acvm::compiler` module and using that as a common value for the assertion as well as the validation in the CLI. Should the assumption of a single global value change, removing that will force us to update the validation logic as well. 

That said if you prefer going the `Result` route I'm not against it, it just seemed like an overkill for this single use case.
 
## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
