### PR TITLE
feat(ssa): Reuse constants from the globals graph when making constants in a function DFG

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -116,11 +116,14 @@ pub(crate) struct GlobalsGraph {
     /// All of the instructions in the global value space.
     /// These are expected to all be Instruction::MakeArray
     instructions: DenseMap<Instruction>,
+
+    #[serde(skip)]
+    constants: HashMap<(FieldElement, NumericType), ValueId>,
 }
 
 impl GlobalsGraph {
     pub(crate) fn from_dfg(dfg: DataFlowGraph) -> Self {
-        Self { values: dfg.values, instructions: dfg.instructions }
+        Self { values: dfg.values, instructions: dfg.instructions, constants: dfg.constants }
     }
 
     /// Iterate over every Value in this DFG in no particular order, including unused Values
@@ -384,6 +387,9 @@ impl DataFlowGraph {
     /// one already exists.
     pub(crate) fn make_constant(&mut self, constant: FieldElement, typ: NumericType) -> ValueId {
         if let Some(id) = self.constants.get(&(constant, typ)) {
+            return *id;
+        }
+        if let Some(id) = self.globals.constants.get(&(constant, typ)) {
             return *id;
         }
         let id = self.values.insert(Value::NumericConstant { constant, typ });


### PR DESCRIPTION
# Description

## Problem\*

Does not resolve any issues, just a small optimization I noticed while working on #7109. This PR is much simpler than what #7109 requires as it checks for constants which have been already declared as globals by the program. 

## Summary\*

I keep the `constants` context map from the DFG in the `GlobalsGraph`. Now when checking whether to reuse a value id when making a constant we also check whether that constants exists in the globals space.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
