### PR TITLE
fix: LSP hover over function with `&mut self`

### DIFF
--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -93,3 +93,6 @@ impl TraitWithDocs for Field {
     fn foo() {}
 }
 
+impl<U> Foo<U> {
+    fn mut_self(&mut self) {}
+}


### PR DESCRIPTION
# Description

## Problem

Reported to me privately by Nico, hovering over a function with `&mut self` would show it as `self` instead of `&mut self`.

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
