### PR TITLE
feat: warn on unnecessary unsafe blocks

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -429,8 +429,6 @@ impl<'context> Elaborator<'context> {
         method_call: MethodCallExpression,
         span: Span,
     ) -> (HirExpression, Type) {
-        dbg!(&method_call);
-
         let object_span = method_call.object.span;
         let (mut object, mut object_type) = self.elaborate_expression(method_call.object);
         object_type = object_type.follow_bindings();

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -58,8 +58,8 @@ impl<'context> Elaborator<'context> {
             ExpressionKind::Comptime(comptime, _) => {
                 return self.elaborate_comptime_block(comptime, expr.span)
             }
-            ExpressionKind::Unsafe(block_expression, span) => {
-                self.elaborate_unsafe_block(block_expression, span)
+            ExpressionKind::Unsafe(block_expression, _) => {
+                self.elaborate_unsafe_block(block_expression, expr.span)
             }
             ExpressionKind::Resolved(id) => return (id, self.interner.id_type(id)),
             ExpressionKind::Interned(id) => {
@@ -150,6 +150,7 @@ impl<'context> Elaborator<'context> {
         let is_nested_unsafe_block =
             !matches!(old_in_unsafe_block, UnsafeBlockStatus::NotInUnsafeBlock);
         if is_nested_unsafe_block {
+            let span = Span::from(span.start()..span.start() + 6); // Only highlight the `unsafe` keyword
             self.push_err(TypeCheckError::NestedUnsafeBlock { span });
         }
 
@@ -159,6 +160,7 @@ impl<'context> Elaborator<'context> {
 
         if let UnsafeBlockStatus::InUnsafeBlockWithoutUnconstrainedCalls = self.unsafe_block_status
         {
+            let span = Span::from(span.start()..span.start() + 6); // Only highlight the `unsafe` keyword
             self.push_err(TypeCheckError::UnnecessaryUnsafeBlock { span });
         }
 

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -32,7 +32,7 @@ use crate::{
     Kind, QuotedType, Shared, StructType, Type,
 };
 
-use super::{Elaborator, LambdaContext};
+use super::{Elaborator, LambdaContext, UnsafeBlockStatus};
 
 impl<'context> Elaborator<'context> {
     pub(crate) fn elaborate_expression(&mut self, expr: Expression) -> (ExprId, Type) {
@@ -58,8 +58,8 @@ impl<'context> Elaborator<'context> {
             ExpressionKind::Comptime(comptime, _) => {
                 return self.elaborate_comptime_block(comptime, expr.span)
             }
-            ExpressionKind::Unsafe(block_expression, _) => {
-                self.elaborate_unsafe_block(block_expression)
+            ExpressionKind::Unsafe(block_expression, span) => {
+                self.elaborate_unsafe_block(block_expression, span)
             }
             ExpressionKind::Resolved(id) => return (id, self.interner.id_type(id)),
             ExpressionKind::Interned(id) => {
@@ -140,15 +140,24 @@ impl<'context> Elaborator<'context> {
         (HirBlockExpression { statements }, block_type)
     }
 
-    fn elaborate_unsafe_block(&mut self, block: BlockExpression) -> (HirExpression, Type) {
+    fn elaborate_unsafe_block(
+        &mut self,
+        block: BlockExpression,
+        span: Span,
+    ) -> (HirExpression, Type) {
         // Before entering the block we cache the old value of `in_unsafe_block` so it can be restored.
-        let old_in_unsafe_block = self.in_unsafe_block;
-        self.in_unsafe_block = true;
+        let old_in_unsafe_block = self.unsafe_block_status;
+        self.unsafe_block_status = UnsafeBlockStatus::InUnsafeBlockWithoutUnconstrainedCalls;
 
         let (hir_block_expression, typ) = self.elaborate_block_expression(block);
 
+        if let UnsafeBlockStatus::InUnsafeBlockWithoutUnconstrainedCalls = self.unsafe_block_status
+        {
+            self.push_err(TypeCheckError::UnnecessaryUnsafeBlock { span });
+        }
+
         // Finally, we restore the original value of `self.in_unsafe_block`.
-        self.in_unsafe_block = old_in_unsafe_block;
+        self.unsafe_block_status = old_in_unsafe_block;
 
         (HirExpression::Unsafe(hir_block_expression), typ)
     }
@@ -410,6 +419,8 @@ impl<'context> Elaborator<'context> {
         method_call: MethodCallExpression,
         span: Span,
     ) -> (HirExpression, Type) {
+        dbg!(&method_call);
+
         let object_span = method_call.object.span;
         let (mut object, mut object_type) = self.elaborate_expression(method_call.object);
         object_type = object_type.follow_bindings();

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -79,6 +79,16 @@ pub struct LambdaContext {
     pub scope_index: usize,
 }
 
+/// Determines whether we are in an unsafe block and, if so, whether
+/// any unconstrained calls were found in it (because if not we'll warn
+/// that the unsafe block is not needed).
+#[derive(Copy, Clone)]
+enum UnsafeBlockStatus {
+    NotInUnsafeBlock,
+    InUnsafeBlockWithoutUnconstrainedCalls,
+    InUnsafeBlockWithConstrainedCalls,
+}
+
 pub struct Elaborator<'context> {
     scopes: ScopeForest,
 
@@ -90,7 +100,7 @@ pub struct Elaborator<'context> {
 
     pub(crate) file: FileId,
 
-    in_unsafe_block: bool,
+    unsafe_block_status: UnsafeBlockStatus,
     nested_loops: usize,
 
     /// Contains a mapping of the current struct or functions's generics to
@@ -202,7 +212,7 @@ impl<'context> Elaborator<'context> {
             def_maps,
             usage_tracker,
             file: FileId::dummy(),
-            in_unsafe_block: false,
+            unsafe_block_status: UnsafeBlockStatus::NotInUnsafeBlock,
             nested_loops: 0,
             generics: Vec::new(),
             lambda_stack: Vec::new(),

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -205,6 +205,8 @@ pub enum TypeCheckError {
     CyclicType { typ: Type, span: Span },
     #[error("Type annotations required before indexing this array or slice")]
     TypeAnnotationsNeededForIndex { span: Span },
+    #[error("Unnecessary `unsafe` block")]
+    UnnecessaryUnsafeBlock { span: Span },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -514,6 +516,13 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                 Diagnostic::simple_error(
                     "Type annotations required before indexing this array or slice".into(), 
                     "Type annotations needed before this point, can't decide if this is an array or slice".into(),
+                    *span,
+                )
+            },
+            TypeCheckError::UnnecessaryUnsafeBlock { span } => {
+                Diagnostic::simple_warning(
+                    "Unnecessary `unsafe` block".into(), 
+                    "".into(),
                     *span,
                 )
             },

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -207,6 +207,8 @@ pub enum TypeCheckError {
     TypeAnnotationsNeededForIndex { span: Span },
     #[error("Unnecessary `unsafe` block")]
     UnnecessaryUnsafeBlock { span: Span },
+    #[error("Unnecessary `unsafe` block")]
+    NestedUnsafeBlock { span: Span },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -523,6 +525,13 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                 Diagnostic::simple_warning(
                     "Unnecessary `unsafe` block".into(), 
                     "".into(),
+                    *span,
+                )
+            },
+            TypeCheckError::NestedUnsafeBlock { span } => {
+                Diagnostic::simple_warning(
+                    "Unnecessary `unsafe` block".into(), 
+                    "Because it's nested inside another `unsafe` block".into(),
                     *span,
                 )
             },

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3894,3 +3894,24 @@ fn warns_on_unneeded_unsafe() {
         CompilationError::TypeError(TypeCheckError::UnnecessaryUnsafeBlock { .. })
     ));
 }
+
+#[test]
+fn warns_on_nested_unsafe() {
+    let src = r#"
+    fn main() { 
+        unsafe { 
+            unsafe {
+                foo() 
+            }
+        }
+    }
+
+    unconstrained fn foo() {}
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        &errors[0].0,
+        CompilationError::TypeError(TypeCheckError::NestedUnsafeBlock { .. })
+    ));
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3875,3 +3875,22 @@ fn errors_on_cyclic_globals() {
         CompilationError::ResolverError(ResolverError::DependencyCycle { .. })
     )));
 }
+
+#[test]
+fn warns_on_unneeded_unsafe() {
+    let src = r#"
+    fn main() { 
+        unsafe { 
+            foo() 
+        }
+    }
+
+    fn foo() {}
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        &errors[0].0,
+        CompilationError::TypeError(TypeCheckError::UnnecessaryUnsafeBlock { .. })
+    ));
+}

--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -271,7 +271,7 @@ impl<K, V, let N: u32, B> HashMap<K, V, N, B> {
 
         for slot in self._table {
             if slot.is_valid() {
-                let (_, value) = unsafe { slot.key_value_unchecked() };
+                let (_, value) = slot.key_value_unchecked();
                 values.push(value);
             }
         }

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -52,7 +52,7 @@ pub comptime fn derive(s: StructDefinition, traits: [TraitDefinition]) -> Quoted
     let mut result = quote {};
 
     for trait_to_derive in traits {
-        let handler = unsafe { HANDLERS.get(trait_to_derive) };
+        let handler = HANDLERS.get(trait_to_derive);
         assert(handler.is_some(), f"No derive function registered for `{trait_to_derive}`");
 
         let trait_impl = handler.unwrap()(s);


### PR DESCRIPTION
# Description

## Problem

Resolves #6866

## Summary



## Additional Context

1. I checked `Aztec-Packages` and there are some occurrences of this warning (and also in the bignum library)
2. I learned that using `unsafe` inside a comptime context isn't needed, so the compiler will automatically warn about this (this happened in one place in the stdlib)

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
