### PR TITLE
fix: proper cleanup when breaking from comptime loop on error

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1730,17 +1730,21 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             self.push_scope();
             self.current_scope_mut().insert(for_.identifier.id, make_value(i));
 
-            match self.evaluate(for_.block) {
-                Ok(_) => (),
-                Err(InterpreterError::Break) => break,
-                Err(InterpreterError::Continue) => continue,
+            let must_break = match self.evaluate(for_.block) {
+                Ok(_) => false,
+                Err(InterpreterError::Break) => true,
+                Err(InterpreterError::Continue) => false,
                 Err(error) => {
                     result = Err(error);
-                    break;
+                    true
                 }
-            }
+            };
 
             self.pop_scope();
+
+            if must_break {
+                break;
+            }
         }
 
         self.in_loop = was_in_loop;
@@ -1756,17 +1760,21 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         loop {
             self.push_scope();
 
-            match self.evaluate(expr) {
-                Ok(_) => (),
-                Err(InterpreterError::Break) => break,
-                Err(InterpreterError::Continue) => continue,
+            let must_break = match self.evaluate(expr) {
+                Ok(_) => false,
+                Err(InterpreterError::Break) => true,
+                Err(InterpreterError::Continue) => false,
                 Err(error) => {
                     result = Err(error);
-                    break;
+                    true
                 }
-            }
+            };
 
             self.pop_scope();
+
+            if must_break {
+                break;
+            }
 
             counter += 1;
             if in_lsp && counter == 10_000 {


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/pull/7096#discussion_r1922597178

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
