### PR TITLE
chore: lock CI to use ubuntu 22.04

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cleanup
         run: |

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -18,7 +18,7 @@ concurrency: deny-${{ github.head_ref || github.run_id }}
 jobs:
   deny:
     name: deny
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/docs-dead-links.yml
+++ b/.github/workflows/docs-dead-links.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   add_label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       has_label: ${{ steps.check-labels.outputs.result }}
     steps:
@@ -49,7 +49,7 @@ jobs:
           }
 
   build_preview:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
 
   deploy_preview:
     needs: [build_preview, add_label]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     if: needs.add_label.outputs.has_label == 'true'
@@ -121,7 +121,7 @@ jobs:
 
   add_comment:
     needs: [deploy_preview]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   clippy:
     name: cargo clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
       RUSTFLAGS: -Dwarnings
@@ -41,7 +41,7 @@ jobs:
 
   rustfmt:
     name: cargo fmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
       RUSTFLAGS: -Dwarnings
@@ -67,7 +67,7 @@ jobs:
 
   eslint:
     name: eslint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -115,7 +115,7 @@ jobs:
   nargo_fmt:
     needs: [build-nargo]
     name: Nargo fmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/publish-acvm.yml
+++ b/.github/workflows/publish-acvm.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     name: Publish in order
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish-docs:
     name: Publish docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout release branch

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -16,7 +16,7 @@ run-name: Publish ES Packages from ${{ inputs.noir-ref }} under @${{ inputs.npm-
 
 jobs:
   build-noirc_abi_wasm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Noir repo
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
           retention-days: 10
 
   build-noir_wasm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
           retention-days: 3
 
   build-acvm_js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
           retention-days: 3
           
   publish-es-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-acvm_js, build-noirc_abi_wasm, build-noir_wasm]
     steps:
       - name: Checkout sources

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   dispatch-publish-es:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Dispatch to publish-nargo
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   conventional-title:
     name: Validate PR title is Conventional Commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check title
         if: github.event_name == 'pull_request_target'
@@ -30,7 +30,7 @@ jobs:
 
   force-push-comment:
     name: Warn external contributors about force-pushing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != 'noir-lang/noir' }} 
     permissions:
       pull-requests: write

