### PR TITLE
feat(experimental): try to infer lambda argument types inside calls

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -223,6 +223,10 @@ impl ExpressionKind {
             struct_type: None,
         }))
     }
+
+    pub fn is_lambda(&self) -> bool {
+        matches!(self, ExpressionKind::Lambda(..))
+    }
 }
 
 impl Recoverable for ExpressionKind {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3980,7 +3980,7 @@ fn checks_visibility_of_trait_related_to_trait_impl_on_method_call() {
 }
 
 #[test]
-fn infers_lambda_argument_from_call_function_type() {
+fn infers_lambda_argument_from_method_call_function_type() {
     let src = r#"
     struct Foo {
         value: Field,
@@ -4005,6 +4005,24 @@ fn infers_lambda_argument_from_call_function_type() {
     fn main() {
         let box = Box { value: Foo { value: 1 } };
         let _ = box.map(|foo| foo.foo());
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn infers_lambda_argument_from_call_function_type() {
+    let src = r#"
+    struct Foo {
+        value: Field,
+    }
+
+    fn call(f: fn(Foo) -> Field) -> Field {
+        f(Foo { value: 1 })
+    }
+
+    fn main() {
+        let _ = call(|foo| foo.value);
     }
     "#;
     assert_no_errors(src);

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3978,3 +3978,34 @@ fn checks_visibility_of_trait_related_to_trait_impl_on_method_call() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn infers_lambda_argument_from_call_function_type() {
+    let src = r#"
+    struct Foo {
+        value: Field,
+    }
+
+    impl Foo {
+        fn foo(self) -> Field {
+            self.value
+        }
+    }
+
+    struct Box<T> {
+        value: T,
+    }
+
+    impl<T> Box<T> {
+        fn map<U>(self, f: fn(T) -> U) -> Box<U> {
+            Box { value: f(self.value) }
+        }
+    }
+
+    fn main() {
+        let box = Box { value: Foo { value: 1 } };
+        let _ = box.map(|foo| foo.foo());
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3015,13 +3015,13 @@ fn do_not_eagerly_error_on_cast_on_type_variable() {
 #[test]
 fn error_on_cast_over_type_variable() {
     let src = r#"
-    pub fn foo<T, U>(x: T, f: fn(T) -> U) -> U {
+    pub fn foo<T, U>(f: fn(T) -> U, x: T, ) -> U {
         f(x)
     }
 
     fn main() {
         let x = "a";
-        let _: Field = foo(x, |x| x as Field);
+        let _: Field = foo(|x| x as Field, x);
     }
     "#;
 
@@ -4023,6 +4023,24 @@ fn infers_lambda_argument_from_call_function_type() {
 
     fn main() {
         let _ = call(|foo| foo.value);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn infers_lambda_argument_from_call_function_type_in_generic_call() {
+    let src = r#"
+    struct Foo {
+        value: Field,
+    }
+
+    fn call<T>(t: T, f: fn(T) -> Field) -> Field {
+        f(t)
+    }
+
+    fn main() {
+        let _ = call(Foo { value: 1 }, |foo| foo.value);
     }
     "#;
     assert_no_errors(src);

--- a/noir_stdlib/src/array/mod.nr
+++ b/noir_stdlib/src/array/mod.nr
@@ -157,7 +157,7 @@ where
     /// }
     /// ```
     pub fn sort(self) -> Self {
-        self.sort_via(|a: T, b: T| a <= b)
+        self.sort_via(|a, b| a <= b)
     }
 }
 

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -285,33 +285,31 @@ impl Expr {
 }
 
 comptime fn modify_array<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_array().map(|exprs: [Expr]| {
+    expr.as_array().map(|exprs| {
         let exprs = modify_expressions(exprs, f);
         new_array(exprs)
     })
 }
 
 comptime fn modify_assert<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_assert().map(|expr: (Expr, Option<Expr>)| {
-        let (predicate, msg) = expr;
+    expr.as_assert().map(|(predicate, msg)| {
         let predicate = predicate.modify(f);
-        let msg = msg.map(|msg: Expr| msg.modify(f));
+        let msg = msg.map(|msg| msg.modify(f));
         new_assert(predicate, msg)
     })
 }
 
 comptime fn modify_assert_eq<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_assert_eq().map(|expr: (Expr, Expr, Option<Expr>)| {
-        let (lhs, rhs, msg) = expr;
+    expr.as_assert_eq().map(|(lhs, rhs, msg)| {
         let lhs = lhs.modify(f);
         let rhs = rhs.modify(f);
-        let msg = msg.map(|msg: Expr| msg.modify(f));
+        let msg = msg.map(|msg| msg.modify(f));
         new_assert_eq(lhs, rhs, msg)
     })
 }
 
 comptime fn modify_assign<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_assign().map(|expr: (Expr, Expr)| {
+    expr.as_assign().map(|expr| {
         let (lhs, rhs) = expr;
         let lhs = lhs.modify(f);
         let rhs = rhs.modify(f);
@@ -320,8 +318,7 @@ comptime fn modify_assign<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> 
 }
 
 comptime fn modify_binary_op<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_binary_op().map(|expr: (Expr, BinaryOp, Expr)| {
-        let (lhs, op, rhs) = expr;
+    expr.as_binary_op().map(|(lhs, op, rhs)| {
         let lhs = lhs.modify(f);
         let rhs = rhs.modify(f);
         new_binary_op(lhs, op, rhs)
@@ -329,34 +326,29 @@ comptime fn modify_binary_op<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) 
 }
 
 comptime fn modify_block<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_block().map(|exprs: [Expr]| {
+    expr.as_block().map(|exprs| {
         let exprs = modify_expressions(exprs, f);
         new_block(exprs)
     })
 }
 
 comptime fn modify_cast<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_cast().map(|expr: (Expr, UnresolvedType)| {
-        let (expr, typ) = expr;
+    expr.as_cast().map(|(expr, typ)| {
         let expr = expr.modify(f);
         new_cast(expr, typ)
     })
 }
 
 comptime fn modify_comptime<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_comptime().map(|exprs: [Expr]| {
-        let exprs = exprs.map(|expr: Expr| expr.modify(f));
+    expr.as_comptime().map(|exprs| {
+        let exprs = exprs.map(|expr| expr.modify(f));
         new_comptime(exprs)
     })
 }
 
 comptime fn modify_constructor<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_constructor().map(|expr: (UnresolvedType, [(Quoted, Expr)])| {
-        let (typ, fields) = expr;
-        let fields = fields.map(|field: (Quoted, Expr)| {
-            let (name, value) = field;
-            (name, value.modify(f))
-        });
+    expr.as_constructor().map(|(typ, fields)| {
+        let fields = fields.map(|(name, value)| (name, value.modify(f)));
         new_constructor(typ, fields)
     })
 }
@@ -365,27 +357,24 @@ comptime fn modify_function_call<Env>(
     expr: Expr,
     f: fn[Env](Expr) -> Option<Expr>,
 ) -> Option<Expr> {
-    expr.as_function_call().map(|expr: (Expr, [Expr])| {
-        let (function, arguments) = expr;
+    expr.as_function_call().map(|(function, arguments)| {
         let function = function.modify(f);
-        let arguments = arguments.map(|arg: Expr| arg.modify(f));
+        let arguments = arguments.map(|arg| arg.modify(f));
         new_function_call(function, arguments)
     })
 }
 
 comptime fn modify_if<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_if().map(|expr: (Expr, Expr, Option<Expr>)| {
-        let (condition, consequence, alternative) = expr;
+    expr.as_if().map(|(condition, consequence, alternative)| {
         let condition = condition.modify(f);
         let consequence = consequence.modify(f);
-        let alternative = alternative.map(|alternative: Expr| alternative.modify(f));
+        let alternative = alternative.map(|alternative| alternative.modify(f));
         new_if(condition, consequence, alternative)
     })
 }
 
 comptime fn modify_index<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_index().map(|expr: (Expr, Expr)| {
-        let (object, index) = expr;
+    expr.as_index().map(|(object, index)| {
         let object = object.modify(f);
         let index = index.modify(f);
         new_index(object, index)
@@ -393,8 +382,7 @@ comptime fn modify_index<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> O
 }
 
 comptime fn modify_for<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_for().map(|expr: (Quoted, Expr, Expr)| {
-        let (identifier, array, body) = expr;
+    expr.as_for().map(|(identifier, array, body)| {
         let array = array.modify(f);
         let body = body.modify(f);
         new_for(identifier, array, body)
@@ -402,8 +390,7 @@ comptime fn modify_for<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Opt
 }
 
 comptime fn modify_for_range<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_for_range().map(|expr: (Quoted, Expr, Expr, Expr)| {
-        let (identifier, from, to, body) = expr;
+    expr.as_for_range().map(|(identifier, from, to, body)| {
         let from = from.modify(f);
         let to = to.modify(f);
         let body = body.modify(f);
@@ -412,18 +399,15 @@ comptime fn modify_for_range<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) 
 }
 
 comptime fn modify_lambda<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_lambda().map(|expr: ([(Expr, Option<UnresolvedType>)], Option<UnresolvedType>, Expr)| {
-        let (params, return_type, body) = expr;
-        let params =
-            params.map(|param: (Expr, Option<UnresolvedType>)| (param.0.modify(f), param.1));
+    expr.as_lambda().map(|(params, return_type, body)| {
+        let params = params.map(|(name, typ)| (name.modify(f), typ));
         let body = body.modify(f);
         new_lambda(params, return_type, body)
     })
 }
 
 comptime fn modify_let<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_let().map(|expr: (Expr, Option<UnresolvedType>, Expr)| {
-        let (pattern, typ, expr) = expr;
+    expr.as_let().map(|(pattern, typ, expr)| {
         let pattern = pattern.modify(f);
         let expr = expr.modify(f);
         new_let(pattern, typ, expr)
@@ -434,18 +418,16 @@ comptime fn modify_member_access<Env>(
     expr: Expr,
     f: fn[Env](Expr) -> Option<Expr>,
 ) -> Option<Expr> {
-    expr.as_member_access().map(|expr: (Expr, Quoted)| {
-        let (object, name) = expr;
+    expr.as_member_access().map(|(object, name)| {
         let object = object.modify(f);
         new_member_access(object, name)
     })
 }
 
 comptime fn modify_method_call<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_method_call().map(|expr: (Expr, Quoted, [UnresolvedType], [Expr])| {
-        let (object, name, generics, arguments) = expr;
+    expr.as_method_call().map(|(object, name, generics, arguments)| {
         let object = object.modify(f);
-        let arguments = arguments.map(|arg: Expr| arg.modify(f));
+        let arguments = arguments.map(|arg| arg.modify(f));
         new_method_call(object, name, generics, arguments)
     })
 }
@@ -454,8 +436,7 @@ comptime fn modify_repeated_element_array<Env>(
     expr: Expr,
     f: fn[Env](Expr) -> Option<Expr>,
 ) -> Option<Expr> {
-    expr.as_repeated_element_array().map(|expr: (Expr, Expr)| {
-        let (expr, length) = expr;
+    expr.as_repeated_element_array().map(|(expr, length)| {
         let expr = expr.modify(f);
         let length = length.modify(f);
         new_repeated_element_array(expr, length)
@@ -466,8 +447,7 @@ comptime fn modify_repeated_element_slice<Env>(
     expr: Expr,
     f: fn[Env](Expr) -> Option<Expr>,
 ) -> Option<Expr> {
-    expr.as_repeated_element_slice().map(|expr: (Expr, Expr)| {
-        let (expr, length) = expr;
+    expr.as_repeated_element_slice().map(|(expr, length)| {
         let expr = expr.modify(f);
         let length = length.modify(f);
         new_repeated_element_slice(expr, length)
@@ -475,36 +455,35 @@ comptime fn modify_repeated_element_slice<Env>(
 }
 
 comptime fn modify_slice<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_slice().map(|exprs: [Expr]| {
+    expr.as_slice().map(|exprs| {
         let exprs = modify_expressions(exprs, f);
         new_slice(exprs)
     })
 }
 
 comptime fn modify_tuple<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_tuple().map(|exprs: [Expr]| {
+    expr.as_tuple().map(|exprs| {
         let exprs = modify_expressions(exprs, f);
         new_tuple(exprs)
     })
 }
 
 comptime fn modify_unary_op<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_unary_op().map(|expr: (UnaryOp, Expr)| {
-        let (op, rhs) = expr;
+    expr.as_unary_op().map(|(op, rhs)| {
         let rhs = rhs.modify(f);
         new_unary_op(op, rhs)
     })
 }
 
 comptime fn modify_unsafe<Env>(expr: Expr, f: fn[Env](Expr) -> Option<Expr>) -> Option<Expr> {
-    expr.as_unsafe().map(|exprs: [Expr]| {
-        let exprs = exprs.map(|expr: Expr| expr.modify(f));
+    expr.as_unsafe().map(|exprs| {
+        let exprs = exprs.map(|expr| expr.modify(f));
         new_unsafe(exprs)
     })
 }
 
 comptime fn modify_expressions<Env>(exprs: [Expr], f: fn[Env](Expr) -> Option<Expr>) -> [Expr] {
-    exprs.map(|expr: Expr| expr.modify(f))
+    exprs.map(|expr| expr.modify(f))
 }
 
 comptime fn new_array(exprs: [Expr]) -> Expr {
@@ -554,12 +533,7 @@ comptime fn new_comptime(exprs: [Expr]) -> Expr {
 }
 
 comptime fn new_constructor(typ: UnresolvedType, fields: [(Quoted, Expr)]) -> Expr {
-    let fields = fields
-        .map(|field: (Quoted, Expr)| {
-            let (name, value) = field;
-            quote { $name: $value }
-        })
-        .join(quote { , });
+    let fields = fields.map(|(name, value)| quote { $name: $value }).join(quote { , });
     quote { $typ { $fields }}.as_expr().unwrap()
 }
 
@@ -590,8 +564,7 @@ comptime fn new_lambda(
     body: Expr,
 ) -> Expr {
     let params = params
-        .map(|param: (Expr, Option<UnresolvedType>)| {
-            let (name, typ) = param;
+        .map(|(name, typ)| {
             if typ.is_some() {
                 let typ = typ.unwrap();
                 quote { $name: $typ }
@@ -678,5 +651,5 @@ comptime fn new_unsafe(exprs: [Expr]) -> Expr {
 }
 
 comptime fn join_expressions(exprs: [Expr], separator: Quoted) -> Quoted {
-    exprs.map(|expr: Expr| expr.quoted()).join(separator)
+    exprs.map(|expr| expr.quoted()).join(separator)
 }

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -101,10 +101,7 @@ pub comptime fn make_trait_impl<Env1, Env2>(
     let where_clause = s.generics().map(|name| quote { $name: $trait_name }).join(quote {,});
 
     // `for_each_field(field1) $join_fields_with for_each_field(field2) $join_fields_with ...`
-    let fields = s.fields_as_written().map(|f: (Quoted, Type)| {
-        let name = f.0;
-        for_each_field(name)
-    });
+    let fields = s.fields_as_written().map(|(name, _)| for_each_field(name));
     let body = body(fields.join(join_fields_with));
 
     quote {

--- a/test_programs/compile_success_empty/inject_context_attribute/src/main.nr
+++ b/test_programs/compile_success_empty/inject_context_attribute/src/main.nr
@@ -40,19 +40,16 @@ comptime fn inject_context(f: FunctionDefinition) {
 }
 
 comptime fn mapping_function(expr: Expr, f: FunctionDefinition) -> Option<Expr> {
-    expr.as_function_call().and_then(|func_call: (Expr, [Expr])| {
-        let (name, arguments) = func_call;
-        name.resolve(Option::some(f)).as_function_definition().and_then(
-            |function_definition: FunctionDefinition| {
-                if function_definition.has_named_attribute("inject_context") {
-                    let arguments = arguments.push_front(quote { _context }.as_expr().unwrap());
-                    let arguments = arguments.map(|arg: Expr| arg.quoted()).join(quote { , });
-                    Option::some(quote { $name($arguments) }.as_expr().unwrap())
-                } else {
-                    Option::none()
-                }
-            },
-        )
+    expr.as_function_call().and_then(|(name, arguments)| {
+        name.resolve(Option::some(f)).as_function_definition().and_then(|function_definition| {
+            if function_definition.has_named_attribute("inject_context") {
+                let arguments = arguments.push_front(quote { _context }.as_expr().unwrap());
+                let arguments = arguments.map(|arg| arg.quoted()).join(quote { , });
+                Option::some(quote { $name($arguments) }.as_expr().unwrap())
+            } else {
+                Option::none()
+            }
+        })
     })
 }
 

--- a/test_programs/compile_success_empty/trait_generics/src/main.nr
+++ b/test_programs/compile_success_empty/trait_generics/src/main.nr
@@ -24,7 +24,7 @@ where
     T: MyInto<U>,
 {
     fn into(self) -> [U; N] {
-        self.map(|x: T| x.into())
+        self.map(|x| x.into())
     }
 }
 

--- a/test_programs/compile_success_empty/unquote_struct/src/main.nr
+++ b/test_programs/compile_success_empty/unquote_struct/src/main.nr
@@ -10,14 +10,7 @@ fn foo(x: Field, y: u32) -> u32 {
 
 // Given a function, wrap its parameters in a struct definition
 comptime fn output_struct(f: FunctionDefinition) -> Quoted {
-    let fields = f
-        .parameters()
-        .map(|param: (Quoted, Type)| {
-            let name = param.0;
-            let typ = param.1;
-            quote { $name: $typ, }
-        })
-        .join(quote {});
+    let fields = f.parameters().map(|(name, typ)| quote { $name: $typ, }).join(quote {});
 
     quote {
         struct Foo { $fields }

--- a/test_programs/noir_test_success/comptime_expr/src/main.nr
+++ b/test_programs/noir_test_success/comptime_expr/src/main.nr
@@ -761,8 +761,7 @@ mod tests {
     }
 
     comptime fn times_two(expr: Expr) -> Option<Expr> {
-        expr.as_integer().and_then(|integer: (Field, bool)| {
-            let (value, _) = integer;
+        expr.as_integer().and_then(|(value, _)| {
             let value = value * 2;
             quote { $value }.as_expr()
         })


### PR DESCRIPTION
# Description

## Problem

No issue, just a limitation of the language before this PR, which is that lambdas in calls always require their parameters to have type annotations (unlike Rust).

## Summar

I've been thinking for days how we could have lambda parameter types be "inferred" from the call they are being passed to.

The first thing that came to my mind is that lambdas are most commonly passed as callbacks after invoking a method on `self`, where either `self` or a part of `self` is given to the lambda (like `Option::map`, `BoundedVec::map`, etc.). So the first thing that I tried in this PR is to eagerly unify a method call's function type with the object type. Then, when elaborating a lambda as a method call argument we pass the potential parameter types of a function type that is in that call position:

```noir
fn map<U>(&self, f: fn(T) -> U) { ... }
                    ^
                  this

self.map(|x| ...)
          ^
    has to unify with this
```

Then these types are unified, without erroring because later we'll check the type of the lambda against the argument anyway.

And... that worked! And that already covers a lot of cases.

Then I did the same thing for function calls, except that there's no `self`, but at least it now works if a callback has a concrete type, like if it's:

```noir
fn foo(f: fn(Foo) -> ...
```

And that worked too! Though I'm not sure there are many uses of that...

BUT: it didn't work in the code Nico shared in Slack, because it's a function call where the first argument given is like a self type, except that it's not a method all:

```noir
for_each_in_bounded_vec(
    discovered_notes,
    |discovered_note, _| {
    })
```

So the final thing I did was to eagerly try to unify argument types as we elaborate them against the target function type. And that made that example work!

It won't work if the lambda comes before the argument (which works in Rust) but I think that pattern is uncommon (though we could try to make it work in the future).

## Additional Context

I don't know if this is the right way to approach this.

I also don't know if unifying eagerly would cause any issues. One thing that's not done here is using "unify_with_coercions", but given that we don't issue the errors that happens in these eager checks, maybe it's fine (maybe it won't work in cases where an array is automatically converted to a slice, though I guess we could make it work in the future).

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
