### PR TITLE
chore: derive PartialEq and Hash for FieldElement

### DIFF
--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -9,7 +9,7 @@ use crate::AcirField;
 
 // XXX: Switch out for a trait and proper implementations
 // This implementation is inefficient, can definitely remove hex usage and Iterator instances for trivial functionality
-#[derive(Default, Clone, Copy, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FieldElement<F: PrimeField>(F);
 
 impl<F: PrimeField> std::fmt::Display for FieldElement<F> {
@@ -40,18 +40,6 @@ impl<F: PrimeField> std::fmt::Display for FieldElement<F> {
 impl<F: PrimeField> std::fmt::Debug for FieldElement<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
-    }
-}
-
-impl<F: PrimeField> std::hash::Hash for FieldElement<F> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write(&self.to_be_bytes());
-    }
-}
-
-impl<F: PrimeField> PartialEq for FieldElement<F> {
-    fn eq(&self, other: &Self) -> bool {
-        self.to_be_bytes() == other.to_be_bytes()
     }
 }
 


### PR DESCRIPTION
# Description

## Problem

`FieldElement::hash` and `FieldElement::eq` allocate by calling `to_be_bytes`. We can derive these traits by delegating to the internal `Fp` implementation.

## Summary

I _think_ the internal `Fp` implementation holds a BigInt, which is a wrapper around `[u64; N]`, and that's what's hashed, so I guess hashing that involves no memory allocations. Same for equality comparison.

## Additional Context

But maybe there's a reason these weren't derived in the first place...?

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
