### PR TITLE
chore: Only resolved globals monomorphization

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -934,11 +934,9 @@ impl<'interner> Monomorphizer<'interner> {
                         .into_hir_expression(self.interner, global.location)
                         .map_err(MonomorphizationError::InterpreterError)?
                 } else {
-                    let let_ = self.interner.get_global_let_statement(*global_id).expect(
-                        "Globals should have a corresponding let statement by monomorphization",
-                    );
-                    let_.expression
+                    unreachable!("All global values should be resolved my monomorphization");
                 };
+
                 self.expr(expr)?
             }
             DefinitionKind::Local(_) => match self.lookup_captured_expr(ident.id) {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -934,7 +934,7 @@ impl<'interner> Monomorphizer<'interner> {
                         .into_hir_expression(self.interner, global.location)
                         .map_err(MonomorphizationError::InterpreterError)?
                 } else {
-                    unreachable!("All global values should be resolved my monomorphization");
+                    unreachable!("All global values should be resolved at compile time and before monomorphization");
                 };
 
                 self.expr(expr)?


### PR DESCRIPTION
# Description

## Problem\*

Small change noticed while working on globals

## Summary\*

We should only allow accessing resolved globals in monomorphization after switching to computing all globals at compile time. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
