### PR TITLE
feat: improve malformed test attribute error

### DIFF
--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -20,6 +20,8 @@ pub enum LexerErrorKind {
     IntegerLiteralTooLarge { span: Span, limit: String },
     #[error("{:?} is not a valid attribute", found)]
     MalformedFuncAttribute { span: Span, found: String },
+    #[error("Malformed test attribute")]
+    MalformedTestAttribute { span: Span },
     #[error("{:?} is not a valid inner attribute", found)]
     InvalidInnerAttribute { span: Span, found: String },
     #[error("Logical and used instead of bitwise and")]
@@ -61,6 +63,7 @@ impl LexerErrorKind {
             LexerErrorKind::InvalidIntegerLiteral { span, .. } => *span,
             LexerErrorKind::IntegerLiteralTooLarge { span, .. } => *span,
             LexerErrorKind::MalformedFuncAttribute { span, .. } => *span,
+            LexerErrorKind::MalformedTestAttribute { span, .. } => *span,
             LexerErrorKind::InvalidInnerAttribute { span, .. } => *span,
             LexerErrorKind::LogicalAnd { span } => *span,
             LexerErrorKind::UnterminatedBlockComment { span } => *span,
@@ -107,6 +110,11 @@ impl LexerErrorKind {
             LexerErrorKind::MalformedFuncAttribute { span, found } => (
                 "Malformed function attribute".to_string(),
                 format!(" {found} is not a valid attribute"),
+                *span,
+            ),
+            LexerErrorKind::MalformedTestAttribute { span } => (
+                "Malformed test attribute".to_string(),
+                "The test attribute can be written in one of these forms: `#[test]`, `#[test(should_fail)]` or `#[test(should_fail_with = \"message\")]`".to_string(),
                 *span,
             ),
             LexerErrorKind::InvalidInnerAttribute { span, found } => (

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -935,13 +935,7 @@ mod tests {
             Err(err) => err,
         };
 
-        // Check if error is MalformedFuncAttribute and found is "foo"
-        let sub_string = match err {
-            LexerErrorKind::MalformedFuncAttribute { found, .. } => found,
-            _ => panic!("expected malformed func attribute error"),
-        };
-
-        assert_eq!(sub_string, "test(invalid_scope)");
+        assert!(matches!(err, LexerErrorKind::MalformedTestAttribute { .. }));
     }
 
     #[test]

--- a/tooling/lsp/src/requests/completion/builtins.rs
+++ b/tooling/lsp/src/requests/completion/builtins.rs
@@ -107,6 +107,15 @@ impl<'a> NodeFinder<'a> {
                 let one_argument_attributes = &["abi", "field", "foreign", "oracle"];
                 self.suggest_one_argument_attributes(prefix, one_argument_attributes);
 
+                if name_matches("test", prefix) || name_matches("should_fail", prefix) {
+                    self.completion_items.push(snippet_completion_item(
+                        "test(should_fail)",
+                        CompletionItemKind::METHOD,
+                        "test(should_fail)",
+                        None,
+                    ));
+                }
+
                 if name_matches("test", prefix) || name_matches("should_fail_with", prefix) {
                     self.completion_items.push(snippet_completion_item(
                         "test(should_fail_with = \"...\")",


### PR DESCRIPTION
# Description

## Problem

Resolves #4676

## Summary

In reality we were producing an error message for this snippet:

```noir
#[test(should_fail_with("Arrays not equal"))]
fn foo() {}
```

though the error message said that it couldn't find a `test` function. The reason is that the lexer couldn't parse the attribute contents well: it split the attribute contents when `(` and `)` were found and tried to match that to some expected format, but because here we have nested parentheses it didn't work. What I did is try to parse that by checking the first and last parentheses.

I also didn't know you could write `#[test(should_fail)]` so I added that as an LSP autocompletion.

## Additional Context

I'm thinking that maybe the attribute contents should be parsed by lexing its contents. With that, we could also keep a nesting counter when `[` and `]` are found, to allow arrays in attributes (it's tricky without lexing the contents because `[` might appear inside a string literal, etc.). But for now this slightly improves the current situation.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
