### PR TITLE
feat: allow specifying multiple patterns in nargo test

### DIFF
--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -215,7 +215,7 @@ fn get_package_tests_in_crate(
     let fm = &context.file_manager;
     let files = fm.as_file_map();
     let tests =
-        context.get_all_test_functions_in_crate_matching(crate_id, FunctionNameMatch::Anything);
+        context.get_all_test_functions_in_crate_matching(crate_id, &FunctionNameMatch::Anything);
 
     let package_tests: Vec<_> = tests
         .into_iter()

--- a/tooling/lsp/src/requests/code_lens_request.rs
+++ b/tooling/lsp/src/requests/code_lens_request.rs
@@ -96,7 +96,7 @@ pub(crate) fn collect_lenses_for_package(
     let fm = &context.file_manager;
     let files = fm.as_file_map();
     let tests =
-        context.get_all_test_functions_in_crate_matching(&crate_id, FunctionNameMatch::Anything);
+        context.get_all_test_functions_in_crate_matching(&crate_id, &FunctionNameMatch::Anything);
     for (func_name, test_function) in tests {
         let location = context.function_meta(&test_function.get_id()).name.location;
         let file_id = location.file;

--- a/tooling/lsp/src/requests/test_run.rs
+++ b/tooling/lsp/src/requests/test_run.rs
@@ -74,7 +74,7 @@ fn on_test_run_request_inner(
 
             let test_functions = context.get_all_test_functions_in_crate_matching(
                 &crate_id,
-                FunctionNameMatch::Exact(function_name),
+                &FunctionNameMatch::Exact(vec![function_name.clone()]),
             );
 
             let (_, test_function) = test_functions.into_iter().next().ok_or_else(|| {

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -33,7 +33,7 @@ pub(crate) mod formatters;
 #[clap(visible_alias = "t")]
 pub(crate) struct TestCommand {
     /// If given, only tests with names containing this string will be run
-    test_name: Option<String>,
+    test_names: Vec<String>,
 
     /// Display output of `println` statements
     #[arg(long)]
@@ -125,15 +125,12 @@ pub(crate) fn run(args: TestCommand, config: NargoConfig) -> Result<(), CliError
     insert_all_files_for_workspace_into_file_manager(&workspace, &mut file_manager);
     let parsed_files = parse_all(&file_manager);
 
-    let pattern = match &args.test_name {
-        Some(name) => {
-            if args.exact {
-                FunctionNameMatch::Exact(name)
-            } else {
-                FunctionNameMatch::Contains(name)
-            }
-        }
-        None => FunctionNameMatch::Anything,
+    let pattern = if args.test_names.is_empty() {
+        FunctionNameMatch::Anything
+    } else if args.exact {
+        FunctionNameMatch::Exact(args.test_names.clone())
+    } else {
+        FunctionNameMatch::Contains(args.test_names.clone())
     };
 
     let formatter: Box<dyn Formatter> = if let Some(format) = args.format {
@@ -161,7 +158,7 @@ struct TestRunner<'a> {
     parsed_files: &'a ParsedFiles,
     workspace: Workspace,
     args: &'a TestCommand,
-    pattern: FunctionNameMatch<'a>,
+    pattern: FunctionNameMatch,
     num_threads: usize,
     formatter: Box<dyn Formatter>,
 }
@@ -186,15 +183,31 @@ impl<'a> TestRunner<'a> {
 
         if tests_count == 0 {
             match &self.pattern {
-                FunctionNameMatch::Exact(pattern) => {
-                    return Err(CliError::Generic(format!(
-                        "Found 0 tests matching input '{pattern}'.",
-                    )))
+                FunctionNameMatch::Exact(patterns) => {
+                    if patterns.len() == 1 {
+                        return Err(CliError::Generic(format!(
+                            "Found 0 tests matching '{}'.",
+                            patterns.first().unwrap()
+                        )));
+                    } else {
+                        return Err(CliError::Generic(format!(
+                            "Found 0 tests matching any of {}.",
+                            patterns.join(", "),
+                        )));
+                    }
                 }
-                FunctionNameMatch::Contains(pattern) => {
-                    return Err(CliError::Generic(
-                        format!("Found 0 tests containing '{pattern}'.",),
-                    ))
+                FunctionNameMatch::Contains(patterns) => {
+                    if patterns.len() == 1 {
+                        return Err(CliError::Generic(format!(
+                            "Found 0 tests containing '{}'.",
+                            patterns.first().unwrap()
+                        )));
+                    } else {
+                        return Err(CliError::Generic(format!(
+                            "Found 0 tests containing any of {}.",
+                            patterns.join(", ")
+                        )));
+                    }
                 }
                 // If we are running all tests in a crate, having none is not an error
                 FunctionNameMatch::Anything => {}
@@ -459,7 +472,7 @@ impl<'a> TestRunner<'a> {
         check_crate_and_report_errors(&mut context, crate_id, &self.args.compile_options)?;
 
         Ok(context
-            .get_all_test_functions_in_crate_matching(&crate_id, self.pattern)
+            .get_all_test_functions_in_crate_matching(&crate_id, &self.pattern)
             .into_iter()
             .map(|(test_name, _)| test_name)
             .collect())
@@ -483,8 +496,8 @@ impl<'a> TestRunner<'a> {
         check_crate(&mut context, crate_id, &self.args.compile_options)
             .expect("Any errors should have occurred when collecting test functions");
 
-        let test_functions = context
-            .get_all_test_functions_in_crate_matching(&crate_id, FunctionNameMatch::Exact(fn_name));
+        let pattern = FunctionNameMatch::Exact(vec![fn_name.to_string()]);
+        let test_functions = context.get_all_test_functions_in_crate_matching(&crate_id, &pattern);
         let (_, test_function) = test_functions.first().expect("Test function should exist");
 
         let blackbox_solver = S::default();

--- a/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
@@ -112,7 +112,7 @@ impl Formatter for PrettyFormatter {
             }
         };
 
-        write!(writer, "[{}] Testing {}... ", &test_result.package_name, &test_result.name)?;
+        write!(writer, "[{}] Testing {} ... ", &test_result.package_name, &test_result.name)?;
         writer.flush()?;
 
         match &test_result.status {

--- a/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -33,7 +33,7 @@ pub struct Options {
 impl Options {
     pub fn function_name_match(&self) -> FunctionNameMatch {
         match self.args.as_slice() {
-            [_test_name, lib] => FunctionNameMatch::Contains(lib.as_str()),
+            [_test_name, lib] => FunctionNameMatch::Contains(vec![lib.clone()]),
             _ => FunctionNameMatch::Anything,
         }
     }
@@ -78,7 +78,7 @@ fn run_stdlib_tests(force_brillig: bool, inliner_aggressiveness: i64) {
 
     let test_functions = context.get_all_test_functions_in_crate_matching(
         context.stdlib_crate_id(),
-        opts.function_name_match(),
+        &opts.function_name_match(),
     );
 
     let test_report: Vec<(String, TestStatus)> = test_functions


### PR DESCRIPTION
# Description

## Problem

Resolves #7150

## Summary

For this, no need to do `nargo test -- one two`, just doing `nargo test one two` works.

## Additional Context

Also adds a space before "..." in nargo test output for each test because otherwise double-clicking the name would include the trailing "..." and copying that after `nargo test` wouldn't find the test. This is now the same as the output of `cargo test`.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
