### PR TITLE
chore: Test RcTracker with starting inc_rc elision re-added

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -705,7 +705,7 @@ impl<'a> FunctionContext<'a> {
         // we consider the array to be moved, so we should have an initial rc of just 1.
         //
         // TODO: this exception breaks #6763
-        let should_inc_rc = true; // !let_expr.expression.is_array_or_slice_literal();
+        let should_inc_rc = !let_expr.expression.is_array_or_slice_literal();
 
         values = values.map(|value| {
             let value = value.eval(self);

--- a/test_programs/execution_success/reference_counts/src/main.nr
+++ b/test_programs/execution_success/reference_counts/src/main.nr
@@ -2,7 +2,7 @@ use std::mem::array_refcount;
 
 fn main() {
     let mut array = [0, 1, 2];
-    assert_refcount(array, 2);
+    assert_refcount(array, 1);
 
     borrow(array, array_refcount(array));
     borrow_mut(&mut array, array_refcount(array));


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Fork of https://github.com/noir-lang/noir/pull/6783 to test it on external repos with the change to start reference counts at 2 reverted to start at 1 again.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
