### PR TITLE
feat(brillig): Set global memory size at program compile time

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -63,6 +63,7 @@ pub(crate) fn gen_brillig_for(
         FunctionContext::return_values(func),
         func.id(),
         true,
+        brillig.globals_memory_size,
     );
     entry_point.name = func.name().to_string();
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
@@ -10,7 +10,7 @@ pub(crate) fn convert_ssa_globals(
     enable_debug_trace: bool,
     globals: &Function,
     used_globals: &HashSet<ValueId>,
-) -> (BrilligArtifact<FieldElement>, HashMap<ValueId, BrilligVariable>) {
+) -> (BrilligArtifact<FieldElement>, HashMap<ValueId, BrilligVariable>, usize) {
     let mut brillig_context = BrilligContext::new_for_global_init(enable_debug_trace);
     // The global space does not have globals itself
     let empty_globals = HashMap::default();
@@ -32,8 +32,10 @@ pub(crate) fn convert_ssa_globals(
 
     brillig_block.compile_globals(&globals.dfg, used_globals);
 
+    let globals_size = brillig_block.brillig_context.global_space_size();
+
     brillig_context.return_instruction();
 
     let artifact = brillig_context.artifact();
-    (artifact, function_context.ssa_value_allocations)
+    (artifact, function_context.ssa_value_allocations, globals_size)
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -95,6 +95,8 @@ pub(crate) struct BrilligContext<F, Registers> {
     /// Whether this context can call procedures or not.
     /// This is used to prevent a procedure from calling another procedure.
     can_call_procedures: bool,
+
+    globals_memory_size: Option<usize>,
 }
 
 /// Regular brillig context to codegen user defined functions
@@ -108,6 +110,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
             next_section: 1,
             debug_show: DebugShow::new(enable_debug_trace),
             can_call_procedures: true,
+            globals_memory_size: None,
         }
     }
 }
@@ -211,6 +214,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, ScratchSpace> {
             next_section: 1,
             debug_show: DebugShow::new(enable_debug_trace),
             can_call_procedures: false,
+            globals_memory_size: None,
         }
     }
 }
@@ -226,7 +230,13 @@ impl<F: AcirField + DebugToString> BrilligContext<F, GlobalSpace> {
             next_section: 1,
             debug_show: DebugShow::new(enable_debug_trace),
             can_call_procedures: false,
+            globals_memory_size: None,
         }
+    }
+
+    pub(crate) fn global_space_size(&self) -> usize {
+        // `GlobalSpace::start()` is inclusive so we must add one to get the accurate total global memory size
+        (self.registers.max_memory_address() + 1) - GlobalSpace::start()
     }
 }
 
@@ -321,6 +331,7 @@ pub(crate) mod tests {
             returns,
             FunctionId::test_new(0),
             false,
+            0,
         );
         entry_point_artifact.link_with(&artifact);
         while let Some(unresolved_fn_label) = entry_point_artifact.first_unresolved_function_call()

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -15,7 +15,6 @@ use acvm::acir::{
 pub(crate) const MAX_STACK_SIZE: usize = 16 * MAX_STACK_FRAME_SIZE;
 pub(crate) const MAX_STACK_FRAME_SIZE: usize = 2048;
 pub(crate) const MAX_SCRATCH_SPACE: usize = 64;
-pub(crate) const MAX_GLOBAL_SPACE: usize = 16384;
 
 impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
     /// Creates an entry point artifact that will jump to the function label provided.
@@ -24,8 +23,11 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         return_parameters: Vec<BrilligParameter>,
         target_function: FunctionId,
         globals_init: bool,
+        globals_memory_size: usize,
     ) -> BrilligArtifact<F> {
         let mut context = BrilligContext::new(false);
+
+        context.globals_memory_size = Some(globals_memory_size);
 
         context.codegen_entry_point(&arguments, &return_parameters);
 
@@ -39,12 +41,15 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         context.artifact()
     }
 
