### PR TITLE
fix: return trait impl method as FuncId if there's only one

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -30,7 +30,7 @@ use crate::{
         traits::{NamedType, ResolvedTraitBound, Trait, TraitConstraint},
     },
     node_interner::{
-        DependencyId, ExprId, GlobalValue, ImplSearchErrorKind, NodeInterner, TraitId,
+        DependencyId, ExprId, FuncId, GlobalValue, ImplSearchErrorKind, NodeInterner, TraitId,
         TraitImplKind, TraitMethodId,
     },
     token::SecondaryAttribute,
@@ -1457,21 +1457,18 @@ impl<'context> Elaborator<'context> {
                 let trait_id = *traits.iter().next().unwrap();
                 let trait_ = self.interner.get_trait(trait_id);
                 let trait_name = self.fully_qualified_trait_path(trait_);
-                let generics = trait_.as_constraint(span).trait_bound.trait_generics;
-                let trait_method_id = trait_.find_method(method_name).unwrap();
 
                 self.push_err(PathResolutionError::TraitMethodNotInScope {
                     ident: Ident::new(method_name.into(), span),
                     trait_name,
                 });
 
-                // If we find a single trait impl method, return it so we don't have to determine the impl
-                if trait_methods.len() == 1 {
-                    let (func_id, _) = trait_methods[0];
-                    return Some(HirMethodReference::FuncId(func_id));
-                }
-
-                return Some(HirMethodReference::TraitMethodId(trait_method_id, generics, false));
+                return Some(self.trait_hir_method_reference(
+                    trait_id,
+                    trait_methods,
+                    method_name,
+                    span,
+                ));
             } else {
                 let traits = vecmap(traits, |trait_id| {
                     let trait_ = self.interner.get_trait(trait_id);
@@ -1497,18 +1494,28 @@ impl<'context> Elaborator<'context> {
             return None;
         }
 
-        // If we find a single trait impl method, return it so we don't have to determine the impl
+        let trait_id = traits_in_scope[0].0;
+        Some(self.trait_hir_method_reference(trait_id, trait_methods, method_name, span))
+    }
+
+    fn trait_hir_method_reference(
+        &self,
+        trait_id: TraitId,
+        trait_methods: Vec<(FuncId, TraitId)>,
+        method_name: &str,
+        span: Span,
+    ) -> HirMethodReference {
+        // If we find a single trait impl method, return it so we don't have to later determine the impl
         if trait_methods.len() == 1 {
             let (func_id, _) = trait_methods[0];
-            return Some(HirMethodReference::FuncId(func_id));
+            return HirMethodReference::FuncId(func_id);
         }
 
         // Return a TraitMethodId with unbound generics. These will later be bound by the type-checker.
-        let trait_id = traits_in_scope[0].0;
         let trait_ = self.interner.get_trait(trait_id);
         let generics = trait_.as_constraint(span).trait_bound.trait_generics;
         let trait_method_id = trait_.find_method(method_name).unwrap();
-        Some(HirMethodReference::TraitMethodId(trait_method_id, generics, false))
+        HirMethodReference::TraitMethodId(trait_method_id, generics, false)
     }
 
     fn lookup_method_in_trait_constraints(

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1426,7 +1426,7 @@ impl<'context> Elaborator<'context> {
         // Only keep unique trait IDs: multiple trait methods might come from the same trait
         // but implemented with different generics (like `Convert<Field>` and `Convert<i32>`).
         let traits: HashSet<TraitId> =
-            trait_methods.into_iter().map(|(_, trait_id)| trait_id).collect();
+            trait_methods.iter().map(|(_, trait_id)| *trait_id).collect();
 
         let traits_in_scope: Vec<_> = traits
             .iter()
@@ -1489,6 +1489,12 @@ impl<'context> Elaborator<'context> {
                 traits,
             });
             return None;
+        }
+
+        // If we find a single trait impl method, return it so we don't have to determine the impl
+        if trait_methods.len() == 1 {
+            let (func_id, _) = trait_methods[0];
+            return Some(HirMethodReference::FuncId(func_id));
         }
 
         // Return a TraitMethodId with unbound generics. These will later be bound by the type-checker.

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1465,6 +1465,12 @@ impl<'context> Elaborator<'context> {
                     trait_name,
                 });
 
+                // If we find a single trait impl method, return it so we don't have to determine the impl
+                if trait_methods.len() == 1 {
+                    let (func_id, _) = trait_methods[0];
+                    return Some(HirMethodReference::FuncId(func_id));
+                }
+
                 return Some(HirMethodReference::TraitMethodId(trait_method_id, generics, false));
             } else {
                 let traits = vecmap(traits, |trait_id| {


### PR DESCRIPTION
# Description

## Problem

Workaround for this issue: https://github.com/noir-lang/noir/pull/6987#issuecomment-2578316933

## Summary

I'm sure a similar issue can happen in other scenarios, though I don't know what code reproduces it. We can use this workaround until we bump into a new error and the fix it in a better way.

Alternatively, we could revert #6987

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
