### PR TITLE
chore: add `noir_check_shuffle` as a critical library

### DIFF
--- a/.github/critical_libraries_status/.gitignore
+++ b/.github/critical_libraries_status/.gitignore
@@ -1,0 +1,3 @@
+.actual.jsonl
+.actual.jsonl.jq
+.failures.jsonl.jq

--- a/CRITICAL_NOIR_LIBRARIES
+++ b/CRITICAL_NOIR_LIBRARIES
@@ -1,3 +1,4 @@
+https://github.com/noir-lang/noir_check_shuffle
 https://github.com/noir-lang/ec
 https://github.com/noir-lang/eddsa
 https://github.com/noir-lang/mimc


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is a dependency of the json parser library.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
