### PR TITLE
feat: Add capacities to brillig vectors and use them in slice ops

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
@@ -8,7 +8,7 @@ use acvm::{
 
 use crate::brillig::brillig_ir::{
     brillig_variable::BrilligVariable, debug_show::DebugToString, registers::RegisterAllocator,
-    BrilligBinaryOp, BrilligContext,
+    BrilligContext,
 };
 
 /// Transforms SSA's black box function calls into the corresponding brillig instructions
@@ -390,19 +390,8 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString, Registers: Re
 
                 brillig_context.mov_instruction(out_len.address, outputs_vector.size);
                 // Returns slice, so we need to allocate memory for it after the fact
-                brillig_context.codegen_usize_op_in_place(
-                    outputs_vector.size,
-                    BrilligBinaryOp::Add,
-                    2_usize,
-                );
-                brillig_context.increase_free_memory_pointer_instruction(outputs_vector.size);
-                // We also need to write the size of the vector to the memory
-                brillig_context.codegen_usize_op_in_place(
-                    outputs_vector.pointer,
-                    BrilligBinaryOp::Sub,
-                    1_usize,
-                );
-                brillig_context.store_instruction(outputs_vector.pointer, out_len.address);
+
+                brillig_context.initialize_externally_returned_vector(*outputs, outputs_vector);
 
                 brillig_context.deallocate_heap_vector(inputs);
                 brillig_context.deallocate_heap_vector(outputs_vector);

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
@@ -213,7 +213,7 @@ mod tests {
             push_back: bool,
             array: Vec<FieldElement>,
             item_to_push: FieldElement,
-            mut expected_return: Vec<FieldElement>,
+            expected_return: Vec<FieldElement>,
         ) {
             let arguments = vec![
                 BrilligParameter::Slice(
@@ -223,11 +223,15 @@ mod tests {
                 BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
             let result_length = array.len() + 1;
+            assert_eq!(result_length, expected_return.len());
+            let result_length_with_metadata = result_length + 2; // Leading length and capacity
+
+            // Entry points don't support returning slices, so we implicitly cast the vector to an array
+            // With the metadata at the start.
             let returns = vec![BrilligParameter::Array(
                 vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
-                result_length + 1, // Leading length since the we return a vector
+                result_length_with_metadata,
             )];
-            expected_return.insert(0, FieldElement::from(result_length));
 
             let (_, mut function_context, mut context) = create_test_environment();
 
@@ -262,14 +266,17 @@ mod tests {
             let bytecode = create_entry_point_bytecode(context, arguments, returns).byte_code;
             let (vm, return_data_offset, return_data_size) =
                 create_and_run_vm(array.into_iter().chain(vec![item_to_push]).collect(), &bytecode);
-            assert_eq!(return_data_size, expected_return.len());
-            assert_eq!(
-                vm.get_memory()[return_data_offset..(return_data_offset + expected_return.len())]
-                    .iter()
-                    .map(|mem_val| mem_val.to_field())
-                    .collect::<Vec<_>>(),
-                expected_return
-            );
+            assert_eq!(return_data_size, result_length_with_metadata);
+            let mut returned_vector: Vec<FieldElement> = vm.get_memory()
+                [return_data_offset..(return_data_offset + result_length_with_metadata)]
+                .iter()
+                .map(|mem_val| mem_val.to_field())
+                .collect();
+            let returned_size = returned_vector.remove(0);
+            assert_eq!(returned_size, result_length.into());
+            let _returned_capacity = returned_vector.remove(0);
+
+            assert_eq!(returned_vector, expected_return);
         }
 
         test_case_push(
@@ -321,7 +328,7 @@ mod tests {
         fn test_case_pop(
             pop_back: bool,
             array: Vec<FieldElement>,
-            mut expected_return_array: Vec<FieldElement>,
+            expected_return_array: Vec<FieldElement>,
             expected_return_item: FieldElement,
         ) {
             let arguments = vec![BrilligParameter::Slice(
@@ -329,15 +336,18 @@ mod tests {
                 array.len(),
             )];
             let result_length = array.len() - 1;
+            assert_eq!(result_length, expected_return_array.len());
+            let result_length_with_metadata = result_length + 2; // Leading length and capacity
 
+            // Entry points don't support returning slices, so we implicitly cast the vector to an array
+            // With the metadata at the start.
             let returns = vec![
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
                 BrilligParameter::Array(
                     vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
-                    result_length + 1,
+                    result_length_with_metadata,
                 ),
-                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
-            expected_return_array.insert(0, FieldElement::from(result_length));
 
             let (_, mut function_context, mut context) = create_test_environment();
 
@@ -367,22 +377,28 @@ mod tests {
                 );
             }
 
-            context.codegen_return(&[target_vector.pointer, removed_item.address]);
+            context.codegen_return(&[removed_item.address, target_vector.pointer]);
 
             let bytecode = create_entry_point_bytecode(context, arguments, returns).byte_code;
-            let expected_return: Vec<_> =
-                expected_return_array.into_iter().chain(vec![expected_return_item]).collect();
+
             let (vm, return_data_offset, return_data_size) =
                 create_and_run_vm(array.clone(), &bytecode);
-            assert_eq!(return_data_size, expected_return.len());
+            // vector + removed item
+            assert_eq!(return_data_size, result_length_with_metadata + 1);
 
-            assert_eq!(
-                vm.get_memory()[return_data_offset..(return_data_offset + expected_return.len())]
-                    .iter()
-                    .map(|mem_val| mem_val.to_field())
-                    .collect::<Vec<_>>(),
-                expected_return
-            );
+            let mut return_data: Vec<FieldElement> = vm.get_memory()
+                [return_data_offset..(return_data_offset + return_data_size)]
+                .iter()
+                .map(|mem_val| mem_val.to_field())
+                .collect();
+            let returned_item = return_data.remove(0);
+            assert_eq!(returned_item, expected_return_item);
+
+            let returned_size = return_data.remove(0);
+            assert_eq!(returned_size, result_length.into());
+            let _returned_capacity = return_data.remove(0);
+
+            assert_eq!(return_data, expected_return_array);
         }
 
         test_case_pop(
@@ -414,7 +430,7 @@ mod tests {
             array: Vec<FieldElement>,
             item: FieldElement,
             index: FieldElement,
-            mut expected_return: Vec<FieldElement>,
+            expected_return: Vec<FieldElement>,
         ) {
             let arguments = vec![
                 BrilligParameter::Slice(
@@ -425,11 +441,15 @@ mod tests {
                 BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
             let result_length = array.len() + 1;
+            assert_eq!(result_length, expected_return.len());
+            let result_length_with_metadata = result_length + 2; // Leading length and capacity
+
+            // Entry points don't support returning slices, so we implicitly cast the vector to an array
+            // With the metadata at the start.
             let returns = vec![BrilligParameter::Array(
                 vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
-                result_length + 1,
+                result_length_with_metadata,
             )];
-            expected_return.insert(0, FieldElement::from(result_length));
 
             let (_, mut function_context, mut context) = create_test_environment();
 
@@ -461,15 +481,18 @@ mod tests {
 
             let bytecode = create_entry_point_bytecode(context, arguments, returns).byte_code;
             let (vm, return_data_offset, return_data_size) = create_and_run_vm(calldata, &bytecode);
-            assert_eq!(return_data_size, expected_return.len());
+            assert_eq!(return_data_size, result_length_with_metadata);
 
-            assert_eq!(
-                vm.get_memory()[return_data_offset..(return_data_offset + expected_return.len())]
-                    .iter()
-                    .map(|mem_val| mem_val.to_field())
-                    .collect::<Vec<_>>(),
-                expected_return
-            );
+            let mut returned_vector: Vec<FieldElement> = vm.get_memory()
+                [return_data_offset..(return_data_offset + result_length_with_metadata)]
+                .iter()
+                .map(|mem_val| mem_val.to_field())
+                .collect();
+            let returned_size = returned_vector.remove(0);
+            assert_eq!(returned_size, result_length.into());
+            let _returned_capacity = returned_vector.remove(0);
+
+            assert_eq!(returned_vector, expected_return);
         }
 
         test_case_insert(
@@ -546,7 +569,7 @@ mod tests {
         fn test_case_remove(
             array: Vec<FieldElement>,
             index: FieldElement,
-            mut expected_array: Vec<FieldElement>,
+            expected_array: Vec<FieldElement>,
             expected_removed_item: FieldElement,
         ) {
             let arguments = vec![
@@ -557,15 +580,16 @@ mod tests {
                 BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
             let result_length = array.len() - 1;
+            assert_eq!(result_length, expected_array.len());
+            let result_length_with_metadata = result_length + 2; // Leading length and capacity
 
             let returns = vec![
+                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
                 BrilligParameter::Array(
                     vec![BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)],
-                    result_length + 1,
+                    result_length_with_metadata,
                 ),
-                BrilligParameter::SingleAddr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE),
             ];
-            expected_array.insert(0, FieldElement::from(result_length));
 
             let (_, mut function_context, mut context) = create_test_environment();
 
@@ -592,24 +616,29 @@ mod tests {
                 &[BrilligVariable::SingleAddr(removed_item)],
             );
 
-            context.codegen_return(&[target_vector.pointer, removed_item.address]);
+            context.codegen_return(&[removed_item.address, target_vector.pointer]);
 
             let calldata: Vec<_> = array.into_iter().chain(vec![index]).collect();
 
             let bytecode = create_entry_point_bytecode(context, arguments, returns).byte_code;
             let (vm, return_data_offset, return_data_size) = create_and_run_vm(calldata, &bytecode);
 
-            let expected_return: Vec<_> =
-                expected_array.into_iter().chain(vec![expected_removed_item]).collect();
-            assert_eq!(return_data_size, expected_return.len());
+            // vector + removed item
+            assert_eq!(return_data_size, result_length_with_metadata + 1);
 
-            assert_eq!(
-                vm.get_memory()[return_data_offset..(return_data_offset + expected_return.len())]
-                    .iter()
-                    .map(|mem_val| mem_val.to_field())
-                    .collect::<Vec<_>>(),
-                expected_return
-            );
+            let mut return_data: Vec<FieldElement> = vm.get_memory()
+                [return_data_offset..(return_data_offset + return_data_size)]
+                .iter()
+                .map(|mem_val| mem_val.to_field())
+                .collect();
+            let returned_item = return_data.remove(0);
+            assert_eq!(returned_item, expected_removed_item);
+
+            let returned_size = return_data.remove(0);
+            assert_eq!(returned_size, result_length.into());
+            let _returned_capacity = return_data.remove(0);
+
+            assert_eq!(return_data, expected_array);
         }
 
         test_case_remove(

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
@@ -79,17 +79,15 @@ impl<'block> BrilligBlock<'block> {
         source_vector: BrilligVector,
         removed_items: &[BrilligVariable],
     ) {
-        let read_pointer = self.brillig_context.allocate_register();
-        self.brillig_context.call_vector_pop_procedure(
-            source_vector,
-            target_vector,
-            read_pointer,
-            removed_items.len(),
-            false,
-        );
-
+        let read_pointer = self.brillig_context.codegen_make_vector_items_pointer(source_vector);
         self.read_variables(read_pointer, removed_items);
         self.brillig_context.deallocate_register(read_pointer);
+
+        self.brillig_context.call_vector_pop_front_procedure(
+            source_vector,
+            target_vector,
+            removed_items.len(),
+        );
     }
 
     pub(crate) fn slice_pop_back_operation(
@@ -99,12 +97,11 @@ impl<'block> BrilligBlock<'block> {
         removed_items: &[BrilligVariable],
     ) {
         let read_pointer = self.brillig_context.allocate_register();
-        self.brillig_context.call_vector_pop_procedure(
+        self.brillig_context.call_vector_pop_back_procedure(
             source_vector,
             target_vector,
             read_pointer,
             removed_items.len(),
-            true,
         );
 
         self.read_variables(read_pointer, removed_items);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_control_flow.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_control_flow.rs
@@ -12,6 +12,42 @@ use super::{
 };
 
 impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
+    pub(crate) fn codegen_iteration<T>(
+        &mut self,
+        make_iterator: impl FnOnce(&mut BrilligContext<F, Registers>) -> T,
+        update_iterator: impl FnOnce(&mut BrilligContext<F, Registers>, &T),
+        make_finish_condition: impl FnOnce(&mut BrilligContext<F, Registers>, &T) -> SingleAddrVariable,
+        on_iteration: impl FnOnce(&mut BrilligContext<F, Registers>, &T),
+        cleanup: impl FnOnce(&mut BrilligContext<F, Registers>, T),
+    ) {
+        let iterator = make_iterator(self);
+
+        let (loop_section, loop_label) = self.reserve_next_section_label();
+        self.enter_section(loop_section);
+
+        // Loop body
+
+        let should_end = make_finish_condition(self, &iterator);
+
+        let (exit_loop_section, exit_loop_label) = self.reserve_next_section_label();
+
+        self.jump_if_instruction(should_end.address, exit_loop_label);
+
+        // Call the on iteration function
+        on_iteration(self, &iterator);
+
+        // Update iterator
+        update_iterator(self, &iterator);
+        self.jump_instruction(loop_label);
+
+        // Exit the loop
+        self.enter_section(exit_loop_section);
+
+        // Deallocate our temporary registers
+        self.deallocate_single_addr(should_end);
+        cleanup(self, iterator);
+    }
+
     /// This codegen will issue a loop for (let iterator_register = loop_start; i < loop_bound; i += step)
     /// The body of the loop should be issued by the caller in the on_iteration closure.
     pub(crate) fn codegen_for_loop(

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
@@ -332,13 +332,22 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         result
     }
 
+    /// Writes a pointer to the items of a given vector
+    pub(crate) fn codegen_vector_items_pointer(
+        &mut self,
+        vector: BrilligVector,
+        result: MemoryAddress,
+    ) {
+        self.codegen_usize_op(vector.pointer, result, BrilligBinaryOp::Add, 3);
+    }
+
     /// Returns a pointer to the items of a given vector
     pub(crate) fn codegen_make_vector_items_pointer(
         &mut self,
         vector: BrilligVector,
     ) -> MemoryAddress {
         let result = self.allocate_register();
-        self.codegen_usize_op(vector.pointer, result, BrilligBinaryOp::Add, 3);
+        self.codegen_vector_items_pointer(vector, result);
         result
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -196,7 +196,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         let deflattened_items_pointer = if is_vector {
             let vector = BrilligVector { pointer: deflattened_array_pointer };
 
-            self.codegen_initialize_vector(vector, deflattened_size_variable);
+            self.codegen_initialize_vector(vector, deflattened_size_variable, None);
 
             self.codegen_make_vector_items_pointer(vector)
         } else {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
@@ -5,7 +5,8 @@ mod mem_copy;
 mod prepare_vector_insert;
 mod prepare_vector_push;
 mod vector_copy;
-mod vector_pop;
+mod vector_pop_back;
+mod vector_pop_front;
 mod vector_remove;
 
 use array_copy::compile_array_copy_procedure;
@@ -15,7 +16,8 @@ use mem_copy::compile_mem_copy_procedure;
 use prepare_vector_insert::compile_prepare_vector_insert_procedure;
 use prepare_vector_push::compile_prepare_vector_push_procedure;
 use vector_copy::compile_vector_copy_procedure;
-use vector_pop::compile_vector_pop_procedure;
+use vector_pop_back::compile_vector_pop_back_procedure;
+use vector_pop_front::compile_vector_pop_front_procedure;
 use vector_remove::compile_vector_remove_procedure;
 
 use crate::brillig::brillig_ir::AcirField;
@@ -36,7 +38,8 @@ pub(crate) enum ProcedureId {
     VectorCopy,
     MemCopy,
     PrepareVectorPush(bool),
-    VectorPop(bool),
+    VectorPopFront,
+    VectorPopBack,
     PrepareVectorInsert,
     VectorRemove,
     CheckMaxStackDepth,
@@ -56,8 +59,11 @@ pub(crate) fn compile_procedure<F: AcirField + DebugToString>(
         ProcedureId::PrepareVectorPush(push_back) => {
             compile_prepare_vector_push_procedure(&mut brillig_context, push_back);
         }
-        ProcedureId::VectorPop(pop_back) => {
-            compile_vector_pop_procedure(&mut brillig_context, pop_back);
+        ProcedureId::VectorPopFront => {
+            compile_vector_pop_front_procedure(&mut brillig_context);
+        }
+        ProcedureId::VectorPopBack => {
+            compile_vector_pop_back_procedure(&mut brillig_context);
         }
         ProcedureId::PrepareVectorInsert => {
             compile_prepare_vector_insert_procedure(&mut brillig_context);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_insert.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_insert.rs
@@ -69,7 +69,7 @@ pub(super) fn compile_prepare_vector_insert_procedure<F: AcirField + DebugToStri
         BrilligBinaryOp::Add,
     );
 
-    brillig_context.codegen_initialize_vector(target_vector, target_size);
+    brillig_context.codegen_initialize_vector(target_vector, target_size, None);
 
     // Copy the elements to the left of the index
     let source_vector_items_pointer =

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_insert.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_insert.rs
@@ -2,7 +2,7 @@ use std::vec;
 
 use acvm::{acir::brillig::MemoryAddress, AcirField};
 
-use super::ProcedureId;
+use super::{prepare_vector_push::reallocate_vector_for_insertion, ProcedureId};
 use crate::brillig::brillig_ir::{
     brillig_variable::{BrilligVector, SingleAddrVariable},
     debug_show::DebugToString,
@@ -58,9 +58,19 @@ pub(super) fn compile_prepare_vector_insert_procedure<F: AcirField + DebugToStri
     let target_vector = BrilligVector { pointer: new_vector_pointer_return };
     let index = SingleAddrVariable::new_usize(index_arg);
 
-    // First we need to allocate the target vector incrementing the size by items.len()
-    let source_size = brillig_context.codegen_make_vector_length(source_vector);
+    let source_rc = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    let source_size = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    let source_capacity = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    let source_items_pointer = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    brillig_context.codegen_read_vector_metadata(
+        source_vector,
+        source_rc,
+        source_size,
+        source_capacity,
+        source_items_pointer,
+    );
 
+    // Target size is source size + item_count
     let target_size = SingleAddrVariable::new_usize(brillig_context.allocate_register());
     brillig_context.memory_op_instruction(
         source_size.address,
@@ -69,24 +79,40 @@ pub(super) fn compile_prepare_vector_insert_procedure<F: AcirField + DebugToStri
         BrilligBinaryOp::Add,
     );
 
-    brillig_context.codegen_initialize_vector(target_vector, target_size, None);
+    // Reallocate the target vector if necessary
+    reallocate_vector_for_insertion(
+        brillig_context,
+        source_vector,
+        source_rc,
+        source_capacity,
+        target_vector,
+        target_size,
+    );
 
-    // Copy the elements to the left of the index
-    let source_vector_items_pointer =
-        brillig_context.codegen_make_vector_items_pointer(source_vector);
     let target_vector_items_pointer =
         brillig_context.codegen_make_vector_items_pointer(target_vector);
 
-    brillig_context.codegen_mem_copy(
-        source_vector_items_pointer,
-        target_vector_items_pointer,
-        index,
+    let was_reused = SingleAddrVariable::new(brillig_context.allocate_register(), 1);
+    brillig_context.memory_op_instruction(
+        source_vector.pointer,
+        target_vector.pointer,
+        was_reused.address,
+        BrilligBinaryOp::Equals,
     );
+
+    brillig_context.codegen_if_not(was_reused.address, |brillig_context| {
+        // Copy the elements to the left of the index
+        brillig_context.codegen_mem_copy(
+            source_items_pointer.address,
+            target_vector_items_pointer,
+            index,
+        );
+    });
 
     // Compute the source pointer just at the index
     let source_pointer_at_index = brillig_context.allocate_register();
     brillig_context.memory_op_instruction(
-        source_vector_items_pointer,
+        source_items_pointer.address,
         index_arg,
         source_pointer_at_index,
         BrilligBinaryOp::Add,
@@ -108,27 +134,30 @@ pub(super) fn compile_prepare_vector_insert_procedure<F: AcirField + DebugToStri
         BrilligBinaryOp::Add,
     );
 
-    // Compute the number of elements to the right of the index
-    let item_count = brillig_context.allocate_register();
+    // Compute the number of elements to the right of the insertion index
+    let element_count_to_the_right = brillig_context.allocate_register();
     brillig_context.memory_op_instruction(
         source_size.address,
         index.address,
-        item_count,
+        element_count_to_the_right,
         BrilligBinaryOp::Sub,
     );
 
     // Copy the elements to the right of the index
-    brillig_context.codegen_mem_copy(
+    brillig_context.codegen_mem_copy_from_the_end(
         source_pointer_at_index,
         target_pointer_after_index,
-        SingleAddrVariable::new_usize(item_count),
+        SingleAddrVariable::new_usize(element_count_to_the_right),
     );
 
+    brillig_context.deallocate_single_addr(source_rc);
+    brillig_context.deallocate_single_addr(source_size);
+    brillig_context.deallocate_single_addr(source_capacity);
+    brillig_context.deallocate_single_addr(source_items_pointer);
+    brillig_context.deallocate_single_addr(target_size);
+    brillig_context.deallocate_register(target_vector_items_pointer);
+    brillig_context.deallocate_single_addr(was_reused);
     brillig_context.deallocate_register(source_pointer_at_index);
     brillig_context.deallocate_register(target_pointer_after_index);
-    brillig_context.deallocate_register(item_count);
-    brillig_context.deallocate_single_addr(source_size);
-    brillig_context.deallocate_single_addr(target_size);
-    brillig_context.deallocate_register(source_vector_items_pointer);
-    brillig_context.deallocate_register(target_vector_items_pointer);
+    brillig_context.deallocate_register(element_count_to_the_right);
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_push.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_push.rs
@@ -142,7 +142,7 @@ pub(super) fn compile_prepare_vector_push_procedure<F: AcirField + DebugToString
 /// Reallocates the target vector for insertion, skipping reallocation if the source vector can be reused.
 /// If it doesn't fit capacity we will reallocate the vector to double the capacity.
 /// Does not copy the items, only reallocates the vector.
-fn reallocate_vector_for_insertion<F: AcirField + DebugToString, Registers: RegisterAllocator>(
+pub(crate) fn reallocate_vector_for_insertion<F: AcirField + DebugToString, Registers: RegisterAllocator>(
     brillig_context: &mut BrilligContext<F, Registers>,
     source_vector: BrilligVector,
     source_rc: SingleAddrVariable,

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_push.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_push.rs
@@ -142,7 +142,10 @@ pub(super) fn compile_prepare_vector_push_procedure<F: AcirField + DebugToString
 /// Reallocates the target vector for insertion, skipping reallocation if the source vector can be reused.
 /// If it doesn't fit capacity we will reallocate the vector to double the capacity.
 /// Does not copy the items, only reallocates the vector.
-pub(crate) fn reallocate_vector_for_insertion<F: AcirField + DebugToString, Registers: RegisterAllocator>(
+pub(crate) fn reallocate_vector_for_insertion<
+    F: AcirField + DebugToString,
+    Registers: RegisterAllocator,
+>(
     brillig_context: &mut BrilligContext<F, Registers>,
     source_vector: BrilligVector,
     source_rc: SingleAddrVariable,

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_copy.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_copy.rs
@@ -53,8 +53,8 @@ pub(super) fn compile_vector_copy_procedure<F: AcirField + DebugToString>(
             let result_vector = BrilligVector { pointer: new_vector_pointer_return };
 
             // Allocate the memory for the new vec
-            let allocation_size = ctx.codegen_make_vector_length(source_vector);
-            ctx.codegen_usize_op_in_place(allocation_size.address, BrilligBinaryOp::Add, 2_usize);
+            let allocation_size = ctx.codegen_make_vector_capacity(source_vector);
+            ctx.codegen_usize_op_in_place(allocation_size.address, BrilligBinaryOp::Add, 3_usize); // Capacity plus 3 (rc, len, cap)
             ctx.codegen_allocate_mem(result_vector.pointer, allocation_size.address);
 
             ctx.codegen_mem_copy(source_vector.pointer, result_vector.pointer, allocation_size);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop.rs
@@ -65,7 +65,7 @@ pub(super) fn compile_vector_pop_procedure<F: AcirField + DebugToString>(
         BrilligBinaryOp::Sub,
     );
 
-    brillig_context.codegen_initialize_vector(target_vector, target_size);
+    brillig_context.codegen_initialize_vector(target_vector, target_size, None);
 
     // Now we offset the source pointer by removed_items.len()
     let source_vector_items_pointer =

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_back.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_back.rs
@@ -11,14 +11,13 @@ use crate::brillig::brillig_ir::{
 };
 
 impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
-    /// Pops items from the vector, returning the new vector and the pointer to the popped items in read_pointer.
-    pub(crate) fn call_vector_pop_procedure(
+    /// Pops items from the back of a vector, returning the new vector and the pointer to the popped items in read_pointer.
+    pub(crate) fn call_vector_pop_back_procedure(
         &mut self,
         source_vector: BrilligVector,
         destination_vector: BrilligVector,
         read_pointer: MemoryAddress,
         item_pop_count: usize,
-        back: bool,
     ) {
         let source_vector_pointer_arg = MemoryAddress::direct(ScratchSpace::start());
         let item_pop_count_arg = MemoryAddress::direct(ScratchSpace::start() + 1);
@@ -28,16 +27,15 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.mov_instruction(source_vector_pointer_arg, source_vector.pointer);
         self.usize_const_instruction(item_pop_count_arg, item_pop_count.into());
 
-        self.add_procedure_call_instruction(ProcedureId::VectorPop(back));
+        self.add_procedure_call_instruction(ProcedureId::VectorPopBack);
 
         self.mov_instruction(destination_vector.pointer, new_vector_pointer_return);
         self.mov_instruction(read_pointer, read_pointer_return);
     }
 }
 
-pub(super) fn compile_vector_pop_procedure<F: AcirField + DebugToString>(
+pub(super) fn compile_vector_pop_back_procedure<F: AcirField + DebugToString>(
     brillig_context: &mut BrilligContext<F, ScratchSpace>,
-    pop_back: bool,
 ) {
     let source_vector_pointer_arg = MemoryAddress::direct(ScratchSpace::start());
     let item_pop_count_arg = MemoryAddress::direct(ScratchSpace::start() + 1);
@@ -65,36 +63,6 @@ pub(super) fn compile_vector_pop_procedure<F: AcirField + DebugToString>(
         BrilligBinaryOp::Sub,
     );
 
-    if pop_back {
-        codegen_pop_back(
-            brillig_context,
-            source_vector,
-            target_vector,
-            target_size,
-            read_pointer_return,
-        );
-    } else {
-        codegen_pop_front(
-            brillig_context,
-            source_vector,
-            target_vector,
-            target_size,
-            item_pop_count_arg,
-            read_pointer_return,
-        );
-    }
-
-    brillig_context.deallocate_single_addr(source_size);
-    brillig_context.deallocate_single_addr(target_size);
-}
-
-fn codegen_pop_back<F: AcirField + DebugToString>(
-    brillig_context: &mut BrilligContext<F, ScratchSpace>,
-    source_vector: BrilligVector,
-    target_vector: BrilligVector,
-    target_size: SingleAddrVariable,
-    read_pointer_return: MemoryAddress,
-) {
     let rc = brillig_context.allocate_register();
     brillig_context.load_instruction(rc, source_vector.pointer);
     let is_rc_one = brillig_context.allocate_register();
@@ -135,36 +103,7 @@ fn codegen_pop_back<F: AcirField + DebugToString>(
     brillig_context.deallocate_register(rc);
     brillig_context.deallocate_register(is_rc_one);
     brillig_context.deallocate_register(source_vector_items_pointer);
-}
 
-fn codegen_pop_front<F: AcirField + DebugToString>(
-    brillig_context: &mut BrilligContext<F, ScratchSpace>,
-    source_vector: BrilligVector,
-    target_vector: BrilligVector,
-    target_size: SingleAddrVariable,
-    item_pop_count: MemoryAddress,
-    read_pointer_return: MemoryAddress,
-) {
-    brillig_context.codegen_initialize_vector(target_vector, target_size, None);
-
-    let source_vector_items_pointer =
-        brillig_context.codegen_make_vector_items_pointer(source_vector);
-    let target_vector_items_pointer =
-        brillig_context.codegen_make_vector_items_pointer(target_vector);
-
-    let source_copy_pointer = brillig_context.allocate_register();
-    brillig_context.memory_op_instruction(
-        source_vector_items_pointer,
-        item_pop_count,
-        source_copy_pointer,
-        BrilligBinaryOp::Add,
-    );
-
-    // Now we copy the source vector starting at index removed_items.len() into the target vector
-    brillig_context.codegen_mem_copy(source_copy_pointer, target_vector_items_pointer, target_size);
-    brillig_context.mov_instruction(read_pointer_return, source_vector_items_pointer);
-
-    brillig_context.deallocate_register(source_copy_pointer);
-    brillig_context.deallocate_register(source_vector_items_pointer);
-    brillig_context.deallocate_register(target_vector_items_pointer);
+    brillig_context.deallocate_single_addr(source_size);
+    brillig_context.deallocate_single_addr(target_size);
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_front.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_front.rs
@@ -1,0 +1,130 @@
+use std::vec;
+
+use acvm::{acir::brillig::MemoryAddress, AcirField};
+
+use super::ProcedureId;
+use crate::brillig::brillig_ir::{
+    brillig_variable::{BrilligVector, SingleAddrVariable},
+    debug_show::DebugToString,
+    registers::{RegisterAllocator, ScratchSpace},
+    BrilligBinaryOp, BrilligContext,
+};
+
+impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
+    /// Pops items from the front of a vector, returning the new vector
+    pub(crate) fn call_vector_pop_front_procedure(
+        &mut self,
+        source_vector: BrilligVector,
+        destination_vector: BrilligVector,
+        item_pop_count: usize,
+    ) {
+        let source_vector_pointer_arg = MemoryAddress::direct(ScratchSpace::start());
+        let item_pop_count_arg = MemoryAddress::direct(ScratchSpace::start() + 1);
+        let new_vector_pointer_return = MemoryAddress::direct(ScratchSpace::start() + 2);
+
+        self.mov_instruction(source_vector_pointer_arg, source_vector.pointer);
+        self.usize_const_instruction(item_pop_count_arg, item_pop_count.into());
+
+        self.add_procedure_call_instruction(ProcedureId::VectorPopFront);
+
+        self.mov_instruction(destination_vector.pointer, new_vector_pointer_return);
+    }
+}
+
+pub(super) fn compile_vector_pop_front_procedure<F: AcirField + DebugToString>(
+    brillig_context: &mut BrilligContext<F, ScratchSpace>,
+) {
+    let source_vector_pointer_arg = MemoryAddress::direct(ScratchSpace::start());
+    let item_pop_count_arg = MemoryAddress::direct(ScratchSpace::start() + 1);
+    let new_vector_pointer_return = MemoryAddress::direct(ScratchSpace::start() + 2);
+
+    brillig_context.set_allocated_registers(vec![
+        source_vector_pointer_arg,
+        item_pop_count_arg,
+        new_vector_pointer_return,
+    ]);
+
+    let source_vector = BrilligVector { pointer: source_vector_pointer_arg };
+    let target_vector = BrilligVector { pointer: new_vector_pointer_return };
+
+    let source_rc = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    let source_size = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    let source_capacity = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    let source_items_pointer = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    brillig_context.codegen_read_vector_metadata(
+        source_vector,
+        source_rc,
+        source_size,
+        source_capacity,
+        source_items_pointer,
+    );
+
+    // target_size = source_size - item_pop_count
+    let target_size = SingleAddrVariable::new_usize(brillig_context.allocate_register());
+    brillig_context.memory_op_instruction(
+        source_size.address,
+        item_pop_count_arg,
+        target_size.address,
+        BrilligBinaryOp::Sub,
+    );
+
+    let is_rc_one = brillig_context.allocate_register();
+    brillig_context.codegen_usize_op(
+        source_rc.address,
+        is_rc_one,
+        BrilligBinaryOp::Equals,
+        1_usize,
+    );
+
+    brillig_context.codegen_branch(is_rc_one, |brillig_context, is_rc_one| {
+        if is_rc_one {
+            // We reuse the source vector, moving the metadata to the right (decreasing capacity)
+            brillig_context.memory_op_instruction(
+                source_vector.pointer,
+                item_pop_count_arg,
+                target_vector.pointer,
+                BrilligBinaryOp::Add,
+            );
+            brillig_context.memory_op_instruction(
+                source_capacity.address,
+                item_pop_count_arg,
+                source_capacity.address,
+                BrilligBinaryOp::Sub,
+            );
+            brillig_context.codegen_initialize_vector_metadata(
+                target_vector,
+                target_size,
+                Some(source_capacity),
+            );
+        } else {
+            brillig_context.codegen_initialize_vector(target_vector, target_size, None);
+
+            let target_vector_items_pointer =
+                brillig_context.codegen_make_vector_items_pointer(target_vector);
+
+            let source_copy_pointer = brillig_context.allocate_register();
+            brillig_context.memory_op_instruction(
+                source_items_pointer.address,
+                item_pop_count_arg,
+                source_copy_pointer,
+                BrilligBinaryOp::Add,
+            );
+            // Now we copy the source vector starting at index removed_items.len() into the target vector
+            brillig_context.codegen_mem_copy(
+                source_copy_pointer,
+                target_vector_items_pointer,
+                target_size,
+            );
+
+            brillig_context.deallocate_register(source_copy_pointer);
+            brillig_context.deallocate_register(target_vector_items_pointer);
+        }
+    });
+
+    brillig_context.deallocate_register(is_rc_one);
+    brillig_context.deallocate_single_addr(target_size);
+    brillig_context.deallocate_single_addr(source_rc);
+    brillig_context.deallocate_single_addr(source_size);
+    brillig_context.deallocate_single_addr(source_capacity);
+    brillig_context.deallocate_single_addr(source_items_pointer);
+}

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_remove.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_remove.rs
@@ -53,7 +53,7 @@ pub(super) fn compile_vector_remove_procedure<F: AcirField + DebugToString>(
     let target_vector = BrilligVector { pointer: new_vector_pointer_return };
     let index = SingleAddrVariable::new_usize(index_arg);
 
-    // First we need to allocate the target vector decrementing the size by removed_items.len()
+    // Reallocate if necessary
     let source_size = brillig_context.codegen_make_vector_length(source_vector);
 
     let target_size = SingleAddrVariable::new_usize(brillig_context.allocate_register());
@@ -64,19 +64,36 @@ pub(super) fn compile_vector_remove_procedure<F: AcirField + DebugToString>(
         BrilligBinaryOp::Sub,
     );
 
-    brillig_context.codegen_initialize_vector(target_vector, target_size, None);
+    let rc = brillig_context.allocate_register();
+    brillig_context.load_instruction(rc, source_vector.pointer);
+    let is_rc_one = brillig_context.allocate_register();
+    brillig_context.codegen_usize_op(rc, is_rc_one, BrilligBinaryOp::Equals, 1_usize);
 
-    // Copy the elements to the left of the index
     let source_vector_items_pointer =
         brillig_context.codegen_make_vector_items_pointer(source_vector);
-    let target_vector_items_pointer =
-        brillig_context.codegen_make_vector_items_pointer(target_vector);
 
-    brillig_context.codegen_mem_copy(
-        source_vector_items_pointer,
-        target_vector_items_pointer,
-        index,
-    );
+    let target_vector_items_pointer = brillig_context.allocate_register();
+
+    brillig_context.codegen_branch(is_rc_one, |brillig_context, is_rc_one| {
+        if is_rc_one {
+            brillig_context.mov_instruction(target_vector.pointer, source_vector.pointer);
+            brillig_context.codegen_update_vector_length(target_vector, target_size);
+            brillig_context
+                .codegen_vector_items_pointer(target_vector, target_vector_items_pointer);
+        } else {
+            brillig_context.codegen_initialize_vector(target_vector, target_size, None);
+
+            // Copy the elements to the left of the index
+            brillig_context
+                .codegen_vector_items_pointer(target_vector, target_vector_items_pointer);
+
+            brillig_context.codegen_mem_copy(
+                source_vector_items_pointer,
+                target_vector_items_pointer,
+                index,
+            );
+        }
+    });
 
     // Compute the source pointer after the removed items
     let source_pointer_after_index = brillig_context.allocate_register();
@@ -124,6 +141,8 @@ pub(super) fn compile_vector_remove_procedure<F: AcirField + DebugToString>(
         SingleAddrVariable::new_usize(item_count),
     );
 
+    brillig_context.deallocate_register(rc);
+    brillig_context.deallocate_register(is_rc_one);
     brillig_context.deallocate_register(source_pointer_after_index);
     brillig_context.deallocate_register(target_pointer_at_index);
     brillig_context.deallocate_register(item_count);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_remove.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_remove.rs
@@ -64,7 +64,7 @@ pub(super) fn compile_vector_remove_procedure<F: AcirField + DebugToString>(
         BrilligBinaryOp::Sub,
     );
 
-    brillig_context.codegen_initialize_vector(target_vector, target_size);
+    brillig_context.codegen_initialize_vector(target_vector, target_size, None);
 
     // Copy the elements to the left of the index
     let source_vector_items_pointer =

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -5,6 +5,8 @@ use acvm::acir::circuit::brillig::{BrilligBytecode, BrilligFunctionId};
 use acvm::acir::circuit::{Circuit, Opcode, OpcodeLocation};
 use acvm::acir::native_types::{Witness, WitnessMap, WitnessStack};
 use acvm::brillig_vm::brillig::Opcode as BrilligOpcode;
+use acvm::brillig_vm::MemoryValue;
+use acvm::AcirField;
 use acvm::{BlackBoxFunctionSolver, FieldElement};
 use nargo::NargoError;
 use noirc_driver::CompiledProgram;
@@ -369,6 +371,12 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ReplDebugger<'a, B> {
         };
 
         for (index, value) in memory.iter().enumerate() {
+            // Zero field is the default value, we omit it when printing memory
+            if let MemoryValue::Field(field) = value {
+                if field == &FieldElement::zero() {
+                    continue;
+                }
+            }
             println!("{index} = {}", value);
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Brillig vectors didn't have capacities, so all operations were O(N) since they required copying the vector.
This PR adds capacities to vectors and uses them in the slice operations to avoid copying when possible.

## Summary\*



## Additional Context

Unfortunately I can't make an e2e test showcasing a simple program where performance is good thanks to this due to reference counter weirdness:
```noir
unconstrained fn main() {
    let mut slice = &[];

    for i in 0..10000 {
        slice = slice.push_back(i);
    }

    assert(slice.len() == 10000);
}
```
```
After Array Set Optimizations:
brillig(inline) fn main f0 {
  b0():
    v1 = allocate
    store u32 0 at v1
    inc_rc []
    v4 = allocate
    store [] at v4
    jmp b1(u32 0)
  b1(v0: u32):
    v6 = lt v0, u32 2⁴×625
    jmpif v6 then: b3, else: b2
  b3():
    v8 = load v1
    v9 = load v4
    v11, v12 = call slice_push_back(v8, v9, v0)
    inc_rc v12
    store v11 at v1
    store v12 at v4
    v14 = add v0, u32 1
    jmp b1(v14)
  b2():
    v7 = load v1
    constrain v7 == u32 2⁴×625
    return 
}
```

The `inc_rc v12` makes it so the slice stored at v4 always has RC=2 so slice op optimizations do not trigger.
They do trigger in other e2e tests though. 


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
