### PR TITLE
feat: Don't increment parameter ref counts at all

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -929,7 +929,7 @@ impl<'a> FunctionContext<'a> {
     /// This will issue DecrementRc instructions for any arrays in the given starting scope
     /// block's parameters. Arrays that are also used in terminator instructions for the scope are
     /// ignored.
-    pub(crate) fn end_scope(&mut self, scope: BasicBlockId, terminator_args: &[ValueId]) {
+    pub(crate) fn end_function(&mut self, scope: BasicBlockId, terminator_args: &[ValueId]) {
         let mut dropped_parameters =
             self.builder.current_function.dfg.block_parameters(scope).to_vec();
 

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -125,10 +125,10 @@ impl<'a> FunctionContext<'a> {
     /// Codegen a function's body and set its return value to that of its last parameter.
     /// For functions returning nothing, this will be an empty list.
     fn codegen_function_body(&mut self, body: &Expression) -> Result<(), RuntimeError> {
-        let entry_block = self.increment_parameter_rcs();
+        // let entry_block = self.builder.current_function.entry_block(); // self.increment_parameter_rcs();
         let return_value = self.codegen_expression(body)?;
         let results = return_value.into_value_list(self);
-        self.end_scope(entry_block, &results);
+        // self.end_function(entry_block, &results);
 
         self.builder.terminate_with_return(results);
         Ok(())


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

We may not need to increment reference counts in parameters at all since https://github.com/noir-lang/noir/pull/6568 eliminates them for arrays, and previously we had eliminated them for references as well, though this was reverted. This PR is speculation that the reversion was only needed because we forgot to also remove the dec_rc in that case, leading to reference counts drifting down too far.

## Additional Context

This is passing locally but I think we're missing a inc_rc when dereferencing that is now required with this change.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
