### PR TITLE
chore: Do not make new instruction if it hasn't changed

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -423,14 +423,18 @@ impl<'brillig> Context<'brillig> {
             .then(|| vecmap(old_results, |result| dfg.type_of_value(*result)));
 
         let call_stack = dfg.get_instruction_call_stack_id(id);
-        let new_results =
-            match dfg.insert_instruction_and_results(instruction, block, ctrl_typevars, call_stack)
-            {
-                InsertInstructionResult::SimplifiedTo(new_result) => vec![new_result],
-                InsertInstructionResult::SimplifiedToMultiple(new_results) => new_results,
-                InsertInstructionResult::Results(_, new_results) => new_results.to_vec(),
-                InsertInstructionResult::InstructionRemoved => vec![],
-            };
+        let new_results = match dfg.insert_instruction_and_results_if_simplified(
+            instruction,
+            block,
+            ctrl_typevars,
+            call_stack,
+            Some(id),
+        ) {
+            InsertInstructionResult::SimplifiedTo(new_result) => vec![new_result],
+            InsertInstructionResult::SimplifiedToMultiple(new_results) => new_results,
+            InsertInstructionResult::Results(_, new_results) => new_results.to_vec(),
+            InsertInstructionResult::InstructionRemoved => vec![],
+        };
         // Optimizations while inserting the instruction should not change the number of results.
         assert_eq!(old_results.len(), new_results.len());
 


### PR DESCRIPTION
# Description

## Problem\*

Followup for https://github.com/noir-lang/noir/pull/7053

## Summary\*

Adds a `Dfg::insert_instruction_and_results_if_simplified` method which receives the existing instruction ID from `constant_folding`, and if the instruction could not be simplified and it still matches the original value, then it's not re-inserted into the `DenseMap`, saving some memory.

In my reference test with `rollup-base-public` it reduced peak memory from 2.7GB to 2.1GB

I suppose a followup could be to try to _remove_ instructions which are no longer needed.

## Additional Context

Noticed that `constant_folding` is involved in the peak memory usage. According to the stack trace it allocates a lot of that memory to make instructions (appears twice, with 32.1% and 13.2%):

<img width="1095" alt="Screenshot 2025-01-14 at 23 56 39" src="https://github.com/user-attachments/assets/ef611b80-59cc-448c-9be0-28f9ccb4e20c" />


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
