### PR TITLE
feat!: Handle generic fields in `StructDefinition::fields` and move old functionality to `StructDefinition::fields_as_written`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -529,7 +529,9 @@ fn struct_def_fields(
 }
 
 /// fn fields_as_written(self) -> [(Quoted, Type)]
-/// Returns (name, type) pairs of each field of this StructDefinition
+/// Returns (name, type) pairs of each field of this StructDefinition.
+///
+/// Note that any generic arguments won't be applied: if you need them to be, use `fields`.
 fn struct_def_fields_as_written(
     interner: &mut NodeInterner,
     arguments: Vec<(Value, Location)>,

--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -66,7 +66,18 @@ comptime fn example(foo: StructDefinition) {
 
 #include_code fields noir_stdlib/src/meta/struct_def.nr rust
 
-Returns each field of this struct as a pair of (field name, field type).
+Returns (name, type) pairs of each field in this struct.
+Any generic types used in each field type is automatically substituted with the
+provided generic arguments.
+
+### fields_as_written
+
+#include_code fields_as_written noir_stdlib/src/meta/struct_def.nr rust
+
+Returns (name, type) pairs of each field in this struct. Each type is as-is
+with any generic arguments unchanged. Unless the field types are not needed,
+users should generally prefer to use `StructDefinition::fields` over this
+function if possible.
 
 ### has_named_attribute
 

--- a/noir_stdlib/src/cmp.nr
+++ b/noir_stdlib/src/cmp.nr
@@ -12,7 +12,7 @@ comptime fn derive_eq(s: StructDefinition) -> Quoted {
     let signature = quote { fn eq(_self: Self, _other: Self) -> bool };
     let for_each_field = |name| quote { (_self.$name == _other.$name) };
     let body = |fields| {
-        if s.fields().len() == 0 {
+        if s.fields_as_written().len() == 0 {
             quote { true }
         } else {
             fields

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -101,7 +101,7 @@ pub comptime fn make_trait_impl<Env1, Env2>(
     let where_clause = s.generics().map(|name| quote { $name: $trait_name }).join(quote {,});
 
     // `for_each_field(field1) $join_fields_with for_each_field(field2) $join_fields_with ...`
-    let fields = s.fields().map(|f: (Quoted, Type)| {
+    let fields = s.fields_as_written().map(|f: (Quoted, Type)| {
         let name = f.0;
         for_each_field(name)
     });
@@ -155,7 +155,7 @@ mod tests {
 
     comptime fn derive_field_count(s: StructDefinition) -> Quoted {
         let typ = s.as_type();
-        let field_count = s.fields().len();
+        let field_count = s.fields_as_written().len();
         quote {
             impl FieldCount for $typ {
                 fn field_count() -> u32 {
@@ -174,7 +174,7 @@ mod tests {
 
     comptime fn assert_field_is_type(s: StructDefinition, typ: Type) {
         // Assert the first field in `s` has type `typ`
-        let fields = s.fields();
+        let fields = s.fields([]);
         assert_eq(fields[0].1, typ);
     }
     // docs:end:annotation-arguments-example

--- a/noir_stdlib/src/meta/struct_def.nr
+++ b/noir_stdlib/src/meta/struct_def.nr
@@ -27,12 +27,22 @@ impl StructDefinition {
     pub comptime fn generics(self) -> [Type] {}
     // docs:end:generics
 
-    /// Returns (name, type) pairs of each field in this struct. Each type is as-is
-    /// with any generic arguments unchanged.
+    /// Returns (name, type) pairs of each field in this struct.
+    /// Any generic types used in each field type is automatically substituted with the
+    /// provided generic arguments.
     #[builtin(struct_def_fields)]
     // docs:start:fields
-    pub comptime fn fields(self) -> [(Quoted, Type)] {}
+    pub comptime fn fields(self, generic_args: [Type]) -> [(Quoted, Type)] {}
     // docs:end:fields
+
+    /// Returns (name, type) pairs of each field in this struct. Each type is as-is
+    /// with any generic arguments unchanged. Unless the field types are not needed,
+    /// users should generally prefer to use `StructDefinition::fields` over this
+    /// function if possible.
+    #[builtin(struct_def_fields_as_written)]
+    // docs:start:fields_as_written
+    pub comptime fn fields_as_written(self) -> [(Quoted, Type)] {}
+    // docs:end:fields_as_written
 
     #[builtin(struct_def_module)]
     // docs:start:module

--- a/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
@@ -12,7 +12,7 @@ pub struct I32AndField {
 comptime fn my_comptime_fn(typ: StructDefinition) {
     let _ = typ.as_type();
     assert_eq(typ.generics().len(), 3);
-    assert_eq(typ.fields().len(), 2);
+    assert_eq(typ.fields_as_written().len(), 2);
     assert_eq(typ.name(), quote { MyType });
 }
 
@@ -44,4 +44,22 @@ mod foo {
     // docs:end:add-generic-example
 }
 
-fn main() {}
+fn main() {
+    comptime {
+        let typ = quote { MyType<i8, i16, i32> }.as_type();
+        let (struct_def, generics) = typ.as_struct().unwrap();
+
+        let fields = struct_def.fields(generics);
+        assert_eq(fields.len(), 2);
+
+        let (field1_name, field1_type) = fields[0];
+        let (field2_name, field2_type) = fields[1];
+        
+        assert_eq(field1_name, quote { field1 });
+        assert_eq(field2_name, quote { field2 });
+
+        // Ensure .fields(generics) actually performs substitutions on generics
+        assert_eq(field1_type, quote { [i8; 10] }.as_type());
+        assert_eq(field2_type, quote { (i16, i32) }.as_type());
+    }
+}

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -100,7 +100,7 @@ fn main() {
         let foo = Foo { x: 0 };
         let foo_type = type_of(foo);
         let (struct_definition, generics) = foo_type.as_struct().unwrap();
-        let fields = struct_definition.fields();
+        let fields = struct_definition.fields(generics);
         assert_eq(fields.len(), 1);
 
         assert_eq(generics.len(), 1);

--- a/test_programs/compile_success_empty/derive_impl/src/main.nr
+++ b/test_programs/compile_success_empty/derive_impl/src/main.nr
@@ -7,7 +7,7 @@ comptime fn derive_default(typ: StructDefinition) -> Quoted {
     );
 
     let type_name = typ.as_type();
-    let fields = typ.fields();
+    let fields = typ.fields_as_written();
 
     let fields = join(make_field_exprs(fields));
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue from a private slack request. Needed for implementing `derive_serialize` recursively so that struct field types have their generics substituted correctly.

## Summary\*

Adds a `generic_args` argument to `StructDefinition::fields` to instantiate the field types with. This means this PR is breaking since this method used to require only `self`.

Since the old functionality of not instantiating can still be useful, I have moved it to a new function `fields_as_written` but wanted to emphasize that if users did need field types, and they don't know what the difference is, that they should prefer to use `fields`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
