### PR TITLE
feat(tooling): Skip program transformation when loaded from cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
  "dirs",
  "file-lock",
  "fm",
+ "fxhash",
  "iai",
  "iter-extended",
  "lazy_static",

--- a/acvm-repo/acir/src/circuit/brillig.rs
+++ b/acvm-repo/acir/src/circuit/brillig.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Inputs for the Brillig VM. These are the initial inputs
 /// that the Brillig VM will use to start.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, Hash)]
 pub enum BrilligInputs<F> {
     Single(Expression<F>),
     Array(Vec<Expression<F>>),
@@ -14,7 +14,7 @@ pub enum BrilligInputs<F> {
 
 /// Outputs for the Brillig VM. Once the VM has completed
 /// execution, this will be the object that is returned.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, Hash)]
 pub enum BrilligOutputs {
     Simple(Witness),
     Array(Vec<Witness>),
@@ -23,7 +23,7 @@ pub enum BrilligOutputs {
 /// This is purely a wrapper struct around a list of Brillig opcode's which represents
 /// a full Brillig function to be executed by the Brillig VM.
 /// This is stored separately on a program and accessed through a [BrilligPointer].
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default, Debug, Hash)]
 pub struct BrilligBytecode<F> {
     pub bytecode: Vec<BrilligOpcode<F>>,
 }

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -25,7 +25,7 @@ use self::{brillig::BrilligBytecode, opcodes::BlockId};
 /// Bounded Expressions are useful if you are eventually going to pass the ACIR
 /// into a proving system which supports PLONK, where arithmetic expressions have a
 /// finite fan-in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
 pub enum ExpressionWidth {
     #[default]
     Unbounded,
@@ -36,13 +36,13 @@ pub enum ExpressionWidth {
 
 /// A program represented by multiple ACIR circuits. The execution trace of these
 /// circuits is dictated by construction of the [crate::native_types::WitnessStack].
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
 pub struct Program<F> {
     pub functions: Vec<Circuit<F>>,
     pub unconstrained_functions: Vec<BrilligBytecode<F>>,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
 pub struct Circuit<F> {
     // current_witness_index is the highest witness index in the circuit. The next witness to be added to this circuit
     // will take on this value. (The value is cached here as an optimization.)
@@ -69,13 +69,13 @@ pub struct Circuit<F> {
     pub assert_messages: Vec<(OpcodeLocation, AssertionPayload<F>)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum ExpressionOrMemory<F> {
     Expression(Expression<F>),
     Memory(BlockId),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct AssertionPayload<F> {
     pub error_selector: u64,
     pub payload: Vec<ExpressionOrMemory<F>>,
@@ -355,7 +355,7 @@ impl<F: AcirField> std::fmt::Debug for Program<F> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
 pub struct PublicInputs(pub BTreeSet<Witness>);
 
 impl PublicInputs {

--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -15,7 +15,7 @@ pub use black_box_function_call::{
 };
 pub use memory_operation::{BlockId, MemOp};
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BlockType {
     Memory,
     CallData(u32),
@@ -29,7 +29,7 @@ impl BlockType {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Opcode<F> {
     /// An `AssertZero` opcode adds the constraint that `P(w) = 0`, where
     /// `w=(w_1,..w_n)` is a tuple of `n` witnesses, and `P` is a multi-variate

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -9,13 +9,13 @@ use thiserror::Error;
 // Note: Some functions will not use all of the witness
 // So we need to supply how many bits of the witness is needed
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum ConstantOrWitnessEnum<F> {
     Constant(F),
     Witness(Witness),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct FunctionInput<F> {
     input: ConstantOrWitnessEnum<F>,
     num_bits: u32,
@@ -79,7 +79,7 @@ impl<F: std::fmt::Display> std::fmt::Display for FunctionInput<F> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BlackBoxFuncCall<F> {
     AES128Encrypt {
         inputs: Vec<FunctionInput<F>>,

--- a/acvm-repo/acir/src/circuit/opcodes/memory_operation.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/memory_operation.rs
@@ -7,7 +7,7 @@ pub struct BlockId(pub u32);
 
 /// Operation on a block of memory
 /// We can either write or read at an index in memory
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, Hash)]
 pub struct MemOp<F> {
     /// A constant expression that can be 0 (read) or 1 (write)
     pub operation: Expression<F>,

--- a/acvm-repo/brillig/src/black_box.rs
+++ b/acvm-repo/brillig/src/black_box.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// These opcodes provide an equivalent of ACIR blackbox functions.
 /// They are implemented as native functions in the VM.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BlackBoxOp {
     /// Encrypts a message using AES128.
     AES128Encrypt {

--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -56,7 +56,7 @@ impl MemoryAddress {
 }
 
 /// Describes the memory layout for an array/vector element
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum HeapValueType {
     // A single field element is enough to represent the value with a given bit size
     Simple(BitSize),
@@ -81,7 +81,7 @@ impl HeapValueType {
 }
 
 /// A fixed-sized array starting from a Brillig memory location.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash)]
 pub struct HeapArray {
     pub pointer: MemoryAddress,
     pub size: usize,
@@ -94,13 +94,13 @@ impl Default for HeapArray {
 }
 
 /// A memory-sized vector passed starting from a Brillig memory location and with a memory-held size
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash)]
 pub struct HeapVector {
     pub pointer: MemoryAddress,
     pub size: MemoryAddress,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 pub enum IntegerBitSize {
     U1,
     U8,
@@ -152,7 +152,7 @@ impl std::fmt::Display for IntegerBitSize {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 pub enum BitSize {
     Field,
     Integer(IntegerBitSize),
@@ -181,7 +181,7 @@ impl BitSize {
 /// While we are usually agnostic to how memory is passed within Brillig,
 /// this needs to be encoded somehow when dealing with an external system.
 /// For simplicity, the extra type information is given right in the ForeignCall instructions.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash)]
 pub enum ValueOrArray {
     /// A single value passed to or from an external call
     /// It is an 'immediate' value - used without dereferencing.
@@ -198,7 +198,7 @@ pub enum ValueOrArray {
     HeapVector(HeapVector),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BrilligOpcode<F> {
     /// Takes the fields in addresses `lhs` and `rhs`
     /// Performs the specified binary operation
@@ -314,7 +314,7 @@ pub enum BrilligOpcode<F> {
 }
 
 /// Binary fixed-length field expressions
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BinaryFieldOp {
     Add,
     Sub,
@@ -332,7 +332,7 @@ pub enum BinaryFieldOp {
 }
 
 /// Binary fixed-length integer expressions
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BinaryIntOp {
     Add,
     Sub,

--- a/compiler/noirc_driver/src/debug.rs
+++ b/compiler/noirc_driver/src/debug.rs
@@ -8,7 +8,7 @@ use std::{
 
 /// For a given file, we store the source code and the path to the file
 /// so consumers of the debug artifact can reconstruct the original source code structure.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash)]
 pub struct DebugFile {
     pub source: String,
     pub path: PathBuf,

--- a/compiler/noirc_driver/src/program.rs
+++ b/compiler/noirc_driver/src/program.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::debug::DebugFile;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Hash)]
 pub struct CompiledProgram {
     pub noir_version: String,
     /// Hash of the [`Program`][noirc_frontend::monomorphization::ast::Program] from which this [`CompiledProgram`]

--- a/compiler/noirc_errors/src/debug_info.rs
+++ b/compiler/noirc_errors/src/debug_info.rs
@@ -94,7 +94,7 @@ impl ProgramDebugInfo {
 }
 
 #[serde_as]
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct DebugInfo {
     /// Map opcode index of an ACIR circuit into the source code location
     /// Serde does not support mapping keys being enums for json, so we indicate

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -63,7 +63,7 @@ pub enum RuntimeError {
     UnknownReference { call_stack: CallStack },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash)]
 pub enum SsaReport {
     Warning(InternalWarning),
     Bug(InternalBug),
@@ -107,7 +107,7 @@ impl From<SsaReport> for FileDiagnostic {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Error, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Error, Serialize, Deserialize, Hash)]
 pub enum InternalWarning {
     #[error("Return variable contains a constant value")]
     ReturnConstant { call_stack: CallStack },
@@ -115,7 +115,7 @@ pub enum InternalWarning {
     VerifyProof { call_stack: CallStack },
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Error, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Error, Serialize, Deserialize, Hash)]
 pub enum InternalBug {
     #[error("Input to brillig function is in a separate subgraph to output")]
     IndependentSubgraph { call_stack: CallStack },

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -238,7 +238,7 @@ impl SsaProgramArtifact {
     }
 }
 
-/// Compiles the [`Program`] into [`ACIR``][acvm::acir::circuit::Program].
+/// Compiles the [`Program`] into [`ACIR`][acvm::acir::circuit::Program].
 ///
 /// The output ACIR is backend-agnostic and so must go through a transformation pass before usage in proof generation.
 #[tracing::instrument(level = "trace", skip_all)]

--- a/tooling/nargo/src/ops/check.rs
+++ b/tooling/nargo/src/ops/check.rs
@@ -2,8 +2,8 @@ use acvm::compiler::CircuitSimulator;
 use noirc_driver::{CompiledProgram, ErrorsAndWarnings};
 use noirc_errors::{CustomDiagnostic, FileDiagnostic};
 
+/// Run each function through a circuit simulator to check that they are solvable.
 pub fn check_program(compiled_program: &CompiledProgram) -> Result<(), ErrorsAndWarnings> {
-    // Check if the program is solvable
     for (i, circuit) in compiled_program.program.functions.iter().enumerate() {
         let mut simulator = CircuitSimulator::default();
         if !simulator.check_circuit(circuit) {

--- a/tooling/nargo/src/ops/transform.rs
+++ b/tooling/nargo/src/ops/transform.rs
@@ -6,6 +6,7 @@ use iter_extended::vecmap;
 use noirc_driver::{CompiledContract, CompiledProgram};
 use noirc_errors::debug_info::DebugInfo;
 
+/// Apply ACVM optimizations on the circuit.
 pub fn transform_program(
     mut compiled_program: CompiledProgram,
     expression_width: ExpressionWidth,
@@ -18,6 +19,7 @@ pub fn transform_program(
     compiled_program
 }
 
+/// Apply the optimizing transformation on each function in the contract.
 pub fn transform_contract(
     contract: CompiledContract,
     expression_width: ExpressionWidth,
@@ -25,7 +27,6 @@ pub fn transform_contract(
     let functions = vecmap(contract.functions, |mut func| {
         func.bytecode =
             transform_program_internal(func.bytecode, &mut func.debug, expression_width);
-
         func
     });
 

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -25,6 +25,7 @@ toml.workspace = true
 [dependencies]
 clap.workspace = true
 fm.workspace = true
+fxhash.workspace = true
 iter-extended.workspace = true
 nargo.workspace = true
 nargo_fmt.workspace = true

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -251,7 +251,6 @@ fn compiled_contracts(
     compile_options: &CompileOptions,
     target_dir: &Path,
 ) -> CompilationResult<()> {
-    // TODO(6669): Should we look for cached artifacts?
     let contract_results: Vec<CompilationResult<()>> = contract_packages
         .par_iter()
         .map(|package| {
@@ -260,7 +259,6 @@ fn compiled_contracts(
             let target_width =
                 get_target_width(package.expression_width, compile_options.expression_width);
             let contract = nargo::ops::transform_contract(contract, target_width);
-            // TODO(6669): Should the circuits in the contracts run through the simulator?
             save_contract(contract, package, target_dir, compile_options.show_artifact_paths);
             Ok(((), warnings))
         })

--- a/tooling/nargo_cli/tests/stdlib-props.rs
+++ b/tooling/nargo_cli/tests/stdlib-props.rs
@@ -61,6 +61,7 @@ fn prepare_and_compile_snippet(
 ) -> CompilationResult<CompiledProgram> {
     let (mut context, root_crate_id) = prepare_snippet(source);
     let options = CompileOptions { force_brillig, ..Default::default() };
+    // TODO: Run nargo::ops::transform_program?
     compile_main(&mut context, root_crate_id, &options, None)
 }
 

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -49,6 +49,7 @@ pub const MAIN_RETURN_NAME: &str = "return";
 /// depends on the types of programs that users want to do. I don't envision string manipulation
 /// in programs, however it is possible to support, with many complications like encoding character set
 /// support.
+#[derive(Hash)]
 pub enum AbiType {
     Field,
     Array {
@@ -77,7 +78,7 @@ pub enum AbiType {
     },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "lowercase")]
 /// Represents whether the parameter is public or known only to the prover.
@@ -89,7 +90,7 @@ pub enum AbiVisibility {
     DataBus,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "lowercase")]
 pub enum Sign {
@@ -146,7 +147,7 @@ impl From<&AbiType> for PrintableType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 /// An argument or return value of the circuit's `main` function.
 pub struct AbiParameter {
@@ -163,7 +164,7 @@ impl AbiParameter {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct AbiReturnType {
     #[cfg_attr(test, proptest(strategy = "arbitrary::arb_abi_type()"))]
@@ -171,7 +172,7 @@ pub struct AbiReturnType {
     pub visibility: AbiVisibility,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct Abi {
     /// An ordered list of the arguments to the program's `main` function, specifying their types and visibility.
@@ -459,7 +460,7 @@ pub enum AbiValue {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(tag = "error_kind", rename_all = "lowercase")]
 pub enum AbiErrorType {
     FmtString { length: u32, item_types: Vec<AbiType> },


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6669 

## Summary\*

`compile_cmd::compile_programs` now detects the case when `nargo::ops::compile::compile_program` has the compiled artefact loaded from cache, rather than recompiled from scratch. When it's loaded from cache, it is assumed to have already gone through the rest of what `compile_cmd::compile_programs` does, which is to apply `nargo::ops::transform_program` on it, which includes ACVM optimisations and setting the target expression width. If the current target expression width is the same as the one the package was compiled with, we can skip doing these steps again. 

That eliminates the risk of running an non-idempotent optimisation that changes our circuit from what has been persisted before. If somebody were to delete the artefacts and compile from scratch with the same nargo version, then again the transformations were only applied once, which should deterministically yield the same result. 

## Additional Context

### What about compiled contracts?

Curiously `compile_cmd::compile_contracts` does not look for persisted artefacts, nor does it apply `nargo::ops::check_program` on the compiled circuits. This is consistent with how [noir_wasm does it](https://github.com/noir-lang/noir/blob/304403f24e2a15b57bb054c4402a8d7f8d275668/compiler/wasm/src/compile.rs#L182-L219), but I'm not sure why these steps aren't done, since under the hood there are the same types involved in both cases. 

### Added `Hash` to a lot of Brillig types

To support the comparison between cached and compiled artefact I added `#[derive(Hash)]` to a lot of types that comprise a `CompiledProgram`. Most of these implemented `Eq`, so that would have been another option. I didn't want to add a `bool` flag to the return value of `noirc_driver::compile_main` to not have a breaking change in the API, although in retrospect I could have added a new method instead. Given that the types seem to implement `Eq` anyway, I don't see the harm in having `Hash` as well, and it could be useful in implementing #6670 

NB this hash is different than the one we use to decide if we can reuse the artefact, which is based roughly on the AST, and doesn't include the transformations. We don't use the hash to detect whether the transformations result in the same hash, only to decide whether the cached version or a fresh one was returned.

### What about Wasm?

The Wasm version doesn't use caching, so it will only apply the transformations once, never repeatedly.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
