### PR TITLE
chore(ci): Active rollup circuits in compilation report

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -388,12 +388,13 @@ jobs:
           path: test-repo
           ref: ${{ matrix.project.ref }}
 
+      - name: Install Yarn dependencies
+        working-directory: ./test-repo/${{ matrix.project.path }}
+        uses: ./.github/actions/setup
+
       - name: Generate compilation report
         working-directory: ./test-repo/${{ matrix.project.path }}
         run: |
-          ls .
-          ls ./scripts
-          yarn install
           chmod +x ./scripts/generate_variants.js
           node ./scripts/generate_variants.js
           mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -391,6 +391,8 @@ jobs:
       - name: Generate compilation report
         working-directory: ./test-repo/${{ matrix.project.path }}
         run: |
+          ls .
+          ls ./scripts
           chmod +x ./scripts/generate_variants.js
           node ./scripts/generate_variants.js
           mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -382,9 +382,17 @@ jobs:
           path: test-repo
           ref: ${{ matrix.project.ref }}
 
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
       - name: Generate compilation report
         working-directory: ./test-repo/${{ matrix.project.path }}
         run: |
+          chmod +x ./scripts/generate_variants.js
+          node ./scripts/generate_variants.js
           mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh
           chmod +x ./compilation_report.sh
           ./compilation_report.sh 1 ${{ matrix.project.package }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -393,6 +393,7 @@ jobs:
         run: |
           ls .
           ls ./scripts
+          yarn
           chmod +x ./scripts/generate_variants.js
           node ./scripts/generate_variants.js
           mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -393,7 +393,7 @@ jobs:
         run: |
           ls .
           ls ./scripts
-          yarn
+          yarn install
           chmod +x ./scripts/generate_variants.js
           node ./scripts/generate_variants.js
           mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -272,12 +272,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset }
-          # TODO: Bring these back once they no longer time out
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-private }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-public }
 

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -335,6 +335,79 @@ jobs:
           retention-days: 3
           overwrite: true
 
+  external_repo_compilation_report_workspace_packages:
+    needs: [build-nargo]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail }
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset }
+          # TODO: Bring these back once they no longer time out
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits, package: rollup_base_public }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits, package: rollup_base_private }
+
+    name: External repo compilation report - ${{ matrix.project.repo }}/${{ matrix.project.path }}
+    steps:
+      - name: Download nargo binary
+        uses: actions/download-artifact@v4
+        with:
+          name: nargo
+          path: ./nargo
+
+      - name: Set nargo on PATH
+        run: |
+          nargo_binary="${{ github.workspace }}/nargo/nargo"
+          chmod +x $nargo_binary
+          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
+          export PATH="$PATH:$(dirname $nargo_binary)"
+          nargo -V
+
+      - uses: actions/checkout@v4
+        with:
+          path: scripts
+          sparse-checkout: |
+            test_programs/compilation_report.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.project.repo }}
+          path: test-repo
+          ref: ${{ matrix.project.ref }}
+
+      - name: Generate compilation report
+        working-directory: ./test-repo/${{ matrix.project.path }}
+        run: |
+          mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh
+          chmod +x ./compilation_report.sh
+          ./compilation_report.sh 1 ${{ matrix.project.package }}
+
+      - name: Move compilation report
+        id: report
+        shell: bash
+        run: |
+          PACKAGE_NAME=${{ matrix.project.path }}
+          PACKAGE_NAME="$(basename $PACKAGE_NAME)${{ matrix.project.package }}"
+          echo $PACKAGE_NAME
+          mv ./test-repo/${{ matrix.project.path }}/compilation_report.json ./compilation_report_$PACKAGE_NAME.json
+          echo "compilation_report_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Upload compilation report
+        uses: actions/upload-artifact@v4
+        with:
+          name: compilation_report_${{ steps.report.outputs.compilation_report_name }}
+          path: compilation_report_${{ steps.report.outputs.compilation_report_name }}.json
+          retention-days: 3
+          overwrite: true
+
+
   upload_compilation_report:
     name: Upload compilation report 
     needs: [generate_compilation_report, external_repo_compilation_report]

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -272,14 +272,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
+          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset }
           # TODO: Bring these back once they no longer time out
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-private }
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-public }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-private }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-public }
 
     name: External repo compilation report - ${{ matrix.project.repo }}/${{ matrix.project.path }}
     steps:
@@ -334,91 +334,6 @@ jobs:
           path: compilation_report_${{ steps.report.outputs.compilation_report_name }}.json
           retention-days: 3
           overwrite: true
