### PR TITLE
feat(ssa): Add flag to DIE pass to be able to keep `store` instructions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -10,7 +10,7 @@ use fxhash::FxHasher64;
 use iter_extended::vecmap;
 use noirc_frontend::hir_def::types::Type as HirType;
 
-use crate::ssa::{ir::function::RuntimeType, opt::flatten_cfg::value_merger::ValueMerger};
+use crate::ssa::opt::flatten_cfg::value_merger::ValueMerger;
 
 use super::{
     basic_block::BasicBlockId,
@@ -506,7 +506,7 @@ impl Instruction {
         }
     }
 
-    pub(crate) fn can_eliminate_if_unused(&self, function: &Function) -> bool {
+    pub(crate) fn can_eliminate_if_unused(&self, function: &Function, flattened: bool) -> bool {
         use Instruction::*;
         match self {
             Binary(binary) => {
@@ -539,8 +539,7 @@ impl Instruction {
             // pass where this check is done, but does mean that we cannot perform mem2reg
             // after the DIE pass.
             Store { .. } => {
-                matches!(function.runtime(), RuntimeType::Acir(_))
-                    && function.reachable_blocks().len() == 1
+                flattened && function.runtime().is_acir() && function.reachable_blocks().len() == 1
             }
 
             Constrain(..)

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -990,7 +990,7 @@ fn brillig_bytecode_size(function: &Function) -> usize {
     simplify_between_unrolls(&mut temp);
 
     // This is to try to prevent hitting ICE.
-    temp.dead_instruction_elimination(false);
+    temp.dead_instruction_elimination(false, true);
 
     convert_ssa_function(&temp, false).byte_code.len()
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/7104

## Summary\*

Adds a `flattened` flag to `Function::dead_instruction_elimination` which is passed to `Instruction::can_eliminate_if_unused` to prevent [this assumption](https://github.com/noir-lang/noir/blob/a6685befe3b103b236997843f69afc07b6ea0a8c/compiler/noirc_evaluator/src/ssa/ir/instruction.rs#L534-L544) from removing the `store` instruction before the inlining, the flattening of the CFG, and mem2reg passes have happened. Thanks @vezenovm for the pointer!

## Additional Context

Originally I thought I would have to track `&mut` block parameters as "use", but the assumptions listed in `can_eliminate_in_unused` suggested that `store` _must_ be removed from ACIR, and to stop that from happening it's enough to give it more information, so it doesn't infer whether other passes happened already based on the number of blocks in the function.

It looked like tracking `&mut` parameters as "use" would be a bigger change, since only [instruction results](https://github.com/noir-lang/noir/blob/a6685befe3b103b236997843f69afc07b6ea0a8c/compiler/noirc_evaluator/src/ssa/opt/die.rs#L177) are checked for use at the moment. Maybe there are other cases which would better be handled that way?

For the use case of https://github.com/noir-lang/noir/pull/7072 I thought we'd just call the function with `false` and be done with it.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
