### PR TITLE
chore(ci): Unify compilation/execution report jobs that take averages with single runs 

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -300,17 +300,17 @@ jobs:
       matrix:
         include:
           # - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-contracts, is_library: true }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner, take_average: true }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail, take_average: true  }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset, take_average: true }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-private, take_average: true }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-public, take_average: true }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-block-merge, take_average: true }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner, num_runs: 5 }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail, num_runs: 5  }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset, num_runs: 5 }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-private, num_runs: 5 }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-base-public, num_runs: 5 }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-block-merge, num_runs: 5 }
           #- project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-block-root-empty }
           #- project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-block-single-tx }
           #- project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-block-root }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-merge, take_average: true }
-          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-root, take_average: true }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-merge, num_runs: 5 }
+          - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-root, num_runs: 5 }
 
     name: External repo compilation and execution reports - ${{ matrix.project.repo }}/${{ matrix.project.path }}
     steps:
@@ -351,12 +351,7 @@ jobs:
           touch parse_time.sh
           chmod +x parse_time.sh
           cp /home/runner/work/noir/noir/scripts/test_programs/parse_time.sh ./parse_time.sh
-          if [ "${{ matrix.project.take_average }}" == "true" ]; then
-            # Take the average of 5 runs 
-            ./compilation_report.sh 1 5
-          else
-            ./compilation_report.sh 1
-          fi
+          ./compilation_report.sh 1 ${{ matrix.project.num_runs }}
       
       - name: Generate execution report
         working-directory: ./test-repo/${{ matrix.project.path }}
@@ -364,12 +359,7 @@ jobs:
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
           mv /home/runner/work/noir/noir/scripts/test_programs/parse_time.sh ./parse_time.sh
-          if [ "${{ matrix.project.take_average }}" == "true" ]; then
-            # Take the average of 5 runs 
-            ./execution_report.sh 1 5
-          else
-            ./execution_report.sh 1
-          fi
+          ./execution_report.sh 1 ${{ matrix.project.num_runs }}
 
       - name: Move compilation report
         id: compilation_report

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -344,41 +344,32 @@ jobs:
           path: test-repo
           ref: ${{ matrix.project.ref }}
 
-      - name: Generate compilation report without averages
+      - name: Generate compilation report
         working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ !matrix.project.take_average }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh
           touch parse_time.sh
           chmod +x parse_time.sh
           cp /home/runner/work/noir/noir/scripts/test_programs/parse_time.sh ./parse_time.sh
-          ./compilation_report.sh 1
-
-      - name: Generate compilation report with averages
-        working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ matrix.project.take_average }}
-        run: |
-          mv /home/runner/work/noir/noir/scripts/test_programs/compilation_report.sh ./compilation_report.sh
-          touch parse_time.sh
-          chmod +x parse_time.sh
-          cp /home/runner/work/noir/noir/scripts/test_programs/parse_time.sh ./parse_time.sh
-          ./compilation_report.sh 1 1
+          if [ "${{ matrix.project.take_average }}" == "true" ]; then
+            # Take the average of 5 runs 
+            ./compilation_report.sh 1 5
+          else
+            ./compilation_report.sh 1
+          fi
       
-      - name: Generate execution report without averages
+      - name: Generate execution report
         working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ !matrix.project.is_library && !matrix.project.take_average }}
+        if: ${{ !matrix.project.is_library }}
         run: |
           mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
           mv /home/runner/work/noir/noir/scripts/test_programs/parse_time.sh ./parse_time.sh
-          ./execution_report.sh 1
-
-      - name: Generate execution report with averages
-        working-directory: ./test-repo/${{ matrix.project.path }}
-        if: ${{ !matrix.project.is_library && matrix.project.take_average }}
-        run: |
-          mv /home/runner/work/noir/noir/scripts/test_programs/execution_report.sh ./execution_report.sh
-          mv /home/runner/work/noir/noir/scripts/test_programs/parse_time.sh ./parse_time.sh
-          ./execution_report.sh 1 1
+          if [ "${{ matrix.project.take_average }}" == "true" ]; then
+            # Take the average of 5 runs 
+            ./execution_report.sh 1 5
+          else
+            ./execution_report.sh 1
+          fi
 
       - name: Move compilation report
         id: compilation_report

--- a/test_programs/compilation_report.sh
+++ b/test_programs/compilation_report.sh
@@ -37,14 +37,8 @@ for dir in ${tests_to_profile[@]}; do
       PACKAGE_NAME=$(basename $current_dir)
     fi
 
-    NUM_RUNS=1
+    NUM_RUNS=$2
     TOTAL_TIME=0
-
-    # Passing a second argument will take an average of five runs
-    # rather than 
-    if [ "$2" == "1" ]; then
-      NUM_RUNS=5
-    fi
 
     for ((i = 1; i <= NUM_RUNS; i++)); do
       NOIR_LOG=trace NARGO_LOG_DIR=./tmp nargo compile --force --silence-warnings

--- a/test_programs/execution_report.sh
+++ b/test_programs/execution_report.sh
@@ -46,12 +46,8 @@ for dir in ${tests_to_profile[@]}; do
     fi
 
 
-    NUM_RUNS=1
+    NUM_RUNS=$2
     TOTAL_TIME=0
-
-    if [ "$2" == "1" ]; then
-      NUM_RUNS=5
-    fi
     
     for ((i = 1; i <= NUM_RUNS; i++)); do
       NOIR_LOG=trace NARGO_LOG_DIR=./tmp nargo execute --silence-warnings


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7002

## Summary\*

Both compilation and execution reports now accept the number of runs we should do for a command rather than depending on a boolean flag. I also unified the github jobs to pass this flag to the script rather than running a separate job depending on whether we want to take averages.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
