### PR TITLE
feat: add `(x | 1)` optimization for booleans

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -256,6 +256,10 @@ impl Binary {
                 if rhs_is_zero {
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }
+                if operand_type == NumericType::bool() && (lhs_is_one || rhs_is_one) {
+                    let one = dfg.make_constant(FieldElement::one(), operand_type);
+                    return SimplifyResult::SimplifiedTo(one);
+                }
                 if dfg.resolve(self.lhs) == dfg.resolve(self.rhs) {
                     return SimplifyResult::SimplifiedTo(self.lhs);
                 }

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
@@ -388,9 +388,9 @@ mod test {
                 v5 = make_array [Field 1, Field 0, v0, Field 0, Field 2, Field 0] : [Field; 6]
                 v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, v0, v1, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 9]
                 v8 = make_array [v0, Field 0, Field 1, Field 0] : [Field; 4]
-                v12 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, u1 0] : [Field; 6]
-                v14 = call multi_scalar_mul(v12, v8) -> [Field; 3]
-                return v14
+                v11 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, Field 0] : [Field; 6]
+                v13 = call multi_scalar_mul(v12, v8) -> [Field; 3]
+                return v13
             }
             "#;
         assert_normalized_ssa_equals(ssa, expected_src);

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
@@ -393,7 +393,7 @@ mod test {
                 v8 = make_array [v0, Field 0, Field 1, Field 0] : [Field; 4]
                 v12 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, u1 0] : [Field; 6]
                 v14 = call multi_scalar_mul(v12, v8) -> [Field; 3]
-                return v13
+                return v14
             }
             "#;
         assert_normalized_ssa_equals(ssa, expected_src);

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
@@ -173,8 +173,12 @@ pub(super) fn simplify_msm(
                 var_scalars.push(zero);
                 let result_x = dfg.make_constant(result_x, NumericType::NativeField);
                 let result_y = dfg.make_constant(result_y, NumericType::NativeField);
+
+                // Pushing a bool here is intentional, multi_scalar_mul takes two arguments:
+                // `points: [(Field, Field, bool); N]` and `scalars: [(Field, Field); N]`.
                 let result_is_infinity =
-                    dfg.make_constant(result_is_infinity, NumericType::NativeField);
+                    dfg.make_constant(result_is_infinity, NumericType::bool());
+
                 var_points.push(result_x);
                 var_points.push(result_y);
                 var_points.push(result_is_infinity);

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
@@ -173,7 +173,8 @@ pub(super) fn simplify_msm(
                 var_scalars.push(zero);
                 let result_x = dfg.make_constant(result_x, NumericType::NativeField);
                 let result_y = dfg.make_constant(result_y, NumericType::NativeField);
-                let result_is_infinity = dfg.make_constant(result_is_infinity, NumericType::bool());
+                let result_is_infinity =
+                    dfg.make_constant(result_is_infinity, NumericType::NativeField);
                 var_points.push(result_x);
                 var_points.push(result_y);
                 var_points.push(result_is_infinity);

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
@@ -176,8 +176,7 @@ pub(super) fn simplify_msm(
 
                 // Pushing a bool here is intentional, multi_scalar_mul takes two arguments:
                 // `points: [(Field, Field, bool); N]` and `scalars: [(Field, Field); N]`.
-                let result_is_infinity =
-                    dfg.make_constant(result_is_infinity, NumericType::bool());
+                let result_is_infinity = dfg.make_constant(result_is_infinity, NumericType::bool());
 
                 var_points.push(result_x);
                 var_points.push(result_y);
@@ -392,8 +391,8 @@ mod test {
                 v5 = make_array [Field 1, Field 0, v0, Field 0, Field 2, Field 0] : [Field; 6]
                 v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, v0, v1, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 9]
                 v8 = make_array [v0, Field 0, Field 1, Field 0] : [Field; 4]
-                v11 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, Field 0] : [Field; 6]
-                v13 = call multi_scalar_mul(v11, v8) -> [Field; 3]
+                v12 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, u1 0] : [Field; 6]
+                v14 = call multi_scalar_mul(v12, v8) -> [Field; 3]
                 return v13
             }
             "#;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
@@ -389,7 +389,7 @@ mod test {
                 v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, v0, v1, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 9]
                 v8 = make_array [v0, Field 0, Field 1, Field 0] : [Field; 4]
                 v11 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, Field 0] : [Field; 6]
-                v13 = call multi_scalar_mul(v12, v8) -> [Field; 3]
+                v13 = call multi_scalar_mul(v11, v8) -> [Field; 3]
                 return v13
             }
             "#;


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue in a slack thread by @michaeljklein 

## Summary\*

Breakout of a change in https://github.com/noir-lang/noir/pull/6771 where slice pop back seemed to be using all of its ctrl_typevars for a tuple instead of the one element that was actually being popped. This only affects the ArrayGet though which is subsequently optimized out.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
