### PR TITLE
feat: better LSP hover for functions

### DIFF
--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -307,7 +307,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
     let mut string = String::new();
     let formatted_parent_module =
         format_parent_module(ReferenceId::Function(id), args, &mut string);
-    let formatted_parent_struct = if let Some(struct_id) = func_meta.struct_id {
+    let formatted_parent_type = if let Some(struct_id) = func_meta.struct_id {
         let struct_type = args.interner.get_struct(struct_id);
         let struct_type = struct_type.borrow();
         if formatted_parent_module {
@@ -331,10 +331,18 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
         format_generic_names(&impl_generics, &mut string);
 
         true
+    } else if let Some(trait_id) = func_meta.trait_id {
+        let trait_ = args.interner.get_trait(trait_id);
+        string.push('\n');
+        string.push_str("    trait ");
+        string.push_str(&trait_.name.0.contents);
+        format_generics(&trait_.generics, &mut string);
+
+        true
     } else {
         false
     };
-    if formatted_parent_module || formatted_parent_struct {
+    if formatted_parent_module || formatted_parent_type {
         string.push('\n');
     }
     string.push_str("    ");

--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -41,8 +41,8 @@ fn use_impl_method() {
 }
 
 mod other;
-use other::another_function;
 use crate::other::other_function;
+use other::another_function;
 
 use one::subone::GenericStruct;
 
@@ -58,3 +58,29 @@ pub fn foo() {}
 comptime fn attr(_: FunctionDefinition) -> Quoted {
     quote { pub fn hello() {} }
 }
+
+struct Foo<T> {}
+
+impl<U> Foo<U> {
+    fn new() -> Self {
+        Foo {}
+    }
+}
+
+fn new_foo() -> Foo<i32> {
+    Foo::new()
+}
+
+trait Bar<T, U> {
+    fn bar_stuff(self);
+}
+
+impl<A> Bar<A, i32> for Foo<A> {
+    fn bar_stuff(self) {}
+}
+
+fn bar_stuff() {
+    let foo = Foo::new();
+    foo.bar_stuff();
+}
+


### PR DESCRIPTION
# Description

## Problem

Some things I noticed were missing when hovering over functions, compared to what Rust Analyzer does.

## Summary

Hovering over a function will now show it's visibility, whether it's comptime/unconstrained, and also show the struct, trait or trait impl it belongs to. Also, numeric generic types previously showed up just as their name, but now they show up with the `let N: ...` syntax.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
