### PR TITLE
chore: remove malformed functions from brillig reports

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -76,7 +76,7 @@ jobs:
       
       - name: Compare gates reports
         id: gates_diff
-        uses: noir-lang/noir-gates-diff@d5fb85deaaf8af176aa98fbb945394d5e207c227
+        uses: noir-lang/noir-gates-diff@2b3906a9432b66bf3361e6ca15baa582795e4e89
         with:
           report: gates_report.json
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)
@@ -121,7 +121,7 @@ jobs:
 
       - name: Compare Brillig bytecode size reports
         id: brillig_bytecode_diff
-        uses: noir-lang/noir-gates-diff@d5fb85deaaf8af176aa98fbb945394d5e207c227
+        uses: noir-lang/noir-gates-diff@2b3906a9432b66bf3361e6ca15baa582795e4e89
         with:
           report: gates_report_brillig.json
           header: |
@@ -170,7 +170,7 @@ jobs:
 
       - name: Compare Brillig execution reports
         id: brillig_execution_diff
-        uses: noir-lang/noir-gates-diff@d5fb85deaaf8af176aa98fbb945394d5e207c227
+        uses: noir-lang/noir-gates-diff@2b3906a9432b66bf3361e6ca15baa582795e4e89
         with:
           report: gates_report_brillig_execution.json
           header: |

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -76,7 +76,7 @@ jobs:
       
       - name: Compare gates reports
         id: gates_diff
-        uses: noir-lang/noir-gates-diff@2b3906a9432b66bf3361e6ca15baa582795e4e89
+        uses: noir-lang/noir-gates-diff@84ada11295b9a1e1da7325af4e45e2db9f775175
         with:
           report: gates_report.json
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)
@@ -121,7 +121,7 @@ jobs:
 
       - name: Compare Brillig bytecode size reports
         id: brillig_bytecode_diff
-        uses: noir-lang/noir-gates-diff@2b3906a9432b66bf3361e6ca15baa582795e4e89
+        uses: noir-lang/noir-gates-diff@84ada11295b9a1e1da7325af4e45e2db9f775175
         with:
           report: gates_report_brillig.json
           header: |
@@ -170,7 +170,7 @@ jobs:
 
       - name: Compare Brillig execution reports
         id: brillig_execution_diff
-        uses: noir-lang/noir-gates-diff@2b3906a9432b66bf3361e6ca15baa582795e4e89
+        uses: noir-lang/noir-gates-diff@84ada11295b9a1e1da7325af4e45e2db9f775175
         with:
           report: gates_report_brillig_execution.json
           header: |

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -76,7 +76,7 @@ jobs:
       
       - name: Compare gates reports
         id: gates_diff
-        uses: noir-lang/noir-gates-diff@1931aaaa848a1a009363d6115293f7b7fc72bb87
+        uses: noir-lang/noir-gates-diff@d5fb85deaaf8af176aa98fbb945394d5e207c227
         with:
           report: gates_report.json
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)
@@ -121,7 +121,7 @@ jobs:
 
       - name: Compare Brillig bytecode size reports
         id: brillig_bytecode_diff
-        uses: noir-lang/noir-gates-diff@d88f7523b013b9edd3f31c5cfddaef87a3fe1b48
+        uses: noir-lang/noir-gates-diff@d5fb85deaaf8af176aa98fbb945394d5e207c227
         with:
           report: gates_report_brillig.json
           header: |
@@ -170,7 +170,7 @@ jobs:
 
       - name: Compare Brillig execution reports
         id: brillig_execution_diff
-        uses: noir-lang/noir-gates-diff@d88f7523b013b9edd3f31c5cfddaef87a3fe1b48
+        uses: noir-lang/noir-gates-diff@d5fb85deaaf8af176aa98fbb945394d5e207c227
         with:
           report: gates_report_brillig_execution.json
           header: |

--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -24,7 +24,7 @@ for pathname in $test_dirs; do
     fi
 
     GATES_INFO=$($BACKEND gates -b "$artifacts_path/$ARTIFACT_NAME/target/program.json")
-    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r ".functions[0] | {package_name: "\"$ARTIFACT_NAME\"", functions: [{name: \"main\", acir_opcodes, opcodes: .acir_opcodes, circuit_size}]}")
+    MAIN_FUNCTION_INFO=$(echo $GATES_INFO | jq -r ".functions[0] | {package_name: "\"$ARTIFACT_NAME\"", functions: [{name: \"main\", acir_opcodes, opcodes: .acir_opcodes, circuit_size}], unconstrained_functions: []}")
     echo -n $MAIN_FUNCTION_INFO >> gates_report.json
 
     if (($ITER == $NUM_ARTIFACTS)); then

--- a/test_programs/gates_report_brillig.sh
+++ b/test_programs/gates_report_brillig.sh
@@ -28,6 +28,6 @@ done
 
 echo "]" >> Nargo.toml
 
-nargo info --force-brillig --json | jq -r "del(.programs[].functions)"  > gates_report_brillig.json
+nargo info --force-brillig --json | jq -r ".programs[].functions = []"  > gates_report_brillig.json
 
 rm Nargo.toml

--- a/test_programs/gates_report_brillig.sh
+++ b/test_programs/gates_report_brillig.sh
@@ -28,6 +28,6 @@ done
 
 echo "]" >> Nargo.toml
 
-nargo info --force-brillig --json > gates_report_brillig.json
+nargo info --force-brillig --json | jq -r "del(.programs[].functions)"  > gates_report_brillig.json
 
 rm Nargo.toml

--- a/test_programs/gates_report_brillig_execution.sh
+++ b/test_programs/gates_report_brillig_execution.sh
@@ -38,6 +38,6 @@ done
 
 echo "]" >> Nargo.toml
 
-nargo info --profile-execution --json > gates_report_brillig_execution.json
+nargo info --profile-execution --json | jq -r ".programs[].functions = [] > gates_report_brillig_execution.json
 
 rm Nargo.toml

--- a/test_programs/gates_report_brillig_execution.sh
+++ b/test_programs/gates_report_brillig_execution.sh
@@ -38,6 +38,6 @@ done
 
 echo "]" >> Nargo.toml
 
-nargo info --profile-execution --json | jq -r ".programs[].functions = [] > gates_report_brillig_execution.json
+nargo info --profile-execution --json | jq -r ".programs[].functions = []" > gates_report_brillig_execution.json
 
 rm Nargo.toml


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Brillig reports cause issues with https://github.com/noir-lang/noir/pull/6851 where I'm being stricter about the data we're feeding into this action so I'm merging this separately so that we get a compatible artifact on master.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
