### PR TITLE
feat: add more lazy removal of instructions with `Instruction::noop`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -592,11 +592,8 @@ impl<'f> PerFunctionContext<'f> {
     /// This is expected to contain any loads which were replaced and any stores which are
     /// no longer needed.
     fn remove_instructions(&mut self) {
-        // The order we iterate blocks in is not important
-        for block in self.post_order.as_slice() {
-            self.inserter.function.dfg[*block]
-                .instructions_mut()
-                .retain(|instruction| !self.instructions_to_remove.contains(instruction));
+        for instruction in &self.instructions_to_remove {
+            self.inserter.function.dfg.remove_instruction(*instruction);
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/rc.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/rc.rs
@@ -64,7 +64,9 @@ impl Function {
         context.find_rcs_in_entry_block(self);
         context.scan_for_array_sets(self);
         let to_remove = context.find_rcs_to_remove(self);
-        remove_instructions(to_remove, self);
+        for instruction in to_remove {
+            self.dfg.remove_instruction(instruction);
+        }
     }
 }
 
@@ -139,16 +141,6 @@ pub(crate) fn pop_rc_for(
     let position = rcs.iter().position(|inc_rc| inc_rc.array == value)?;
 
     Some(rcs.remove(position))
-}
-
-fn remove_instructions(to_remove: HashSet<InstructionId>, function: &mut Function) {
-    if !to_remove.is_empty() {
-        for block in function.reachable_blocks() {
-            function.dfg[block]
-                .instructions_mut()
-                .retain(|instruction| !to_remove.contains(instruction));
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

## Problem\*

Followup to #6899 

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
