### PR TITLE
feat(optimization): Don't defunctionalize acir functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -74,7 +74,9 @@ impl DefunctionalizationContext {
     /// Defunctionalize all functions in the Ssa
     fn defunctionalize_all(mut self, ssa: &mut Ssa) {
         for function in ssa.functions.values_mut() {
-            self.defunctionalize(function);
+            if function.runtime().is_brillig() {
+                self.defunctionalize(function);
+            }
         }
     }
 


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

This shouldn't be necessary know that we separate constrained-ness during monomorphization. Not sure if it'd result in any optimization changes yet though.

This seems to be causing a panic currently passing a function to brillig. We could maybe just change the translator to translate function inputs as fields.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
