### PR TITLE
chore: update variable names in stdlib tests to be more correct

### DIFF
--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -286,7 +286,7 @@ mod tests {
     fn test_to_be_bytes() {
         let field = 2;
         let bytes: [u8; 8] = field.to_be_bytes();
-        assert_eq(bits, [0, 0, 0, 0, 0, 0, 0, 2]);
+        assert_eq(bytes, [0, 0, 0, 0, 0, 0, 0, 2]);
         assert_eq(Field::from_be_bytes::<8>(bytes), field);
     }
     // docs:end:to_be_bytes_example
@@ -296,7 +296,7 @@ mod tests {
     fn test_to_le_bytes() {
         let field = 2;
         let bytes: [u8; 8] = field.to_le_bytes();
-        assert_eq(bits, [2, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq(bytes, [2, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq(Field::from_le_bytes::<8>(bytes), field);
     }
     // docs:end:to_le_bytes_example
@@ -306,7 +306,7 @@ mod tests {
     fn test_to_be_radix() {
         let field = 2;
         let bytes: [u8; 8] = field.to_be_radix(256);
-        assert_eq(bits, [0, 0, 0, 0, 0, 0, 0, 2]);
+        assert_eq(bytes, [0, 0, 0, 0, 0, 0, 0, 2]);
         assert_eq(Field::from_be_bytes::<8>(bytes), field);
     }
     // docs:end:to_be_radix_example
@@ -316,7 +316,7 @@ mod tests {
     fn test_to_le_radix() {
         let field = 2;
         let bytes: [u8; 8] = field.to_le_radix(256);
-        assert_eq(bits, [2, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq(bytes, [2, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq(Field::from_le_bytes::<8>(bytes), field);
     }
     // docs:end:to_le_radix_example

--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -285,9 +285,9 @@ mod tests {
     // docs:start:to_be_bytes_example
     fn test_to_be_bytes() {
         let field = 2;
-        let bits: [u8; 8] = field.to_be_bytes();
+        let bytes: [u8; 8] = field.to_be_bytes();
         assert_eq(bits, [0, 0, 0, 0, 0, 0, 0, 2]);
-        assert_eq(Field::from_be_bytes::<8>(bits), field);
+        assert_eq(Field::from_be_bytes::<8>(bytes), field);
     }
     // docs:end:to_be_bytes_example
 
@@ -295,9 +295,9 @@ mod tests {
     // docs:start:to_le_bytes_example
     fn test_to_le_bytes() {
         let field = 2;
-        let bits: [u8; 8] = field.to_le_bytes();
+        let bytes: [u8; 8] = field.to_le_bytes();
         assert_eq(bits, [2, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq(Field::from_le_bytes::<8>(bits), field);
+        assert_eq(Field::from_le_bytes::<8>(bytes), field);
     }
     // docs:end:to_le_bytes_example
 
@@ -305,9 +305,9 @@ mod tests {
     // docs:start:to_be_radix_example
     fn test_to_be_radix() {
         let field = 2;
-        let bits: [u8; 8] = field.to_be_radix(256);
+        let bytes: [u8; 8] = field.to_be_radix(256);
         assert_eq(bits, [0, 0, 0, 0, 0, 0, 0, 2]);
-        assert_eq(Field::from_be_bytes::<8>(bits), field);
+        assert_eq(Field::from_be_bytes::<8>(bytes), field);
     }
     // docs:end:to_be_radix_example
 
@@ -315,9 +315,9 @@ mod tests {
     // docs:start:to_le_radix_example
     fn test_to_le_radix() {
         let field = 2;
-        let bits: [u8; 8] = field.to_le_radix(256);
+        let bytes: [u8; 8] = field.to_le_radix(256);
         assert_eq(bits, [2, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq(Field::from_le_bytes::<8>(bits), field);
+        assert_eq(Field::from_le_bytes::<8>(bytes), field);
     }
     // docs:end:to_le_radix_example
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/AztecProtocol/ab2/issues/11

## Summary\*

A byte array is being referred to as `bits` due to some copy-pasting of code.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
