### PR TITLE
chore: simplify `field_less_than` in stdlib

### DIFF
--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -213,11 +213,7 @@ pub comptime fn modulus_le_bytes() -> [u8] {}
 
 /// An unconstrained only built in to efficiently compare fields.
 #[builtin(field_less_than)]
-unconstrained fn __field_less_than(x: Field, y: Field) -> bool {}
-
-pub(crate) unconstrained fn field_less_than(x: Field, y: Field) -> bool {
-    __field_less_than(x, y)
-}
+pub(crate) unconstrained fn field_less_than(x: Field, y: Field) -> bool {}
 
 // Convert a 32 byte array to a field element by modding
 pub fn bytes32_to_field(bytes32: [u8; 32]) -> Field {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Not sure why we have this wrapper so seeing if we can just remove it.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
