### PR TITLE
fix: typos in documentation files

### DIFF
--- a/tooling/readme.md
+++ b/tooling/readme.md
@@ -4,7 +4,7 @@ Below we briefly describe the purpose of each tool-related crate in this reposit
 
 ## nargo
 
-This is the default package manager used by Noir. One may draw similarities to Rusts' Cargo.
+This is the default package manager used by Noir. One may draw similarities to Rust's Cargo.
 
 ## nargo_fmt
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `Rusts'` to `Rust's`

Please review the changes and let me know if any additional changes are needed.