### PR TITLE
feat: show printable byte arrays as byte strings in SSA

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call.rs
@@ -842,27 +842,27 @@ mod tests {
 
     #[test]
     fn simplify_derive_generators_has_correct_type() {
-        let src = "
+        let src = r#"
             brillig(inline) fn main f0 {
               b0():
-                v0 = make_array [u8 68, u8 69, u8 70, u8 65, u8 85, u8 76, u8 84, u8 95, u8 68, u8 79, u8 77, u8 65, u8 73, u8 78, u8 95, u8 83, u8 69, u8 80, u8 65, u8 82, u8 65, u8 84, u8 79, u8 82] : [u8; 24]
+                v0 = make_array b"DEFAULT_DOMAIN_SEPARATOR"
 
                 // This call was previously incorrectly simplified to something that returned `[Field; 3]`
                 v2 = call derive_pedersen_generators(v0, u32 0) -> [(Field, Field, u1); 1]
 
                 return v2
             }
-            ";
+            "#;
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = "
+        let expected = r#"
             brillig(inline) fn main f0 {
               b0():
-                v15 = make_array [u8 68, u8 69, u8 70, u8 65, u8 85, u8 76, u8 84, u8 95, u8 68, u8 79, u8 77, u8 65, u8 73, u8 78, u8 95, u8 83, u8 69, u8 80, u8 65, u8 82, u8 65, u8 84, u8 79, u8 82] : [u8; 24]
+                v15 = make_array b"DEFAULT_DOMAIN_SEPARATOR"
                 v19 = make_array [Field 3728882899078719075161482178784387565366481897740339799480980287259621149274, Field -9903063709032878667290627648209915537972247634463802596148419711785767431332, u1 0] : [(Field, Field, u1); 1]
                 return v19
             }
-            ";
+            "#;
         assert_normalized_ssa_equals(ssa, expected);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use acvm::acir::AcirField;
+use im::Vector;
 use iter_extended::vecmap;
+
+use crate::ssa::ir::types::{NumericType, Type};
 
 use super::{
     basic_block::BasicBlockId,
@@ -220,6 +223,28 @@ fn display_instruction_inner(
             )
         }
         Instruction::MakeArray { elements, typ } => {
+            // If the array is a byte array, we check if all the bytes are printable ascii characters
+            // and, if so, we print the array as a string literal (easier to understand).
+            // It could happen that the byte array is a random byte sequence that happens to be printable
+            // (it didn't come from a string literal) but this still reduces the noise in the output
+            // and actually represents the same value.
+            let (element_types, is_slice) = match typ {
+                Type::Array(types, _) => (types, false),
+                Type::Slice(types) => (types, true),
+                _ => panic!("Expected array or slice type for MakeArray"),
+            };
+            if element_types.len() == 1
+                && element_types[0] == Type::Numeric(NumericType::Unsigned { bit_size: 8 })
+            {
+                if let Some(string) = try_byte_array_to_string(elements, function) {
+                    if is_slice {
+                        return writeln!(f, "make_array &b{:?}", string);
+                    } else {
+                        return writeln!(f, "make_array b{:?}", string);
+                    }
+                }
+            }
+
             write!(f, "make_array [")?;
 
             for (i, element) in elements.iter().enumerate() {
@@ -232,6 +257,25 @@ fn display_instruction_inner(
             writeln!(f, "] : {typ}")
         }
     }
+}
+
+fn try_byte_array_to_string(elements: &Vector<ValueId>, function: &Function) -> Option<String> {
+    let mut string = String::new();
+    for element in elements {
+        let element = function.dfg.get_numeric_constant(*element)?;
+        let element = element.try_to_u32()?;
+        if element > 0xFF {
+            return None;
+        }
+        let byte = element as u8;
+        if byte.is_ascii_alphanumeric() || byte.is_ascii_punctuation() || byte.is_ascii_whitespace()
+        {
+            string.push(byte as char);
+        } else {
+            return None;
+        }
+    }
+    Some(string)
 }
 
 fn result_types(function: &Function, results: &[ValueId]) -> String {

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -467,7 +467,7 @@ impl<'a> Parser<'a> {
                 return Ok(ParsedInstruction::MakeArray { target, elements, typ });
             } else if let Some(string) = self.eat_byte_str()? {
                 let u8 = Type::Numeric(NumericType::Unsigned { bit_size: 8 });
-                let typ = Type::Array(Arc::new(vec![u8.clone()]), string.bytes().count() as u32);
+                let typ = Type::Array(Arc::new(vec![u8.clone()]), string.len() as u32);
                 let elements = string
                     .bytes()
                     .map(|byte| ParsedValue::NumericConstant {

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use super::{
-    ir::{instruction::BinaryOp, types::Type},
+    ir::{
+        instruction::BinaryOp,
+        types::{NumericType, Type},
+    },
     Ssa,
 };
 
@@ -448,12 +451,39 @@ impl<'a> Parser<'a> {
         }
 
         if self.eat_keyword(Keyword::MakeArray)? {
-            self.eat_or_error(Token::LeftBracket)?;
-            let elements = self.parse_comma_separated_values()?;
-            self.eat_or_error(Token::RightBracket)?;
-            self.eat_or_error(Token::Colon)?;
-            let typ = self.parse_type()?;
-            return Ok(ParsedInstruction::MakeArray { target, elements, typ });
+            if self.eat(Token::Ampersand)? {
+                let Some(string) = self.eat_byte_str()? else {
+                    return self.expected_byte_string();
+                };
+                let u8 = Type::Numeric(NumericType::Unsigned { bit_size: 8 });
+                let typ = Type::Slice(Arc::new(vec![u8.clone()]));
+                let elements = string
+                    .bytes()
+                    .map(|byte| ParsedValue::NumericConstant {
+                        constant: FieldElement::from(byte as u128),
+                        typ: u8.clone(),
+                    })
+                    .collect();
+                return Ok(ParsedInstruction::MakeArray { target, elements, typ });
+            } else if let Some(string) = self.eat_byte_str()? {
+                let u8 = Type::Numeric(NumericType::Unsigned { bit_size: 8 });
+                let typ = Type::Array(Arc::new(vec![u8.clone()]), string.bytes().count() as u32);
+                let elements = string
+                    .bytes()
+                    .map(|byte| ParsedValue::NumericConstant {
+                        constant: FieldElement::from(byte as u128),
+                        typ: u8.clone(),
+                    })
+                    .collect();
+                return Ok(ParsedInstruction::MakeArray { target, elements, typ });
+            } else {
+                self.eat_or_error(Token::LeftBracket)?;
+                let elements = self.parse_comma_separated_values()?;
+                self.eat_or_error(Token::RightBracket)?;
+                self.eat_or_error(Token::Colon)?;
+                let typ = self.parse_type()?;
+                return Ok(ParsedInstruction::MakeArray { target, elements, typ });
+            }
         }
 
         if self.eat_keyword(Keyword::Not)? {
@@ -796,6 +826,18 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn eat_byte_str(&mut self) -> ParseResult<Option<String>> {
+        if matches!(self.token.token(), Token::ByteStr(..)) {
+            let token = self.bump()?;
+            match token.into_token() {
+                Token::ByteStr(string) => Ok(Some(string)),
+                _ => unreachable!(),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
     fn eat(&mut self, token: Token) -> ParseResult<bool> {
         if self.token.token() == &token {
             self.bump()?;
@@ -843,6 +885,13 @@ impl<'a> Parser<'a> {
 
     fn expected_string_or_data<T>(&mut self) -> ParseResult<T> {
         Err(ParserError::ExpectedStringOrData {
+            found: self.token.token().clone(),
+            span: self.token.to_span(),
+        })
+    }
+
+    fn expected_byte_string<T>(&mut self) -> ParseResult<T> {
+        Err(ParserError::ExpectedByteString {
             found: self.token.token().clone(),
             span: self.token.to_span(),
         })
@@ -911,6 +960,8 @@ pub(crate) enum ParserError {
     ExpectedInstructionOrTerminator { found: Token, span: Span },
     #[error("Expected a string literal or 'data', found '{found}'")]
     ExpectedStringOrData { found: Token, span: Span },
+    #[error("Expected a byte string literal, found '{found}'")]
+    ExpectedByteString { found: Token, span: Span },
     #[error("Expected a value, found '{found}'")]
     ExpectedValue { found: Token, span: Span },
     #[error("Multiple return values only allowed for call")]
@@ -928,6 +979,7 @@ impl ParserError {
             | ParserError::ExpectedType { span, .. }
             | ParserError::ExpectedInstructionOrTerminator { span, .. }
             | ParserError::ExpectedStringOrData { span, .. }
+            | ParserError::ExpectedByteString { span, .. }
             | ParserError::ExpectedValue { span, .. } => *span,
             ParserError::MultipleReturnValuesOnlyAllowedForCall { second_target, .. } => {
                 second_target.span

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -90,6 +90,30 @@ fn test_make_composite_array() {
 }
 
 #[test]
+fn test_make_byte_array_with_string_literal() {
+    let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v9 = make_array b\"Hello world!\"
+            return v9
+        }
+        ";
+    assert_ssa_roundtrip(src);
+}
+
+#[test]
+fn test_make_byte_slice_with_string_literal() {
+    let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v9 = make_array &b\"Hello world!\"
+            return v9
+        }
+        ";
+    assert_ssa_roundtrip(src);
+}
+
+#[test]
 fn test_block_parameters() {
     let src = "
         acir(inline) fn main f0 {
@@ -228,14 +252,14 @@ fn test_constrain_with_static_message() {
 
 #[test]
 fn test_constrain_with_dynamic_message() {
-    let src = "
+    let src = r#"
         acir(inline) fn main f0 {
           b0(v0: Field, v1: Field):
-            v7 = make_array [u8 123, u8 120, u8 125, u8 32, u8 123, u8 121, u8 125] : [u8; 7]
+            v7 = make_array b"{x} {y}"
             constrain v0 == Field 1, data v7, u32 2, v0, v1
             return
         }
-        ";
+        "#;
     assert_ssa_roundtrip(src);
 }
 

--- a/compiler/noirc_evaluator/src/ssa/parser/token.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/token.rs
@@ -30,6 +30,7 @@ pub(crate) enum Token {
     Ident(String),
     Int(FieldElement),
     Str(String),
+    ByteStr(String),
     Keyword(Keyword),
     IntType(IntType),
     /// =
@@ -79,6 +80,7 @@ impl Display for Token {
             Token::Ident(ident) => write!(f, "{}", ident),
             Token::Int(int) => write!(f, "{}", int),
             Token::Str(string) => write!(f, "{string:?}"),
+            Token::ByteStr(string) => write!(f, "{string:?}"),
             Token::Keyword(keyword) => write!(f, "{}", keyword),
             Token::IntType(int_type) => write!(f, "{}", int_type),
             Token::Assign => write!(f, "="),


### PR DESCRIPTION
# Description

## Problem

Doesn't resolve any issue, but might make debugging SSA a bit easier.

## Summary

In Noir string literals are just arrays of bytes. When going from code to SSA we always get byte arrays and it's hard to relate those back to string literals.

In this PR, when printing a `make_array` instruction whose array (or slice) consists of all printable ascii bytes, we now show that as a byte string literal (`b"..."`). I know Noir doesn't have `b"..."` like in Rust, but I used the same notation to make it clear that it's really a byte array.

For example, for this Noir program:

```noir
fn main() {
    let x = 1;
    println(f"X is {x}");
}
```

The final SSA before this PR was:

```
acir(inline) fn main f0 {
  b0():
    v7 = make_array [u8 88, u8 32, u8 105, u8 115, u8 32, u8 123, u8 120, u8 125] : [u8; 8]
    call f1(u1 1, v7, u32 1, Field 1)
    return
}
brillig(inline) fn print_unconstrained f1 {
  b0(v0: u1, v1: [u8; 8], v2: Field, v3: Field):
    v15 = make_array [u8 123, u8 34, u8 107, u8 105, u8 110, u8 100, u8 34, u8 58, u8 34, u8 102, u8 105, u8 101, u8 108, u8 100, u8 34, u8 125] : [u8; 16]
    call v16(v0, v1, v2, v3, v15, u1 1)
    return
}
```

And with this PR:

```
acir(inline) fn main f0 {
  b0():
    v7 = make_array b"X is {x}"
    call f1(u1 1, v7, u32 1, Field 1)
    return
}
brillig(inline) fn print_unconstrained f1 {
  b0(v0: u1, v1: [u8; 8], v2: Field, v3: Field):
    v15 = make_array b"{\"kind\":\"field\"}"
    call v16(v0, v1, v2, v3, v15, u1 1)
    return
}
```

I think the last one is a bit clearer.

This will also help when debugging SSA issues: we can include a couple of `println(...)` around a code segment that doesn't work well, and we can easily find out where those `println` statements ended up being.

## Additional Context

It could happen that one wrote a byte array that happens to have all printable ascii characters. For example:

```noir
fn main() {
    let x: [u8; _] = [65, 66, 67, 123];
    println(x);
}
```

In that case the SSA will be:

```
acir(inline) fn main f0 {
  b0():
    v3 = make_array b"ABC{"
    inc_rc v3
    call f1(u1 1, v3)
    return
}
```

which might be confusing, though in the end if we understand that `b"..."` is just another way to print a byte array then it shouldn't cause any issues while debugging SSA (we could have an env var to disable this special printing, though let's see if we really need it).

Some context around why I did this: I was debugging format strings and I couldn't easily see how a format string ended up being in SSA. With this PR it's clear the format string with the formatting remains as-is.

By the way, I think Erlang also behaves this way: strings are just byte arrays and Erlang will print them as strings if all the bytes are printable.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
