### PR TITLE
feat: remove `max_bit_size` from `Instruction::Truncate`

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_variable.rs
@@ -1141,14 +1141,13 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
         &mut self,
         lhs: AcirVar,
         rhs: u32,
-        max_bit_size: u32,
     ) -> Result<AcirVar, RuntimeError> {
         // 2^{rhs}
         let divisor = self.add_constant(F::from(2_u128).pow(&F::from(rhs as u128)));
         let one = self.add_constant(F::one());
 
         //  Computes lhs = 2^{rhs} * q + r
-        let (_, remainder) = self.euclidean_division_var(lhs, divisor, max_bit_size, one)?;
+        let (_, remainder) = self.euclidean_division_var(lhs, divisor, F::max_num_bits(), one)?;
 
         Ok(remainder)
     }

--- a/compiler/noirc_evaluator/src/acir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_variable.rs
@@ -1137,11 +1137,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
     /// Returns an `AcirVar` which will be constrained to be lhs mod 2^{rhs}
     /// In order to do this, we 'simply' perform euclidean division of lhs by 2^{rhs}
     /// The remainder of the division is then lhs mod 2^{rhs}
-    pub(crate) fn truncate_var(
-        &mut self,
-        lhs: AcirVar,
-        rhs: u32,
-    ) -> Result<AcirVar, RuntimeError> {
+    pub(crate) fn truncate_var(&mut self, lhs: AcirVar, rhs: u32) -> Result<AcirVar, RuntimeError> {
         // 2^{rhs}
         let divisor = self.add_constant(F::from(2_u128).pow(&F::from(rhs as u128)));
         let one = self.add_constant(F::one());

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -746,8 +746,7 @@ impl<'a> Context<'a> {
                 self.define_result_var(dfg, instruction_id, result_acir_var);
             }
             Instruction::Truncate { value, bit_size } => {
-                let result_acir_var =
-                    self.convert_ssa_truncate(*value, *bit_size, dfg)?;
+                let result_acir_var = self.convert_ssa_truncate(*value, *bit_size, dfg)?;
                 self.define_result_var(dfg, instruction_id, result_acir_var);
             }
             Instruction::EnableSideEffectsIf { condition } => {

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -745,9 +745,9 @@ impl<'a> Context<'a> {
                 let result_acir_var = self.acir_context.not_var(acir_var, typ)?;
                 self.define_result_var(dfg, instruction_id, result_acir_var);
             }
-            Instruction::Truncate { value, bit_size, max_bit_size } => {
+            Instruction::Truncate { value, bit_size } => {
                 let result_acir_var =
-                    self.convert_ssa_truncate(*value, *bit_size, *max_bit_size, dfg)?;
+                    self.convert_ssa_truncate(*value, *bit_size, dfg)?;
                 self.define_result_var(dfg, instruction_id, result_acir_var);
             }
             Instruction::EnableSideEffectsIf { condition } => {
@@ -2065,7 +2065,6 @@ impl<'a> Context<'a> {
         &mut self,
         value_id: ValueId,
         bit_size: u32,
-        max_bit_size: u32,
         dfg: &DataFlowGraph,
     ) -> Result<AcirVar, RuntimeError> {
         let mut var = self.convert_numeric_value(value_id, dfg)?;
@@ -2090,7 +2089,7 @@ impl<'a> Context<'a> {
             ),
         };
 
-        self.acir_context.truncate_var(var, bit_size, max_bit_size)
+        self.acir_context.truncate_var(var, bit_size)
     }
 
     /// Returns a vector of `AcirVar`s constrained to be result of the function call.

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -273,9 +273,8 @@ impl FunctionBuilder {
         &mut self,
         value: ValueId,
         bit_size: u32,
-        max_bit_size: u32,
     ) -> ValueId {
-        self.insert_instruction(Instruction::Truncate { value, bit_size, max_bit_size }, None)
+        self.insert_instruction(Instruction::Truncate { value, bit_size }, None)
             .first()
     }
 

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -269,13 +269,8 @@ impl FunctionBuilder {
 
     /// Insert a truncate instruction at the end of the current block.
     /// Returns the result of the truncate instruction.
-    pub(crate) fn insert_truncate(
-        &mut self,
-        value: ValueId,
-        bit_size: u32,
-    ) -> ValueId {
-        self.insert_instruction(Instruction::Truncate { value, bit_size }, None)
-            .first()
+    pub(crate) fn insert_truncate(&mut self, value: ValueId, bit_size: u32) -> ValueId {
+        self.insert_instruction(Instruction::Truncate { value, bit_size }, None).first()
     }
 
     /// Insert a constrain instruction at the end of the current block.

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -635,10 +635,9 @@ impl Instruction {
             }),
             Instruction::Cast(value, typ) => Instruction::Cast(f(*value), *typ),
             Instruction::Not(value) => Instruction::Not(f(*value)),
-            Instruction::Truncate { value, bit_size } => Instruction::Truncate {
-                value: f(*value),
-                bit_size: *bit_size,
-            },
+            Instruction::Truncate { value, bit_size } => {
+                Instruction::Truncate { value: f(*value), bit_size: *bit_size }
+            }
             Instruction::Constrain(lhs, rhs, assert_message) => {
                 // Must map the `lhs` and `rhs` first as the value `f` is moved with the closure
                 let lhs = f(*lhs);
@@ -710,7 +709,7 @@ impl Instruction {
             }
             Instruction::Cast(value, _) => *value = f(*value),
             Instruction::Not(value) => *value = f(*value),
-            Instruction::Truncate { value, bit_size: _, } => {
+            Instruction::Truncate { value, bit_size: _ } => {
                 *value = f(*value);
             }
             Instruction::Constrain(lhs, rhs, assert_message) => {

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -220,10 +220,7 @@ impl Binary {
                         if modulus.is_power_of_two() {
                             let bit_size = modulus.ilog2();
                             return SimplifyResult::SimplifiedToInstruction(
-                                Instruction::Truncate {
-                                    value: self.lhs,
-                                    bit_size,
-                                },
+                                Instruction::Truncate { value: self.lhs, bit_size },
                             );
                         }
                     }
@@ -301,10 +298,7 @@ impl Binary {
                                 let value = if lhs_value.is_some() { self.rhs } else { self.lhs };
                                 let num_bits = bitmask_plus_one.ilog2();
                                 return SimplifyResult::SimplifiedToInstruction(
-                                    Instruction::Truncate {
-                                        value,
-                                        bit_size: num_bits,
-                                    },
+                                    Instruction::Truncate { value, bit_size: num_bits },
                                 );
                             }
                         }

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -223,7 +223,6 @@ impl Binary {
                                 Instruction::Truncate {
                                     value: self.lhs,
                                     bit_size,
-                                    max_bit_size: lhs_type.bit_size(),
                                 },
                             );
                         }
@@ -305,7 +304,6 @@ impl Binary {
                                     Instruction::Truncate {
                                         value,
                                         bit_size: num_bits,
-                                        max_bit_size: lhs_type.bit_size(),
                                     },
                                 );
                             }

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -180,9 +180,9 @@ fn display_instruction_inner(
         }
         Instruction::Cast(lhs, typ) => writeln!(f, "cast {} as {typ}", show(*lhs)),
         Instruction::Not(rhs) => writeln!(f, "not {}", show(*rhs)),
-        Instruction::Truncate { value, bit_size, max_bit_size } => {
+        Instruction::Truncate { value, bit_size } => {
             let value = show(*value);
-            writeln!(f, "truncate {value} to {bit_size} bits, max_bit_size: {max_bit_size}",)
+            writeln!(f, "truncate {value} to {bit_size} bits",)
         }
         Instruction::Constrain(lhs, rhs, error) => {
             write!(f, "constrain {} == {}", show(*lhs), show(*rhs))?;

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -886,7 +886,7 @@ mod test {
             acir(inline) fn main f0 {
               b0(v0: u16, v1: u16):
                 v2 = div v0, v1
-                v3 = truncate v2 to 8 bits, max_bit_size: 16
+                v3 = truncate v2 to 8 bits
                 return v3
             }
             ";
@@ -924,7 +924,7 @@ mod test {
             acir(inline) fn main f0 {
               b0(v0: u16, v1: u16):
                 v2 = div v0, v1
-                v3 = truncate v2 to 8 bits, max_bit_size: 16
+                v3 = truncate v2 to 8 bits
                 return v3
             }
             ";
@@ -946,7 +946,7 @@ mod test {
             acir(inline) fn main f0 {
               b0(v0: u16, v1: u16):
                 v3 = div v0, u16 255
-                v4 = truncate v3 to 8 bits, max_bit_size: 16
+                v4 = truncate v3 to 8 bits
                 return v4
             }
             ";

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -1244,7 +1244,7 @@ mod test {
           b0(v0: [u8; 2]):
             v2 = array_get v0, index u8 0 -> u8
             v3 = cast v2 as u32
-            v4 = truncate v3 to 1 bits, max_bit_size: 32
+            v4 = truncate v3 to 1 bits
             v5 = cast v4 as u1
             v6 = allocate -> &mut Field
             store u8 0 at v6
@@ -1271,7 +1271,7 @@ mod test {
           b0(v0: [u8; 2]):
             v2 = array_get v0, index u8 0 -> u8
             v3 = cast v2 as u32
-            v4 = truncate v3 to 1 bits, max_bit_size: 32
+            v4 = truncate v3 to 1 bits
             v5 = cast v4 as u1
             v6 = allocate -> &mut Field
             store u8 0 at v6

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -150,7 +150,7 @@ impl Context<'_> {
             // Unchecked mul as this is a wrapping operation that we later truncate
             let result =
                 self.insert_binary(lhs_field, BinaryOp::Mul { unchecked: true }, pow_field);
-            let result = self.insert_truncate(result, bit_size, max_bit);
+            let result = self.insert_truncate(result, bit_size);
             self.insert_cast(result, typ)
         }
     }
@@ -184,7 +184,7 @@ impl Context<'_> {
                 BinaryOp::Add { unchecked: true },
                 lhs_as_field,
             );
-            let one_complement = self.insert_truncate(one_complement, bit_size, bit_size + 1);
+            let one_complement = self.insert_truncate(one_complement, bit_size);
             let one_complement = self.insert_cast(one_complement, NumericType::signed(bit_size));
             // Performs the division on the 1-complement (or the operand if positive)
             let shifted_complement = self.insert_binary(one_complement, BinaryOp::Div, pow);
@@ -201,7 +201,7 @@ impl Context<'_> {
                 BinaryOp::Sub { unchecked: true },
                 lhs_sign_as_int,
             );
-            self.insert_truncate(shifted, bit_size, bit_size + 1)
+            self.insert_truncate(shifted, bit_size)
         }
     }
 
@@ -280,9 +280,8 @@ impl Context<'_> {
         &mut self,
         value: ValueId,
         bit_size: u32,
-        max_bit_size: u32,
     ) -> ValueId {
-        self.insert_instruction(Instruction::Truncate { value, bit_size, max_bit_size }, None)
+        self.insert_instruction(Instruction::Truncate { value, bit_size }, None)
             .first()
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -276,13 +276,8 @@ impl Context<'_> {
 
     /// Insert a truncate instruction at the end of the current block.
     /// Returns the result of the truncate instruction.
-    pub(crate) fn insert_truncate(
-        &mut self,
-        value: ValueId,
-        bit_size: u32,
-    ) -> ValueId {
-        self.insert_instruction(Instruction::Truncate { value, bit_size }, None)
-            .first()
+    pub(crate) fn insert_truncate(&mut self, value: ValueId, bit_size: u32) -> ValueId {
+        self.insert_instruction(Instruction::Truncate { value, bit_size }, None).first()
     }
 
     /// Insert a cast instruction at the end of the current block.

--- a/compiler/noirc_evaluator/src/ssa/parser/ast.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/ast.rs
@@ -126,7 +126,6 @@ pub(crate) enum ParsedInstruction {
         target: Identifier,
         value: ParsedValue,
         bit_size: u32,
-        max_bit_size: u32,
     },
 }
 

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -270,7 +270,7 @@ impl Translator {
                 let address = self.translate_value(address)?;
                 self.builder.insert_store(address, value);
             }
-            ParsedInstruction::Truncate { target, value, bit_size} => {
+            ParsedInstruction::Truncate { target, value, bit_size } => {
                 let value = self.translate_value(value)?;
                 let value_id = self.builder.insert_truncate(value, bit_size);
                 self.define_variable(target, value_id)?;

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -270,9 +270,9 @@ impl Translator {
                 let address = self.translate_value(address)?;
                 self.builder.insert_store(address, value);
             }
-            ParsedInstruction::Truncate { target, value, bit_size, max_bit_size } => {
+            ParsedInstruction::Truncate { target, value, bit_size} => {
                 let value = self.translate_value(value)?;
-                let value_id = self.builder.insert_truncate(value, bit_size, max_bit_size);
+                let value_id = self.builder.insert_truncate(value, bit_size);
                 self.define_variable(target, value_id)?;
             }
         }

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -506,12 +506,8 @@ impl<'a> Parser<'a> {
             let value = self.parse_value_or_error()?;
             self.eat_or_error(Token::Keyword(Keyword::To))?;
             let bit_size = self.eat_int_or_error()?.to_u128() as u32;
-            self.eat_or_error(Token::Keyword(Keyword::Bits))?;
-            self.eat_or_error(Token::Comma)?;
-            self.eat_or_error(Token::Keyword(Keyword::MaxBitSize))?;
-            self.eat_or_error(Token::Colon)?;
-            let max_bit_size = self.eat_int_or_error()?.to_u128() as u32;
-            return Ok(ParsedInstruction::Truncate { target, value, bit_size, max_bit_size });
+            self.eat_or_error(Token::Keyword(Keyword::Bits))?;``
+            return Ok(ParsedInstruction::Truncate { target, value, bit_size });
         }
 
         if let Some(op) = self.eat_binary_op()? {

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -506,7 +506,7 @@ impl<'a> Parser<'a> {
             let value = self.parse_value_or_error()?;
             self.eat_or_error(Token::Keyword(Keyword::To))?;
             let bit_size = self.eat_int_or_error()?.to_u128() as u32;
-            self.eat_or_error(Token::Keyword(Keyword::Bits))?;``
+            self.eat_or_error(Token::Keyword(Keyword::Bits))?;
             return Ok(ParsedInstruction::Truncate { target, value, bit_size });
         }
 

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -361,7 +361,7 @@ fn test_truncate() {
     let src = "
         acir(inline) fn main f0 {
           b0(v0: Field):
-            v1 = truncate v0 to 8 bits, max_bit_size: 16
+            v1 = truncate v0 to 8 bits
             return
         }
         ";

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -382,7 +382,7 @@ impl<'a> FunctionContext<'a> {
                 match operator {
                     BinaryOpKind::Add | BinaryOpKind::Subtract => {
                         // Result is computed modulo the bit size
-                        let result = self.builder.insert_truncate(result, bit_size, bit_size + 1);
+                        let result = self.builder.insert_truncate(result, bit_size);
                         let result = self.insert_safe_cast(
                             result,
                             NumericType::unsigned(bit_size),
@@ -396,7 +396,7 @@ impl<'a> FunctionContext<'a> {
                         // Result is computed modulo the bit size
                         let mut result =
                             self.builder.insert_cast(result, NumericType::unsigned(2 * bit_size));
-                        result = self.builder.insert_truncate(result, bit_size, 2 * bit_size);
+                        result = self.builder.insert_truncate(result, bit_size);
 
                         self.check_signed_overflow(result, lhs, rhs, operator, bit_size, location);
                         self.insert_safe_cast(result, result_type, location)
@@ -461,7 +461,7 @@ impl<'a> FunctionContext<'a> {
             one,
             Some("attempt to bit-shift with overflow".to_owned().into()),
         );
-        self.builder.insert_truncate(result, bit_size, bit_size + 1)
+        self.builder.insert_truncate(result, bit_size)
     }
 
     /// Insert constraints ensuring that the operation does not overflow the bit size of the result
@@ -641,7 +641,7 @@ impl<'a> FunctionContext<'a> {
         let incoming_type_size = self.builder.type_of_value(value).bit_size();
         let target_type_size = typ.bit_size();
         if target_type_size < incoming_type_size {
-            value = self.builder.insert_truncate(value, target_type_size, incoming_type_size);
+            value = self.builder.insert_truncate(value, target_type_size);
         }
 
         self.builder.insert_cast(value, typ)


### PR DESCRIPTION
# Description

## Problem\*

Resolves #6998 

## Summary\*

This PR just tries to remove this field as the only place it impacts ACIR seems irrelevant.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
