### PR TITLE
chore: remove extra layer of indirection for pedersen in stdlib

### DIFF
--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -32,10 +32,6 @@ pub fn pedersen_commitment<let N: u32>(input: [Field; N]) -> EmbeddedCurvePoint 
     pedersen_commitment_with_separator(input, 0)
 }
 
-pub fn pedersen_hash_with_separator<let N: u32>(input: [Field; N], separator: u32) -> Field {
-    pedersen_hash_with_separator_noir(input, separator)
-}
-
 pub fn pedersen_commitment_with_separator<let N: u32>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
     let value = __pedersen_commitment_with_separator(input, separator);
     if (value[0] == 0) & (value[1] == 0) {
@@ -44,6 +40,9 @@ pub fn pedersen_commitment_with_separator<let N: u32>(input: [Field; N], separat
         EmbeddedCurvePoint { x: value[0], y: value[1], is_infinite: false }
     }
 }
+
+#[foreign(pedersen_commitment)]
+fn __pedersen_commitment_with_separator<let N: u32>(input: [Field; N], separator: u32) -> [Field; 2] {}
 
 #[no_predicates]
 fn pedersen_commitment_with_separator_noir<let N: u32>(input: [Field; N], separator: u32) -> EmbeddedCurvePoint {
@@ -56,8 +55,16 @@ fn pedersen_commitment_with_separator_noir<let N: u32>(input: [Field; N], separa
     multi_scalar_mul(generators, points)
 }
 
+
+// docs:start:pedersen_hash
+pub fn pedersen_hash<let N: u32>(input: [Field; N]) -> Field
+// docs:end:pedersen_hash
+{
+    pedersen_hash_with_separator(input, 0)
+}
+
 #[no_predicates]
-fn pedersen_hash_with_separator_noir<let N: u32>(input: [Field; N], separator: u32) -> Field {
+pub fn pedersen_hash_with_separator<let N: u32>(input: [Field; N], separator: u32) -> Field {
     let mut scalars: Vec<EmbeddedCurveScalar> = Vec::from_slice([EmbeddedCurveScalar { lo: 0, hi: 0 }; N].as_slice()); //Vec::new();
 
     for i in 0..N {
@@ -74,18 +81,6 @@ fn pedersen_hash_with_separator_noir<let N: u32>(input: [Field; N], separator: u
     multi_scalar_mul_slice(vec_generators.slice, scalars.slice)[0]
 }
 
-// docs:start:pedersen_hash
-pub fn pedersen_hash<let N: u32>(input: [Field; N]) -> Field
-// docs:end:pedersen_hash
-{
-    pedersen_hash_with_separator_noir(input, 0)
-}
-
-#[foreign(pedersen_hash)]
-fn __pedersen_hash_with_separator<let N: u32>(input: [Field; N], separator: u32) -> Field {}
-
-#[foreign(pedersen_commitment)]
-fn __pedersen_commitment_with_separator<let N: u32>(input: [Field; N], separator: u32) -> [Field; 2] {}
 
 #[field(bn254)]
 pub fn derive_generators<let N: u32, let M: u32>(domain_separator_bytes: [u8; M], starting_index: u32) -> [EmbeddedCurvePoint; N] {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes the `__pedersen_hash_with_separator` function from the stdlib and inlines `pedersen_hash_with_separator_noir` into `pedersen_hash_with_separator`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
