### PR TITLE
fix(ssa): Check arrays used as a terminator argument in the RC tracker 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -965,6 +965,36 @@ mod test {
     }
 
     #[test]
+    fn do_not_remove_inc_rcs_for_arrays_in_terminator() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: [Field; 2]):
+            inc_rc v0
+            inc_rc v0
+            inc_rc v0
+            v2 = array_get v0, index u32 0 -> Field
+            inc_rc v0
+            return v0, v2
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let expected = "
+        brillig(inline) fn main f0 {
+          b0(v0: [Field; 2]):
+            inc_rc v0
+            v2 = array_get v0, index u32 0 -> Field
+            inc_rc v0
+            return v0, v2
+        }
+        ";
+
+        let ssa = ssa.dead_instruction_elimination();
+        assert_normalized_ssa_equals(ssa, expected);
+    }
+
+    #[test]
     fn do_not_remove_inc_rc_if_used_as_call_arg() {
         // We do not want to remove inc_rc instructions on values
         // that are passed as call arguments.

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -1032,7 +1032,7 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
 
         // Even though these ACIR functions only have 1 block, we have not inlined and flattened anything yet.
-        let ssa = ssa.dead_instruction_elimination_inner(false, false);
+        let ssa = ssa.dead_instruction_elimination_inner(false);
 
         let expected = "
           acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -681,7 +681,7 @@ impl RcTracker {
                 // get rid of IncRCs arrays that can potentially be mutated outside.
                 for arg in arguments {
                     let typ = function.dfg.type_of_value(*arg);
-                    if matches!(&typ, Type::Array(_, _) | Type::Slice(_)) {
+                    if matches!(&typ, Type::Array(..) | Type::Slice(..)) {
                         self.mutated_array_types.insert(typ);
                     }
                 }

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -942,42 +942,6 @@ mod test {
     }
 
     #[test]
-    fn not_remove_inc_rcs_for_input_parameters() {
-        let src = "
-        brillig(inline) fn main f0 {
-          b0(v0: [Field; 2]):
-            inc_rc v0
-            inc_rc v0
-            inc_rc v0
-            v2 = array_get v0, index u32 0 -> Field
-            inc_rc v0
-            return v2
-        }
-        ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let main = ssa.main();
-
-        // The instruction count never includes the terminator instruction
-        assert_eq!(main.dfg[main.entry_block()].instructions().len(), 5);
-
-        let expected = "
-        brillig(inline) fn main f0 {
-          b0(v0: [Field; 2]):
-            inc_rc v0
-            v2 = array_get v0, index u32 0 -> Field
-            inc_rc v0
-            return v2
-        }
-        ";
-
-        // We want to be able to switch this on during preprocessing.
-        let keep_rcs_of_parameters = true;
-        let ssa = ssa.dead_instruction_elimination_inner(true, keep_rcs_of_parameters);
-        assert_normalized_ssa_equals(ssa, expected);
-    }
-
-    #[test]
     fn remove_inc_rcs_that_are_never_mutably_borrowed() {
         let src = "
         brillig(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -607,19 +607,6 @@ struct RcTracker {
 }
 
 impl RcTracker {
-    /// Mark any array parameters to the function itself as possibly mutated,
-    /// so we don't get rid of RC instructions just because we don't mutate
-    /// them in this function, which could potentially cause them to be
-    /// mutated outside the function without our consent.
-    fn track_function_parameters(&mut self, function: &Function) {
-        for parameter in function.parameters() {
-            let typ = function.dfg.type_of_value(*parameter);
-            if typ.contains_an_array() {
-                self.mutated_array_types.insert(typ);
-            }
-        }
-    }
-
     fn track_inc_rcs_to_remove(&mut self, instruction_id: InstructionId, function: &Function) {
         let instruction = &function.dfg[instruction_id];
 

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -157,8 +157,6 @@ impl Context {
 
         let mut rc_tracker = RcTracker::default();
 
-        rc_tracker.track_function_parameters(function);
-
         // Indexes of instructions that might be out of bounds.
         // We'll remove those, but before that we'll insert bounds checks for them.
         let mut possible_index_out_of_bounds_indexes = Vec::new();

--- a/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
@@ -58,7 +58,7 @@ impl Ssa {
             // Try to reduce the number of blocks.
             function.simplify_function();
             // Remove leftover instructions.
-            function.dead_instruction_elimination(true, false, true);
+            function.dead_instruction_elimination(true, false);
 
             // Put it back into the SSA, so the next functions can pick it up.
             self.functions.insert(id, function);

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -1035,7 +1035,7 @@ fn brillig_bytecode_size(
     simplify_between_unrolls(&mut temp);
 
     // This is to try to prevent hitting ICE.
-    temp.dead_instruction_elimination(false, true, false);
+    temp.dead_instruction_elimination(false, true);
 
     convert_ssa_function(&temp, false, globals).byte_code.len()
 }

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -6,18 +6,17 @@ use nargo::{
     constants::PROVER_INPUT_FILE, foreign_calls::DefaultForeignCallBuilder, package::Package,
 };
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml};
-use noirc_abi::input_parser::Format;
 use noirc_artifacts::program::ProgramArtifact;
 use noirc_driver::{CompileOptions, NOIR_ARTIFACT_VERSION_STRING};
 use prettytable::{row, table, Row};
 use rayon::prelude::*;
 use serde::Serialize;
 
-use crate::{cli::fs::inputs::read_inputs_from_file, errors::CliError};
+use crate::errors::CliError;
 
 use super::{
     compile_cmd::{compile_workspace_full, get_target_width},
-    fs::program::read_program_from_file,
+    fs::{inputs::read_inputs_from_file_any_format, program::read_program_from_file},
     NargoConfig, PackageOptions,
 };
 

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -6,6 +6,7 @@ use nargo::{
     constants::PROVER_INPUT_FILE, foreign_calls::DefaultForeignCallBuilder, package::Package,
 };
 use nargo_toml::{get_package_manifest, resolve_workspace_from_toml};
+use noirc_abi::input_parser::Format;
 use noirc_artifacts::program::ProgramArtifact;
 use noirc_driver::{CompileOptions, NOIR_ARTIFACT_VERSION_STRING};
 use prettytable::{row, table, Row};
@@ -16,7 +17,7 @@ use crate::errors::CliError;
 
 use super::{
     compile_cmd::{compile_workspace_full, get_target_width},
-    fs::{inputs::read_inputs_from_file_any_format, program::read_program_from_file},
+    fs::{inputs::read_inputs_from_file, program::read_program_from_file},
     NargoConfig, PackageOptions,
 };
 
@@ -243,9 +244,10 @@ fn profile_brillig_execution(
     let mut program_info = Vec::new();
     for (package, program_artifact) in binary_packages.iter() {
         // Parse the initial witness values from Prover.toml or Prover.json
-        let (inputs_map, _) = read_inputs_from_file_any_format(
+        let (inputs_map, _) = read_inputs_from_file(
             &package.root_dir,
             prover_name,
+            Format::Toml,
             &program_artifact.abi,
         )?;
         let initial_witness = program_artifact.abi.encode(&inputs_map, None)?;

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -243,11 +243,10 @@ fn profile_brillig_execution(
 ) -> Result<Vec<ProgramInfo>, CliError> {
     let mut program_info = Vec::new();
     for (package, program_artifact) in binary_packages.iter() {
-        // Parse the initial witness values from Prover.toml
-        let (inputs_map, _) = read_inputs_from_file(
+        // Parse the initial witness values from Prover.toml or Prover.json
+        let (inputs_map, _) = read_inputs_from_file_any_format(
             &package.root_dir,
             prover_name,
-            Format::Toml,
             &program_artifact.abi,
         )?;
         let initial_witness = program_artifact.abi.encode(&inputs_map, None)?;


### PR DESCRIPTION
# Description

## Problem\*

Resolves failures in https://github.com/AztecProtocol/aztec-packages/pull/11294 from the preprocessing pass. https://github.com/noir-lang/noir/pull/7163 is a bit too conservative with marking that we should keep the inc rcs on any parameters. Doing so happens to also fix the test case, but marking arrays passed to terminators is the more accurate fix for how the RC tracker should be looking at mutated arrays. 

## Summary\*

We want to make sure we do not remove inc rcs on arrays that are potentially mutated elsewhere. To do so, we check whether an array was passed to a store instruction or a call. We used to only run DIE (which removes these RCs) at the end of the SSA optimizations where we were aggressively inlining. 

Now that we are starting to process functions in isolation we triggered a bug as outlined here https://github.com/AztecProtocol/aztec-packages/pull/11294#issuecomment-2608216917. We need to account for whether an array is used in a terminator argument such as a return as that returned array may be mutated later.

## Additional Context

Will need to add a new test making sure we do not remove an inc rc on an array type used in a terminator argument.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
