### PR TITLE
fix: Simplify defunctionalize return

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -440,9 +440,7 @@ mod tests {
             b1():
               constrain v0 == Field 3
               v8 = call f3(v1) -> u32
-              jmp b2(v8)
-            b2(v2: u32):
-              jmp b4(v2)
+              jmp b4(v8)
             b3():
               v10 = call f2(v1) -> u32
               jmp b4(v10)

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -434,17 +434,17 @@ mod tests {
           }
           brillig(inline) fn apply f4 {
             b0(v0: Field, v1: u32):
-              v5 = eq v0, Field 2
-              jmpif v5 then: b3, else: b1
+              v4 = eq v0, Field 2
+              jmpif v4 then: b2, else: b1
             b1():
               constrain v0 == Field 3
-              v8 = call f3(v1) -> u32
-              jmp b4(v8)
-            b3():
-              v10 = call f2(v1) -> u32
-              jmp b4(v10)
-            b4(v3: u32):
-              return v3
+              v7 = call f3(v1) -> u32
+              jmp b3(v7)
+            b2():
+              v9 = call f2(v1) -> u32
+              jmp b3(v9)
+            b3(v2: u32):
+              return v2
           }
         ";
         assert_normalized_ssa_equals(ssa, expected);

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -343,22 +343,21 @@ fn create_apply_function(
     })
 }
 
-/// Crates a return block, if no previous return exists, it will create a final return
-/// Else, it will create a bypass return block that points to the previous return block
+/// If no previous return target exists, it will create a final return,
+/// otherwise returns the existing return block to jump to.
 fn build_return_block(
     builder: &mut FunctionBuilder,
     previous_block: BasicBlockId,
     passed_types: &[Type],
     target: Option<BasicBlockId>,
 ) -> BasicBlockId {
+    if let Some(return_block) = target {
+        return return_block;
+    }
     let return_block = builder.insert_block();
     builder.switch_to_block(return_block);
-
     let params = vecmap(passed_types, |typ| builder.add_block_parameter(return_block, typ.clone()));
-    match target {
-        None => builder.terminate_with_return(params),
-        Some(target) => builder.terminate_with_jmp(target, params),
-    }
+    builder.terminate_with_return(params);
     builder.switch_to_block(previous_block);
     return_block
 }


### PR DESCRIPTION
# Description

## Problem\*

Extracted from https://github.com/noir-lang/noir/pull/7072
Depends on https://github.com/noir-lang/noir/pull/7100 to fix SSA parsing

## Summary\*

Skips the creation of unnecessary blocks in the `apply` functions during `defunctionalize`, jumping straight to the return block.

## Additional Context

At the time I thought it might play a role in the inlining cost calculation, although it might not do so, as the final jumps are not considered actual instructions I think. These blocks would be removed by a `simplify` pass, but I didn't see a reason they should be generated in the first place.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
