### PR TITLE
fix: check infix expression is valid in program input

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1187,7 +1187,6 @@ impl Type {
             | Type::Forall(_, _)
             | Type::Quoted(_)
             | Type::Slice(_)
-            | Type::InfixExpr(_, _, _)
             | Type::TraitAsType(..) => false,
 
             Type::Alias(alias, generics) => {
@@ -1205,6 +1204,10 @@ impl Type {
                 .get_fields(generics)
                 .into_iter()
                 .all(|(_, field)| field.is_valid_for_program_input()),
+
+            Type::InfixExpr(lhs, _, rhs) => {
+                lhs.is_valid_for_program_input() && rhs.is_valid_for_program_input()
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3623,3 +3623,15 @@ fn use_type_alias_to_generic_concrete_type_in_method_call() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn allows_struct_with_generic_infix_type_as_main_input() {
+    let src = r#"
+        struct Foo<let N: u32> {
+            x: [u64; N * 2],
+        }
+
+        fn main(_x: Foo<18>) {}
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3625,13 +3625,39 @@ fn use_type_alias_to_generic_concrete_type_in_method_call() {
 }
 
 #[test]
-fn allows_struct_with_generic_infix_type_as_main_input() {
+fn allows_struct_with_generic_infix_type_as_main_input_1() {
     let src = r#"
         struct Foo<let N: u32> {
             x: [u64; N * 2],
         }
 
         fn main(_x: Foo<18>) {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn allows_struct_with_generic_infix_type_as_main_input_2() {
+    let src = r#"
+        struct Foo<let N: u32> {
+            x: [u64; N * 2],
+        }
+
+        fn main(_x: Foo<2 * 9>) {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn allows_struct_with_generic_infix_type_as_main_input_3() {
+    let src = r#"
+        struct Foo<let N: u32> {
+            x: [u64; N * 2],
+        }
+
+        global N = 9;
+
+        fn main(_x: Foo<N * 2>) {}
     "#;
     assert_no_errors(src);
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #6438

## Summary

## Additional Context

This doesn't fix the panic that's mentioned [here](https://github.com/zkpassport/noir_rsa/pull/2) though, I'll see if I can find out why that happens.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
