### PR TITLE
chore: clarify to_radix docs examples

### DIFF
--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -384,9 +384,15 @@ mod tests {
     #[test]
     // docs:start:to_be_radix_example
     fn test_to_be_radix() {
-        let field = 2;
+        // 259, in base 256, big endian, is [1, 3].
+        // i.e. 3 * 256^0 + 1 * 256^1
+        let field = 259;
+
+        // The radix (in this example, 256) must be a power of 2.
+        // The length of the returned byte array can be specified to be
+        // >= the amount of space needed.
         let bytes: [u8; 8] = field.to_be_radix(256);
-        assert_eq(bytes, [0, 0, 0, 0, 0, 0, 0, 2]);
+        assert_eq(bytes, [0, 0, 0, 0, 0, 0, 1, 3]);
         assert_eq(Field::from_be_bytes::<8>(bytes), field);
     }
     // docs:end:to_be_radix_example
@@ -394,9 +400,15 @@ mod tests {
     #[test]
     // docs:start:to_le_radix_example
     fn test_to_le_radix() {
-        let field = 2;
+        // 259, in base 256, little endian, is [3, 1].
+        // i.e. 3 * 256^0 + 1 * 256^1
+        let field = 259;
+
+        // The radix (in this example, 256) must be a power of 2.
+        // The length of the returned byte array can be specified to be
+        // >= the amount of space needed.
         let bytes: [u8; 8] = field.to_le_radix(256);
-        assert_eq(bytes, [2, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq(bytes, [3, 1, 0, 0, 0, 0, 0, 0]);
         assert_eq(Field::from_le_bytes::<8>(bytes), field);
     }
     // docs:end:to_le_radix_example


### PR DESCRIPTION
# Description

The current example always forces my brain to think, because the choice of converting `2` to base `256` doesn't actually demonstrate what to_radix does, because `2` base `256` is just `2`.

I'm suggesting using a number larger than the base instead (`259`), so that we can see that it results in `[3, 1]` and `[1, 3]` for le and be cases resp.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
