### PR TITLE
fix(LSP): correct signature for assert and assert_eq

### DIFF
--- a/tooling/lsp/src/requests/signature_help.rs
+++ b/tooling/lsp/src/requests/signature_help.rs
@@ -240,7 +240,7 @@ impl<'a> SignatureFinder<'a> {
         self.hardcoded_signature_information(
             active_parameter,
             "assert",
-            &["predicate: bool", "[failure_message: str<N>]"],
+            &["predicate: bool", "[failure_message: T]"],
         )
     }
 
@@ -251,7 +251,7 @@ impl<'a> SignatureFinder<'a> {
         self.hardcoded_signature_information(
             active_parameter,
             "assert_eq",
-            &["lhs: T", "rhs: T", "[failure_message: str<N>]"],
+            &["lhs: T", "rhs: T", "[failure_message: U]"],
         )
     }
 

--- a/tooling/lsp/src/requests/signature_help/tests.rs
+++ b/tooling/lsp/src/requests/signature_help/tests.rs
@@ -206,13 +206,13 @@ mod signature_help_tests {
         assert_eq!(signature_help.signatures.len(), 1);
 
         let signature = &signature_help.signatures[0];
-        assert_eq!(signature.label, "assert(predicate: bool, [failure_message: str<N>])");
+        assert_eq!(signature.label, "assert(predicate: bool, [failure_message: T])");
 
         let params = signature.parameters.as_ref().unwrap();
         assert_eq!(params.len(), 2);
 
         check_label(&signature.label, &params[0].label, "predicate: bool");
-        check_label(&signature.label, &params[1].label, "[failure_message: str<N>]");
+        check_label(&signature.label, &params[1].label, "[failure_message: T]");
 
         assert_eq!(signature.active_parameter, Some(0));
     }
@@ -229,14 +229,14 @@ mod signature_help_tests {
         assert_eq!(signature_help.signatures.len(), 1);
 
         let signature = &signature_help.signatures[0];
-        assert_eq!(signature.label, "assert_eq(lhs: T, rhs: T, [failure_message: str<N>])");
+        assert_eq!(signature.label, "assert_eq(lhs: T, rhs: T, [failure_message: U])");
 
         let params = signature.parameters.as_ref().unwrap();
         assert_eq!(params.len(), 3);
 
         check_label(&signature.label, &params[0].label, "lhs: T");
         check_label(&signature.label, &params[1].label, "rhs: T");
-        check_label(&signature.label, &params[2].label, "[failure_message: str<N>]");
+        check_label(&signature.label, &params[2].label, "[failure_message: U]");
 
         assert_eq!(signature.active_parameter, Some(0));
     }


### PR DESCRIPTION
# Description

## Problem

The signature shown in LSP for `assert` and `assert_eq` is slightly misleading.

## Summary

Just a small thing, but some days ago Nico told me that it would be nice if the assertion failure message could be a `fmtstr` and it turns out you can use any type for it. I wrote that signature when I didn't know that was the case.


## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
