### PR TITLE
feat: Add `BoundedVec::from_parts` and `BoundedVec::from_parts_unchecked`

### DIFF
--- a/docs/docs/noir/standard_library/containers/boundedvec.md
+++ b/docs/docs/noir/standard_library/containers/boundedvec.md
@@ -246,6 +246,42 @@ Example:
 let bounded_vec: BoundedVec<Field, 10> = BoundedVec::from_array([1, 2, 3])
 ```
 
+### from_parts
+
+```rust
+pub fn from_parts(mut array: [T; MaxLen], len: u32) -> Self
+```
+
+Creates a new BoundedVec from the given array and length.
+The given length must be less than or equal to the length of the array.
+
+This function will zero out any elements at or past index `len` of `array`.
+This incurs extra runtime cost of O(MaxLen). If you are sure your array is
+zeroed after that index, you can use `from_parts_unsafe` to remove the extra loop.
+
+Example:
+
+#include_code from-parts noir_stdlib/src/collections/bounded_vec.nr rust
+
+### from_parts_unsafe
+
+```rust
+pub fn from_parts_unsafe(array: [T; MaxLen], len: u32) -> Self
+```
+
+Creates a new BoundedVec from the given array and length.
+The given length must be less than or equal to the length of the array.
+
+This function is unsafe because it expects all elements past the `len` index
+of `array` to be zeroed, but does not check for this internally. Use `from_parts`
+for a safe version of this function which does zero out any indices past the
+given length. Invalidating this assumption can notably cause `BoundedVec::eq`
+to give incorrect results since it will check even elements past `len`.
+
+Example:
+
+#include_code from-parts-unsafe noir_stdlib/src/collections/bounded_vec.nr rust
+
 ### map
 
 ```rust

--- a/docs/docs/noir/standard_library/containers/boundedvec.md
+++ b/docs/docs/noir/standard_library/containers/boundedvec.md
@@ -257,16 +257,16 @@ The given length must be less than or equal to the length of the array.
 
 This function will zero out any elements at or past index `len` of `array`.
 This incurs extra runtime cost of O(MaxLen). If you are sure your array is
-zeroed after that index, you can use `from_parts_unsafe` to remove the extra loop.
+zeroed after that index, you can use `from_parts_unchecked` to remove the extra loop.
 
 Example:
 
 #include_code from-parts noir_stdlib/src/collections/bounded_vec.nr rust
 
-### from_parts_unsafe
+### from_parts_unchecked
 
 ```rust
-pub fn from_parts_unsafe(array: [T; MaxLen], len: u32) -> Self
+pub fn from_parts_unchecked(array: [T; MaxLen], len: u32) -> Self
 ```
 
 Creates a new BoundedVec from the given array and length.
@@ -280,7 +280,7 @@ to give incorrect results since it will check even elements past `len`.
 
 Example:
 
-#include_code from-parts-unsafe noir_stdlib/src/collections/bounded_vec.nr rust
+#include_code from-parts-unchecked noir_stdlib/src/collections/bounded_vec.nr rust
 
 ### map
 

--- a/docs/docs/noir/standard_library/containers/boundedvec.md
+++ b/docs/docs/noir/standard_library/containers/boundedvec.md
@@ -256,7 +256,7 @@ Creates a new BoundedVec from the given array and length.
 The given length must be less than or equal to the length of the array.
 
 This function will zero out any elements at or past index `len` of `array`.
-This incurs extra runtime cost of O(MaxLen). If you are sure your array is
+This incurs an extra runtime cost of O(MaxLen). If you are sure your array is
 zeroed after that index, you can use `from_parts_unchecked` to remove the extra loop.
 
 Example:

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -426,7 +426,7 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
     ///
     /// This function will zero out any elements at or past index `len` of `array`.
     /// This incurs extra runtime cost of O(MaxLen). If you are sure your array is
-    /// zeroed after that index, you can use `from_parts_unsafe` to remove the extra loop.
+    /// zeroed after that index, you can use `from_parts_unchecked` to remove the extra loop.
     ///
     /// Example:
     ///
