### PR TITLE
chore: remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,38 +683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
-name = "camino"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,7 +2819,6 @@ dependencies = [
  "tempfile",
  "termcolor",
  "termion",
- "test-binary",
  "test-case",
  "thiserror",
  "tokio",
@@ -4254,9 +4221,6 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -4697,19 +4661,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "test-binary"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7cb854285c40b61c0fade358bf63a2bb1226688a1ea11432ea65349209e6e3"
-dependencies = [
- "camino",
- "cargo_metadata",
- "once_cell",
- "paste",
- "thiserror",
-]
 
 [[package]]
 name = "test-case"
@@ -5422,7 +5373,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -88,11 +88,9 @@ proptest.workspace = true
 sha2.workspace = true
 sha3.workspace = true
 iai = "0.1.1"
-test-binary = "3.0.2"
 test-case.workspace = true
 lazy_static.workspace = true
 light-poseidon = "0.2.0"
-
 
 [[bench]]
 name = "criterion"

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -12,8 +12,6 @@ mod tests {
 
     use super::*;
 
-    test_binary::build_test_binary_once!(mock_backend, "../backend_interface/test-binaries");
-
     // Utilities to keep the test matrix labels more intuitive.
     #[derive(Debug, Clone, Copy)]
     struct ForceBrillig(pub bool);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We no longer use the `test-binary` package since removing any connection to backends in the noir codebase.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
