### PR TITLE
feat: concat3

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -60,6 +60,7 @@
         "combinators",
         "compinit",
         "comptime",
+        "concat",
         "cpus",
         "cranelift",
         "critesjosh",

--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -255,6 +255,23 @@ fn main() {
 }
 ```
 
+### concat
+
+Concatenates this array with another array.
+
+```rust
+fn concat<let M: u32>(self, array2: [T; M]) -> [T; N + M]
+```
+
+```rust
+fn main() {
+    let arr1 = [1, 2, 3, 4];
+    let arr2 = [6, 7, 8, 9, 10, 11];
+    let concatenated_arr = arr1.concat(arr2);
+    assert(concatenated_arr == [1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
+}
+```
+
 ### as_str_unchecked
 
 Converts a byte array of type `[u8; N]` to a string. Note that this performs no UTF-8 validation -

--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -272,6 +272,24 @@ fn main() {
 }
 ```
 
+### concat3
+
+Concatenates this array with another array.
+
+```rust
+fn concat3<let M: u32, let L: u32>(self, array2: [T; M], array3: [T; L]) -> [T; N + M + L]
+```
+
+```rust
+fn main() {
+    let arr1 = [1, 2, 3];
+    let arr2 = [4, 5, 6];
+    let arr3 = [7, 8, 9];
+    let concatenated_arr = arr1.concat3(arr2, arr3);
+    assert(concatenated_arr == [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+}
+```
+
 ### as_str_unchecked
 
 Converts a byte array of type `[u8; N]` to a string. Note that this performs no UTF-8 validation -

--- a/noir_stdlib/src/array/mod.nr
+++ b/noir_stdlib/src/array/mod.nr
@@ -136,6 +136,29 @@ impl<T, let N: u32> [T; N] {
         }
         ret
     }
+
+    /// Concatenates this array with another array.
+    ///
+    /// Example:
+    ///
+    /// ```noir
+    /// fn main() {
+    ///     let arr1 = [1, 2, 3, 4];
+    ///     let arr2 = [6, 7, 8, 9, 10, 11];
+    ///     let concatenated_arr = arr1.concat(arr2);
+    ///     assert(concatenated_arr == [1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
+    /// }
+    /// ```
+    pub fn concat<let M: u32>(self, array2: [T; M]) -> [T; N + M] {
+        let mut result = [self[0]; N + M];
+        for i in 1..N {
+            result[i] = self[i];
+        }
+        for i in 0..M {
+            result[i + N] = array2[i];
+        }
+        result
+    }
 }
 
 impl<T, let N: u32> [T; N]

--- a/noir_stdlib/src/array/mod.nr
+++ b/noir_stdlib/src/array/mod.nr
@@ -159,6 +159,38 @@ impl<T, let N: u32> [T; N] {
         }
         result
     }
+
+    /// Concatenates this array with two other arrays.
+    ///
+    /// For unconstrained functions, this is more efficient than calling
+    /// `arr1.concat(arr2.concat(arr3))`.
+    ///
+    /// Example:
+    ///
+    /// ```noir
+    /// fn main() {
+    ///     let arr1 = [1, 2, 3];
+    ///     let arr2 = [4, 5, 6];
+    ///     let arr3 = [7, 8, 9];
+    ///     let concatenated_arr = arr1.concat3(arr2, arr3);
+    ///     assert(concatenated_arr == [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    /// }
+    /// ```
+    pub fn concat3<let M: u32, let L: u32>(self, array2: [T; M], array3: [T; L]) -> [T; N + M + L] {
+        let mut result = [self[0]; N + M + L];
+        for i in 1..N {
+            result[i] = self[i];
+        }
+        let mut offset = N;
+        for i in 0..M {
+            result[offset + i] = array2[i];
+        }
+        offset += M;
+        for i in 0..L {
+            result[offset + i] = array3[i];
+        }
+        result
+    }
 }
 
 impl<T, let N: u32> [T; N]
@@ -262,5 +294,14 @@ mod test {
         let arr2 = [6, 7, 8, 9, 10, 11];
         let concatenated_arr = arr1.concat(arr2);
         assert(concatenated_arr == [1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
-    }   
+    }
+
+    #[test]
+    fn concat3() {
+        let arr1 = [1, 2, 3];
+        let arr2 = [4, 5, 6];
+        let arr3 = [7, 8, 9];
+        let concatenated_arr = arr1.concat3(arr2, arr3);
+        assert(concatenated_arr == [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
 }

--- a/noir_stdlib/src/array/mod.nr
+++ b/noir_stdlib/src/array/mod.nr
@@ -255,4 +255,12 @@ mod test {
     fn map_empty() {
         assert_eq([].map(|x| x + 1), []);
     }
+
+    #[test]
+    fn concat() {
+        let arr1 = [1, 2, 3, 4];
+        let arr2 = [6, 7, 8, 9, 10, 11];
+        let concatenated_arr = arr1.concat(arr2);
+        assert(concatenated_arr == [1, 2, 3, 4, 6, 7, 8, 9, 10, 11]);
+    }   
 }


### PR DESCRIPTION
# Description

This builds off #7199 (hence the diff also including the `concat` method. I haven't learned graphite.

I might've gone a bit far with this one: an ugly method called `concat3` which concatenates 3 arrays. The question then becomes: where do you stop? Where does the madness end? 4? 5? Maybe extra ones should be created through some metaprogramming magic?
Anyway, I would put concat3 to good use immediately, but I could also just use `concat`. If you think that instead I should just use `concat` and accept the slowdown due to the unnecessary `for` loops when doing `arr1.concat(arr2.concat(arr3))`, I guess I could...

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
