### PR TITLE
fix: Do a shallow follow_bindings before unification

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -959,7 +959,8 @@ impl<'interner> Monomorphizer<'interner> {
 
     /// Convert a non-tuple/struct type to a monomorphized type
     fn convert_type(typ: &HirType, location: Location) -> Result<ast::Type, MonomorphizationError> {
-        Ok(match typ {
+        let typ = typ.follow_bindings_shallow();
+        Ok(match typ.as_ref() {
             HirType::FieldElement => ast::Type::Field,
             HirType::Integer(sign, bits) => ast::Type::Integer(*sign, *bits),
             HirType::Bool => ast::Type::Bool,
@@ -1125,7 +1126,8 @@ impl<'interner> Monomorphizer<'interner> {
 
     // Similar to `convert_type` but returns an error if any type variable can't be defaulted.
     fn check_type(typ: &HirType, location: Location) -> Result<(), MonomorphizationError> {
-        match typ {
+        let typ = typ.follow_bindings_shallow();
+        match typ.as_ref() {
             HirType::FieldElement
             | HirType::Integer(..)
             | HirType::Bool


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6457

## Summary\*

Finishes monomorphization in the program above in ~1.3s on my machine compared to master which stack overflows after 1min 12s.

Fixes the issue by performing a shallow follow bindings call before each unification. This follows immediate type variable links but stops once a non-type variable is reached. This prevents the issue in the program above because previously in unification we'd unify as soon as possible. If `self` is unbound but `other` is a bound type variable, we could be continuously adding another link to the chain. E.g. `tv3 -> tv2 -> tv1 -> Field` unified with `tv4` may become `tv4 -> tv3 -> tv2 -> tv1 -> Field`.

With this change we follow bindings beforehand so we'd unify `tv4` to `Field` and would never build up the large chain to begin with.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
