### PR TITLE
feat: lock on Nargo.toml on several nargo commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,6 +3017,7 @@ dependencies = [
  "dirs",
  "file-lock",
  "fm",
+ "fs2",
  "fxhash",
  "iai",
  "iter-extended",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,8 +83,6 @@ noir_lsp = { path = "tooling/lsp" }
 noir_debugger = { path = "tooling/debugger" }
 noirc_abi = { path = "tooling/noirc_abi" }
 noirc_artifacts = { path = "tooling/noirc_artifacts" }
-bb_abstraction_leaks = { path = "tooling/bb_abstraction_leaks" }
-acvm_cli = { path = "tooling/acvm_cli" }
 
 # Arkworks
 ark-bn254 = { version = "^0.5.0", default-features = false, features = [

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -74,6 +74,7 @@ termion = "3.0.0"
 tracing-subscriber.workspace = true
 tracing-appender = "0.2.3"
 clap_complete = "4.5.36"
+fs2 = "0.4.3"
 
 [target.'cfg(not(unix))'.dependencies]
 tokio-util = { version = "0.7.8", features = ["compat"] }

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -177,32 +177,12 @@ fn generate_test_cases(
     }
     let test_cases = test_cases.join("\n");
 
-    // We need to isolate test cases in the same group, otherwise they overwrite each other's artifacts.
-    // On CI we use `cargo nextest`, which runs tests in different processes; for this we use a file lock.
-    // Locally we might be using `cargo test`, which run tests in the same process; in this case the file lock
-    // wouldn't work, becuase the process itself has the lock, and it looks like it can have N instances without
-    // any problems; for this reason we also use a `Mutex`.
-    let mutex_name = format! {"TEST_MUTEX_{}", test_name.to_uppercase()};
     write!(
         test_file,
         r#"
-lazy_static::lazy_static! {{
-    /// Prevent concurrent tests in the matrix from overwriting the compilation artifacts in {test_dir}
-    static ref {mutex_name}: std::sync::Mutex<()> = std::sync::Mutex::new(());
-}}
-
 {test_cases}
 fn test_{test_name}(force_brillig: ForceBrillig, inliner_aggressiveness: Inliner) {{
     let test_program_dir = PathBuf::from("{test_dir}");
-
-    // Ignore poisoning errors if some of the matrix cases failed.
-    let mutex_guard = {mutex_name}.lock().unwrap_or_else(|e| e.into_inner());
-
-    let file_guard = file_lock::FileLock::lock(
-        test_program_dir.join("Nargo.toml"),
-        true,
-        file_lock::FileOptions::new().read(true).write(true).append(true)
-    ).expect("failed to lock Nargo.toml");
 
     let mut nargo = Command::cargo_bin("nargo").unwrap();
     nargo.arg("--program-dir").arg(test_program_dir);
@@ -221,9 +201,6 @@ fn test_{test_name}(force_brillig: ForceBrillig, inliner_aggressiveness: Inliner
     }}
 
     {test_content}
-
-    drop(file_guard);
-    drop(mutex_guard);
 }}
 "#
     )

--- a/tooling/nargo_cli/src/cli/check_cmd.rs
+++ b/tooling/nargo_cli/src/cli/check_cmd.rs
@@ -1,4 +1,5 @@
 use crate::errors::CliError;
+use crate::lock::Lock;
 
 use clap::Args;
 use fm::FileManager;
@@ -34,6 +35,8 @@ pub(crate) struct CheckCommand {
 
 pub(crate) fn run(args: CheckCommand, config: NargoConfig) -> Result<(), CliError> {
     let toml_path = get_package_manifest(&config.program_dir)?;
+    let lock = Lock::lock(toml_path.clone());
+
     let selection = args.package_options.package_selection();
     let workspace = resolve_workspace_from_toml(
         &toml_path,
@@ -57,6 +60,9 @@ pub(crate) fn run(args: CheckCommand, config: NargoConfig) -> Result<(), CliErro
             println!("[{}] Constraint system successfully built!", package.name);
         }
     }
+
+    lock.unlock();
+
     Ok(())
 }
 

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -21,6 +21,7 @@ use super::fs::{inputs::read_inputs_from_file, witness::save_witness_to_dir};
 use super::{NargoConfig, PackageOptions};
 use crate::cli::fs::program::read_program_from_file;
 use crate::errors::CliError;
+use crate::lock::Lock;
 
 /// Executes a circuit to calculate its return value
 #[derive(Debug, Clone, Args)]
@@ -48,6 +49,8 @@ pub(crate) struct ExecuteCommand {
 
 pub(crate) fn run(args: ExecuteCommand, config: NargoConfig) -> Result<(), CliError> {
     let toml_path = get_package_manifest(&config.program_dir)?;
+    let lock = Lock::lock(toml_path.clone());
+
     let selection = args.package_options.package_selection();
     let workspace = resolve_workspace_from_toml(
         &toml_path,
@@ -98,6 +101,9 @@ pub(crate) fn run(args: ExecuteCommand, config: NargoConfig) -> Result<(), CliEr
             }
         }
     }
+
+    lock.unlock();
+
     Ok(())
 }
 

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -13,7 +13,7 @@ use prettytable::{row, table, Row};
 use rayon::prelude::*;
 use serde::Serialize;
 
-use crate::{cli::fs::inputs::read_inputs_from_file, errors::CliError};
+use crate::{cli::fs::inputs::read_inputs_from_file, errors::CliError, lock::Lock};
 
 use super::{
     compile_cmd::{compile_workspace_full, get_target_width},
@@ -49,6 +49,8 @@ pub(crate) struct InfoCommand {
 
 pub(crate) fn run(mut args: InfoCommand, config: NargoConfig) -> Result<(), CliError> {
     let toml_path = get_package_manifest(&config.program_dir)?;
+    let lock = Lock::lock(toml_path.clone());
+
     let selection = args.package_options.package_selection();
     let workspace = resolve_workspace_from_toml(
         &toml_path,
@@ -117,6 +119,8 @@ pub(crate) fn run(mut args: InfoCommand, config: NargoConfig) -> Result<(), CliE
             program_table.printstd();
         }
     }
+
+    lock.unlock();
 
     Ok(())
 }

--- a/tooling/nargo_cli/src/lock.rs
+++ b/tooling/nargo_cli/src/lock.rs
@@ -1,0 +1,26 @@
+use std::{fs::File, path::PathBuf};
+
+use fs2::FileExt as _;
+
+/// A lock used to lock the Nargo.toml file so two concurrent runs of nargo
+/// commands (for example two `nargo execute`) don't overwrite output artifacts.
+pub(crate) struct Lock {
+    file: File,
+}
+
+impl Lock {
+    #[allow(clippy::self_named_constructors)]
+    pub(crate) fn lock(toml_path: PathBuf) -> Self {
+        let file = File::open(toml_path).expect("Expected Nargo.toml to exist");
+        if file.try_lock_exclusive().is_err() {
+            eprintln!("Waiting for lock on Nargo.toml...");
+        }
+
+        file.lock_exclusive().expect("Failed to lock Nargo.toml");
+        Self { file }
+    }
+
+    pub(crate) fn unlock(&self) {
+        self.file.unlock().expect("Failed to unlock Nargo.toml");
+    }
+}

--- a/tooling/nargo_cli/src/main.rs
+++ b/tooling/nargo_cli/src/main.rs
@@ -9,6 +9,7 @@
 
 mod cli;
 mod errors;
+mod lock;
 
 use std::env;
 


### PR DESCRIPTION
# Description

## Problem

Something mentioned over Slack.

## Summary

nargo_cli's `build.rs` was using a combination of mutexes and file locks. Instead of only doing it there, this PR moves the file lock to almost every `nargo` command. That means that if you do `nargo execute` twice on the same directory, the second invocation will wait until the first one ends.

I changed from `file_lock` to `fs2` because it allows doing `try_lock_exclusive` so we can show the user a message saying we are waiting for a lock...

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
