### PR TITLE
feat!: turn CannotReexportItemWithLessVisibility into an error

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -183,7 +183,7 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
             }
             DefCollectorErrorKind::PathResolutionError(error) => error.into(),
             DefCollectorErrorKind::CannotReexportItemWithLessVisibility{item_name, desired_visibility} => {
-                Diagnostic::simple_warning(
+                Diagnostic::simple_error(
                     format!("cannot re-export {item_name} because it has less visibility than this use statement"),
                     format!("consider marking {item_name} as {desired_visibility}"),
                     item_name.span())


### PR DESCRIPTION
# Description

## Problem

Resolves #6933

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
