### PR TITLE
fix: detect cycles in globals

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::{
-    ast::ItemVisibility, hir_def::traits::ResolvedTraitBound, usage_tracker::UsageTracker,
-    StructField, StructType, TypeBindings,
+    ast::ItemVisibility, hir_def::traits::ResolvedTraitBound, node_interner::GlobalValue,
+    usage_tracker::UsageTracker, StructField, StructType, TypeBindings,
 };
 use crate::{
     ast::{
@@ -1689,7 +1689,7 @@ impl<'context> Elaborator<'context> {
 
             self.debug_comptime(location, |interner| value.display(interner).to_string());
 
-            self.interner.get_global_mut(global_id).value = Some(value);
+            self.interner.get_global_mut(global_id).value = GlobalValue::Resolved(value);
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -28,8 +28,8 @@ use crate::{
         traits::{NamedType, ResolvedTraitBound, Trait, TraitConstraint},
     },
     node_interner::{
-        DependencyId, ExprId, ImplSearchErrorKind, NodeInterner, TraitId, TraitImplKind,
-        TraitMethodId,
+        DependencyId, ExprId, GlobalValue, ImplSearchErrorKind, NodeInterner, TraitId,
+        TraitImplKind, TraitMethodId,
     },
     token::SecondaryAttribute,
     Generics, Kind, ResolvedGeneric, Type, TypeBinding, TypeBindings, UnificationError,
@@ -426,7 +426,8 @@ impl<'context> Elaborator<'context> {
                 let rhs = stmt.expression;
                 let span = self.interner.expr_span(&rhs);
 
-                let Some(global_value) = &self.interner.get_global(id).value else {
+                let GlobalValue::Resolved(global_value) = &self.interner.get_global(id).value
+                else {
                     self.push_err(ResolverError::UnevaluatedGlobalType { span });
                     return None;
                 };

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -568,11 +568,11 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             DefinitionKind::Local(_) => self.lookup(&ident),
             DefinitionKind::Global(global_id) => {
                 // Avoid resetting the value if it is already known
-                if let Some(value) = &self.elaborator.interner.get_global(*global_id).value {
+                let global_id = *global_id;
+                let global_info = self.elaborator.interner.get_global(global_id);
+                if let Some(value) = &global_info.value {
                     Ok(value.clone())
                 } else {
-                    let global_id = *global_id;
-                    let crate_of_global = self.elaborator.interner.get_global(global_id).crate_id;
                     let let_ =
                         self.elaborator.interner.get_global_let_statement(global_id).ok_or_else(
                             || {
@@ -581,7 +581,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                             },
                         )?;
 
-                    if let_.runs_comptime() || crate_of_global != self.crate_id {
+                    if let_.runs_comptime() || global_info.crate_id != self.crate_id {
                         self.evaluate_let(let_.clone())?;
                     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -575,6 +575,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 match &global_info.value {
                     GlobalValue::Resolved(value) => Ok(value.clone()),
                     GlobalValue::Resolving => {
+                        // Note that the error we issue here isn't very informative (it doesn't include the actual cycle)
+                        // but the general dependency cycle detector will give a better error later on during compilation.
                         let location = self.elaborator.interner.expr_location(&id);
                         Err(InterpreterError::GlobalsDependencyCycle { location })
                     }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -11,7 +11,7 @@
 use crate::ast::{FunctionKind, IntegerBitSize, Signedness, UnaryOp, Visibility};
 use crate::hir::comptime::InterpreterError;
 use crate::hir::type_check::{NoMatchingImplFoundError, TypeCheckError};
-use crate::node_interner::{ExprId, ImplSearchErrorKind};
+use crate::node_interner::{ExprId, GlobalValue, ImplSearchErrorKind};
 use crate::token::FmtStrFragment;
 use crate::{
     debug::DebugInstrumenter,
@@ -895,7 +895,7 @@ impl<'interner> Monomorphizer<'interner> {
             DefinitionKind::Global(global_id) => {
                 let global = self.interner.get_global(*global_id);
 
-                let expr = if let Some(value) = global.value.clone() {
+                let expr = if let GlobalValue::Resolved(value) = global.value.clone() {
                     value
                         .into_hir_expression(self.interner, global.location)
                         .map_err(MonomorphizationError::InterpreterError)?

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -609,7 +609,14 @@ pub struct GlobalInfo {
     pub crate_id: CrateId,
     pub location: Location,
     pub let_statement: StmtId,
-    pub value: Option<comptime::Value>,
+    pub value: GlobalValue,
+}
+
+#[derive(Debug, Clone)]
+pub enum GlobalValue {
+    Unresolved,
+    Resolving,
+    Resolved(comptime::Value),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -861,7 +868,7 @@ impl NodeInterner {
             crate_id,
             let_statement,
             location,
-            value: None,
+            value: GlobalValue::Unresolved,
         });
         self.global_attributes.insert(id, attributes);
         id

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3855,3 +3855,23 @@ fn disallows_underscore_on_right_hand_side() {
 
     assert_eq!(name, "_");
 }
+
+#[test]
+fn errors_on_cyclic_globals() {
+    let src = r#"
+    pub comptime global A: u32 = B;
+    pub comptime global B: u32 = A;
+
+    fn main() { }
+    "#;
+    let errors = get_program_errors(src);
+
+    assert!(errors.iter().any(|(error, _)| matches!(
+        error,
+        CompilationError::InterpreterError(InterpreterError::GlobalsDependencyCycle { .. })
+    )));
+    assert!(errors.iter().any(|(error, _)| matches!(
+        error,
+        CompilationError::ResolverError(ResolverError::DependencyCycle { .. })
+    )));
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #6780

## Summary

This program:

```noir
comptime global A: u32 = B;
comptime global B: u32 = A;

fn main() { }
```

now gives these errors:

```
error: Variable not in scope
  ┌─ src/main.nr:2:26
  │
2 │ comptime global B: u32 = A;
  │                          - Could not find variable
  │

error: This global recursively depends on itself
  ┌─ src/main.nr:1:26
  │
1 │ comptime global A: u32 = B;
  │                          -
  │

error: Dependency cycle found
  ┌─ src/main.nr:1:17
  │
1 │ comptime global A: u32 = B;
  │                 - 'A' recursively depends on itself: A -> B -> A
  │

Aborting due to 3 previous errors
```


## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
