### PR TITLE
feat: avoid duplicate arrays in SSA

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
@@ -51,6 +51,14 @@ impl<'f> FunctionInserter<'f> {
 
                     let new_array_clone = new_array.clone();
                     let new_id = self.function.dfg.make_array(new_array, typ.clone());
+
+                    // If we got the same value (can happen because a function's dfg will cache
+                    // identical arrays) we don't cache the new value as it would end to an infinite loop
+                    // when trying to resolve it.
+                    if new_id == value {
+                        return value;
+                    }
+
                     self.values.insert(value, new_id);
                     self.const_arrays.insert((new_array_clone, typ), new_id);
                     new_id

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -844,9 +844,7 @@ mod test {
         assert_eq!(instructions.len(), 10);
     }
 
-    // This test currently fails. It being fixed will address the issue https://github.com/noir-lang/noir/issues/5756
     #[test]
-    #[should_panic]
     fn constant_array_deduplication() {
         // fn main f0 {
         //   b0(v0: u64):


### PR DESCRIPTION
# Description

## Problem

Resolves #5756

## Summary

Though I didn't notice the example program was reduced by a lot (the keccak call did disappear, but a lot of constrains and array_get are still there).

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
