### PR TITLE
chore(ci): Take averages for compilation and execution report of small programs

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -348,16 +348,14 @@ jobs:
       
       - name: Generate execution report without averages
         working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ !matrix.project.is_library }}
-        if: ${{ !matrix.project.take_average }}
+        if: ${{ !matrix.project.is_library }} && ${{ !matrix.project.take_average }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
           ./execution_report.sh 1
 
       - name: Generate execution report with averages
         working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ !matrix.project.is_library }}
-        if: ${{ matrix.project.take_average }}
+        if: ${{ !matrix.project.is_library }} && ${{ matrix.project.take_average }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
           ./execution_report.sh 1 1

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -252,13 +252,13 @@ jobs:
       - name: Generate Compilation report
         working-directory: ./test_programs
         run: |
-          ./compilation_report.sh
+          ./compilation_report.sh 0 1
           mv compilation_report.json ../compilation_report.json
 
       - name: Generate Execution report
         working-directory: ./test_programs
         run: |
-          ./execution_report.sh
+          ./execution_report.sh 0 1
           mv execution_report.json ../execution_report.json
           
       - name: Upload compilation report
@@ -286,10 +286,10 @@ jobs:
       matrix:
         include:
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts, is_library: true }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/parity-root, take_average: true }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner, take_average: true }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail, take_average: true  }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset, take_average: true }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-private }
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-public }
 
@@ -330,19 +330,37 @@ jobs:
           path: test-repo
           ref: ${{ matrix.project.ref }}
 
-      - name: Generate compilation report
+      - name: Generate compilation report without averages
         working-directory: ./test-repo/${{ matrix.project.path }}
+        if: ${{ !matrix.project.take_average }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh
           chmod +x ./compilation_report.sh
           ./compilation_report.sh 1
+
+      - name: Generate compilation report with averages
+        working-directory: ./test-repo/${{ matrix.project.path }}
+        if: ${{ matrix.project.take_average }}
+        run: |
+          mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh
+          chmod +x ./compilation_report.sh
+          ./compilation_report.sh 1 1
       
-      - name: Generate execution report
+      - name: Generate execution report without averages
         working-directory: ./test-repo/${{ matrix.project.path }}
         if: ${{ !matrix.project.is_library }}
+        if: ${{ !matrix.project.take_average }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
           ./execution_report.sh 1
+
+      - name: Generate execution report with averages
+        working-directory: ./test-repo/${{ matrix.project.path }}
+        if: ${{ !matrix.project.is_library }}
+        if: ${{ matrix.project.take_average }}
+        run: |
+          mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
+          ./execution_report.sh 1 1
 
       - name: Move compilation report
         id: compilation_report

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -348,14 +348,14 @@ jobs:
       
       - name: Generate execution report without averages
         working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ !matrix.project.is_library }} && ${{ !matrix.project.take_average }}
+        if: ${{ !matrix.project.is_library && !matrix.project.take_average }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
           ./execution_report.sh 1
 
       - name: Generate execution report with averages
         working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ !matrix.project.is_library }} && ${{ matrix.project.take_average }}
