### PR TITLE
fix(unrolling): Fetch original bytecode size from the original function

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -74,7 +74,7 @@ impl Ssa {
                 if let Some(max_incr_pct) = max_bytecode_increase_percent {
                     let orig_function = orig_function.expect("took snapshot to compare");
                     let new_size = function.num_instructions();
-                    let orig_size = function.num_instructions();
+                    let orig_size = orig_function.num_instructions();
                     if !is_new_size_ok(orig_size, new_size, max_incr_pct) {
                         *function = orig_function;
                     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves silly bug from https://github.com/noir-lang/noir/pull/7242

## Summary\*

Actually use the original function for fetching the bytecode size.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
