### PR TITLE
fix: mutable global pattern didn't have a span

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/global.rs
+++ b/compiler/noirc_frontend/src/parser/parser/global.rs
@@ -59,7 +59,8 @@ impl<'a> Parser<'a> {
 
 fn ident_to_pattern(ident: Ident, mutable: bool) -> Pattern {
     if mutable {
-        Pattern::Mutable(Box::new(Pattern::Identifier(ident)), Span::default(), false)
+        let span = ident.span();
+        Pattern::Mutable(Box::new(Pattern::Identifier(ident)), span, false)
     } else {
         Pattern::Identifier(ident)
     }
@@ -140,6 +141,8 @@ mod tests {
             panic!("Expected identifier pattern");
         };
         assert_eq!("foo", name.to_string());
+        assert_eq!(pattern.span().start(), 11);
+        assert_eq!(pattern.span().end(), 14);
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

Without a span, LSP's document symbol crashed.

## Summary

Replaces a default span with a correct one.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
