### PR TITLE
chore: Update url to 2.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ checksum = "fc4159b76af02757139baf42c0c971c6dc155330999fbfd8eddb29b97fb2db68"
 dependencies = [
  "codespan-reporting",
  "lsp-types 0.88.0",
- "url 2.5.3",
+ "url 2.5.4",
 ]
 
 [[package]]
@@ -2657,7 +2657,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "url 2.5.3",
+ "url 2.5.4",
 ]
 
 [[package]]
@@ -2670,7 +2670,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "url 2.5.3",
+ "url 2.5.4",
 ]
 
 [[package]]
@@ -2886,7 +2886,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "toml 0.7.8",
- "url 2.5.3",
+ "url 2.5.4",
 ]
 
 [[package]]
@@ -5178,9 +5178,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ serde_json = "1.0"
 smol_str = { version = "0.1.17", features = ["serde"] }
 thiserror = "1.0.21"
 toml = "0.7.2"
-url = "2.2.0"
+url = "2.5.4"
 base64 = "0.21.2"
 fxhash = "0.2.1"
 build-data = "0.1.3"


### PR DESCRIPTION
# Description

## Problem

deny/deny (pull request) CI action started failing because of the advisories requiring url to be >= 2.5.4.

## Summary

Updating url module version

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
