### PR TITLE
fix: Fix panic in comptime code

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -554,8 +554,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         match &definition.kind {
             DefinitionKind::Function(function_id) => {
                 let typ = self.elaborator.interner.id_type(id).follow_bindings();
-                let bindings =
-                    Rc::new(self.elaborator.interner.get_instantiation_bindings(id).clone());
+                let bindings = self.elaborator.interner.try_get_instantiation_bindings(id);
+                let bindings = Rc::new(bindings.map_or(TypeBindings::default(), Clone::clone));
                 Ok(Value::Function(*function_id, typ, bindings))
             }
             DefinitionKind::Local(_) => self.lookup(&ident),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Fixes a panic that can occur in comptime code sometimes when calling a function which previously failed to completely resolve. Can't seem to repro it again though.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
