### PR TITLE
fix: Make `nargo::ops::transform_program` idempotent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "ark-bn254",
  "bn254_blackbox_solver",
  "brillig_vm",
+ "fxhash",
  "indexmap 1.9.3",
  "num-bigint",
  "proptest",

--- a/acvm-repo/acvm/Cargo.toml
+++ b/acvm-repo/acvm/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true
-
+fxhash.workspace = true
 acir.workspace = true
 brillig_vm.workspace = true
 acvm_blackbox_solver.workspace = true

--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -76,23 +76,13 @@ pub fn compile<F: AcirField>(
     acir: Circuit<F>,
     expression_width: ExpressionWidth,
 ) -> (Circuit<F>, AcirTransformationMap) {
-    let mut pass = 0;
-    let mut prev_acir = acir;
-    loop {
-        let (acir, acir_opcode_positions) = optimize_internal(prev_acir);
+    let (acir, acir_opcode_positions) = optimize_internal(acir);
 
-        let (mut acir, acir_opcode_positions) =
-            transform_internal(acir, expression_width, acir_opcode_positions);
+    let (mut acir, acir_opcode_positions) =
+        transform_internal(acir, expression_width, acir_opcode_positions);
 
-        let transformation_map = AcirTransformationMap::new(&acir_opcode_positions);
+    let transformation_map = AcirTransformationMap::new(&acir_opcode_positions);
+    acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
 
-        acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
-
-        if pass == 2 {
-            return (acir, transformation_map);
-        }
-        println!("AFTER PASS {pass}: {acir}");
-        pass += 1;
-        prev_acir = acir;
-    }
+    (acir, transformation_map)
 }

--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -14,7 +14,7 @@ pub use optimizers::optimize;
 use optimizers::optimize_internal;
 pub use simulator::CircuitSimulator;
 use transformers::transform_internal;
-pub use transformers::MIN_EXPRESSION_WIDTH;
+pub use transformers::{transform, MIN_EXPRESSION_WIDTH};
 
 /// We need multiple passes to stabilize the output.
 /// The value was determined by running tests.

