### PR TITLE
chore: early check type equality in try_unify

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1742,6 +1742,13 @@ impl Type {
     ) -> Result<(), UnificationError> {
         use Type::*;
 
+        // If the two types are exactly the same then they trivially unify.
+        // This check avoids potentially unifying very complex types (usually infix
+        // expressions) when they are the same.
+        if self == other {
+            return Ok(());
+        }
+
         let lhs = self.follow_bindings_shallow();
         let rhs = other.follow_bindings_shallow();
 

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -63,12 +63,15 @@ impl Type {
                 let dummy_span = Span::default();
                 // evaluate_to_field_element also calls canonicalize so if we just called
                 // `self.evaluate_to_field_element(..)` we'd get infinite recursion.
-                if let (Ok(lhs_value), Ok(rhs_value)) = (
-                    lhs.evaluate_to_field_element_helper(&kind, dummy_span, run_simplifications),
-                    rhs.evaluate_to_field_element_helper(&kind, dummy_span, run_simplifications),
-                ) {
-                    if let Ok(result) = op.function(lhs_value, rhs_value, &kind, dummy_span) {
-                        return Type::Constant(result, kind);
+                if let Ok(lhs_value) =
+                    lhs.evaluate_to_field_element_helper(&kind, dummy_span, run_simplifications)
+                {
+                    if let Ok(rhs_value) =
+                        rhs.evaluate_to_field_element_helper(&kind, dummy_span, run_simplifications)
+                    {
+                        if let Ok(result) = op.function(lhs_value, rhs_value, &kind, dummy_span) {
+                            return Type::Constant(result, kind);
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Description

## Problem

Resolves #7256

## Summary

While debugging this I realized that `try_unify` was being called with `self` and `other` being complex infix expressions that were actually the **same** expression (same type variables, etc.). When that happened canonicalizing and trying to unify both would involve a lot of computations (it ends up trying to unify lots of `u32` for a reason that I still didn't sit down to investigate). I tried doing an early equality check in `try_unify` and, magically, the time to compile the relevant program went from 10 minutes to 3 seconds.

## Additional Context

I _think_ checking for equality here is fine because it means there's nothing to unify, but let me know if this is not okay.

The second commit is just a micro-optimization: when doing `if let (_, _) = (a, b)`, `a` and `b` are evaluated and then pattern-matched. Because `evaluate_to_field_element` might be an expensive call this just ends up doing one of those calls if it ends up returning `Err`.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
