### PR TITLE
chore(refactor): Remove globals field on Ssa object and use only the shared globals graph

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -2896,7 +2896,7 @@ mod test {
     use std::collections::BTreeMap;
 
     use crate::{
-        acir::{BrilligStdlibFunc, Function},
+        acir::BrilligStdlibFunc,
         brillig::Brillig,
         ssa::{
             function_builder::FunctionBuilder,

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -3328,8 +3328,7 @@ mod test {
         build_basic_foo_with_return(&mut builder, foo_id, true, InlineType::default());
         build_basic_foo_with_return(&mut builder, bar_id, true, InlineType::default());
 
-        let mut ssa = builder.finish();
-        ssa.globals = Function::new("globals".to_owned(), ssa.main_id);
+        let ssa = builder.finish();
         let brillig = ssa.to_brillig(false);
 
         let (acir_functions, brillig_functions, _, _) = ssa
@@ -3467,8 +3466,7 @@ mod test {
 
         build_basic_foo_with_return(&mut builder, foo_id, true, InlineType::default());
 
-        let mut ssa = builder.finish();
-        ssa.globals = Function::new("globals".to_owned(), ssa.main_id);
+        let ssa = builder.finish();
         // We need to generate  Brillig artifacts for the regular Brillig function and pass them to the ACIR generation pass.
         let brillig = ssa.to_brillig(false);
         println!("{}", ssa);
@@ -3557,8 +3555,7 @@ mod test {
         // Build an ACIR function which has the same logic as the Brillig function above
         build_basic_foo_with_return(&mut builder, bar_id, false, InlineType::Fold);
 
-        let mut ssa = builder.finish();
-        ssa.globals = Function::new("globals".to_owned(), ssa.main_id);
+        let ssa = builder.finish();
         // We need to generate  Brillig artifacts for the regular Brillig function and pass them to the ACIR generation pass.
         let brillig = ssa.to_brillig(false);
         println!("{}", ssa);

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -142,7 +142,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     /// Making the assumption that the block ID passed in belongs to this
     /// function.
     fn create_block_label_for_current_function(&self, block_id: BasicBlockId) -> Label {
-        Self::create_block_label(self.function_context.function_id, block_id)
+        Self::create_block_label(self.function_context.function_id(), block_id)
     }
     /// Creates a unique label for a block using the function Id and the block ID.
     ///

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -19,6 +19,8 @@ use super::{constant_allocation::ConstantAllocation, variable_liveness::Variable
 
 #[derive(Default)]
 pub(crate) struct FunctionContext {
+    /// A `FunctionContext` is necessary for using a Brillig block's code gen, but sometimes
+    /// such as with globals, we are not within a function and do not have a function id.
     function_id: Option<FunctionId>,
     /// Map from SSA values its allocation. Since values can be only defined once in SSA form, we insert them here on when we allocate them at their definition.
     pub(crate) ssa_value_allocations: HashMap<ValueId, BrilligVariable>,
@@ -50,19 +52,6 @@ impl FunctionContext {
             constant_allocation: constants,
         }
     }
-
-    // pub(crate) fn new_for_globals() -> Self {
-    //     // Self {
-    //     //     function_id: id,
-    //     //     ssa_value_allocations: HashMap::default(),
-    //     //     blocks: reverse_post_order,
-    //     //     liveness,
-    //     //     constant_allocation: constants,
-    //     // }
-    //     Self {
-    //         ..Default::default()
-    //     }
-    // }
 
     pub(crate) fn function_id(&self) -> FunctionId {
         self.function_id.expect("ICE: function_id should already be set")

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -17,8 +17,9 @@ use fxhash::FxHashMap as HashMap;
 
 use super::{constant_allocation::ConstantAllocation, variable_liveness::VariableLiveness};
 
+#[derive(Default)]
 pub(crate) struct FunctionContext {
-    pub(crate) function_id: FunctionId,
+    function_id: Option<FunctionId>,
     /// Map from SSA values its allocation. Since values can be only defined once in SSA form, we insert them here on when we allocate them at their definition.
     pub(crate) ssa_value_allocations: HashMap<ValueId, BrilligVariable>,
     /// The block ids of the function in reverse post order.
@@ -42,12 +43,29 @@ impl FunctionContext {
         let liveness = VariableLiveness::from_function(function, &constants);
 
         Self {
-            function_id: id,
+            function_id: Some(id),
             ssa_value_allocations: HashMap::default(),
             blocks: reverse_post_order,
             liveness,
             constant_allocation: constants,
         }
+    }
+
+    // pub(crate) fn new_for_globals() -> Self {
+    //     // Self {
+    //     //     function_id: id,
+    //     //     ssa_value_allocations: HashMap::default(),
+    //     //     blocks: reverse_post_order,
+    //     //     liveness,
+    //     //     constant_allocation: constants,
+    //     // }
+    //     Self {
+    //         ..Default::default()
+    //     }
+    // }
+
+    pub(crate) fn function_id(&self) -> FunctionId {
+        self.function_id.expect("ICE: function_id should already be set")
     }
 
     pub(crate) fn ssa_type_to_parameter(typ: &Type) -> BrilligParameter {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
@@ -17,7 +17,6 @@ pub(crate) fn convert_ssa_globals(
     let empty_globals = HashMap::default();
     // We can use any ID here as this context is only going to be used for globals which does not differentiate
     // by functions and blocks. The only Label that should be used in the globals context is `Label::globals_init()`
-    // let mut function_context = FunctionContext::new(globals);
     let mut function_context = FunctionContext::default();
     brillig_context.enter_context(Label::globals_init());
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
@@ -1,14 +1,15 @@
 use acvm::FieldElement;
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use super::{
-    BrilligArtifact, BrilligBlock, BrilligVariable, Function, FunctionContext, Label, ValueId,
+use super::{BrilligArtifact, BrilligBlock, BrilligVariable, FunctionContext, Label, ValueId};
+use crate::{
+    brillig::{brillig_ir::BrilligContext, DataFlowGraph},
+    ssa::ir::dfg::GlobalsGraph,
 };
-use crate::brillig::{brillig_ir::BrilligContext, DataFlowGraph};
 
 pub(crate) fn convert_ssa_globals(
     enable_debug_trace: bool,
-    globals: &Function,
+    globals: GlobalsGraph,
     used_globals: &HashSet<ValueId>,
 ) -> (BrilligArtifact<FieldElement>, HashMap<ValueId, BrilligVariable>) {
     let mut brillig_context = BrilligContext::new_for_global_init(enable_debug_trace);
@@ -16,7 +17,8 @@ pub(crate) fn convert_ssa_globals(
     let empty_globals = HashMap::default();
     // We can use any ID here as this context is only going to be used for globals which does not differentiate
     // by functions and blocks. The only Label that should be used in the globals context is `Label::globals_init()`
-    let mut function_context = FunctionContext::new(globals);
+    // let mut function_context = FunctionContext::new(globals);
+    let mut function_context = FunctionContext::default();
     brillig_context.enter_context(Label::globals_init());
 
     let block_id = DataFlowGraph::default().make_block();
@@ -30,7 +32,8 @@ pub(crate) fn convert_ssa_globals(
         building_globals: true,
     };
 
-    brillig_block.compile_globals(&globals.dfg, used_globals);
+    let globals_dfg = DataFlowGraph::from(globals);
+    brillig_block.compile_globals(&globals_dfg, used_globals);
 
     brillig_context.return_instruction();
 

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -89,10 +89,7 @@ impl Ssa {
             return brillig;
         }
 
-        let func_id = brillig_reachable_function_ids
-            .first()
-            .expect("ICE: Should have a reachable function at this point");
-        let globals = (*self.functions[func_id].dfg.globals).clone();
+        let globals = (*self.functions[&self.main_id].dfg.globals).clone();
         let (artifact, brillig_globals, globals_size) =
             convert_ssa_globals(enable_debug_trace, globals, &self.used_global_values);
         brillig.globals = artifact;

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -89,6 +89,8 @@ impl Ssa {
             return brillig;
         }
 
+        // Globals are computed once at compile time and shared across all functions,
+        // thus we can just fetch globals from the main function.
         let globals = (*self.functions[&self.main_id].dfg.globals).clone();
         let (artifact, brillig_globals, globals_size) =
             convert_ssa_globals(enable_debug_trace, globals, &self.used_global_values);

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -84,8 +84,16 @@ impl Ssa {
 
         let mut brillig = Brillig::default();
 
+        if brillig_reachable_function_ids.is_empty() {
+            return brillig;
+        }
+
+        let func_id = brillig_reachable_function_ids
+            .first()
+            .expect("ICE: Should have a reachable function at this point");
+        let globals = (*self.functions[func_id].dfg.globals).clone();
         let (artifact, brillig_globals) =
-            convert_ssa_globals(enable_debug_trace, &self.globals, &self.used_global_values);
+            convert_ssa_globals(enable_debug_trace, globals, &self.used_global_values);
         brillig.globals = artifact;
 
         for brillig_function_id in brillig_reachable_function_ids {

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -20,13 +20,16 @@ use super::{
 
 impl Display for Ssa {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        for (id, global_value) in self.globals.dfg.values_iter() {
+        let globals = (*self.functions[&self.main_id].dfg.globals).clone();
+        let globals_dfg = DataFlowGraph::from(globals);
+
+        for (id, global_value) in globals_dfg.values_iter() {
             match global_value {
                 Value::NumericConstant { constant, typ } => {
                     writeln!(f, "g{} = {typ} {constant}", id.to_u32())?;
                 }
                 Value::Instruction { instruction, .. } => {
-                    display_instruction(&self.globals.dfg, *instruction, true, f)?;
+                    display_instruction(&globals_dfg, *instruction, true, f)?;
                 }
                 Value::Global(_) => {
                     panic!("Value::Global should only be in the function dfg");
@@ -35,7 +38,7 @@ impl Display for Ssa {
             };
         }
 
-        if self.globals.dfg.values_iter().next().is_some() {
+        if globals_dfg.values_iter().next().is_some() {
             writeln!(f)?;
         }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -36,11 +36,12 @@ impl Ssa {
             .flat_map(|(_, func)| func.dead_instruction_elimination(true, flattened))
             .collect();
 
+        let globals = &self.functions[&self.main_id].dfg.globals;
         // Check which globals are used across all functions
-        for (id, value) in self.globals.dfg.values_iter().rev() {
+        for (id, value) in globals.values_iter().rev() {
             if used_global_values.contains(&id) {
                 if let Value::Instruction { instruction, .. } = &value {
-                    let instruction = &self.globals.dfg[*instruction];
+                    let instruction = &globals[*instruction];
                     instruction.for_each_value(|value_id| {
                         used_global_values.insert(value_id);
                     });

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -13,7 +13,7 @@ use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
         call_stack::CallStackId,
-        dfg::InsertInstructionResult,
+        dfg::{GlobalsGraph, InsertInstructionResult},
         function::{Function, FunctionId, RuntimeType},
         instruction::{Instruction, InstructionId, TerminatorInstruction},
         value::{Value, ValueId},
@@ -170,7 +170,7 @@ struct PerFunctionContext<'function> {
     /// True if we're currently working on the entry point function.
     inlining_entry: bool,
 
-    globals: &'function Function,
+    globals: &'function GlobalsGraph,
 }
 
 /// Utility function to find out the direct calls of a function.
@@ -578,7 +578,8 @@ impl InlineContext {
     ) -> Function {
         let entry_point = &ssa.functions[&self.entry_point];
 
-        let mut context = PerFunctionContext::new(&mut self, entry_point, &ssa.globals);
+        let globals = &entry_point.dfg.globals;
+        let mut context = PerFunctionContext::new(&mut self, entry_point, globals);
         context.inlining_entry = true;
 
         for (_, value) in entry_point.dfg.globals.values_iter() {
@@ -629,7 +630,8 @@ impl InlineContext {
             );
         }
 
-        let mut context = PerFunctionContext::new(self, source_function, &ssa.globals);
+        let globals = &source_function.dfg.globals;
+        let mut context = PerFunctionContext::new(self, source_function, globals);
 
         let parameters = source_function.parameters();
         assert_eq!(parameters.len(), arguments.len());
@@ -652,7 +654,7 @@ impl<'function> PerFunctionContext<'function> {
     fn new(
         context: &'function mut InlineContext,
         source_function: &'function Function,
-        globals: &'function Function,
+        globals: &'function GlobalsGraph,
     ) -> Self {
         Self {
             context,
@@ -679,8 +681,7 @@ impl<'function> PerFunctionContext<'function> {
             value @ Value::Instruction { instruction, .. } => {
                 if self.source_function.dfg.is_global(id) {
                     if self.context.builder.current_function.dfg.runtime().is_acir() {
-                        let Instruction::MakeArray { elements, typ } =
-                            &self.globals.dfg[*instruction]
+                        let Instruction::MakeArray { elements, typ } = &self.globals[*instruction]
                         else {
                             panic!("Only expect Instruction::MakeArray for a global");
                         };

--- a/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
+        dfg::GlobalsGraph,
         function::{Function, FunctionId},
         map::SparseMap,
         post_order::PostOrder,
@@ -25,7 +26,8 @@ impl Ssa {
         let mut context = Context::default();
         context.populate_functions(&self.functions);
         for function in self.functions.values_mut() {
-            context.normalize_ids(function, &self.globals);
+            let globals = (*function.dfg.globals).clone();
+            context.normalize_ids(function, &globals);
         }
         self.functions = context.functions.into_btree();
     }
@@ -65,14 +67,14 @@ impl Context {
         }
     }
 
-    fn normalize_ids(&mut self, old_function: &mut Function, globals: &Function) {
+    fn normalize_ids(&mut self, old_function: &mut Function, globals: &GlobalsGraph) {
         self.new_ids.blocks.clear();
         self.new_ids.values.clear();
 
         let new_function_id = self.new_ids.function_ids[&old_function.id()];
         let new_function = &mut self.functions[new_function_id];
 
-        for (_, value) in globals.dfg.values_iter() {
+        for (_, value) in globals.values_iter() {
             new_function.dfg.make_global(value.get_type().into_owned());
         }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
@@ -25,8 +25,8 @@ impl Ssa {
     pub(crate) fn normalize_ids(&mut self) {
         let mut context = Context::default();
         context.populate_functions(&self.functions);
+        let globals = (*self.functions[&self.main_id].dfg.globals).clone();
         for function in self.functions.values_mut() {
-            let globals = (*function.dfg.globals).clone();
             context.normalize_ids(function, &globals);
         }
         self.functions = context.functions.into_btree();

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -79,11 +79,11 @@ impl Ssa {
             if has_unrolled && is_brillig {
                 if let Some(max_incr_pct) = max_bytecode_increase_percent {
                     if global_cache.is_none() {
+                        let globals = (*function.dfg.globals).clone();
                         // DIE is run at the end of our SSA optimizations, so we mark all globals as in use here.
-                        let used_globals =
-                            &self.globals.dfg.values_iter().map(|(id, _)| id).collect();
+                        let used_globals = &globals.values_iter().map(|(id, _)| id).collect();
                         let (_, brillig_globals) =
-                            convert_ssa_globals(false, &self.globals, used_globals);
+                            convert_ssa_globals(false, globals, used_globals);
                         global_cache = Some(brillig_globals);
                     }
                     let brillig_globals = global_cache.as_ref().unwrap();

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -448,7 +448,6 @@ impl Translator {
 
     fn finish(self) -> Ssa {
         let mut ssa = self.builder.finish();
-        ssa.globals = self.globals_function;
 
         // Normalize the IDs so we have a better chance of matching the SSA we parsed
         // after the step-by-step reconstruction done during translation. This assumes

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
@@ -20,7 +20,6 @@ use super::ValueId;
 pub(crate) struct Ssa {
     #[serde_as(as = "Vec<(_, _)>")]
     pub(crate) functions: BTreeMap<FunctionId, Function>,
-    pub(crate) globals: Function,
     pub(crate) used_global_values: HashSet<ValueId>,
     pub(crate) main_id: FunctionId,
     #[serde(skip)]
@@ -58,9 +57,6 @@ impl Ssa {
             next_id: AtomicCounter::starting_after(max_id),
             entry_point_to_generated_index: BTreeMap::new(),
             error_selector_to_type: error_types,
-            // These fields should be set afterwards as globals are generated
-            // outside of the FunctionBuilder, which is where the `Ssa` is instantiated.
-            globals: Function::new_for_globals(),
             // This field is set only after running DIE and is utilized
             // for optimizing implementation of globals post-SSA.
             used_global_values: HashSet::default(),


### PR DESCRIPTION
# Description

## Problem\*

No issue, but just a general refactor. We have repeated declaration of globals (the shared `globals: Arc<GlobalsGraph>` field on `DataFlowGraph` and the `globals: Function` on `Ssa`). We need the globals field on the DFG for resolving constants https://github.com/noir-lang/noir/pull/7040. However, the globals field on the `Ssa` object is only used by the SSA printer and the brillig codegen. Which in both case could use the globals graph from any function.

## Summary\*

I removed `globals: Function` from `Ssa` and use the globals graph from a function in the places where the `Ssa` field was being used. 

Certain interfaces such as the printer and Brillig codegen still utilize the `DataFlowGraph` type so some conversions from a `GlobalsGraph` to a `DataFlowGraph` were necessary to avoid larger changes. 

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
