### PR TITLE
feat: improve parser recovery of constructor field with '::' instead of ':'

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -428,8 +428,8 @@ impl<'a> Parser<'a> {
         Some(if self.eat_colon() {
             let expression = self.parse_expression_or_error();
             (ident, expression)
-        } else if self.at(Token::Assign) {
-            // If we find '=' instead of ':', assume the user meant ':`, error and continue
+        } else if self.at(Token::DoubleColon) || self.at(Token::Assign) {
+            // If we find '='  or '::' instead of ':', assume the user meant ':`, error and continue
             self.expected_token(Token::Colon);
             self.bump();
             let expression = self.parse_expression_or_error();
@@ -1367,6 +1367,34 @@ mod tests {
         let (name, expr) = constructor.fields.remove(0);
         assert_eq!(name.to_string(), "y");
         assert_eq!(expr.to_string(), "y");
+    }
+
+    #[test]
+    fn parses_constructor_recovers_if_double_colon_instead_of_colon() {
+        let src = "
+        Foo { x: 1, y:: z }
+                     ^^
+        ";
+        let (src, span) = get_source_with_error_span(src);
+        let mut parser = Parser::for_str(&src);
+        let expr = parser.parse_expression_or_error();
+
+        let error = get_single_error(&parser.errors, span);
+        assert_eq!(error.to_string(), "Expected a ':' but found '::'");
+
+        let ExpressionKind::Constructor(mut constructor) = expr.kind else {
+            panic!("Expected constructor");
+        };
+        assert_eq!(constructor.typ.to_string(), "Foo");
+        assert_eq!(constructor.fields.len(), 2);
+
+        let (name, expr) = constructor.fields.remove(0);
+        assert_eq!(name.to_string(), "x");
+        assert_eq!(expr.to_string(), "1");
+
+        let (name, expr) = constructor.fields.remove(0);
+        assert_eq!(name.to_string(), "y");
+        assert_eq!(expr.to_string(), "z");
     }
 
     #[test]


### PR DESCRIPTION

# Description

## Problem

Resolves #1153

## Summary

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
