### PR TITLE
fix: (LSP) check visibility of module that re-exports item, if any

### DIFF
--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -46,6 +46,7 @@ impl<'a> CodeActionFinder<'a> {
                     *module_def_id,
                     self.module_id,
                     *visibility,
+                    *defining_module,
                     self.interner,
                     self.def_maps,
                 ) {

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -38,6 +38,7 @@ impl<'a> NodeFinder<'a> {
                     *module_def_id,
                     self.module_id,
                     *visibility,
+                    *defining_module,
                     self.interner,
                     self.def_maps,
                 ) {

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1643,6 +1643,29 @@ fn main() {
     }
 
     #[test]
+    async fn checks_visibility_of_module_that_exports_item_if_any() {
+        let src = r#"
+            mod foo {
+                mod bar {
+                    pub fn hello_world() {}
+                }
+
+                pub use bar::hello_world;
+            }
+
+            fn main() {
+                hello_w>|<
+            }
+        "#;
+        let mut items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = items.remove(0);
+        assert_eq!(item.label, "hello_world()");
+        assert_eq!(item.label_details.unwrap().detail.unwrap(), "(use foo::hello_world)");
+    }
+
+    #[test]
     async fn test_auto_import_suggests_modules_too() {
         let src = r#"mod foo {
         pub mod barbaz {


### PR DESCRIPTION
# Description

## Problem

After #6366, and while working on #6370, I noticed the trait `Add` (and other ops) weren't suggested anymore. The reason is that they are re-exported from a different module, and private in their own module. #6366 didn't take that into account so this PR fixes that.

## Summary

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
