### PR TITLE
chore: Formatting issues / minor errors in the docs

### DIFF
--- a/docs/docs/getting_started/quick_start.md
+++ b/docs/docs/getting_started/quick_start.md
@@ -114,7 +114,7 @@ bb verify -k ./target/vk -p ./target/proof
 
 Notice that in order to verify a proof, the verifier knows nothing but the circuit, which is compiled and used to generate the verification key. This is obviously quite important: private inputs remain private.
 
-As for the public inputs, you may have noticed they haven't been specified. This behavior varies with each particular backend, but barretenberg typically attaches them to the proof. You can see them by parsing and splitting it. For example for if your public inputs are 32 bytes:
+As for the public inputs, you may have noticed they haven't been specified. This behavior varies with each particular backend, but barretenberg typically attaches them to the proof. You can see them by parsing and splitting it. For example if your public inputs are 32 bytes:
 
 ```bash
 head -c 32 ./target/proof | od -An -v -t x1 | tr -d $' \n'

--- a/docs/docs/getting_started/quick_start.md
+++ b/docs/docs/getting_started/quick_start.md
@@ -68,6 +68,7 @@ We can now use `nargo` to generate a _Prover.toml_ file, where our input values 
 ```sh
 cd hello_world
 nargo check
+```
 
 Let's feed some valid values into this file:
 

--- a/docs/docs/noir/concepts/data_types/slices.mdx
+++ b/docs/docs/noir/concepts/data_types/slices.mdx
@@ -75,7 +75,7 @@ View the corresponding test file [here][test-file].
 
 ### pop_front
 
-Returns a tuple of two items, the first element of the array and the rest of the array.
+Returns a tuple of two items, the first element of the slice and the rest of the slice.
 
 ```rust
 fn pop_front(_self: Self) -> (T, Self)
@@ -91,7 +91,7 @@ View the corresponding test file [here][test-file].
 
 ### pop_back
 
-Returns a tuple of two items, the beginning of the array with the last element omitted and the last element.
+Returns a tuple of two items, the beginning of the slice with the last element omitted and the last element.
 
 ```rust
 fn pop_back(_self: Self) -> (Self, T)

--- a/docs/docs/noir/concepts/data_types/slices.mdx
+++ b/docs/docs/noir/concepts/data_types/slices.mdx
@@ -57,7 +57,7 @@ View the corresponding test file [here][test-file].
 
 ### push_front
 
-Returns a new array with the specified element inserted at index 0. The existing elements indexes are incremented by 1.
+Returns a new slice with the specified element inserted at index 0. The existing elements indexes are incremented by 1.
 
 ```rust
 fn push_front(_self: Self, _elem: T) -> Self

--- a/docs/docs/noir/concepts/generics.md
+++ b/docs/docs/noir/concepts/generics.md
@@ -36,6 +36,7 @@ impl<let N: u32> BigInt<N> {
     fn first(first: BigInt<N>, second: BigInt<N>) -> Self {
         assert(first.limbs != second.limbs);
         first
+    }
 
     fn second(first: BigInt<N>, second: Self) -> Self {
         assert(first.limbs != second.limbs);

--- a/docs/docs/noir/concepts/generics.md
+++ b/docs/docs/noir/concepts/generics.md
@@ -163,9 +163,9 @@ fn example() {
     // there is no matching impl for `u32: MyTrait`. 
     //
     // Substituting the `10` on the left hand side of this assert
-    // with `10 as u32` would also fail with a type mismatch as we 
+    // with `10 as u32` would fail with a type mismatch as we 
     // are expecting a `Field` from the right hand side.
-    assert(10 as u32 == foo.generic_method::<Field>());
+    assert(10 == foo.generic_method::<Field>());
 }
 ```
 

--- a/docs/docs/noir/concepts/generics.md
+++ b/docs/docs/noir/concepts/generics.md
@@ -97,7 +97,17 @@ fn main() {
     // We can use first_element_is_equal for arrays of any type
     // as long as we have an Eq impl for the types we pass in
     let array = [MyStruct::new(), MyStruct::new()];
-    assert(array_eq(array, array, MyStruct::eq));
+    assert(first_element_is_equal(array, array));
+}
+
+struct MyStruct {
+    foo: Field
+}
+
+impl MyStruct {
+    fn new() -> Self {
+        MyStruct { foo: 0 }
+    }
 }
 
 impl Eq for MyStruct {


### PR DESCRIPTION
# Description
Suggestions of minor changes in docs

## Problem

1. Some code section was not properly formatted due to missing ``` in quick start page
2. An extra word `for` in section of quick start page
3. `push_front` says to return an `array`
4. `pop_front` & `pop_back` say to return `array`s
5. Missing `}` in a code section in generics page
6. Calling functions with generic parameters is not executable and the comments doesn't match the code
7. Example in tubofish operator section doesn't match the comment

## Summary
1. Added the missing ``` 
2. Removed the extra word
3. Changed to `slice`
4. Changed to `slice`
5. Added the `}` 
6. Added `MyStruct` implementation and changed `main` last assert to match the comment
7. Updated the code to match the comment


## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
