### PR TITLE
Update arrays.md

### DIFF
--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -93,7 +93,7 @@ So anywhere `self` appears, it refers to the variable `self: [T; N]`.
 Returns the length of an array
 
 ```rust
-fn len(self) -> Field
+fn len(self) -> u32
 ```
 
 example


### PR DESCRIPTION
It seems the return type of `len` is `u32` according to https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/array/mod.nr

Also, I am wondering if indices in `for` loops are `u32` also, or should be, as according to the beginning of https://noir-lang.org/docs/noir/concepts/data_types/integers they are `u64`.

Thanks!