### PR TITLE
chore: Revert "fix: Don't remove necessary RC instructions in DIE pass (#6585)"

### DIFF
--- a/test_programs/execution_success/reference_counts/src/main.nr
+++ b/test_programs/execution_success/reference_counts/src/main.nr
@@ -1,6 +1,6 @@
 fn main() {
     let mut array = [0, 1, 2];
-    assert_refcount(array, 2);
+    assert_refcount(array, 1);
 
     borrow(array, std::mem::array_refcount(array));
     borrow_mut(&mut array, std::mem::array_refcount(array));
@@ -13,13 +13,13 @@ fn borrow(array: [Field; 3], rc_before_call: u32) {
 }
 
 fn borrow_mut(array: &mut [Field; 3], rc_before_call: u32) {
-    assert_refcount(*array, rc_before_call + 1);
+    assert_refcount(*array, rc_before_call + 0); // Issue! This should be rc_before_call + 1
     array[0] = 5;
     println(array[0]);
 }
 
 fn copy_mut(mut array: [Field; 3], rc_before_call: u32) {
-    assert_refcount(array, rc_before_call + 1);
+    assert_refcount(array, rc_before_call + 0); // Issue! This should be rc_before_call + 1
     array[0] = 6;
     println(array[0]);
 }


### PR DESCRIPTION
This reverts commit 440d94d8149ede5f211437e9405f65b460cfcbf8.

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This commit was failing the e2e tests

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
