### PR TITLE
chore: Remove inliner override for `reference_counts` test

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -60,13 +60,9 @@ const IGNORED_BRILLIG_TESTS: [&str; 11] = [
 ];
 
 /// Tests which aren't expected to work with the default inliner cases.
-const INLINER_MIN_OVERRIDES: [(&str, i64); 2] = [
+const INLINER_MIN_OVERRIDES: [(&str, i64); 1] = [
     // 0 works if PoseidonHasher::write is tagged as `inline_always`, otherwise 22.
     ("eddsa", 0),
-    // (#6583): The RcTracker in the DIE SSA pass is removing inc_rcs that are still needed.
-    // This triggers differently depending on the optimization level (although all are wrong),
-    // so we arbitrarily only run with the inlined versions.
-    ("reference_counts", 0),
 ];
 
 /// Some tests are expected to have warnings


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

After https://github.com/noir-lang/noir/pull/6685, reference counts are the same inlined or not again

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
