### PR TITLE
chore: update docs to use devcontainer feature

### DIFF
--- a/docs/docs/how_to/using-devcontainers.mdx
+++ b/docs/docs/how_to/using-devcontainers.mdx
@@ -60,29 +60,15 @@ Github comes with a default codespace and you can use it to code your own devcon
 
 #### 3. Create a folder called `.devcontainer` in the root of your repository.
 
-#### 4. Create a Dockerfile in that folder, and paste the following code:
-
-```docker
-FROM --platform=linux/amd64 node:lts-bookworm-slim
-SHELL ["/bin/bash", "-c"]
-RUN apt update && apt install -y curl bash git tar gzip libc++-dev
-RUN curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-ENV PATH="/root/.nargo/bin:$PATH"
-RUN noirup
-ENTRYPOINT ["nargo"]
-```
-#### 5. Create a file called `devcontainer.json` in the same folder, and paste the following code:
+#### 4. Create a file called `devcontainer.json` in the same folder, and paste the following code:
 
 ```json
 {
  "name": "Noir on Codespaces",
- "build": {
-    "context": ".",
-    "dockerfile": "Dockerfile"
-  },
-  "customizations": {
-    "vscode": {
-      "extensions": ["noir-lang.vscode-noir"]
+ "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/noir-lang/features/noir:latest": {
+      "version": "1.0.0-beta.1"
     }
   }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates documentation to use the noir devcontainer feature rather than a dockerfile.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