+        if: ${{ !matrix.project.is_library && matrix.project.take_average }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
           ./execution_report.sh 1 1

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -50,7 +50,7 @@ for dir in ${tests_to_profile[@]}; do
     for ((i = 1; i <= NUM_RUNS; i++)); do
       COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
       echo $COMPILE_TIME
-      TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $COMPILE_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
+      TOTAL_TIME=$($total_time + $(echo $time_str | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc))
     done
     AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
 

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -45,16 +45,13 @@ for dir in ${tests_to_profile[@]}; do
       NUM_RUNS=5
     fi
 
-    echo "num_runs: $NUM_RUNS"
-
     for ((i = 1; i <= NUM_RUNS; i++)); do
       COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
-      echo $COMPILE_TIME
-      # Convert to seconds and add to total time
-      TOTAL_TIME=$(($total_time + $(echo $COMPILE_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)))
+      # Convert time to seconds and add to total time
+      TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $COMPILE_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
     done
 
-    AVG_TIME=$(($TOTAL_TIME / $NUM_RUNS))
+    AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
     # Keep only last three decimal points
     AVG_TIME=$(awk '{printf "%.3f\n", $1}' <<< "$AVG_TIME")
 

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -49,6 +49,7 @@ for dir in ${tests_to_profile[@]}; do
 
     for ((i = 1; i <= NUM_RUNS; i++)); do
       COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
+      echo $COMPILE_TIME
       TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $COMPILE_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
     done
     AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
@@ -56,7 +57,11 @@ for dir in ${tests_to_profile[@]}; do
     echo $PACKAGE_NAME
     echo $AVG_TIME
 
-    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\""$AVG_TIME"s\"" >> $current_dir/compilation_report.json
+    # Keep only last three decimal points
+    AVG_TIME=$(awk '{printf "%.3f\n", $1}' <<< "$AVG_TIME")
+    echo $AVG_TIME
+
+    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"0m"$AVG_TIME"s\"" >> $current_dir/compilation_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "}" >> $current_dir/compilation_report.json

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -10,7 +10,7 @@ tests_to_profile=("sha256_regression" "regression_4709" "ram_blowup_regression")
 echo "{\"compilation_reports\": [ " > $current_dir/compilation_report.json
 
 # If there is an argument that means we want to generate a report for only the current directory
-if [ "$#" -ne 0 ]; then
+if [ "$1" == "1" ]; then
   base_path="$current_dir"
   tests_to_profile=(".")
 fi
@@ -32,12 +32,31 @@ for dir in ${tests_to_profile[@]}; do
     # The default package to run is the supplied list hardcoded at the top of the script
     PACKAGE_NAME=$dir
     # Otherwise default to the current directory as the package we want to run
-    if [ "$#" -ne 0 ]; then
+    if [ "$1" == "1" ]; then
       PACKAGE_NAME=$(basename $current_dir)
     fi
 
-    COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
-    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"$COMPILE_TIME\"" >> $current_dir/compilation_report.json
+    NUM_RUNS=1
+    TOTAL_TIME=0
+
+    # Passing a second argument will take an average of five runs
+    # rather than 
+    if [ "$2" == "1" ]; then
+      NUM_RUNS=5
+    fi
+
+    echo "num_runs: $NUM_RUNS"
+
+    for ((i = 1; i <= NUM_RUNS; i++)); do
+      COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
+      TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $COMPILE_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
+    done
+    AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
+
+    echo $PACKAGE_NAME
+    echo $AVG_TIME
+
+    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\""$AVG_TIME"s\"" >> $current_dir/compilation_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "}" >> $current_dir/compilation_report.json

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -50,16 +50,13 @@ for dir in ${tests_to_profile[@]}; do
     for ((i = 1; i <= NUM_RUNS; i++)); do
       COMPILE_TIME=$((time nargo compile --force --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
       echo $COMPILE_TIME
-      TOTAL_TIME=$($total_time + $(echo $time_str | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc))
+      # Convert to seconds and add to total time
+      TOTAL_TIME=$(($total_time + $(echo $COMPILE_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)))
     done
-    AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
 
-    echo $PACKAGE_NAME
-    echo $AVG_TIME
-
+    AVG_TIME=$(($TOTAL_TIME / $NUM_RUNS))
     # Keep only last three decimal points
     AVG_TIME=$(awk '{printf "%.3f\n", $1}' <<< "$AVG_TIME")
-    echo $AVG_TIME
 
     echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"0m"$AVG_TIME"s\"" >> $current_dir/compilation_report.json
     

--- a/test_programs/execution_report.sh
+++ b/test_programs/execution_report.sh
@@ -51,9 +51,7 @@ for dir in ${tests_to_profile[@]}; do
     if [ "$2" == "1" ]; then
       NUM_RUNS=5
     fi
-
-    echo "num_runs: $NUM_RUNS"
-
+    
     for ((i = 1; i <= NUM_RUNS; i++)); do
       EXECUTION_TIME=$((time nargo execute --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
       # Convert to seconds and add to total time

--- a/test_programs/execution_report.sh
+++ b/test_programs/execution_report.sh
@@ -10,7 +10,7 @@ tests_to_profile=("sha256_regression" "regression_4709" "ram_blowup_regression")
 echo "{\"execution_reports\": [ " > $current_dir/execution_report.json
 
 # If there is an argument that means we want to generate a report for only the current directory
-if [ "$#" -ne 0 ]; then
+if [ "$1" == "1" ]; then
   base_path="$current_dir"
   tests_to_profile=(".")
 fi
@@ -32,7 +32,7 @@ for dir in ${tests_to_profile[@]}; do
     # The default package to run is the supplied list hardcoded at the top of the script
     PACKAGE_NAME=$dir
     # Otherwise default to the current directory as the package we want to run
-    if [ "$#" -ne 0 ]; then
+    if [ "$1" == "1" ]; then
       PACKAGE_NAME=$(basename $current_dir)
     fi
 
@@ -44,8 +44,26 @@ for dir in ${tests_to_profile[@]}; do
       exit 1
     fi
 
-    COMPILE_TIME=$((time nargo execute --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
-    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"$COMPILE_TIME\"" >> $current_dir/execution_report.json
+
+    NUM_RUNS=1
+    TOTAL_TIME=0
+
+    if [ "$2" == "1" ]; then
+      NUM_RUNS=5
+    fi
+
+    echo "num_runs: $NUM_RUNS"
+
+    for ((i = 1; i <= NUM_RUNS; i++)); do
+      EXECUTION_TIME=$((time nargo execute --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
+      TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $EXECUTION_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
+    done
+    AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
+
+    echo $PACKAGE_NAME
+    echo $AVG_TIME
+
+    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\""$AVG_TIME"s\"" >> $current_dir/execution_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "}" >> $current_dir/execution_report.json

--- a/test_programs/execution_report.sh
+++ b/test_programs/execution_report.sh
@@ -56,18 +56,13 @@ for dir in ${tests_to_profile[@]}; do
 
     for ((i = 1; i <= NUM_RUNS; i++)); do
       EXECUTION_TIME=$((time nargo execute --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
-      echo $EXECUTION_TIME
       # Convert to seconds and add to total time
-      TOTAL_TIME=$($total_time + $(echo $EXECUTION_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc))
+      TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $EXECUTION_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
     done
+
     AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
-
-    echo $PACKAGE_NAME
-    echo $AVG_TIME
-
     # Keep only last three decimal points
     AVG_TIME=$(awk '{printf "%.3f\n", $1}' <<< "$AVG_TIME")
-    echo $AVG_TIME
 
     echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"0m"$AVG_TIME"s\"" >> $current_dir/execution_report.json
     

--- a/test_programs/execution_report.sh
+++ b/test_programs/execution_report.sh
@@ -56,6 +56,7 @@ for dir in ${tests_to_profile[@]}; do
 
     for ((i = 1; i <= NUM_RUNS; i++)); do
       EXECUTION_TIME=$((time nargo execute --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
+      echo $EXECUTION_TIME
       TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $EXECUTION_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
     done
     AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
@@ -63,7 +64,11 @@ for dir in ${tests_to_profile[@]}; do
     echo $PACKAGE_NAME
     echo $AVG_TIME
 
-    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\""$AVG_TIME"s\"" >> $current_dir/execution_report.json
+    # Keep only last three decimal points
+    AVG_TIME=$(awk '{printf "%.3f\n", $1}' <<< "$AVG_TIME")
+    echo $AVG_TIME
+
+    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"0m"$AVG_TIME"s\"" >> $current_dir/execution_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "}" >> $current_dir/execution_report.json

--- a/test_programs/execution_report.sh
+++ b/test_programs/execution_report.sh
@@ -57,7 +57,8 @@ for dir in ${tests_to_profile[@]}; do
     for ((i = 1; i <= NUM_RUNS; i++)); do
       EXECUTION_TIME=$((time nargo execute --silence-warnings) 2>&1 | grep real | grep -oE '[0-9]+m[0-9]+.[0-9]+s')
       echo $EXECUTION_TIME
-      TOTAL_TIME=$(echo "$TOTAL_TIME + $(echo $EXECUTION_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc)" | bc)
+      # Convert to seconds and add to total time
+      TOTAL_TIME=$($total_time + $(echo $EXECUTION_TIME | sed -E 's/([0-9]+)m([0-9.]+)s/\1 * 60 + \2/' | bc))
     done
     AVG_TIME=$(echo "$TOTAL_TIME / $NUM_RUNS" | bc -l)
 


### PR DESCRIPTION
# Description

## Problem\*

No issue as just a small improvement on existing compiler reports

## Summary\*

For very small programs (e.g. less than 2 seconds) the compilation and execution reports can be deceiving as they can vary greatly per run. This PR adds logic to take an average of certain small programs to get more accurate reports.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
