### PR TITLE
feat: let the LSP import code action insert into existing use statements

### DIFF
--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -70,6 +70,7 @@ mod solver;
 mod tests;
 mod trait_impl_method_stub_generator;
 mod types;
+mod use_segment_positions;
 mod utils;
 mod visibility;
 

--- a/tooling/lsp/src/requests/code_action/tests.rs
+++ b/tooling/lsp/src/requests/code_action/tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{notifications::on_did_open_text_document, test_utils, tests::apply_text_edit};
+use crate::{notifications::on_did_open_text_document, test_utils, tests::apply_text_edits};
 
 use lsp_types::{
     CodeActionContext, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
@@ -70,9 +70,8 @@ pub(crate) async fn assert_code_action(title: &str, src: &str, expected: &str) {
 
     let workspace_edit = action.edit.as_ref().unwrap();
     let text_edits = workspace_edit.changes.as_ref().unwrap().iter().next().unwrap().1;
-    assert_eq!(text_edits.len(), 1);
 
-    let result = apply_text_edit(&src.replace(">|<", ""), &text_edits[0]);
+    let result = apply_text_edits(&src.replace(">|<", ""), text_edits);
     if result != expected {
         println!("Expected:\n```\n{}\n```\n\nGot:\n```\n{}\n```", expected, result);
         assert_eq!(result, expected);

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1447,7 +1447,7 @@ fn main() {
         );
 
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
@@ -1493,7 +1493,7 @@ mod foo {
         );
 
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
     }
 
@@ -1538,7 +1538,7 @@ mod foo {
         );
 
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
     }
 
@@ -1582,7 +1582,7 @@ fn main() {
         let item = items.remove(0);
 
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
     }
 
@@ -1666,7 +1666,7 @@ mod foo {
         );
 
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
     }
 
