### PR TITLE
fix: numeric generic doesn't have a default type

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -241,11 +241,9 @@ impl Kind {
     /// during monomorphization.
     pub(crate) fn default_type(&self) -> Option<Type> {
         match self {
-            Kind::Any => None,
             Kind::IntegerOrField => Some(Type::default_int_or_field_type()),
             Kind::Integer => Some(Type::default_int_type()),
-            Kind::Normal => None,
-            Kind::Numeric(typ) => Some(*typ.clone()),
+            Kind::Any | Kind::Normal | Kind::Numeric(..) => None,
         }
     }
 

--- a/test_programs/compile_failure/cannot_deduce_numeric_generic/Nargo.toml
+++ b/test_programs/compile_failure/cannot_deduce_numeric_generic/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cannot_deduce_numeric_generic"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_failure/cannot_deduce_numeric_generic/src/main.nr
+++ b/test_programs/compile_failure/cannot_deduce_numeric_generic/src/main.nr
@@ -1,0 +1,8 @@
+fn foo<let N: u32>() -> u32 {
+    N
+}
+
+fn main() {
+    let _ = foo();
+}
+


### PR DESCRIPTION
# Description

## Problem

Resolves #6379

## Summary

Even though `Kind::Numeric` holds a type, say, `u32`, that type is not the default value that should be used if we can't bind that var.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
