### PR TITLE
fix(ssa): Unused functions removals post folding constant Brillig calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -136,6 +136,9 @@ pub(crate) fn optimize_into_acir(
         print_codegen_timings: options.print_codegen_timings,
     }
     .run_pass(|ssa| ssa.fold_constants_with_brillig(&brillig), "Inlining Brillig Calls Inlining")
+    // It could happen that we inlined all calls to a given brillig function.
+    // In that case it's unused so we can remove it. This is what we check next.
+    .run_pass(Ssa::remove_unreachable_functions, "Removing Unreachable Functions (3rd)")
     .run_pass(Ssa::dead_instruction_elimination, "Dead Instruction Elimination (2nd)")
     .finish();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -98,49 +98,6 @@ impl Ssa {
             function.constant_fold(false, brillig_info);
         }
 
-        // It could happen that we inlined all calls to a given brillig function.
-        // In that case it's unused so we can remove it. This is what we check next.
-        self.remove_unused_brillig_functions(brillig_functions)
-    }
-
-    fn remove_unused_brillig_functions(
-        mut self,
-        mut brillig_functions: BTreeMap<FunctionId, Function>,
-    ) -> Ssa {
-        // Remove from the above map functions that are called
-        for function in self.functions.values() {
-            for block_id in function.reachable_blocks() {
-                for instruction_id in function.dfg[block_id].instructions() {
-                    let instruction = &function.dfg[*instruction_id];
-                    let Instruction::Call { func: func_id, arguments: _ } = instruction else {
-                        continue;
-                    };
-
-                    let func_value = &function.dfg[*func_id];
-                    let Value::Function(func_id) = func_value else { continue };
-
-                    if function.runtime().is_acir() {
-                        brillig_functions.remove(func_id);
-                    }
-                }
-            }
-        }
-
-        // The ones that remain are never called: let's remove them.
-        for (func_id, func) in &brillig_functions {
-            // We never want to remove the main function (it could be `unconstrained` or it
-            // could have been turned into brillig if `--force-brillig` was given).
-            // We also don't want to remove entry points.
-            let runtime = func.runtime();
-            if self.main_id == *func_id
-                || (runtime.is_entry_point() && matches!(runtime, RuntimeType::Acir(_)))
-            {
-                continue;
-            }
-
-            self.functions.remove(func_id);
-        }
-
         self
     }
 }
@@ -1341,6 +1298,7 @@ mod test {
             }
             ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 
@@ -1369,6 +1327,7 @@ mod test {
             }
             ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 
@@ -1397,6 +1356,7 @@ mod test {
             }
             ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 
@@ -1426,6 +1386,7 @@ mod test {
             }
             ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 
@@ -1455,6 +1416,7 @@ mod test {
             }
             ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 
@@ -1489,6 +1451,7 @@ mod test {
             }
             ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 
@@ -1524,6 +1487,7 @@ mod test {
         ";
 
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 
@@ -1565,6 +1529,7 @@ mod test {
         ";
 
         let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
         assert_normalized_ssa_equals(ssa, expected);
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Silly bug leftover from https://github.com/noir-lang/noir/pull/7260, but also fixes this removal pass to be more accurate. We are not checking the new call graph of unused functions.

e.g. for the following SSA:
```
        g0 = Field 2

        acir(inline) fn main f0 {
          b0():
            v1 = call f1() -> Field
            return v1
        }

        brillig(inline) fn entry_point f1 {
          b0():
            v1 = call f2() -> Field
            return v1
        }

        brillig(inline) fn one f2 {
          b0():
            v1 = add g0, Field 3
            return v1
        }
```
After constant folding we would still have:
```
        brillig(inline) fn one f2 {
          b0():
            v1 = add g0, Field 3
            return v1
        }
```
even though it would be unused. This is because we would only inline Brillig calls for ACIR entry points. Thus, we would still have a call to f2, even though f1 is now unused, thus f2 is also unused.

## Summary\*

I simply moved to using our pre-existing `remove_unreachable_functions` pass. I felt this kept a better separation of concerns for the passes and was a more complete removal of unreachable functions.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
