### PR TITLE
fix: Do not warn on unused self in traits

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -404,7 +404,8 @@ impl<'context> Elaborator<'context> {
         // so we need to reintroduce the same IDs into scope here.
         for parameter in &func_meta.parameter_idents {
             let name = self.interner.definition_name(parameter.id).to_owned();
-            self.add_existing_variable_to_scope(name, parameter.clone(), true);
+            let warn_if_unused = !(func_meta.trait_impl.is_some() && name == "self");
+            self.add_existing_variable_to_scope(name, parameter.clone(), warn_if_unused);
         }
 
         self.add_trait_constraints_to_scope(&func_meta);

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -274,3 +274,23 @@ fn no_warning_on_indirect_struct_if_it_has_an_abi_attribute() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn no_warning_on_self_in_trait_impl() {
+    let src = r#" 
+    struct Bar {}
+
+    trait Foo {
+        fn foo(self, a: u64);
+    }
+
+    impl Foo for Bar {
+        fn foo(self, _a: u64) {}
+    }
+
+    fn main() {
+        let _ = Bar {};
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6297 

## Summary\*

Sets `warn_if_unused` to `false` for the `self` parameter of a function if it's for a trait implementation.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
