### PR TITLE
fix(lsp): suggest all possible trait methods, but only visible ones

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1104,12 +1104,8 @@ impl<'context> Elaborator<'context> {
     }
 
     fn set_trait_impl_functions_visibility(&mut self, trait_impl: &UnresolvedTraitImpl) {
-        let trait_visibility = if let Some(trait_id) = trait_impl.trait_id {
-            let trait_ = self.interner.get_trait(trait_id);
-            Some(trait_.visibility)
-        } else {
-            None
-        };
+        let Some(trait_id) = trait_impl.trait_id else { return; };
+        let trait_visibility = self.interner.get_trait(trait_id).visibility;
 
         for (_, function, _) in &trait_impl.methods.functions {
             // A trait impl method has the same visibility as its trait

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1104,15 +1104,15 @@ impl<'context> Elaborator<'context> {
     }
 
     fn set_trait_impl_functions_visibility(&mut self, trait_impl: &UnresolvedTraitImpl) {
-        let Some(trait_id) = trait_impl.trait_id else { return; };
+        let Some(trait_id) = trait_impl.trait_id else {
+            return;
+        };
         let trait_visibility = self.interner.get_trait(trait_id).visibility;
 
         for (_, function, _) in &trait_impl.methods.functions {
             // A trait impl method has the same visibility as its trait
-            if let Some(trait_visibility) = trait_visibility {
-                let modifiers = self.interner.function_modifiers_mut(function);
-                modifiers.visibility = trait_visibility;
-            }
+            let modifiers = self.interner.function_modifiers_mut(function);
+            modifiers.visibility = trait_visibility;
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -103,7 +103,7 @@ impl<'context> Elaborator<'context> {
 
         // Restore the methods that were taken before the for loop
         let the_trait = self.interner.get_trait_mut(trait_id);
-        the_trait.methods = methods;
+        the_trait.set_methods(methods);
 
         // Emit MethodNotInTrait error for methods in the impl block that
         // don't have a corresponding method signature defined in the trait

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -103,7 +103,7 @@ impl<'context> Elaborator<'context> {
 
         // Restore the methods that were taken before the for loop
         let the_trait = self.interner.get_trait_mut(trait_id);
-        the_trait.set_methods(methods);
+        the_trait.methods = methods;
 
         // Emit MethodNotInTrait error for methods in the impl block that
         // don't have a corresponding method signature defined in the trait

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -54,14 +54,14 @@ impl<'context> Elaborator<'context> {
                 }
 
                 this.interner.update_trait(*trait_id, |trait_def| {
-                    trait_def.set_trait_bounds(resolved_trait_bounds);
-                    trait_def.set_where_clause(where_clause);
+                    trait_def.trait_bounds = resolved_trait_bounds;
+                    trait_def.where_clause = where_clause;
                 });
 
                 let methods = this.resolve_trait_methods(*trait_id, unresolved_trait);
 
                 this.interner.update_trait(*trait_id, |trait_def| {
-                    trait_def.set_methods(methods);
+                    trait_def.methods = methods;
                 });
             });
 

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -56,6 +56,7 @@ impl<'context> Elaborator<'context> {
                 this.interner.update_trait(*trait_id, |trait_def| {
                     trait_def.trait_bounds = resolved_trait_bounds;
                     trait_def.where_clause = where_clause;
+                    trait_def.visibility = unresolved_trait.trait_def.visibility;
                 });
 
                 let methods = this.resolve_trait_methods(*trait_id, unresolved_trait);

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -54,15 +54,15 @@ impl<'context> Elaborator<'context> {
                 }
 
                 this.interner.update_trait(*trait_id, |trait_def| {
-                    trait_def.trait_bounds = resolved_trait_bounds;
-                    trait_def.where_clause = where_clause;
-                    trait_def.visibility = unresolved_trait.trait_def.visibility;
+                    trait_def.set_trait_bounds(resolved_trait_bounds);
+                    trait_def.set_where_clause(where_clause);
+                    trait_def.set_visibility(unresolved_trait.trait_def.visibility);
                 });
 
                 let methods = this.resolve_trait_methods(*trait_id, unresolved_trait);
 
                 this.interner.update_trait(*trait_id, |trait_def| {
-                    trait_def.methods = methods;
+                    trait_def.set_methods(methods);
                 });
             });
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1228,9 +1228,10 @@ pub(crate) fn collect_trait_impl_items(
     for item in std::mem::take(&mut trait_impl.items) {
         match item.item.kind {
             TraitImplItemKind::Function(mut impl_method) => {
-                // Regardless of what visibility was on the source code, treat it as public
-                // (a warning is produced during parsing for this)
-                impl_method.def.visibility = ItemVisibility::Public;
+                // Set the impl method visibility as temporarily private.
+                // Eventually when we find out what trait is this impl for we'll set it
+                // to the trait's visibility.
+                impl_method.def.visibility = ItemVisibility::Private;
 
                 let func_id = interner.push_empty_fn();
                 let location = Location::new(impl_method.span(), file_id);

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -149,6 +149,22 @@ impl PartialEq for Trait {
 }
 
 impl Trait {
+    pub fn set_methods(&mut self, methods: Vec<TraitFunction>) {
+        self.methods = methods;
+    }
+
+    pub fn set_trait_bounds(&mut self, trait_bounds: Vec<ResolvedTraitBound>) {
+        self.trait_bounds = trait_bounds;
+    }
+
+    pub fn set_where_clause(&mut self, where_clause: Vec<TraitConstraint>) {
+        self.where_clause = where_clause;
+    }
+
+    pub fn set_visibility(&mut self, visibility: ItemVisibility) {
+        self.visibility = visibility;
+    }
+
     pub fn find_method(&self, name: &str) -> Option<TraitMethodId> {
         for (idx, method) in self.methods.iter().enumerate() {
             if &method.name == name {

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -1,7 +1,7 @@
 use iter_extended::vecmap;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::ast::{Ident, NoirFunction};
+use crate::ast::{Ident, ItemVisibility, NoirFunction};
 use crate::hir::type_check::generics::TraitGenerics;
 use crate::ResolvedGeneric;
 use crate::{
@@ -66,6 +66,7 @@ pub struct Trait {
     pub name: Ident,
     pub generics: Generics,
     pub location: Location,
+    pub visibility: ItemVisibility,
 
     /// When resolving the types of Trait elements, all references to `Self` resolve
     /// to this TypeVariable. Then when we check if the types of trait impl elements

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -148,18 +148,6 @@ impl PartialEq for Trait {
 }
 
 impl Trait {
-    pub fn set_methods(&mut self, methods: Vec<TraitFunction>) {
-        self.methods = methods;
-    }
-
-    pub fn set_trait_bounds(&mut self, trait_bounds: Vec<ResolvedTraitBound>) {
-        self.trait_bounds = trait_bounds;
-    }
-
-    pub fn set_where_clause(&mut self, where_clause: Vec<TraitConstraint>) {
-        self.where_clause = where_clause;
-    }
-
     pub fn find_method(&self, name: &str) -> Option<TraitMethodId> {
         for (idx, method) in self.methods.iter().enumerate() {
             if &method.name == name {

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -2268,9 +2268,10 @@ impl Methods {
     }
 
     /// Iterate through each method, starting with the direct methods
-    pub fn iter(&self) -> impl Iterator<Item = (FuncId, Option<&Type>)> + '_ {
-        let trait_impl_methods = self.trait_impl_methods.iter().map(|m| (m.method, m.typ.as_ref()));
-        let direct = self.direct.iter().copied().map(|func_id| (func_id, None));
+    pub fn iter(&self) -> impl Iterator<Item = (FuncId, Option<&Type>, Option<TraitId>)> + '_ {
+        let trait_impl_methods =
+            self.trait_impl_methods.iter().map(|m| (m.method, m.typ.as_ref(), Some(m.trait_id)));
+        let direct = self.direct.iter().copied().map(|func_id| (func_id, None, None));
         direct.chain(trait_impl_methods)
     }
 
@@ -2283,7 +2284,7 @@ impl Methods {
     ) -> Option<FuncId> {
         // When adding methods we always check they do not overlap, so there should be
         // at most 1 matching method in this list.
-        for (method, method_type) in self.iter() {
+        for (method, method_type, _trait_id) in self.iter() {
             if Self::method_matches(typ, has_self_param, method, method_type, interner) {
                 return Some(method);
             }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -729,6 +729,7 @@ impl NodeInterner {
             crate_id: unresolved_trait.crate_id,
             location: Location::new(unresolved_trait.trait_def.span, unresolved_trait.file_id),
             generics,
+            visibility: ItemVisibility::Private,
             self_type_typevar: TypeVariable::unbound(self.next_type_variable_id(), Kind::Normal),
             methods: Vec::new(),
             method_ids: unresolved_trait.method_ids.clone(),

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -245,7 +245,7 @@ impl<'a> NodeFinder<'a> {
         let mut idents: Vec<Ident> = Vec::new();
 
         // Find in which ident we are in, and in which part of it
-        // (it could be that we are completting in the middle of an ident)
+        // (it could be that we are completing in the middle of an ident)
         for segment in &path.segments {
             let ident = &segment.ident;
 

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2879,4 +2879,25 @@ fn main() {
         let items = get_completions(src).await;
         assert_eq!(items.len(), 1);
     }
+
+    #[test]
+    async fn test_does_not_suggest_trait_function_not_visible() {
+        let src = r#"
+        mod moo {
+            trait Foo {
+                fn foobar();
+            }
+
+            impl Foo for Field {
+                fn foobar() {}
+            }
+        }
+
+        fn main() {
+            Field::fooba>|<
+        }
+
+        "#;
+        assert_completion(src, vec![]).await;
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2900,4 +2900,34 @@ fn main() {
         "#;
         assert_completion(src, vec![]).await;
     }
+
+    #[test]
+    async fn test_suggests_multiple_trait_methods() {
+        let src = r#"
+        mod moo {
+            pub trait Foo {
+                fn foobar();
+            }
+
+            impl Foo for Field {
+                fn foobar() {}
+            }
+
+            pub trait Bar {
+                fn foobar();
+            }
+
+            impl Bar for Field {
+                fn foobar() {}
+            }
+        }
+
+        fn main() {
+            Field::fooba>|<
+        }
+
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 2);
+    }
 }

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -399,7 +399,10 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
     }
     string.push_str("    ");
 
-    if func_modifiers.visibility != ItemVisibility::Private {
+    if func_modifiers.visibility != ItemVisibility::Private
+        && func_meta.trait_id.is_none()
+        && func_meta.trait_impl.is_none()
+    {
         string.push_str(&func_modifiers.visibility.to_string());
         string.push(' ');
     }
@@ -1154,7 +1157,7 @@ mod hover_tests {
         assert!(hover_text.starts_with(
             "    two
     impl<A> Bar<A, i32> for Foo<A>
-    pub fn bar_stuff(self)"
+    fn bar_stuff(self)"
         ));
     }
 


### PR DESCRIPTION
# Description

## Problem

Towards #6956

## Summary

I noticed a couple of issues in how we suggest trait methods in LSP:
1. We don't show all of the trait methods if more than one could be called (only one, the first one). That is, if there are multiple traits with the same method name and none is currently imported, all of those should be suggested.
2. Non-visible trait methods were suggested

Solving these two things required some changes on the compiler side, outside of just LSP, and to avoid eventually creating a giant PR that solves all of #6956 I decided to split just this into a smaller PR.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
