### PR TITLE
fix: remove redundant condition in script in setStable.ts

### DIFF
--- a/docs/scripts/setStable.ts
+++ b/docs/scripts/setStable.ts
@@ -26,7 +26,7 @@ async function main() {
       ...data
         .filter(
           (release) =>
-            !release.prerelease && !release.tag_name.includes('aztec') && !release.tag_name.includes('aztec'),
+            !release.prerelease && !release.tag_name.includes('aztec'),
         )
         .filter((release) => !IGNORE_VERSIONS.includes(release.tag_name.replace('v', '')))
         .map((release) => release.tag_name),


### PR DESCRIPTION
# Description

## Problem\*

I noticed that the condition `!release.tag_name.includes('aztec')` was duplicated in the script.
This is unnecessary and makes the code harder to maintain.
I’ve removed the duplicate to clean it up and improve readability. The logic remains the same, just more concise.



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
