### PR TITLE
fix: allow calling trait impl method from struct if multiple impls exist

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -738,7 +738,10 @@ impl<'context> Elaborator<'context> {
             span: before_last_segment.turbofish_span(),
         });
         let item = PathResolutionItem::TraitFunction(trait_id, turbofish, func_id);
-        let errors = if let Some(error) = error { vec![error] } else { Vec::new() };
+        let mut errors = path_resolution.errors;
+        if let Some(error) = error {
+            errors.push(error);
+        }
         Some(TraitPathResolution { method, item: Some(item), errors })
     }
 

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -186,22 +186,22 @@ impl Trait {
         (ordered, named)
     }
 
-    /// Returns a TraitConstraint for this trait using Self as the object
-    /// type and the uninstantiated generics for any trait generics.
-    pub fn as_constraint(&self, span: Span) -> TraitConstraint {
+    pub fn get_trait_generics(&self, span: Span) -> TraitGenerics {
         let ordered = vecmap(&self.generics, |generic| generic.clone().as_named_generic());
         let named = vecmap(&self.associated_types, |generic| {
             let name = Ident::new(generic.name.to_string(), span);
             NamedType { name, typ: generic.clone().as_named_generic() }
         });
+        TraitGenerics { ordered, named }
+    }
 
+    /// Returns a TraitConstraint for this trait using Self as the object
+    /// type and the uninstantiated generics for any trait generics.
+    pub fn as_constraint(&self, span: Span) -> TraitConstraint {
+        let trait_generics = self.get_trait_generics(span);
         TraitConstraint {
             typ: Type::TypeVariable(self.self_type_typevar.clone()),
-            trait_bound: ResolvedTraitBound {
-                trait_generics: TraitGenerics { ordered, named },
-                trait_id: self.id,
-                span,
-            },
+            trait_bound: ResolvedTraitBound { trait_generics, trait_id: self.id, span },
         }
     }
 }

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1365,3 +1365,32 @@ fn calls_trait_method_using_struct_name_when_multiple_impls_exist() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn calls_trait_method_using_struct_name_when_multiple_impls_exist_and_errors_turbofish() {
+    let src = r#"
+    trait From2<T> {
+        fn from2(input: T) -> Self;
+    }
+    struct U60Repr {}
+    impl From2<[Field; 3]> for U60Repr {
+        fn from2(_: [Field; 3]) -> Self {
+            U60Repr {}
+        }
+    }
+    impl From2<Field> for U60Repr {
+        fn from2(_: Field) -> Self {
+            U60Repr {}
+        }
+    }
+    fn main() {
+        let _ = U60Repr::<Field>::from2([1, 2, 3]);
+    }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        errors[0].0,
+        CompilationError::TypeError(TypeCheckError::TypeMismatch { .. })
+    ));
+}

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1341,9 +1341,7 @@ fn regression_6530() {
     assert_eq!(errors.len(), 0);
 }
 
-// See https://github.com/noir-lang/noir/issues/7090
 #[test]
-#[should_panic]
 fn calls_trait_method_using_struct_name_when_multiple_impls_exist() {
     let src = r#"
     trait From2<T> {


### PR DESCRIPTION
# Description

## Problem

Resolves #7090

## Summary

Try to solve `Struct::method` in a special way like we solve `Trait::method` in a special way.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
