### PR TITLE
chore: fix typo in types.rs

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -2199,7 +2199,7 @@ impl Type {
         }
 
         let recur_on_binding = |id, replacement: &Type| {
-            // Prevent recuring forever if there's a `T := T` binding
+            // Prevent recurring forever if there's a `T := T` binding
             if replacement.type_variable_id() == Some(id) {
                 replacement.clone()
             } else {


### PR DESCRIPTION
# Multiple Typo Fixes Across Files

## Description

This pull request addresses various typographical errors across four different files in the repository. Each fix enhances the clarity and professionalism of the comments and documentation.

### Summary of Changes

#### **File:** `compiler/noirc_frontend/src/hir_def/types.rs`
- **Typo:** "recuring" corrected to "recurring."
  - **Original:** `Prevent recuring forever...`
  - **Corrected:** `Prevent recurring forever...`

#### **File:** `test_programs/compile_success_empty/trait_method_mut_self/src/main.nr`
- **Typo:** "Curently" corrected to "Currently."
  - **Original:** `TODO: Curently, without the annotation...`
  - **Corrected:** `TODO: Currently, without the annotation...`

#### **File:** `test_programs/execution_success/brillig_conditional/src/main.nr`
- **Typo:** "conditonal" corrected to "conditional."
  - **Original:** `The features being tested is basic conditonal on brillig`
  - **Corrected:** `The features being tested is basic conditional on brillig`

#### **File:** `tooling/nargo_fmt/src/formatter/use_tree_merge.rs`
- **Typo:** "loosing" corrected to "losing."
  - **Original:** `result in just "foo::bar", loosing "foo"`
  - **Corrected:** `result in just "foo::bar", losing "foo"`



