### PR TITLE
chore: Have rust-analyzer use the stable toolchain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     },
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    }
+    },
+    "rust-analyzer.server.extraEnv": { "RUSTUP_TOOLCHAIN": "stable" }
 }


### PR DESCRIPTION
# Description

## Problem\*

Today when working inside of Noir I suddenly started getting red all over any functions or structures that used proc macros: 
![image](https://github.com/user-attachments/assets/73da5865-8de9-4e0d-b598-f998dd7a5913)

This was littering my code base and was quite annoying as it made it harder to see legitimate errors.

## Summary\*

According to https://rust-analyzer.github.io/manual.html#toolchain we can force rust-analyzer to use the stable toolchain via an environment variable. So even though our rust toolchain is set to `1.74.1` we should not be out of sync with rust-analyzer updates. 

My proc macros errors from rust-analyzer are all gone now.

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