--- a/.github/workflows/recrawler.yml
+++ b/.github/workflows/recrawler.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   algolia_recrawl:
     name: Algolia Recrawl
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Algolia crawler creation and crawl
         uses: algolia/algoliasearch-crawler-github-actions@v1.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       release-pr: ${{ steps.release.outputs.pr }}
       tag-name: ${{ steps.release.outputs.tag_name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Run release-please
         id: release
@@ -23,7 +23,7 @@ jobs:
     name: Update acvm workspace package versions
     needs: [release-please]
     if: ${{ needs.release-please.outputs.release-pr }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout release branch
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
     name: Update docs
     needs: [release-please, update-acvm-workspace-package-versions]
     if: ${{ needs.release-please.outputs.release-pr }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
  
     steps:
       - name: Checkout release branch
@@ -110,7 +110,7 @@ jobs:
 
   release-end:
     name: Release End
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # We want this job to always run (even if the dependant jobs fail) as we need apply changes to the sticky comment.
     if: ${{ always() }}
     
@@ -145,7 +145,7 @@ jobs:
     name: Build binaries
     needs: [release-please]
     if: ${{ needs.release-please.outputs.tag-name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Dispatch to publish workflow
         uses: benc-uk/workflow-dispatch@v1
@@ -160,7 +160,7 @@ jobs:
     name: Publish ES packages
     needs: [release-please]
     if: ${{ needs.release-please.outputs.tag-name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Dispatch to publish-es-packages
         uses: benc-uk/workflow-dispatch@v1
@@ -174,7 +174,7 @@ jobs:
     name: Publish acvm
     needs: [release-please]
     if: ${{ needs.release-please.outputs.tag-name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     steps:
       - name: Dispatch to publish-acvm

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-nargo:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Noir repo
@@ -42,7 +42,7 @@ jobs:
   compare_gates_reports:
     name: Circuit sizes
     needs: [build-nargo]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 
@@ -93,7 +93,7 @@ jobs:
   compare_brillig_bytecode_size_reports:
     name: Brillig bytecode sizes
     needs: [build-nargo]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 
@@ -142,7 +142,7 @@ jobs:
   compare_brillig_execution_reports:
     name: Brillig execution trace sizes  
     needs: [build-nargo]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 
@@ -191,7 +191,7 @@ jobs:
   generate_memory_report:
     name: Peak memory usage  
     needs: [build-nargo]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 
@@ -237,7 +237,7 @@ jobs:
   generate_compilation_report:
     name: Compilation time
     needs: [build-nargo]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   code:
     name: Code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
 
   docs:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   yarn-lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     
     steps:
@@ -60,7 +60,7 @@ jobs:
           retention-days: 3
 
   build-noirc-abi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -92,7 +92,7 @@ jobs:
           retention-days: 10
 
   build-noir-wasm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -127,7 +127,7 @@ jobs:
           retention-days: 3
 
   build-acvm-js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -161,7 +161,7 @@ jobs:
   test-acvm_js-node:
     needs: [build-acvm-js]
     name: ACVM JS (Node.js)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -183,7 +183,7 @@ jobs:
   test-acvm_js-browser:
     needs: [build-acvm-js]
     name: ACVM JS (Browser)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -208,7 +208,7 @@ jobs:
   test-noirc-abi:
     needs: [build-noirc-abi]
     name: noirc_abi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -236,7 +236,7 @@ jobs:
   test-noir-js:
     needs: [build-nargo, build-acvm-js, build-noirc-abi]
     name: Noir JS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -283,7 +283,7 @@ jobs:
   test-noir-wasm:
     needs: [build-noir-wasm, build-nargo]
     name: noir_wasm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -327,7 +327,7 @@ jobs:
   test-noir-codegen:
     needs: [build-acvm-js, build-noirc-abi, build-nargo]
     name: noir_codegen
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -374,7 +374,7 @@ jobs:
 
   test-integration-node:
     name: Integration Tests (Node)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-acvm-js, build-noir-wasm, build-nargo, build-noirc-abi]
     timeout-minutes: 30
 
@@ -435,7 +435,7 @@ jobs:
 
   test-integration-browser:
     name: Integration Tests (Browser)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-acvm-js, build-noir-wasm, build-noirc-abi]
     timeout-minutes: 30
 
@@ -480,7 +480,7 @@ jobs:
 
   test-examples:
     name: Example scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-nargo]
     timeout-minutes: 30
 
@@ -523,7 +523,7 @@ jobs:
 
   critical-library-list:
     name: Load critical library list
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       libraries: ${{ steps.get_critical_libraries.outputs.libraries }}
 
@@ -542,7 +542,7 @@ jobs:
 
   external-repo-checks:
     needs: [build-nargo, critical-library-list]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only run when 'run-external-checks' label is present
     if: contains(github.event.pull_request.labels.*.name, 'run-external-checks')
     timeout-minutes: 30
@@ -599,7 +599,7 @@ jobs:
   # This allows us to add/remove test jobs without having to update the required workflows.
   tests-end:
     name: End
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
     if: ${{ always() }}
     needs:

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build-test-artifacts:
     name: Build test artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   run-tests:
     name: "Run tests (partition ${{matrix.partition}})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-test-artifacts]
     strategy:
       fail-fast: false
@@ -95,7 +95,7 @@ jobs:
   # This allows us to add/remove test jobs without having to update the required workflows.
   tests-end:
     name: Rust End
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
     if: ${{ always() }}
     needs: 

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build-test-artifacts:
     name: Build test artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   run-tests:
     name: "Run tests (partition ${{matrix.partition}})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-test-artifacts]
     strategy:
       fail-fast: false
@@ -82,7 +82,7 @@ jobs:
   # This allows us to add/remove test jobs without having to update the required workflows.
   tests-end:
     name: Rust End
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
     if: ${{ always() }}
     needs: 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Simpler solution to https://github.com/noir-lang/noir/pull/6746 to just lock ourselves to the old runner image to buy more time.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
