### PR TITLE
feat(ssa): Expand instructions that can be hoisted in loop invariant code motion

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -341,7 +341,7 @@ mod test {
         // However, as the instruction has side effects, we want to make sure
         // we do not hoist the instruction to the loop preheader.
         // Keeping this load then also prevents any instructions that use
-        // this load result from being hoisted as well.
+        // the load's result from being hoisted as well.
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: u32, v1: u32):


### PR DESCRIPTION
# Description

## Problem\*

No issue as something I noticed while profiling the blob

## Summary\*

~~In https://github.com/noir-lang/noir/pull/6563 we added a pass for loop invariant code motion. In the PR we block hoisting instructions out of loops that may have side effects or are unsafe to hoist (such as load and store). We reuse the `can_be_deduplicated` method on `Instruction`. However, PR #6563 was too restrictive and set `deduplicate_with_predicate` to be false. This prevents operations such as `ArrayGet` and `ArraySet` with dynamic indices from being hoisted. In ACIR gen this is not safe as we rely on the `EnableSideEffectsIf` context to appropriately handle predicates, but as loop invariant code motion only applies to Brillig we can safely hoist these instructions.~~

EDIT: This would require extra logic and checks so going to close this PR for now. 

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
