### PR TITLE
fix: allow type aliases in let patterns

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -590,6 +590,11 @@ impl TypeAlias {
 
         self.typ.substitute(&substitutions)
     }
+
+    pub fn instantiate(&self, interner: &NodeInterner) -> Type {
+        let args = vecmap(&self.generics, |_| interner.next_type_variable());
+        self.get_type(&args)
+    }
 }
 
 /// A shared, mutable reference to some T.

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3555,7 +3555,7 @@ fn alias_in_let_pattern() {
         type Bar<U> = Foo<U>;
 
         fn main() {
-            let U { x } = Foo { x: [0] };
+            let Bar { x } = Foo { x: [0] };
             // This is just to show the compiler knows this is an array.
             // The assert_eq isn't run by the frontend tests.
             assert_eq(x.len(), 1);

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3557,8 +3557,7 @@ fn alias_in_let_pattern() {
         fn main() {
             let Bar { x } = Foo { x: [0] };
             // This is just to show the compiler knows this is an array.
-            // The assert_eq isn't run by the frontend tests.
-            assert_eq(x.len(), 1);
+            let _: [Field; 1] = x;
         }
     "#;
     assert_no_errors(src);

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3546,3 +3546,20 @@ fn uses_self_in_import() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn alias_in_let_pattern() {
+    let src = r#"
+        struct Foo<T> { x: T }
+
+        type Bar<U> = Foo<U>;
+
+        fn main() {
+            let U { x } = Foo { x: [0] };
+            // This is just to show the compiler knows this is an array.
+            // The assert_eq isn't run by the frontend tests.
+            assert_eq(x.len(), 1);
+        }
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -31,22 +31,3 @@ fn allows_usage_of_type_alias_as_return_type() {
     "#;
     assert_no_errors(src);
 }
-
-// This is a regression test for https://github.com/noir-lang/noir/issues/6347
-#[test]
-#[should_panic = r#"ResolverError(Expected { span: Span(Span { start: ByteIndex(95), end: ByteIndex(98) }), expected: "type", got: "type alias" }"#]
-fn allows_destructuring_a_type_alias_of_a_struct() {
-    let src = r#"
-    struct Foo {
-        inner: Field
-    }
-
-    type Bar = Foo;
-
-    fn main() {
-        let Bar { inner } = Foo { inner: 42 };
-        assert_eq(inner, 42);
-    }
-    "#;
-    assert_no_errors(src);
-}


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6347

## Summary\*

We were calling `lookup` only expecting a StructId, so I added another case for a type alias in general.

## Additional Context

If the type alias resolves to a non-struct type we still issue an error. E.g. if we had `type Bar = ();`

```
  ┌─ src/main.nr:8:9
  │
8 │     let Bar { inner } = Foo { inner: 42 };
  │         ------------- () has no fields to construct it with
  │
```

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
