### PR TITLE
feat: LSP auto-import will try to add to existing use statements

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -327,6 +327,7 @@ pub enum PathKind {
 pub struct UseTree {
     pub prefix: Path,
     pub kind: UseTreeKind,
+    pub span: Span,
 }
 
 impl Display for UseTree {

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -67,6 +67,7 @@ mod modules;
 mod notifications;
 mod requests;
 mod solver;
+mod tests;
 mod trait_impl_method_stub_generator;
 mod types;
 mod utils;

--- a/tooling/lsp/src/requests/code_action/remove_unused_import.rs
+++ b/tooling/lsp/src/requests/code_action/remove_unused_import.rs
@@ -106,11 +106,12 @@ fn use_tree_without_unused_import(
                 let mut prefix = use_tree.prefix.clone();
                 prefix.segments.extend(new_use_tree.prefix.segments);
 
-                Some(UseTree { prefix, kind: new_use_tree.kind })
+                Some(UseTree { prefix, kind: new_use_tree.kind, span: use_tree.span })
             } else {
                 Some(UseTree {
                     prefix: use_tree.prefix.clone(),
                     kind: UseTreeKind::List(new_use_trees),
+                    span: use_tree.span,
                 })
             };
 

--- a/tooling/lsp/src/requests/code_action/tests.rs
+++ b/tooling/lsp/src/requests/code_action/tests.rs
@@ -1,11 +1,11 @@
 #![cfg(test)]
 
-use crate::{notifications::on_did_open_text_document, test_utils};
+use crate::{notifications::on_did_open_text_document, test_utils, tests::apply_text_edit};
 
 use lsp_types::{
     CodeActionContext, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
     DidOpenTextDocumentParams, PartialResultParams, Position, Range, TextDocumentIdentifier,
-    TextDocumentItem, TextEdit, WorkDoneProgressParams,
+    TextDocumentItem, WorkDoneProgressParams,
 };
 
 use super::on_code_action_request;
@@ -77,17 +77,4 @@ pub(crate) async fn assert_code_action(title: &str, src: &str, expected: &str) {
         println!("Expected:\n```\n{}\n```\n\nGot:\n```\n{}\n```", expected, result);
         assert_eq!(result, expected);
     }
-}
-
-fn apply_text_edit(src: &str, text_edit: &TextEdit) -> String {
-    let mut lines: Vec<_> = src.lines().collect();
-    assert_eq!(text_edit.range.start.line, text_edit.range.end.line);
-
-    let mut line = lines[text_edit.range.start.line as usize].to_string();
-    line.replace_range(
-        text_edit.range.start.character as usize..text_edit.range.end.character as usize,
-        &text_edit.new_text,
-    );
-    lines[text_edit.range.start.line as usize] = &line;
-    lines.join("\n")
 }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -88,6 +88,42 @@ pub(crate) fn on_completion_request(
     future::ready(result)
 }
 
+/// The position of a segment in a `use` statement.
+/// We use this to determine how an auto-import should be inserted.
+#[derive(Debug, Default, Copy, Clone)]
+enum UseSegmentPosition {
+    /// The segment either doesn't exist in the source code or there are multiple segments.
+    /// In this case auto-import will add a new use statement.
+    #[default]
+    NoneOrMultiple,
+    /// The segment is the last one in the `use` statement (or nested use statement):
+    ///
+    /// use foo::bar;
+    ///          ^^^
+    ///
+    /// Auto-import will transform it to this:
+    ///
+    /// use foo::bar::{self, baz};
+    Last { span: Span },
+    /// The segment happens before another simple (ident) segment:
+    ///
+    /// use foo::bar::qux;
+    ///          ^^^
+    ///
+    /// Auto-import will transform it to this:
+    ///
+    /// use foo::bar::{qux, baz};
+    BeforeSegment { segment_span_until_end: Span },
+    /// The segment happens before a list:
+    ///
+    /// use foo::bar::{qux, another};
+    ///
+    /// Auto-import will transform it to this:
+    ///
+    /// use foo::bar::{qux, another, baz};
+    BeforeList { first_entry_span: Span, list_is_empty: bool },
+}
+
 struct NodeFinder<'a> {
     files: &'a FileMap,
     file: FileId,
@@ -115,6 +151,11 @@ struct NodeFinder<'a> {
     nesting: usize,
     /// The line where an auto_import must be inserted
     auto_import_line: usize,
+    /// Remember where each segment in a `use` statement is located.
+    /// The key is the full segment, so for `use foo::bar::baz` we'll have three
+    /// segments: `foo`, `foo::bar` and `foo::bar::baz`, where the span is just
+    /// for the last identifier (`foo`, `bar` and `baz` in the previous example).
+    use_segment_positions: HashMap<String, UseSegmentPosition>,
     self_type: Option<Type>,
     in_comptime: bool,
 }
