### PR TITLE
feat: Avoid incrementing reference counts in some cases

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -916,9 +916,10 @@ impl<'a> FunctionContext<'a> {
         let parameters = self.builder.current_function.dfg.block_parameters(entry).to_vec();
 
         for parameter in parameters {
-            // Use `update_array_reference_count` here to avoid reference counts for
-            // immutable arrays that aren't behind references.
-            self.builder.update_array_reference_count(parameter, true, false);
+            // Avoid reference counts for immutable arrays that aren't behind references.
+            if self.builder.current_function.dfg.value_is_reference(parameter) {
+                self.builder.increment_array_reference_count(parameter);
+            }
         }
 
         entry
@@ -935,7 +936,9 @@ impl<'a> FunctionContext<'a> {
         dropped_parameters.retain(|parameter| !terminator_args.contains(parameter));
 
         for parameter in dropped_parameters {
-            self.builder.update_array_reference_count(parameter, false, false);
+            if self.builder.current_function.dfg.value_is_reference(parameter) {
+                self.builder.decrement_array_reference_count(parameter);
+            }
         }
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Fixes https://github.com/noir-lang/noir/issues/6565

## Summary\*

Avoids incrementing array reference counts in some cases:
- If the parameter is an immutable array (we used to rely on the remove paired rc pass for this case)
- No longer increment rcs when dereferencing lvalues

## Additional Context

Since immutable arrays no longer issue rc instructions, the "remove paired rcs" pass is less needed. Now it only really applies when a user passes a mutable array but never mutates it (although it does still apply if that array is only passed to other mutating functions which is useful).

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
