### PR TITLE
chore: Reverse ssa parser diff order

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -44,7 +44,7 @@ pub(crate) fn assert_normalized_ssa_equals(mut ssa: super::Ssa, expected: &str) 
     let expected = trim_leading_whitespace_from_lines(expected);
 
     if ssa != expected {
-        println!("Got:\n~~~\n{}\n~~~\nExpected:\n~~~\n{}\n~~~", ssa, expected);
-        similar_asserts::assert_eq!(ssa, expected);
+        println!("Expected:\n~~~\n{expected}\n~~~\nGot:\n~~~\n{ssa}\n~~~");
+        similar_asserts::assert_eq!(expected, ssa);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

The parser diff appears reversed when an SSA test is incorrect so I swapped the order so that it is more natural.

## Additional Context

Before it resembled:
```
- actual line
+ expected line
```
This reverses it to be more like a git diff:
```
- expected line
+ actual line
```

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
