### PR TITLE
chore: improve docs clarity

### DIFF
--- a/docs/docs/explainers/explainer-recursion.md
+++ b/docs/docs/explainers/explainer-recursion.md
@@ -111,7 +111,7 @@ He might find it more efficient to generate a proof for that setup phase separat
 
 ## What params do I need
 
-As you can see in the [recursion reference](noir/standard_library/recursion.mdx), a simple recursive proof requires:
+As you can see in the [recursion reference](../noir/standard_library/recursion.mdx), a simple recursive proof requires:
 
 - The proof to verify
 - The Verification Key of the circuit that generated the proof

--- a/docs/docs/explainers/explainer-recursion.md
+++ b/docs/docs/explainers/explainer-recursion.md
@@ -111,7 +111,7 @@ He might find it more efficient to generate a proof for that setup phase separat
 
 ## What params do I need
 
-As you can see in the [recursion reference](../noir/standard_library/recursion.mdx), a simple recursive proof requires:
+As you can see in the [recursion reference](noir/standard_library/recursion.mdx), a simple recursive proof requires:
 
 - The proof to verify
 - The Verification Key of the circuit that generated the proof

--- a/docs/docs/how_to/debugger/debugging_with_vs_code.md
+++ b/docs/docs/how_to/debugger/debugging_with_vs_code.md
@@ -59,7 +59,7 @@ We can also inspect the values of variables by directly hovering on them on the 
 
 Let's set a break point at the `keccak256` function, so we can continue execution up to the point when it's first invoked without having to go one step at a time. 
 
-We just need to click the to the right of the line number 18. Once the breakpoint appears, we can click the `continue` button or use its corresponding keyboard shortcut (`F5` by default).
+We just need to click to the right of the line number 18. Once the breakpoint appears, we can click the `continue` button or use its corresponding keyboard shortcut (`F5` by default).
 
 ![Breakpoint](@site/static/img/debugger/7-break.png)
 

--- a/docs/docs/noir/modules_packages_crates/crates_and_packages.md
+++ b/docs/docs/noir/modules_packages_crates/crates_and_packages.md
@@ -32,7 +32,7 @@ Every crate has a root, which is the source file that the compiler starts, this 
 
 ## Packages
 
-A Nargo _package_ is a collection of one of more crates that provides a set of functionality. A package must include a Nargo.toml file.
+A Nargo _package_ is a collection of one or more crates that provides a set of functionality. A package must include a Nargo.toml file.
 
 A package _must_ contain either a library or a binary crate, but not both.
 

--- a/docs/docs/noir/modules_packages_crates/workspaces.md
+++ b/docs/docs/noir/modules_packages_crates/workspaces.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 Workspaces are a feature of nargo that allow you to manage multiple related Noir packages in a single repository. A workspace is essentially a group of related projects that share common build output directories and configurations.
 
