### PR TITLE
fix: always inline `derive_generators`

### DIFF
--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -75,6 +75,7 @@ pub fn pedersen_hash_with_separator<let N: u32>(input: [Field; N], separator: u3
 }
 
 #[field(bn254)]
+#[inline_always]
 pub fn derive_generators<let N: u32, let M: u32>(
     domain_separator_bytes: [u8; M],
     starting_index: u32,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

If I turn down the inliner aggressiveness I start getting failures here due to the need for `domain_generator_bytes` to be a constant. This PR adds an attribute to always inline this function.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
