### PR TITLE
chore: embed package name in logs

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -282,7 +282,7 @@ pub fn add_dep(
 ///
 /// This returns a (possibly empty) vector of any warnings found on success.
 /// On error, this returns a non-empty vector of warnings and error messages, with at least one error.
-#[tracing::instrument(level = "trace", skip(context))]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn check_crate(
     context: &mut Context,
     crate_id: CrateId,

--- a/cspell.json
+++ b/cspell.json
@@ -235,6 +235,7 @@
         "varargs",
         "vecmap",
         "vitkov",
+        "walkdir",
         "wasi",
         "wasmer",
         "Weierstraß",

--- a/tooling/nargo/src/ops/compile.rs
+++ b/tooling/nargo/src/ops/compile.rs
@@ -75,6 +75,7 @@ pub fn compile_program(
     )
 }
 
+#[tracing::instrument(level = "trace", name = "compile_program" skip_all, fields(package = package.name.to_string()))]
 pub fn compile_program_with_debug_instrumenter(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,
@@ -92,6 +93,7 @@ pub fn compile_program_with_debug_instrumenter(
     noirc_driver::compile_main(&mut context, crate_id, compile_options, cached_program)
 }
 
+#[tracing::instrument(level = "trace", skip_all, fields(package_name = package.name.to_string()))]
 pub fn compile_contract(
     file_manager: &FileManager,
     parsed_files: &ParsedFiles,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Currently we don't allow easy distinguishing between the output for different packages within a workspace. This PR adds a span for this which we label with the package name.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
