### PR TITLE
fix!: Include kind in `StructDefinition::generics` and fix derivation of Eq in structs with numeric generics

### DIFF
--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -42,7 +42,8 @@ any generics, the generics are also included as-is.
 
 #include_code generics noir_stdlib/src/meta/struct_def.nr rust
 
-Returns each generic on this struct.
+Returns each generic on this struct. Each generic is represented as a tuple containing the type, 
+and an optional containing the numeric type if it's a numeric generic.
 
 Example:
 

--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -48,20 +48,21 @@ Example:
 
 ```
 #[example]
-struct Foo<T, U> {
-    bar: [T; 2],
+struct Foo<T, U, let K: u32> {
+    bar: [T; K],
     baz: Baz<U, U>,
 }
 
 comptime fn example(foo: StructDefinition) {
-    assert_eq(foo.generics().len(), 2);
-
-    let (first_generic_type, first_generic_numeric) = foo.generics()[0];
-    assert(first_generic_numeric.is_none());
+    assert_eq(foo.generics().len(), 3);
 
     // Fails because `T` isn't in scope
     // let t = quote { T }.as_type();
-    // assert_eq(first_generic_type, t);
+    // assert_eq(foo.generics()[0].0, t);
+    assert(foo.generics()[0].1.is_none());
+
+    // Last generic is numeric, so we have the numeric type available to us
+    assert(foo.generics()[2].1.is_some());
 }
 ```
 

