### PR TITLE
fix: don't deduplicate constraints in blocks that are not dominated

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -1341,4 +1341,26 @@ mod test {
         let ssa = ssa.fold_constants_with_brillig(&brillig);
         assert_normalized_ssa_equals(ssa, expected);
     }
+
+    #[test]
+    fn does_not_use_cached_constrain_in_block_that_is_not_dominated() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0(v0: Field, v1: Field):
+                v3 = eq v0, Field 0
+                jmpif v3 then: b1, else: b2
+              b1():
+                v5 = eq v1, Field 1
+                constrain v1 == Field 1
+                jmp b2()
+              b2():
+                v6 = eq v1, Field 0
+                constrain v1 == Field 0
+                return
+            }
+            ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.fold_constants_using_constraints();
+        assert_normalized_ssa_equals(ssa, src);
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -1392,4 +1392,28 @@ mod test {
         let ssa = ssa.fold_constants_using_constraints();
         assert_normalized_ssa_equals(ssa, src);
     }
+
+    #[test]
+    fn does_not_hoist_constrain_to_common_ancestor() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0(v0: Field, v1: Field):
+                v3 = eq v0, Field 0
+                jmpif v3 then: b1, else: b2
+              b1():
+                constrain v1 == Field 1
+                jmp b2()
+              b2():
+                jmpif v0 then: b3, else: b4
+              b3():
+                constrain v1 == Field 1 // This was incorrectly hoisted to b0 but this condition is not valid when going b0 -> b2 -> b4
+                jmp b4()
+              b4():
+                return
+            }
+            ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.fold_constants_using_constraints();
+        assert_normalized_ssa_equals(ssa, src);
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -270,11 +270,13 @@ impl<'brillig> Context<'brillig> {
                     return;
                 }
                 CacheResult::NeedToHoistToCommonBlock(dominator, _cached) => {
-                    // Just change the block to insert in the common dominator instead.
-                    // This will only move the current instance of the instruction right now.
-                    // When constant folding is run a second time later on, it'll catch
-                    // that the previous instance can be deduplicated to this instance.
-                    block = dominator;
+                    if instruction_can_be_hoisted(&instruction, dfg, self.use_constraint_info) {
+                        // Just change the block to insert in the common dominator instead.
+                        // This will only move the current instance of the instruction right now.
+                        // When constant folding is run a second time later on, it'll catch
+                        // that the previous instance can be deduplicated to this instance.
+                        block = dominator;
+                    }
                 }
             }
         }
@@ -619,6 +621,20 @@ impl<'brillig> Context<'brillig> {
             }
         }
     }
+}
+
+fn instruction_can_be_hoisted(
+    instruction: &Instruction,
+    dfg: &mut DataFlowGraph,
+    deduplicate_with_predicate: bool,
+) -> bool {
+    // These two can never be hoisted as they have a side-effect
+    // (though it's fine to de-duplicate them, just not fine to hoist them)
+    if matches!(instruction, Instruction::Constrain(..) | Instruction::RangeCheck { .. }) {
+        return false;
+    }
+
+    instruction.can_be_deduplicated(dfg, deduplicate_with_predicate)
 }
 
 impl ResultCache {


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/6588

## Summary

Alternative to the approach in #6627. Here we keep track of all the simplifications a value could have (one per block) while #6627 only kept one simplification... which works, but this PR should result in more simplifications 🤞 

## Additional Context

There are a lot of nested structures in this file and it would be nice to somehow refactor it... but maybe it can be done in a separate PR, now that we have a regression test for the bug.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