-Each Noir project (with it's own Nargo.toml file) can be thought of as a package. Each package is expected to contain exactly one "named circuit", being the "name" defined in Nargo.toml with the program logic defined in `./src/main.nr`.
+Each Noir project (with its own Nargo.toml file) can be thought of as a package. Each package is expected to contain exactly one "named circuit", being the "name" defined in Nargo.toml with the program logic defined in `./src/main.nr`.
 
 For a project with the following structure:
 

--- a/docs/docs/noir/standard_library/is_unconstrained.md
+++ b/docs/docs/noir/standard_library/is_unconstrained.md
@@ -1,7 +1,7 @@
 ---
 title: Is Unconstrained Function
 description:
-  The is_unconstrained function returns wether the context at that point of the program is unconstrained or not.
+  The is_unconstrained function returns whether the context at that point of the program is unconstrained or not.
 keywords:
   [
     unconstrained

--- a/docs/versioned_docs/version-v0.36.0/getting_started/quick_start.md
+++ b/docs/versioned_docs/version-v0.36.0/getting_started/quick_start.md
@@ -97,7 +97,7 @@ bb prove -b ./target/hello_world.json -w ./target/hello_world.gz -o ./target/pro
 
 :::tip
 
-Naming can be confusing, specially as you pass them to the `bb` commands. If unsure, it won't hurt to delete the target folder and start anew to make sure you're using the most recent versions of the compiled circuit and witness.
+Naming can be confusing, especially as you pass them to the `bb` commands. If unsure, it won't hurt to delete the target folder and start anew to make sure you're using the most recent versions of the compiled circuit and witness.
 
 :::
 

--- a/docs/versioned_docs/version-v0.36.0/how_to/debugger/debugging_with_vs_code.md
+++ b/docs/versioned_docs/version-v0.36.0/how_to/debugger/debugging_with_vs_code.md
@@ -59,7 +59,7 @@ We can also inspect the values of variables by directly hovering on them on the 
 
 Let's set a break point at the `keccak256` function, so we can continue execution up to the point when it's first invoked without having to go one step at a time. 
 
-We just need to click the to the right of the line number 18. Once the breakpoint appears, we can click the `continue` button or use its corresponding keyboard shortcut (`F5` by default).
+We just need to click to the right of the line number 18. Once the breakpoint appears, we can click the `continue` button or use its corresponding keyboard shortcut (`F5` by default).
 
 ![Breakpoint](@site/static/img/debugger/7-break.png)
 

--- a/docs/versioned_docs/version-v0.36.0/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v0.36.0/noir/modules_packages_crates/workspaces.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 Workspaces are a feature of nargo that allow you to manage multiple related Noir packages in a single repository. A workspace is essentially a group of related projects that share common build output directories and configurations.
 
-Each Noir project (with it's own Nargo.toml file) can be thought of as a package. Each package is expected to contain exactly one "named circuit", being the "name" defined in Nargo.toml with the program logic defined in `./src/main.nr`.
+Each Noir project (with its own Nargo.toml file) can be thought of as a package. Each package is expected to contain exactly one "named circuit", being the "name" defined in Nargo.toml with the program logic defined in `./src/main.nr`.
 
 For a project with the following structure:
 

--- a/docs/versioned_docs/version-v0.36.0/noir/standard_library/mem.md
+++ b/docs/versioned_docs/version-v0.36.0/noir/standard_library/mem.md
@@ -42,7 +42,7 @@ fn checked_transmute<T, U>(value: T) -> U
 Transmutes a value of one type into the same value but with a new type `U`.
 
 This function is safe to use since both types are asserted to be equal later during compilation after the concrete values for generic types become known.
-This function is useful for cases where the compiler may fails a type check that is expected to pass where
+This function is useful for cases where the compiler may fail a type check that is expected to pass where
 a user knows the two types to be equal. For example, when using arithmetic generics there are cases the compiler
 does not see as equal, such as `[Field; N*(A + B)]` and `[Field; N*A + N*B]`, which users may know to be equal.
 In these cases, `checked_transmute` can be used to cast the value to the desired type while also preserving safety

--- a/docs/versioned_docs/version-v1.0.0-beta.1/explainers/explainer-writing-noir.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.1/explainers/explainer-writing-noir.md
@@ -16,7 +16,7 @@ When writing firmware for a battery-powered microcontroller, you think of cpu cy
 
 > Code is written to create applications that perform specific tasks within specific constraints
 
-And these constraints differ depending on where the compiled code is execute.
+And these constraints differ depending on where the compiled code is executed.
 
 ### The Ethereum Virtual Machine (EVM)
 


### PR DESCRIPTION
# Description
I've reviewed all the .md and .mdx files in the repository and fixed typos and grammar errors that clearly altered the meaning and affected the clarity of the documentation.

I also noticed some awkward wording and punctuation but left them unchanged, as they do not significantly affect readability or comprehension.

In the commit message, I briefly explained the corrections and why they were necessary to improve the overall clarity of the documentation.

Hope this helps.
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Fix typos and grammar errors

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
