### PR TITLE
feat: better error message when trying to invoke struct function field

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -99,6 +99,8 @@ pub enum TypeCheckError {
     CannotMutateImmutableVariable { name: String, span: Span },
     #[error("No method named '{method_name}' found for type '{object_type}'")]
     UnresolvedMethodCall { method_name: String, object_type: Type, span: Span },
+    #[error("No method named '{method_name}' found for type '{object_type}'")]
+    CannotInvokeStructFieldFunctionType { method_name: String, object_type: Type, span: Span },
     #[error("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?}")]
     IntegerSignedness { sign_x: Signedness, sign_y: Signedness, span: Span },
     #[error("Integers must have the same bit width LHS is {bit_width_x}, RHS is {bit_width_y}")]
@@ -511,6 +513,13 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             TypeCheckError::CyclicType { typ: _, span } => {
                 Diagnostic::simple_error(error.to_string(), "Cyclic types have unlimited size and are prohibited in Noir".into(), *span)
             }
+            TypeCheckError::CannotInvokeStructFieldFunctionType { method_name, object_type, span } => {
+                Diagnostic::simple_error(
+                    format!("No method named '{method_name}' found for type '{object_type}'"), 
+                    format!("to call the function stored in '{method_name}', surround the field access with parentheses: '(', ')'"),
+                    *span,
+                )
+            },
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -99,7 +99,7 @@ pub enum TypeCheckError {
     CannotMutateImmutableVariable { name: String, span: Span },
     #[error("No method named '{method_name}' found for type '{object_type}'")]
     UnresolvedMethodCall { method_name: String, object_type: Type, span: Span },
-    #[error("No method named '{method_name}' found for type '{object_type}'")]
+    #[error("Cannot invoke function field '{method_name}' on type '{object_type}' as a method")]
     CannotInvokeStructFieldFunctionType { method_name: String, object_type: Type, span: Span },
     #[error("Integers must have the same signedness LHS is {sign_x:?}, RHS is {sign_y:?}")]
     IntegerSignedness { sign_x: Signedness, sign_y: Signedness, span: Span },
@@ -515,7 +515,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             }
             TypeCheckError::CannotInvokeStructFieldFunctionType { method_name, object_type, span } => {
                 Diagnostic::simple_error(
-                    format!("No method named '{method_name}' found for type '{object_type}'"), 
+                    format!("Cannot invoke function field '{method_name}' on type '{object_type}' as a method"), 
                     format!("to call the function stored in '{method_name}', surround the field access with parentheses: '(', ')'"),
                     *span,
                 )

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1088,7 +1088,7 @@ impl Type {
     }
 
     pub fn is_function(&self) -> bool {
-        match self.follow_bindings() {
+        match self.follow_bindings_shallow().as_ref() {
             Type::Function(..) => true,
             Type::Alias(alias_type, _) => alias_type.borrow().typ.is_function(),
             _ => false,

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1087,6 +1087,14 @@ impl Type {
         }
     }
 
+    pub fn is_function(&self) -> bool {
+        match self.follow_bindings() {
+            Type::Function(..) => true,
+            Type::Alias(alias_type, _) => alias_type.borrow().typ.is_function(),
+            _ => false,
+        }
+    }
+
     /// True if this type can be used as a parameter to `main` or a contract function.
     /// This is only false for unsized types like slices or slices that do not make sense
     /// as a program input such as named generics or mutable references.


### PR DESCRIPTION
# Description

## Problem

Resolves #5651

## Summary

Now the error shows up like this:

```
error: No method named 'wrapped' found for type 'Foo'
  ┌─ src/main.nr:7:9
  │
7 │         self.wrapped(x)
  │         --------------- to call the function stored in 'wrapped', surround the field access with parentheses: '(', ')'
```

## Additional Context

Rust's error message is a bit better, but I think we can't do it like that with what we have right now:

![image](https://github.com/user-attachments/assets/b05d0df9-2efd-4e2b-a44c-186ba21abbe2)

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
