### PR TITLE
fix: preserve newlines between comments when formatting statements

### DIFF
--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -1165,7 +1165,7 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
 
         // Finally format the comment, if any
         group.text(self.chunk(|formatter| {
-            formatter.skip_comments_and_whitespace();
+            formatter.skip_comments_and_whitespace_writing_multiple_lines_if_found();
         }));
 
         group.decrease_indentation();

--- a/tooling/nargo_fmt/src/formatter/function.rs
+++ b/tooling/nargo_fmt/src/formatter/function.rs
@@ -575,4 +575,34 @@ fn baz() { let  z  = 3  ;
         let expected = src;
         assert_format(src, expected);
     }
+
+    #[test]
+    fn keeps_newlines_between_comments_no_statements() {
+        let src = "fn foo() {
+    // foo
+
+    // bar
+
+    // baz
+}
+";
+        let expected = src;
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn keeps_newlines_between_comments_one_statement() {
+        let src = "fn foo() {
+    let x = 1;
+
+    // foo
+
+    // bar
+
+    // baz
+}
+";
+        let expected = src;
+        assert_format(src, expected);
+    }
 }


### PR DESCRIPTION
# Description

## Problem

Just a small formatter issue I found while trying to reduce some code by commenting it.

## Summary

Previously this code:

```noir
fn main() {
    let a = 1;

    // let x = 1;

    // let y = 2;
}
```

was formatted to this one:

```noir
fn main() {
    let a = 1;

    // let x = 1;
    // let y = 2;
}
```

With this PR the newline between comments is preserved.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