--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -91,9 +91,8 @@ pub fn compile<F: AcirField>(
     let (mut acir, acir_opcode_positions) = loop {
         let (acir, acir_opcode_positions) = optimize_internal(prev_acir);
 
-        let opcodes_hash = fxhash::hash64(&acir.opcodes);
         // Stop if we have already done at least one transform and an extra optimization changed nothing.
-        if pass > 0 && prev_opcodes_hash == opcodes_hash {
+        if pass > 0 && prev_opcodes_hash == fxhash::hash64(&acir.opcodes) {
             break (acir, acir_opcode_positions);
         }
 
@@ -101,8 +100,9 @@ pub fn compile<F: AcirField>(
             transform_internal(acir, expression_width, acir_opcode_positions);
 
         let opcodes_hash = fxhash::hash64(&acir.opcodes);
+
         // Stop if the output hasn't change in this loop or we went too long.
-        if pass == MAX_OPTIMIZER_PASSES || prev_opcodes_hash == opcodes_hash {
+        if pass == MAX_OPTIMIZER_PASSES - 1 || prev_opcodes_hash == opcodes_hash {
             break (acir, acir_opcode_positions);
         }
 

--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -23,7 +23,7 @@ use super::{transform_assert_messages, AcirTransformationMap};
 pub fn optimize<F: AcirField>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformationMap) {
     let (mut acir, new_opcode_positions) = optimize_internal(acir);
 
-    let transformation_map = AcirTransformationMap::new(new_opcode_positions);
+    let transformation_map = AcirTransformationMap::new(&new_opcode_positions);
 
     acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
 

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -17,12 +17,12 @@ pub use csat::MIN_EXPRESSION_WIDTH;
 
 use super::{
     optimizers::MergeExpressionsOptimizer, transform_assert_messages, AcirTransformationMap,
+    MAX_OPTIMIZER_PASSES,
 };
 
-/// The `MergeExpressionOptimizer` needs multiple passes to stabilize the output.
-const MAX_OPTIMIZER_PASSES: usize = 3;
-
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
+///
+/// TODO: Can this be removed?
 fn _transform<F: AcirField>(
     mut acir: Circuit<F>,
     expression_width: ExpressionWidth,
@@ -58,6 +58,8 @@ pub(super) fn transform_internal<F: AcirField>(
     // Allow multiple passes until we have stable output.
     let mut prev_opcodes_hash = fxhash::hash64(&acir.opcodes);
 
+    // For most test programs it would be enough to loop here, but some of them
+    // don't stabilize unless we also repeat the backend agnostic optimizations.
     for _ in 0..MAX_OPTIMIZER_PASSES {
         let (new_acir, new_acir_opcode_positions) =
             transform_internal_once(acir, expression_width, acir_opcode_positions);

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -48,7 +48,7 @@ fn _transform<F: AcirField>(
 ///
 /// Accepts an injected `acir_opcode_positions` to allow transformations to be applied directly after optimizations.
 ///
-/// Does multiple passes until the output stabilises.
+/// Does multiple passes until the output stabilizes.
 #[tracing::instrument(level = "trace", name = "transform_acir", skip(acir, acir_opcode_positions))]
 pub(super) fn transform_internal<F: AcirField>(
     mut acir: Circuit<F>,
@@ -64,6 +64,13 @@ pub(super) fn transform_internal<F: AcirField>(
 
         acir = new_acir;
         acir_opcode_positions = new_acir_opcode_positions;
+
+        let new_opcodes_hash = fxhash::hash64(&acir.opcodes);
+
+        if new_opcodes_hash == prev_opcodes_hash {
+            break;
+        }
+        prev_opcodes_hash = new_opcodes_hash;
     }
     // After the elimination of intermediate variables the `current_witness_index` is potentially higher than it needs to be,
     // which would cause gaps if we ran the optimization a second time, making it look like new variables were added.
@@ -76,7 +83,7 @@ pub(super) fn transform_internal<F: AcirField>(
 ///
 /// Accepts an injected `acir_opcode_positions` to allow transformations to be applied directly after optimizations.
 ///
-/// Does a single optimisation pass.
+/// Does a single optimization pass.
 #[tracing::instrument(
     level = "trace",
     name = "transform_acir_once",

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -20,8 +20,7 @@ use super::{
 };
 
 /// The `MergeExpressionOptimizer` needs multiple passes to stabilize the output.
-/// Testing showed two passes to be enough.
-const MAX_OPTIMIZER_PASSES: usize = 2;
+const MAX_OPTIMIZER_PASSES: usize = 3;
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
 fn _transform<F: AcirField>(
@@ -59,7 +58,7 @@ pub(super) fn transform_internal<F: AcirField>(
     // Allow multiple passes until we have stable output.
     let mut prev_opcodes_hash = fxhash::hash64(&acir.opcodes);
 
-    for _ in 0..1 {
+    for _ in 0..MAX_OPTIMIZER_PASSES {
         let (new_acir, new_acir_opcode_positions) =
             transform_internal_once(acir, expression_width, acir_opcode_positions);
 

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -15,34 +15,7 @@ mod csat;
 pub(crate) use csat::CSatTransformer;
 pub use csat::MIN_EXPRESSION_WIDTH;
 
-use super::{
-    optimizers::MergeExpressionsOptimizer, transform_assert_messages, AcirTransformationMap,
-    MAX_OPTIMIZER_PASSES,
-};
-
-/// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
-///
-/// TODO: Can this be removed?
-fn _transform<F: AcirField>(
-    mut acir: Circuit<F>,
-    expression_width: ExpressionWidth,
-) -> (Circuit<F>, AcirTransformationMap) {
-    // Track original acir opcode positions throughout the transformation passes of the compilation
-    // by applying the modifications done to the circuit opcodes and also to the opcode_positions (delete and insert)
-    let mut acir_opcode_positions =
-        acir.opcodes.iter().enumerate().map(|(i, _)| i).collect::<Vec<_>>();
-
-    let (new_acir, new_acir_opcode_positions) =
-        transform_internal(acir, expression_width, acir_opcode_positions);
-
-    acir = new_acir;
-    acir_opcode_positions = new_acir_opcode_positions;
-
-    let transformation_map = AcirTransformationMap::new(&acir_opcode_positions);
-    acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
-
-    (acir, transformation_map)
-}
+use super::{optimizers::MergeExpressionsOptimizer, MAX_OPTIMIZER_PASSES};
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
 ///

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -418,6 +418,12 @@ mod tests {
 
                 if verbose {
                     // Compare where the most likely difference is.
+                    similar_asserts::assert_eq!(
+                        format!("{}", program_1.program),
+                        format!("{}", program_2.program),
+                        "optimization not idempotent for test program '{}'",
+                        package.name
+                    );
                     assert_eq!(
                         program_1.program, program_2.program,
                         "optimization not idempotent for test program '{}'",

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -413,11 +413,6 @@ mod tests {
 
                 let width = get_target_width(package.expression_width, None);
 
-                // Figure out if there is an upper bound to repeating the entire optimization step after which the results are stable:
-                // for i in 0..2 {
-                //     program_0 = nargo::ops::transform_program(program_0, width);
-                // }
-
                 let program_1 = nargo::ops::transform_program(program_0, width);
                 let program_2 = nargo::ops::transform_program(program_1.clone(), width);
 

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -414,7 +414,7 @@ mod tests {
                 let width = get_target_width(package.expression_width, None);
 
                 // Figure out if there is an upper bound to repeating the entire optimization step after which the results are stable:
-                // for i in 0..0 {
+                // for i in 0..2 {
                 //     program_0 = nargo::ops::transform_program(program_0, width);
                 // }
 

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -414,7 +414,7 @@ mod tests {
                 let width = get_target_width(package.expression_width, None);
 
                 // Figure out if there is an upper bound to repeating the entire optimization step after which the results are stable:
-                // for _ in 0..2 {
+                // for i in 0..0 {
                 //     program_0 = nargo::ops::transform_program(program_0, width);
                 // }
 

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -413,6 +413,11 @@ mod tests {
 
                 let width = get_target_width(package.expression_width, None);
 
+                // Figure out if there is an upper bound to repeating the entire optimization step after which the results are stable:
+                // for _ in 0..2 {
+                //     program_0 = nargo::ops::transform_program(program_0, width);
+                // }
+
                 let program_1 = nargo::ops::transform_program(program_0, width);
                 let program_2 = nargo::ops::transform_program(program_1.clone(), width);
 


### PR DESCRIPTION
# Description

## Problem\*

Followup for https://github.com/noir-lang/noir/pull/6694 

## Summary\*

Makes `nargo::ops::transform_program` idempotent by adding two loops, both up to 3 passes, exiting early if the opcode hash doesn't change:
* an outer loop in `acvm::compiler::compile` that includes `optimize_internal` and `transform_internal` 
* an inner loop in `acvm::compiler::transformers::transform_internal`

## Additional Context

Here's the journey I went through investigating the source of changes across optimisation runs.

### Ever increasing `current_witness_index`

On the `slice_loop` example the `Circuit::current_witness_index` field increased by 2 after each pass. This seems to be because:
1. It is increased by the number of intermediate variables created [here](https://github.com/noir-lang/noir/blob/dc96de7c7a3d3c325b955edb277534653204cc5a/acvm-repo/acvm/src/compiler/transformers/mod.rs#L83) even though the mutable reference is [also increased](https://github.com/noir-lang/noir/blob/dc96de7c7a3d3c325b955edb277534653204cc5a/acvm-repo/acvm/src/compiler/transformers/csat.rs#L279-L281), hence the double increment
2. The intermediate variables are (in this case entirely) [eliminated](https://github.com/noir-lang/noir/blob/dc96de7c7a3d3c325b955edb277534653204cc5a/acvm-repo/acvm/src/compiler/transformers/mod.rs#L162-L163) later, but the current index isn't adjusted accordingly. 

The PR adds a brute force step to visit each opcode and collect the remaining witnesses to set the next one correctly. 

Alternatively we could implement `PartialEq` for `Circuit` in a way that it ignores `current_witness_index`. 

After this fix we have the following tests still flagging the transformation as non-idempotent:
* `7_function`
* `conditional_1`
* `fold_fibonacci`
* `hashmap`
* `regression_5252`
* `regression_6451`
* `sha256`
* `sha256_regression`
* `sha256_var_size_regression`
* `sha256_var_witness_const_regression`
* `slices`
* `to_be_bytes`

### Multiple passes

For the above I found that adding the following to the test makes all of them pass:

```rust
                for _ in 0..2 {
                    program_0 = nargo::ops::transform_program(program_0, width);
                }
```

So two extra full passes to stabilise the optimisation currently. An example where 1 extra pass is not enough was `conditional_1`. Ideally we would find which part of the transformation needs to be repeated to avoid having to do a full pass; our initial hypothesis was to look at #6668 

I had to add a loop around `transform_internal` allowing 3 passes before the tests indicated more stability than before. The expectation was that we only need to loop around `MergeExpressionOptimizer`, but that doesn't seem to be true. Even after this, the following two programs fail:

* `7_function`
* `slices`
The difference in both cases is the removal of a range check:
```console
assertion failed: `(left == right)`: optimization not idempotent for test program 'slices''
  left: `"func 0\ncurrent witness index : 617\nprivate parameters indices : [0]\npublic parameters indices : [1]\nreturn value indices : []\nEXPR [ (1, _1) -10 ]\nEXPR [ (-1, _0) (-1, _2) 10 ]\nBRILLIG CALL func 0: in..."` (truncated)
 right: `"func 0\ncurrent witness index : 617\nprivate parameters indices : [0]\npublic parameters indices : [1]\nreturn value indices : []\nEXPR [ (1, _1) -10 ]\nEXPR [ (-1, _0) (-1, _2) 10 ]\nBRILLIG CALL func 0: in..."` (truncated)

Differences (-left|+right):
 BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(13))], q_c: 0 })], outputs: [Simple(Witness(14))]
 EXPR [ (1, _13, _14) (1, _15) -1 ]
 EXPR [ (1, _13, _15) 0 ]
 EXPR [ (1, _7) (-1, _16) 5 ]
-BLACKBOX::RANGE [(16)] [ ]
 EXPR [ (-1, _17) 0 ]
 EXPR [ (1, _0, _4) (-1, _489) 0 ]
 EXPR [ (-10, _4, _8) (-1, _490) 0 ]
 EXPR [ (10, _8) (-1, _18) (1, _489) (1, _490) 0 ]
```

For these to stabilise had to move the loop to be around the entire transformation that includes the initial backend agnostic `optimize_internal` as well:

```rust
/// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] specific optimizations to a [`Circuit`].
pub fn compile<F: AcirField>(
    acir: Circuit<F>,
    expression_width: ExpressionWidth,
) -> (Circuit<F>, AcirTransformationMap) {
    let mut pass = 0;
    let mut prev_acir = acir;

    let (mut acir, acir_opcode_positions) = loop {
        let (acir, acir_opcode_positions) = optimize_internal(prev_acir);
        let (acir, acir_opcode_positions) =
            transform_internal(acir, expression_width, acir_opcode_positions);

        if pass == 2 {
            break (acir, acir_opcode_positions);
        }
        pass += 1;
        prev_acir = acir;
    };

    let transformation_map = AcirTransformationMap::new(&acir_opcode_positions);
    acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);

    (acir, transformation_map)
}
```

The final solution has an inner and an outer loop, treating both as black boxes.


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
