### PR TITLE
chore: switch to 1.0.0-beta versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,9 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@v4
         with:
           token: ${{ secrets.NOIR_RELEASES_TOKEN }}
-          command: manifest
 
   update-acvm-workspace-package-versions:
     name: Update acvm workspace package versions

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,11 +3,13 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "prerelease": true,
+  "prerelease-type": "beta",
   "pull-request-title-pattern": "chore: Release Noir(${version})",
   "group-pull-request-title-pattern": "chore: Release Noir(${version})",
   "packages": {
     ".": {
       "release-type": "simple",
+      "versioning": "prerelease",
       "component": "noir",
       "package-name": "noir",
       "include-component-in-tag": false,
@@ -52,6 +54,7 @@
     },
     "acvm-repo": {
       "release-type": "simple",
+      "versioning": "prerelease",
       "package-name": "acvm",
       "component": "acvm",
       "include-component-in-tag": false,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR switches release-please over to using `1.0.0-beta.0` versioning. The final digit will keep increasing until we switch back to the normal versioning strategy.

Before we merge this I need to do some thinking on what potential knock on effects there may be on npm/crates.io releases.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
