### PR TITLE
fix: Keep format string literal when converting comptime value to HIR expression

### DIFF
--- a/test_programs/execution_success/debug_logs/src/main.nr
+++ b/test_programs/execution_success/debug_logs/src/main.nr
@@ -1,6 +1,17 @@
+global A: Field = 50;
+global B: Field = 100;
+global GLOBAL_FMT_STR: fmtstr<14, (Field, Field)> = f"i: {A}, j: {B}";
+global GLOBAL_FMT_STR_BIG: fmtstr<22, (Field, Field, Field)> = f"i: {A}, j: {B}, k: {A}";
+
 fn main(x: Field, y: pub Field) {
     let string = "i: {i}, j: {j}";
     println(string);
+
+    println(GLOBAL_FMT_STR);
+    println(GLOBAL_FMT_STR_BIG);
+
+    let LOCAL_FMT_STR: fmtstr<14, (Field, Field)> = f"i: {A}, j: {B}";
+    println(LOCAL_FMT_STR);
 
     // TODO: fmtstr cannot be printed
     // let fmt_str: fmtstr<14, (Field, Field)> = f"i: {x}, j: {y}";

--- a/test_programs/execution_success/debug_logs/src/main.nr
+++ b/test_programs/execution_success/debug_logs/src/main.nr
@@ -13,7 +13,7 @@ fn main(x: Field, y: pub Field) {
     let LOCAL_FMT_STR: fmtstr<14, (Field, Field)> = f"i: {A}, j: {B}";
     println(LOCAL_FMT_STR);
 
-    // TODO: fmtstr cannot be printed
+    // TODO: fmtstr cannot be printed inside another fmtstr 
     // let fmt_str: fmtstr<14, (Field, Field)> = f"i: {x}, j: {y}";
     // let fmt_fmt_str = f"fmtstr: {fmt_str}, i: {x}";
     // println(fmt_fmt_str);


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6990 

## Summary\*

Go to the issue for the initial context. What I did is a little bit hack-y, but it seemed like the simplest way to prevent this panic without making significant changes to how we monomorphize. 

Format strings are the only comptime type which we lower into a different type (in this case a string literal). I changed the `Value::FormatString` case in `into_hir_expression` to return a `HirLiteral::FmtStr` in the format that the type is expected to be. This required creating a new placeholder expression. In this case I used a string with a single whitespace character as this required minimal changes and does not change the functionality of fmt strings which are entirely used for logging. 

I added some global fmt strings to the `debug_logs` test:
These prints:
```noir
global A: Field = 50;
global B: Field = 100;
global GLOBAL_FMT_STR: fmtstr<14, (Field, Field)> = f"i: {A}, j: {B}";
global GLOBAL_FMT_STR_BIG: fmtstr<22, (Field, Field, Field)> = f"i: {A}, j: {B}, k: {A}";

fn main(..) {
    println(GLOBAL_FMT_STR);
    println(GLOBAL_FMT_STR_BIG);
}
```
Give this output:
```
i: 50, j: 100
i: 50, j: 100, k: 50
```

## Additional Context

We do not currently allow nested format strings. Having this extra whitespace may cause some difficulty if we ever activate the ability to have nested format strings.    

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
