### PR TITLE
fix: do not remove memory blocks used as brillig input

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
@@ -1,4 +1,4 @@
-use acir::circuit::{opcodes::BlockId, Circuit, Opcode};
+use acir::circuit::{brillig::BrilligInputs, opcodes::BlockId, Circuit, Opcode};
 use std::collections::HashSet;
 
 /// `UnusedMemoryOptimizer` will remove initializations of memory blocks which are unused.
@@ -28,6 +28,13 @@ impl<F> UnusedMemoryOptimizer<F> {
                 }
                 Opcode::MemoryOp { block_id, .. } => {
                     unused_memory_initialization.remove(block_id);
+                }
+                Opcode::BrilligCall { inputs, .. } => {
+                    for input in inputs {
+                        if let BrilligInputs::MemoryArray(block) = input {
+                            unused_memory_initialization.remove(block);
+                        }
+                    }
                 }
                 _ => (),
             }

--- a/test_programs/compile_success_no_bug/regression_7062/Nargo.toml
+++ b/test_programs/compile_success_no_bug/regression_7062/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_7062"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_no_bug/regression_7062/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_7062/src/main.nr
@@ -1,6 +1,8 @@
 fn main(args: [Field; 2]) {
     /// Safety: n/a
     unsafe { store(args) };
+    // Dummy test to remove the 'underconstraint bug'
+    assert(args[0] + args[1] != 0);
 }
 
 pub unconstrained fn store(_: [Field]) {}

--- a/test_programs/compile_success_no_bug/regression_7062/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_7062/src/main.nr
@@ -1,0 +1,6 @@
+fn main(args: [Field; 2]) {
+    /// Safety: n/a
+    unsafe { store(args) };
+}
+
+pub unconstrained fn store(_: [Field]) {}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7062 

## Summary\*
The unused memory optimisation was not checking for brillig inputs


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
