### PR TITLE
fix: LSP code action wasn't triggering on beginning or end of identifier

### DIFF
--- a/compiler/noirc_errors/src/position.rs
+++ b/compiler/noirc_errors/src/position.rs
@@ -95,7 +95,7 @@ impl Span {
     }
 
     pub fn intersects(&self, other: &Span) -> bool {
-        self.end() > other.start() && self.start() < other.end()
+        self.end() >= other.start() && self.start() <= other.end()
     }
 
     pub fn is_smaller(&self, other: &Span) -> bool {

--- a/compiler/noirc_errors/src/position.rs
+++ b/compiler/noirc_errors/src/position.rs
@@ -97,6 +97,8 @@ impl Span {
     /// Returns `true` if any point of `self` intersects a point of `other`.
     /// If either span is empty, the point where the span is empty is considered
     /// to be part of the span (so, for example, `1..1` intersects `1..3`).
+    /// If both spans are empty, they are considered to intersect if they are the same
+    /// span (so `1..1` intersects `1..1`).
     pub fn intersects(&self, other: &Span) -> bool {
         self.end() >= other.start() && self.start() <= other.end()
     }

--- a/compiler/noirc_errors/src/position.rs
+++ b/compiler/noirc_errors/src/position.rs
@@ -95,10 +95,7 @@ impl Span {
     }
 
     /// Returns `true` if any point of `self` intersects a point of `other`.
-    /// If either span is empty, the point where the span is empty is considered
-    /// to be part of the span (so, for example, `1..1` intersects `1..3`).
-    /// If both spans are empty, they are considered to intersect if they are the same
-    /// span (so `1..1` intersects `1..1`).
+    /// Adjacent spans are considered to intersect (so, for example, `0..1` intersects `1..3`).
     pub fn intersects(&self, other: &Span) -> bool {
         self.end() >= other.start() && self.start() <= other.end()
     }

--- a/compiler/noirc_errors/src/position.rs
+++ b/compiler/noirc_errors/src/position.rs
@@ -94,6 +94,9 @@ impl Span {
         self.start() <= other.start() && self.end() >= other.end()
     }
 
+    /// Returns `true` if any point of `self` intersects a point of `other`.
+    /// If either span is empty, the point where the span is empty is considered
+    /// to be part of the span (so, for example, `1..1` intersects `1..3`).
     pub fn intersects(&self, other: &Span) -> bool {
         self.end() >= other.start() && self.start() <= other.end()
     }
@@ -138,5 +141,39 @@ impl Location {
 
     pub fn contains(&self, other: &Location) -> bool {
         self.file == other.file && self.span.contains(&other.span)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Span;
+
+    #[test]
+    fn test_intersects() {
+        assert!(Span::from(5..10).intersects(&Span::from(5..10)));
+
+        assert!(Span::from(5..10).intersects(&Span::from(5..5)));
+        assert!(Span::from(5..5).intersects(&Span::from(5..10)));
+
+        assert!(Span::from(10..10).intersects(&Span::from(5..10)));
+        assert!(Span::from(5..10).intersects(&Span::from(10..10)));
+
+        assert!(Span::from(5..10).intersects(&Span::from(6..9)));
+        assert!(Span::from(6..9).intersects(&Span::from(5..10)));
+
+        assert!(Span::from(5..10).intersects(&Span::from(4..11)));
+        assert!(Span::from(4..11).intersects(&Span::from(5..10)));
+
+        assert!(Span::from(5..10).intersects(&Span::from(4..6)));
+        assert!(Span::from(4..6).intersects(&Span::from(5..10)));
+
+        assert!(Span::from(5..10).intersects(&Span::from(9..11)));
+        assert!(Span::from(9..11).intersects(&Span::from(5..10)));
+
+        assert!(!Span::from(5..10).intersects(&Span::from(3..4)));
+        assert!(!Span::from(3..4).intersects(&Span::from(5..10)));
+
+        assert!(!Span::from(5..10).intersects(&Span::from(11..12)));
+        assert!(!Span::from(11..12).intersects(&Span::from(5..10)));
     }
 }

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -189,6 +189,31 @@ fn foo(x: SomeTypeInBar) {}"#;
     }
 
     #[test]
+    async fn test_import_code_action_for_struct_at_beginning_of_name() {
+        let title = "Import foo::bar::SomeTypeInBar";
+
+        let src = r#"mod foo {
+    pub mod bar {
+        pub struct SomeTypeInBar {}
+    }
+}
+
+fn foo(x: >|<SomeTypeInBar) {}"#;
+
+        let expected = r#"use foo::bar::SomeTypeInBar;
+
+mod foo {
+    pub mod bar {
+        pub struct SomeTypeInBar {}
+    }
+}
+
+fn foo(x: SomeTypeInBar) {}"#;
+
+        assert_code_action(title, src, expected).await;
+    }
+
+    #[test]
     async fn test_qualify_code_action_for_module() {
         let title = "Qualify as foo::bar::some_module_in_bar";
 


### PR DESCRIPTION
# Description

## Problem

I noticed that LSP code actions weren't triggering when the cursor was right at the beginning (or end) of an identifier. This is a very common use case so this PR fixes that.

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
