### PR TITLE
fix: correct reversed callstacks

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/call_stack.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/call_stack.rs
@@ -62,6 +62,7 @@ impl CallStackHelper {
             result.push(self.locations[call_stack.index()].value);
             call_stack = parent;
         }
+        result.reverse();
         result
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Set the correct order for the call stack.


## Summary\*
This fix is included in #7034, but we are waiting for the Aztec-Packages noir-sync to pass before merging it. However the sync is failing due to not having the fix.
In order to resolve this, the fix has been manually applied to the sync, and with this PR I also apply it on the Noir repo.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X ] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
