### PR TITLE
fix: don't always use an exclusive lock in `nargo check`

### DIFF
--- a/tooling/nargo_cli/src/cli/check_cmd.rs
+++ b/tooling/nargo_cli/src/cli/check_cmd.rs
@@ -26,7 +26,7 @@ pub(crate) struct CheckCommand {
 
     /// Force overwrite of existing files
     #[clap(long = "overwrite")]
-    allow_overwrite: bool,
+    pub(super) allow_overwrite: bool,
 
     #[clap(flatten)]
     compile_options: CompileOptions,

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -224,10 +224,14 @@ fn command_dir(cmd: &NargoCommand, program_dir: &Path) -> Result<Option<PathBuf>
     Ok(Some(nargo_toml::find_root(program_dir, workspace)?))
 }
 
+/// Returns:
+/// - `Some(true)` if an exclusive lock is needed
+/// - `Some(false)` if an read lock is needed
+/// - None if no lock is needed
 fn needs_lock(cmd: &NargoCommand) -> Option<bool> {
     match cmd {
-        NargoCommand::Check(..)
-        | NargoCommand::Compile(..)
+        NargoCommand::Check(check_command) => Some(check_command.allow_overwrite),
+        NargoCommand::Compile(..)
         | NargoCommand::Execute(..)
         | NargoCommand::Export(..)
         | NargoCommand::Info(..) => Some(true),


### PR DESCRIPTION
# Description

## Problem

Resolves #7118

## Summary\*



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
