### PR TITLE
fix(ssa): Track all local allocations during flattening

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -203,10 +203,12 @@ struct Context<'f> {
     arguments_stack: Vec<Vec<ValueId>>,
 
     /// Stores all allocations local to the current branch.
-    /// Since these branches are local to the current branch (ie. only defined within one branch of
+    ///
+    /// Since these branches are local to the current branch (i.e. only defined within one branch of
     /// an if expression), they should not be merged with their previous value or stored value in
-    /// the other branch since there is no such value. The ValueId here is that which is returned
-    /// by the allocate instruction.
+    /// the other branch since there is no such value.
+    ///
+    /// The `ValueId` here is that which is returned by the allocate instruction.
     local_allocations: HashSet<ValueId>,
 }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -874,6 +874,7 @@ mod tests {
         // acir fn main f0 {
         //   b0():
         //     v9 = allocate
+        //     store Field 0 at v9
         //     v10 = allocate
         //     jmp b1()
         //   b1():
@@ -902,8 +903,8 @@ mod tests {
 
         let b1_instructions = main.dfg[b1].instructions();
 
-        // We expect the last eq to be optimized out, only the store from above remains
-        assert_eq!(b1_instructions.len(), 1);
+        // We expect the last eq to be optimized out
+        assert_eq!(b1_instructions.len(), 0);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -415,13 +415,11 @@ impl<'f> PerFunctionContext<'f> {
                 let address = self.inserter.function.dfg.resolve(*address);
                 let value = self.inserter.function.dfg.resolve(*value);
 
-                // FIXME: This causes errors in the sha256 tests
-                //
                 // If there was another store to this instruction without any (unremoved) loads or
                 // function calls in-between, we can remove the previous store.
-                // if let Some(last_store) = references.last_stores.get(&address) {
-                //     self.instructions_to_remove.insert(*last_store);
-                // }
+                if let Some(last_store) = references.last_stores.get(&address) {
+                    self.instructions_to_remove.insert(*last_store);
+                }
 
                 if self.inserter.function.dfg.value_is_reference(value) {
                     if let Some(expression) = references.expressions.get(&value) {
@@ -876,7 +874,6 @@ mod tests {
         // acir fn main f0 {
         //   b0():
         //     v9 = allocate
-        //     store Field 0 at v9
         //     v10 = allocate
         //     jmp b1()
         //   b1():
@@ -901,9 +898,7 @@ mod tests {
         // in the same block, and the store is not needed before the later store.
         // The rest of the stores are also removed as no loads are done within any blocks
         // to the stored values.
-        //
-        // NOTE: This store is not removed due to the FIXME when handling Instruction::Store.
-        assert_eq!(count_stores(b1, &main.dfg), 1);
+        assert_eq!(count_stores(b1, &main.dfg), 0);
 
         let b1_instructions = main.dfg[b1].instructions();
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/6434#discussion_r1828469417

## Summary\*

When there is a duplicate store in the same block without a load or call in between we used to remove that store in mem2reg. After https://github.com/noir-lang/noir/pull/6434 reactivating the following snippet:
```
                if let Some(last_store) = references.last_stores.get(&address) {
                    self.instructions_to_remove.insert(*last_store);
                }
``` 
gives this error:
<img width="806" alt="Screenshot 2024-11-25 at 6 11 15 PM" src="https://github.com/user-attachments/assets/1f93474d-cd52-4857-813a-2b21e5817b35">

In https://github.com/noir-lang/noir/pull/6434, when handing side effects during flattening we switched to doing `prev_value = load foo; store (if c then 3 else prev_value) in foo`. However, the first store to an allocation has no previous value (`foo = allocate; store 3 in foo`). So if we replace the first store with a load, the load is not going to be removed by mem2reg as it now does not have a known value. Now that the load is not being removed the allocation will also remain and not be removed by DIE as expected. We then finally error in ACIR gen for having a remaining allocation. 

#### Fix

I brought back the set of local allocations we had prior to #6434. In #6434 we also tried to account for this first store to an allocation case, however, we are currently only looking at stores which immediately follow an allocation instruction. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
