### PR TITLE
feat(stdlib): Make Hasher trait generic over input type

### DIFF
--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -152,23 +152,23 @@ comptime fn derive_hash(s: StructDefinition) -> Quoted {
 // docs:end:derive_hash
 
 // Hasher trait shall be implemented by algorithms to provide hash-agnostic means.
-pub trait Hasher<T> {
+pub trait Hasher<T: Hash> {
     fn finish(self) -> Field;
 
     fn write(&mut self, input: T);
 }
 
 // BuildHasher is a factory trait, responsible for production of specific Hasher.
-pub trait BuildHasher<H, T>
+pub trait BuildHasher<H, T: Hash>
 where
     H: Hasher<T>,
 {
     fn build_hasher(self) -> H;
 }
 
-pub struct BuildHasherDefault<H, T>;
+pub struct BuildHasherDefault<H, T: Hash>;
 
-impl<H, T> BuildHasher<H, T> for BuildHasherDefault<H, T>
+impl<H, T: Hash> BuildHasher<H, T> for BuildHasherDefault<H, T>
 where
     H: Hasher<T> + Default,
 {
@@ -177,7 +177,7 @@ where
     }
 }
 
-impl<H, T> Default for BuildHasherDefault<H, T>
+impl<H, T: Hash> Default for BuildHasherDefault<H, T>
 where
     H: Hasher<T> + Default,
 {

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -80,7 +80,7 @@ pub fn derive_generators<let N: u32, let M: u32>(
     starting_index: u32,
 ) -> [EmbeddedCurvePoint; N] {
     crate::assert_constant(domain_separator_bytes);
-    // TODO(https://github.com/noir-lang/noir/issues/5672): Add back assert_constant on starting_index
+    crate::assert_constant(starting_index);
     __derive_generators(domain_separator_bytes, starting_index)
 }
 
@@ -132,7 +132,7 @@ pub fn poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32)
 pub trait Hash {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>;
+        H: Hasher;
 }
 
 // docs:start:derive_hash
@@ -152,34 +152,33 @@ comptime fn derive_hash(s: StructDefinition) -> Quoted {
 // docs:end:derive_hash
 
 // Hasher trait shall be implemented by algorithms to provide hash-agnostic means.
-pub trait Hasher<T: Hash> {
+pub trait Hasher {
     fn finish(self) -> Field;
-
-    fn write(&mut self, input: T);
+    fn write(&mut self, input: Field);
 }
 
 // BuildHasher is a factory trait, responsible for production of specific Hasher.
-pub trait BuildHasher<H, T: Hash>
+pub trait BuildHasher<H>
 where
-    H: Hasher<T>,
+    H: Hasher,
 {
     fn build_hasher(self) -> H;
 }
 
-pub struct BuildHasherDefault<H, T: Hash>;
+pub struct BuildHasherDefault<H>;
 
-impl<H, T: Hash> BuildHasher<H, T> for BuildHasherDefault<H, T>
+impl<H> BuildHasher<H> for BuildHasherDefault<H>
 where
-    H: Hasher<T> + Default,
+    H: Hasher + Default,
 {
     fn build_hasher(_self: Self) -> H {
         H::default()
     }
 }
 
-impl<H, T: Hash> Default for BuildHasherDefault<H, T>
+impl<H> Default for BuildHasherDefault<H>
 where
-    H: Hasher<T> + Default,
+    H: Hasher + Default,
 {
     fn default() -> Self {
         BuildHasherDefault {}
@@ -189,116 +188,107 @@ where
 impl Hash for Field {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self);
-    }
-}
-
-impl Hash for u1 {
-    fn hash<H>(self, state: &mut H)
-    where
-        H: Hasher<Field>,
-    {
-        H::write(state, self as Field);
+        state.write(self);
     }
 }
 
 impl Hash for u8 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for u16 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for u32 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for u64 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for i8 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for i16 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for i32 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for i64 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for bool {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self as Field);
+        state.write(self as Field);
     }
 }
 
 impl Hash for () {
     fn hash<H>(_self: Self, _state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {}
 }
 
 impl Hash for U128 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
-        H::write(state, self.lo as Field);
-        H::write(state, self.hi as Field);
+        state.write(self.lo as Field);
+        state.write(self.hi as Field);
     }
 }
 
