### PR TITLE
fix(sea): mem2reg to treat block input references as alias

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -99,19 +99,19 @@ pub(crate) fn optimize_into_acir(
     .run_pass(Ssa::resolve_is_unconstrained, "After Resolving IsUnconstrained:")
     .run_pass(|ssa| ssa.inline_functions(options.inliner_aggressiveness), "After Inlining:")
     // Run mem2reg with the CFG separated into blocks
-    .run_pass(Ssa::mem2reg, "After Mem2Reg:")
-    .run_pass(Ssa::simplify_cfg, "After Simplifying:")
+    .run_pass(Ssa::mem2reg, "After Mem2Reg (1st):")
+    .run_pass(Ssa::simplify_cfg, "After Simplifying (1st):")
     .run_pass(Ssa::as_slice_optimization, "After `as_slice` optimization")
     .try_run_pass(
         Ssa::evaluate_static_assert_and_assert_constant,
         "After `static_assert` and `assert_constant`:",
     )?
     .try_run_pass(Ssa::unroll_loops_iteratively, "After Unrolling:")?
-    .run_pass(Ssa::simplify_cfg, "After Simplifying:")
+    .run_pass(Ssa::simplify_cfg, "After Simplifying (2nd):")
     .run_pass(Ssa::flatten_cfg, "After Flattening:")
     .run_pass(Ssa::remove_bit_shifts, "After Removing Bit Shifts:")
     // Run mem2reg once more with the flattened CFG to catch any remaining loads/stores
-    .run_pass(Ssa::mem2reg, "After Mem2Reg:")
+    .run_pass(Ssa::mem2reg, "After Mem2Reg (2nd):")
     // Run the inlining pass again to handle functions with `InlineType::NoPredicates`.
     // Before flattening is run, we treat functions marked with the `InlineType::NoPredicates` as an entry point.
     // This pass must come immediately following `mem2reg` as the succeeding passes

--- a/test_programs/execution_success/references/src/main.nr
+++ b/test_programs/execution_success/references/src/main.nr
@@ -1,7 +1,6 @@
 fn main(mut x: Field) {
     add1(&mut x);
     assert(x == 3);
-
     let mut s = S { y: x };
     s.add2();
     assert(s.y == 5);
@@ -21,18 +20,16 @@ fn main(mut x: Field) {
     let mut c = C { foo: 0, bar: &mut C2 { array: &mut [1, 2] } };
     *c.bar.array = [3, 4];
     assert(*c.bar.array == [3, 4]);
-
     regression_1887();
     regression_2054();
     regression_2030();
     regression_2255();
-
+    regression_6443();
     assert(x == 3);
     regression_2218_if_inner_if(x, 10);
     regression_2218_if_inner_else(20, x);
     regression_2218_else(x, 3);
     regression_2218_loop(x, 10);
-
     regression_2560(s_ref);
 }
 
@@ -106,6 +103,7 @@ fn regression_2030() {
     let _ = *array[0];
     *array[0] = 1;
 }
+
 // The `mut x: &mut ...` caught a bug handling lvalues where a double-dereference would occur internally
 // in one step rather than being tracked by two separate steps. This lead to assigning the 1 value to the
 // incorrect outer `mut` reference rather than the correct `&mut` reference.
@@ -116,6 +114,18 @@ fn regression_2255() {
 }
 
 fn regression_2255_helper(mut x: &mut Field) {
+    *x = 1;
+}
+
+// Similar to `regression_2255` but without the double-dereferencing.
+// The test checks that `mem2reg` does not eliminate storing to a reference passed as a parameter.
+fn regression_6443() {
+    let x = &mut 0;
+    regression_6443_helper(x);
+    assert(*x == 1);
+}
+
+fn regression_6443_helper(x: &mut Field) {
     *x = 1;
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6443

## Summary\*

The `mem2reg` SSA pass eliminates stores that have no use, but as testing with different inliner aggressiveness showed it also eliminated stores into mutable references passed to a function. This is an effect that is expected to be visible outside, after the call. It turns out that `PerFuncContext::is_store_alias_used` _does_ consider the input reference parameters of the function as stopping conditions for removing a store to an address, but it does so only if there is an alias for the address which appears in the input parameters. This wasn't the case, and the removal went ahead. 

I added a method that adds a self-alias to all block parameters if they are reference types and don't already have aliases from the merge of the predecessor blocks. 

## Additional Context

See investigation in the ticket, e.g. https://github.com/noir-lang/noir/issues/6443#issuecomment-2456767668 shows a minimal failing form.

After merging this into https://github.com/noir-lang/noir/pull/6429 I only have these tests failing:

```
failures:
    tests::execution_success::test_eddsa::true_0_expects
    tests::execution_success::test_eddsa::true_i64_min_expects
    tests::execution_success::test_slice_dynamic_index::true_i64_min_expects
```

Which means it potentially fixes #6440 and #6442 as well.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
