### PR TITLE
fix(ssa): Use number of SSA instructions for the Brillig unrolling bytecode size limit

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function.rs
@@ -211,6 +211,16 @@ impl Function {
 
         unreachable!("SSA Function {} has no reachable return instruction!", self.id())
     }
+
+    pub(crate) fn num_instructions(&self) -> usize {
+        self.reachable_blocks()
+            .iter()
+            .map(|block| {
+                let block = &self.dfg[*block];
+                block.instructions().len() + block.terminator().is_some() as usize
+            })
+            .sum()
+    }
 }
 
 impl Clone for Function {

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -24,10 +24,6 @@ use acvm::{acir::AcirField, FieldElement};
 use im::HashSet;
 
 use crate::{
-    brillig::{
-        brillig_gen::{brillig_globals::convert_ssa_globals, convert_ssa_function},
-        brillig_ir::brillig_variable::BrilligVariable,
-    },
     errors::RuntimeError,
     ssa::{
         ir::{
@@ -60,7 +56,7 @@ impl Ssa {
         mut self,
         max_bytecode_increase_percent: Option<i32>,
     ) -> Result<Ssa, RuntimeError> {
-        let mut global_cache = None;
+        // let mut global_cache = None;
 
         for function in self.functions.values_mut() {
             let is_brillig = function.runtime().is_brillig();
@@ -78,20 +74,9 @@ impl Ssa {
             // to the globals and a mutable reference to the function at the same time, both part of the `Ssa`.
             if has_unrolled && is_brillig {
                 if let Some(max_incr_pct) = max_bytecode_increase_percent {
-                    if global_cache.is_none() {
-                        let globals = (*function.dfg.globals).clone();
-                        let used_globals = &globals.values_iter().map(|(id, _)| id).collect();
-                        let globals_dfg = DataFlowGraph::from(globals);
-                        // DIE is run at the end of our SSA optimizations, so we mark all globals as in use here.
-                        let (_, brillig_globals, _) =
-                            convert_ssa_globals(false, &globals_dfg, used_globals, function.id());
-                        global_cache = Some(brillig_globals);
-                    }
-                    let brillig_globals = global_cache.as_ref().unwrap();
-
                     let orig_function = orig_function.expect("took snapshot to compare");
-                    let new_size = brillig_bytecode_size(function, brillig_globals);
-                    let orig_size = brillig_bytecode_size(&orig_function, brillig_globals);
+                    let new_size = function.num_instructions();
+                    let orig_size = function.num_instructions();
                     if !is_new_size_ok(orig_size, new_size, max_incr_pct) {
                         *function = orig_function;
                     }
@@ -1020,25 +1005,6 @@ fn simplify_between_unrolls(function: &mut Function) {
     function.simplify_function();
     // Do another mem2reg after simplify_cfg to aid the next unroll
     function.mem2reg();
-}
-
-/// Convert the function to Brillig bytecode and return the resulting size.
-fn brillig_bytecode_size(
-    function: &Function,
-    globals: &HashMap<ValueId, BrilligVariable>,
-) -> usize {
-    // We need to do some SSA passes in order for the conversion to be able to go ahead,
-    // otherwise we can hit `unreachable!()` instructions in `convert_ssa_instruction`.
-    // Creating a clone so as not to modify the originals.
-    let mut temp = function.clone();
-
-    // Might as well give it the best chance.
-    simplify_between_unrolls(&mut temp);
-
-    // This is to try to prevent hitting ICE.
-    temp.dead_instruction_elimination(false, true);
-
-    convert_ssa_function(&temp, false, globals).byte_code.len()
 }
 
 /// Decide if the new bytecode size is acceptable, compared to the original.

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -56,7 +56,6 @@ impl Ssa {
         mut self,
         max_bytecode_increase_percent: Option<i32>,
     ) -> Result<Ssa, RuntimeError> {
-        // let mut global_cache = None;
 
         for function in self.functions.values_mut() {
             let is_brillig = function.runtime().is_brillig();

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -56,7 +56,6 @@ impl Ssa {
         mut self,
         max_bytecode_increase_percent: Option<i32>,
     ) -> Result<Ssa, RuntimeError> {
-
         for function in self.functions.values_mut() {
             let is_brillig = function.runtime().is_brillig();
 


### PR DESCRIPTION
# Description

## Problem\*

Pulls a change out of https://github.com/noir-lang/noir/pull/7236 that was causing panics with less aggressive inliner settings. Comment for reference: https://github.com/noir-lang/noir/pull/7236#discussion_r1935634486.

I labelled this PR a fix rather than a chore as it does prevent possible panics. 

## Summary\*

After performing an unroll in the Brillig runtime we have a setting that lets us set an upper bound on the bytecode size increase percentage. However, we have certain intrinsics (e.g. DerivePedersenGenerators) that we expect to entirely compile-time and fully resolved by Brillig gen. 

Another possible fix would be to set any method which calls `derive_generators` (such as `pedersen_hash_with_separator`) as `#[inline_always]`. However, we still do not have a guarantee that the `separator` has been resolved to a constant. Let's say we know `derive_generators` is called by `pedersen_hash_with_separator`. Even if  `pedersen_hash_with_separator` is always inlined into its parent we cannot guarantee that the input for the separator comes from the parent's function parameter. This issue will exist with any other intrinsics we expect to be fully resolved by compile-time. 

By using the number of SSA instructions we can also avoid the extra compilation to Brillig as well as having to expose extra Brillig gen logic to the SSA passes. This gives us a better separation of concerns. 

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
