### PR TITLE
feat: LSP autocomplete module declaration

### DIFF
--- a/compiler/fm/src/file_map.rs
+++ b/compiler/fm/src/file_map.rs
@@ -19,6 +19,10 @@ impl PathString {
     pub fn from_path(p: PathBuf) -> Self {
         PathString(p)
     }
+
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
 }
 impl From<PathBuf> for PathString {
     fn from(pb: PathBuf) -> PathString {
@@ -82,7 +86,7 @@ impl FileMap {
     }
 
     pub fn get_name(&self, file_id: FileId) -> Result<PathString, Error> {
-        let name = self.files.get(file_id.as_usize())?.name().clone();
+        let name = self.get_absolute_name(file_id)?;
 
         // See if we can make the file name a bit shorter/easier to read if it starts with the current directory
         if let Some(current_dir) = &self.current_dir {
@@ -91,6 +95,11 @@ impl FileMap {
             }
         }
 
+        Ok(name)
+    }
+
+    pub fn get_absolute_name(&self, file_id: FileId) -> Result<PathString, Error> {
+        let name = self.files.get(file_id.as_usize())?.name().clone();
         Ok(name)
     }
 }

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -308,6 +308,7 @@ pub struct ModuleDeclaration {
     pub visibility: ItemVisibility,
     pub ident: Ident,
     pub outer_attributes: Vec<SecondaryAttribute>,
+    pub has_semicolon: bool,
 }
 
 impl std::fmt::Display for ModuleDeclaration {

--- a/compiler/noirc_frontend/src/parser/parser/module.rs
+++ b/compiler/noirc_frontend/src/parser/parser/module.rs
@@ -25,6 +25,7 @@ impl<'a> Parser<'a> {
                 visibility,
                 ident: Ident::default(),
                 outer_attributes,
+                has_semicolon: false,
             });
         };
 
@@ -41,10 +42,16 @@ impl<'a> Parser<'a> {
                 is_contract,
             })
         } else {
-            if !self.eat_semicolons() {
+            let has_semicolon = self.eat_semicolons();
+            if !has_semicolon {
                 self.expected_token(Token::Semicolon);
             }
-            ItemKind::ModuleDecl(ModuleDeclaration { visibility, ident, outer_attributes })
+            ItemKind::ModuleDecl(ModuleDeclaration {
+                visibility,
+                ident,
+                outer_attributes,
+                has_semicolon,
+            })
         }
     }
 }


### PR DESCRIPTION
# Description

## Problem

No issue, just something that Rust Analyzer does but our current LSP doesn't.

## Summary

Example for a "main" module:

![lsp-complete-module-declaration](https://github.com/user-attachments/assets/b0f3433e-f599-492a-bab7-b58b99612dd4)

Example for a "non-main" module:

![lsp-complete-module-declaration-2](https://github.com/user-attachments/assets/faa496f1-4408-43bf-aeb6-48003f0a98fa)

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
