### PR TITLE
chore: update example to show how to split public inputs in bash

### DIFF
--- a/examples/codegen_verifier/codegen_verifier.sh
+++ b/examples/codegen_verifier/codegen_verifier.sh
@@ -16,10 +16,16 @@ nargo execute witness
 PROOF_PATH=./target/proof
 $BACKEND prove -b ./target/hello_world.json -w ./target/witness.gz -o $PROOF_PATH
 
-NUM_PUBLIC_INPUTS=1
+# Sanity check that proof is valid.
+$BACKEND verify -k ./target/vk -p ./target/proof
+
+NUM_PUBLIC_INPUTS=2
 PUBLIC_INPUT_BYTES=$((32 * $NUM_PUBLIC_INPUTS))
 HEX_PUBLIC_INPUTS=$(head -c $PUBLIC_INPUT_BYTES $PROOF_PATH | od -An -v -t x1 | tr -d $' \n')
 HEX_PROOF=$(tail -c +$(($PUBLIC_INPUT_BYTES + 1)) $PROOF_PATH | od -An -v -t x1 | tr -d $' \n')
+
+# Split public inputs into strings where each string represents a `bytes32`.
+SPLIT_HEX_PUBLIC_INPUTS=$(sed -e 's/.\{64\}/0x&,/g' <<< $HEX_PUBLIC_INPUTS)
 
 # Spin up an anvil node to deploy the contract to
 anvil &
@@ -31,8 +37,7 @@ DEPLOY_INFO=$(forge create UltraVerifier \
 VERIFIER_ADDRESS=$(echo $DEPLOY_INFO | jq -r '.deployedTo')
 
 # Call the verifier contract with our proof.
-# Note that we haven't needed to split up `HEX_PUBLIC_INPUTS` as there's only a single public input
-cast call $VERIFIER_ADDRESS "verify(bytes, bytes32[])(bool)" "0x$HEX_PROOF" "[0x$HEX_PUBLIC_INPUTS]"
+cast call $VERIFIER_ADDRESS "verify(bytes, bytes32[])(bool)" "0x$HEX_PROOF" "[$SPLIT_HEX_PUBLIC_INPUTS]"
 
 # Stop anvil node again
 kill %-

--- a/examples/codegen_verifier/src/main.nr
+++ b/examples/codegen_verifier/src/main.nr
@@ -1,3 +1,3 @@
-fn main(x: Field, y: pub Field) {
+fn main(x: pub Field, y: pub Field) {
     assert(x != y);
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I was debugging a user's issue with the smart contract verifier and needed to be able to run a program with multiple public inputs through this example. I've then modified it to properly split the public inputs string into multiple string to represent each `bytes32`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
