### PR TITLE
chore(ci): Display times in compilation and execution reports only with seconds

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -425,7 +425,7 @@ jobs:
 
       - name: Parse compilation report
         id: compilation_report
-        uses: noir-lang/noir-bench-report@0d7464a8c39170523932d7846b6e6b458a294aea
+        uses: noir-lang/noir-bench-report@81d04cbb962b6dbc84db866d5dd5f1fdaba81ad0
         with:
           report: compilation_report.json
           header: |
@@ -538,7 +538,7 @@ jobs:
 
       - name: Parse memory report
         id: memory_report
-        uses: noir-lang/noir-bench-report@0d7464a8c39170523932d7846b6e6b458a294aea
+        uses: noir-lang/noir-bench-report@81d04cbb962b6dbc84db866d5dd5f1fdaba81ad0
         with:
           report: memory_report.json
           header: |
@@ -582,7 +582,7 @@ jobs:
 
       - name: Parse execution report
         id: execution_report
-        uses: noir-lang/noir-bench-report@0954121203ee55dcda5c7397b9c669c439a20922
+        uses: noir-lang/noir-bench-report@81d04cbb962b6dbc84db866d5dd5f1fdaba81ad0
         with:
           report: execution_report.json
           header: |

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -425,7 +425,7 @@ jobs:
 
       - name: Parse compilation report
         id: compilation_report
-        uses: noir-lang/noir-bench-report@81d04cbb962b6dbc84db866d5dd5f1fdaba81ad0
+        uses: noir-lang/noir-bench-report@e408e131e96c3615b4f820d7d642360fb4d6e2f4
         with:
           report: compilation_report.json
           header: |
@@ -538,7 +538,7 @@ jobs:
 
       - name: Parse memory report
         id: memory_report
-        uses: noir-lang/noir-bench-report@81d04cbb962b6dbc84db866d5dd5f1fdaba81ad0
+        uses: noir-lang/noir-bench-report@e408e131e96c3615b4f820d7d642360fb4d6e2f4
         with:
           report: memory_report.json
           header: |
@@ -582,7 +582,7 @@ jobs:
 
       - name: Parse execution report
         id: execution_report
-        uses: noir-lang/noir-bench-report@81d04cbb962b6dbc84db866d5dd5f1fdaba81ad0
+        uses: noir-lang/noir-bench-report@e408e131e96c3615b4f820d7d642360fb4d6e2f4
         with:
           report: execution_report.json
           header: |

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -55,7 +55,7 @@ for dir in ${tests_to_profile[@]}; do
     # Keep only last three decimal points
     AVG_TIME=$(awk '{printf "%.3f\n", $1}' <<< "$AVG_TIME")
 
-    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"0m"$AVG_TIME"s\"" >> $current_dir/compilation_report.json
+    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\""$AVG_TIME"s\"" >> $current_dir/compilation_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "}" >> $current_dir/compilation_report.json

--- a/test_programs/execution_report.sh
+++ b/test_programs/execution_report.sh
@@ -62,7 +62,7 @@ for dir in ${tests_to_profile[@]}; do
     # Keep only last three decimal points
     AVG_TIME=$(awk '{printf "%.3f\n", $1}' <<< "$AVG_TIME")
 
-    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\"0m"$AVG_TIME"s\"" >> $current_dir/execution_report.json
+    echo -e " {\n    \"artifact_name\":\"$PACKAGE_NAME\",\n    \"time\":\""$AVG_TIME"s\"" >> $current_dir/execution_report.json
     
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "}" >> $current_dir/execution_report.json


### PR DESCRIPTION
# Description

## Problem\*

In https://github.com/noir-lang/noir/pull/6874 we moved to computing an average of multiple runs of `nargo compile` and `nargo execute`. The noir-bench-report still expects our time input to have the format of the output from the `time` command (e.g. `[0-9]+m[0-9]+.[0-9]+s`). In that PR we just prepended `0m` as to not to have to convert back to minutes. This suffix clutters the report output. 

## Summary\*

In this PR I decided to just keep with total seconds rather than converting back to minutes and seconds. It is simpler to work with one unit in my opinion. If we have reports that really need to be represented in minutes, we can address that at the time (if we have reports of that size it most likely means we have larger issues than how we display our reports). 

Updates to the commit in this PR https://github.com/noir-lang/noir-bench-report/pull/6

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
