### PR TITLE
chore: add regression test for #7213

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/tests.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/tests.rs
@@ -327,59 +327,18 @@ fn can_handle_recursion() {
     // Regression test for https://github.com/noir-lang/noir/issues/7213
     let program = "
 
-    global ELEMENT_COUNT: u32 = 100;
+    global RECURSION_LIMIT: u32 = 33;
 
     comptime fn main() {
-        let values: [u32; ELEMENT_COUNT] = [0; ELEMENT_COUNT];
-        let _ = quicksort(values);
+        recurse(RECURSION_LIMIT);
     }
     
-    comptime fn partition<let N: u32>(
-        arr: &mut [u32; N],
-        low: u32,
-        high: u32,
-    ) -> u32 {
-        let pivot = high;
-        let mut i = low;
-        for j in low..high {
-            if arr[j] < arr[pivot] {
-                let temp = arr[i];
-                arr[i] = arr[j];
-                arr[j] = temp;
-    
-                i += 1;
-            }
-        }
-    
-        let temp = arr[i];
-        arr[i] = arr[pivot];
-        arr[pivot] = temp;
-        i
-    }
-    
-    comptime fn quicksort_recursive<let N: u32>(
-        arr: &mut [u32; N],
-        low: u32,
-        high: u32,
-    ) {
-        if low < high {
-            let pivot_index = partition(arr, low, high);
-            if pivot_index > 0 {
-                quicksort_recursive(arr, low, pivot_index - 1);
-            }
-            quicksort_recursive(arr, pivot_index + 1, high);
+    comptime fn recurse(n: u32) {
+        if n > 0 {
+            recurse(n-1);
         }
     }
-    
-    comptime fn quicksort<let N: u32>(
-        _arr: [u32; N],
-    ) -> [u32; N] {
-        let mut arr: [u32; N] = _arr;
-        if N > 1 {
-            quicksort_recursive(&mut arr, 0, N - 1);
-        }
-        arr
-    }    
+
     ";
     let result = interpret(program);
     assert_eq!(result, Value::Unit);


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7213 

## Summary\*

This PR adds a regression test for a minimal reproduction for #7213 where we show that in the comptime context we disallow recursing more than 32 layers deep. This is a serious limiter on the quicksort algorithm in https://github.com/noir-lang/noir_sort

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
