### PR TITLE
fix(nargo_fmt): let doc comment could come after regular comment

### DIFF
--- a/noir_stdlib/src/collections/umap.nr
+++ b/noir_stdlib/src/collections/umap.nr
@@ -114,8 +114,7 @@ impl<K, V, B> UHashMap<K, V, B> {
     {
         // docs:end:contains_key
         /// Safety: unconstrained context
-        unsafe { self.get(key) }
-            .is_some()
+        unsafe { self.get(key) }.is_some()
     }
 
     // Returns true if the map contains no elements.


### PR DESCRIPTION
# Description

## Problem

Resolves #7045

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
