### PR TITLE
chore: Change Id to use a u32

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -1880,7 +1880,7 @@ impl<'a> Context<'a> {
                 // This conversion is for debugging support only, to allow the
                 // debugging instrumentation code to work. Taking the reference
                 // of a function in ACIR is useless.
-                let id = self.acir_context.add_constant(function_id.to_usize());
+                let id = self.acir_context.add_constant(function_id.to_u32());
                 AcirValue::Var(id, AcirType::field())
             }
             Value::ForeignFunction(_) => unimplemented!(

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -1614,7 +1614,7 @@ impl<'block> BrilligBlock<'block> {
 
                 self.brillig_context.const_instruction(
                     new_variable.extract_single_addr(),
-                    value_id.to_usize().into(),
+                    value_id.to_u32().into(),
                 );
                 new_variable
             }

--- a/compiler/noirc_evaluator/src/ssa/ir/map.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/map.rs
@@ -4,7 +4,7 @@ use std::{
     collections::BTreeMap,
     hash::Hash,
     str::FromStr,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
 };
 use thiserror::Error;
 
@@ -18,7 +18,7 @@ use thiserror::Error;
 /// another map where it will likely be invalid.
 #[derive(Serialize, Deserialize)]
 pub(crate) struct Id<T> {
-    index: usize,
+    index: u32,
     // If we do not skip this field it will simply serialize as `"_marker":null` which is useless extra data
     #[serde(skip)]
     _marker: std::marker::PhantomData<T>,
@@ -26,14 +26,12 @@ pub(crate) struct Id<T> {
 
 impl<T> Id<T> {
     /// Constructs a new Id for the given index.
-    /// This constructor is deliberately private to prevent
-    /// constructing invalid IDs.
-    pub(crate) fn new(index: usize) -> Self {
+    pub(crate) fn new(index: u32) -> Self {
         Self { index, _marker: std::marker::PhantomData }
     }
 
     /// Returns the underlying index of this Id.
-    pub(crate) fn to_usize(self) -> usize {
+    pub(crate) fn to_u32(self) -> u32 {
         self.index
     }
 
@@ -187,7 +185,7 @@ impl<T> DenseMap<T> {
     /// Adds an element to the map.
     /// Returns the identifier/reference to that element.
     pub(crate) fn insert(&mut self, element: T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len().try_into().unwrap());
         self.storage.push(element);
         id
     }
@@ -195,7 +193,7 @@ impl<T> DenseMap<T> {
     /// Given the Id of the element being created, adds the element
     /// returned by the given function to the map
     pub(crate) fn insert_with_id(&mut self, f: impl FnOnce(Id<T>) -> T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len().try_into().unwrap());
         self.storage.push(f(id));
         id
     }
@@ -204,7 +202,7 @@ impl<T> DenseMap<T> {
     ///
     /// The id-element pairs are ordered by the numeric values of the ids.
     pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = (Id<T>, &T)> {
-        let ids_iter = (0..self.storage.len()).map(|idx| Id::new(idx));
+        let ids_iter = (0..self.storage.len() as u32).map(|idx| Id::new(idx));
         ids_iter.zip(self.storage.iter())
     }
 }
@@ -219,13 +217,13 @@ impl<T> std::ops::Index<Id<T>> for DenseMap<T> {
     type Output = T;
 
     fn index(&self, id: Id<T>) -> &Self::Output {
-        &self.storage[id.index]
+        &self.storage[id.index as usize]
     }
 }
 
 impl<T> std::ops::IndexMut<Id<T>> for DenseMap<T> {
     fn index_mut(&mut self, id: Id<T>) -> &mut Self::Output {
-        &mut self.storage[id.index]
+        &mut self.storage[id.index as usize]
     }
 }
 
@@ -253,7 +251,7 @@ impl<T> SparseMap<T> {
     /// Adds an element to the map.
     /// Returns the identifier/reference to that element.
     pub(crate) fn insert(&mut self, element: T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len().try_into().unwrap());
         self.storage.insert(id, element);
         id
     }
@@ -261,7 +259,7 @@ impl<T> SparseMap<T> {
     /// Given the Id of the element being created, adds the element
     /// returned by the given function to the map
     pub(crate) fn insert_with_id(&mut self, f: impl FnOnce(Id<T>) -> T) -> Id<T> {
-        let id = Id::new(self.storage.len());
+        let id = Id::new(self.storage.len().try_into().unwrap());
         self.storage.insert(id, f(id));
         id
     }
@@ -365,7 +363,7 @@ impl<K: Eq + Hash, V> std::ops::Index<&K> for TwoWayMap<K, V> {
 /// This type wraps an AtomicUsize so it can safely be used across threads.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct AtomicCounter<T> {
-    next: AtomicUsize,
+    next: AtomicU32,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -373,7 +371,7 @@ impl<T> AtomicCounter<T> {
     /// Create a new counter starting after the given Id.
     /// Use AtomicCounter::default() to start at zero.
     pub(crate) fn starting_after(id: Id<T>) -> Self {
-        Self { next: AtomicUsize::new(id.index + 1), _marker: Default::default() }
+        Self { next: AtomicU32::new(id.index + 1), _marker: Default::default() }
     }
 
     /// Return the next fresh id

--- a/compiler/noirc_evaluator/src/ssa/ir/map.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/map.rs
@@ -26,7 +26,10 @@ pub(crate) struct Id<T> {
 
 impl<T> Id<T> {
     /// Constructs a new Id for the given index.
-    pub(crate) fn new(index: u32) -> Self {
+    ///
+    /// This is private so that we can guarantee ids created from this function
+    /// point to valid T values in their external maps.
+    fn new(index: u32) -> Self {
         Self { index, _marker: std::marker::PhantomData }
     }
 
@@ -41,7 +44,7 @@ impl<T> Id<T> {
     /// as unlike DenseMap::push and SparseMap::push, the Ids created
     /// here are likely invalid for any particularly map.
     #[cfg(test)]
-    pub(crate) fn test_new(index: usize) -> Self {
+    pub(crate) fn test_new(index: u32) -> Self {
         Self::new(index)
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -268,7 +268,7 @@ fn create_apply_functions(
 }
 
 fn function_id_to_field(function_id: FunctionId) -> FieldElement {
-    (function_id.to_usize() as u128).into()
+    (function_id.to_u32() as u128).into()
 }
 
 /// Creates an apply function for the given signature and variants

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -1146,7 +1146,7 @@ mod tests {
 
         let refs = loop0.find_pre_header_reference_values(function, &loops.cfg).unwrap();
         assert_eq!(refs.len(), 1);
-        assert!(refs.contains(&ValueId::new(2)));
+        assert!(refs.contains(&ValueId::test_new(2)));
 
         let (loads, stores) = loop0.count_loads_and_stores(function, &refs);
         assert_eq!(loads, 1);

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -57,7 +57,7 @@ impl Translator {
         // A FunctionBuilder must be created with a main Function, so here wer remove it
         // from the parsed SSA to avoid adding it twice later on.
         let main_function = parsed_ssa.functions.remove(0);
-        let main_id = FunctionId::new(0);
+        let main_id = FunctionId::test_new(0);
         let mut builder = FunctionBuilder::new(main_function.external_name.clone(), main_id);
         builder.set_runtime(main_function.runtime_type);
 
@@ -65,7 +65,7 @@ impl Translator {
         let mut function_id_counter = 1;
         let mut functions = HashMap::new();
         for function in &parsed_ssa.functions {
-            let function_id = FunctionId::new(function_id_counter);
+            let function_id = FunctionId::test_new(function_id_counter);
             function_id_counter += 1;
 
             functions.insert(function.internal_name.clone(), function_id);


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

Changes `Id` to be represented by a `u32` instead of a `usize` to save memory.

## Additional Context

Unsure on performance implications since I also used `.try_into().unwrap()` to panic if the length is greater than a u32 over `as u32` which would be faster but silently wrap.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
