### PR TITLE
fix(nargo_fmt): don't consider identifiers the same if they are equal…

### DIFF
--- a/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
@@ -179,7 +179,12 @@ impl Ord for Segment {
 
         if let (Segment::Plain(self_string), Segment::Plain(other_string)) = (self, other) {
             // Case-insensitive comparison for plain segments
-            self_string.to_lowercase().cmp(&other_string.to_lowercase())
+            let ordering = self_string.to_lowercase().cmp(&other_string.to_lowercase());
+            if ordering == Ordering::Equal {
+                self_string.cmp(&other_string)
+            } else {
+                ordering
+            }
         } else {
             order_number_ordering
         }
@@ -619,5 +624,11 @@ use std::merkle::compute_merkle_root;
         let src = "use std::{as_witness, merkle::compute_merkle_root};";
         let expected = "use std::{as_witness, merkle::compute_merkle_root};\n";
         assert_format(src, expected);
+    }
+
+    #[test]
+    fn does_not_merge_same_identifiers_if_equal_case_insensitive() {
+        let src = "use bigint::{BigNum, bignum::BigNumTrait};\n";
+        assert_format(src, src);
     }
 }

--- a/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
@@ -181,7 +181,7 @@ impl Ord for Segment {
             // Case-insensitive comparison for plain segments
             let ordering = self_string.to_lowercase().cmp(&other_string.to_lowercase());
             if ordering == Ordering::Equal {
-                self_string.cmp(&other_string)
+                self_string.cmp(other_string)
             } else {
                 ordering
             }


### PR DESCRIPTION
… case insensitive

# Description

## Problem

Resolves https://github.com/noir-lang/noir/pull/7037#issuecomment-2587969966

## Summary

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
