### PR TITLE
chore: Do not print entire functions when running debug trace

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -37,7 +37,7 @@ pub fn optimize<F: AcirField>(acir: Circuit<F>) -> (Circuit<F>, AcirTransformati
 /// Applies [`ProofSystemCompiler`][crate::ProofSystemCompiler] independent optimizations to a [`Circuit`].
 ///
 /// Accepts an injected `acir_opcode_positions` to allow optimizations to be applied in a loop.
-#[tracing::instrument(level = "trace", name = "optimize_acir" skip(acir))]
+#[tracing::instrument(level = "trace", name = "optimize_acir" skip(acir, acir_opcode_positions))]
 pub(super) fn optimize_internal<F: AcirField>(
     acir: Circuit<F>,
     acir_opcode_positions: Vec<usize>,

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -387,7 +387,11 @@ impl DependencyContext {
             })
             .collect();
 
-        trace!("making {} under constrained reports for function {}", warnings.len(), function.name());
+        trace!(
+            "making {} under constrained reports for function {}",
+            warnings.len(),
+            function.name()
+        );
         warnings
     }
 

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -108,7 +108,7 @@ struct DependencyContext {
 }
 
 /// Structure keeping track of value ids descending from Brillig calls'
-/// arguments and results, also storing information on results
+/// arguments and results, also storing information osn results
 /// already properly constrained
 #[derive(Clone, Debug)]
 struct BrilligTaintedIds {
@@ -229,7 +229,7 @@ impl DependencyContext {
         function: &Function,
         all_functions: &BTreeMap<FunctionId, Function>,
     ) {
-        trace!("processing instructions of block {} of function {}", block, function);
+        trace!("processing instructions of block {} of function {}", block, function.id());
 
         for instruction in function.dfg[block].instructions() {
             let mut arguments = Vec::new();
@@ -321,7 +321,7 @@ impl DependencyContext {
                                 // Record arguments/results for each Brillig call for the check
                                 trace!(
                                     "Brillig function {} called at {}",
-                                    all_functions[&callee],
+                                    callee,
                                     instruction
                                 );
                                 self.tainted.insert(

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -319,7 +319,6 @@ impl DependencyContext {
                         Value::Function(callee) => match all_functions[&callee].runtime() {
                             RuntimeType::Brillig(_) => {
                                 // Record arguments/results for each Brillig call for the check
-                                trace!("Brillig function {} called at {}", callee, instruction);
                                 self.tainted.insert(
                                     *instruction,
                                     BrilligTaintedIds::new(&arguments, &results),
@@ -403,8 +402,6 @@ impl DependencyContext {
     /// Check if any of the recorded Brillig calls have been properly constrained
     /// by given values after recording partial constraints, if so stop tracking them
     fn clear_constrained(&mut self, constrained_values: &[ValueId], function: &Function) {
-        trace!("attempting to clear Brillig calls constrained by values: {:?}", constrained_values);
-
         // Remove numeric constants
         let constrained_values =
             constrained_values.iter().filter(|v| function.dfg.get_numeric_constant(**v).is_none());

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -319,11 +319,7 @@ impl DependencyContext {
                         Value::Function(callee) => match all_functions[&callee].runtime() {
                             RuntimeType::Brillig(_) => {
                                 // Record arguments/results for each Brillig call for the check
-                                trace!(
-                                    "Brillig function {} called at {}",
-                                    callee,
-                                    instruction
-                                );
+                                trace!("Brillig function {} called at {}", callee, instruction);
                                 self.tainted.insert(
                                     *instruction,
                                     BrilligTaintedIds::new(&arguments, &results),
@@ -376,7 +372,7 @@ impl DependencyContext {
             }
         }
 
-        trace!("resulting Brillig involved values: {:?}", self.tainted);
+        trace!("Number tainted Brillig calls: {}", self.tainted.len());
     }
 
     /// Every Brillig call not properly constrained should remain in the tainted set

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -387,7 +387,7 @@ impl DependencyContext {
             })
             .collect();
 
-        trace!("making following reports for function {}: {:?}", function.name(), warnings);
+        trace!("making {} under constrained reports for function {}", warnings.len(), function.name());
         warnings
     }
 


### PR DESCRIPTION
# Description

## Problem\*

I was running `NOIR_LOG=trace nargo` on some programs and my entire output was entirely filled with the SSA of my program. I was unsure where we were printing this SSA, but then I found that a couple trace macros are called in the under constrained values check where we state which function we are processing. We should print the ID, not the entire function.

## Summary\*

I switched to using func IDs instead of the entire function. This makes the trace actually readable. I could turn off the underconstrained check, but I think we should switch this to use an ID either way. Someone attempting to use `trace` should not have to know that they need this flag in order to get some reasonable debug output.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
