### PR TITLE
chore(ssa): Use correct prefix when printing array values in global space

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -169,13 +169,14 @@ fn display_instruction(
         write!(f, "{} = ", value_list)?;
     }
 
-    display_instruction_inner(dfg, &dfg[instruction], results, f)
+    display_instruction_inner(dfg, &dfg[instruction], results, in_global_space, f)
 }
 
 fn display_instruction_inner(
     dfg: &DataFlowGraph,
     instruction: &Instruction,
     results: &[ValueId],
+    in_global_space: bool,
     f: &mut Formatter,
 ) -> Result {
     let show = |id| value(dfg, id);
@@ -286,7 +287,11 @@ fn display_instruction_inner(
                 if i != 0 {
                     write!(f, ", ")?;
                 }
-                write!(f, "{}", show(*element))?;
+                let mut value = show(*element);
+                if in_global_space {
+                    value = value.replace('v', "g");
+                }
+                write!(f, "{}", value)?;
             }
 
             writeln!(f, "] : {typ}")


### PR DESCRIPTION
# Description

## Problem\*

No issue just little thing I found that was bugging me. 

Printing global arrays currently looks like this:
```
g0 = Field 1
g1 = make_array [Field 1, Field 1] : [Field; 2]
g2 = Field 0
g3 = make_array [Field 0, Field 0] : [Field; 2]
g4 = make_array [v1, v3] : [[Field; 2]; 2]
```
However, the last line should look like this: `g4 = make_array [g1, g3] : [[Field; 2]; 2]`

## Summary\*

I account for whether we are in the global space when printing elements from MakeArray. 

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
