### PR TITLE
feat!: Composable foreign call handlers

### DIFF
--- a/tooling/debugger/src/foreign_calls.rs
+++ b/tooling/debugger/src/foreign_calls.rs
@@ -4,8 +4,8 @@ use acvm::{
     AcirField, FieldElement,
 };
 use nargo::{
-    foreign_calls::{DefaultForeignCallExecutor, ForeignCallExecutor},
-    PrintOutput,
+    foreign_calls::{layers::Layer, ForeignCallExecutor},
+    PrintForeignCallExecutor, PrintOutput,
 };
 use noirc_artifacts::debug::{DebugArtifact, DebugVars, StackFrame};
 use noirc_errors::debug_info::{DebugFnId, DebugVarId};
@@ -44,23 +44,24 @@ pub trait DebugForeignCallExecutor: ForeignCallExecutor<FieldElement> {
     fn current_stack_frame(&self) -> Option<StackFrame<FieldElement>>;
 }
 
-pub struct DefaultDebugForeignCallExecutor<'a> {
-    executor: DefaultForeignCallExecutor<'a, FieldElement>,
+#[derive(Default)]
+pub struct DefaultDebugForeignCallExecutor {
     pub debug_vars: DebugVars<FieldElement>,
 }
 
-impl<'a> DefaultDebugForeignCallExecutor<'a> {
-    pub fn new(output: PrintOutput<'a>) -> Self {
-        Self {
-            executor: DefaultForeignCallExecutor::new(output, None, None, None),
-            debug_vars: DebugVars::default(),
-        }
+impl DefaultDebugForeignCallExecutor {
+    #[allow(clippy::new_ret_no_self, dead_code)]
+    pub fn new(output: PrintOutput<'_>) -> impl DebugForeignCallExecutor + '_ {
+        Layer::default().add(PrintForeignCallExecutor::new(output)).add(Self::default())
     }
 
-    pub fn from_artifact(output: PrintOutput<'a>, artifact: &DebugArtifact) -> Self {
-        let mut ex = Self::new(output);
+    pub fn from_artifact<'a>(
+        output: PrintOutput<'a>,
+        artifact: &DebugArtifact,
+    ) -> impl DebugForeignCallExecutor + 'a {
+        let mut ex = Self::default();
         ex.load_artifact(artifact);
-        ex
+        Layer::default().add(PrintForeignCallExecutor::new(output)).add(ex)
     }
 
     pub fn load_artifact(&mut self, artifact: &DebugArtifact) {
@@ -73,7 +74,7 @@ impl<'a> DefaultDebugForeignCallExecutor<'a> {
     }
 }
 
-impl DebugForeignCallExecutor for DefaultDebugForeignCallExecutor<'_> {
+impl DebugForeignCallExecutor for DefaultDebugForeignCallExecutor {
     fn get_variables(&self) -> Vec<StackFrame<FieldElement>> {
         self.debug_vars.get_variables()
     }
@@ -91,7 +92,7 @@ fn debug_fn_id(value: &FieldElement) -> DebugFnId {
     DebugFnId(value.to_u128() as u32)
 }
 
-impl ForeignCallExecutor<FieldElement> for DefaultDebugForeignCallExecutor<'_> {
+impl ForeignCallExecutor<FieldElement> for DefaultDebugForeignCallExecutor {
     fn execute(
         &mut self,
         foreign_call: &ForeignCallWaitInfo<FieldElement>,
@@ -166,7 +167,21 @@ impl ForeignCallExecutor<FieldElement> for DefaultDebugForeignCallExecutor<'_> {
                 self.debug_vars.pop_fn();
                 Ok(ForeignCallResult::default())
             }
-            None => self.executor.execute(foreign_call),
+            None => Err(ForeignCallError::NoHandler(foreign_call_name.to_string())),
         }
+    }
+}
+
+impl<H, I> DebugForeignCallExecutor for Layer<H, I, FieldElement>
+where
+    H: DebugForeignCallExecutor,
+    I: ForeignCallExecutor<FieldElement>,
+{
+    fn get_variables(&self) -> Vec<StackFrame<FieldElement>> {
+        self.handler().get_variables()
+    }
+
+    fn current_stack_frame(&self) -> Option<StackFrame<FieldElement>> {
+        self.handler().current_stack_frame()
     }
 }

--- a/tooling/debugger/src/foreign_calls.rs
+++ b/tooling/debugger/src/foreign_calls.rs
@@ -54,7 +54,7 @@ impl DefaultDebugForeignCallExecutor {
         output: PrintOutput<'_>,
         ex: DefaultDebugForeignCallExecutor,
     ) -> impl DebugForeignCallExecutor + '_ {
-        Layer::new(DefaultForeignCallExecutor::new(output, None, None, None)).add(ex)
+        Layer::new(ex, DefaultForeignCallExecutor::new(output, None, None, None))
     }
 
     #[allow(clippy::new_ret_no_self, dead_code)]

--- a/tooling/nargo/src/foreign_calls/layers.rs
+++ b/tooling/nargo/src/foreign_calls/layers.rs
@@ -27,8 +27,8 @@ impl<F: AcirField> ForeignCallExecutor<F> for Empty {
 
 /// Forwards to the inner executor if its own handler doesn't handle the call.
 pub struct Layer<H, I, F> {
-    handler: H,
-    inner: I,
+    pub handler: H,
+    pub inner: I,
     _field: PhantomData<F>,
 }
 
@@ -50,6 +50,7 @@ where
 
 impl<H, F> Layer<H, Empty, F> {
     /// Create a layer from a handler.
+    /// If the handler doesn't handle a call, an empty response is returned.
     pub fn new(handler: H) -> Self {
         Layer { handler, inner: Empty, _field: PhantomData }
     }

--- a/tooling/nargo/src/foreign_calls/layers.rs
+++ b/tooling/nargo/src/foreign_calls/layers.rs
@@ -69,7 +69,7 @@ impl<H, I, F> Layer<H, I, F> {
 
 impl<H, F> Layer<H, Empty, F> {
     /// Create a layer from a handler.
-    /// If the handler doesn't handle a call, an empty response is returned.
+    /// If the handler doesn't handle a call, a default empty response is returned.
     pub fn or_empty(handler: H) -> Self {
         Self { handler, inner: Empty, _field: PhantomData }
     }
@@ -77,7 +77,7 @@ impl<H, F> Layer<H, Empty, F> {
 
 impl<H, F> Layer<H, Unhandled, F> {
     /// Create a layer from a handler.
-    /// If the handler doesn't handle a call, nothing will.
+    /// If the handler doesn't handle a call, `NoHandler` error is returned.
     pub fn or_unhandled(handler: H) -> Self {
         Self { handler, inner: Unhandled, _field: PhantomData }
     }
@@ -91,7 +91,7 @@ impl<F> Layer<Unhandled, Unhandled, F> {
 }
 
 impl<H, I, F> Layer<H, I, F> {
-    /// Compose layers.
+    /// Add another layer on top of this one.
     pub fn add_layer<J>(self, handler: J) -> Layer<J, Self, F> {
         Layer::new(handler, self)
     }
@@ -107,6 +107,8 @@ impl<H, I, F> Layer<H, I, F> {
 
 /// Compose handlers.
 pub trait Layering {
+    /// Layer an executor on top of this one.
+    /// The `other` executor will be called first.
     fn add_layer<L, F>(self, other: L) -> Layer<L, Self, F>
     where
         Self: Sized + ForeignCallExecutor<F>,
@@ -114,8 +116,6 @@ pub trait Layering {
 }
 
 impl<T> Layering for T {
-    /// Add an executor layer on top of this one.
-    /// The `other` layer will be called first.
     fn add_layer<L, F>(self, other: L) -> Layer<L, T, F>
     where
         T: Sized + ForeignCallExecutor<F>,

--- a/tooling/nargo/src/foreign_calls/layers.rs
+++ b/tooling/nargo/src/foreign_calls/layers.rs
@@ -1,0 +1,98 @@
+use std::marker::PhantomData;
+
+use acvm::{acir::brillig::ForeignCallResult, pwg::ForeignCallWaitInfo, AcirField};
+use noirc_printable_type::ForeignCallError;
+
+use super::ForeignCallExecutor;
+
+/// Returns an empty result when called.
+///
+/// If all executors have no handler for the given foreign call then we cannot
+/// return a correct response to the ACVM. The best we can do is to return an empty response,
+/// this allows us to ignore any foreign calls which exist solely to pass information from inside
+/// the circuit to the environment (e.g. custom logging) as the execution will still be able to progress.
+///
+/// We optimistically return an empty response for all oracle calls as the ACVM will error
+/// should a response have been required.
+pub struct Empty;
+
+impl<F: AcirField> ForeignCallExecutor<F> for Empty {
+    fn execute(
+        &mut self,
+        _foreign_call: &ForeignCallWaitInfo<F>,
+    ) -> Result<ForeignCallResult<F>, ForeignCallError> {
+        Ok(ForeignCallResult::default())
+    }
+}
+
+/// Forwards to the inner executor if its own handler doesn't handle the call.
+pub struct Layer<H, I, F> {
+    handler: H,
+    inner: I,
+    _field: PhantomData<F>,
+}
+
+impl<H, I, F> ForeignCallExecutor<F> for Layer<H, I, F>
+where
+    H: ForeignCallExecutor<F>,
+    I: ForeignCallExecutor<F>,
+{
+    fn execute(
+        &mut self,
+        foreign_call: &ForeignCallWaitInfo<F>,
+    ) -> Result<ForeignCallResult<F>, ForeignCallError> {
+        match self.handler.execute(foreign_call) {
+            Err(ForeignCallError::NoHandler(_)) => self.inner.execute(foreign_call),
+            handled => handled,
+        }
+    }
+}
+
+impl<H, F> Layer<H, Empty, F> {
+    /// Create a layer from a handler.
+    pub fn new(handler: H) -> Self {
+        Layer { handler, inner: Empty, _field: PhantomData }
+    }
+}
+
+impl<H, I, F> Layer<H, I, F> {
+    /// Compose layers.
+    #[allow(clippy::should_implement_trait)]
+    pub fn add<J>(self, handler: J) -> Layer<J, Self, F> {
+        Layer { handler, inner: self, _field: PhantomData }
+    }
+
+    pub fn handler(&self) -> &H {
+        &self.handler
+    }
+
+    pub fn inner(&self) -> &I {
+        &self.inner
+    }
+}
+
+/// We can create an empty layer and compose on top of it;
+/// the `inner` will never be called.
+impl<F> Default for Layer<Empty, Empty, F> {
+    fn default() -> Self {
+        Self::new(Empty)
+    }
+}
+
+/// Support disabling a layer by making it optional.
+/// This way we can still have a known static type for a composition,
+/// because layers are always added, potentially wrapped in an `Option`.
+impl<H, F> ForeignCallExecutor<F> for Option<H>
+where
+    H: ForeignCallExecutor<F>,
+{
+    fn execute(
+        &mut self,
+        foreign_call: &ForeignCallWaitInfo<F>,
+    ) -> Result<ForeignCallResult<F>, ForeignCallError> {
+        match self {
+            Some(handler) => handler.execute(foreign_call),
+            None => Err(ForeignCallError::NoHandler(foreign_call.function.clone())),
+        }
+    }
+}

--- a/tooling/nargo/src/foreign_calls/layers.rs
+++ b/tooling/nargo/src/foreign_calls/layers.rs
@@ -60,11 +60,26 @@ where
     }
 }
 
+impl<H, I, F> Layer<H, I, F> {
+    /// Create a layer from two handlers
+    pub fn new(handler: H, inner: I) -> Self {
+        Self { handler, inner, _field: PhantomData }
+    }
+}
+
 impl<H, F> Layer<H, Empty, F> {
     /// Create a layer from a handler.
     /// If the handler doesn't handle a call, an empty response is returned.
-    pub fn new(handler: H) -> Self {
+    pub fn or_empty(handler: H) -> Self {
         Self { handler, inner: Empty, _field: PhantomData }
+    }
+}
+
+impl<H, F> Layer<H, Unhandled, F> {
+    /// Create a layer from a handler.
+    /// If the handler doesn't handle a call, nothing will.
+    pub fn or_unhandled(handler: H) -> Self {
+        Self { handler, inner: Unhandled, _field: PhantomData }
     }
 }
 
@@ -88,14 +103,6 @@ impl<H, I, F> Layer<H, I, F> {
 
     pub fn inner(&self) -> &I {
         &self.inner
-    }
-}
-
-/// We can create an empty layer and compose on top of it;
-/// the `inner` will never be called.
-impl<F> Default for Layer<Empty, Empty, F> {
-    fn default() -> Self {
-        Self::new(Empty)
     }
 }
 

--- a/tooling/nargo/src/foreign_calls/mocker.rs
+++ b/tooling/nargo/src/foreign_calls/mocker.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use acvm::{
     acir::brillig::{ForeignCallParam, ForeignCallResult},
     pwg::ForeignCallWaitInfo,
@@ -78,8 +80,9 @@ impl<F: AcirField> MockForeignCallExecutor<F> {
     }
 }
 
-impl<F: AcirField + Serialize + for<'a> Deserialize<'a>> ForeignCallExecutor<F>
-    for MockForeignCallExecutor<F>
+impl<F> ForeignCallExecutor<F> for MockForeignCallExecutor<F>
+where
+    F: AcirField + Serialize + for<'a> Deserialize<'a>,
 {
     fn execute(
         &mut self,
@@ -172,5 +175,33 @@ impl<F: AcirField + Serialize + for<'a> Deserialize<'a>> ForeignCallExecutor<F>
                 }
             }
         }
+    }
+}
+
+/// Handler that panics if any of the mock functions are called.
+pub(crate) struct DisabledMockForeignCallExecutor<F> {
+    _field: PhantomData<F>,
+}
+
+impl<F> ForeignCallExecutor<F> for DisabledMockForeignCallExecutor<F> {
+    fn execute(
+        &mut self,
+        foreign_call: &ForeignCallWaitInfo<F>,
+    ) -> Result<ForeignCallResult<F>, ForeignCallError> {
+        let foreign_call_name = foreign_call.function.as_str();
+        if let Some(call) = ForeignCall::lookup(foreign_call_name) {
+            match call {
+                ForeignCall::CreateMock
+                | ForeignCall::SetMockParams
+                | ForeignCall::GetMockLastParams
+                | ForeignCall::SetMockReturns
+                | ForeignCall::SetMockTimes
+                | ForeignCall::ClearMock => {
+                    panic!("unexpected mock call: {}", foreign_call.function)
+                }
+                _ => {}
+            }
+        }
+        Err(ForeignCallError::NoHandler(foreign_call.function.clone()))
     }
 }

--- a/tooling/nargo/src/foreign_calls/mocker.rs
+++ b/tooling/nargo/src/foreign_calls/mocker.rs
@@ -47,7 +47,7 @@ impl<F: PartialEq> MockedCall<F> {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct MockForeignCallExecutor<F> {
+pub struct MockForeignCallExecutor<F> {
     /// Mocks have unique ids used to identify them in Noir, allowing to update or remove them.
     last_mock_id: usize,
     /// The registered mocks
@@ -179,6 +179,7 @@ where
 }
 
 /// Handler that panics if any of the mock functions are called.
+#[allow(dead_code)] // TODO: Make the mocker optional
 pub(crate) struct DisabledMockForeignCallExecutor<F> {
     _field: PhantomData<F>,
 }

--- a/tooling/nargo/src/foreign_calls/mod.rs
+++ b/tooling/nargo/src/foreign_calls/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use acvm::{acir::brillig::ForeignCallResult, pwg::ForeignCallWaitInfo, AcirField};
-use layers::Layer;
+use layers::{Layer, Layering};
 use mocker::MockForeignCallExecutor;
 use noirc_printable_type::ForeignCallError;
 use print::{PrintForeignCallExecutor, PrintOutput};
@@ -94,15 +94,12 @@ impl DefaultForeignCallExecutor {
         B: ForeignCallExecutor<F> + 'a,
     {
         // Adding them in the opposite order, so print is the outermost layer.
-        Layer::new(
-            resolver_url.map(|resolver_url| {
-                let id = rand::thread_rng().gen();
-                RPCForeignCallExecutor::new(resolver_url, id, root_path, package_name)
-            }),
-            base,
-        )
-        .add(MockForeignCallExecutor::default())
-        .add(PrintForeignCallExecutor::new(output))
+        base.add_layer(resolver_url.map(|resolver_url| {
+            let id = rand::thread_rng().gen();
+            RPCForeignCallExecutor::new(resolver_url, id, root_path, package_name)
+        }))
+        .add_layer(MockForeignCallExecutor::default())
+        .add_layer(PrintForeignCallExecutor::new(output))
     }
 }
 

--- a/tooling/nargo/src/foreign_calls/print.rs
+++ b/tooling/nargo/src/foreign_calls/print.rs
@@ -12,8 +12,14 @@ pub enum PrintOutput<'a> {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct PrintForeignCallExecutor<'a> {
-    pub(crate) output: PrintOutput<'a>,
+pub struct PrintForeignCallExecutor<'a> {
+    output: PrintOutput<'a>,
+}
+
+impl<'a> PrintForeignCallExecutor<'a> {
+    pub fn new(output: PrintOutput<'a>) -> Self {
+        Self { output }
+    }
 }
 
 impl<F: AcirField> ForeignCallExecutor<F> for PrintForeignCallExecutor<'_> {

--- a/tooling/nargo/src/foreign_calls/rpc.rs
+++ b/tooling/nargo/src/foreign_calls/rpc.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::ForeignCallExecutor;
 
 #[derive(Debug)]
-pub(crate) struct RPCForeignCallExecutor {
+pub struct RPCForeignCallExecutor {
     /// A randomly generated id for this `DefaultForeignCallExecutor`.
     ///
     /// This is used so that a single `external_resolver` can distinguish between requests from multiple
@@ -54,7 +54,7 @@ struct ResolveForeignCallRequest<F> {
 type ResolveForeignCallResult<F> = Result<ForeignCallResult<F>, ForeignCallError>;
 
 impl RPCForeignCallExecutor {
-    pub(crate) fn new(
+    pub fn new(
         resolver_url: &str,
         id: u64,
         root_path: Option<PathBuf>,

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -18,7 +18,7 @@ pub mod foreign_calls;
 
 pub use self::errors::NargoError;
 #[cfg(feature = "execute")]
-pub use self::foreign_calls::print::PrintOutput;
+pub use self::foreign_calls::print::{PrintForeignCallExecutor, PrintOutput};
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -18,7 +18,7 @@ pub mod foreign_calls;
 
 pub use self::errors::NargoError;
 #[cfg(feature = "execute")]
-pub use self::foreign_calls::print::{PrintForeignCallExecutor, PrintOutput};
+pub use self::foreign_calls::print::PrintOutput;
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -13,16 +13,14 @@ use noirc_driver::{compile_no_check, CompileError, CompileOptions, DEFAULT_EXPRE
 use noirc_errors::{debug_info::DebugInfo, FileDiagnostic};
 use noirc_frontend::hir::{def_map::TestFunction, Context};
 use noirc_printable_type::ForeignCallError;
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::try_to_diagnose_runtime_error,
     foreign_calls::{
-        mocker::MockForeignCallExecutor,
-        print::{PrintForeignCallExecutor, PrintOutput},
-        rpc::RPCForeignCallExecutor,
-        ForeignCall, ForeignCallExecutor,
+        layers::{Empty, Layer},
+        print::PrintOutput,
+        DefaultForeignCallExecutor, DefaultForeignCallLayers, ForeignCallExecutor,
     },
     NargoError,
 };
@@ -97,7 +95,7 @@ pub fn run_test<B: BlackBoxFunctionSolver<FieldElement>>(
 
                 if let TestStatus::Fail { .. } = status {
                     if ignore_foreign_call_failures
-                        && foreign_call_executor.encountered_unknown_foreign_call
+                        && foreign_call_executor.encountered_unknown_foreign_call()
                     {
                         TestStatus::Skipped
                     } else {
@@ -278,33 +276,58 @@ fn check_expected_failure_message(
 }
 
 /// A specialized foreign call executor which tracks whether it has encountered any unknown foreign calls
-struct TestForeignCallExecutor<'a, F> {
-    /// The executor for any [`ForeignCall::Print`] calls.
-    printer: PrintForeignCallExecutor<'a>,
-    mocker: MockForeignCallExecutor<F>,
-    external: Option<RPCForeignCallExecutor>,
-
+#[derive(Default)]
+struct UnknownForeignCallProbe {
     encountered_unknown_foreign_call: bool,
 }
 
-impl<'a, F: Default> TestForeignCallExecutor<'a, F> {
+impl<F> ForeignCallExecutor<F> for UnknownForeignCallProbe {
+    fn execute(
+        &mut self,
+        foreign_call: &ForeignCallWaitInfo<F>,
+    ) -> Result<ForeignCallResult<F>, ForeignCallError> {
+        self.encountered_unknown_foreign_call = true;
+        Err(ForeignCallError::NoHandler(foreign_call.function.clone()))
+    }
+}
+
+/// A specialized foreign call executor which tracks whether it has encountered any unknown foreign calls
+struct TestForeignCallExecutor<'a, F> {
+    executor: DefaultForeignCallLayers<'a, Layer<UnknownForeignCallProbe, Empty, F>, F>,
+}
+
+impl<'a, F> TestForeignCallExecutor<'a, F>
+where
+    F: Default + AcirField + Serialize + for<'de> Deserialize<'de> + 'a,
+{
+    #[allow(clippy::new_ret_no_self)]
     fn new(
         output: PrintOutput<'a>,
         resolver_url: Option<&str>,
         root_path: Option<PathBuf>,
         package_name: Option<String>,
     ) -> Self {
-        let id = rand::thread_rng().gen();
-        let printer = PrintForeignCallExecutor::new(output);
-        let external_resolver = resolver_url.map(|resolver_url| {
-            RPCForeignCallExecutor::new(resolver_url, id, root_path, package_name)
-        });
-        TestForeignCallExecutor {
-            printer,
-            mocker: MockForeignCallExecutor::default(),
-            external: external_resolver,
-            encountered_unknown_foreign_call: false,
-        }
+        let base = Layer::new(UnknownForeignCallProbe { encountered_unknown_foreign_call: false });
+
+        let executor = DefaultForeignCallExecutor::with_base(
+            base,
+            output,
+            resolver_url,
+            root_path,
+            package_name,
+        );
+
+        Self { executor }
+    }
+}
+
+impl<'a, F> TestForeignCallExecutor<'a, F> {
+    fn encountered_unknown_foreign_call_mut(&mut self) -> &mut bool {
+        &mut self.executor.inner.inner.inner.handler.encountered_unknown_foreign_call
+    }
+
+    fn encountered_unknown_foreign_call(&mut self) -> bool {
+        *self.encountered_unknown_foreign_call_mut()
     }
 }
 
@@ -316,47 +339,7 @@ impl<'a, F: AcirField + Serialize + for<'b> Deserialize<'b>> ForeignCallExecutor
         foreign_call: &ForeignCallWaitInfo<F>,
     ) -> Result<ForeignCallResult<F>, ForeignCallError> {
         // If the circuit has reached a new foreign call opcode then it can't have failed from any previous unknown foreign calls.
-        self.encountered_unknown_foreign_call = false;
-
-        let foreign_call_name = foreign_call.function.as_str();
-        match ForeignCall::lookup(foreign_call_name) {
-            Some(ForeignCall::Print) => self.printer.execute(foreign_call),
-
-            Some(
-                ForeignCall::CreateMock
-                | ForeignCall::SetMockParams
-                | ForeignCall::GetMockLastParams
-                | ForeignCall::SetMockReturns
-                | ForeignCall::SetMockTimes
-                | ForeignCall::ClearMock,
-            ) => self.mocker.execute(foreign_call),
-
-            None => {
-                // First check if there's any defined mock responses for this foreign call.
-                match self.mocker.execute(foreign_call) {
-                    Err(ForeignCallError::NoHandler(_)) => (),
-                    response_or_error => return response_or_error,
-                };
-
-                if let Some(external_resolver) = &mut self.external {
-                    // If the user has registered a n external resolver then we forward any remaining oracle calls there.
-                    match external_resolver.execute(foreign_call) {
-                        Err(ForeignCallError::NoHandler(_)) => (),
-                        response_or_error => return response_or_error,
-                    };
-                }
-
-                self.encountered_unknown_foreign_call = true;
-
-                // If all executors have no handler for the given foreign call then we cannot
-                // return a correct response to the ACVM. The best we can do is to return an empty response,
-                // this allows us to ignore any foreign calls which exist solely to pass information from inside
-                // the circuit to the environment (e.g. custom logging) as the execution will still be able to progress.
-                //
-                // We optimistically return an empty response for all oracle calls as the ACVM will error
-                // should a response have been required.
-                Ok(ForeignCallResult::default())
-            }
-        }
+        *self.encountered_unknown_foreign_call_mut() = false;
+        self.executor.execute(foreign_call)
     }
 }

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -295,7 +295,7 @@ impl<'a, F: Default> TestForeignCallExecutor<'a, F> {
         package_name: Option<String>,
     ) -> Self {
         let id = rand::thread_rng().gen();
-        let printer = PrintForeignCallExecutor { output };
+        let printer = PrintForeignCallExecutor::new(output);
         let external_resolver = resolver_url.map(|resolver_url| {
             RPCForeignCallExecutor::new(resolver_url, id, root_path, package_name)
         });
@@ -339,7 +339,7 @@ impl<'a, F: AcirField + Serialize + for<'b> Deserialize<'b>> ForeignCallExecutor
                 };
 
                 if let Some(external_resolver) = &mut self.external {
-                    // If the user has registered an external resolver then we forward any remaining oracle calls there.
+                    // If the user has registered a n external resolver then we forward any remaining oracle calls there.
                     match external_resolver.execute(foreign_call) {
                         Err(ForeignCallError::NoHandler(_)) => (),
                         response_or_error => return response_or_error,

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     errors::try_to_diagnose_runtime_error,
     foreign_calls::{
-        layers::{Empty, Layer, Unhandled},
+        layers::{Empty, Unhandled},
         print::PrintOutput,
         DefaultForeignCallExecutor, DefaultForeignCallLayers, ForeignCallExecutor,
     },
@@ -277,7 +277,7 @@ fn check_expected_failure_message(
 
 /// A specialized foreign call executor which tracks whether it has encountered any unknown foreign calls
 struct TestForeignCallExecutor<'a, F> {
-    executor: DefaultForeignCallLayers<'a, Layer<Unhandled, Unhandled, F>, F>,
+    executor: DefaultForeignCallLayers<'a, Unhandled, F>,
     encountered_unknown_foreign_call: bool,
 }
 
@@ -292,11 +292,9 @@ where
         root_path: Option<PathBuf>,
         package_name: Option<String>,
     ) -> Self {
-        // Create a base layer that doesn't handle any call.
-        let base = Layer::unhandled();
-
+        // Use a base layer that doesn't handle anything, which we handle in the `execute` below.
         let executor = DefaultForeignCallExecutor::with_base(
-            base,
+            Unhandled,
             output,
             resolver_url,
             root_path,

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -18,9 +18,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     errors::try_to_diagnose_runtime_error,
     foreign_calls::{
-        layers::{Empty, Unhandled},
-        print::PrintOutput,
-        DefaultForeignCallExecutor, DefaultForeignCallLayers, ForeignCallExecutor,
+        layers, print::PrintOutput, DefaultForeignCallExecutor, DefaultForeignCallLayers,
+        ForeignCallExecutor,
     },
     NargoError,
 };
@@ -277,7 +276,7 @@ fn check_expected_failure_message(
 
 /// A specialized foreign call executor which tracks whether it has encountered any unknown foreign calls
 struct TestForeignCallExecutor<'a, F> {
-    executor: DefaultForeignCallLayers<'a, Unhandled, F>,
+    executor: DefaultForeignCallLayers<'a, layers::Unhandled, F>,
     encountered_unknown_foreign_call: bool,
 }
 
@@ -294,7 +293,7 @@ where
     ) -> Self {
         // Use a base layer that doesn't handle anything, which we handle in the `execute` below.
         let executor = DefaultForeignCallExecutor::with_base(
-            Unhandled,
+            layers::Unhandled,
             output,
             resolver_url,
             root_path,
@@ -317,8 +316,7 @@ impl<'a, F: AcirField + Serialize + for<'b> Deserialize<'b>> ForeignCallExecutor
         match self.executor.execute(foreign_call) {
             Err(ForeignCallError::NoHandler(_)) => {
                 self.encountered_unknown_foreign_call = true;
-                let mut empty = Empty;
-                empty.execute(foreign_call)
+                layers::Empty.execute(foreign_call)
             }
             other => other,
         }


### PR DESCRIPTION
# Description

## Problem\*

Followup for https://github.com/noir-lang/noir/pull/6849

## Summary\*

Adds a `foreign_calls::layer::Layer` construct which is used to compose `ForeignCallExecutor` instances. `DefaultForeignCallExecutor`, `DebugForeignCallExecutor` and `TestForeignCallExecutor` are reimplemented with this layering. 

The `DefaultForeignCallExecutor` allows us to inject a base layer, which the `TestForeignCallExecutor` uses to change the behaviour when nothing handles the call; this way we can reuse the default composition without having to repeat the logic in the test, similar to how the `DefaultDebugForeignCallExecutor` did it earlier.

Follow up for this would be:
* Make the _mock_ layer in the `DefaultForeignCallExecutor` optional, so that during normal execution no contract can install a mock and then handle foreign calls that should hit URLs. A `DisabledMockForeignCallExecutor` has been added in this PR, but it's unused. (I'm not sure this is a legit concern, but I didn't see any reason it wouldn't work).
* Make `run_test` accept a generic function to create a `ForeignCallExecutor` on top of the `Unhandled` base handler, instead of explicitly creating a `DefaultForeignCallExecutor`, so that we don't depend on `RPCForeignCallExecutor` in the tests, and then we can compile them to Wasm.  https://github.com/noir-lang/noir/pull/6858

## Additional Context

It's a breaking change because it changes the return type of `DefaultForeignCallHandler::new`, although the way it's called is the same for now.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
