### PR TITLE
chore(LSP): several improvements for enums and enum variants

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -2,7 +2,7 @@ use iter_extended::vecmap;
 use noirc_errors::Location;
 
 use crate::{
-    ast::{Documented, EnumVariant, FunctionKind, NoirEnumeration, UnresolvedType, Visibility},
+    ast::{EnumVariant, FunctionKind, NoirEnumeration, UnresolvedType, Visibility},
     hir_def::{
         expr::{HirEnumConstructorExpression, HirExpression, HirIdent},
         function::{FuncMeta, FunctionBody, HirFunction, Parameters},
@@ -21,14 +21,13 @@ impl Elaborator<'_> {
         &mut self,
         enum_: &NoirEnumeration,
         type_id: TypeId,
-        documented_variant: &Documented<EnumVariant>,
+        variant: &EnumVariant,
         variant_arg_types: Vec<Type>,
         variant_index: usize,
         datatype: &Shared<DataType>,
         self_type: &Type,
         self_type_unresolved: UnresolvedType,
     ) {
-        let variant = &documented_variant.item;
         let name_string = variant.name.to_string();
         let datatype_ref = datatype.borrow();
         let location = Location::new(variant.name.span(), self.file);

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -2,7 +2,7 @@ use iter_extended::vecmap;
 use noirc_errors::Location;
 
 use crate::{
-    ast::{EnumVariant, FunctionKind, NoirEnumeration, UnresolvedType, Visibility},
+    ast::{Documented, EnumVariant, FunctionKind, NoirEnumeration, UnresolvedType, Visibility},
     hir_def::{
         expr::{HirEnumConstructorExpression, HirExpression, HirIdent},
         function::{FuncMeta, FunctionBody, HirFunction, Parameters},
@@ -21,13 +21,14 @@ impl Elaborator<'_> {
         &mut self,
         enum_: &NoirEnumeration,
         type_id: TypeId,
-        variant: &EnumVariant,
+        documented_variant: &Documented<EnumVariant>,
         variant_arg_types: Vec<Type>,
         variant_index: usize,
         datatype: &Shared<DataType>,
         self_type: &Type,
         self_type_unresolved: UnresolvedType,
     ) {
+        let variant = &documented_variant.item;
         let name_string = variant.name.to_string();
         let datatype_ref = datatype.borrow();
         let location = Location::new(variant.name.span(), self.file);
@@ -70,6 +71,7 @@ impl Elaborator<'_> {
             type_id: Some(type_id),
             trait_id: None,
             trait_impl: None,
+            enum_variant_index: Some(variant_index),
             is_entry_point: false,
             has_inline_attribute: false,
             function_body: FunctionBody::Resolved,

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -660,7 +660,7 @@ impl<'context> Elaborator<'context> {
 
         let struct_id = struct_type.borrow().id;
         let reference_location = Location::new(last_segment.ident.span(), self.file);
-        self.interner.add_struct_reference(struct_id, reference_location, is_self_type);
+        self.interner.add_type_reference(struct_id, reference_location, is_self_type);
 
         (expr, Type::DataType(struct_type, generics))
     }

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1832,8 +1832,6 @@ impl<'context> Elaborator<'context> {
             };
 
             for (i, variant) in typ.enum_def.variants.iter().enumerate() {
-                self.interner.add_definition_location(ReferenceId::EnumVariant(*type_id, i), None);
-
                 let types = vecmap(&variant.item.parameters, |typ| self.resolve_type(typ.clone()));
                 let name = variant.item.name.clone();
                 datatype.borrow_mut().push_variant(EnumVariant::new(name, types.clone()));
@@ -1849,6 +1847,8 @@ impl<'context> Elaborator<'context> {
                     &self_type,
                     unresolved.clone(),
                 );
+
+                self.interner.add_definition_location(ReferenceId::EnumVariant(*type_id, i), None);
             }
         }
     }

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1006,6 +1006,7 @@ impl<'context> Elaborator<'context> {
             type_id: struct_id,
             trait_id,
             trait_impl: self.current_trait_impl,
+            enum_variant_index: None,
             parameters: parameters.into(),
             parameter_idents,
             return_type: func.def.return_type.clone(),
@@ -1840,7 +1841,7 @@ impl<'context> Elaborator<'context> {
                 self.define_enum_variant_function(
                     &typ.enum_def,
                     *type_id,
-                    &variant.item,
+                    &variant,
                     types,
                     i,
                     &datatype,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1832,6 +1832,8 @@ impl<'context> Elaborator<'context> {
                 span: typ.enum_def.span,
             };
 
+            datatype.borrow_mut().init_variants();
+
             for (i, variant) in typ.enum_def.variants.iter().enumerate() {
                 let types = vecmap(&variant.item.parameters, |typ| self.resolve_type(typ.clone()));
                 let name = variant.item.name.clone();

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -234,7 +234,7 @@ impl<'context> Elaborator<'context> {
         let struct_id = struct_type.borrow().id;
 
         let reference_location = Location::new(name_span, self.file);
-        self.interner.add_struct_reference(struct_id, reference_location, is_self_type);
+        self.interner.add_type_reference(struct_id, reference_location, is_self_type);
 
         for (field_index, field) in fields.iter().enumerate() {
             let reference_location = Location::new(field.0.span(), self.file);

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -158,7 +158,7 @@ impl<'context> Elaborator<'context> {
                 // Record the location of the type reference
                 self.interner.push_type_ref_location(resolved_type.clone(), location);
                 if !is_synthetic {
-                    self.interner.add_struct_reference(
+                    self.interner.add_type_reference(
                         data_type.borrow().id,
                         location,
                         is_self_type_name,

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -336,12 +336,12 @@ impl<'a> ModCollector<'a> {
         krate: CrateId,
     ) -> Vec<(CompilationError, FileId)> {
         let mut definition_errors = vec![];
-        for struct_definition in types {
+        for enum_definition in types {
             if let Some((id, the_enum)) = collect_enum(
                 &mut context.def_interner,
                 &mut self.def_collector.def_map,
                 &mut context.usage_tracker,
-                struct_definition,
+                enum_definition,
                 self.file_id,
                 self.module_id,
                 krate,

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1072,7 +1072,7 @@ pub fn collect_struct(
         }
     };
 
-    interner.set_doc_comments(ReferenceId::Struct(id), doc_comments);
+    interner.set_doc_comments(ReferenceId::Type(id), doc_comments);
 
     for (index, field) in unresolved.struct_def.fields.iter().enumerate() {
         if !field.doc_comments.is_empty() {
@@ -1106,7 +1106,7 @@ pub fn collect_struct(
     }
 
     if interner.is_in_lsp_mode() {
-        interner.register_struct(id, name.to_string(), visibility, parent_module_id);
+        interner.register_type(id, name.to_string(), visibility, parent_module_id);
     }
 
     Some((id, unresolved))
@@ -1167,7 +1167,7 @@ pub fn collect_enum(
         }
     };
 
-    interner.set_doc_comments(ReferenceId::Enum(id), doc_comments);
+    interner.set_doc_comments(ReferenceId::Type(id), doc_comments);
 
     for (index, variant) in unresolved.enum_def.variants.iter().enumerate() {
         if !variant.doc_comments.is_empty() {
@@ -1201,7 +1201,7 @@ pub fn collect_enum(
     }
 
     if interner.is_in_lsp_mode() {
-        interner.register_enum(id, name.to_string(), visibility, parent_module_id);
+        interner.register_type(id, name.to_string(), visibility, parent_module_id);
     }
 
     Some((id, unresolved))

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -31,7 +31,7 @@ pub struct ModuleData {
     /// True if this module is a `contract Foo { ... }` module containing contract functions
     pub is_contract: bool,
 
-    /// True if this module is actually a struct
+    /// True if this module is actually a type
     pub is_type: bool,
 
     pub attributes: Vec<SecondaryAttribute>,
@@ -44,7 +44,7 @@ impl ModuleData {
         outer_attributes: Vec<SecondaryAttribute>,
         inner_attributes: Vec<SecondaryAttribute>,
         is_contract: bool,
-        is_struct: bool,
+        is_type: bool,
     ) -> ModuleData {
         let mut attributes = outer_attributes;
         attributes.extend(inner_attributes);
@@ -57,7 +57,7 @@ impl ModuleData {
             definitions: ItemScope::default(),
             location,
             is_contract,
-            is_type: is_struct,
+            is_type,
             attributes,
         }
     }

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -141,6 +141,9 @@ pub struct FuncMeta {
     /// The trait impl this function belongs to, if any
     pub trait_impl: Option<TraitImplId>,
 
+    /// If this function is the one related to an enum variant, this holds its index (relative to `type_id`)
+    pub enum_variant_index: Option<usize>,
+
     /// True if this function is an entry point to the program.
     /// For non-contracts, this means the function is `main`.
     pub is_entry_point: bool,

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -448,13 +448,19 @@ impl DataType {
         self.body = TypeBody::Struct(fields);
     }
 
-    pub(crate) fn push_variant(&mut self, variant: EnumVariant) {
+    pub(crate) fn init_variants(&mut self) {
         match &mut self.body {
             TypeBody::None => {
-                self.body = TypeBody::Enum(vec![variant]);
+                self.body = TypeBody::Enum(vec![]);
             }
+            _ => panic!("Called init_variants but body was None"),
+        }
+    }
+
+    pub(crate) fn push_variant(&mut self, variant: EnumVariant) {
+        match &mut self.body {
             TypeBody::Enum(variants) => variants.push(variant),
-            TypeBody::Struct(_) => panic!("Called push_variant on a non-variant type {self}"),
+            _ => panic!("Called push_variant on {self} but body wasn't an enum"),
         }
     }
 

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -60,7 +60,7 @@ impl NodeInterner {
         match reference {
             ReferenceId::Module(id) => self.module_attributes(&id).location,
             ReferenceId::Function(id) => self.function_modifiers(&id).name_location,
-            ReferenceId::Struct(id) | ReferenceId::Enum(id) => {
+            ReferenceId::Type(id) => {
                 let typ = self.get_type(id);
                 let typ = typ.borrow();
                 Location::new(typ.name.span(), typ.location.file)
@@ -109,8 +109,8 @@ impl NodeInterner {
             ModuleDefId::FunctionId(func_id) => {
                 self.add_function_reference(func_id, location);
             }
-            ModuleDefId::TypeId(struct_id) => {
-                self.add_struct_reference(struct_id, location, is_self_type);
+            ModuleDefId::TypeId(type_id) => {
+                self.add_type_reference(type_id, location, is_self_type);
             }
             ModuleDefId::TraitId(trait_id) => {
                 self.add_trait_reference(trait_id, location, is_self_type);
@@ -128,13 +128,13 @@ impl NodeInterner {
         self.add_reference(ReferenceId::Module(id), location, false);
     }
 
-    pub(crate) fn add_struct_reference(
+    pub(crate) fn add_type_reference(
         &mut self,
         id: TypeId,
         location: Location,
         is_self_type: bool,
     ) {
-        self.add_reference(ReferenceId::Struct(id), location, is_self_type);
+        self.add_reference(ReferenceId::Type(id), location, is_self_type);
     }
 
     pub(crate) fn add_struct_member_reference(
@@ -326,25 +326,14 @@ impl NodeInterner {
         self.register_name_for_auto_import(name, ModuleDefId::GlobalId(id), visibility, None);
     }
 
-    pub(crate) fn register_struct(
+    pub(crate) fn register_type(
         &mut self,
         id: TypeId,
         name: String,
         visibility: ItemVisibility,
         parent_module_id: ModuleId,
     ) {
-        self.add_definition_location(ReferenceId::Struct(id), Some(parent_module_id));
-        self.register_name_for_auto_import(name, ModuleDefId::TypeId(id), visibility, None);
-    }
-
-    pub(crate) fn register_enum(
-        &mut self,
-        id: TypeId,
-        name: String,
-        visibility: ItemVisibility,
-        parent_module_id: ModuleId,
-    ) {
-        self.add_definition_location(ReferenceId::Enum(id), Some(parent_module_id));
+        self.add_definition_location(ReferenceId::Type(id), Some(parent_module_id));
         self.register_name_for_auto_import(name, ModuleDefId::TypeId(id), visibility, None);
     }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -299,9 +299,8 @@ pub enum DependencyId {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ReferenceId {
     Module(ModuleId),
-    Struct(TypeId),
+    Type(TypeId),
     StructMember(TypeId, usize),
-    Enum(TypeId),
     EnumVariant(TypeId, usize),
     Trait(TraitId),
     Global(GlobalId),

--- a/tooling/lsp/src/modules.rs
+++ b/tooling/lsp/src/modules.rs
@@ -16,7 +16,7 @@ pub(crate) fn module_def_id_to_reference_id(module_def_id: ModuleDefId) -> Refer
     match module_def_id {
         ModuleDefId::ModuleId(id) => ReferenceId::Module(id),
         ModuleDefId::FunctionId(id) => ReferenceId::Function(id),
-        ModuleDefId::TypeId(id) => ReferenceId::Struct(id),
+        ModuleDefId::TypeId(id) => ReferenceId::Type(id),
         ModuleDefId::TypeAliasId(id) => ReferenceId::Alias(id),
         ModuleDefId::TraitId(id) => ReferenceId::Trait(id),
         ModuleDefId::GlobalId(id) => ReferenceId::Global(id),

--- a/tooling/lsp/src/requests/code_action/fill_struct_fields.rs
+++ b/tooling/lsp/src/requests/code_action/fill_struct_fields.rs
@@ -27,21 +27,14 @@ impl<'a> CodeActionFinder<'a> {
         let typ = self.interner.get_type(type_id);
         let typ = typ.borrow();
 
-        // Might be an enum
-        if !typ.is_struct() {
-            return;
-        }
-
         // First get all of the struct's fields
-        let mut fields = typ.get_fields_as_written();
+        let Some(mut fields) = typ.get_fields_as_written() else {
+            return;
+        };
 
         // Remove the ones that already exists in the constructor
         for (constructor_field, _) in &constructor.fields {
             fields.retain(|field| field.name.0.contents != constructor_field.0.contents);
-        }
-
-        if fields.is_empty() {
-            return;
         }
 
         // Some fields are missing. Let's suggest a quick fix that adds them.

--- a/tooling/lsp/src/requests/code_action/fill_struct_fields.rs
+++ b/tooling/lsp/src/requests/code_action/fill_struct_fields.rs
@@ -20,15 +20,20 @@ impl<'a> CodeActionFinder<'a> {
         };
 
         let location = Location::new(path.span, self.file);
-        let Some(ReferenceId::Struct(struct_id)) = self.interner.find_referenced(location) else {
+        let Some(ReferenceId::Type(type_id)) = self.interner.find_referenced(location) else {
             return;
         };
 
-        let struct_type = self.interner.get_type(struct_id);
-        let struct_type = struct_type.borrow();
+        let typ = self.interner.get_type(type_id);
+        let typ = typ.borrow();
+
+        // Might be an enum
+        if !typ.is_struct() {
+            return;
+        }
 
         // First get all of the struct's fields
-        let mut fields = struct_type.get_fields_as_written();
+        let mut fields = typ.get_fields_as_written();
 
         // Remove the ones that already exists in the constructor
         for (constructor_field, _) in &constructor.fields {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -207,8 +207,11 @@ impl<'a> NodeFinder<'a> {
         let struct_type = struct_type.borrow();
 
         // First get all of the struct's fields
-        let mut fields: Vec<_> =
-            struct_type.get_fields_as_written().into_iter().enumerate().collect();
+        let Some(fields) = struct_type.get_fields_as_written() else {
+            return;
+        };
+
+        let mut fields = fields.into_iter().enumerate().collect::<Vec<_>>();
 
         // Remove the ones that already exists in the constructor
         for (used_name, _) in &constructor_expression.fields {
@@ -805,9 +808,11 @@ impl<'a> NodeFinder<'a> {
         prefix: &str,
         self_prefix: bool,
     ) {
-        for (field_index, (name, visibility, typ)) in
-            struct_type.get_fields_with_visibility(generics).iter().enumerate()
-        {
+        let Some(fields) = struct_type.get_fields_with_visibility(generics) else {
+            return;
+        };
+
+        for (field_index, (name, visibility, typ)) in fields.iter().enumerate() {
             if !struct_member_is_visible(struct_type.id, *visibility, self.module_id, self.def_maps)
             {
                 continue;

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -199,7 +199,7 @@ impl<'a> NodeFinder<'a> {
         };
 
         let location = Location::new(span, self.file);
-        let Some(ReferenceId::Struct(struct_id)) = self.interner.find_referenced(location) else {
+        let Some(ReferenceId::Type(struct_id)) = self.interner.find_referenced(location) else {
             return;
         };
 
@@ -1953,8 +1953,7 @@ fn name_matches(name: &str, prefix: &str) -> bool {
 fn module_def_id_from_reference_id(reference_id: ReferenceId) -> Option<ModuleDefId> {
     match reference_id {
         ReferenceId::Module(module_id) => Some(ModuleDefId::ModuleId(module_id)),
-        ReferenceId::Struct(struct_id) => Some(ModuleDefId::TypeId(struct_id)),
-        ReferenceId::Enum(enum_id) => Some(ModuleDefId::TypeId(enum_id)),
+        ReferenceId::Type(struct_id) => Some(ModuleDefId::TypeId(struct_id)),
         ReferenceId::Trait(trait_id) => Some(ModuleDefId::TraitId(trait_id)),
         ReferenceId::Function(func_id) => Some(ModuleDefId::FunctionId(func_id)),
         ReferenceId::Alias(type_alias_id) => Some(ModuleDefId::TypeAliasId(type_alias_id)),

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -428,6 +428,8 @@ impl<'a> NodeFinder<'a> {
         function_kind: FunctionKind,
         skip_first_argument: bool,
     ) -> String {
+        let is_enum_variant = func_meta.enum_variant_index.is_some();
+
         let mut text = String::new();
         text.push_str(name);
         text.push('(');
@@ -457,7 +459,11 @@ impl<'a> NodeFinder<'a> {
             text.push_str("${");
             text.push_str(&index.to_string());
             text.push(':');
-            self.hir_pattern_to_argument(pattern, &mut text);
+            if is_enum_variant {
+                text.push_str("()");
+            } else {
+                self.hir_pattern_to_argument(pattern, &mut text);
+            }
             text.push('}');
 
             index += 1;

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -113,7 +113,7 @@ impl<'a> NodeFinder<'a> {
     fn struct_completion_item(&self, name: String, struct_id: TypeId) -> CompletionItem {
         let completion_item =
             simple_completion_item(name.clone(), CompletionItemKind::STRUCT, Some(name));
-        self.completion_item_with_doc_comments(ReferenceId::Struct(struct_id), completion_item)
+        self.completion_item_with_doc_comments(ReferenceId::Type(struct_id), completion_item)
     }
 
     pub(super) fn struct_field_completion_item(

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -20,8 +20,8 @@ mod completion_tests {
 
     use lsp_types::{
         CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionParams,
-        CompletionResponse, DidOpenTextDocumentParams, PartialResultParams, Position,
-        TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
+        CompletionResponse, DidOpenTextDocumentParams, Documentation, PartialResultParams,
+        Position, TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
         WorkDoneProgressParams,
     };
     use tokio::test;
@@ -3076,5 +3076,34 @@ fn main() {
 }
         "#;
         assert_eq!(new_code, expected);
+    }
+
+    #[test]
+    async fn test_suggests_enum_variant_differently_than_a_function_call() {
+        let src = r#"
+        enum Enum {
+            /// Some docs
+            Variant(Field, i32)
+        }
+
+        fn foo() {
+            Enum::Var>|<
+        }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(item.label, "Variant(…)".to_string());
+
+        let details = item.label_details.as_ref().unwrap();
+        assert_eq!(details.description, Some("Variant(Field, i32)".to_string()));
+
+        assert_eq!(item.detail, Some("Variant(Field, i32)".to_string()));
+
+        let Documentation::MarkupContent(markdown) = item.documentation.as_ref().unwrap() else {
+            panic!("Expected markdown docs");
+        };
+        assert!(markdown.value.contains("Some docs"));
     }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3101,6 +3101,8 @@ fn main() {
 
         assert_eq!(item.detail, Some("Variant(Field, i32)".to_string()));
 
+        assert_eq!(item.insert_text, Some("Variant(${1:()}, ${2:()})".to_string()));
+
         let Documentation::MarkupContent(markdown) = item.documentation.as_ref().unwrap() else {
             panic!("Expected markdown docs");
         };

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -1259,4 +1259,37 @@ mod hover_tests {
                 .await;
         assert!(hover_text.contains("fn mut_self(&mut self)"));
     }
+
+    #[test]
+    async fn hover_on_empty_enum_type() {
+        let hover_text =
+            get_hover_text("workspace", "two/src/lib.nr", Position { line: 100, character: 8 })
+                .await;
+        assert!(hover_text.contains(
+            "    two
+    enum EmptyColor {
+    }
+
+---
+
+ Red, blue, etc."
+        ));
+    }
+
+    #[test]
+    async fn hover_on_non_empty_enum_type() {
+        let hover_text =
+            get_hover_text("workspace", "two/src/lib.nr", Position { line: 103, character: 8 })
+                .await;
+        assert!(hover_text.contains(
+            "    two
+    enum Color {
+        Red,
+    }
+
+---
+
+ Red, blue, etc."
+        ));
+    }
 }

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -1292,4 +1292,19 @@ mod hover_tests {
  Red, blue, etc."
         ));
     }
+
+    #[test]
+    async fn hover_on_enum_variant() {
+        let hover_text =
+            get_hover_text("workspace", "two/src/lib.nr", Position { line: 105, character: 6 })
+                .await;
+        assert!(hover_text.contains(
+            "    two::Color
+    Red
+
+---
+
+ Like a tomato"
+        ));
+    }
 }

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -173,6 +173,11 @@ impl<'a> InlayHintCollector<'a> {
         if let Some(ReferenceId::Function(func_id)) = referenced {
             let func_meta = self.interner.function_meta(&func_id);
 
+            // No hints for enum variants
+            if func_meta.enum_variant_index.is_some() {
+                return;
+            }
+
             let mut parameters = func_meta.parameters.iter().peekable();
             let mut parameters_count = func_meta.parameters.len();
 

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -109,8 +109,7 @@ impl<'a> InlayHintCollector<'a> {
                         self.push_type_hint(lsp_location, &variant_type, false, include_colon);
                     }
                     ReferenceId::Module(_)
-                    | ReferenceId::Struct(_)
-                    | ReferenceId::Enum(_)
+                    | ReferenceId::Type(_)
                     | ReferenceId::Trait(_)
                     | ReferenceId::Function(_)
                     | ReferenceId::Alias(_)

--- a/tooling/lsp/src/requests/signature_help/tests.rs
+++ b/tooling/lsp/src/requests/signature_help/tests.rs
@@ -240,4 +240,31 @@ mod signature_help_tests {
 
         assert_eq!(signature.active_parameter, Some(0));
     }
+
+    #[test]
+    async fn test_signature_help_for_enum_variant() {
+        let src = r#"
+            enum Enum {
+                Variant(Field, i32)
+            }
+
+            fn bar() {
+                Enum::Variant(>|<(), ());
+            }
+        "#;
+
+        let signature_help = get_signature_help(src).await;
+        assert_eq!(signature_help.signatures.len(), 1);
+
+        let signature = &signature_help.signatures[0];
+        assert_eq!(signature.label, "enum Enum::Variant(Field, i32)");
+
+        let params = signature.parameters.as_ref().unwrap();
+        assert_eq!(params.len(), 2);
+
+        check_label(&signature.label, &params[0].label, "Field");
+        check_label(&signature.label, &params[1].label, "i32");
+
+        assert_eq!(signature.active_parameter, Some(0));
+    }
 }

--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -103,5 +103,9 @@ enum EmptyColor {}
 /// Red, blue, etc.
 enum Color {
     /// Like a tomato
-    Red,
+    Red(Field),
+}
+
+fn test_enum() -> Color {
+    Color::Red(1)
 }

--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -96,3 +96,11 @@ impl TraitWithDocs for Field {
 impl<U> Foo<U> {
     fn mut_self(&mut self) {}
 }
+
+/// Red, blue, etc.
+enum EmptyColor {}
+
+/// Red, blue, etc.
+enum Color {
+    Red,
+}

--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -102,5 +102,6 @@ enum EmptyColor {}
 
 /// Red, blue, etc.
 enum Color {
+    /// Like a tomato
     Red,
 }


### PR DESCRIPTION
# Description

## Problem

Part of #988

## Summary

Now enum variants show up as they do in Rust Analyzer.

Completion:

![image](https://github.com/user-attachments/assets/8e936fa9-548c-42af-b44b-a2b84a7ea2ce)

Signature help:

![image](https://github.com/user-attachments/assets/0fa73eb0-8993-4fea-b09f-f52ddbf490cf)

Hover:

![image](https://github.com/user-attachments/assets/181395fd-d195-43c7-9cba-89ee19aa6808)

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
