### PR TITLE
chore: clean up gates reports script

### DIFF
--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -24,7 +24,7 @@ for pathname in $test_dirs; do
     fi
 
     GATES_INFO=$($BACKEND gates -b "$artifacts_path/$ARTIFACT_NAME/target/program.json")
-    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r ".functions[0] | {package_name: "\"$ARTIFACT_NAME\"", functions: [{name: \"main\", opcodes: .acir_opcodes, circuit_size}]}")
+    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r ".functions[0] | {package_name: "\"$ARTIFACT_NAME\"", functions: [{name: \"main\", .acir_opcodes, opcodes: .acir_opcodes, circuit_size}]}")
     echo -n $MAIN_FUNCTION_INFO >> gates_report.json
 
     if (($ITER == $NUM_ARTIFACTS)); then

--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -24,7 +24,7 @@ for pathname in $test_dirs; do
     fi
 
     GATES_INFO=$($BACKEND gates -b "$artifacts_path/$ARTIFACT_NAME/target/program.json")
-    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r ".functions[0] | {package_name: "\"$ARTIFACT_NAME\"", functions: [{name: \"main\", .acir_opcodes, opcodes: .acir_opcodes, circuit_size}]}")
+    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r ".functions[0] | {package_name: "\"$ARTIFACT_NAME\"", functions: [{name: \"main\", acir_opcodes, opcodes: .acir_opcodes, circuit_size}]}")
     echo -n $MAIN_FUNCTION_INFO >> gates_report.json
 
     if (($ITER == $NUM_ARTIFACTS)); then

--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -24,13 +24,13 @@ for pathname in $test_dirs; do
     fi
 
     GATES_INFO=$($BACKEND gates -b "$artifacts_path/$ARTIFACT_NAME/target/program.json")
-    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r '.functions[0] | .name = "main"')
-    echo "{\"package_name\": \"$ARTIFACT_NAME\", \"functions\": [$MAIN_FUNCTION_INFO]" >> gates_report.json
+    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r ".functions[0] | {package_name: "\"$ARTIFACT_NAME\"", functions: [{name: \"main\", opcodes: .acir_opcodes, circuit_size}]}")
+    echo -n $MAIN_FUNCTION_INFO >> gates_report.json
 
     if (($ITER == $NUM_ARTIFACTS)); then
-        echo "}" >> gates_report.json
+        echo "" >> gates_report.json
     else 
-        echo "}, " >> gates_report.json
+        echo "," >> gates_report.json
     fi
 
     ITER=$(( $ITER + 1 ))


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR resolves us having a billion lines of output from `gates_per_opcode` which are irrelevant for us. 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
