### PR TITLE
feat(ssa): Hoist add and mul binary ops using known induction variables

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -22,7 +22,7 @@ use super::{
     value::{Value, ValueId},
 };
 
-mod binary;
+pub(crate) mod binary;
 mod call;
 mod cast;
 mod constrain;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -294,7 +294,7 @@ impl Binary {
 }
 
 /// Evaluate a binary operation with constant arguments.
-fn eval_constant_binary_op(
+pub(crate) fn eval_constant_binary_op(
     lhs: FieldElement,
     rhs: FieldElement,
     operator: BinaryOp,

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -15,7 +15,7 @@ use crate::ssa::{
         basic_block::BasicBlockId,
         function::Function,
         function_inserter::FunctionInserter,
-        instruction::{Instruction, InstructionId},
+        instruction::{binary::eval_constant_binary_op, Instruction, InstructionId},
         types::Type,
         value::ValueId,
     },
@@ -207,6 +207,7 @@ impl<'f> LoopInvariantContext<'f> {
 
         let can_be_deduplicated = instruction.can_be_deduplicated(self.inserter.function, false)
             || matches!(instruction, Instruction::MakeArray { .. })
+            || matches!(instruction, Instruction::Binary(_))
             || self.can_be_deduplicated_from_upper_bound(&instruction);
 
         is_loop_invariant && can_be_deduplicated
@@ -230,6 +231,27 @@ impl<'f> LoopInvariantContext<'f> {
                 } else {
                     false
                 }
+            }
+            Instruction::Binary(binary) => {
+                let operand_type =
+                    self.inserter.function.dfg.type_of_value(binary.lhs).unwrap_numeric();
+
+                let lhs_const =
+                    self.inserter.function.dfg.get_numeric_constant_with_type(binary.lhs);
+                let rhs_const =
+                    self.inserter.function.dfg.get_numeric_constant_with_type(binary.rhs);
+                let (lhs, rhs) = match (
+                    lhs_const,
+                    rhs_const,
+                    self.outer_induction_variables.get(&binary.lhs),
+                    self.outer_induction_variables.get(&binary.rhs),
+                ) {
+                    (Some((lhs, _)), None, None, Some(upper_bound)) => (lhs, *upper_bound),
+                    (None, Some((rhs, _)), Some(upper_bound), None) => (*upper_bound, rhs),
+                    _ => return false,
+                };
+
+                eval_constant_binary_op(lhs, rhs, binary.operator, operand_type).is_some()
             }
             _ => false,
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -15,7 +15,7 @@ use crate::ssa::{
         basic_block::BasicBlockId,
         function::Function,
         function_inserter::FunctionInserter,
-        instruction::{binary::eval_constant_binary_op, Instruction, InstructionId},
+        instruction::{binary::eval_constant_binary_op, BinaryOp, Instruction, InstructionId},
         types::Type,
         value::ValueId,
     },
@@ -233,6 +233,10 @@ impl<'f> LoopInvariantContext<'f> {
                 }
             }
             Instruction::Binary(binary) => {
+                if !matches!(binary.operator, BinaryOp::Add | BinaryOp::Mul) {
+                  return false;
+                }
+                
                 let operand_type =
                     self.inserter.function.dfg.type_of_value(binary.lhs).unwrap_numeric();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -234,9 +234,9 @@ impl<'f> LoopInvariantContext<'f> {
             }
             Instruction::Binary(binary) => {
                 if !matches!(binary.operator, BinaryOp::Add | BinaryOp::Mul) {
-                  return false;
+                    return false;
                 }
-                
+
                 let operand_type =
                     self.inserter.function.dfg.type_of_value(binary.lhs).unwrap_numeric();
 


### PR DESCRIPTION
# Description

## Problem\*

Followup to https://github.com/noir-lang/noir/pull/6848 whose largest regression was in brillig opcodes executed https://github.com/noir-lang/noir/pull/6848#issuecomment-2549554990. 

## Summary\*

In #6848 we marked certain binary ops as not being able to be hoisted due to the overflow checks inside of ACIR gen and Brillig gen. However, if a binary operation has one variable that is from an outer loop's induction variable we can determine whether or not there would be an overflow. This re-uses logic introduced in https://github.com/noir-lang/noir/pull/6639.

This PR currently just tries to hoist add and mul instructions as they are simpler. For example, `Sub` overflows depends on if the induction variable is on the lhs or the rhs (e.g. if it is the rhs we should check the induction variable's upper bound but if it is the lhs we should check the lower bound). These can be done in follow-ups if we are comfortable with this approach.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