@@ -308,7 +298,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
         for elem in self {
             elem.hash(state);
@@ -322,7 +312,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
         self.len().hash(state);
         for elem in self {
@@ -338,7 +328,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
         self.0.hash(state);
         self.1.hash(state);
@@ -353,7 +343,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
         self.0.hash(state);
         self.1.hash(state);
@@ -370,7 +360,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
         self.0.hash(state);
         self.1.hash(state);
@@ -389,7 +379,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher<Field>,
+        H: Hasher,
     {
         self.0.hash(state);
         self.1.hash(state);

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -132,7 +132,7 @@ pub fn poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32)
 pub trait Hash {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher;
+        H: Hasher<Field>;
 }
 
 // docs:start:derive_hash
@@ -152,35 +152,34 @@ comptime fn derive_hash(s: StructDefinition) -> Quoted {
 // docs:end:derive_hash
 
 // Hasher trait shall be implemented by algorithms to provide hash-agnostic means.
-// TODO: consider making the types generic here ([u8], [Field], etc.)
-pub trait Hasher {
+pub trait Hasher<T> {
     fn finish(self) -> Field;
 
-    fn write(&mut self, input: Field);
+    fn write(&mut self, input: T);
 }
 
 // BuildHasher is a factory trait, responsible for production of specific Hasher.
-pub trait BuildHasher<H>
+pub trait BuildHasher<H, T>
 where
-    H: Hasher,
+    H: Hasher<T>,
 {
     fn build_hasher(self) -> H;
 }
 
-pub struct BuildHasherDefault<H>;
+pub struct BuildHasherDefault<H, T>;
 
-impl<H> BuildHasher<H> for BuildHasherDefault<H>
+impl<H, T> BuildHasher<H, T> for BuildHasherDefault<H, T>
 where
-    H: Hasher + Default,
+    H: Hasher<T> + Default,
 {
     fn build_hasher(_self: Self) -> H {
         H::default()
     }
 }
 
-impl<H> Default for BuildHasherDefault<H>
+impl<H, T> Default for BuildHasherDefault<H, T>
 where
-    H: Hasher + Default,
+    H: Hasher<T> + Default,
 {
     fn default() -> Self {
         BuildHasherDefault {}
@@ -190,7 +189,7 @@ where
 impl Hash for Field {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self);
     }
@@ -199,7 +198,7 @@ impl Hash for Field {
 impl Hash for u1 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -208,7 +207,7 @@ impl Hash for u1 {
 impl Hash for u8 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -217,7 +216,7 @@ impl Hash for u8 {
 impl Hash for u16 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -226,7 +225,7 @@ impl Hash for u16 {
 impl Hash for u32 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -235,7 +234,7 @@ impl Hash for u32 {
 impl Hash for u64 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -244,7 +243,7 @@ impl Hash for u64 {
 impl Hash for i8 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -253,7 +252,7 @@ impl Hash for i8 {
 impl Hash for i16 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -262,7 +261,7 @@ impl Hash for i16 {
 impl Hash for i32 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -271,7 +270,7 @@ impl Hash for i32 {
 impl Hash for i64 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -280,7 +279,7 @@ impl Hash for i64 {
 impl Hash for bool {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self as Field);
     }
@@ -289,14 +288,14 @@ impl Hash for bool {
 impl Hash for () {
     fn hash<H>(_self: Self, _state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {}
 }
 
 impl Hash for U128 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         H::write(state, self.lo as Field);
         H::write(state, self.hi as Field);
@@ -309,7 +308,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         for elem in self {
             elem.hash(state);
@@ -323,7 +322,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         self.len().hash(state);
         for elem in self {
@@ -339,7 +338,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         self.0.hash(state);
         self.1.hash(state);
@@ -354,7 +353,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         self.0.hash(state);
         self.1.hash(state);
@@ -371,7 +370,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         self.0.hash(state);
         self.1.hash(state);
@@ -390,7 +389,7 @@ where
 {
     fn hash<H>(self, state: &mut H)
     where
-        H: Hasher,
+        H: Hasher<Field>,
     {
         self.0.hash(state);
         self.1.hash(state);


### PR DESCRIPTION
~~Makes the Hasher trait generic with type parameter T to support different input types beyond Field.~~ This change:
- ~~Adds type parameter T to Hasher trait~~
- ~~Updates BuildHasher and BuildHasherDefault accordingly~~
- ~~Maintains backwards compatibility with existing Field implementations~~
- Removes TODO comment about generic types