### PR TITLE
fix: git dependency trailing slash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,7 @@ dependencies = [
  "noirc_frontend",
  "semver",
  "serde",
+ "test-case",
  "thiserror",
  "toml 0.7.8",
  "url 2.5.3",

--- a/tooling/nargo_toml/Cargo.toml
+++ b/tooling/nargo_toml/Cargo.toml
@@ -25,3 +25,4 @@ noirc_driver.workspace = true
 semver = "1.0.20"
 
 [dev-dependencies]
+test-case.workspace = true

--- a/tooling/nargo_toml/src/git.rs
+++ b/tooling/nargo_toml/src/git.rs
@@ -9,10 +9,13 @@ fn resolve_folder_name(base: &url::Url, tag: &str) -> String {
     folder_name
 }
 
+/// Path to the `nargo` directory under `$HOME`.
 fn nargo_crates() -> PathBuf {
     dirs::home_dir().unwrap().join("nargo")
 }
 
+/// Target directory to download dependencies into, e.g.
+/// `$HOME/nargo/github.com/noir-lang/noir-bignum/v0.1.2`
 fn git_dep_location(base: &url::Url, tag: &str) -> PathBuf {
     let folder_name = resolve_folder_name(base, tag);
 
@@ -52,4 +55,19 @@ pub(crate) fn clone_git_repo(url: &str, tag: &str) -> Result<PathBuf, String> {
         .expect("git clone command failed to start");
 
     Ok(loc)
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::resolve_folder_name;
+
+    #[test]
+    fn test_resolve_folder_name() {
+        let url = "https://github.com/noir-lang/noir-bignum/";
+        let tag = "v0.4.2";
+        let dir = resolve_folder_name(&Url::parse(url).unwrap(), tag);
+        assert_eq!(dir, "github.com/noir-lang/noir-bignum/v0.4.2");
+    }
 }

--- a/tooling/nargo_toml/src/git.rs
+++ b/tooling/nargo_toml/src/git.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 fn resolve_folder_name(base: &url::Url, tag: &str) -> String {
     let mut folder = PathBuf::from("");
     for part in [base.domain().unwrap(), base.path(), tag] {
-        folder.push(part.trim_start_matches("/"));
+        folder.push(part.trim_start_matches('/'));
     }
     folder.to_string_lossy().into_owned()
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6720

## Summary\*

The location to store dependencies didn't handle the case where there _wasn't_ a trailing slash as expected, resulting in the dependencies with and without a trailing slash treated as different crates.

## Additional Context

For example the crate in question was downloaded to two different locations:
* `~/nargo/github.com/noir-lang/noir-bignumv0.4.2/src/lib.nr`
* `~/nargo/github.com/noir-lang/noir-bignum/v0.4.2/src/lib.nr`

These got mapped to separate `CrateId` in [prepare_dependency](https://github.com/noir-lang/noir/blob/da9a74a2c70be8ba2a72b7dfb24393c029a27564/compiler/noirc_driver/src/lib.rs#L267-L272), which then caused [unification](https://github.com/noir-lang/noir/blob/da9a74a2c70be8ba2a72b7dfb24393c029a27564/compiler/noirc_frontend/src/hir_def/types.rs#L1639) to fail because the `StructId` contains the crate ID.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
