### PR TITLE
fix: wrong module to lookup trait when using crate or super

### DIFF
--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -717,7 +717,7 @@ fn calls_trait_function_if_it_is_in_scope() {
 }
 
 #[test]
-fn calls_trait_function_it_is_only_candidate_in_scope() {
+fn calls_trait_function_if_it_is_only_candidate_in_scope() {
     let src = r#"
     use private_mod::Foo;
 
@@ -744,6 +744,36 @@ fn calls_trait_function_it_is_only_candidate_in_scope() {
         }
 
         impl Foo2 for super::Bar {
+            fn foo() -> i32 {
+                42
+            }
+        }
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn calls_trait_function_if_it_is_only_candidate_in_scope_in_nested_module_using_super() {
+    let src = r#"
+    mod moo {
+        use super::public_mod::Foo;
+
+        pub fn method() {
+            let _ = super::Bar::foo();
+        }
+    }
+
+    fn main() {}
+
+    pub struct Bar {}
+
+    pub mod public_mod {
+        pub trait Foo {
+            fn foo() -> i32;
+        }
+
+        impl Foo for super::Bar {
             fn foo() -> i32 {
                 42
             }


### PR DESCRIPTION
# Description

## Problem

Some warnings found in noir-bignum regarding traits.

## Summary

When doing path lookup there's a concept of "importing module", which is the module the triggered the path lookup, and "starting module", which is where we start looking names. Most of the time these are the same, for example if we do `use foo::Bar` we start at the current module and also look up `foo` in the current module. But when doing `use crate::...` or `use super::..` the starting module changes.

The code was using "starting module" instead of "importing module" to find traits in scope. This PR fixes that to use "importing module".

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
