### PR TITLE
fix: Allow implicit associated types on integer type kinds

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    ast::ItemVisibility, graph::CrateGraph, hir_def::traits::ResolvedTraitBound,
+    ast::{ItemVisibility, UnresolvedType}, graph::CrateGraph, hir_def::traits::ResolvedTraitBound,
     node_interner::GlobalValue, usage_tracker::UsageTracker, StructField, StructType, TypeBindings,
 };
 use crate::{
@@ -766,7 +766,7 @@ impl<'context> Elaborator<'context> {
     ) -> Vec<ResolvedGeneric> {
         where_clause
             .iter_mut()
-            .flat_map(|constraint| self.add_missing_named_generics(&mut constraint.trait_bound))
+            .flat_map(|constraint| self.add_missing_named_generics(&constraint.typ, &mut constraint.trait_bound))
             .collect()
     }
 
@@ -782,7 +782,7 @@ impl<'context> Elaborator<'context> {
     ///
     /// with a vector of `<A, B>` returned so that the caller can then modify the function to:
     /// `fn foo<T, A, B>() where T: Foo<Bar = A, Baz = B> { ... }`
-    fn add_missing_named_generics(&mut self, bound: &mut TraitBound) -> Vec<ResolvedGeneric> {
+    fn add_missing_named_generics(&mut self, object: &UnresolvedType, bound: &mut TraitBound) -> Vec<ResolvedGeneric> {
         let mut added_generics = Vec::new();
 
         let Ok(item) = self.resolve_path_or_error(bound.trait_path.clone()) else {
@@ -796,6 +796,8 @@ impl<'context> Elaborator<'context> {
         let the_trait = self.get_trait_mut(trait_id);
 
         if the_trait.associated_types.len() > bound.trait_generics.named_args.len() {
+            let trait_name = the_trait.name.to_string();
+
             for associated_type in &the_trait.associated_types.clone() {
                 if !bound
                     .trait_generics
@@ -806,10 +808,12 @@ impl<'context> Elaborator<'context> {
                     // This generic isn't contained in the bound's named arguments,
                     // so add it by creating a fresh type variable.
                     let new_generic_id = self.interner.next_type_variable_id();
-                    let type_var = TypeVariable::unbound(new_generic_id, Kind::Normal);
+                    let kind = associated_type.type_var.kind();
+                    let type_var = TypeVariable::unbound(new_generic_id, kind);
 
                     let span = bound.trait_path.span;
-                    let name = associated_type.name.clone();
+                    let name = format!("<{object} as {trait_name}>::{}",associated_type.name.clone());
+                    let name = Rc::new(name);
                     let typ = Type::NamedGeneric(type_var.clone(), name.clone());
                     let typ = self.interner.push_quoted_type(typ);
                     let typ = UnresolvedTypeData::Resolved(typ).with_span(span);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -822,8 +822,7 @@ impl<'context> Elaborator<'context> {
                     let type_var = TypeVariable::unbound(new_generic_id, kind);
 
                     let span = bound.trait_path.span;
-                    let name =
-                        format!("<{object} as {trait_name}>::{}", associated_type.name);
+                    let name = format!("<{object} as {trait_name}>::{}", associated_type.name);
                     let name = Rc::new(name);
                     let typ = Type::NamedGeneric(type_var.clone(), name.clone());
                     let typ = self.interner.push_quoted_type(typ);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -823,7 +823,7 @@ impl<'context> Elaborator<'context> {
 
                     let span = bound.trait_path.span;
                     let name =
-                        format!("<{object} as {trait_name}>::{}", associated_type.name.clone());
+                        format!("<{object} as {trait_name}>::{}", associated_type.name);
                     let name = Rc::new(name);
                     let typ = Type::NamedGeneric(type_var.clone(), name.clone());
                     let typ = self.interner.push_quoted_type(typ);

--- a/test_programs/compile_success_empty/serialize/src/main.nr
+++ b/test_programs/compile_success_empty/serialize/src/main.nr
@@ -5,13 +5,12 @@ trait Serialize {
     fn serialize(self) -> [Field; Self::Size];
 }
 
-impl<A, B, let AS: u32, let BS: u32> Serialize for (A, B)
+impl<A, B> Serialize for (A, B)
 where
-    A: Serialize<Size = AS>,
-    B: Serialize<Size = BS>,
+    A: Serialize,
+    B: Serialize,
 {
-    // let Size = <A as Serialize>::Size + <B as Serialize>::Size;
-    let Size: u32 = AS + BS;
+    let Size = <A as Serialize>::Size + <B as Serialize>::Size;
 
     fn serialize(self: Self) -> [Field; Self::Size] {
         let mut array: [Field; Self::Size] = std::mem::zeroed();
@@ -28,12 +27,11 @@ where
     }
 }
 
-impl<T, let N: u32, let TS: u32> Serialize for [T; N]
+impl<T, let N: u32> Serialize for [T; N]
 where
-    T: Serialize<Size = TS>,
+    T: Serialize,
 {
-    // let Size = <T as Serialize>::Size * N;
-    let Size: u32 = TS * N;
+    let Size = <T as Serialize>::Size * N;
 
     fn serialize(self: Self) -> [Field; Self::Size] {
         let mut array: [Field; Self::Size] = std::mem::zeroed();


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/7077

## Summary\*

Fixes the kind of implicit associated types and improves their name in error messages to match the `<T as Trait>::Type` syntax a user would use.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
