### PR TITLE
fix: always return an array of `u8`s when simplifying `Intrinsic::ToRadix` calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -60,16 +60,9 @@ pub(super) fn simplify_call(
                 } else {
                     unreachable!("ICE: Intrinsic::ToRadix return type must be array")
                 };
-                constant_to_radix(
-                    endian,
-                    field,
-                    2,
-                    limb_count,
-                    Type::bool(),
-                    dfg,
-                    block,
-                    call_stack,
-                )
+                constant_to_radix(endian, field, 2, limb_count, |values| {
+                    make_constant_array(dfg, values.into_iter(), Type::bool(), block, call_stack)
+                })
             } else {
                 SimplifyResult::None
             }
@@ -84,16 +77,9 @@ pub(super) fn simplify_call(
                 } else {
                     unreachable!("ICE: Intrinsic::ToRadix return type must be array")
                 };
-                constant_to_radix(
-                    endian,
-                    field,
-                    radix,
-                    limb_count,
-                    Type::unsigned(8),
-                    dfg,
-                    block,
-                    call_stack,
-                )
+                constant_to_radix(endian, field, radix, limb_count, |values| {
+                    make_constant_array(dfg, values.into_iter(), Type::unsigned(8), block, call_stack)
+                })
             } else {
                 SimplifyResult::None
             }
@@ -679,10 +665,7 @@ fn constant_to_radix(
     field: FieldElement,
     radix: u32,
     limb_count: u32,
-    limb_type: Type,
-    dfg: &mut DataFlowGraph,
-    block: BasicBlockId,
-    call_stack: &CallStack,
+    mut make_array: impl FnMut(Vec<FieldElement>) -> ValueId,
 ) -> SimplifyResult {
     let bit_size = u32::BITS - (radix - 1).leading_zeros();
     let radix_big = BigUint::from(radix);
@@ -703,8 +686,7 @@ fn constant_to_radix(
         if endian == Endian::Big {
             limbs.reverse();
         }
-        let result_array =
-            make_constant_array(dfg, limbs.into_iter(), limb_type, block, call_stack);
+        let result_array = make_array(limbs);
         SimplifyResult::SimplifiedTo(result_array)
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -60,7 +60,16 @@ pub(super) fn simplify_call(
                 } else {
                     unreachable!("ICE: Intrinsic::ToRadix return type must be array")
                 };
-                constant_to_radix(endian, field, 2, limb_count, dfg, block, call_stack)
+                constant_to_radix(
+                    endian,
+                    field,
+                    2,
+                    limb_count,
+                    Type::bool(),
+                    dfg,
+                    block,
+                    call_stack,
+                )
             } else {
                 SimplifyResult::None
             }
@@ -75,7 +84,16 @@ pub(super) fn simplify_call(
                 } else {
                     unreachable!("ICE: Intrinsic::ToRadix return type must be array")
                 };
-                constant_to_radix(endian, field, radix, limb_count, dfg, block, call_stack)
+                constant_to_radix(
+                    endian,
+                    field,
+                    radix,
+                    limb_count,
+                    Type::unsigned(8),
+                    dfg,
+                    block,
+                    call_stack,
+                )
             } else {
                 SimplifyResult::None
             }
@@ -661,6 +679,7 @@ fn constant_to_radix(
     field: FieldElement,
     radix: u32,
     limb_count: u32,
+    limb_type: Type,
     dfg: &mut DataFlowGraph,
     block: BasicBlockId,
     call_stack: &CallStack,
@@ -684,13 +703,8 @@ fn constant_to_radix(
         if endian == Endian::Big {
             limbs.reverse();
         }
-        let result_array = make_constant_array(
-            dfg,
-            limbs.into_iter(),
-            Type::unsigned(bit_size),
-            block,
-            call_stack,
-        );
+        let result_array =
+            make_constant_array(dfg, limbs.into_iter(), limb_type, block, call_stack);
         SimplifyResult::SimplifiedTo(result_array)
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -78,7 +78,13 @@ pub(super) fn simplify_call(
                     unreachable!("ICE: Intrinsic::ToRadix return type must be array")
                 };
                 constant_to_radix(endian, field, radix, limb_count, |values| {
-                    make_constant_array(dfg, values.into_iter(), Type::unsigned(8), block, call_stack)
+                    make_constant_array(
+                        dfg,
+                        values.into_iter(),
+                        Type::unsigned(8),
+                        block,
+                        call_stack,
+                    )
                 })
             } else {
                 SimplifyResult::None


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6662 

## Summary\*

If someone attempts to do a decomposition into radices other than 2 or 256 then we'll end up returning the incorrect type. This PR solves this issue.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
