### PR TITLE
fix: Minimal change to avoid reverting entire PR #6685

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -705,7 +705,7 @@ impl<'a> FunctionContext<'a> {
         // we consider the array to be moved, so we should have an initial rc of just 1.
         //
         // TODO: this exception breaks #6763
-        let should_inc_rc = true;// !let_expr.expression.is_array_or_slice_literal();
+        let should_inc_rc = true; // !let_expr.expression.is_array_or_slice_literal();
 
         values = values.map(|value| {
             let value = value.eval(self);

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -703,7 +703,9 @@ impl<'a> FunctionContext<'a> {
         // Don't mutate the reference count if we're assigning an array literal to a Let:
         // `let mut foo = [1, 2, 3];`
         // we consider the array to be moved, so we should have an initial rc of just 1.
-        let should_inc_rc = !let_expr.expression.is_array_or_slice_literal();
+        //
+        // TODO: this exception breaks #6763
+        let should_inc_rc = true;// !let_expr.expression.is_array_or_slice_literal();
 
         values = values.map(|value| {
             let value = value.eval(self);

--- a/test_programs/execution_success/reference_counts/src/main.nr
+++ b/test_programs/execution_success/reference_counts/src/main.nr
@@ -2,7 +2,7 @@ use std::mem::array_refcount;
 
 fn main() {
     let mut array = [0, 1, 2];
-    assert_refcount(array, 1);
+    assert_refcount(array, 2);
 
     borrow(array, array_refcount(array));
     borrow_mut(&mut array, array_refcount(array));


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/6763
Replaces https://github.com/noir-lang/noir/pull/6774

## Summary\*

Always incrementing the rc of an array from a let binding fixes the issue in the test in https://github.com/noir-lang/noir/issues/6763. We can revert this one part of #6685 for now and hopefully re-add it later when we figure out why it breaks.

## Additional Context

This means reference counts essentially start at 2 again so the first mutation of an array will always incur a copy.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
