### PR TITLE
chore(ssa): Activate loop invariant code motion on ACIR functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -27,12 +27,7 @@ use super::unrolling::{Loop, Loops};
 impl Ssa {
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) fn loop_invariant_code_motion(mut self) -> Ssa {
-        let brillig_functions = self
-            .functions
-            .iter_mut()
-            .filter(|(_, func)| matches!(func.runtime(), RuntimeType::Brillig(_)));
-
-        for (_, function) in brillig_functions {
+        for function in self.functions.values_mut() {
             function.loop_invariant_code_motion();
         }
 
@@ -63,6 +58,7 @@ impl Loops {
         }
 
         context.map_dependent_instructions();
+        context.inserter.map_data_bus_in_place();
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -13,7 +13,7 @@ use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
-        function::{Function, RuntimeType},
+        function::Function,
         function_inserter::FunctionInserter,
         instruction::{Instruction, InstructionId},
         types::Type,


### PR DESCRIPTION
# Description

## Problem\*

Part of general effort to optimize the compiler.

## Summary\*

Loop invariant code motion most affects the Brillig runtime, as in that runtime we actually keep loops and may possibly re-execute unnecessary instructions. In ACIR all loops are unrolled so when the pass was introduced I was thinking that running it may be an unnecessary cost when compiling to ACIR. However, the pass should provide benefits to the compilation pipeline itself.

For ACIR programs with large upper loop bounds, unrolling is oftentimes the pass that takes up the most time. If we can reduce the number of opcodes inside of a loop, unrolling should take less time. This becomes most obvious when paired with https://github.com/noir-lang/noir/pull/6782, as a large constant array it most likely going to be one of the heavier instructions to process due to its large number of values.

We probably will want some kind of heuristic to determine whether it is worth it to run this pass for ACIR. Running this pass in ACIR is still most likely unnecessary for the majority of programs, but will benefit those programs with lots of heavy loop invariants. 

## Additional Context

Compiling the `blob` circuit:
Master:
Loop invariant code motion - 0ms
Unrolling - 44s
This branch w/ https://github.com/noir-lang/noir/pull/6784:
Loop invariant code motion - 152ms
Unrolling - 27s (38.6% improvement)


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
