### PR TITLE
fix: consider prereleases to be compatible with pre-1.0.0 releases

### DIFF
--- a/tooling/nargo_toml/src/errors.rs
+++ b/tooling/nargo_toml/src/errors.rs
@@ -80,6 +80,8 @@ pub enum ManifestError {
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum SemverError {
+    #[error("Invalid value for `compiler_version` in package {package_name}. Requirements may only refer to full releases")]
+    InvalidCompilerVersionRequirement { package_name: CrateName, required_compiler_version: String },
     #[error("Incompatible compiler version in package {package_name}. Required compiler version is {required_compiler_version} but the compiler version is {compiler_version_found}.\n Update the compiler_version field in Nargo.toml to >={required_compiler_version} or compile this project with version {required_compiler_version}")]
     IncompatibleVersion {
         package_name: CrateName,


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6578 

## Summary\*

This is a quick fix for #6578. We now treat prereleases as equivalent to the full releases for the purposes of `compiler_version` and can address this more permanently closer to the 1.0.0 release.

I've also disallowed placing requirements on compiler versions other than standard releases in order to simplify things.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
