### PR TITLE
chore: add end step for formatting workflow

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -143,3 +143,29 @@ jobs:
       - name: Format test suite
         working-directory: ./test_programs
         run: ./format.sh check
+
+  # This is a job which depends on all test jobs and reports the overall status.
+  # This allows us to add/remove test jobs without having to update the required workflows.
+  formatting-end:
+    name: Formatting End
+    runs-on: ubuntu-22.04
+    # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
+    if: ${{ always() }}
+    needs:
+      - clippy
+      - rustfmt
+      - eslint
+      - nargo_fmt
+
+    steps:
+        - name: Report overall success
+          run: |
+            if [[ $FAIL == true ]]; then
+                exit 1
+            else
+                exit 0
+            fi
+          env:
+            # We treat any skipped or failing jobs as a failure for the workflow as a whole.
+            FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+

--- a/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
@@ -54,7 +54,7 @@ fn main() {
 
         let (field1_name, field1_type) = fields[0];
         let (field2_name, field2_type) = fields[1];
-        
+
         assert_eq(field1_name, quote { field1 });
         assert_eq(field2_name, quote { field2 });
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds an end step to the formatting workflow so that we can make it required.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
