### PR TITLE
fix: Allow array map on empty arrays

### DIFF
--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -203,6 +203,8 @@ fn main() {
 
 Same as fold, but uses the first element as the starting element.
 
+Requires `self` to be non-empty.
+
 ```rust
 fn reduce(self, f: fn(T, T) -> T) -> T
 ```

--- a/noir_stdlib/src/array/mod.nr
+++ b/noir_stdlib/src/array/mod.nr
@@ -43,8 +43,8 @@ impl<T, let N: u32> [T; N] {
     /// assert_eq(b, [2, 4, 6]);
     /// ```
     pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> [U; N] {
-        let first_elem = crate::mem::zeroed();
-        let mut ret = [first_elem; N];
+        let uninitialized = crate::mem::zeroed();
+        let mut ret = [uninitialized; N];
 
         for i in 0..self.len() {
             ret[i] = f(self[i]);

--- a/noir_stdlib/src/array/mod.nr
+++ b/noir_stdlib/src/array/mod.nr
@@ -46,7 +46,7 @@ impl<T, let N: u32> [T; N] {
         let first_elem = crate::mem::zeroed();
         let mut ret = [first_elem; N];
 
-        for i in 1..self.len() {
+        for i in 0..self.len() {
             ret[i] = f(self[i]);
         }
 

--- a/noir_stdlib/src/array/mod.nr
+++ b/noir_stdlib/src/array/mod.nr
@@ -43,7 +43,7 @@ impl<T, let N: u32> [T; N] {
     /// assert_eq(b, [2, 4, 6]);
     /// ```
     pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> [U; N] {
-        let first_elem = f(self[0]);
+        let first_elem = crate::mem::zeroed();
         let mut ret = [first_elem; N];
 
         for i in 1..self.len() {
@@ -79,6 +79,8 @@ impl<T, let N: u32> [T; N] {
     }
 
     /// Same as fold, but uses the first element as the starting element.
+    ///
+    /// Requires the input array to be non-empty.
     /// 
     /// Example:
     /// 
@@ -215,5 +217,12 @@ impl<let N: u32> From<str<N>> for [u8; N] {
     /// Returns an array of the string bytes.
     fn from(s: str<N>) -> Self {
         s.as_bytes()
+    }
+}
+
+mod test {
+    #[test]
+    fn map_empty() {
+        assert_eq([].map(|x| x + 1), []);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves a private issue sent to me on slack

## Summary\*

Array map is a fairly old method written before we had `std::mem::zeroed`. Now that we have zeroed, we can allow mapping empty arrays since we can use `zeroed` to get the filler `U` value for the starting elements.

## Additional Context

While I was at it I included a small clarification to `reduce`'s docs that it requires a non-empty array

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
