### PR TITLE
fix: LSP auto-import text indent

### DIFF
--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1587,6 +1587,54 @@ fn main() {
     }
 
     #[test]
+    async fn test_auto_import_inserts_after_last_use_in_nested_module() {
+        let src = r#"mod foo {
+    pub mod bar {
+        pub fn hello_world() {}
+    }
+}
+
+mod baz {
+    fn qux() {}
+}
+
+mod other {
+    use baz::qux;
+
+    fn main() {
+        hel>|<
+    }
+}"#;
+
+        let expected = r#"mod foo {
+    pub mod bar {
+        pub fn hello_world() {}
+    }
+}
+
+mod baz {
+    fn qux() {}
+}
+
+mod other {
+    use baz::qux;
+    use super::foo::bar::hello_world;
+
+    fn main() {
+        hel
+    }
+}"#;
+        let mut items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = items.remove(0);
+
+        let changed =
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
+        assert_eq!(changed, expected);
+    }
+
+    #[test]
     async fn test_does_not_auto_import_test_functions() {
         let src = r#"
             mod foo {

--- a/tooling/lsp/src/use_segment_positions.rs
+++ b/tooling/lsp/src/use_segment_positions.rs
@@ -318,7 +318,7 @@ fn new_use_completion_item_additional_text_edits(
     request: UseCompletionItemAdditionTextEditsRequest,
 ) -> Vec<TextEdit> {
     let line = request.auto_import_line as u32;
-    let character = (request.nesting * 4) as u32;
+    let character = 0;
     let indent = " ".repeat(request.nesting * 4);
     let mut newlines = "\n";
 
@@ -331,6 +331,6 @@ fn new_use_completion_item_additional_text_edits(
 
     vec![TextEdit {
         range: Range { start: Position { line, character }, end: Position { line, character } },
-        new_text: format!("use {};{}{}", request.full_path, newlines, indent),
+        new_text: format!("{}use {};{}", indent, request.full_path, newlines),
     }]
 }


### PR DESCRIPTION
# Description

## Problem

LSP auto-import was trying to insert `use ...;` at line N, character 4 if the import should go inside a `mod`. The problem is, if that line is empty inserting at character 4 doesn't work.

## Summary

Instead of inserting at the desired indentation, we now insert the indentation. That is, instead of inserting `use ...;` at character 4, we insert `    use ...;`.

Originally we also inserted an indent in the line following the `use`, so if you had:

```noir
mod a {
    use foo; // imagine the new import goes after this line
    fn bar() {}
}
```

we inserted "use bar;\n    " so that `fn bar() {}` remains indented. However, we also have logic to insert a newline between the new import and whatever comes next, so we actually never need to put an indentation after the use (and it's wrong to do so because we'll end up with a line with just indentation).

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
