### PR TITLE
chore: docs fix spelling issues

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
@@ -8,7 +8,7 @@ pub(crate) struct UnusedMemoryOptimizer<F> {
 }
 
 impl<F> UnusedMemoryOptimizer<F> {
-    /// Creates a new `UnusedMemoryOptimizer ` by collecting unused memory init
+    /// Creates a new `UnusedMemoryOptimizer` by collecting unused memory init
     /// opcodes from `Circuit`.
     pub(crate) fn new(circuit: Circuit<F>) -> Self {
         let unused_memory_initializations = Self::collect_unused_memory_initializations(&circuit);

--- a/acvm-repo/acvm/src/compiler/transformers/csat.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/csat.rs
@@ -81,7 +81,7 @@ impl CSatTransformer {
         // The last optimization to do is to create intermediate variables in order to flatten the fan-in and the amount of mul terms
         // If a opcode has more than one mul term. We may need an intermediate variable for each one. Since not every variable will need to link to
         // the mul term, we could possibly do it that way.
-        // We wil call this a partial opcode scan optimization which will result in the opcodes being able to fit into the correct width
+        // We will call this a partial opcode scan optimization which will result in the opcodes being able to fit into the correct width
         let mut opcode =
             self.partial_opcode_scan_optimization(opcode, intermediate_variables, num_witness);
         opcode.sort();

--- a/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/bigint.rs
@@ -10,7 +10,7 @@ use crate::pwg::OpcodeResolutionError;
 
 /// Resolve BigInt opcodes by storing BigInt values (and their moduli) by their ID in the BigIntSolver
 /// - When it encounters a bigint operation opcode, it performs the operation on the stored values
-///   and store the result using the provided ID.
+///   and store the results using the provided ID.
 /// - When it gets a to_bytes opcode, it simply looks up the value and resolves the output witness accordingly.
 #[derive(Default)]
 pub(crate) struct AcvmBigIntSolver {

--- a/acvm-repo/acvm/src/pwg/blackbox/hash.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/hash.rs
@@ -114,7 +114,7 @@ pub(crate) fn solve_poseidon2_permutation_opcode<F: AcirField>(
         return Err(OpcodeResolutionError::BlackBoxFunctionFailed(
             acir::BlackBoxFunc::Poseidon2Permutation,
             format!(
-                "the number of inputs does not match specified length. {} != {}",
+                "the number of inputs does not match the specified length. {} != {}",
                 inputs.len(),
                 len
             ),

--- a/acvm-repo/acvm/src/pwg/blackbox/logic.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/logic.rs
@@ -43,7 +43,7 @@ pub(super) fn xor<F: AcirField>(
     })
 }
 
-/// Derives the rest of the witness based on the initial low level variables
+/// Derive the rest of the witness based on the initial low level variables
 fn solve_logic_opcode<F: AcirField>(
     initial_witness: &mut WitnessMap<F>,
     a: &FunctionInput<F>,

--- a/acvm-repo/acvm/src/pwg/blackbox/range.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/range.rs
@@ -13,7 +13,7 @@ pub(crate) fn solve_range_opcode<F: AcirField>(
     let skip_bitsize_checks = true;
     let w_value = input_to_value(initial_witness, *input, skip_bitsize_checks)?;
     if w_value.num_bits() > input.num_bits() {
-        return Err(OpcodeResolutionError::UnsatisfiedConstrain {
+        return Err(OpcodeResolutionError::UnsatisfiedConstraint {
             opcode_location: ErrorLocation::Unresolved,
             payload: None,
         });


### PR DESCRIPTION
# Description

**acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs**
- Fixed typo: "`UnusedMemoryOptimizer `" → "Creates a new `UnusedMemoryOptimizer`"
  
**acvm-repo/acvm/src/compiler/transformers/csat.rs**
- Fixed typo: "We wil" → "We will"
   
 **acvm-repo/acvm/src/pwg/blackbox/bigint.rs**
 - Fixed typo: "the result" → "the results"
     
 **acvm-repo/acvm/src/pwg/blackbox/hash.rs**
 - Fixed typo: "match specified" → "match the specified"
       
 **acvm-repo/acvm/src/pwg/blackbox/logic.rs**
 - Fixed typo: "Derives the" → "Derive the"
         
 **acvm-repo/acvm/src/pwg/blackbox/range.rs**
 - Fixed typo: "return Err(OpcodeResolutionError::UnsatisfiedConstrain {" → "return Err(OpcodeResolutionError::UnsatisfiedConstraint {"