### PR TITLE
fix: prevent panic within `remove_possibly_mutated_cached_make_arrays`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -734,7 +734,6 @@ impl<'brillig> Context<'brillig> {
                 _ => return,
             };
 
-
             if matches!(instruction, Instruction::MakeArray { .. }) {
                 self.cached_instruction_results.remove(instruction);
             }

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -725,9 +725,8 @@ impl<'brillig> Context<'brillig> {
 
         // Should we consider calls to slice_push_back and similar to be mutating operations as well?
         if let Store { value: array, .. } | ArraySet { array, .. } = instruction {
-            let instruction = match &function.dfg[*array] {
-                Value::Instruction { instruction, .. } => &function.dfg[*instruction],
-                _ => return,
+            let Some(instruction) = function.dfg.get_local_or_global_instruction(*array) else {
+                return
             };
 
             if matches!(instruction, Instruction::MakeArray { .. }) {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -726,6 +726,7 @@ impl<'brillig> Context<'brillig> {
         // Should we consider calls to slice_push_back and similar to be mutating operations as well?
         if let Store { value: array, .. } | ArraySet { array, .. } = instruction {
             if function.dfg.is_global(*array) {
+                // Early return as we expect globals to be immutable.
                 return;
             };
 

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -725,9 +725,15 @@ impl<'brillig> Context<'brillig> {
 
         // Should we consider calls to slice_push_back and similar to be mutating operations as well?
         if let Store { value: array, .. } | ArraySet { array, .. } = instruction {
-            let Some(instruction) = function.dfg.get_local_or_global_instruction(*array) else {
-                return
+            if function.dfg.is_global(*array) {
+                return;
             };
+
+            let instruction = match &function.dfg[*array] {
+                Value::Instruction { instruction, .. } => &function.dfg[*instruction],
+                _ => return,
+            };
+
 
             if matches!(instruction, Instruction::MakeArray { .. }) {
                 self.cached_instruction_results.remove(instruction);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This adds a quick fix for the panic in https://github.com/AztecProtocol/aztec-packages/pull/11696 that @vezenovm raised. 

I (or someone) needs to look at this more closely as we should potentially distinguish between local and global arrays here. For the time being it fixes the panic however.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
