### PR TITLE
fix: don't fail parsing macro if there are parser warnings

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -247,7 +247,7 @@ impl<'context> Elaborator<'context> {
 
         if value != Value::Unit {
             let items = value
-                .into_top_level_items(location, self.interner)
+                .into_top_level_items(location, self)
                 .map_err(|error| error.into_compilation_error_pair())?;
 
             self.add_items(items, generated_items, location);

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -927,7 +927,7 @@ impl<'context> Elaborator<'context> {
         };
 
         let location = Location::new(span, self.file);
-        match value.into_expression(self.interner, location) {
+        match value.into_expression(self, location) {
             Ok(new_expr) => {
                 // At this point the Expression was already elaborated and we got a Value.
                 // We'll elaborate this value turned into Expression to inline it and get

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1322,7 +1322,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 let bindings = unwrap_rc(bindings);
                 let mut result = self.call_function(function_id, arguments, bindings, location)?;
                 if call.is_macro_call {
-                    let expr = result.into_expression(self.elaborator.interner, location)?;
+                    let expr = result.into_expression(self.elaborator, location)?;
                     let expr = self.elaborate_in_function(self.current_function, |elaborator| {
                         elaborator.elaborate_expression(expr).0
                     });

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -5,6 +5,7 @@ use acvm::FieldElement;
 use iter_extended::try_vecmap;
 use noirc_errors::Location;
 
+use crate::elaborator::Elaborator;
 use crate::hir::comptime::display::tokens_to_string;
 use crate::hir::comptime::value::add_token_spans;
 use crate::lexer::Lexer;
@@ -493,7 +494,7 @@ pub(super) fn lex(input: &str) -> Vec<Token> {
 }
 
 pub(super) fn parse<'a, T, F>(
-    interpreter: &mut Interpreter,
+    elaborator: &mut Elaborator,
     (value, location): (Value, Location),
     parser: F,
     rule: &'static str,
@@ -504,9 +505,9 @@ where
     let tokens = get_quoted((value, location))?;
     let quoted = add_token_spans(tokens.clone(), location.span);
     let (result, warnings) =
-        parse_tokens(tokens, quoted, interpreter.elaborator.interner, location, parser, rule)?;
+        parse_tokens(tokens, quoted, elaborator.interner, location, parser, rule)?;
     for warning in warnings {
-        interpreter.elaborator.errors.push((warning.into(), location.file));
+        elaborator.errors.push((warning.into(), location.file));
     }
     Ok(result)
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -8,7 +8,7 @@ use noirc_errors::Location;
 use crate::hir::comptime::display::tokens_to_string;
 use crate::hir::comptime::value::add_token_spans;
 use crate::lexer::Lexer;
-use crate::parser::Parser;
+use crate::parser::{Parser, ParserError};
 use crate::{
     ast::{
         BlockExpression, ExpressionKind, Ident, IntegerBitSize, LValue, Pattern, Signedness,
@@ -493,7 +493,7 @@ pub(super) fn lex(input: &str) -> Vec<Token> {
 }
 
 pub(super) fn parse<'a, T, F>(
-    interner: &NodeInterner,
+    interpreter: &mut Interpreter,
     (value, location): (Value, Location),
     parser: F,
     rule: &'static str,
@@ -503,7 +503,12 @@ where
 {
     let tokens = get_quoted((value, location))?;
     let quoted = add_token_spans(tokens.clone(), location.span);
-    parse_tokens(tokens, quoted, interner, location, parser, rule)
+    let (result, warnings) =
+        parse_tokens(tokens, quoted, interpreter.elaborator.interner, location, parser, rule)?;
+    for warning in warnings {
+        interpreter.elaborator.errors.push((warning.into(), location.file));
+    }
+    Ok(result)
 }
 
 pub(super) fn parse_tokens<'a, T, F>(
@@ -513,7 +518,7 @@ pub(super) fn parse_tokens<'a, T, F>(
     location: Location,
     parsing_function: F,
     rule: &'static str,
-) -> IResult<T>
+) -> IResult<(T, Vec<ParserError>)>
 where
     F: FnOnce(&mut Parser<'a>) -> T,
 {

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -10,6 +10,7 @@ use crate::{
         resolution::errors::ResolverError,
         type_check::TypeCheckError,
     },
+    parser::{ParserError, ParserErrorReason},
 };
 
 use super::{assert_no_errors, get_program_errors};
@@ -160,4 +161,34 @@ fn uses_correct_type_for_attribute_arguments() {
     fn main() {}
     "#;
     assert_no_errors(src);
+}
+
+#[test]
+fn does_not_fail_to_parse_macro_on_parser_warning() {
+    let src = r#"
+    #[make_bar]
+    pub unconstrained fn foo() {}
+
+    comptime fn make_bar(_: FunctionDefinition) -> Quoted {
+        quote {
+            pub fn bar() {
+                unsafe { 
+                    foo();
+                }
+            }
+        }
+    }
+
+    fn main() {
+        bar()
+    }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ParseError(parser_error) = &errors[0].0 else {
+        panic!("Expected a ParseError, got {:?}", errors[0].0);
+    };
+
+    assert!(matches!(parser_error.reason(), Some(ParserErrorReason::MissingSafetyComment)));
 }

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -10,7 +10,7 @@ use crate::{
         resolution::errors::ResolverError,
         type_check::TypeCheckError,
     },
-    parser::{ParserError, ParserErrorReason},
+    parser::ParserErrorReason,
 };
 
 use super::{assert_no_errors, get_program_errors};


### PR DESCRIPTION
# Description

## Problem

Resolves #6968

## Summary

The issue was that parser warnings made macro parsing failed. Instead, in this PR we report those warnings and move on (only if all parser errors were warnings).

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
