### PR TITLE
chore: exclude dependency fetching time from benchmarks

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -365,6 +365,13 @@ jobs:
           repository: ${{ matrix.project.repo }}
           path: test-repo
           ref: ${{ matrix.project.ref }}
+      
+      - name: Generate compilation report
+        working-directory: ./test-repo/${{ matrix.project.path }}
+        run: |
+          # We run `nargo check` to pre-fetch any dependencies so we don't measure the time to download these
+          # when benchmarking.
+          nargo check
 
       - name: Generate compilation report
         working-directory: ./test-repo/${{ matrix.project.path }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -366,7 +366,7 @@ jobs:
           path: test-repo
           ref: ${{ matrix.project.ref }}
       
-      - name: Generate compilation report
+      - name: Fetch noir dependencies
         working-directory: ./test-repo/${{ matrix.project.path }}
         run: |
           # We run `nargo check` to pre-fetch any dependencies so we don't measure the time to download these


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We currently measure the time to download these in the compilation benchmarks (on the first iteration) so this step goes and downloads these ahead of time.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
