### PR TITLE
feat(lsp): use trait method docs for trait impl method docs on hover

### DIFF
--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -3,7 +3,7 @@ name = "noir_lsp"
 description = "Language server for Noir"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true#
+edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
@@ -16,7 +16,7 @@ workspace = true
 acvm.workspace = true
 codespan-lsp.workspace = true
 lsp-types.workspace = true
-nargo.workspace = true
+nargo = { workspace = true, features = ["rpc"] }
 nargo_fmt.workspace = true
 nargo_toml.workspace = true
 noirc_driver.workspace = true

--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -84,3 +84,12 @@ fn bar_stuff() {
     foo.bar_stuff();
 }
 
+trait TraitWithDocs {
+    /// Some docs
+    fn foo();
+}
+
+impl TraitWithDocs for Field {
+    fn foo() {}
+}
+


### PR DESCRIPTION
# Description

## Problem

Requested by Nico and it's something small so I decided to do it.

Similar to Rust Analyzer, when you hover over a trait impl method which doesn't have docs, show the docs of the trait method being implemented.

## Summary

![image](https://github.com/user-attachments/assets/635273d5-bc53-4684-bee1-0dba3f56e9f6)

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
