### PR TITLE
feat(test): Run test matrix on stdlib tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,6 +2587,7 @@ dependencies = [
  "termcolor",
  "termion",
  "test-binary",
+ "test-case",
  "thiserror",
  "tokio",
  "tokio-util 0.7.10",
@@ -4421,6 +4422,39 @@ dependencies = [
  "once_cell",
  "paste",
  "thiserror",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+ "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 similar-asserts = "1.5.0"
 tempfile = "3.6.0"
+test-case = "3.3.1"
 jsonrpc = { version = "0.16.0", features = ["minreq_http"] }
 flate2 = "1.0.24"
 color-eyre = "0.6.2"

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -86,6 +86,7 @@ sha2.workspace = true
 sha3.workspace = true
 iai = "0.1.1"
 test-binary = "3.0.2"
+test-case.workspace = true
 light-poseidon = "0.2.0"
 
 

--- a/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -1,4 +1,5 @@
 //! Execute unit tests in the Noir standard library.
+#![allow(clippy::items_after_test_module)]
 use clap::Parser;
 use fm::FileManager;
 use noirc_driver::{check_crate, file_manager_with_stdlib, CompileOptions};

--- a/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -12,6 +12,7 @@ use nargo::{
     parse_all, prepare_package,
 };
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use test_case::test_matrix;
 
 #[derive(Parser, Debug)]
 #[command(ignore_errors = true)]
@@ -29,14 +30,22 @@ pub struct Options {
 impl Options {
     pub fn function_name_match(&self) -> FunctionNameMatch {
         match self.args.as_slice() {
-            [_, lib] => FunctionNameMatch::Contains(lib.as_str()),
+            [_test_name, lib] => FunctionNameMatch::Contains(lib.as_str()),
             _ => FunctionNameMatch::Anything,
         }
     }
 }
 
-#[test]
-fn run_stdlib_tests() {
+/// Inliner aggressiveness results in different SSA.
+/// Inlining happens if `inline_cost - retain_cost < aggressiveness` (see `inlining.rs`).
+/// NB the CLI uses maximum aggressiveness.
+///
+/// Even with the same inlining aggressiveness, forcing Brillig can trigger different behaviour.
+#[test_matrix(
+    [false, true],
+    [i64::MIN, 0, i64::MAX]
+)]
+fn run_stdlib_tests(force_brillig: bool, inliner_aggressiveness: i64) {
     let opts = Options::parse();
 
     let mut file_manager = file_manager_with_stdlib(&PathBuf::from("."));
@@ -80,7 +89,7 @@ fn run_stdlib_tests() {
                 None,
                 Some(dummy_package.root_dir.clone()),
                 Some(dummy_package.name.to_string()),
-                &CompileOptions::default(),
+                &CompileOptions { force_brillig, inliner_aggressiveness, ..Default::default() },
             );
             (test_name, status)
         })


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6349

## Summary\*

Added a `test_matrix` around `run_stdlib_tests` to call it with/without forcing Brillig and to try various inlining aggressiveness (min, 0, max).

## Additional Context

The syntax to call a specific test still works, but now it runs with all compiler options combinations from the matrix:
```console
❯ cargo test -q -p nargo_cli --test stdlib-tests -- run_stdlib_tests trait_eq::inequality

running 6 tests
[stdlib] Testing collections::bounded_vec::bounded_vec_tests::trait_eq::inequality... ok
[stdlib] 1 test passed
[stdlib] Testing collections::bounded_vec::bounded_vec_tests::trait_eq::inequality... ok
[stdlib] 1 test passed
[stdlib] Testing collections::bounded_vec::bounded_vec_tests::trait_eq::inequality... FAIL
Failed to solve program: 'Failed to solve brillig function'

error: Failed to solve program: 'Failed to solve brillig function'
    ┌─ std/collections/bounded_vec.nr:598:20
    │
598 │             assert(bounded_vec1 != bounded_vec2);
    │                    ----------------------------
    │
    = Call stack:
      1. std/collections/bounded_vec.nr:598:20

[stdlib] 1 test failed
[stdlib] Testing collections::bounded_vec::bounded_vec_tests::trait_eq::inequality... ok
[stdlib] 1 test passed
[stdlib] Testing collections::bounded_vec::bounded_vec_tests::trait_eq::inequality... ok
[stdlib] 1 test passed
[stdlib] Testing collections::bounded_vec::bounded_vec_tests::trait_eq::inequality... ok
[stdlib] 1 test passed
..F...
failures:

---- run_stdlib_tests::true_0_expects stdout ----
thread 'run_stdlib_tests::true_0_expects' panicked at tooling/nargo_cli/tests/stdlib-tests.rs:100:5:
assertion failed: test_report.iter().all(|(_, status)| !status.failed())
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    run_stdlib_tests::true_0_expects

test result: FAILED. 5 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s

error: test failed, to rerun pass `-p nargo_cli --test stdlib-tests`
```

This error was fixed by https://github.com/noir-lang/noir/pull/6355

We can also run just the one combination that failed like so:

```shell
cargo test -q -p nargo_cli --test stdlib-tests -- run_stdlib_tests::true_0 trait_eq::inequality
```

Running all tests uncovered more problems:

```
❯ cargo test -q -p nargo_cli --test stdlib-tests 

..
[stdlib] Testing hash::assert_pedersen... error: Argument is not constant
   ┌─ std/hash/mod.nr:82:5
   │
82 │     crate::assert_constant(domain_separator_bytes);
   │     ----------------------------------------------
   │
   = Call stack:
     1. std/hash/mod.nr:82:5

...
[stdlib] Testing schnorr::test_zero_signature... error: Argument is not constant
   ┌─ std/hash/mod.nr:82:5
   │
82 │     crate::assert_constant(domain_separator_bytes);
   │     ----------------------------------------------
   │
   = Call stack:
     1. std/hash/mod.nr:82:5

[stdlib] 76 tests passed, 2 tests failed
...
failures:
    run_stdlib_tests::true_0_expects
    run_stdlib_tests::true_i64_min_expects

test result: FAILED. 4 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.31s

error: test failed, to rerun pass `-p nargo_cli --test stdlib-tests`

```
This was fixed by https://github.com/noir-lang/noir/pull/6350

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