-
-  external_repo_compilation_report_workspace_packages:
-    needs: [build-nargo]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts }
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail }
-          # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset }
-          # TODO: Bring these back once they no longer time out
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits, package: rollup_base_public }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits, package: rollup_base_private }
-
-    name: External repo compilation report - ${{ matrix.project.repo }}/${{ matrix.project.path }}
-    steps:
-      - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
-
-      - uses: actions/checkout@v4
-        with:
-          path: scripts
-          sparse-checkout: |
-            test_programs/compilation_report.sh
-          sparse-checkout-cone-mode: false
-
-      - uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ matrix.project.repo }}
-          path: test-repo
-          ref: ${{ matrix.project.ref }}
-
-      - name: Install Yarn dependencies
-        working-directory: ./test-repo/${{ matrix.project.path }}
-        uses: ./.github/actions/setup
-
-      - name: Generate compilation report
-        working-directory: ./test-repo/${{ matrix.project.path }}
-        run: |
-          chmod +x ./scripts/generate_variants.js
-          node ./scripts/generate_variants.js
-          mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh
-          chmod +x ./compilation_report.sh
-          ./compilation_report.sh 1 ${{ matrix.project.package }}
-
-      - name: Move compilation report
-        id: report
-        shell: bash
-        run: |
-          PACKAGE_NAME=${{ matrix.project.path }}
-          PACKAGE_NAME="$(basename $PACKAGE_NAME)${{ matrix.project.package }}"
-          echo $PACKAGE_NAME
-          mv ./test-repo/${{ matrix.project.path }}/compilation_report.json ./compilation_report_$PACKAGE_NAME.json
-          echo "compilation_report_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
-
-      - name: Upload compilation report
-        uses: actions/upload-artifact@v4
-        with:
-          name: compilation_report_${{ steps.report.outputs.compilation_report_name }}
-          path: compilation_report_${{ steps.report.outputs.compilation_report_name }}.json
-          retention-days: 3
-          overwrite: true
-
 
   upload_compilation_report:
     name: Upload compilation report 

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -375,18 +375,18 @@ jobs:
             test_programs/compilation_report.sh
           sparse-checkout-cone-mode: false
 
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           repository: ${{ matrix.project.repo }}
           path: test-repo
           ref: ${{ matrix.project.ref }}
-
-      - uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
 
       - name: Generate compilation report
         working-directory: ./test-repo/${{ matrix.project.path }}

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -29,12 +29,19 @@ for dir in ${tests_to_profile[@]}; do
 
     cd $base_path/$dir
 
+    # The default package to run is the supplied list hardcoded at the top of the script
     PACKAGE_NAME=$dir
-    if [ "$#" -ne 0 ]; then
+    # If a specific package name has been provided use that name
+    if [ "$#" -eq  2 ]; then
+      PACKAGE_NAME=$2
+    # Otherwise default to the current directory as the package we want to run
+    elif [ "$#" -ne 0 ]; then
       PACKAGE_NAME=$(basename $current_dir)
     fi
 
-    COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
+    echo $PACKAGE_NAME
+
+    COMPILE_TIME=$((time nargo compile --force --silence-warnings --package $PACKAGE_NAME) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
     echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"$COMPILE_TIME\"" >> $current_dir/compilation_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -41,7 +41,7 @@ for dir in ${tests_to_profile[@]}; do
 
     echo $PACKAGE_NAME
 
-    COMPILE_TIME=$((time nargo compile --force --silence-warnings --package $PACKAGE_NAME) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
+    COMPILE_TIME=$((time nargo compile --force --silence-warnings --package $PACKAGE_NAME --benchmark-codegen) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
     echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"$COMPILE_TIME\"" >> $current_dir/compilation_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -36,11 +36,6 @@ for dir in ${tests_to_profile[@]}; do
       PACKAGE_NAME=$(basename $current_dir)
     fi
 
-    echo $PACKAGE_NAME
-
-    # Compile again just for benchmarking purposes
-    time nargo compile --force --silence-warnings --benchmark-codegen
-    
     COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
     echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"$COMPILE_TIME\"" >> $current_dir/compilation_report.json
     

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -31,17 +31,17 @@ for dir in ${tests_to_profile[@]}; do
 
     # The default package to run is the supplied list hardcoded at the top of the script
     PACKAGE_NAME=$dir
-    # If a specific package name has been provided use that name
-    if [ "$#" -eq  2 ]; then
-      PACKAGE_NAME=$2
     # Otherwise default to the current directory as the package we want to run
-    elif [ "$#" -ne 0 ]; then
+    if [ "$#" -ne 0 ]; then
       PACKAGE_NAME=$(basename $current_dir)
     fi
 
     echo $PACKAGE_NAME
 
-    COMPILE_TIME=$((time nargo compile --force --silence-warnings --package $PACKAGE_NAME --benchmark-codegen) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
+    # Compile again just for benchmarking purposes
+    time nargo compile --force --silence-warnings --benchmark-codegen
+    
+    COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
     echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"$COMPILE_TIME\"" >> $current_dir/compilation_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then


### PR DESCRIPTION
# Description

## Problem\*

Started as investigations into https://github.com/noir-lang/noir/pull/6750#discussion_r1878881848, but looks like the memory issues have been resolved by recent updates. Specifically this switch to `u32` for Id https://github.com/noir-lang/noir/pull/6807.

## Summary\*

Simply activates the two commented out rollup circuits. 

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
