### PR TITLE
chore: revert #6375

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -458,7 +458,13 @@ impl FunctionBuilder {
         match self.type_of_value(value) {
             Type::Numeric(_) => (),
             Type::Function => (),
-            Type::Reference(_) => (),
+            Type::Reference(element) => {
+                if element.contains_an_array() {
+                    let reference = value;
+                    let value = self.insert_load(reference, element.as_ref().clone());
+                    self.update_array_reference_count(value, increment);
+                }
+            }
             Type::Array(..) | Type::Slice(..) => {
                 // If there are nested arrays or slices, we wait until ArrayGet
                 // is issued to increment the count of that array.


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Reverts #6375 as it was causing problems in aztec-packages and this change keeps reoccurring in syncs.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
