### PR TITLE
fix: Add missing `is_empty` check for enums

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -161,6 +161,7 @@ impl CollectedItems {
     pub fn is_empty(&self) -> bool {
         self.functions.is_empty()
             && self.structs.is_empty()
+            && self.enums.is_empty()
             && self.type_aliases.is_empty()
             && self.traits.is_empty()
             && self.globals.is_empty()


### PR DESCRIPTION
# Description

## Problem\*

Resolves a comment: https://github.com/AztecProtocol/aztec-packages/pull/11294/files/feca4ed10f4978832b51d39d3c055a972073826f#r1937967005

## Summary\*

This check shouldn't have caused any existing bugs since enums are still experimental, but we'll need it going forward if people want to generate new enums in comptime code.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
