### PR TITLE
fix: set local_module before elaborating each trait

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -23,6 +23,8 @@ use super::Elaborator;
 impl<'context> Elaborator<'context> {
     pub fn collect_traits(&mut self, traits: &BTreeMap<TraitId, UnresolvedTrait>) {
         for (trait_id, unresolved_trait) in traits {
+            self.local_module = unresolved_trait.module_id;
+
             self.recover_generics(|this| {
                 this.current_trait = Some(*trait_id);
 

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -294,3 +294,23 @@ fn no_warning_on_self_in_trait_impl() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn resolves_trait_where_clause_in_the_correct_module() {
+    // This is a regression test for https://github.com/noir-lang/noir/issues/6479
+    let src = r#" 
+    mod foo {
+        pub trait Foo {}
+    }
+    
+    use foo::Foo;
+    
+    pub trait Bar<T>
+    where
+        T: Foo,
+    {}
+    
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/6479

## Summary

This was actually more than just a visibility bug: it could happen that we just elaborated a trait in a nested module, and `local_module` ended up in that nested module; then finding types for where clauses would find them even if they were normally unreachable. For example this code compiled fine:

```noir
mod foo {
    pub trait Foo {}
}

pub trait Bar<T>
where
    T: Foo, // Here Foo was incorrectly found
{}
```

## Additional Context

I wonder if directly setting `local_module` should be forbidden, and instead we should always use `replace_module`.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