@@ -457,18 +457,18 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
     /// Example:
     ///
     /// ```noir
-    /// let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 0], 3);
+    /// let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
     /// assert_eq(vec.len(), 3);
     ///
     /// // invalid use!
-    /// let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 1], 3);
-    /// let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 2], 3);
+    /// let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 1], 3);
+    /// let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 2], 3);
     ///
     /// // both vecs have length 3 so we'd expect them to be equal, but this
     /// // fails because elements past the length are still checked in eq
     /// assert_eq(vec1, vec2); // fails
     /// ```
-    pub fn from_parts_unsafe(array: [T; MaxLen], len: u32) -> Self {
+    pub fn from_parts_unchecked(array: [T; MaxLen], len: u32) -> Self {
         assert(len <= MaxLen);
         BoundedVec { storage: array, len }
     }
@@ -673,19 +673,19 @@ mod bounded_vec_tests {
         }
 
         #[test]
-        fn from_parts_unsafe() {
-            // docs:start:from-parts-unsafe
-            let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 0], 3);
+        fn from_parts_unchecked() {
+            // docs:start:from-parts-unchecked
+            let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
             assert_eq(vec.len(), 3);
 
             // invalid use!
-            let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 1], 3);
-            let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 2], 3);
+            let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 1], 3);
+            let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 2], 3);
 
             // both vecs have length 3 so we'd expect them to be equal, but this
             // fails because elements past the length are still checked in eq
             assert(vec1 != vec2);
-            // docs:end:from-parts-unsafe
+            // docs:end:from-parts-unchecked
         }
     }
 }

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -425,7 +425,7 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
     /// The given length must be less than or equal to the length of the array.
     ///
     /// This function will zero out any elements at or past index `len` of `array`.
-    /// This incurs extra runtime cost of O(MaxLen). If you are sure your array is
+    /// This incurs an extra runtime cost of O(MaxLen). If you are sure your array is
     /// zeroed after that index, you can use `from_parts_unchecked` to remove the extra loop.
     ///
     /// Example:

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -369,10 +369,7 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
     pub fn pop(&mut self) -> T {
         assert(self.len > 0);
         self.len -= 1;
-
-        let elem = self.storage[self.len];
-        self.storage[self.len] = crate::mem::zeroed();
-        elem
+        self.storage[self.len]
     }
 
     /// Returns true if the given predicate returns true for any element
@@ -427,11 +424,17 @@ where
     T: Eq,
 {
     fn eq(self, other: BoundedVec<T, MaxLen>) -> bool {
-        // TODO: https://github.com/noir-lang/noir/issues/4837
-        //
-        // We make the assumption that the user has used the proper interface for working with `BoundedVec`s
-        // rather than directly manipulating the internal fields as this can result in an inconsistent internal state.
-        (self.len == other.len) & (self.storage == other.storage)
+        if self.len != other.len {
+            false
+        } else {
+            let mut result = true;
+            for i in 0 .. MaxLen {
+                if i < self.len {
+                    result &= self.storage[i] == other.storage[i];
+                }
+            }
+            result
+        }
     }
 }
 

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -369,7 +369,10 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
     pub fn pop(&mut self) -> T {
         assert(self.len > 0);
         self.len -= 1;
-        self.storage[self.len]
+
+        let elem = self.storage[self.len];
+        self.storage[self.len] = crate::mem::zeroed();
+        elem
     }
 
     /// Returns true if the given predicate returns true for any element
@@ -417,6 +420,58 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
         }
         ret
     }
