### PR TITLE
chore(docs): moving references to noir-starter to awesome-noir

### DIFF
--- a/docs/docs/how_to/how-to-oracles.md
+++ b/docs/docs/how_to/how-to-oracles.md
@@ -14,7 +14,7 @@ sidebar_position: 1
 This guide shows you how to use oracles in your Noir program. For the sake of clarity, it assumes that:
 
 - You have read the [explainer on Oracles](../explainers/explainer-oracle.md) and are comfortable with the concept.
-- You have a Noir program to add oracles to. You can create one using the [vite-hardhat starter](https://github.com/noir-lang/noir-starter/tree/main/vite-hardhat) as a boilerplate.
+- You have a Noir program to add oracles to. You can create one using one of the starters in [awesome-noir](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates).
 - You understand the concept of a JSON-RPC server. Visit the [JSON-RPC website](https://www.jsonrpc.org/) if you need a refresher.
 - You are comfortable with server-side JavaScript (e.g. Node.js, managing packages, etc.).
 

--- a/docs/docs/how_to/how-to-solidity-verifier.mdx
+++ b/docs/docs/how_to/how-to-solidity-verifier.mdx
@@ -289,12 +289,10 @@ For example, chains like `zkSync ERA` and `Polygon zkEVM` do not currently suppo
 - Linea
 - Moonbeam
 
-If you test any other chains, please open a PR on this page to update the list. See [this doc](https://github.com/noir-lang/noir-starter/tree/main/with-foundry#testing-on-chain) for more info about testing verifier contracts on different EVM chains.
+If you test any other chains, please open a PR on this page to update the list.
 
 ## What's next
 
-Now that you know how to call a Noir Solidity Verifier on a smart contract using Remix, you should be comfortable with using it with some programmatic frameworks, such as [hardhat](https://github.com/noir-lang/noir-starter/tree/main/vite-hardhat) and [foundry](https://github.com/noir-lang/noir-starter/tree/main/with-foundry).
-
-You can find other tools, examples, boilerplates and libraries in the [awesome-noir](https://github.com/noir-lang/awesome-noir) repository.
+Now that you know how to call a Noir Solidity Verifier on a smart contract using Remix, you should be comfortable with using it with some programmatic frameworks. You can find other tools, examples, boilerplates and libraries in the [awesome-noir](https://github.com/noir-lang/awesome-noir) repository.
 
 You should also be ready to write and deploy your first NoirJS app and start generating proofs on websites, phones, and NodeJS environments! Head on to the [NoirJS tutorial](../tutorials/noirjs_app.md) to learn how to do that.

--- a/docs/docs/how_to/using-devcontainers.mdx
+++ b/docs/docs/how_to/using-devcontainers.mdx
@@ -91,7 +91,7 @@ ENTRYPOINT ["nargo"]
 
 This will pull the new image and build it, so it could take a minute or so
 
-#### 8. Done! 
+#### 8. Done!   
 Just wait for the build to finish, and there's your easy Noir environment. Some examples of how to use it can be found in the [awesome-noir](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates) repository.
 
 ## How do I use it?

--- a/docs/docs/how_to/using-devcontainers.mdx
+++ b/docs/docs/how_to/using-devcontainers.mdx
@@ -92,12 +92,7 @@ ENTRYPOINT ["nargo"]
 This will pull the new image and build it, so it could take a minute or so
 
 #### 8. Done! 
-Just wait for the build to finish, and there's your easy Noir environment.
-
-
-Refer to [noir-starter](https://github.com/noir-lang/noir-starter/) as an example of how devcontainers can be used together with codespaces.
-
-
+Just wait for the build to finish, and there's your easy Noir environment. Some examples of how to use it can be found in the [awesome-noir](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates) repository.
 
 ## How do I use it?
 

--- a/docs/docs/tutorials/noirjs_app.md
+++ b/docs/docs/tutorials/noirjs_app.md
@@ -301,4 +301,4 @@ If you want to continue learning by doing, here are some challenges for you:
 - Change the circuit to accept a [public input](../noir/concepts/data_types/#private--public-types) as the cutoff age. It could be different depending on the purpose, for example!
 - Enjoy Noir's Rust-like syntax and write a struct `Country` that implements a trait `MinAge` with a method `get_min_age`. Then, make a struct `Person` have an `u8` as its age and a country of type `Country`. You can pass a `person` in JS just like a JSON object `person: { age, country: { min_age: 18 }}`
 
-The world is your stage, just have fun with ZK! You can see how noirjs is used in some common frameworks in the [awesome-noir repo]([https://github.com/noir-lang/awesome](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates)).
+The world is your stage, just have fun with ZK! You can see how NoirJS is used in some common frameworks in the [awesome-noir repo]([https://github.com/noir-lang/awesome](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates)).

--- a/docs/docs/tutorials/noirjs_app.md
+++ b/docs/docs/tutorials/noirjs_app.md
@@ -301,6 +301,4 @@ If you want to continue learning by doing, here are some challenges for you:
 - Change the circuit to accept a [public input](../noir/concepts/data_types/#private--public-types) as the cutoff age. It could be different depending on the purpose, for example!
 - Enjoy Noir's Rust-like syntax and write a struct `Country` that implements a trait `MinAge` with a method `get_min_age`. Then, make a struct `Person` have an `u8` as its age and a country of type `Country`. You can pass a `person` in JS just like a JSON object `person: { age, country: { min_age: 18 }}`
 
-The world is your stage, just have fun with ZK! You can see how noirjs is used in a full stack Next.js hardhat application in the [noir-starter repo here](https://github.com/noir-lang/noir-starter/tree/main/vite-hardhat). The example shows how to calculate a proof in the browser and verify it with a deployed Solidity verifier contract from noirjs.
-
-Check out other starters, tools, or just cool projects in the [awesome noir repository](https://github.com/noir-lang/awesome-noir).
+The world is your stage, just have fun with ZK! You can see how noirjs is used in some common frameworks in the [awesome-noir repo]([https://github.com/noir-lang/awesome](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates)).

--- a/docs/docs/tutorials/noirjs_app.md
+++ b/docs/docs/tutorials/noirjs_app.md
@@ -301,4 +301,4 @@ If you want to continue learning by doing, here are some challenges for you:
 - Change the circuit to accept a [public input](../noir/concepts/data_types/#private--public-types) as the cutoff age. It could be different depending on the purpose, for example!
 - Enjoy Noir's Rust-like syntax and write a struct `Country` that implements a trait `MinAge` with a method `get_min_age`. Then, make a struct `Person` have an `u8` as its age and a country of type `Country`. You can pass a `person` in JS just like a JSON object `person: { age, country: { min_age: 18 }}`
 
-The world is your stage, just have fun with ZK! You can see how NoirJS is used in some common frameworks in the [awesome-noir repo]([https://github.com/noir-lang/awesome](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates)).
+The world is your stage, just have fun with ZK! You can see how noirjs is used in some common frameworks in the [awesome-noir repo](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates).


### PR DESCRIPTION
As decided in our mid/long-term sustainability plan, we're slowly moving out noir-starter as the go-to starter. This PR replaces them in docs by Awesome Noir