### PR TITLE
chore: turn on overflow checks in CI rust tests

### DIFF
--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -52,7 +52,7 @@ jobs:
           tool: nextest@0.9.67
 
       - name: Build and archive tests
-        run: cargo nextest archive --workspace --release --archive-file nextest-archive.tar.zst
+        run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
       
       - name: Upload archive to workflow
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: x86_64-unknown-linux-gnu
+          key: x86_64-unknown-linux-gnu-debug
           cache-on-failure: true
           save-if: ${{ github.event_name != 'merge_group' }}
 

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -39,7 +39,7 @@ jobs:
           tool: nextest@0.9.67
 
       - name: Build and archive tests
-        run: cargo nextest archive --workspace --release --archive-file nextest-archive.tar.zst
+        run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
       
       - name: Upload archive to workflow
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

This PR runs all of our rust tests in debug mode so that we can catch overflows such as in #7143 which appear in tests.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