-    fn calldata_start_offset() -> usize {
-        ReservedRegisters::len() + MAX_STACK_SIZE + MAX_SCRATCH_SPACE + MAX_GLOBAL_SPACE
+    fn calldata_start_offset(&self) -> usize {
+        ReservedRegisters::len()
+            + MAX_STACK_SIZE
+            + MAX_SCRATCH_SPACE
+            + self.globals_memory_size.expect("The memory size of globals should be set")
     }
 
-    fn return_data_start_offset(calldata_size: usize) -> usize {
-        Self::calldata_start_offset() + calldata_size
+    fn return_data_start_offset(&self, calldata_size: usize) -> usize {
+        self.calldata_start_offset() + calldata_size
     }
 
     /// Adds the instructions needed to handle entry point parameters
@@ -70,7 +75,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         // Set initial value of free memory pointer: calldata_start_offset + calldata_size + return_data_size
         self.const_instruction(
             SingleAddrVariable::new_usize(ReservedRegisters::free_memory_pointer()),
-            (Self::calldata_start_offset() + calldata_size + return_data_size).into(),
+            (self.calldata_start_offset() + calldata_size + return_data_size).into(),
         );
 
         // Set initial value of stack pointer: ReservedRegisters.len()
@@ -82,7 +87,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         // Copy calldata
         self.copy_and_cast_calldata(arguments);
 
-        let mut current_calldata_pointer = Self::calldata_start_offset();
+        let mut current_calldata_pointer = self.calldata_start_offset();
 
         // Initialize the variables with the calldata
         for (argument_variable, argument) in argument_variables.iter_mut().zip(arguments) {
@@ -158,7 +163,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
     fn copy_and_cast_calldata(&mut self, arguments: &[BrilligParameter]) {
         let calldata_size = Self::flattened_tuple_size(arguments);
         self.calldata_copy_instruction(
-            MemoryAddress::direct(Self::calldata_start_offset()),
+            MemoryAddress::direct(self.calldata_start_offset()),
             calldata_size,
             0,
         );
@@ -178,11 +183,11 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
             if bit_size < F::max_num_bits() {
                 self.cast_instruction(
                     SingleAddrVariable::new(
-                        MemoryAddress::direct(Self::calldata_start_offset() + i),
+                        MemoryAddress::direct(self.calldata_start_offset() + i),
                         bit_size,
                     ),
                     SingleAddrVariable::new_field(MemoryAddress::direct(
-                        Self::calldata_start_offset() + i,
+                        self.calldata_start_offset() + i,
                     )),
                 );
             }
@@ -336,7 +341,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         let return_data_size = Self::flattened_tuple_size(return_parameters);
 
         // Return data has a reserved space after calldata
-        let return_data_offset = Self::return_data_start_offset(calldata_size);
+        let return_data_offset = self.return_data_start_offset(calldata_size);
         let mut return_data_index = return_data_offset;
 
         for (return_param, returned_variable) in return_parameters.iter().zip(&returned_variables) {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
@@ -171,7 +171,6 @@ impl GlobalSpace {
     fn update_max_address(&mut self, register: MemoryAddress) {
         let index = register.unwrap_direct();
         assert!(index >= Self::start(), "Global space malformed");
-        dbg!(index);
         if index > self.max_memory_address {
             self.max_memory_address = index;
         }

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -32,6 +32,7 @@ pub struct Brillig {
     /// Maps SSA function labels to their brillig artifact
     ssa_function_to_brillig: HashMap<FunctionId, BrilligArtifact<FieldElement>>,
     globals: BrilligArtifact<FieldElement>,
+    globals_memory_size: usize,
 }
 
 impl Brillig {
@@ -84,9 +85,10 @@ impl Ssa {
 
         let mut brillig = Brillig::default();
 
-        let (artifact, brillig_globals) =
+        let (artifact, brillig_globals, globals_size) =
             convert_ssa_globals(enable_debug_trace, &self.globals, &self.used_global_values);
         brillig.globals = artifact;
+        brillig.globals_memory_size = globals_size;
 
         for brillig_function_id in brillig_reachable_function_ids {
             let func = &self.functions[&brillig_function_id];

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -82,7 +82,7 @@ impl Ssa {
                         // DIE is run at the end of our SSA optimizations, so we mark all globals as in use here.
                         let used_globals =
                             &self.globals.dfg.values_iter().map(|(id, _)| id).collect();
-                        let (_, brillig_globals) =
+                        let (_, brillig_globals, _) =
                             convert_ssa_globals(false, &self.globals, used_globals);
                         global_cache = Some(brillig_globals);
                     }

--- a/cspell.json
+++ b/cspell.json
@@ -32,6 +32,7 @@
         "boilerplates",
         "bridgekeeper",
         "brillig",
+        "brillig_",
         "bunx",
         "bytecount",
         "cachix",


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7107 

## Summary\*

The `Brillig` codegen context structure now also carries a new `globals_memory_size` field. This is then used to set the globals memory size in a Brillig context. When generating an entry point the BrilligContext is now expected to have a specified globals memory size. It then uses this globals memory size to set the calldata start offset for when copying and casting calldata.

## Additional Context

I had thought about using an atomic global for the max global size, but I felt passing a local variable was cleaner and it is more clear where the value is set.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
