### PR TITLE
fix: parser would hand on function type with colon in it

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -15,7 +15,7 @@ impl<'a> Parser<'a> {
             typ
         } else {
             self.expected_label(ParsingRuleLabel::Type);
-            self.unspecified_type_at_previous_token_end()
+            UnresolvedTypeData::Error.with_span(self.span_at_previous_token_end())
         }
     }
 
@@ -658,6 +658,14 @@ mod tests {
             panic!("Expected a function type")
         };
         assert!(unconstrained);
+    }
+
+    #[test]
+    fn parses_function_type_with_colon_in_parameter() {
+        let src = "fn(value: T) -> Field";
+        let mut parser = Parser::for_str(src);
+        let _ = parser.parse_type_or_error();
+        assert!(!parser.errors.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

@nventuro Found that this snippet crashed VSCode:

```noir
impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
    fn for_each<U, Env>(self, f: fn[Env](value: T, index: u32)) {
        for i in 0..MaxLen {
            if i < self.len() {
                f(self.get_unchecked(i), i);
            }
        }
    }
}
```

## Summary

It turns out that a function type like this: `fn(value: T)` crashed the compiler. The reason is that parsing an fn parameter called `parse_type_or_error` and considered that an error if it returned `UnresolvedTypeData::Error`. The problem is that that method returned `UnresolvedTypeData::Unspecified` in that case. I think at one point I accidentally changed it to return `Unspecified` in order to reuse a function. The name is `parse_type_or_error` so returning `Error` is the correct thing to do, and it also solves the issue.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
