### PR TITLE
chore: Update pprof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "criterion",
  "flate2",
  "fxhash",
- "pprof 0.13.0",
+ "pprof",
  "serde",
  "serde-big-array",
  "serde-generate",
@@ -156,6 +156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -604,7 +613,7 @@ dependencies = [
  "lazy_static",
  "noir_grumpkin",
  "num-bigint",
- "pprof 0.12.1",
+ "pprof",
 ]
 
 [[package]]
@@ -1415,6 +1424,26 @@ checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
  "env_filter",
  "log",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2807,7 +2836,7 @@ dependencies = [
  "notify",
  "notify-debouncer-full",
  "paste",
- "pprof 0.13.0",
+ "pprof",
  "predicates 2.1.5",
  "prettytable-rs",
  "proptest",
@@ -3579,32 +3608,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978385d59daf9269189d052ca8a84c1acfd0715c0599a5d5188d4acc078ca46a"
+checksum = "ebbe2f8898beba44815fdc9e5a4ae9c929e21c5dc29b0c774a15555f7f58d6d0"
 dependencies = [
- "backtrace",
- "cfg-if 1.0.0",
- "criterion",
- "findshlibs",
- "inferno",
- "libc",
- "log",
- "nix 0.26.4",
- "once_cell",
- "parking_lot 0.12.3",
- "smallvec",
- "symbolic-demangle",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "pprof"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
-dependencies = [
+ "aligned-vec",
  "backtrace",
  "cfg-if 1.0.0",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ codespan-reporting = "0.11.1"
 criterion = "0.5.0"
 # Note that using the "frame-pointer" feature breaks framegraphs on linux
 # https://github.com/tikv/pprof-rs/pull/172
-pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
+pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
 cfg-if = "1.0.0"
 dirs = "4"

--- a/acvm-repo/bn254_blackbox_solver/Cargo.toml
+++ b/acvm-repo/bn254_blackbox_solver/Cargo.toml
@@ -30,7 +30,7 @@ num-bigint.workspace = true
 [dev-dependencies]
 ark-std.workspace = true
 criterion = "0.5.0"
-pprof = { version = "0.12", features = [
+pprof = { version = "0.14", features = [
     "flamegraph",
     "frame-pointer",
     "criterion",


### PR DESCRIPTION
# Description

## Problem

deny/deny (pull request) CI action started failing because of the advisories requiring pprof to be >= 0.14.

## Summary\*

Fixing pprof version

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
