### PR TITLE
feat: avoid unnecessary memory allocations in brillig VM

### DIFF
--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -273,10 +273,12 @@ impl<F: AcirField> Memory<F> {
     }
 
     fn resize_to_fit(&mut self, size: usize) {
-        // Calculate new memory size
-        let new_size = std::cmp::max(self.inner.len(), size);
-        // Expand memory to new size with default values if needed
-        self.inner.resize(new_size, MemoryValue::default());
+        let current_size = self.inner.len();
+        if size >= current_size {
+            // Expand memory to new size with default values if needed
+            let additional = size - current_size;
+            self.inner.reserve(additional);
+        }
     }
 
     /// Sets the values after `address` to `values`


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I noticed that we're doing a lot of resizing of the underlying vec when writing to memory. 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
