### PR TITLE
Multiple Typo Fixes Across Files

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -2199,7 +2199,7 @@ impl Type {
         }
 
         let recur_on_binding = |id, replacement: &Type| {
-            // Prevent recuring forever if there's a `T := T` binding
+            // Prevent recurring forever if there's a `T := T` binding
             if replacement.type_variable_id() == Some(id) {
                 replacement.clone()
             } else {

--- a/test_programs/compile_success_empty/trait_method_mut_self/src/main.nr
+++ b/test_programs/compile_success_empty/trait_method_mut_self/src/main.nr
@@ -71,7 +71,7 @@ where
 {
     // Check that we can call a trait method instead of a trait implementation
     // TODO: Need to remove the need for this type annotation
-    // TODO: Curently, without the annotation we will get `Expression type is ambiguous` when trying to use the `hasher`
+    // TODO: Currently, without the annotation we will get `Expression type is ambiguous` when trying to use the `hasher`
     let mut hasher: H = H::default();
     // Regression that the object is converted to a mutable reference type `&mut _`.
     // Otherwise will see `Expected type &mut _, found type H`.

--- a/test_programs/execution_success/brillig_conditional/src/main.nr
+++ b/test_programs/execution_success/brillig_conditional/src/main.nr
@@ -1,6 +1,6 @@
 // Tests a very simple program.
 //
-// The features being tested is basic conditonal on brillig
+// The features being tested is basic conditional on brillig
 fn main(x: Field) {
     /// Safety: testing context
     unsafe {

--- a/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
@@ -122,7 +122,7 @@ enum Segment {
     /// Represents the end of a path.
     /// This is needed because we have want to merge "foo" and "foo::bar",
     /// we need to know that "foo" is the end of a path, and "foo::bar" is another one.
-    /// If we don't, merging "foo" and "foo::bar" will result in just "foo::bar", loosing "foo",
+    /// If we don't, merging "foo" and "foo::bar" will result in just "foo::bar", losing "foo",
     /// when we actually want "foo::{self, bar}".
     SelfReference,
     Crate,


### PR DESCRIPTION
# Multiple Typo Fixes Across Files

## Description

This pull request addresses various typographical errors across four different files in the repository. Each fix enhances the clarity and professionalism of the comments and documentation.

### Summary of Changes

#### **File:** `compiler/noirc_frontend/src/hir_def/types.rs`
- **Typo:** "recuring" corrected to "recurring."
  - **Original:** `Prevent recuring forever...`
  - **Corrected:** `Prevent recurring forever...`

#### **File:** `test_programs/compile_success_empty/trait_method_mut_self/src/main.nr`
- **Typo:** "Curently" corrected to "Currently."
  - **Original:** `TODO: Curently, without the annotation...`
  - **Corrected:** `TODO: Currently, without the annotation...`

#### **File:** `test_programs/execution_success/brillig_conditional/src/main.nr`
- **Typo:** "conditonal" corrected to "conditional."
  - **Original:** `The features being tested is basic conditonal on brillig`
  - **Corrected:** `The features being tested is basic conditional on brillig`

#### **File:** `tooling/nargo_fmt/src/formatter/use_tree_merge.rs`
- **Typo:** "loosing" corrected to "losing."
  - **Original:** `result in just "foo::bar", loosing "foo"`
  - **Corrected:** `result in just "foo::bar", losing "foo"`

### Why These Fixes Are Important

- Improves code comments and documentation quality for better understanding.
- Reflects professionalism in codebase standards.
- Reduces potential confusion for contributors and users referencing the code.

## Checklist

- [x] Identified and corrected all typos listed above.
- [x] Verified no additional typos were introduced in this process.
- [x] Followed the [contributing guidelines](https://github.com/noir-lang/noir/blob/master/CONTRIBUTING.md).

---

### Notes for Reviewers

These changes are minor and non-functional, only affecting comments and documentation. Let me know if there are additional revisions or improvements you'd like. Thank you for reviewing!
