### PR TITLE
fix: remove assumed parent traits

### DIFF
--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -261,3 +261,24 @@ fn errors_if_impl_trait_constraint_is_not_satisfied() {
     assert_eq!(typ, "SomeGreeter");
     assert_eq!(impl_trait, "Foo");
 }
+
+#[test]
+fn removes_assumed_parent_traits_after_function_ends() {
+    let src = r#"
+    trait Foo {}
+    trait Bar: Foo {}
+
+    pub fn foo<T>()
+    where
+        T: Bar,
+    {}
+
+    pub fn bar<T>()
+    where
+        T: Foo,
+    {}
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/AztecProtocol/aztec-packages/pull/9425#issuecomment-2438553794

## Summary

When entering a function we were adding assumed traits, and also for parent traits, but we weren't removing parent traits.

## Additional Context

I added a test that gives a warning saying "constraint T: Foo" is not needed without this PR (that's how I realized the bug was related to lingering assumed traits).

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
