### PR TITLE
feat: suggest removing `!` from macro call that doesn't return Quoted

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -502,7 +502,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
             ResolverError::MacroIsNotComptime { span } => {
                 Diagnostic::simple_error(
                     "This macro call is to a non-comptime function".into(),
-                    "Macro calls must be comptime functions".into(),
+                    "Macro calls must be to comptime functions".into(),
                     *span,
                 )
             },

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -502,7 +502,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
             ResolverError::MacroIsNotComptime { span } => {
                 Diagnostic::simple_error(
                     "This macro call is to a non-comptime function".into(),
-                    "Macro calls must be to comptime functions".into(),
+                    "Macro calls must be comptime functions".into(),
                     *span,
                 )
             },

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -434,11 +434,15 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                 let msg = format!("Expected {expected_count} generic{expected_plural} from this function, but {actual_count} {actual_plural} provided");
                 Diagnostic::simple_error(msg, "".into(), *span)
             },
-            TypeCheckError::MacroReturningNonExpr { typ, span } => Diagnostic::simple_error(
-                format!("Expected macro call to return a `Quoted` but found a(n) `{typ}`"),
-                "Macro calls must return quoted values, otherwise there is no code to insert".into(),
-                *span,
-            ),
+            TypeCheckError::MacroReturningNonExpr { typ, span } =>  {
+                let mut error = Diagnostic::simple_error(
+                    format!("Expected macro call to return a `Quoted` but found a(n) `{typ}`"),
+                    "Macro calls must return quoted values, otherwise there is no code to insert.".into(),
+                    *span,
+                );
+                error.add_secondary("Hint: remove the `!` from the end of the call name.".to_string(), *span);
+                error
+            },
             TypeCheckError::UnsupportedTurbofishUsage { span } => {
                 let msg = "turbofish (`::<_>`)  usage at this position isn't supported yet";
                 Diagnostic::simple_error(msg.to_string(), "".to_string(), *span)

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -440,7 +440,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                     "Macro calls must return quoted values, otherwise there is no code to insert.".into(),
                     *span,
                 );
-                error.add_secondary("Hint: remove the `!` from the end of the call name.".to_string(), *span);
+                error.add_secondary("Hint: remove the `!` from the end of the function name.".to_string(), *span);
                 error
             },
             TypeCheckError::UnsupportedTurbofishUsage { span } => {

--- a/tooling/lsp/src/requests/code_action/remove_bang_from_call.rs
+++ b/tooling/lsp/src/requests/code_action/remove_bang_from_call.rs
@@ -1,0 +1,97 @@
+use lsp_types::TextEdit;
+use noirc_errors::{Location, Span};
+use noirc_frontend::{node_interner::ReferenceId, QuotedType, Type};
+
+use crate::byte_span_to_range;
+
+use super::CodeActionFinder;
+
+impl<'a> CodeActionFinder<'a> {
+    pub(super) fn remove_bang_from_call(&mut self, span: Span) {
+        // If we can't find the referenced function, there's nothing we can do
+        let Some(ReferenceId::Function(func_id)) =
+            self.interner.find_referenced(Location::new(span, self.file))
+        else {
+            return;
+        };
+
+        // If the return type is Quoted, all is good
+        let func_meta = self.interner.function_meta(&func_id);
+        if let Type::Quoted(QuotedType::Quoted) = func_meta.return_type() {
+            return;
+        }
+
+        // The `!` comes right after the name
+        let byte_span = span.end() as usize..span.end() as usize + 1;
+        let Some(range) = byte_span_to_range(self.files, self.file, byte_span) else {
+            return;
+        };
+
+        let title = "Remove `!` from call".to_string();
+        let text_edit = TextEdit { range, new_text: "".to_string() };
+
+        let code_action = self.new_quick_fix(title, text_edit);
+        self.code_actions.push(code_action);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::test;
+
+    use crate::requests::code_action::tests::assert_code_action;
+
+    #[test]
+    async fn test_removes_bang_from_call() {
+        let title = "Remove `!` from call";
+
+        let src = r#"
+        fn foo() {}
+
+        fn main() {
+            fo>|<o!();
+        }
+        "#;
+
+        let expected = r#"
+        fn foo() {}
+
+        fn main() {
+            foo();
+        }
+        "#;
+
+        assert_code_action(title, src, expected).await;
+    }
+
+    #[test]
+    async fn test_removes_bang_from_method_call() {
+        let title = "Remove `!` from call";
+
+        let src = r#"
+        struct Foo {}
+
+        impl Foo {
+          fn foo(self) {}
+        }
+
+        fn bar(foo: Foo) {
+            foo.fo>|<o!();
+        }
+        "#;
+
+        let expected = r#"
+        struct Foo {}
+
+        impl Foo {
+          fn foo(self) {}
+        }
+
+        fn bar(foo: Foo) {
+            foo.foo();
+        }
+        "#;
+
+        assert_code_action(title, src, expected).await;
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #6380 with the bonus

## Summary

![lsp-remove-bang](https://github.com/user-attachments/assets/e7cb3af7-8706-4d45-8d28-12987da0593f)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
