### PR TITLE
chore: redo typo PR by donatik27

### DIFF
--- a/docs/docs/noir/standard_library/mem.md
+++ b/docs/docs/noir/standard_library/mem.md
@@ -42,7 +42,7 @@ fn checked_transmute<T, U>(value: T) -> U
 Transmutes a value of one type into the same value but with a new type `U`.
 
 This function is safe to use since both types are asserted to be equal later during compilation after the concrete values for generic types become known.
-This function is useful for cases where the compiler may fails a type check that is expected to pass where
+This function is useful for cases where the compiler may fail a type check that is expected to pass where
 a user knows the two types to be equal. For example, when using arithmetic generics there are cases the compiler
 does not see as equal, such as `[Field; N*(A + B)]` and `[Field; N*A + N*B]`, which users may know to be equal.
 In these cases, `checked_transmute` can be used to cast the value to the desired type while also preserving safety

--- a/docs/docs/noir/standard_library/meta/index.md
+++ b/docs/docs/noir/standard_library/meta/index.md
@@ -128,7 +128,7 @@ way to write your derive handler. The arguments are as follows:
 - `for_each_field`: An operation to be performed on each field. E.g. `|name| quote { (self.$name == other.$name) }`.
 - `join_fields_with`: A separator to join each result of `for_each_field` with.
   E.g. `quote { & }`. You can also use an empty `quote {}` for no separator.
-- `body`: The result of the field operations are passed into this function for any final processing.
+- `body`: The result of the field operations is passed into this function for any final processing.
   This is the place to insert any setup/teardown code the trait requires. If the trait doesn't require
   any such code, you can return the body as-is: `|body| body`.
 

--- a/docs/docs/noir/standard_library/meta/typ.md
+++ b/docs/docs/noir/standard_library/meta/typ.md
@@ -101,7 +101,7 @@ If this is a tuple type, returns each element type of the tuple.
 Retrieves the trait implementation that implements the given
 trait constraint for this type. If the trait constraint is not
 found, `None` is returned. Note that since the concrete trait implementation
-for a trait constraint specified from a `where` clause is unknown,
+for a trait constraint specified in a `where` clause is unknown,
 this function will return `None` in these cases. If you only want to know
 whether a type implements a trait, use `implements` instead.
 


### PR DESCRIPTION
Thanks donatik27 for https://github.com/noir-lang/noir/pull/6573. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.