### PR TITLE
fix: remove `compiler_version` from new `Nargo.toml`

### DIFF
--- a/tooling/nargo_cli/src/cli/init_cmd.rs
+++ b/tooling/nargo_cli/src/cli/init_cmd.rs
@@ -5,7 +5,6 @@ use super::NargoConfig;
 use clap::Args;
 use nargo::constants::{PKG_FILE, SRC_DIR};
 use nargo::package::{CrateName, PackageType};
-use noirc_driver::NOIRC_VERSION;
 use std::path::PathBuf;
 
 /// Create a Noir project in the current directory.
@@ -66,7 +65,6 @@ pub(crate) fn initialize_project(
 name = "{package_name}"
 type = "{package_type}"
 authors = [""]
-compiler_version = ">={NOIRC_VERSION}"
 
 [dependencies]"#
     );


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

`nargo new` will create `Nargo.toml` file with an invalid `compiler_version` field after #6580 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
