### PR TITLE
fix: Treat all parameters as possible aliases of each other

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -205,14 +205,6 @@ impl Type {
         }
     }
 
-    /// If this is a reference type, return its element type.
-    pub(crate) fn reference_element_type(&self) -> Option<&Type> {
-        match self {
-            Type::Reference(typ) => Some(typ.as_ref()),
-            _ => None,
-        }
-    }
-
     /// True if this is a reference type or if it is a composite type which contains a reference.
     pub(crate) fn contains_reference(&self) -> bool {
         match self {

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -204,6 +204,25 @@ impl Type {
             Type::Slice(element_types) | Type::Array(element_types, _) => element_types[0].first(),
         }
     }
+
+    /// If this is a reference type, return its element type.
+    pub(crate) fn reference_element_type(&self) -> Option<&Type> {
+        match self {
+            Type::Reference(typ) => Some(typ.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// True if this is a reference type or if it is a composite type which contains a reference.
+    pub(crate) fn contains_reference(&self) -> bool {
+        match self {
+            Type::Reference(_) => true,
+            Type::Numeric(_) | Type::Function => false,
+            Type::Array(elements, _) | Type::Slice(elements) => {
+                elements.iter().any(|elem| elem.contains_reference())
+            }
+        }
+    }
 }
 
 /// Composite Types are essentially flattened struct or tuple types.

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -306,7 +306,9 @@ impl<'f> PerFunctionContext<'f> {
     fn analyze_block(&mut self, block: BasicBlockId, mut references: Block) {
         let instructions = self.inserter.function.dfg[block].take_instructions();
 
-        self.add_aliases_for_reference_parameters(block, &mut references);
+        if block == self.inserter.function.entry_block() {
+            self.add_aliases_for_reference_parameters(block, &mut references);
+        }
 
         for instruction in instructions {
             self.analyze_instruction(block, &mut references, instruction);

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -355,23 +355,17 @@ impl<'f> PerFunctionContext<'f> {
         }
 
         for aliases in aliases.into_values() {
-            if let Some(alias) = aliases.single_alias() {
-                let expression =
-                    references.expressions.entry(alias).or_insert(Expression::Other(alias));
-                references
-                    .aliases
-                    .entry(expression.clone())
-                    .or_insert_with(|| AliasSet::known(alias));
-            } else if let Some(first) = aliases.first() {
-                let expression = Expression::Other(first);
-                let previous = references.aliases.insert(expression.clone(), aliases.clone());
-                assert!(previous.is_none());
+            let first = aliases.first();
+            let first = first.expect("All parameters alias at least themselves or we early return");
 
-                aliases.for_each(|alias| {
-                    let previous = references.expressions.insert(alias, expression.clone());
-                    assert!(previous.is_none());
-                });
-            }
+            let expression = Expression::Other(first);
+            let previous = references.aliases.insert(expression.clone(), aliases.clone());
+            assert!(previous.is_none());
+
+            aliases.for_each(|alias| {
+                let previous = references.expressions.insert(alias, expression.clone());
+                assert!(previous.is_none());
+            });
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/alias_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/alias_set.rs
@@ -73,4 +73,11 @@ impl AliasSet {
             }
         }
     }
+
+    /// Return the first ValueId in the alias set as long as there is at least one.
+    /// The ordering is arbitrary (by lowest ValueId) so this method should only be
+    /// used when you need an arbitrary ValueId from the alias set.
+    pub(super) fn first(&self) -> Option<ValueId> {
+        self.aliases.as_ref().and_then(|aliases| aliases.first().copied())
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6474

## Summary\*

We allow mutable aliasing so all parameters can potentially be mutably aliased. We were over-eager in an optimization previously where we assumed parameters weren't aliased, and thus optimized out loads that were needed in some cases.

I've tried to preserve the optimization while fixing the bug best I could. This check is now type-aware so we assume parameters are possibly aliased with any other parameter of the same type, but a `&mut i32` cannot alias a `&mut Field`. The only caveat is that we can't really handle arrays or reference types containing other references within so for these we revert to the pre-optimization behavior of assuming `AliasSet::unknown()` for all references since these nested references may also reference other parameters but we don't have the ValueIds to be able to say "these inner references may _only_ reference other parameters (and not other references inside the function).

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
