### PR TITLE
fix: distinguish TypePath with and without turbofish

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -802,8 +802,8 @@ impl Display for AsTraitPath {
 impl Display for TypePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}::{}", self.typ, self.item)?;
-        if !self.turbofish.is_empty() {
-            write!(f, "::{}", self.turbofish)?;
+        if let Some(turbofish) = &self.turbofish {
+            write!(f, "::{}", turbofish)?;
         }
         Ok(())
     }

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -408,7 +408,7 @@ pub struct AsTraitPath {
 pub struct TypePath {
     pub typ: UnresolvedType,
     pub item: Ident,
-    pub turbofish: GenericTypeArgs,
+    pub turbofish: Option<GenericTypeArgs>,
 }
 
 // Note: Path deliberately doesn't implement Recoverable.

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -1245,7 +1245,9 @@ impl TypePath {
 
     pub fn accept_children(&self, visitor: &mut impl Visitor) {
         self.typ.accept(visitor);
-        self.turbofish.accept(visitor);
+        if let Some(turbofish) = &self.turbofish {
+            turbofish.accept(visitor);
+        }
     }
 }
 

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -762,8 +762,12 @@ impl<'context> Elaborator<'context> {
             .func_id(self.interner)
             .expect("Expected trait function to be a DefinitionKind::Function");
 
-        let generics = self.resolve_type_args(path.turbofish, func_id, span).0;
-        let generics = (!generics.is_empty()).then_some(generics);
+        let generics = if let Some(turbofish) = path.turbofish {
+            let generics = self.resolve_type_args(turbofish, func_id, span).0;
+            (!generics.is_empty()).then_some(generics)
+        } else {
+            None
+        };
 
         let location = Location::new(span, self.file);
         let id = self.interner.function_definition_id(func_id);

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -620,7 +620,9 @@ fn remove_interned_in_expression_kind(
         }
         ExpressionKind::TypePath(mut path) => {
             path.typ = remove_interned_in_unresolved_type(interner, path.typ);
-            path.turbofish = remove_interned_in_generic_type_args(interner, path.turbofish);
+            path.turbofish = path
+                .turbofish
+                .map(|turbofish| remove_interned_in_generic_type_args(interner, turbofish));
             ExpressionKind::TypePath(path)
         }
         ExpressionKind::Resolved(id) => {

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -4,7 +4,7 @@ use noirc_errors::Span;
 use crate::{
     ast::{
         ArrayLiteral, BlockExpression, CallExpression, CastExpression, ConstructorExpression,
-        Expression, ExpressionKind, GenericTypeArgs, Ident, IfExpression, IndexExpression, Literal,
+        Expression, ExpressionKind, Ident, IfExpression, IndexExpression, Literal,
         MemberAccessExpression, MethodCallExpression, Statement, TypePath, UnaryOp, UnresolvedType,
     },
     parser::{labels::ParsingRuleLabel, parser::parse_many::separated_by_comma, ParserErrorReason},
@@ -553,9 +553,9 @@ impl<'a> Parser<'a> {
             if generics.is_empty() {
                 self.expected_token(Token::Less);
             }
-            generics
+            Some(generics)
         } else {
-            GenericTypeArgs::default()
+            None
         };
 
         Some(ExpressionKind::TypePath(TypePath { typ, item, turbofish }))
@@ -1587,7 +1587,7 @@ mod tests {
         };
         assert_eq!(type_path.typ.to_string(), "Field");
         assert_eq!(type_path.item.to_string(), "foo");
-        assert!(type_path.turbofish.is_empty());
+        assert!(type_path.turbofish.is_none());
     }
 
     #[test]
@@ -1599,7 +1599,7 @@ mod tests {
         };
         assert_eq!(type_path.typ.to_string(), "Field");
         assert_eq!(type_path.item.to_string(), "foo");
-        assert!(!type_path.turbofish.is_empty());
+        assert!(type_path.turbofish.is_some());
     }
 
     #[test]

--- a/test_programs/compile_success_empty/type_path/src/main.nr
+++ b/test_programs/compile_success_empty/type_path/src/main.nr
@@ -5,6 +5,11 @@ fn main() {
             $foo::static()
         }
     }
+
+    // Make sure this call works fine: in the past we used to not distinguish
+    // whether a TypePath had generics or not, always resolved them, filling them
+    // up with Type::Error, and eventually leading to an ICE.
+    let _ = Field::from_be_bytes([1]);
 }
 
 pub struct Foo {}

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -382,9 +382,9 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
             formatter.format_type(type_path.typ);
             formatter.write_token(Token::DoubleColon);
             formatter.write_identifier(type_path.item);
-            if !type_path.turbofish.is_empty() {
+            if let Some(turbofish) = type_path.turbofish {
                 formatter.write_token(Token::DoubleColon);
-                formatter.format_generic_type_args(type_path.turbofish);
+                formatter.format_generic_type_args(turbofish);
             }
         }));
         group


### PR DESCRIPTION
# Description

## Problem

Resolves #6188

## Summary

We couldn't distinguish between `Field::foo` and `Field::<>::foo`, assuming it was always `Field::<>::foo`, trying to resolve the generics and filling missing ones with `Type::Error`, eventually leading to a compiler error.

## Additional Context

While working on this I noticed that `Type::kind` might be returning the incorrect Kind for some types:

https://github.com/noir-lang/noir/blob/4e44e1f4a71a1a8efc17462c55a85b9cb7fdeae3/compiler/noirc_frontend/src/hir_def/types.rs#L1379

I talked about this with Michael, I might send a follow-up PR if I can find some code that doesn't work if we don't change that.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
