### PR TITLE
feat(opt): Reduce array cloning by initializing refcounts to 0, not 1

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
@@ -12,6 +12,8 @@ use super::{
     BrilligContext, ReservedRegisters, BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
 };
 
+const INITIAL_ARRAY_REF_COUNT: usize = 0;
+
 impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
     /// Allocates an array of size `size` and stores the pointer to the array
     /// in `pointer_register`
@@ -424,7 +426,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.indirect_const_instruction(
             array.pointer,
             BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
-            1_usize.into(),
+            INITIAL_ARRAY_REF_COUNT.into(),
         );
     }
 
@@ -438,7 +440,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.indirect_const_instruction(
             vector.pointer,
             BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
-            1_usize.into(),
+            INITIAL_ARRAY_REF_COUNT.into(),
         );
 
         // Write size
@@ -498,7 +500,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.indirect_const_instruction(
             vector.pointer,
             BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
-            1_usize.into(),
+            INITIAL_ARRAY_REF_COUNT.into(),
         );
 
         // Initialize size


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

I noticed after storing an array in a variable we were always issuing an `inc_rc` which lead to arrays having an rc of `2` to begin with instead of `1`, meaning the first mutation would always be cloned.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
