### PR TITLE
fix: allow calling trait impl method from struct if multiple impls exist

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -407,8 +407,8 @@ impl<'context> Elaborator<'context> {
         // Gather a list of items for which their trait is in scope.
         let mut results = Vec::new();
 
-        for (trait_id, item) in values.iter() {
-            let trait_id = trait_id.expect("The None option was already considered before");
+        for (key, item) in values.iter() {
+            let (_, trait_id) = key.expect("The None option was already considered before");
             let trait_ = self.interner.get_trait(trait_id);
             let Some(map) = starting_module.scope().types().get(&trait_.name) else {
                 continue;
@@ -424,15 +424,15 @@ impl<'context> Elaborator<'context> {
         if results.is_empty() {
             if values.len() == 1 {
                 // This is the backwards-compatible case where there's a single trait method but it's not in scope
-                let (trait_id, item) = values.iter().next().expect("Expected an item");
-                let trait_id = trait_id.expect("The None option was already considered before");
+                let (key, item) = values.iter().next().expect("Expected an item");
+                let (_, trait_id) = key.expect("The None option was already considered before");
                 let per_ns = PerNs { types: None, values: Some(*item) };
                 return StructMethodLookupResult::FoundOneTraitMethodButNotInScope(
                     per_ns, trait_id,
                 );
             } else {
                 let trait_ids = vecmap(values, |(trait_id, _)| {
-                    trait_id.expect("The none option was already considered before")
+                    trait_id.expect("The none option was already considered before").1
                 });
                 return StructMethodLookupResult::NotFound(trait_ids);
             }

--- a/compiler/noirc_frontend/src/hir/def_map/item_scope.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/item_scope.rs
@@ -166,9 +166,4 @@ impl ItemScope {
     pub fn values(&self) -> &HashMap<Ident, Scope> {
         &self.values
     }
-
-    pub fn remove_definition(&mut self, name: &Ident) {
-        self.types.remove(name);
-        self.values.remove(name);
-    }
 }

--- a/compiler/noirc_frontend/src/hir/def_map/item_scope.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/item_scope.rs
@@ -68,12 +68,11 @@ impl ItemScope {
         };
 
         match mod_def {
-            ModuleDefId::ModuleId(_) => add_item(&mut self.types),
-            ModuleDefId::FunctionId(_) => add_item(&mut self.values),
-            ModuleDefId::TypeId(_) => add_item(&mut self.types),
-            ModuleDefId::TypeAliasId(_) => add_item(&mut self.types),
-            ModuleDefId::TraitId(_) => add_item(&mut self.types),
-            ModuleDefId::GlobalId(_) => add_item(&mut self.values),
+            ModuleDefId::ModuleId(_)
+            | ModuleDefId::TypeId(_)
+            | ModuleDefId::TypeAliasId(_)
+            | ModuleDefId::TraitId(_) => add_item(&mut self.types),
+            ModuleDefId::FunctionId(_) | ModuleDefId::GlobalId(_) => add_item(&mut self.values),
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -106,11 +106,6 @@ impl ModuleData {
         self.declare(name, ItemVisibility::Public, id.into(), Some(trait_id))
     }
 
-    pub fn remove_function(&mut self, name: &Ident) {
-        self.scope.remove_definition(name);
-        self.definitions.remove_definition(name);
-    }
-
     pub fn declare_global(
         &mut self,
         name: Ident,

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1382,7 +1382,8 @@ impl NodeInterner {
                 });
 
                 if trait_id.is_none() && matches!(self_type, Type::Struct(..)) {
-                    if let Some(existing) = self.lookup_direct_method(self_type, &method_name, true)
+                    if let Some(existing) =
+                        self.lookup_direct_method(self_type, &method_name, false)
                     {
                         return Some(existing);
                     }
@@ -1752,14 +1753,14 @@ impl NodeInterner {
         &self,
         typ: &Type,
         method_name: &str,
-        has_self_arg: bool,
+        check_self_arg_type: bool,
     ) -> Option<FuncId> {
         let key = get_type_method_key(typ)?;
 
         self.methods
             .get(&key)
             .and_then(|h| h.get(method_name))
-            .and_then(|methods| methods.find_direct_method(typ, has_self_arg, self))
+            .and_then(|methods| methods.find_direct_method(typ, check_self_arg_type, self))
     }
 
     /// Looks up a methods that apply to the given type but are defined in traits.
@@ -1767,14 +1768,14 @@ impl NodeInterner {
         &self,
         typ: &Type,
         method_name: &str,
-        has_self_arg: bool,
+        check_self_arg_type: bool,
     ) -> Vec<(FuncId, TraitId)> {
         let key = get_type_method_key(typ);
         if let Some(key) = key {
             self.methods
                 .get(&key)
                 .and_then(|h| h.get(method_name))
-                .map(|methods| methods.find_trait_methods(typ, has_self_arg, self))
+                .map(|methods| methods.find_trait_methods(typ, check_self_arg_type, self))
                 .unwrap_or_default()
         } else {
             Vec::new()
@@ -1786,12 +1787,12 @@ impl NodeInterner {
         &self,
         typ: &Type,
         method_name: &str,
-        has_self_arg: bool,
+        check_self_arg_type: bool,
     ) -> Vec<(FuncId, TraitId)> {
         self.methods
             .get(&TypeMethodKey::Generic)
             .and_then(|h| h.get(method_name))
-            .map(|methods| methods.find_trait_methods(typ, has_self_arg, self))
+            .map(|methods| methods.find_trait_methods(typ, check_self_arg_type, self))
             .unwrap_or_default()
     }
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -2833,6 +2833,50 @@ fn duplicate_struct_field() {
 }
 
 #[test]
+fn duplicate_struct_method_without_self() {
+    let src = r#"
+    pub struct Foo {
+    }
+
+    impl Foo {
+        fn bar() {}
+        fn bar() {}
+    }
+
+    fn main() {}
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ResolverError(ResolverError::DuplicateDefinition { .. }) = &errors[0].0
+    else {
+        panic!("Expected a duplicate error, got {:?}", errors[0].0);
+    };
+}
+
+#[test]
+fn duplicate_struct_method_with_self() {
+    let src = r#"
+    pub struct Foo {
+    }
+
+    impl Foo {
+        fn bar(self) { let _ = self; }
+        fn bar(self) { let _ = self; }
+    }
+
+    fn main() {}
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ResolverError(ResolverError::DuplicateDefinition { .. }) = &errors[0].0
+    else {
+        panic!("Expected a duplicate error, got {:?}", errors[0].0);
+    };
+}
+
+#[test]
 fn trait_constraint_on_tuple_type() {
     let src = r#"
         trait Foo<A> {

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1238,7 +1238,7 @@ fn warns_if_trait_is_not_in_scope_for_generic_function_call_and_there_is_only_on
 }
 
 #[test]
-fn calls_trait_method_using_struct_name_when_multiple_impls_exist() {
+fn calls_trait_method_using_struct_name_when_multiple_impls_exist_first_one() {
     let src = r#"
     trait From2<T> {
         fn from2(input: T) -> Self;
@@ -1260,6 +1260,34 @@ fn calls_trait_method_using_struct_name_when_multiple_impls_exist() {
 
     fn main() {
         let _ = U60Repr::from2([1, 2, 3]);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn calls_trait_method_using_struct_name_when_multiple_impls_exist_second_one() {
+    let src = r#"
+    trait From2<T> {
+        fn from2(input: T) -> Self;
+    }
+
+    struct U60Repr {}
+
+    impl From2<[Field; 3]> for U60Repr {
+        fn from2(_: [Field; 3]) -> Self {
+            U60Repr {}
+        }
+    }
+
+    impl From2<Field> for U60Repr {
+        fn from2(_: Field) -> Self {
+            U60Repr {}
+        }
+    }
+
+    fn main() {
+        let _ = U60Repr::from2(1);
     }
     "#;
     assert_no_errors(src);

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1236,3 +1236,31 @@ fn warns_if_trait_is_not_in_scope_for_generic_function_call_and_there_is_only_on
     assert_eq!(ident.to_string(), "foo");
     assert_eq!(trait_name, "private_mod::Foo");
 }
+
+#[test]
+fn calls_trait_method_using_struct_name_when_multiple_impls_exist() {
+    let src = r#"
+    trait From2<T> {
+        fn from2(input: T) -> Self;
+    }
+
+    struct U60Repr {}
+
+    impl From2<[Field; 3]> for U60Repr {
+        fn from2(_: [Field; 3]) -> Self {
+            U60Repr {}
+        }
+    }
+
+    impl From2<Field> for U60Repr {
+        fn from2(_: Field) -> Self {
+            U60Repr {}
+        }
+    }
+
+    fn main() {
+        let _ = U60Repr::from2([1, 2, 3]);
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Makes [this](https://github.com/noir-lang/noir-bignum/pull/95#discussion_r1916374270) work

## Summary

Edit: this one is very had to fix. The main issue is that:
1. We have to solve `U60Repr::from2()`
2. That's a call, so we have to solve what the call is pointing to, that is, solve `U60Repr::from2`
3. That's a path lookup. In our code a path lookup, for functions, end up returning a single `FuncId`. In this case it's a trait method so there are potentially multiple `FuncId`, so we'd need to represent the result in a different way here. And once we do that, change the code to support this new result variant.

---

It seems we had logic in place to remove a method definition if it gives an error while adding it. When multiple trait impl methods existed for the same struct (in different impls), the second definition would erase both, though only from the `ModuleData` (I think the definitions still exist somewhere else so that's why using `Trait::` worked).

I'm not sure why that was done, but I changed it to not do that. All tests seem to pass, so either that was unneeded or there is a scenario that breaks with this change but it's untested.

## Additional Context

I also introduced refactors/renames to make the code a bit clearer.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
