### PR TITLE
fix: slightly better formatting of empty blocks with comments

### DIFF
--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -995,7 +995,12 @@ impl<'a> Formatter<'a> {
 
     /// Appends the string to the current buffer line by line, with some pre-checks.
     fn write_chunk_lines(&mut self, string: &str) {
-        for (index, line) in string.lines().enumerate() {
+        let lines: Vec<_> = string.lines().collect();
+
+        let mut index = 0;
+        while index < lines.len() {
+            let line = &lines[index];
+
             // Don't indent the first line (it should already be indented).
             // Also don't indent if the current line already has a space as the last char
             // (it means it's already indented)
@@ -1014,6 +1019,14 @@ impl<'a> Formatter<'a> {
                 self.write(line.trim_start());
             } else {
                 self.write(line);
+            }
+
+            index += 1;
+
+            // If a newline comes next too, write multiple lines to preserve original formatting
+            while index < lines.len() && lines[index].is_empty() {
+                self.write_multiple_lines_without_skipping_whitespace_and_comments();
+                index += 1;
             }
         }
     }

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -643,7 +643,10 @@ mod foo;
         /* hello */
     }
         ";
-        let expected = "struct Foo { /* hello */ }\n";
+        let expected = "struct Foo {
+    /* hello */
+}
+";
         assert_format(src, expected);
     }
 

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -1142,6 +1142,9 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
     pub(super) fn empty_block_contents_chunk(&mut self) -> Option<ChunkGroup> {
         let mut group = ChunkGroup::new();
         group.increase_indentation();
+
+        let newlines_count = self.following_newlines_count();
+
         let mut chunk = self.chunk(|formatter| {
             formatter.skip_comments_and_whitespace_writing_multiple_lines_if_found();
         });
@@ -1151,15 +1154,13 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
             // so there's nothing to write.
             None
         } else {
-            if chunk.string.trim_start().starts_with("//") {
-                group.text(chunk);
-                group.decrease_indentation();
-                group.line();
-            } else {
+            // If we have a trailing comment, preserve it in the same line
+            if newlines_count == 0 && !chunk.string.trim_start().starts_with("//") {
                 chunk.string = format!(" {} ", chunk.string.trim());
-                group.text(chunk);
-                group.decrease_indentation();
             }
+            group.text(chunk);
+            group.decrease_indentation();
+            group.line();
             Some(group)
         }
     }

--- a/tooling/nargo_fmt/src/formatter/module.rs
+++ b/tooling/nargo_fmt/src/formatter/module.rs
@@ -31,27 +31,17 @@ impl<'a> Formatter<'a> {
         self.write_space();
         self.write_identifier(submodule.name);
         self.write_space();
+        self.write_left_brace();
         if parsed_module_is_empty(&submodule.contents) {
-            self.write_left_brace();
-            self.increase_indentation();
-
-            let comments_count_before = self.written_comments_count;
-            self.skip_comments_and_whitespace_writing_multiple_lines_if_found();
-            self.decrease_indentation();
-            if self.written_comments_count > comments_count_before {
-                self.write_line();
-                self.write_indentation();
-            }
-            self.write_right_brace();
+            self.format_empty_block_contents();
         } else {
-            self.write_left_brace();
             self.increase_indentation();
             self.write_line();
             self.format_parsed_module(submodule.contents, self.ignore_next);
             self.decrease_indentation();
             self.write_indentation();
-            self.write_right_brace();
         }
+        self.write_right_brace();
     }
 }
 
@@ -99,6 +89,18 @@ mod foo;\n";
     fn format_empty_submodule() {
         let src = "mod foo {    }";
         let expected = "mod foo {}\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_empty_submodule_2() {
+        let src = "mod foo { mod bar {    
+
+    } }";
+        let expected = "mod foo {
+    mod bar {}
+}
+";
         assert_format(src, expected);
     }
 


### PR DESCRIPTION
# Description

## Problem

While coding in Noir I noticed this code:

```noir
mod foo {
  mod bar {
  }
}
```

ended up being formatted like this:

```noir
mod foo {
  mod bar {
}
}
```

## Summary

It wasn't working well because the code for submodules wasn't reusing a function to format empty blocks. The reason is that I implemented submodules first, then eventually came up with a function to format empty blocks but forgot to use it there.

I also found some other edge cases so I fixed them (an existing test got changed, its formatting is slightly better now).

(This is all minor, but it's nice if things are consistent)

## Additional Context

I checked and with this nothing is reformatted in this repo or Aztec-Packages: there are no empty blocks with comments, because that usually happens as you are coding but not in the final state of the code.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