+
+    /// Creates a new BoundedVec from the given array and length.
+    /// The given length must be less than or equal to the length of the array.
+    ///
+    /// This function will zero out any elements at or past index `len` of `array`.
+    /// This incurs extra runtime cost of O(MaxLen). If you are sure your array is
+    /// zeroed after that index, you can use `from_parts_unsafe` to remove the extra loop.
+    ///
+    /// Example:
+    ///
+    /// ```noir
+    /// let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
+    /// assert_eq(vec.len(), 3);
+    /// ```
+    pub fn from_parts(mut array: [T; MaxLen], len: u32) -> Self {
+        assert(len <= MaxLen);
+        let zeroed = crate::mem::zeroed();
+        for i in 0..MaxLen {
+            if i >= len {
+                array[i] = zeroed;
+            }
+        }
+        BoundedVec { storage: array, len }
+    }
+
+    /// Creates a new BoundedVec from the given array and length.
+    /// The given length must be less than or equal to the length of the array.
+    ///
+    /// This function is unsafe because it expects all elements past the `len` index
+    /// of `array` to be zeroed, but does not check for this internally. Use `from_parts`
+    /// for a safe version of this function which does zero out any indices past the
+    /// given length. Invalidating this assumption can notably cause `BoundedVec::eq`
+    /// to give incorrect results since it will check even elements past `len`.
+    ///
+    /// Example:
+    ///
+    /// ```noir
+    /// let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 0], 3);
+    /// assert_eq(vec.len(), 3);
+    ///
+    /// // invalid use!
+    /// let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 1], 3);
+    /// let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 2], 3);
+    ///
+    /// // both vecs have length 3 so we'd expect them to be equal, but this
+    /// // fails because elements past the length are still checked in eq
+    /// assert_eq(vec1, vec2); // fails
+    /// ```
+    pub fn from_parts_unsafe(array: [T; MaxLen], len: u32) -> Self {
+        assert(len <= MaxLen);
+        BoundedVec { storage: array, len }
+    }
 }
 
 impl<T, let MaxLen: u32> Eq for BoundedVec<T, MaxLen>
@@ -424,16 +479,14 @@ where
     T: Eq,
 {
     fn eq(self, other: BoundedVec<T, MaxLen>) -> bool {
-        if self.len != other.len {
-            false
+        // TODO: https://github.com/noir-lang/noir/issues/4837
+        //
+        // We make the assumption that the user has used the proper interface for working with `BoundedVec`s
+        // rather than directly manipulating the internal fields as this can result in an inconsistent internal state.
+        if self.len == other.len {
+            self.storage == other.storage
         } else {
-            let mut result = true;
-            for i in 0 .. MaxLen {
-                if i < self.len {
-                    result &= self.storage[i] == other.storage[i];
-                }
-            }
-            result
+            false
         }
     }
 }
@@ -599,6 +652,40 @@ mod bounded_vec_tests {
             bounded_vec2.push(2);
 
             assert(bounded_vec1 != bounded_vec2);
+        }
+    }
+
+    mod from_parts {
+        use crate::collections::bounded_vec::BoundedVec;
+
+        #[test]
+        fn from_parts() {
+            // docs:start:from-parts
+            let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
+            assert_eq(vec.len(), 3);
+
+            // Any elements past the given length are zeroed out, so these
+            // two BoundedVecs will be completely equal
+            let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 1], 3);
+            let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 2], 3);
+            assert_eq(vec1, vec2);
+            // docs:end:from-parts
+        }
+
+        #[test]
+        fn from_parts_unsafe() {
+            // docs:start:from-parts-unsafe
+            let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 0], 3);
+            assert_eq(vec.len(), 3);
+
+            // invalid use!
+            let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 1], 3);
+            let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts_unsafe([1, 2, 3, 2], 3);
+
+            // both vecs have length 3 so we'd expect them to be equal, but this
+            // fails because elements past the length are still checked in eq
+            assert(vec1 != vec2);
+            // docs:end:from-parts-unsafe
         }
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves a private issue in a slack conversation

## Summary\*

Adds two functions:
- `BoundedVec::from_parts` to create a bounded vec from an array and a length
- `BoundedVec::from_parts_unchecked` to do the same, but this version does not check or zero out any elements past the given length. If arrays with non-zeroed elements past the given length are given then this can result in two otherwise equal bounded vecs returning false for `BoundedVec::eq`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
