### PR TITLE
fix!: Disallow `#[export]` on associated methods

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -216,6 +216,13 @@ impl<'a> ModCollector<'a> {
                     errors.push((error.into(), self.file_id));
                 }
 
+                if noir_function.def.attributes.has_export() {
+                    let error = DefCollectorErrorKind::ExportOnAssociatedFunction {
+                        span: noir_function.name_ident().span(),
+                    };
+                    errors.push((error.into(), self.file_id));
+                }
+
                 let location = Location::new(noir_function.def.span, self.file_id);
                 context.def_interner.push_function(*func_id, &noir_function.def, module, location);
             }
@@ -1087,6 +1094,12 @@ pub fn collect_impl(
             };
             errors.push((error.into(), file_id));
             continue;
+        }
+        if method.def.attributes.has_export() {
+            let error = DefCollectorErrorKind::ExportOnAssociatedFunction {
+                span: method.name_ident().span(),
+            };
+            errors.push((error.into(), file_id));
         }
 
         let func_id = interner.push_empty_fn();

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -944,6 +944,7 @@ pub fn collect_function(
     } else {
         function.name() == MAIN_FUNCTION
     };
+    let has_export = function.def.attributes.has_export();
 
     let name = function.name_ident().clone();
     let func_id = interner.push_empty_fn();
@@ -954,7 +955,7 @@ pub fn collect_function(
         interner.register_function(func_id, &function.def);
     }
 
