### PR TITLE
chore(nargo): Remove old profile as part of info cmd

### DIFF
--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -1,13 +1,10 @@
-use std::collections::HashMap;
-
 use acvm::acir::circuit::ExpressionWidth;
 use clap::Args;
 use iter_extended::vecmap;
 use nargo::package::{CrateName, Package};
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
-use noirc_artifacts::{debug::DebugArtifact, program::ProgramArtifact};
+use noirc_artifacts::program::ProgramArtifact;
 use noirc_driver::{CompileOptions, NOIR_ARTIFACT_VERSION_STRING};
-use noirc_errors::{debug_info::OpCodesCount, Location};
 use prettytable::{row, table, Row};
 use rayon::prelude::*;
 use serde::Serialize;
@@ -40,9 +37,6 @@ pub(crate) struct InfoCommand {
     #[clap(long, hide = true)]
     json: bool,
 
-    #[clap(long, hide = true)]
-    profile_info: bool,
-
     #[clap(flatten)]
     compile_options: CompileOptions,
 }
@@ -70,16 +64,6 @@ pub(crate) fn run(args: InfoCommand, config: NargoConfig) -> Result<(), CliError
             Ok((package.clone(), program))
         })
         .collect::<Result<_, _>>()?;
-
-    if args.profile_info {
-        for (_, compiled_program) in &binary_packages {
-            let debug_artifact = DebugArtifact::from(compiled_program.clone());
-            for function_debug in compiled_program.debug_symbols.debug_infos.iter() {
-                let span_opcodes = function_debug.count_span_opcodes();
-                print_span_opcodes(span_opcodes, &debug_artifact);
-            }
-        }
-    }
 
     let program_info = binary_packages
         .into_iter()
@@ -112,55 +96,6 @@ pub(crate) fn run(args: InfoCommand, config: NargoConfig) -> Result<(), CliError
     }
 
     Ok(())
-}
-
-/// Provides profiling information on
-///
-/// Number of OpCodes in relation to Noir source file
-/// and line number information
-fn print_span_opcodes(
-    span_opcodes_map: HashMap<Location, OpCodesCount>,
-    debug_artifact: &DebugArtifact,
-) {
-    let mut pairs: Vec<(&Location, &OpCodesCount)> = span_opcodes_map.iter().collect();
-
-    pairs.sort_by(|a, b| {
-        a.1.acir_size.cmp(&b.1.acir_size).then_with(|| a.1.brillig_size.cmp(&b.1.brillig_size))
-    });
-
-    for (location, opcodes_count) in pairs {
-        let debug_file = debug_artifact.file_map.get(&location.file).unwrap();
-
-        let start_byte = byte_index(&debug_file.source, location.span.start() + 1);
-        let end_byte = byte_index(&debug_file.source, location.span.end() + 1);
-        let range = start_byte..end_byte;
-        let span_content = &debug_file.source[range];
-        let line = debug_artifact.location_line_index(*location).unwrap() + 1;
-        println!(
-            "Ln. {}: {} (ACIR:{}, Brillig:{} opcode|s) in file: {}",
-            line,
-            span_content,
-            opcodes_count.acir_size,
-            opcodes_count.brillig_size,
-            debug_file.path.to_str().unwrap()
-        );
-    }
-}
-fn byte_index(string: &str, index: u32) -> usize {
-    let mut byte_index = 0;
-    let mut char_index = 0;
-
-    #[allow(clippy::explicit_counter_loop)]
-    for (byte_offset, _) in string.char_indices() {
-        if char_index == index {
-            return byte_index;
-        }
-
-        byte_index = byte_offset;
-        char_index += 1;
-    }
-
-    byte_index
 }
 
 #[derive(Debug, Default, Serialize)]


### PR DESCRIPTION
# Description

## Problem\*

Just something I noticed while working on `nargo info`. The `--profile-info` flag is hidden and I am willing to bet largely unused. We can move to the noir-profiler under `tooling/profiler` as it is much more informative and easier to navigate. 

## Summary\*

I have removed `--profile-info` from `nargo info` and the subsequent methods related to it. 

## Additional Context

I would also like to remove the "Profile" codelens @asterite @TomAFrench. I was trying to use it on `1_mul` and `sha256_regression` and nothing would happen while the other code lens commands worked. 

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
