### PR TITLE
feat(LSP): auto-import trait reexport if trait is not visible

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -6,7 +6,7 @@ use std::{
 use async_lsp::ResponseError;
 use completion_items::{
     field_completion_item, simple_completion_item, snippet_completion_item,
-    trait_impl_method_completion_item,
+    trait_impl_method_completion_item, TraitReexport,
 };
 use convert_case::{Case, Casing};
 use fm::{FileId, FileMap, PathString};
@@ -28,7 +28,6 @@ use noirc_frontend::{
         def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId},
         resolution::visibility::{
             item_in_module_is_visible, method_call_is_visible, struct_member_is_visible,
-            trait_member_is_visible,
         },
     },
     hir_def::traits::Trait,
@@ -41,7 +40,8 @@ use sort_text::underscore_sort_text;
 
 use crate::{
     requests::to_lsp_location, trait_impl_method_stub_generator::TraitImplMethodStubGenerator,
-    use_segment_positions::UseSegmentPositions, utils, LspState,
+    use_segment_positions::UseSegmentPositions, utils, visibility::module_def_id_is_visible,
+    LspState,
 };
 
 use super::process_request;
@@ -679,12 +679,40 @@ impl<'a> NodeFinder<'a> {
                     }
                 }
 
+                let mut trait_reexport = None;
+
                 if let Some(trait_id) = trait_id {
                     let modifiers = self.interner.function_modifiers(&func_id);
                     let visibility = modifiers.visibility;
-                    if !trait_member_is_visible(trait_id, visibility, self.module_id, self.def_maps)
-                    {
-                        continue;
+                    let module_def_id = ModuleDefId::TraitId(trait_id);
+                    if !module_def_id_is_visible(
+                        module_def_id,
+                        self.module_id,
+                        visibility,
+                        None, // defining module
+                        self.interner,
+                        self.def_maps,
+                    ) {
+                        // Try to find a visible reexport of the trait
+                        // that is visible from the current module
+                        let Some((visible_module_id, name, _)) =
+                            self.interner.get_trait_reexports(trait_id).iter().find(
+                                |(module_id, _, visibility)| {
+                                    module_def_id_is_visible(
+                                        module_def_id,
+                                        self.module_id,
+                                        *visibility,
+                                        Some(*module_id),
+                                        self.interner,
+                                        self.def_maps,
+                                    )
+                                },
+                            )
+                        else {
+                            continue;
+                        };
+
+                        trait_reexport = Some(TraitReexport { module_id: visible_module_id, name });
                     }
                 }
 
@@ -706,7 +734,7 @@ impl<'a> NodeFinder<'a> {
                     function_completion_kind,
                     function_kind,
                     None, // attribute first type
-                    trait_id,
+                    trait_id.map(|id| (id, trait_reexport.as_ref())),
                     self_prefix,
                 );
                 if !completion_items.is_empty() {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -6,7 +6,7 @@ use std::{
 use async_lsp::ResponseError;
 use completion_items::{
     field_completion_item, simple_completion_item, snippet_completion_item,
-    trait_impl_method_completion_item, TraitReexport,
+    trait_impl_method_completion_item,
 };
 use convert_case::{Case, Casing};
 use fm::{FileId, FileMap, PathString};
@@ -44,7 +44,7 @@ use crate::{
     LspState,
 };
 
-use super::process_request;
+use super::{process_request, TraitReexport};
 
 mod auto_import;
 mod builtins;

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -16,8 +16,9 @@ use lsp_types::{
 };
 use nargo_fmt::Config;
 
+use noirc_frontend::ast::Ident;
 use noirc_frontend::graph::CrateId;
-use noirc_frontend::hir::def_map::CrateDefMap;
+use noirc_frontend::hir::def_map::{CrateDefMap, ModuleId};
 use noirc_frontend::parser::ParserError;
 use noirc_frontend::usage_tracker::UsageTracker;
 use noirc_frontend::{graph::Dependency, node_interner::NodeInterner};
@@ -617,6 +618,12 @@ pub(crate) fn find_all_references(
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Represents a trait reexported from a given module with a name.
+pub(crate) struct TraitReexport<'a> {
+    pub(super) module_id: &'a ModuleId,
+    pub(super) name: &'a Ident,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

## Problem

Part of #6956

## Summary

A trait might be private in a module but publicly reexported from a parent module. That trait can be used but referring to it via the module it's in, rather than the module it's reexported from, is an error.

This PR makes LSP suggest a visible reexport if a trait is not visible where it's defined. For example, there's `std::ops::arith::Add` in the standard library, which is actually hidden but reexported as `std::ops::Add`. Here's how it works now when autocompleting `add`:

![lsp-auto-import-trait-via-reexport](https://github.com/user-attachments/assets/04c2fb94-901f-4c27-a88a-e9dff027970f)

And the same thing is done in the code action that suggests importing a trait:

![lsp-code-action-import-trait-via-reexport](https://github.com/user-attachments/assets/7b6e84bf-10d5-4f09-8c62-bda31a91738f)

## Additional Context

Rust Analyzer works the same way. I initially thought we could hardcode it just for the stdlib ops, but Rust Analyzer managed to do it with any traits I defined so I figured they track reexports and suggest those.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
