### PR TITLE
fix: avoid unnecessary echo before readarray in check-critical-librar…

### DIFF
--- a/scripts/check-critical-libraries.sh
+++ b/scripts/check-critical-libraries.sh
@@ -11,8 +11,7 @@ if [[ -z $1 ]]; then
 fi
 noirup -v $1
 
-CRITICAL_LIBRARIES=$(grep -v "^#\|^$" ./CRITICAL_NOIR_LIBRARIES)
-readarray -t REPOS_TO_CHECK < <(echo "$CRITICAL_LIBRARIES")
+readarray -t REPOS_TO_CHECK < <(grep -v -E '^#|^$' ./CRITICAL_NOIR_LIBRARIES)
 
 getLatestReleaseTagForRepo() {
     REPO_NAME=$1


### PR DESCRIPTION
# Description

Replaced `echo "$CRITICAL_LIBRARIES"` with direct output from `grep` to `readarray`. This makes the code more efficient and readable by:  

- Eliminating an extra process (`echo`), reducing resource usage.  
- Avoiding potential issues with special characters and empty lines.  
- Keeping the logic clearer by directly passing filtered data to `readarray`.  

Check one:
- [x] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
