### PR TITLE
fix: correct signed integer handling in `noirc_abi`

### DIFF
--- a/tooling/noirc_abi/proptest-regressions/input_parser/json.txt
+++ b/tooling/noirc_abi/proptest-regressions/input_parser/json.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b3f9ae88d54944ca274764f4d99a2023d4b0ac09beb89bc599cbba1e45dd3620 # shrinks to (typ, value) = (Integer { sign: Signed, width: 1 }, -1)

--- a/tooling/noirc_abi/proptest-regressions/input_parser/toml.txt
+++ b/tooling/noirc_abi/proptest-regressions/input_parser/toml.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9d200afb8f5c01e3414d24eebe1436a7eef5377a46a9a9235aaa7f81e0b33656 # shrinks to (typ, value) = (Integer { sign: Signed, width: 8 }, -1)

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -401,3 +401,25 @@ mod test {
         assert!(parse_str_to_field(&noncanonical_field).is_err());
     }
 }
+
+#[cfg(test)]
+mod arbitrary {
+    use proptest::prelude::*;
+
+    use crate::{AbiType, Sign};
+
+    pub(super) fn arb_signed_integer_type_and_value() -> BoxedStrategy<(AbiType, i64)> {
+        (2u32..=64)
+            .prop_flat_map(|width| {
+                let typ = Just(AbiType::Integer { width, sign: Sign::Signed });
+                let value = if width == 64 {
+                    // Avoid overflow
+                    i64::MIN..i64::MAX
+                } else {
+                    -(2i64.pow(width - 1))..(2i64.pow(width - 1) - 1)
+                };
+                (typ, value)
+            })
+            .boxed()
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

This is a starting point for #6637. The tests are currently failing on both inputs as a negative input will be written back to file as if it were a positive integer.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
