### PR TITLE
chore: Update memory report to run noir-contracts repo

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -387,8 +387,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # TODO: Bring this report back under a flag. The `noir-contracts` report takes just under 30 minutes.
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset }


### PR DESCRIPTION
# Description

## Problem\*

No issue

## Summary\*

I just saw https://github.com/noir-lang/noir/pull/6807 and noticed that `ram_blowup_regression` went down by 50%. I remembered that this is a pattern common in the noir contracts so I want to test bringing back the noir-contracts repo to the memory report. Previously it took just under 30 minutes and had a peak memory of ~9 GB.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
