### PR TITLE
fix: allow multiple trait impls for the same trait as long as one is in scope

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, rc::Rc};
 
+use im::HashSet;
 use iter_extended::vecmap;
 use noirc_errors::{Location, Span};
 use rustc_hash::FxHashMap as HashMap;
@@ -1422,9 +1423,14 @@ impl<'context> Elaborator<'context> {
         let module_id = self.module_id();
         let module_data = self.get_module(module_id);
 
-        let trait_methods_in_scope: Vec<_> = trait_methods
+        // Only keep unique trait IDs: multiple trait methods might come from the same trait
+        // but implemented with different generics (like `Convert<Field>` and `Convert<i32>`).
+        let traits: HashSet<TraitId> =
+            trait_methods.into_iter().map(|(_, trait_id)| trait_id).collect();
+
+        let traits_in_scope: Vec<_> = traits
             .iter()
-            .filter_map(|(func_id, trait_id)| {
+            .filter_map(|trait_id| {
                 let trait_ = self.interner.get_trait(*trait_id);
                 let trait_name = &trait_.name;
                 let Some(map) = module_data.scope().types().get(trait_name) else {
@@ -1434,30 +1440,34 @@ impl<'context> Elaborator<'context> {
                     return None;
                 };
                 if imported_item.0 == ModuleDefId::TraitId(*trait_id) {
-                    Some((*func_id, *trait_id, trait_name))
+                    Some((*trait_id, trait_name))
                 } else {
                     None
                 }
             })
             .collect();
 
-        for (_, _, trait_name) in &trait_methods_in_scope {
+        for (_, trait_name) in &traits_in_scope {
             self.usage_tracker.mark_as_used(module_id, trait_name);
         }
 
-        if trait_methods_in_scope.is_empty() {
-            if trait_methods.len() == 1 {
-                // This is the backwards-compatible case where there's a single trait method but it's not in scope
-                let (func_id, trait_id) = trait_methods[0];
+        if traits_in_scope.is_empty() {
+            if traits.len() == 1 {
+                // This is the backwards-compatible case where there's a single trait but it's not in scope
+                let trait_id = *traits.iter().next().unwrap();
                 let trait_ = self.interner.get_trait(trait_id);
                 let trait_name = self.fully_qualified_trait_path(trait_);
+                let generics = trait_.as_constraint(span).trait_bound.trait_generics;
+                let trait_method_id = trait_.find_method(method_name).unwrap();
+
                 self.push_err(PathResolutionError::TraitMethodNotInScope {
                     ident: Ident::new(method_name.into(), span),
                     trait_name,
                 });
-                return Some(HirMethodReference::FuncId(func_id));
+
+                return Some(HirMethodReference::TraitMethodId(trait_method_id, generics, false));
             } else {
-                let traits = vecmap(trait_methods, |(_, trait_id)| {
+                let traits = vecmap(traits, |trait_id| {
                     let trait_ = self.interner.get_trait(trait_id);
                     self.fully_qualified_trait_path(trait_)
                 });
@@ -1469,8 +1479,8 @@ impl<'context> Elaborator<'context> {
             }
         }
 
-        if trait_methods_in_scope.len() > 1 {
-            let traits = vecmap(trait_methods, |(_, trait_id)| {
+        if traits_in_scope.len() > 1 {
+            let traits = vecmap(traits, |trait_id| {
                 let trait_ = self.interner.get_trait(trait_id);
                 self.fully_qualified_trait_path(trait_)
             });
@@ -1481,8 +1491,12 @@ impl<'context> Elaborator<'context> {
             return None;
         }
 
-        let func_id = trait_methods_in_scope[0].0;
-        Some(HirMethodReference::FuncId(func_id))
+        // Return a TraitMethodId with unbound generics. These will later be bound by the type-checker.
+        let trait_id = traits_in_scope[0].0;
+        let trait_ = self.interner.get_trait(trait_id);
+        let generics = trait_.as_constraint(span).trait_bound.trait_generics;
+        let trait_method_id = trait_.find_method(method_name).unwrap();
+        Some(HirMethodReference::TraitMethodId(trait_method_id, generics, false))
     }
 
     fn lookup_method_in_trait_constraints(

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -2313,6 +2313,14 @@ impl NodeInterner {
     pub fn doc_comments(&self, id: ReferenceId) -> Option<&Vec<String>> {
         self.doc_comments.get(&id)
     }
+
+    pub fn get_expr_id_from_index(&self, index: impl Into<Index>) -> Option<ExprId> {
+        let index = index.into();
+        match self.nodes.get(index) {
+            Some(Node::Expression(_)) => Some(ExprId(index)),
+            _ => None,
+        }
+    }
 }
 
 impl Methods {

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1008,6 +1008,38 @@ fn errors_if_multiple_trait_methods_are_in_scope_for_method_call() {
 }
 
 #[test]
+fn calls_trait_method_if_it_is_in_scope_with_multiple_candidates_but_only_one_decided_by_generics()
+{
+    let src = r#"
+    struct Foo {
+        inner: Field,
+    }
+
+    trait Converter<N> {
+        fn convert(self) -> N;
+    }
+
+    impl Converter<Field> for Foo {
+        fn convert(self) -> Field {
+            self.inner
+        }
+    }
+
+    impl Converter<u32> for Foo {
+        fn convert(self) -> u32 {
+            self.inner as u32
+        }
+    }
+
+    fn main() {
+        let foo = Foo { inner: 42 };
+        let _: u32 = foo.convert();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn type_checks_trait_default_method_and_errors() {
     let src = r#"
         pub trait Foo {

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -452,9 +452,7 @@ fn get_trait_impl_func_id(
     args: &ProcessRequestCallbackArgs,
     func_meta: &FuncMeta,
 ) -> Option<FuncId> {
-    if func_meta.trait_id.is_none() {
-        return None;
-    }
+    func_meta.trait_id?;
 
     let index = args.interner.find_location_index(args.location)?;
     let expr_id = args.interner.get_expr_id_from_index(index)?;


### PR DESCRIPTION
# Description

## Problem

This code used to give an error saying multiple traits (`Convert` and `Convert`) were in scope:

```noir
struct Foo {
    inner: Field,
}

trait Converter<N> {
    fn convert(self) -> N;
}

impl Converter<Field> for Foo {
    fn convert(self) -> Field {
        self.inner
    }
}

impl Converter<u32> for Foo {
    fn convert(self) -> u32 {
        self.inner as u32
    }
}

fn main() {
    let foo = Foo { inner: 42 };
    let _: u32 = foo.convert();
}
```

## Summary

Now the error is gone. We search if there's only one trait, not one trait method, in scope. In the snippet above there are two but they are for the same trait so it's fine. Later on the type-checker checks that it's only bound to the one for `u32`.

If we remove the `u32` type annotation, we get this error:

```
error: Multiple trait impls match the object type `Foo`
   ┌─ src/main.nr:25:13
   │
25 │     let x = foo.convert();
   │             ----------- Ambiguous impl
   │
   = Candidate 1: `Foo: Converter<Field>`
   = Candidate 2: `Foo: Converter<u32>`
``` 

## Additional Context

To be honest, I'm not sure where's the code that eventually checks what's the impl for `foo.convert()` that matches against `u32`, but seeing it work, and seeing the error we get when there are multiple matching impls, I'm confident it's working fine (it seems to be in `verify_trait_constraint` right before we end analyzing a function)

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
