### PR TITLE
fix: disable failure persistance in nargo test fuzzing

### DIFF
--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -13,6 +13,7 @@ use noirc_driver::{compile_no_check, CompileError, CompileOptions};
 use noirc_errors::{debug_info::DebugInfo, FileDiagnostic};
 use noirc_frontend::hir::{def_map::TestFunction, Context};
 use noirc_printable_type::ForeignCallError;
+use proptest::test_runner::Config;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -114,7 +115,9 @@ pub fn run_test<B: BlackBoxFunctionSolver<FieldElement>>(
                     use acvm::acir::circuit::Program;
                     use noir_fuzzer::FuzzedExecutor;
                     use proptest::test_runner::TestRunner;
-                    let runner = TestRunner::default();
+
+                    let runner =
+                        TestRunner::new(Config { failure_persistence: None, ..Config::default() });
 
                     let executor =
                         |program: &Program<FieldElement>,


### PR DESCRIPTION
# Description

## Problem

Running `nargo test` with fuzz tests outputs

> proptest: FileFailurePersistence::SourceParallel set, but no source file known

which is just noise.

## Summary

To reproduce, have a project with this file:

```noir
# src/main.nr
#[test]
fn one(_input: u8) {}
```

Run `nargo test`. You get:

```
[one] Running 1 test function
proptest: FileFailurePersistence::SourceParallel set, but no source file known
[one] Testing one... ok
[one] 1 test passed
```

With this PR:

```
[one] Running 1 test function
[one] Testing one... ok
[one] 1 test passed
```

## Additional Context

It seems the default failure persistence is a directory called "proptest-regressions". But even when that directory exists we get the error. I assume here that `nargo test` never produces proptest regressions and that this PR doesn't break things.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
