### PR TITLE
fix: preserve types when reading from calldata arrays

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -1334,7 +1334,7 @@ impl<'a> Context<'a> {
         typ: &Type,
     ) -> Result<AcirValue, RuntimeError> {
         match typ {
-            Type::Numeric(_) => self.array_get_value(&Type::field(), call_data_block, offset),
+            Type::Numeric(_) => self.array_get_value(typ, call_data_block, offset),
             Type::Array(arc, len) => {
                 let mut result = im::Vector::new();
                 for _i in 0..*len {

--- a/test_programs/execution_success/regression_7143/Nargo.toml
+++ b/test_programs/execution_success/regression_7143/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7143"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_7143/Prover.toml
+++ b/test_programs/execution_success/regression_7143/Prover.toml
@@ -1,0 +1,3 @@
+array = [0]
+x = 0
+return = 1

--- a/test_programs/execution_success/regression_7143/src/main.nr
+++ b/test_programs/execution_success/regression_7143/src/main.nr
@@ -1,0 +1,3 @@
+fn main(x: u32, array: call_data(0) [bool; 1]) -> pub bool {
+    !array[x]
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7143

## Summary\*

This pulls out a fix that @aakoshh made in the sync PR so we have a regression test for it.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
