### PR TITLE
chore(ci: bump mac github runner image to `macos-14`

### DIFF
--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   build-apple-darwin:
-    runs-on: macos-12
+    runs-on: macos-14
     env:
       CROSS_CONFIG: ${{ github.workspace }}/.github/Cross.toml
       NIGHTLY_RELEASE: ${{ inputs.tag == '' }}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently us `macos-12` but this is now deprecated https://github.com/actions/runner-images/issues/10721

This PR updates us to `macos-14`

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
