### PR TITLE
fix: remove unnecessary cast in bit-shift

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -128,9 +128,7 @@ impl Context<'_> {
             let bit_size_var = self.numeric_constant(FieldElement::from(bit_size as u128), u8_type);
             let overflow = self.insert_binary(rhs, BinaryOp::Lt, bit_size_var);
             let predicate = self.insert_cast(overflow, typ);
-            // we can safely cast to unsigned because overflow_checks prevent bit-shift with a negative value
-            let rhs_unsigned = self.insert_cast(rhs, NumericType::unsigned(bit_size));
-            let pow = self.pow(base, rhs_unsigned);
+            let pow = self.pow(base, rhs);
             let pow = self.insert_cast(pow, typ);
             (FieldElement::max_num_bits(), self.insert_binary(predicate, BinaryOp::Mul, pow))
         };


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6788 

## Summary\*
Since bit shift are now forced to be done with u8 rhs operand, we do not need to cast it to unsigned type anymore.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
