### PR TITLE
feat(cli): Add CLI option to filter by contract function name

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -73,7 +73,7 @@ pub struct CompileOptions {
     /// Only show SSA passes whose name contains the provided string.
     /// This setting takes precedence over `show_ssa` if it's not empty.
     #[arg(long, hide = true)]
-    pub show_ssa_pass_name: Option<String>,
+    pub show_ssa_pass: Option<String>,
 
     /// Only show the SSA and ACIR for the contract function with a given name.
     #[arg(long, hide = true)]
@@ -500,7 +500,7 @@ fn compile_contract_inner(
         if let Some(ref name_filter) = options.show_contract_fn {
             let show = name == *name_filter;
             options.show_ssa &= show;
-            options.show_ssa_pass_name = options.show_ssa_pass_name.filter(|_| show);
+            options.show_ssa_pass = options.show_ssa_pass.filter(|_| show);
         };
 
         let function = match compile_no_check(context, &options, function_id, None, true) {
@@ -659,7 +659,7 @@ pub fn compile_no_check(
 
     let return_visibility = program.return_visibility;
     let ssa_evaluator_options = noirc_evaluator::ssa::SsaEvaluatorOptions {
-        ssa_logging: match &options.show_ssa_pass_name {
+        ssa_logging: match &options.show_ssa_pass {
             Some(string) => SsaLogging::Contains(string.clone()),
             None => {
                 if options.show_ssa {

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -77,7 +77,7 @@ pub struct CompileOptions {
 
     /// Only show the SSA and ACIR for the contract function with a given name.
     #[arg(long, hide = true)]
-    pub show_contract_function_name: Option<String>,
+    pub show_contract_fn: Option<String>,
 
     /// Emit the unoptimized SSA IR to file.
     /// The IR will be dumped into the workspace target directory,
@@ -446,7 +446,7 @@ pub fn compile_contract(
 
         if options.print_acir {
             for contract_function in &compiled_contract.functions {
-                if let Some(ref name) = options.show_contract_function_name {
+                if let Some(ref name) = options.show_contract_fn {
                     if name != &contract_function.name {
                         continue;
                     }
@@ -497,7 +497,7 @@ fn compile_contract_inner(
 
         let mut options = options.clone();
 
-        if let Some(ref name_filter) = options.show_contract_function_name {
+        if let Some(ref name_filter) = options.show_contract_fn {
             let show = name == *name_filter;
             options.show_ssa &= show;
             options.show_ssa_pass_name = options.show_ssa_pass_name.filter(|_| show);


### PR DESCRIPTION
# Description

## Problem\*

Resolves having to hack around the code to restrict which contract function to show.

## Summary\*

Adds a `--show-contract-fn` CLI option to restrict the effects of `--show-ssa`, `--show-ssa-pass` and `--print-acir` to a single function in a contract, ie. a single circuit. 

Example:
```
cargo run --release -p nargo_cli -- \
  --program-dir $PROGRAM_DIR compile \
  --package token_contract  \
  --print-acir \
  --show-ssa-pass "Remove IfElse" \
  --show-contract-fn public_dispatch 
```

Note that `--show-ssa-pass-name` has been shortened to `--show-ssa-pass`.

## Additional Context

Often when investigating the size increase of a contract circuit such as the `public_dispatch` function of the `Token` contract in https://github.com/AztecProtocol/aztec-packages/pull/11138#issuecomment-2582218784 I want to see the SSA, but currently running `compile` would show the SSA of 36 different functions, which, even when restricted to a single pass, results in 14MB of text in this example.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
