### PR TITLE
Fix optimizer to keep track of changing opcode locations

### DIFF
--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -79,42 +79,47 @@ fn transform_assert_messages<F: Clone>(
 ///
 /// Runs multiple passes until the output stabilizes.
 pub fn compile<F: AcirField>(
-    acir: Circuit<F>,
+    mut acir: Circuit<F>,
     expression_width: ExpressionWidth,
 ) -> (Circuit<F>, AcirTransformationMap) {
-    if MAX_OPTIMIZER_PASSES == 0 {
-        let acir_opcode_positions = (0..acir.opcodes.len()).collect::<Vec<_>>();
-        let transformation_map = AcirTransformationMap::new(&acir_opcode_positions);
-        return (acir, transformation_map);
+    let mut acir_opcode_positions = (0..acir.opcodes.len()).collect::<Vec<_>>();
+
+    if MAX_OPTIMIZER_PASSES > 0 {
+        let mut pass = 0;
+        let mut prev_opcodes_hash = fxhash::hash64(&acir.opcodes);
+        let mut prev_acir = acir;
+        let mut prev_acir_opcode_positions = acir_opcode_positions;
+
+        // For most test programs it would be enough to only loop `transform_internal`,
+        // but some of them don't stabilize unless we also repeat the backend agnostic optimizations.
+        let (new_acir, new_acir_opcode_positions) = loop {
+            let (acir, acir_opcode_positions) =
+                optimize_internal(prev_acir, prev_acir_opcode_positions);
+
+            // Stop if we have already done at least one transform and an extra optimization changed nothing.
+            if pass > 0 && prev_opcodes_hash == fxhash::hash64(&acir.opcodes) {
+                break (acir, acir_opcode_positions);
+            }
+
+            let (acir, acir_opcode_positions) =
+                transform_internal(acir, expression_width, acir_opcode_positions);
+
+            let opcodes_hash = fxhash::hash64(&acir.opcodes);
+
+            // Stop if the output hasn't change in this loop or we went too long.
+            if pass == MAX_OPTIMIZER_PASSES - 1 || prev_opcodes_hash == opcodes_hash {
+                break (acir, acir_opcode_positions);
+            }
+
+            pass += 1;
+            prev_acir = acir;
+            prev_opcodes_hash = opcodes_hash;
+            prev_acir_opcode_positions = acir_opcode_positions;
+        };
+
+        acir = new_acir;
+        acir_opcode_positions = new_acir_opcode_positions;
     }
-    let mut pass = 0;
-    let mut prev_opcodes_hash = fxhash::hash64(&acir.opcodes);
-    let mut prev_acir = acir;
-
-    // For most test programs it would be enough to only loop `transform_internal`,
-    // but some of them don't stabilize unless we also repeat the backend agnostic optimizations.
-    let (mut acir, acir_opcode_positions) = loop {
-        let (acir, acir_opcode_positions) = optimize_internal(prev_acir);
-
-        // Stop if we have already done at least one transform and an extra optimization changed nothing.
-        if pass > 0 && prev_opcodes_hash == fxhash::hash64(&acir.opcodes) {
-            break (acir, acir_opcode_positions);
-        }
-
-        let (acir, acir_opcode_positions) =
-            transform_internal(acir, expression_width, acir_opcode_positions);
-
-        let opcodes_hash = fxhash::hash64(&acir.opcodes);
-
-        // Stop if the output hasn't change in this loop or we went too long.
-        if pass == MAX_OPTIMIZER_PASSES - 1 || prev_opcodes_hash == opcodes_hash {
-            break (acir, acir_opcode_positions);
-        }
-
-        pass += 1;
-        prev_acir = acir;
-        prev_opcodes_hash = opcodes_hash;
-    };
 
     let transformation_map = AcirTransformationMap::new(&acir_opcode_positions);
     acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);

--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -21,7 +21,11 @@ use super::{transform_assert_messages, AcirTransformationMap};
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
 pub fn optimize<F: AcirField>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformationMap) {
-    let (mut acir, new_opcode_positions) = optimize_internal(acir);
+    // Track original acir opcode positions throughout the transformation passes of the compilation
+    // by applying the modifications done to the circuit opcodes and also to the opcode_positions (delete and insert)
+    let acir_opcode_positions = (0..acir.opcodes.len()).collect();
+
+    let (mut acir, new_opcode_positions) = optimize_internal(acir, acir_opcode_positions);
 
     let transformation_map = AcirTransformationMap::new(&new_opcode_positions);
 
@@ -31,12 +35,13 @@ pub fn optimize<F: AcirField>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformati
 }
 
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
+///
+/// Accepts an injected `acir_opcode_positions` to allow optimizations to be applied in a loop.
 #[tracing::instrument(level = "trace", name = "optimize_acir" skip(acir))]
-pub(super) fn optimize_internal<F: AcirField>(acir: Circuit<F>) -> (Circuit<F>, Vec<usize>) {
-    // Track original acir opcode positions throughout the transformation passes of the compilation
-    // by applying the modifications done to the circuit opcodes and also to the opcode_positions (delete and insert)
-    let acir_opcode_positions = (0..acir.opcodes.len()).collect();
-
+pub(super) fn optimize_internal<F: AcirField>(
+    acir: Circuit<F>,
+    acir_opcode_positions: Vec<usize>,
+) -> (Circuit<F>, Vec<usize>) {
     if acir.opcodes.len() == 1 && matches!(acir.opcodes[0], Opcode::BrilligCall { .. }) {
         info!("Program is fully unconstrained, skipping optimization pass");
         return (acir, acir_opcode_positions);


### PR DESCRIPTION
# Description

## Problem\*

Resolves the issue while trying to merge https://github.com/AztecProtocol/aztec-packages/pull/10483
Mirroring https://github.com/AztecProtocol/aztec-packages/pull/10483/commits/13539806da191988e44a9335c8aa82098dfa3566

## Summary\*

Unlike `transform_internal`, `optimize_internal` did not take an `acir_opcode_positions` which would have allowed it to be chained. This caused the second iteration of the loop to reset `acir_opcode_positions` to the default values, which indicated no change when the `AcirTransformationMap` was derived from it. The consequence was that the `assert_messages` and `debug` information did not align with the new opcode locations, which changed in the first iteration. 

## Additional Context

The way to debug this on `aztec-packages` went like this. 
First build everything with `./bootstrap.sh`, then in one terminal start an oracle:

```shell
export LOG_LEVEL=debug
cd aztec-packages/yarn-project/txe
yarn start
```

In another terminal run a test (one of the failing ones):
```shell
export NARGO=$(pwd)/aztec-packages/noir/noir-repo/target/release/nargo 
cd aztec-packages/noir-projects/noir-contracts
$NARGO test --silence-warnings --oracle-resolver http://localhost:8080 --package nft_contract transfer_to_public_failure_not_an_owner 
```

Then change something in the Noir codebase and recompile:
```shell
cd aztec-packages/noir 
./bootstrap.sh
```

With `MAX_OPTIMIZER_PASSES=1` the test passed, otherwise failed. The `LOG_LEVEL=debug` showed the index of the failing opcode. Curiously it was the same in both tests (the oracle is expected to fail, the test verifies it fails with the right message).

One of the things I tried was to print the ACIR opcodes with, with a change in the code so it prints the optimised version, after transformations:
```
$NARGO compile --package nft_contract --print-acir 
```
Comparing the ACIR indicated that 1 or 3 passes doesn't make any difference. Since it was also the same opcode, I started to suspect that it is actually the assertion message that gets lost.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
