### PR TITLE
fix: consistent file_id across installation paths

### DIFF
--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -97,7 +97,7 @@ fn insert_all_files_for_package_into_file_manager(
         .parent()
         .unwrap_or_else(|| panic!("The entry path is expected to be a single file within a directory and so should have a parent {:?}", package.entry_path));
 
-    for entry in WalkDir::new(entry_path_parent) {
+    for entry in WalkDir::new(entry_path_parent).sort_by_file_name() {
         let Ok(entry) = entry else {
             continue;
         };


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue where monomorphisation hash differ between compilations from different installation folders

## Summary\*
The file id are given by iterating over Noir source folders, but the iteration may depend on the file system state.
To fix this, I simply enumerate files in file names order.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
