### PR TITLE
chore: build docs in the merge queue

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -2,10 +2,12 @@ name: Deploy preview for PR
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   add_label:
     runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
     outputs:
       has_label: ${{ steps.check-labels.outputs.result }}
     steps:


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I've added the `build_preview`  as a required job due to PRs which break the docs being approved. This PR ensures that this job is run in the merge queue to unblock this.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
