### PR TITLE
chore: simplify a couple of enum variants

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -560,7 +560,7 @@ impl<'brillig> Context<'brillig> {
         );
 
         match evaluation_result {
-            EvaluationResult::NotABrilligCall | EvaluationResult::CannotEvaluate(_) => None,
+            EvaluationResult::NotABrilligCall | EvaluationResult::CannotEvaluate => None,
             EvaluationResult::Evaluated(memory_values) => {
                 let mut memory_index = 0;
                 let new_results = vecmap(old_results, |old_result| {
@@ -601,14 +601,14 @@ impl<'brillig> Context<'brillig> {
         };
 
         if !arguments.iter().all(|argument| dfg.is_constant(*argument)) {
-            return EvaluationResult::CannotEvaluate(*func_id);
+            return EvaluationResult::CannotEvaluate;
         }
 
         let mut brillig_arguments = Vec::new();
         for argument in arguments {
             let typ = dfg.type_of_value(*argument);
             let Some(parameter) = type_to_brillig_parameter(&typ) else {
-                return EvaluationResult::CannotEvaluate(*func_id);
+                return EvaluationResult::CannotEvaluate;
             };
             brillig_arguments.push(parameter);
         }
@@ -617,12 +617,12 @@ impl<'brillig> Context<'brillig> {
         for return_id in func.returns().iter() {
             let typ = func.dfg.type_of_value(*return_id);
             if type_to_brillig_parameter(&typ).is_none() {
-                return EvaluationResult::CannotEvaluate(*func_id);
+                return EvaluationResult::CannotEvaluate;
             }
         }
 
         let Ok(generated_brillig) = gen_brillig_for(func, brillig_arguments, brillig) else {
-            return EvaluationResult::CannotEvaluate(*func_id);
+            return EvaluationResult::CannotEvaluate;
         };
 
         let mut calldata = Vec::new();
@@ -639,7 +639,7 @@ impl<'brillig> Context<'brillig> {
             VM::new(calldata, bytecode, foreign_call_results, &black_box_solver, profiling_active);
         let vm_status: VMStatus<_> = vm.process_opcodes();
         let VMStatus::Finished { return_data_offset, return_data_size } = vm_status else {
-            return EvaluationResult::CannotEvaluate(*func_id);
+            return EvaluationResult::CannotEvaluate;
         };
 
         let memory =
@@ -771,7 +771,7 @@ enum EvaluationResult {
     NotABrilligCall,
     /// The instruction was a call to a brillig function, but we couldn't evaluate it.
     /// This can occur in the situation where the brillig function reaches a "trap" or a foreign call opcode.
-    CannotEvaluate(FunctionId),
+    CannotEvaluate,
     /// The instruction was a call to a brillig function and we were able to evaluate it,
     /// returning evaluation memory values.
     Evaluated(Vec<MemoryValue<FieldElement>>),

--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -79,7 +79,7 @@ pub struct Turbofish {
 /// Any item that can appear before the last segment in a path.
 #[derive(Debug)]
 enum IntermediatePathResolutionItem {
-    Module(ModuleId),
+    Module,
     Struct(StructId, Option<Turbofish>),
     TypeAlias(TypeAliasId, Option<Turbofish>),
     Trait(TraitId, Option<Turbofish>),
@@ -180,7 +180,7 @@ impl<'context> Elaborator<'context> {
         let mut current_module_id = starting_module;
         let mut current_module = self.get_module(starting_module);
 
-        let mut intermediate_item = IntermediatePathResolutionItem::Module(current_module_id);
+        let mut intermediate_item = IntermediatePathResolutionItem::Module;
 
         let first_segment =
             &path.segments.first().expect("ice: could not fetch first segment").ident;
@@ -222,7 +222,7 @@ impl<'context> Elaborator<'context> {
                         });
                     }
 
-                    (id, false, IntermediatePathResolutionItem::Module(id))
+                    (id, false, IntermediatePathResolutionItem::Module)
                 }
                 ModuleDefId::TypeId(id) => (
                     id.module_id(),
@@ -460,9 +460,7 @@ fn merge_intermediate_path_resolution_item_with_module_def_id(
         ModuleDefId::TraitId(trait_id) => PathResolutionItem::Trait(trait_id),
         ModuleDefId::GlobalId(global_id) => PathResolutionItem::Global(global_id),
         ModuleDefId::FunctionId(func_id) => match intermediate_item {
-            IntermediatePathResolutionItem::Module(_) => {
-                PathResolutionItem::ModuleFunction(func_id)
-            }
+            IntermediatePathResolutionItem::Module => PathResolutionItem::ModuleFunction(func_id),
             IntermediatePathResolutionItem::Struct(struct_id, generics) => {
                 PathResolutionItem::StructFunction(struct_id, generics, func_id)
             }


### PR DESCRIPTION
# Description

## Problem

No issue, but these produce some warnings for me locally.

## Summary

It's probably because I have something wrong in my configured Rust version that I'm getting these warnings but, regardless, this code simplification is probably good.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
