### PR TITLE
fix: Typo in u128 docs

### DIFF
--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -79,7 +79,7 @@ fn main() {
 You can construct a U128 from its limbs:
 ```rust
 fn main(x: u64, y: u64) {
-    let x = U128::from_u64s_be(x,y);
+    let z = U128::from_u64s_be(x,y);
     assert(z.hi == x as Field);
     assert(z.lo == y as Field);
 }


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
