### PR TITLE
feat: use a full `BlackBoxFunctionSolver` implementation when execution brillig during acirgen

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs
@@ -13,6 +13,7 @@ use acvm::acir::circuit::opcodes::{
 };
 use acvm::acir::circuit::{AssertionPayload, ExpressionOrMemory, ExpressionWidth, Opcode};
 use acvm::brillig_vm::{MemoryValue, VMStatus, VM};
+use acvm::BlackBoxFunctionSolver;
 use acvm::{
     acir::AcirField,
     acir::{
@@ -107,7 +108,9 @@ impl From<NumericType> for AcirType {
 /// Context object which holds the relationship between
 /// `Variables`(AcirVar) and types such as `Expression` and `Witness`
 /// which are placed into ACIR.
-pub(crate) struct AcirContext<F: AcirField> {
+pub(crate) struct AcirContext<F: AcirField, B: BlackBoxFunctionSolver<F>> {
+    blackbox_solver: B,
+
     /// Two-way map that links `AcirVar` to `AcirVarData`.
     ///
     /// The vars object is an instance of the `TwoWayMap`, which provides a bidirectional mapping between `AcirVar` and `AcirVarData`.
@@ -132,7 +135,7 @@ pub(crate) struct AcirContext<F: AcirField> {
     pub(crate) warnings: Vec<SsaReport>,
 }
 
-impl<F: AcirField> AcirContext<F> {
+impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
     pub(crate) fn set_expression_width(&mut self, expression_width: ExpressionWidth) {
         self.expression_width = expression_width;
     }
@@ -1758,8 +1761,8 @@ impl<F: AcirField> AcirContext<F> {
             brillig_stdlib_func,
         );
 
-        fn range_constraint_value<G: AcirField>(
-            context: &mut AcirContext<G>,
+        fn range_constraint_value<G: AcirField, C: BlackBoxFunctionSolver<G>>(
+            context: &mut AcirContext<G, C>,
             value: &AcirValue,
         ) -> Result<(), RuntimeError> {
             match value {
@@ -1878,7 +1881,7 @@ impl<F: AcirField> AcirContext<F> {
         inputs: &[BrilligInputs<F>],
         outputs_types: &[AcirType],
     ) -> Option<Vec<AcirValue>> {
-        let mut memory = (execute_brillig(code, inputs)?).into_iter();
+        let mut memory = (execute_brillig(code, &self.blackbox_solver, inputs)?).into_iter();
 
         let outputs_var = vecmap(outputs_types.iter(), |output| match output {
             AcirType::NumericType(_) => {
@@ -2164,8 +2167,9 @@ pub(crate) struct AcirVar(usize);
 /// Returns the finished state of the Brillig VM if execution can complete.
 ///
 /// Returns `None` if complete execution of the Brillig bytecode is not possible.
-fn execute_brillig<F: AcirField>(
+fn execute_brillig<F: AcirField, B: BlackBoxFunctionSolver<F>>(
     code: &[BrilligOpcode<F>],
+    blackbox_solver: &B,
     inputs: &[BrilligInputs<F>],
 ) -> Option<Vec<MemoryValue<F>>> {
     // Set input values
@@ -2191,12 +2195,8 @@ fn execute_brillig<F: AcirField>(
     }
 
     // Instantiate a Brillig VM given the solved input registers and memory, along with the Brillig bytecode.
-    //
-    // We pass a stubbed solver here as a concrete solver implies a field choice which conflicts with this function
-    // being generic.
-    let solver = acvm::blackbox_solver::StubbedBlackBoxSolver;
     let profiling_active = false;
-    let mut vm = VM::new(calldata, code, Vec::new(), &solver, profiling_active);
+    let mut vm = VM::new(calldata, code, Vec::new(), blackbox_solver, profiling_active);
 
     // Run the Brillig VM on these inputs, bytecode, etc!
     let vm_status = vm.process_opcodes();

--- a/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs
@@ -30,6 +30,7 @@ use crate::brillig::{brillig_gen::brillig_fn::FunctionContext as BrilligFunction
 use crate::errors::{InternalError, InternalWarning, RuntimeError, SsaReport};
 pub(crate) use acir_ir::generated_acir::GeneratedAcir;
 use acvm::acir::circuit::opcodes::{AcirFunctionId, BlockType};
+use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use noirc_frontend::monomorphization::ast::InlineType;
 
 use acvm::acir::circuit::brillig::{BrilligBytecode, BrilligFunctionId};
@@ -156,7 +157,7 @@ struct Context<'a> {
     current_side_effects_enabled_var: AcirVar,
 
     /// Manages and builds the `AcirVar`s to which the converted SSA values refer.
-    acir_context: AcirContext<FieldElement>,
+    acir_context: AcirContext<FieldElement, Bn254BlackBoxSolver>,
 
     /// Track initialized acir dynamic arrays
     ///


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently do not solve any field specific blackbox functions when solving brillig calls during acirgen which results in less optimized acir. This PR updates the acir context so that we pass in a full `Bn254BlackBoxSolver`

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
