### PR TITLE
feat: Allow resolved types in constructors

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -644,7 +644,7 @@ impl<'context> Elaborator<'context> {
         last_segment: Option<PathSegment>,
     ) -> (HirExpression, Type) {
         let typ = typ.follow_bindings_shallow();
-        let (r#type, struct_generics) = match typ.as_ref() {
+        let (r#type, generics) = match typ.as_ref() {
             Type::DataType(r#type, struct_generics) if r#type.borrow().is_struct() => {
                 (r#type, struct_generics)
             }
@@ -659,7 +659,7 @@ impl<'context> Elaborator<'context> {
         self.mark_struct_as_constructed(r#type.clone());
 
         // `last_segment` is optional if this constructor was resolved from a quoted type
-        let mut generics = struct_generics.clone();
+        let mut generics = generics.clone();
         let mut is_self_type = false;
         let mut constructor_type_span = span;
 
@@ -680,7 +680,7 @@ impl<'context> Elaborator<'context> {
 
         let field_types = r#type
             .borrow()
-            .get_fields_with_visibility(struct_generics)
+            .get_fields_with_visibility(&generics)
             .expect("This type should already be validated to be a struct");
 
         let fields =

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -680,7 +680,7 @@ impl<'context> Elaborator<'context> {
 
         let field_types = r#type
             .borrow()
-            .get_fields_with_visibility(&struct_generics)
+            .get_fields_with_visibility(struct_generics)
             .expect("This type should already be validated to be a struct");
 
         let fields =

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -777,13 +777,12 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     /// For an enum like:
-    /// ```
     /// enum Foo {
     ///    A(i32, u32),
     ///    B(Field),
     ///    C
     /// }
-    /// ```
+    ///
     /// this will translate the call `Foo::A(1, 2)` into `(0, (1, 2), (0,), ())` where
     /// the first field `0` is the tag value, the second is `A`, third is `B`, and fourth is `C`.
     /// Each variant that isn't the desired variant has zeroed values filled in for its data.

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -295,11 +295,13 @@ impl<'a> Parser<'a> {
         }
 
         // A constructor where the type is an interned unresolved type data is valid
-        if matches!(self.token.token(), Token::InternedUnresolvedTypeData(..))
-            && self.next_is(Token::LeftBrace)
+        if matches!(
+            self.token.token(),
+            Token::InternedUnresolvedTypeData(..) | Token::QuotedType(..)
+        ) && self.next_is(Token::LeftBrace)
         {
             let span = self.current_token_span;
-            let typ = self.parse_interned_type().unwrap();
+            let typ = self.parse_interned_type().or_else(|| self.parse_resolved_type()).unwrap();
             self.eat_or_error(Token::LeftBrace);
             let typ = UnresolvedType { typ, span };
             return Some(self.parse_constructor(typ));

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -316,7 +316,7 @@ impl<'a> Parser<'a> {
         Some(UnresolvedTypeData::AsTraitPath(Box::new(as_trait_path)))
     }
 
-    fn parse_resolved_type(&mut self) -> Option<UnresolvedTypeData> {
+    pub(super) fn parse_resolved_type(&mut self) -> Option<UnresolvedTypeData> {
         if let Some(token) = self.eat_kind(TokenKind::QuotedType) {
             match token.into_token() {
                 Token::QuotedType(id) => {

--- a/test_programs/compile_success_empty/resolved_type_in_constructor/Nargo.toml
+++ b/test_programs/compile_success_empty/resolved_type_in_constructor/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "resolved_type_in_constructor"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/resolved_type_in_constructor/src/main.nr
+++ b/test_programs/compile_success_empty/resolved_type_in_constructor/src/main.nr
@@ -4,7 +4,7 @@ fn main() {
 
 comptime fn my_macro() -> Quoted {
     let typ = quote { Foo }.as_type();
-    quote[$typ {}]
+    quote [$typ {}]
 }
 
 struct Foo {}

--- a/test_programs/compile_success_empty/resolved_type_in_constructor/src/main.nr
+++ b/test_programs/compile_success_empty/resolved_type_in_constructor/src/main.nr
@@ -1,0 +1,10 @@
+fn main() {
+    let _ = my_macro!();
+}
+
+comptime fn my_macro() -> Quoted {
+    let typ = quote { Foo }.as_type();
+    quote[$typ {}]
+}
+
+struct Foo {}


### PR DESCRIPTION
# Description

## Problem\*

From a private ask by Jan

## Summary\*

Allows already resolved types in constructor expressions. These types are the result of comptime code and simplify creating constructors by not requiring you to specify the full path to an unresolved type - which you may not be able to get at all.

## Additional Context

Allows, e.g:

```noir
fn main() {
    // Unquotes to `let _ = Foo {}` which resolves despite Foo not being in scope
    let _ = my_macro!();
}

mod foo {
    pub struct Foo {}

    comptime fn my_macro() {
        // quote Foo without needing to specify the full path to it in the quoted snippet
        let typ = quote[Foo].as_type();
        quote[$typ {}]
    }
}
```

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