@@ -159,6 +200,7 @@ impl<'a> NodeFinder<'a> {
             suggested_module_def_ids: HashSet::new(),
             nesting: 0,
             auto_import_line: 0,
+            use_segment_positions: HashMap::new(),
             self_type: None,
             in_comptime: false,
         }
@@ -1035,6 +1077,123 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
+    /// Determine where each segment in a `use` statement is located.
+    fn gather_use_tree_segments(&mut self, use_tree: &UseTree, mut prefix: String) {
+        let kind_string = match use_tree.prefix.kind {
+            PathKind::Crate => Some("crate".to_string()),
+            PathKind::Super => Some("super".to_string()),
+            PathKind::Dep | PathKind::Plain => None,
+        };
+        if let Some(kind_string) = kind_string {
+            if let Some(segment) = use_tree.prefix.segments.first() {
+                self.insert_use_segment_position(
+                    kind_string,
+                    UseSegmentPosition::BeforeSegment {
+                        segment_span_until_end: Span::from(
+                            segment.ident.span().start()..use_tree.span.end() - 1,
+                        ),
+                    },
+                );
+            } else {
+                self.insert_use_segment_position_before_use_tree_kind(use_tree, kind_string);
+            }
+        }
+
+        let prefix_segments_len = use_tree.prefix.segments.len();
+        for (index, segment) in use_tree.prefix.segments.iter().enumerate() {
+            let ident = &segment.ident;
+            if !prefix.is_empty() {
+                prefix.push_str("::");
+            };
+            prefix.push_str(&ident.0.contents);
+
+            if index < prefix_segments_len - 1 {
+                self.insert_use_segment_position(
+                    prefix.clone(),
+                    UseSegmentPosition::BeforeSegment {
+                        segment_span_until_end: Span::from(
+                            use_tree.prefix.segments[index + 1].ident.span().start()
+                                ..use_tree.span.end() - 1,
+                        ),
+                    },
+                );
+            } else {
+                self.insert_use_segment_position_before_use_tree_kind(use_tree, prefix.clone());
+            }
+        }
+
+        match &use_tree.kind {
+            UseTreeKind::Path(ident, alias) => {
+                if !prefix.is_empty() {
+                    prefix.push_str("::");
+                }
+                prefix.push_str(&ident.0.contents);
+
+                if alias.is_none() {
+                    self.insert_use_segment_position(
+                        prefix,
+                        UseSegmentPosition::Last { span: ident.span() },
+                    );
+                } else {
+                    self.insert_use_segment_position(prefix, UseSegmentPosition::NoneOrMultiple);
+                }
+            }
+            UseTreeKind::List(use_trees) => {
+                for use_tree in use_trees {
+                    self.gather_use_tree_segments(use_tree, prefix.clone());
+                }
+            }
+        }
+    }
+
+    fn insert_use_segment_position_before_use_tree_kind(
+        &mut self,
+        use_tree: &UseTree,
+        prefix: String,
+    ) {
+        match &use_tree.kind {
+            UseTreeKind::Path(ident, _alias) => {
+                self.insert_use_segment_position(
+                    prefix,
+                    UseSegmentPosition::BeforeSegment {
+                        segment_span_until_end: Span::from(
+                            ident.span().start()..use_tree.span.end() - 1,
+                        ),
+                    },
+                );
+            }
+            UseTreeKind::List(use_trees) => {
+                if let Some(first_use_tree) = use_trees.first() {
+                    self.insert_use_segment_position(
+                        prefix,
+                        UseSegmentPosition::BeforeList {
+                            first_entry_span: first_use_tree.prefix.span(),
+                            list_is_empty: false,
+                        },
+                    );
+                } else {
+                    self.insert_use_segment_position(
+                        prefix,
+                        UseSegmentPosition::BeforeList {
+                            first_entry_span: Span::from(
+                                use_tree.span.end() - 1..use_tree.span.end() - 1,
+                            ),
+                            list_is_empty: true,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    fn insert_use_segment_position(&mut self, segment: String, position: UseSegmentPosition) {
+        if self.use_segment_positions.get(&segment).is_none() {
+            self.use_segment_positions.insert(segment, position);
+        } else {
+            self.use_segment_positions.insert(segment, UseSegmentPosition::NoneOrMultiple);
+        }
+    }
+
     fn includes_span(&self, span: Span) -> bool {
         span.start() as usize <= self.byte_index && self.byte_index <= span.end() as usize
     }
@@ -1042,10 +1201,11 @@ impl<'a> NodeFinder<'a> {
 
 impl<'a> Visitor for NodeFinder<'a> {
     fn visit_item(&mut self, item: &Item) -> bool {
-        if let ItemKind::Import(..) = &item.kind {
+        if let ItemKind::Import(use_tree, _) = &item.kind {
             if let Some(lsp_location) = to_lsp_location(self.files, self.file, item.span) {
                 self.auto_import_line = (lsp_location.range.end.line + 1) as usize;
             }
+            self.gather_use_tree_segments(use_tree, String::new());
         }
 
         self.includes_span(item.span)

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -1,13 +1,18 @@
 use lsp_types::{Position, Range, TextEdit};
+
+use noirc_errors::Span;
 use noirc_frontend::hir::def_map::ModuleDefId;
 
-use crate::modules::{relative_module_full_path, relative_module_id_path};
+use crate::{
+    modules::{relative_module_full_path, relative_module_id_path},
+    requests::to_lsp_location,
+};
 
 use super::{
     kinds::{FunctionCompletionKind, FunctionKind, RequestedItems},
     name_matches,
     sort_text::auto_import_sort_text,
-    NodeFinder,
+    NodeFinder, UseSegmentPosition,
 };
 
 impl<'a> NodeFinder<'a> {
@@ -77,30 +82,164 @@ impl<'a> NodeFinder<'a> {
                     label_details.detail = Some(format!("(use {})", full_path));
                     completion_item.label_details = Some(label_details);
 
-                    let line = self.auto_import_line as u32;
-                    let character = (self.nesting * 4) as u32;
-                    let indent = " ".repeat(self.nesting * 4);
-                    let mut newlines = "\n";
+                    // See if there's a single place where one of the parent paths is located
+                    let (use_segment_position, name) =
+                        self.find_use_segment_position(full_path.clone());
+                    match use_segment_position {
+                        UseSegmentPosition::NoneOrMultiple => {
+                            // The parent path either isn't in any use statement, or it exists in multiple
+                            // use statements. In either case we'll add a new use statement.
+                            completion_item.additional_text_edits =
+                                Some(self.new_use_completion_item_additional_text_edits(full_path));
+                        }
+                        UseSegmentPosition::Last { span } => {
+                            // We have
+                            //
+                            // use foo::bar;
+                            //          ^^^ -> span
+                            //
+                            // and we want to transform it to:
+                            //
+                            // use foo::bar::{self, baz};
+                            //             ^^^^^^^^^^^^^
+                            //
+                            // So we need one text edit:
+                            // 1. insert "::{self, baz}" right after the span
+                            if let Some(lsp_location) = to_lsp_location(self.files, self.file, span)
+                            {
+                                let range = lsp_location.range;
+                                completion_item.additional_text_edits = Some(vec![TextEdit {
+                                    new_text: format!("::{{self, {}}}", name),
+                                    range: Range { start: range.end, end: range.end },
+                                }]);
+                            } else {
+                                completion_item.additional_text_edits = Some(
+                                    self.new_use_completion_item_additional_text_edits(full_path),
+                                );
+                            }
+                        }
+                        UseSegmentPosition::BeforeSegment { segment_span_until_end } => {
+                            // Go past the end
+                            let segment_span_until_end = Span::from(
+                                segment_span_until_end.start()..segment_span_until_end.end() + 1,
+                            );
 
-                    // If the line we are inserting into is not an empty line, insert an extra line to make some room
-                    if let Some(line_text) = self.lines.get(line as usize) {
-                        if !line_text.trim().is_empty() {
-                            newlines = "\n\n";
+                            // We have
+                            //
+                            // use foo::bar::{one, two};
+                            //          ^^^^^^^^^^^^^^^ -> segment_span_until_end
+                            //
+                            // and we want to transform it to:
+                            //
+                            // use foo::{bar::{one, two}, baz};
+                            //          ^               ^^^^^^
+                            //
+                            // So we need two text edits:
+                            // 1. insert "{" right before the segment span
+                            // 2. insert ", baz}" right after the segment span
+                            if let Some(lsp_location) =
+                                to_lsp_location(self.files, self.file, segment_span_until_end)
+                            {
+                                let range = lsp_location.range;
+                                completion_item.additional_text_edits = Some(vec![
+                                    TextEdit {
+                                        new_text: "{".to_string(),
+                                        range: Range { start: range.start, end: range.start },
+                                    },
+                                    TextEdit {
+                                        new_text: format!(", {}}}", name),
+                                        range: Range { start: range.end, end: range.end },
+                                    },
+                                ]);
+                            } else {
+                                completion_item.additional_text_edits = Some(
+                                    self.new_use_completion_item_additional_text_edits(full_path),
+                                );
+                            }
+                        }
+                        UseSegmentPosition::BeforeList { first_entry_span, list_is_empty } => {
+                            // We have
+                            //
+                            // use foo::bar::{one, two};
+                            //                ^^^ -> first_entry_span
+                            //
+                            // and we want to transform it to:
+                            //
+                            // use foo::bar::{baz, one, two};
+                            //                ^^^^
+                            //
+                            // So we need one text edit:
+                            // 1. insert "baz, " right before the first entry span
+                            if let Some(lsp_location) =
+                                to_lsp_location(self.files, self.file, first_entry_span)
+                            {
+                                let range = lsp_location.range;
+                                completion_item.additional_text_edits = Some(vec![TextEdit {
+                                    new_text: if list_is_empty {
+                                        name
+                                    } else {
+                                        format!("{}, ", name)
+                                    },
+                                    range: Range { start: range.start, end: range.start },
+                                }]);
+                            } else {
+                                completion_item.additional_text_edits = Some(
+                                    self.new_use_completion_item_additional_text_edits(full_path),
+                                );
+                            }
                         }
                     }
-
-                    completion_item.additional_text_edits = Some(vec![TextEdit {
-                        range: Range {
-                            start: Position { line, character },
-                            end: Position { line, character },
-                        },
-                        new_text: format!("use {};{}{}", full_path, newlines, indent),
-                    }]);
 
                     completion_item.sort_text = Some(auto_import_sort_text());
 
                     self.completion_items.push(completion_item);
                 }
+            }
+        }
+    }
+
+    fn new_use_completion_item_additional_text_edits(&self, full_path: String) -> Vec<TextEdit> {
+        let line = self.auto_import_line as u32;
+        let character = (self.nesting * 4) as u32;
+        let indent = " ".repeat(self.nesting * 4);
+        let mut newlines = "\n";
+
+        // If the line we are inserting into is not an empty line, insert an extra line to make some room
+        if let Some(line_text) = self.lines.get(line as usize) {
+            if !line_text.trim().is_empty() {
+                newlines = "\n\n";
+            }
+        }
+
+        vec![TextEdit {
+            range: Range { start: Position { line, character }, end: Position { line, character } },
+            new_text: format!("use {};{}{}", full_path, newlines, indent),
+        }]
+    }
+
+    /// Given a full path like `foo::bar::baz`, returns the first non-"NoneOrMultiple" segment position
+    /// trying each successive parent, together with the name after the parent.
+    ///
+    /// For example, first we'll check if `foo::bar` has a single position. If not, we'll try with `foo`.
+    fn find_use_segment_position(&self, full_path: String) -> (UseSegmentPosition, String) {
+        // Build a parent path to know in which full segment we need to add this import
+        let mut segments: Vec<_> = full_path.split("::").collect();
+        let mut name = segments.pop().unwrap().to_string();
+        let mut parent_path = segments.join("::");
+
+        loop {
+            let use_segment_position =
+                self.use_segment_positions.get(&parent_path).cloned().unwrap_or_default();
+
+            if let UseSegmentPosition::NoneOrMultiple = use_segment_position {
+                if let Some(next_name) = segments.pop() {
+                    name = format!("{next_name}::{name}");
+                    parent_path = segments.join("::");
+                } else {
+                    return (UseSegmentPosition::NoneOrMultiple, String::new());
+                }
+            } else {
+                return (use_segment_position, name);
             }
         }
     }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -15,12 +15,13 @@ mod completion_tests {
             on_completion_request,
         },
         test_utils,
+        tests::apply_text_edit,
     };
 
     use lsp_types::{
         CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionParams,
-        CompletionResponse, DidOpenTextDocumentParams, PartialResultParams, Position, Range,
-        TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, TextEdit,
+        CompletionResponse, DidOpenTextDocumentParams, PartialResultParams, Position,
+        TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
         WorkDoneProgressParams,
     };
     use tokio::test;
@@ -1392,29 +1393,50 @@ mod completion_tests {
 
     #[test]
     async fn test_auto_imports() {
-        let src = r#"
-            mod foo {
-                mod bar {
-                    pub fn hello_world() {}
+        let src = r#"mod foo {
+    mod bar {
+        pub fn hello_world() {}
 
-                    struct Foo {
-                    }
+        struct Foo {
+        }
 
-                    impl Foo {
-                        // This is here to make sure it's not offered for completion
-                        fn hello_world() {}
-                    }
-                }
-            }
+        impl Foo {
+            // This is here to make sure it's not offered for completion
+            fn hello_world() {}
+        }
+    }
+}
 
-            fn main() {
-                hel>|<
-            }
+fn main() {
+    hel>|<
+}
         "#;
-        let items = get_completions(src).await;
+
+        let expected = r#"use foo::bar::hello_world;
+
+mod foo {
+    mod bar {
+        pub fn hello_world() {}
+
+        struct Foo {
+        }
+
+        impl Foo {
+            // This is here to make sure it's not offered for completion
+            fn hello_world() {}
+        }
+    }
+}
+
+fn main() {
+    hel
+}
+        "#;
+
+        let mut items = get_completions(src).await;
         assert_eq!(items.len(), 1);
 
-        let item = &items[0];
+        let item = items.remove(0);
         assert_eq!(item.label, "hello_world()");
         assert_eq!(
             item.label_details,
@@ -1424,38 +1446,45 @@ mod completion_tests {
             })
         );
 
-        assert_eq!(
-            item.additional_text_edits,
-            Some(vec![TextEdit {
-                range: Range {
-                    start: Position { line: 0, character: 0 },
-                    end: Position { line: 0, character: 0 },
-                },
-                new_text: "use foo::bar::hello_world;\n".to_string(),
-            }])
+        let changed = apply_text_edit(
+            &src.replace(">|<", ""),
+            &item.additional_text_edits.unwrap().remove(0),
         );
-
+        assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
 
     #[test]
     async fn test_auto_imports_when_in_nested_module_and_item_is_further_nested() {
-        let src = r#"
-            #[something]
-            mod foo {
-                mod bar {
-                    pub fn hello_world() {}
-                }
+        let src = r#"#[something]
+mod foo {
+    mod bar {
+        pub fn hello_world() {}
+    }
 
-                fn foo() {
-                    hel>|<
-                }
-            }
+    fn foo() {
+        hel>|<
+    }
+}
         "#;
-        let items = get_completions(src).await;
+
+        let expected = r#"#[something]
+mod foo {
+    use bar::hello_world;
+
+    mod bar {
+        pub fn hello_world() {}
+    }
+
+    fn foo() {
+        hel
+    }
+}
+        "#;
+        let mut items = get_completions(src).await;
         assert_eq!(items.len(), 1);
 
-        let item = &items[0];
+        let item = items.remove(0);
         assert_eq!(item.label, "hello_world()");
         assert_eq!(
             item.label_details,
@@ -1465,37 +1494,44 @@ mod completion_tests {
             })
         );
 
-        assert_eq!(
-            item.additional_text_edits,
-            Some(vec![TextEdit {
-                range: Range {
-                    start: Position { line: 3, character: 4 },
-                    end: Position { line: 3, character: 4 },
-                },
-                new_text: "use bar::hello_world;\n\n    ".to_string(),
-            }])
+        let changed = apply_text_edit(
+            &src.replace(">|<", ""),
+            &item.additional_text_edits.unwrap().remove(0),
         );
+        assert_eq!(changed, expected);
     }
 
     #[test]
     async fn test_auto_imports_when_in_nested_module_and_item_is_not_further_nested() {
-        let src = r#"
-            mod foo {
-                mod bar {
-                    pub fn hello_world() {}
-                }
+        let src = r#"mod foo {
+    mod bar {
+        pub fn hello_world() {}
+    }
 
-                mod baz {
-                    fn foo() {
-                        hel>|<
-                    }
-                }
-            }
-        "#;
-        let items = get_completions(src).await;
+    mod baz {
+        fn foo() {
+            hel>|<
+        }
+    }
+}"#;
+
+        let expected = r#"mod foo {
+    mod bar {
+        pub fn hello_world() {}
+    }
+
+    mod baz {
+        use super::bar::hello_world;
+
+        fn foo() {
+            hel
+        }
+    }
+}"#;
+        let mut items = get_completions(src).await;
         assert_eq!(items.len(), 1);
 
-        let item = &items[0];
+        let item = items.remove(0);
         assert_eq!(item.label, "hello_world()");
         assert_eq!(
             item.label_details,
@@ -1505,47 +1541,49 @@ mod completion_tests {
             })
         );
 
-        assert_eq!(
-            item.additional_text_edits,
-            Some(vec![TextEdit {
-                range: Range {
-                    start: Position { line: 7, character: 8 },
-                    end: Position { line: 7, character: 8 },
-                },
-                new_text: "use super::bar::hello_world;\n\n        ".to_string(),
-            }])
+        let changed = apply_text_edit(
+            &src.replace(">|<", ""),
+            &item.additional_text_edits.unwrap().remove(0),
         );
+        assert_eq!(changed, expected);
     }
 
     #[test]
     async fn test_auto_import_inserts_after_last_use() {
-        let src = r#"
-            mod foo {
-                mod bar {
-                    pub fn hello_world() {}
-                }
-            }
+        let src = r#"mod foo {
+    mod bar {
+        pub fn hello_world() {}
+    }
+}
 
-            use foo::bar;
+use foo::bar;
 
-            fn main() {
-                hel>|<
-            }
-        "#;
-        let items = get_completions(src).await;
+fn main() {
+    hel>|<
+}"#;
+
+        let expected = r#"mod foo {
+    mod bar {
+        pub fn hello_world() {}
+    }
+}
+
+use foo::bar;
+use foo::bar::hello_world;
+
+fn main() {
+    hel
+}"#;
+        let mut items = get_completions(src).await;
         assert_eq!(items.len(), 1);
 
-        let item = &items[0];
-        assert_eq!(
-            item.additional_text_edits,
-            Some(vec![TextEdit {
-                range: Range {
-                    start: Position { line: 8, character: 0 },
-                    end: Position { line: 8, character: 0 },
-                },
-                new_text: "use foo::bar::hello_world;\n".to_string(),
-            }])
+        let item = items.remove(0);
+
+        let changed = apply_text_edit(
+            &src.replace(">|<", ""),
+            &item.additional_text_edits.unwrap().remove(0),
         );
+        assert_eq!(changed, expected);
     }
 
     #[test]
@@ -1589,22 +1627,36 @@ mod completion_tests {
 
     #[test]
     async fn test_auto_import_suggests_modules_too() {
-        let src = r#"
-            mod foo {
-                pub mod barbaz {
-                    fn hello_world() {}
-                }
-            }
+        let src = r#"mod foo {
+        pub mod barbaz {
+            fn hello_world() {}
+        }
+    }
 
-            fn main() {
-                barb>|<
-            }
-        "#;
-        let items = get_completions(src).await;
+    fn main() {
+        barb>|<
+    }
+}"#;
+
+        let expected = r#"use foo::barbaz;
+
+mod foo {
+        pub mod barbaz {
+            fn hello_world() {}
+        }
+    }
+
+    fn main() {
+        barb
+    }
+}"#;
+
+        let mut items = get_completions(src).await;
         assert_eq!(items.len(), 1);
 
-        let item = &items[0];
+        let item = items.remove(0);
         assert_eq!(item.label, "barbaz");
+
         assert_eq!(
             item.label_details,
             Some(CompletionItemLabelDetails {
@@ -1612,6 +1664,12 @@ mod completion_tests {
                 description: None
             })
         );
+
+        let changed = apply_text_edit(
+            &src.replace(">|<", ""),
+            &item.additional_text_edits.unwrap().remove(0),
+        );
+        assert_eq!(changed, expected);
     }
 
     #[test]

--- a/tooling/lsp/src/tests.rs
+++ b/tooling/lsp/src/tests.rs
@@ -1,0 +1,16 @@
+#![cfg(test)]
+
+use lsp_types::TextEdit;
+
+pub(crate) fn apply_text_edit(src: &str, text_edit: &TextEdit) -> String {
+    let mut lines: Vec<_> = src.lines().collect();
+    assert_eq!(text_edit.range.start.line, text_edit.range.end.line);
+
+    let mut line = lines[text_edit.range.start.line as usize].to_string();
+    line.replace_range(
+        text_edit.range.start.character as usize..text_edit.range.end.character as usize,
+        &text_edit.new_text,
+    );
+    lines[text_edit.range.start.line as usize] = &line;
+    lines.join("\n")
+}

--- a/tooling/lsp/src/tests.rs
+++ b/tooling/lsp/src/tests.rs
@@ -14,3 +14,19 @@ pub(crate) fn apply_text_edit(src: &str, text_edit: &TextEdit) -> String {
     lines[text_edit.range.start.line as usize] = &line;
     lines.join("\n")
 }
+
+pub(crate) fn apply_text_edits(src: &str, text_edits: &mut [TextEdit]) -> String {
+    let mut text = src.to_string();
+
+    // Text edits must be applied from last to first, otherwise if we apply a text edit
+    // that comes before another one, that other one becomes invalid (it will edit the wrong
+    // piece of code).
+    text_edits.sort_by_key(|edit| (edit.range.start.line, edit.range.start.character));
+    text_edits.reverse();
+
+    for text_edit in text_edits {
+        text = apply_text_edit(&text, text_edit);
+    }
+
+    text
+}


### PR DESCRIPTION
# Description

## Problem

No problem, just makes it easier to avoid having to manually manage use statements.

## Summary

LSP auto-import will now behave like Rust Analyzer, where if there's a single location we can add a new use statement too, we do it. That way if the user specified multiple use statements, that decision is respected.

![lsp-auto-import-into-existing-use](https://github.com/user-attachments/assets/a9aefbee-66a5-4a8e-a149-f952d42c05b8)

## Additional Context

There are two more things I'd like to eventually do, as follow-ups, when I have time in-between other tasks:
1. The code action that adds an import will still always insert a new use statement: we also have to teach it to try to insert into an existing use statement
2. To know where a new use statement should go to I made the code compute all segment positions. That should be fast, but of course it will take more time than no time. In LSP completion (and code action) you can tell the client that you are first going to return a list of results, and then when one is selected that result is augmented... so for example at that point we can compute whether we need to create a new use statement or insert into an existing one, slightly speeding things up.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
