### PR TITLE
feat: simplify CFG after `resolve_is_unconstrained` SSA pass

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -154,10 +154,11 @@ fn optimize_all(builder: SsaBuilder, options: &SsaEvaluatorOptions) -> Result<Ss
         .run_pass(Ssa::defunctionalize, "Defunctionalization")
         .run_pass(Ssa::remove_paired_rc, "Removing Paired rc_inc & rc_decs")
         .run_pass(Ssa::resolve_is_unconstrained, "Resolving IsUnconstrained")
+        .run_pass(Ssa::simplify_cfg, "Simplifying (1st)")
         .run_pass(|ssa| ssa.inline_functions(options.inliner_aggressiveness), "Inlining (1st)")
         // Run mem2reg with the CFG separated into blocks
         .run_pass(Ssa::mem2reg, "Mem2Reg (1st)")
-        .run_pass(Ssa::simplify_cfg, "Simplifying (1st)")
+        .run_pass(Ssa::simplify_cfg, "Simplifying (2nd)")
         .run_pass(Ssa::as_slice_optimization, "`as_slice` optimization")
         .run_pass(Ssa::remove_unreachable_functions, "Removing Unreachable Functions")
         .try_run_pass(


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We often use the results of `std::runtime::is_unconstrained` in control flow so it makes sense to simplify the CFG based on the results immediately as this can avoid us needing to inline functions into blocks which will eventually be pruned.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