-    if !is_test && !is_entry_point_function {
+    if !is_test && !is_entry_point_function && !has_export {
         let item = UnusedItem::Function(func_id);
         usage_tracker.add_unused_item(module, name.clone(), item, visibility);
     }
@@ -1257,6 +1258,7 @@ pub(crate) fn collect_global(
     // Add the statement to the scope so its path can be looked up later
     let result = def_map.modules[module_id.0].declare_global(name.clone(), visibility, global_id);
 
+    // Globals marked as ABI don't have to be used.
     if !is_abi {
         let parent_module_id = ModuleId { krate: crate_id, local_id: module_id };
         usage_tracker.add_unused_item(

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -84,6 +84,8 @@ pub enum DefCollectorErrorKind {
     UnsupportedNumericGenericType(#[from] UnsupportedNumericGenericType),
     #[error("The `#[test]` attribute may only be used on a non-associated function")]
     TestOnAssociatedFunction { span: Span },
+    #[error("The `#[export]` attribute may only be used on a non-associated function")]
+    ExportOnAssociatedFunction { span: Span },
 }
 
 impl DefCollectorErrorKind {
@@ -182,8 +184,8 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
             DefCollectorErrorKind::PathResolutionError(error) => error.into(),
             DefCollectorErrorKind::CannotReexportItemWithLessVisibility{item_name, desired_visibility} => {
                 Diagnostic::simple_warning(
-                    format!("cannot re-export {item_name} because it has less visibility than this use statement"), 
-                    format!("consider marking {item_name} as {desired_visibility}"), 
+                    format!("cannot re-export {item_name} because it has less visibility than this use statement"),
+                    format!("consider marking {item_name} as {desired_visibility}"),
                     item_name.span())
             }
             DefCollectorErrorKind::NonStructTypeInImpl { span } => Diagnostic::simple_error(
@@ -298,7 +300,11 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
                 String::new(),
                 *span,
             ),
-
+            DefCollectorErrorKind::ExportOnAssociatedFunction { span } => Diagnostic::simple_error(
+                "The `#[export]` attribute is disallowed on `impl` methods".into(),
+                String::new(),
+                *span,
+            ),
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -193,11 +193,7 @@ impl CrateDefMap {
             module.value_definitions().filter_map(|id| {
                 if let Some(func_id) = id.as_function() {
                     let attributes = interner.function_attributes(&func_id);
-                    if attributes.secondary.contains(&SecondaryAttribute::Export) {
-                        Some(func_id)
-                    } else {
-                        None
-                    }
+                    attributes.has_export().then_some(func_id)
                 } else {
                     None
                 }

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -676,9 +676,7 @@ impl Attributes {
     /// This is useful for finding out if we should compile a contract method
     /// as an entry point or not.
     pub fn has_contract_library_method(&self) -> bool {
-        self.secondary
-            .iter()
-            .any(|attribute| attribute == &SecondaryAttribute::ContractLibraryMethod)
+        self.has_secondary_attr(SecondaryAttribute::ContractLibraryMethod)
     }
 
     pub fn is_test_function(&self) -> bool {
@@ -718,11 +716,21 @@ impl Attributes {
     }
 
     pub fn has_varargs(&self) -> bool {
-        self.secondary.iter().any(|attr| matches!(attr, SecondaryAttribute::Varargs))
+        self.has_secondary_attr(SecondaryAttribute::Varargs)
     }
 
     pub fn has_use_callers_scope(&self) -> bool {
-        self.secondary.iter().any(|attr| matches!(attr, SecondaryAttribute::UseCallersScope))
+        self.has_secondary_attr(SecondaryAttribute::UseCallersScope)
+    }
+
+    /// True if the function is marked with an `#[export]` attribute.
+    pub fn has_export(&self) -> bool {
+        self.has_secondary_attr(SecondaryAttribute::Export)
+    }
+
+    /// Check if secondary attributes contain a specific instance.
+    fn has_secondary_attr(&self, attr: SecondaryAttribute) -> bool {
+        self.secondary.iter().any(|a| *a == attr)
     }
 }
 

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -676,7 +676,7 @@ impl Attributes {
     /// This is useful for finding out if we should compile a contract method
     /// as an entry point or not.
     pub fn has_contract_library_method(&self) -> bool {
-        self.has_secondary_attr(SecondaryAttribute::ContractLibraryMethod)
+        self.has_secondary_attr(&SecondaryAttribute::ContractLibraryMethod)
     }
 
     pub fn is_test_function(&self) -> bool {
@@ -716,21 +716,21 @@ impl Attributes {
     }
 
     pub fn has_varargs(&self) -> bool {
-        self.has_secondary_attr(SecondaryAttribute::Varargs)
+        self.has_secondary_attr(&SecondaryAttribute::Varargs)
     }
 
     pub fn has_use_callers_scope(&self) -> bool {
-        self.has_secondary_attr(SecondaryAttribute::UseCallersScope)
+        self.has_secondary_attr(&SecondaryAttribute::UseCallersScope)
     }
 
     /// True if the function is marked with an `#[export]` attribute.
     pub fn has_export(&self) -> bool {
-        self.has_secondary_attr(SecondaryAttribute::Export)
+        self.has_secondary_attr(&SecondaryAttribute::Export)
     }
 
     /// Check if secondary attributes contain a specific instance.
-    fn has_secondary_attr(&self, attr: SecondaryAttribute) -> bool {
-        self.secondary.iter().any(|a| *a == attr)
+    pub fn has_secondary_attr(&self, attr: &SecondaryAttribute) -> bool {
+        self.secondary.contains(attr)
     }
 }
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3821,3 +3821,27 @@ fn disallows_test_attribute_on_trait_impl_method() {
         ));
     });
 }
+
+#[test]
+fn disallows_export_attribute_on_impl_method() {
+    test_disallows_attribute_on_impl_method("export", |error| {
+        assert!(matches!(
+            error,
+            CompilationError::DefinitionError(
+                DefCollectorErrorKind::ExportOnAssociatedFunction { .. }
+            )
+        ));
+    });
+}
+
+#[test]
+fn disallows_export_attribute_on_trait_impl_method() {
+    test_disallows_attribute_on_trait_impl_method("export", |error| {
+        assert!(matches!(
+            error,
+            CompilationError::DefinitionError(
+                DefCollectorErrorKind::ExportOnAssociatedFunction { .. }
+            )
+        ));
+    });
+}

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -225,8 +225,30 @@ fn does_not_warn_on_unused_global_if_it_has_an_abi_attribute() {
 }
 
 #[test]
+fn does_not_warn_on_unused_struct_if_it_has_an_abi_attribute() {
+    let src = r#"
+    #[abi(dummy)]
+    struct Foo { bar: u8 }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn does_not_warn_on_unused_function_if_it_has_an_export_attribute() {
+    let src = r#"
+    #[export]
+    fn foo() {}
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn no_warning_on_inner_struct_when_parent_is_used() {
-    let src = r#" 
+    let src = r#"
     struct Bar {
         inner: [Field; 3],
     }
@@ -247,7 +269,7 @@ fn no_warning_on_inner_struct_when_parent_is_used() {
 
 #[test]
 fn no_warning_on_struct_if_it_has_an_abi_attribute() {
-    let src = r#" 
+    let src = r#"
     #[abi(functions)]
     struct Foo {
         a: Field,
@@ -260,7 +282,7 @@ fn no_warning_on_struct_if_it_has_an_abi_attribute() {
 
 #[test]
 fn no_warning_on_indirect_struct_if_it_has_an_abi_attribute() {
-    let src = r#" 
+    let src = r#"
     struct Bar {
         field: Field,
     }
@@ -277,7 +299,7 @@ fn no_warning_on_indirect_struct_if_it_has_an_abi_attribute() {
 
 #[test]
 fn no_warning_on_self_in_trait_impl() {
-    let src = r#" 
+    let src = r#"
     struct Bar {}
 
     trait Foo {
@@ -298,18 +320,18 @@ fn no_warning_on_self_in_trait_impl() {
 #[test]
 fn resolves_trait_where_clause_in_the_correct_module() {
     // This is a regression test for https://github.com/noir-lang/noir/issues/6479
-    let src = r#" 
+    let src = r#"
     mod foo {
         pub trait Foo {}
     }
-    
+
     use foo::Foo;
-    
+
     pub trait Bar<T>
     where
         T: Foo,
     {}
-    
+
     fn main() {}
     "#;
     assert_no_errors(src);

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -35,6 +35,8 @@ pub struct UsageTracker {
 }
 
 impl UsageTracker {
+    /// Register an item as unused, waiting to be marked as used later.
+    /// Things that should not emit warnings should not be added at all.
     pub(crate) fn add_unused_item(
         &mut self,
         module_id: ModuleId,
@@ -73,6 +75,7 @@ impl UsageTracker {
         };
     }
 
+    /// Get all the unused items per module.
     pub fn unused_items(&self) -> &HashMap<ModuleId, HashMap<Ident, UnusedItem>> {
         &self.unused_items
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6526

## Summary\*

Reports the use of `#[export]` on struct and trait method implementations as errors, following the pattern of https://github.com/noir-lang/noir/pull/6449

## Additional Context

Only top level functions can be exported as circuits.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
