### PR TITLE
chore: Parse negatives in SSA parser

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/parser.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser.rs
@@ -735,10 +735,17 @@ impl<'a> Parser<'a> {
     }
 
     fn eat_int(&mut self) -> ParseResult<Option<FieldElement>> {
+        let negative = self.eat(Token::Dash)?;
+
         if matches!(self.token.token(), Token::Int(..)) {
             let token = self.bump()?;
             match token.into_token() {
-                Token::Int(int) => Ok(Some(int)),
+                Token::Int(mut int) => {
+                    if negative {
+                        int = -int;
+                    }
+                    Ok(Some(int))
+                }
                 _ => unreachable!(),
             }
         } else {

--- a/compiler/noirc_evaluator/src/ssa/parser/lexer.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/lexer.rs
@@ -60,6 +60,7 @@ impl<'a> Lexer<'a> {
             Some(']') => self.single_char_token(Token::RightBracket),
             Some('&') => self.single_char_token(Token::Ampersand),
             Some('-') if self.peek_char() == Some('>') => self.double_char_token(Token::Arrow),
+            Some('-') => self.single_char_token(Token::Dash),
             Some(ch) if ch.is_ascii_alphanumeric() || ch == '_' => self.eat_alpha_numeric(ch),
             Some(char) => Err(LexerError::UnexpectedCharacter {
                 char,

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -425,3 +425,14 @@ fn test_slice() {
         ";
     assert_ssa_roundtrip(src);
 }
+
+#[test]
+fn test_negative() {
+    let src = "
+        acir(inline) fn main f0 {
+          b0():
+            return Field -1
+        }
+        ";
+    assert_ssa_roundtrip(src);
+}

--- a/compiler/noirc_evaluator/src/ssa/parser/token.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/token.rs
@@ -57,6 +57,8 @@ pub(crate) enum Token {
     Equal,
     /// &
     Ampersand,
+    /// -
+    Dash,
     Eof,
 }
 
@@ -90,6 +92,7 @@ impl Display for Token {
             Token::Arrow => write!(f, "->"),
             Token::Equal => write!(f, "=="),
             Token::Ampersand => write!(f, "&"),
+            Token::Dash => write!(f, "-"),
             Token::Eof => write!(f, "(end of stream)"),
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

SSA parser does not parse negative integer values currently

## Summary\*

Found while updating https://github.com/noir-lang/noir/pull/6434

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
