### PR TITLE
fix: (formatter) indent after infix lhs

### DIFF
--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -705,6 +705,12 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
             }
         };
 
+        // Indent right after the lhs so that if there's a trailing comment,
+        // the next line is indented correctly.
+        if increase_indentation {
+            group.increase_indentation();
+        }
+
         let mut comment_chunk_after_lhs = self.skip_comments_and_whitespace_chunk();
 
         // If the comment is not empty but doesn't have newlines, it's surely `/* comment */`.
@@ -717,10 +723,6 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
             group.text(comment_chunk_after_lhs);
         } else {
             group.trailing_comment(comment_chunk_after_lhs);
-        }
-
-        if increase_indentation {
-            group.increase_indentation();
         }
 
         group.space_or_line();
@@ -1419,6 +1421,23 @@ global y = 1;
 }
 ";
         assert_format_with_max_width(src, expected, "one + two + three + four".len() - 1);
+    }
+
+    #[test]
+    fn format_infix_with_trailing_comments() {
+        let src = "fn foo() {
+    let x = 1 // one
++ 2 // two
++ 3; // three
+}
+";
+        let expected = "fn foo() {
+    let x = 1 // one
+        + 2 // two
+        + 3; // three
+}
+";
+        assert_format(src, expected);
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

Resolves #4980

## Summary

In reality the new formatter didn't crash anymore, it just formatted this:

```noir
fn foo() {
    let x = 1 // one
        + 2 // two
        + 3; // three
}
```

like this:

```noir
fn foo() {
    let x = 1 // one
    + 2 // two
        + 3; // three
}
```

but making it look like the first snippet was easy, so here's that PR :-)

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
