### PR TITLE
chore: Use Vec for callstacks

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -2905,7 +2905,6 @@ mod test {
         ssa::{
             function_builder::FunctionBuilder,
             ir::{
-                call_stack::CallStack,
                 function::FunctionId,
                 instruction::BinaryOp,
                 map::Id,
@@ -2932,8 +2931,7 @@ mod test {
             builder.new_function("foo".into(), foo_id, inline_type);
         }
         // Set a call stack for testing whether `brillig_locations` in the `GeneratedAcir` was accurately set.
-        let mut stack = CallStack::unit(Location::dummy());
-        stack.push_back(Location::dummy());
+        let stack = vec![Location::dummy(), Location::dummy()];
         let call_stack =
             builder.current_function.dfg.call_stack_data.get_or_insert_locations(stack);
         builder.set_call_stack(call_stack);

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -201,7 +201,7 @@ impl RuntimeError {
             RuntimeError::UnknownLoopBound { .. } => {
                 let primary_message = self.to_string();
                 let location =
-                    self.call_stack().back().expect("Expected RuntimeError to have a location");
+                    self.call_stack().last().expect("Expected RuntimeError to have a location");
 
                 Diagnostic::simple_error(
                     primary_message,
@@ -212,7 +212,7 @@ impl RuntimeError {
             _ => {
                 let message = self.to_string();
                 let location =
-                    self.call_stack().back().unwrap_or_else(|| panic!("Expected RuntimeError to have a location. Error message: {message}"));
+                    self.call_stack().last().unwrap_or_else(|| panic!("Expected RuntimeError to have a location. Error message: {message}"));
 
                 Diagnostic::simple_error(message, String::new(), location.span)
             }

--- a/compiler/noirc_evaluator/src/ssa/ir/call_stack.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/call_stack.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use noirc_errors::Location;
 
-pub(crate) type CallStack = im::Vector<Location>;
+pub(crate) type CallStack = Vec<Location>;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) struct CallStackId(u32);
@@ -57,9 +57,9 @@ impl Default for CallStackHelper {
 impl CallStackHelper {
     /// Construct a CallStack from a CallStackId
     pub(crate) fn get_call_stack(&self, mut call_stack: CallStackId) -> CallStack {
-        let mut result = im::Vector::new();
+        let mut result = Vec::new();
         while let Some(parent) = self.locations[call_stack.index()].parent {
-            result.push_back(self.locations[call_stack.index()].value);
+            result.push(self.locations[call_stack.index()].value);
             call_stack = parent;
         }
         result


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Switch back to Vec for callstacks since im::Vector preallocates memory.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
