### PR TITLE
feat(LSP): suggest enum variants without parameters

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -804,18 +804,14 @@ impl<'a> NodeFinder<'a> {
         };
 
         for (index, variant) in variants.iter().enumerate() {
+            // Variants with parameters are represented as functions and are suggested in `complete_type_methods`
             if variant.is_function || !name_matches(&variant.name.0.contents, prefix) {
                 continue;
             }
 
-            if !variant.is_function {
-                let item = self.enum_variant_completion_item(
-                    variant.name.to_string(),
-                    data_type.id,
-                    index,
-                );
-                self.completion_items.push(item);
-            }
+            let item =
+                self.enum_variant_completion_item(variant.name.to_string(), data_type.id, index);
+            self.completion_items.push(item);
         }
     }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -809,8 +809,11 @@ impl<'a> NodeFinder<'a> {
             }
 
             if !variant.is_function {
-                let item =
-                    self.enum_member_completion_item(variant.name.to_string(), data_type.id, index);
+                let item = self.enum_variant_completion_item(
+                    variant.name.to_string(),
+                    data_type.id,
+                    index,
+                );
                 self.completion_items.push(item);
             }
         }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     future::{self, Future},
+    ops::Deref,
 };
 
 use async_lsp::ResponseError;
@@ -1915,7 +1916,7 @@ fn get_array_element_type(typ: Type) -> Option<Type> {
 }
 
 fn get_type_type_id(typ: &Type) -> Option<TypeId> {
-    match typ {
+    match typ.follow_bindings_shallow().deref() {
         Type::DataType(struct_type, _) => Some(struct_type.borrow().id),
         Type::Alias(type_alias, generics) => {
             let type_alias = type_alias.borrow();

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -86,7 +86,14 @@ impl<'a> NodeFinder<'a> {
                 None,  // trait_id
                 false, // self_prefix
             ),
-            ModuleDefId::TypeId(struct_id) => vec![self.struct_completion_item(name, struct_id)],
+            ModuleDefId::TypeId(type_id) => {
+                let data_type = self.interner.get_type(type_id);
+                if data_type.borrow().is_struct() {
+                    vec![self.struct_completion_item(name, type_id)]
+                } else {
+                    vec![self.enum_completion_item(name, type_id)]
+                }
+            }
             ModuleDefId::TypeAliasId(id) => vec![self.type_alias_completion_item(name, id)],
             ModuleDefId::TraitId(trait_id) => vec![self.trait_completion_item(name, trait_id)],
             ModuleDefId::GlobalId(global_id) => vec![self.global_completion_item(name, global_id)],
@@ -110,10 +117,16 @@ impl<'a> NodeFinder<'a> {
         self.completion_item_with_doc_comments(ReferenceId::Module(id), completion_item)
     }
 
-    fn struct_completion_item(&self, name: String, struct_id: TypeId) -> CompletionItem {
+    fn struct_completion_item(&self, name: String, type_id: TypeId) -> CompletionItem {
         let completion_item =
             simple_completion_item(name.clone(), CompletionItemKind::STRUCT, Some(name));
-        self.completion_item_with_doc_comments(ReferenceId::Type(struct_id), completion_item)
+        self.completion_item_with_doc_comments(ReferenceId::Type(type_id), completion_item)
+    }
+
+    fn enum_completion_item(&self, name: String, type_id: TypeId) -> CompletionItem {
+        let completion_item =
+            simple_completion_item(name.clone(), CompletionItemKind::ENUM, Some(name));
+        self.completion_item_with_doc_comments(ReferenceId::Type(type_id), completion_item)
     }
 
     pub(super) fn struct_field_completion_item(

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -153,6 +153,20 @@ impl<'a> NodeFinder<'a> {
         self.completion_item_with_doc_comments(ReferenceId::Global(global_id), completion_item)
     }
 
+    pub(super) fn enum_member_completion_item(
+        &self,
+        name: String,
+        type_id: TypeId,
+        variant_index: usize,
+    ) -> CompletionItem {
+        let completion_item =
+            simple_completion_item(name.clone(), CompletionItemKind::ENUM_MEMBER, Some(name));
+        self.completion_item_with_doc_comments(
+            ReferenceId::EnumVariant(type_id, variant_index),
+            completion_item,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn function_completion_items(
         &self,

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -113,20 +113,18 @@ impl<'a> NodeFinder<'a> {
         name: impl Into<String>,
         id: ModuleId,
     ) -> CompletionItem {
-        let completion_item = module_completion_item(name);
-        self.completion_item_with_doc_comments(ReferenceId::Module(id), completion_item)
+        let item = module_completion_item(name);
+        self.completion_item_with_doc_comments(ReferenceId::Module(id), item)
     }
 
     fn struct_completion_item(&self, name: String, type_id: TypeId) -> CompletionItem {
-        let completion_item =
-            simple_completion_item(name.clone(), CompletionItemKind::STRUCT, Some(name));
-        self.completion_item_with_doc_comments(ReferenceId::Type(type_id), completion_item)
+        let items = simple_completion_item(name.clone(), CompletionItemKind::STRUCT, Some(name));
+        self.completion_item_with_doc_comments(ReferenceId::Type(type_id), items)
     }
 
     fn enum_completion_item(&self, name: String, type_id: TypeId) -> CompletionItem {
-        let completion_item =
-            simple_completion_item(name.clone(), CompletionItemKind::ENUM, Some(name));
-        self.completion_item_with_doc_comments(ReferenceId::Type(type_id), completion_item)
+        let item = simple_completion_item(name.clone(), CompletionItemKind::ENUM, Some(name));
+        self.completion_item_with_doc_comments(ReferenceId::Type(type_id), item)
     }
 
     pub(super) fn struct_field_completion_item(
@@ -137,33 +135,27 @@ impl<'a> NodeFinder<'a> {
         field_index: usize,
         self_type: bool,
     ) -> CompletionItem {
-        let completion_item = struct_field_completion_item(field, typ, self_type);
-        self.completion_item_with_doc_comments(
-            ReferenceId::StructMember(struct_id, field_index),
-            completion_item,
-        )
+        let item = struct_field_completion_item(field, typ, self_type);
+        let reference_id = ReferenceId::StructMember(struct_id, field_index);
+        self.completion_item_with_doc_comments(reference_id, item)
     }
 
     fn type_alias_completion_item(&self, name: String, id: TypeAliasId) -> CompletionItem {
-        let completion_item =
-            simple_completion_item(name.clone(), CompletionItemKind::STRUCT, Some(name));
-        self.completion_item_with_doc_comments(ReferenceId::Alias(id), completion_item)
+        let item = simple_completion_item(name.clone(), CompletionItemKind::STRUCT, Some(name));
+        self.completion_item_with_doc_comments(ReferenceId::Alias(id), item)
     }
 
     fn trait_completion_item(&self, name: String, trait_id: TraitId) -> CompletionItem {
-        let completion_item =
-            simple_completion_item(name.clone(), CompletionItemKind::INTERFACE, Some(name));
-        self.completion_item_with_doc_comments(ReferenceId::Trait(trait_id), completion_item)
+        let item = simple_completion_item(name.clone(), CompletionItemKind::INTERFACE, Some(name));
+        self.completion_item_with_doc_comments(ReferenceId::Trait(trait_id), item)
     }
 
     fn global_completion_item(&self, name: String, global_id: GlobalId) -> CompletionItem {
         let global = self.interner.get_global(global_id);
         let typ = self.interner.definition_type(global.definition_id);
         let description = typ.to_string();
-
-        let completion_item =
-            simple_completion_item(name, CompletionItemKind::CONSTANT, Some(description));
-        self.completion_item_with_doc_comments(ReferenceId::Global(global_id), completion_item)
+        let item = simple_completion_item(name, CompletionItemKind::CONSTANT, Some(description));
+        self.completion_item_with_doc_comments(ReferenceId::Global(global_id), item)
     }
 
     pub(super) fn enum_variant_completion_item(
@@ -172,15 +164,12 @@ impl<'a> NodeFinder<'a> {
         type_id: TypeId,
         variant_index: usize,
     ) -> CompletionItem {
-        let completion_item = simple_completion_item(
-            name.clone(),
-            CompletionItemKind::ENUM_MEMBER,
-            Some(name.clone()),
-        );
-        let completion_item = completion_item_with_detail(completion_item, name);
+        let kind = CompletionItemKind::ENUM_MEMBER;
+        let item = simple_completion_item(name.clone(), kind, Some(name.clone()));
+        let item = completion_item_with_detail(item, name);
         self.completion_item_with_doc_comments(
             ReferenceId::EnumVariant(type_id, variant_index),
-            completion_item,
+            item,
         )
     }
 

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -124,7 +124,7 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn enum_completion_item(&self, name: String, type_id: TypeId) -> CompletionItem {
-        let completion_item =
+        let mut completion_item =
             simple_completion_item(name.clone(), CompletionItemKind::ENUM, Some(name));
         self.completion_item_with_doc_comments(ReferenceId::Type(type_id), completion_item)
     }
@@ -166,7 +166,7 @@ impl<'a> NodeFinder<'a> {
         self.completion_item_with_doc_comments(ReferenceId::Global(global_id), completion_item)
     }
 
-    pub(super) fn enum_member_completion_item(
+    pub(super) fn enum_variant_completion_item(
         &self,
         name: String,
         type_id: TypeId,

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -124,7 +124,7 @@ impl<'a> NodeFinder<'a> {
     }
 
     fn enum_completion_item(&self, name: String, type_id: TypeId) -> CompletionItem {
-        let mut completion_item =
+        let completion_item =
             simple_completion_item(name.clone(), CompletionItemKind::ENUM, Some(name));
         self.completion_item_with_doc_comments(ReferenceId::Type(type_id), completion_item)
     }
@@ -172,8 +172,12 @@ impl<'a> NodeFinder<'a> {
         type_id: TypeId,
         variant_index: usize,
     ) -> CompletionItem {
-        let completion_item =
-            simple_completion_item(name.clone(), CompletionItemKind::ENUM_MEMBER, Some(name));
+        let completion_item = simple_completion_item(
+            name.clone(),
+            CompletionItemKind::ENUM_MEMBER,
+            Some(name.clone()),
+        );
+        let completion_item = completion_item_with_detail(completion_item, name);
         self.completion_item_with_doc_comments(
             ReferenceId::EnumVariant(type_id, variant_index),
             completion_item,

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -368,6 +368,8 @@ impl<'a> NodeFinder<'a> {
         if let (Some(type_id), Some(variant_index)) =
             (func_meta.type_id, func_meta.enum_variant_index)
         {
+            completion_item.kind = Some(CompletionItemKind::ENUM_MEMBER);
+
             self.completion_item_with_doc_comments(
                 ReferenceId::EnumVariant(type_id, variant_index),
                 completion_item,

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3108,4 +3108,35 @@ fn main() {
         };
         assert!(markdown.value.contains("Some docs"));
     }
+
+    #[test]
+    async fn test_suggests_enum_variant_without_parameters() {
+        let src = r#"
+        enum Enum {
+            /// Some docs
+            Variant
+        }
+
+        fn foo() {
+            Enum::Var>|<
+        }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(item.kind, Some(CompletionItemKind::ENUM_MEMBER));
+        assert_eq!(item.label, "Variant".to_string());
+
+        let details = item.label_details.as_ref().unwrap();
+        assert_eq!(details.description, Some("Variant".to_string()));
+
+        assert_eq!(item.detail, None);
+        assert_eq!(item.insert_text, None);
+
+        let Documentation::MarkupContent(markdown) = item.documentation.as_ref().unwrap() else {
+            panic!("Expected markdown docs");
+        };
+        assert!(markdown.value.contains("Some docs"));
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3140,4 +3140,21 @@ fn main() {
         };
         assert!(markdown.value.contains("Some docs"));
     }
+
+    #[test]
+    async fn test_suggests_enum_type() {
+        let src = r#"
+        enum ThisIsAnEnum {
+        }
+
+        fn foo() {
+            ThisIsA>|<
+        }
+        "#;
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = &items[0];
+        assert_eq!(item.kind, Some(CompletionItemKind::ENUM));
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3132,7 +3132,7 @@ fn main() {
         let details = item.label_details.as_ref().unwrap();
         assert_eq!(details.description, Some("Variant".to_string()));
 
-        assert_eq!(item.detail, None);
+        assert_eq!(item.detail, Some("Variant".to_string()));
         assert_eq!(item.insert_text, None);
 
         let Documentation::MarkupContent(markdown) = item.documentation.as_ref().unwrap() else {

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3094,6 +3094,7 @@ fn main() {
         assert_eq!(items.len(), 1);
 
         let item = &items[0];
+        assert_eq!(item.kind, Some(CompletionItemKind::ENUM_MEMBER));
         assert_eq!(item.label, "Variant(…)".to_string());
 
         let details = item.label_details.as_ref().unwrap();


### PR DESCRIPTION
# Description

## Problem

Now that enum variants without parameters can be referenced without `()`, those variants weren't offered in LSP completion.

## Summary

Let's LSP suggest enum variants without parameters.

Also changes these completions to use the `EnumMember` kind so that they end up with a different icon than the one for functions. Finally, also changes the icon for enum types themselves (previously they would use the icon for structs).

![image](https://github.com/user-attachments/assets/410c44d9-b2e7-4471-9600-a580f48bd2e3)

![image](https://github.com/user-attachments/assets/e92f810e-594e-476f-99bc-b68f2878adf0)


## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
