### PR TITLE
chore: remove temporary allocations from `num_bits`

### DIFF
--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -371,6 +371,12 @@ mod tests {
     use super::{AcirField, FieldElement};
     use proptest::prelude::*;
 
+    #[test]
+    fn requires_one_bit_to_hold_zero() {
+        let field = FieldElement::<ark_bn254::Fr>::zero();
+        assert_eq!(field.num_bits(), 1);
+    }
+    
     proptest! {
         #[test]
         fn num_bits_agrees_with_ilog2(num in 1u128..) {

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -213,7 +213,11 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
         let mut iter = bytes.iter().skip_while(|x| (**x) == 0);
 
         // The first non-zero byte in the decomposition may have some leading zero-bits.
-        let head_byte = iter.next().copied().unwrap_or(0);
+        let Some(head_byte) = iter.next() else {
+            // If we don't have a non-zero byte then the field element is zero,
+            // which we consider to require a single bit to represent.
+            return 1;
+        };
         let num_bits_for_head_byte = head_byte.ilog2();
 
         // Each remaining byte in the byte decomposition requires 8 bits.

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -376,7 +376,7 @@ mod tests {
         let field = FieldElement::<ark_bn254::Fr>::zero();
         assert_eq!(field.num_bits(), 1);
     }
-    
+
     proptest! {
         #[test]
         fn num_bits_agrees_with_ilog2(num in 1u128..) {

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -373,7 +373,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn num_bits_agrees_with_ilog2(num: u128) {
+        fn num_bits_agrees_with_ilog2(num in 1u128..) {
             let field = FieldElement::<ark_bn254::Fr>::from(num);
             prop_assert_eq!(field.num_bits(), num.ilog2());
         }

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -371,6 +371,14 @@ mod tests {
     use super::{AcirField, FieldElement};
     use proptest::prelude::*;
 
+    proptest! {
+        #[test]
+        fn num_bits_agrees_with_ilog2(num: u128) {
+            let field = FieldElement::<ark_bn254::Fr>::from(num);
+            prop_assert_eq!(field.num_bits(), num.ilog2());
+        }
+    }
+
     #[test]
     fn serialize_fixed_test_vectors() {
         // Serialized field elements from of 0, -1, -2, -3


### PR DESCRIPTION
# Description

## Problem\*

Closes #4759 

## Summary\*

I found this due to #6550.

We make heavy use of the `num_bits` method during compilation but this is currently doing a lot of unnecessary allocations in order to perform a full bit decomposition of the field element. We can rework this to work on the byte decomposition which removes 96% of all the temporary allocations from compilation.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
