### PR TITLE
chore: free memory for silenced warnings early

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -316,7 +316,7 @@ pub fn check_crate(
         })
         .filter(|diagnostic| {
             // We filter out any warnings if they're going to be ignored later on to free up memory.
-            !options.silence_warnings || diagnostic.diagnostic.kind == DiagnosticKind::Warning
+            !options.silence_warnings || diagnostic.diagnostic.kind != DiagnosticKind::Warning
         })
         .collect();
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -10,7 +10,7 @@ use clap::Args;
 use fm::{FileId, FileManager};
 use iter_extended::vecmap;
 use noirc_abi::{AbiParameter, AbiType, AbiValue};
-use noirc_errors::{CustomDiagnostic, FileDiagnostic};
+use noirc_errors::{CustomDiagnostic, DiagnosticKind, FileDiagnostic};
 use noirc_evaluator::create_program;
 use noirc_evaluator::errors::RuntimeError;
 use noirc_evaluator::ssa::{SsaLogging, SsaProgramArtifact};
@@ -301,7 +301,6 @@ pub fn check_crate(
     crate_id: CrateId,
     options: &CompileOptions,
 ) -> CompilationResult<()> {
-    let mut errors = vec![];
     let error_on_unused_imports = true;
     let diagnostics = CrateDefMap::collect_defs(
         crate_id,
@@ -309,15 +308,22 @@ pub fn check_crate(
         options.debug_comptime_in_file.as_deref(),
         error_on_unused_imports,
     );
-    errors.extend(diagnostics.into_iter().map(|(error, file_id)| {
-        let diagnostic = CustomDiagnostic::from(&error);
-        diagnostic.in_file(file_id)
-    }));
+    let warnings_and_errors: Vec<FileDiagnostic> = diagnostics
+        .into_iter()
+        .map(|(error, file_id)| {
+            let diagnostic = CustomDiagnostic::from(&error);
+            diagnostic.in_file(file_id)
+        })
+        .filter(|diagnostic| {
+            // We filter out any warnings if they're going to be ignored later on to free up memory.
+            !options.silence_warnings || diagnostic.diagnostic.kind == DiagnosticKind::Warning
+        })
+        .collect();
 
-    if has_errors(&errors, options.deny_warnings) {
-        Err(errors)
+    if has_errors(&warnings_and_errors, options.deny_warnings) {
+        Err(warnings_and_errors)
     } else {
-        Ok(((), errors))
+        Ok(((), warnings_and_errors))
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The protocol circuits currently print out 250k lines of warnings to the console which reminded me that we track all of the typechecking warnings through the full compilation flow even if we've decided to silence them (as they do in aztec-packages).

This PR updates `check_crate` to drop all these warnings before we start the SSA passes so that we can free up some memory.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
