### PR TITLE
feat: Add value merge optimization

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -323,6 +323,10 @@ fn check_for_noop_value_merge(dfg: &DataFlowGraph, lhs: ValueId, rhs: ValueId) -
         _ => return None,
     };
 
+    if !dfg.type_of_value(rhs_cond).is_bool() {
+        return None;
+    }
+
     let (lhs_cond, lhs_value, lhs_is_not) = match source_instruction(dfg, lhs)? {
         Instruction::Binary(Binary { lhs, rhs, operator: BinaryOp::Add }) => {
             match source_instruction(dfg, *lhs)? {

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -90,6 +90,11 @@ impl Type {
         matches!(self, Type::Numeric(NumericType::Unsigned { .. }))
     }
 
+    /// Returns true if this type is a boolean (u1)
+    pub(crate) fn is_bool(&self) -> bool {
+        matches!(self, Type::Numeric(NumericType::Unsigned { bit_size: 1 }))
+    }
+
     /// Create a new signed integer type with the given amount of bits.
     pub(crate) fn signed(bit_size: u32) -> Type {
         Type::Numeric(NumericType::Signed { bit_size })


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

Found while working on https://github.com/noir-lang/noir/issues/5771.

Adds an optimization for:
```
b0(v1: Field, v2: u1):
  v3 = not v2
  v4 = v2 as Field
  v5 = v3 as Field
  v6 = mul v4, v1
  v7 = mul v5, v1
  v8 = add v6, v7  // if v2 { v1 } else { v1 }
```
Down to `v1`.

Although we have a similar optimization directly on `Instruction::IfElse`, it's possible it can fail if references are involved and one value is a Load that is later resolved to be equal to the other value.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