--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -56,9 +56,12 @@ struct Foo<T, U> {
 comptime fn example(foo: StructDefinition) {
     assert_eq(foo.generics().len(), 2);
 
+    let (first_generic_type, first_generic_numeric) = foo.generics()[0];
+    assert(first_generic_numeric.is_none());
+
     // Fails because `T` isn't in scope
     // let t = quote { T }.as_type();
-    // assert_eq(foo.generics()[0], t);
+    // assert_eq(first_generic_type, t);
 }
 ```
 

--- a/docs/docs/noir/standard_library/meta/trait_impl.md
+++ b/docs/docs/noir/standard_library/meta/trait_impl.md
@@ -25,8 +25,10 @@ comptime {
     let generics = my_impl.trait_generic_args();
     assert_eq(generics.len(), 2);
 
-    assert_eq(generics[0], quote { i32 }.as_type());
-    assert_eq(generics[1], quote { Field }.as_type());
+    assert_eq(generics[0].0, quote { i32 }.as_type());
+    assert(generics[0].1.is_none());
+    assert_eq(generics[1].0, quote { Field }.as_type());
+    assert(generics[1].1.is_none());
 }
 ```
 

--- a/docs/versioned_docs/version-v0.36.0/noir/standard_library/meta/struct_def.md
+++ b/docs/versioned_docs/version-v0.36.0/noir/standard_library/meta/struct_def.md
@@ -44,7 +44,7 @@ comptime fn add_generic(s: StructDefinition) {
 
         let generics = s.generics();
         assert_eq(generics.len(), 1);
-        assert_eq(generics[0], new_generic);
+        assert_eq(generics[0].0, new_generic);
     }
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L35-L44" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L35-L44</a></sub></sup>

--- a/docs/versioned_docs/version-v0.36.0/noir/standard_library/meta/struct_def.md
+++ b/docs/versioned_docs/version-v0.36.0/noir/standard_library/meta/struct_def.md
@@ -44,7 +44,7 @@ comptime fn add_generic(s: StructDefinition) {
 
         let generics = s.generics();
         assert_eq(generics.len(), 1);
-        assert_eq(generics[0].0, new_generic);
+        assert_eq(generics[0], new_generic);
     }
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L35-L44" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L35-L44</a></sub></sup>

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -97,22 +97,13 @@ pub comptime fn make_trait_impl<Env1, Env2>(
 ) -> Quoted {
     // docs:end:make_trait_impl
     let typ = s.as_type();
-    // Urgh, if we emit he type directly, the compiler fails to match it with the type in impl generics.
-    let typ = f"{typ}".quoted_contents();
 
     let mut impl_generics = &[];
     let mut where_clause = &[];
     for g in s.generics() {
         let (typ, numeric_type) = g;
-        // Urgh again, if we emit the type directly, since <let T: u32> expects T to be an ident, will fail parsing
-        let typ = f"{typ}".quoted_contents();
-
-        if numeric_type.is_some() {
-            let numeric_type = numeric_type.unwrap_unchecked();
-            // Numeric generics expect the name to be an ident, not a type
-            impl_generics = impl_generics.push_back(quote { let $typ : $numeric_type });
-        } else {
-            impl_generics = impl_generics.push_back(quote { $typ });
+        impl_generics = impl_generics.push_back(quote { $typ });
+        if numeric_type.is_none() {
             where_clause = where_clause.push_back(quote { $typ: $trait_name });
         }
     }

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -97,8 +97,28 @@ pub comptime fn make_trait_impl<Env1, Env2>(
 ) -> Quoted {
     // docs:end:make_trait_impl
     let typ = s.as_type();
-    let impl_generics = s.generics().map(|g| quote { $g }).join(quote {,});
-    let where_clause = s.generics().map(|name| quote { $name: $trait_name }).join(quote {,});
+    // Urgh, if we emit he type directly, the compiler fails to match it with the type in impl generics.
+    let typ = f"{typ}".quoted_contents();
+
+    let mut impl_generics = &[];
+    let mut where_clause = &[];
+    for g in s.generics() {
+        let (typ, numeric_type) = g;
+        // Urgh again, if we emit the type directly, since <let T: u32> expects T to be an ident, will fail parsing
+        let typ = f"{typ}".quoted_contents();
+
+        if numeric_type.is_some() {
+            let numeric_type = numeric_type.unwrap_unchecked();
+            // Numeric generics expect the name to be an ident, not a type
+            impl_generics = impl_generics.push_back(quote { let $typ : $numeric_type });
+        } else {
+            impl_generics = impl_generics.push_back(quote { $typ });
+            where_clause = where_clause.push_back(quote { $typ: $trait_name });
+        }
+    }
+
+    let impl_generics = impl_generics.join(quote {, });
+    let where_clause = where_clause.join(quote {, });
 
     // `for_each_field(field1) $join_fields_with for_each_field(field2) $join_fields_with ...`
     let fields = s.fields_as_written().map(|f: (Quoted, Type)| {

--- a/noir_stdlib/src/meta/struct_def.nr
+++ b/noir_stdlib/src/meta/struct_def.nr
@@ -1,3 +1,5 @@
+use crate::option::Option;
+
 impl StructDefinition {
     #[builtin(struct_def_add_attribute)]
     // docs:start:add_attribute
@@ -21,10 +23,11 @@ impl StructDefinition {
     pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
     // docs:end:has_named_attribute
 
-    /// Return each generic on this struct.
+    /// Return (type, option<type>) pairs of each generic in this struct definition.
+    /// If a generic is numeric, the second element of the pair will contain the numeric type.
     #[builtin(struct_def_generics)]
     // docs:start:generics
-    pub comptime fn generics(self) -> [Type] {}
+    pub comptime fn generics(self) -> [(Type, Option<Type>)] {}
     // docs:end:generics
 
     /// Returns (name, type) pairs of each field in this struct.

--- a/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
@@ -39,7 +39,9 @@ mod foo {
 
         let generics = s.generics();
         assert_eq(generics.len(), 1);
-        assert_eq(generics[0], new_generic);
+        let (typ, numeric) = generics[0];
+        assert_eq(typ, new_generic);
+        assert(numeric.is_none());
     }
     // docs:end:add-generic-example
 }

--- a/test_programs/compile_success_empty/eq_derivation_with_numeric_generics/Nargo.toml
+++ b/test_programs/compile_success_empty/eq_derivation_with_numeric_generics/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "eq_derivation_with_numeric_generics"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/eq_derivation_with_numeric_generics/src/main.nr
+++ b/test_programs/compile_success_empty/eq_derivation_with_numeric_generics/src/main.nr
@@ -1,0 +1,12 @@
+#[derive(Eq)]
+struct Foo<let T: u32> {
+    a: [Field; T],
+    b: u32,
+}
+
+fn main() {
+    let foo = Foo { a: [0; 10], b: 27 };
+    let bar = Foo { a: [0; 10], b: 28 };
+    assert(foo != bar);
+}
+


### PR DESCRIPTION
# Description

## Problem\*

Eq derivation didn't work in structs with numeric generics

## Summary\*

This PR changes the implementation of `struct_def_generics` to return tuples of the type and the numeric type, if the type is of numeric kind.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