@@ -1703,7 +1703,7 @@ fn main() {
 
         let item = items.remove(0);
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
@@ -1741,7 +1741,7 @@ fn main() {
 
         let item = items.remove(0);
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
@@ -1781,7 +1781,7 @@ fn main() {
 
         let item = items.remove(0);
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
@@ -1827,7 +1827,7 @@ fn main() {
 
         let item = items.remove(0);
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
@@ -1865,7 +1865,7 @@ fn main() {
 
         let item = items.remove(0);
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
@@ -1905,7 +1905,7 @@ fn main() {
 
         let item = items.remove(0);
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }
@@ -1941,7 +1941,7 @@ fn main() {
 
         let item = items.remove(0);
         let changed =
-            apply_text_edits(&src.replace(">|<", ""), &mut item.additional_text_edits.unwrap());
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
         assert_eq!(item.sort_text, Some(auto_import_sort_text()));
     }

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -378,7 +378,7 @@ fn character_to_line_offset(line: &str, character: u32) -> Result<usize, Error> 
     }
 }
 
-fn to_lsp_location<'a, F>(
+pub(crate) fn to_lsp_location<'a, F>(
     files: &'a F,
     file_id: F::FileId,
     definition_span: noirc_errors::Span,

--- a/tooling/lsp/src/tests.rs
+++ b/tooling/lsp/src/tests.rs
@@ -15,17 +15,18 @@ pub(crate) fn apply_text_edit(src: &str, text_edit: &TextEdit) -> String {
     lines.join("\n")
 }
 
-pub(crate) fn apply_text_edits(src: &str, text_edits: &mut [TextEdit]) -> String {
+pub(crate) fn apply_text_edits(src: &str, text_edits: &[TextEdit]) -> String {
     let mut text = src.to_string();
 
     // Text edits must be applied from last to first, otherwise if we apply a text edit
     // that comes before another one, that other one becomes invalid (it will edit the wrong
     // piece of code).
+    let mut text_edits = text_edits.to_vec();
     text_edits.sort_by_key(|edit| (edit.range.start.line, edit.range.start.character));
     text_edits.reverse();
 
     for text_edit in text_edits {
-        text = apply_text_edit(&text, text_edit);
+        text = apply_text_edit(&text, &text_edit);
     }
 
     text

--- a/tooling/lsp/src/use_segment_positions.rs
+++ b/tooling/lsp/src/use_segment_positions.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+use noirc_errors::Span;
+use noirc_frontend::ast::{PathKind, UseTree, UseTreeKind};
+
+/// The position of a segment in a `use` statement.
+/// We use this to determine how an auto-import should be inserted.
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) enum UseSegmentPosition {
+    /// The segment either doesn't exist in the source code or there are multiple segments.
+    /// In this case auto-import will add a new use statement.
+    #[default]
+    NoneOrMultiple,
+    /// The segment is the last one in the `use` statement (or nested use statement):
+    ///
+    /// use foo::bar;
+    ///          ^^^
+    ///
+    /// Auto-import will transform it to this:
+    ///
+    /// use foo::bar::{self, baz};
+    Last { span: Span },
+    /// The segment happens before another simple (ident) segment:
+    ///
+    /// use foo::bar::qux;
+    ///          ^^^
+    ///
+    /// Auto-import will transform it to this:
+    ///
+    /// use foo::bar::{qux, baz};
+    BeforeSegment { segment_span_until_end: Span },
+    /// The segment happens before a list:
+    ///
+    /// use foo::bar::{qux, another};
+    ///
+    /// Auto-import will transform it to this:
+    ///
+    /// use foo::bar::{qux, another, baz};
+    BeforeList { first_entry_span: Span, list_is_empty: bool },
+}
+
+/// Remembers where each segment in a `use` statement is located.
+/// The key is the full segment, so for `use foo::bar::baz` we'll have three
+/// segments: `foo`, `foo::bar` and `foo::bar::baz`, where the span is just
+/// for the last identifier (`foo`, `bar` and `baz` in the previous example).
+#[derive(Default)]
+pub(crate) struct UseSegmentPositions {
+    use_segment_positions: HashMap<String, UseSegmentPosition>,
+}
+
+impl UseSegmentPositions {
+    pub(crate) fn add(&mut self, use_tree: &UseTree) {
+        self.gather_use_tree_segments(use_tree, String::new());
+    }
+
+    /// Given a full path like `foo::bar::baz`, returns the first non-"NoneOrMultiple" segment position
+    /// trying each successive parent, together with the name after the parent.
+    ///
+    /// For example, first we'll check if `foo::bar` has a single position. If not, we'll try with `foo`.
+    pub(crate) fn get(&self, full_path: &str) -> (UseSegmentPosition, String) {
+        // Build a parent path to know in which full segment we need to add this import
+        let mut segments: Vec<_> = full_path.split("::").collect();
+        let mut name = segments.pop().unwrap().to_string();
+        let mut parent_path = segments.join("::");
+
+        loop {
+            let use_segment_position =
+                self.use_segment_positions.get(&parent_path).cloned().unwrap_or_default();
+
+            if let UseSegmentPosition::NoneOrMultiple = use_segment_position {
+                if let Some(next_name) = segments.pop() {
+                    name = format!("{next_name}::{name}");
+                    parent_path = segments.join("::");
+                } else {
+                    return (UseSegmentPosition::NoneOrMultiple, String::new());
+                }
+            } else {
+                return (use_segment_position, name);
+            }
+        }
+    }
+
+    fn gather_use_tree_segments(&mut self, use_tree: &UseTree, mut prefix: String) {
+        let kind_string = match use_tree.prefix.kind {
+            PathKind::Crate => Some("crate".to_string()),
+            PathKind::Super => Some("super".to_string()),
+            PathKind::Dep | PathKind::Plain => None,
+        };
+        if let Some(kind_string) = kind_string {
+            if let Some(segment) = use_tree.prefix.segments.first() {
+                self.insert_use_segment_position(
+                    kind_string,
+                    UseSegmentPosition::BeforeSegment {
+                        segment_span_until_end: Span::from(
+                            segment.ident.span().start()..use_tree.span.end() - 1,
+                        ),
+                    },
+                );
+            } else {
+                self.insert_use_segment_position_before_use_tree_kind(use_tree, kind_string);
+            }
+        }
+
+        let prefix_segments_len = use_tree.prefix.segments.len();
+        for (index, segment) in use_tree.prefix.segments.iter().enumerate() {
+            let ident = &segment.ident;
+            if !prefix.is_empty() {
+                prefix.push_str("::");
+            };
+            prefix.push_str(&ident.0.contents);
+
+            if index < prefix_segments_len - 1 {
+                self.insert_use_segment_position(
+                    prefix.clone(),
+                    UseSegmentPosition::BeforeSegment {
+                        segment_span_until_end: Span::from(
+                            use_tree.prefix.segments[index + 1].ident.span().start()
+                                ..use_tree.span.end() - 1,
+                        ),
+                    },
+                );
+            } else {
+                self.insert_use_segment_position_before_use_tree_kind(use_tree, prefix.clone());
+            }
+        }
+
+        match &use_tree.kind {
+            UseTreeKind::Path(ident, alias) => {
+                if !prefix.is_empty() {
+                    prefix.push_str("::");
+                }
+                prefix.push_str(&ident.0.contents);
+
+                if alias.is_none() {
+                    self.insert_use_segment_position(
+                        prefix,
+                        UseSegmentPosition::Last { span: ident.span() },
+                    );
+                } else {
+                    self.insert_use_segment_position(prefix, UseSegmentPosition::NoneOrMultiple);
+                }
+            }
+            UseTreeKind::List(use_trees) => {
+                for use_tree in use_trees {
+                    self.gather_use_tree_segments(use_tree, prefix.clone());
+                }
+            }
+        }
+    }
+
+    fn insert_use_segment_position_before_use_tree_kind(
+        &mut self,
+        use_tree: &UseTree,
+        prefix: String,
+    ) {
+        match &use_tree.kind {
+            UseTreeKind::Path(ident, _alias) => {
+                self.insert_use_segment_position(
+                    prefix,
+                    UseSegmentPosition::BeforeSegment {
+                        segment_span_until_end: Span::from(
+                            ident.span().start()..use_tree.span.end() - 1,
+                        ),
+                    },
+                );
+            }
+            UseTreeKind::List(use_trees) => {
+                if let Some(first_use_tree) = use_trees.first() {
+                    self.insert_use_segment_position(
+                        prefix,
+                        UseSegmentPosition::BeforeList {
+                            first_entry_span: first_use_tree.prefix.span(),
+                            list_is_empty: false,
+                        },
+                    );
+                } else {
+                    self.insert_use_segment_position(
+                        prefix,
+                        UseSegmentPosition::BeforeList {
+                            first_entry_span: Span::from(
+                                use_tree.span.end() - 1..use_tree.span.end() - 1,
+                            ),
+                            list_is_empty: true,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    fn insert_use_segment_position(&mut self, segment: String, position: UseSegmentPosition) {
+        if self.use_segment_positions.get(&segment).is_none() {
+            self.use_segment_positions.insert(segment, position);
+        } else {
+            self.use_segment_positions.insert(segment, UseSegmentPosition::NoneOrMultiple);
+        }
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Like #6354 but for the import code action.

## Summary

Tries to extract and reuse all the logic that's used for this in autocompletion, and use it for this code action.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
