### PR TITLE
feat: infer lambda parameter types from return type and let type

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -983,9 +983,8 @@ impl<'context> Elaborator<'context> {
         target_type: Option<&Type>,
     ) -> (HirExpression, Type) {
         if let Some(Type::Alias(type_alias, generics)) = target_type {
-            if let Type::Function(args, _, _, _) = type_alias.borrow().get_type(generics) {
-                return self.elaborate_lambda_with_parameter_type_hints(lambda, Some(&args));
-            }
+            let typ = type_alias.borrow().get_type(generics);
+            return self.elaborate_lambda_with_target_type(lambda, Some(&typ));
         }
 
         if let Some(Type::Function(args, _, _, _)) = target_type {

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -967,14 +967,37 @@ impl<'context> Elaborator<'context> {
         let mut element_types = Vec::with_capacity(tuple.len());
 
         for (index, element) in tuple.into_iter().enumerate() {
-            let expr_target_type =
-                if let Some(Type::Tuple(types)) = target_type { types.get(index) } else { None };
-            let (id, typ) = self.elaborate_expression_with_target_type(element, expr_target_type);
-            element_ids.push(id);
-            element_types.push(typ);
+            self.elaborate_tuple_element(
+                index,
+                element,
+                &mut element_ids,
+                &mut element_types,
+                target_type,
+            );
         }
 
         (HirExpression::Tuple(element_ids), Type::Tuple(element_types))
+    }
+
+    fn elaborate_tuple_element(
+        &mut self,
+        index: usize,
+        element: Expression,
+        element_ids: &mut Vec<ExprId>,
+        element_types: &mut Vec<Type>,
+        target_type: Option<&Type>,
+    ) {
+        if let Some(Type::Alias(type_alias, generics)) = target_type {
+            let typ = type_alias.borrow().get_type(generics);
+            let typ = Some(&typ);
+            return self.elaborate_tuple_element(index, element, element_ids, element_types, typ);
+        }
+
+        let expr_target_type =
+            if let Some(Type::Tuple(types)) = target_type { types.get(index) } else { None };
+        let (id, typ) = self.elaborate_expression_with_target_type(element, expr_target_type);
+        element_ids.push(id);
+        element_types.push(typ);
     }
 
     fn elaborate_lambda_with_target_type(

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -144,11 +144,11 @@ impl<'context> Elaborator<'context> {
     ) -> (HirBlockExpression, Type) {
         self.push_scope();
         let mut block_type = Type::Unit;
-        let mut statements = Vec::with_capacity(block.statements.len());
-        let one_statement = block.statements.len() == 1;
+        let statements_len = block.statements.len();
+        let mut statements = Vec::with_capacity(statements_len);
 
         for (i, statement) in block.statements.into_iter().enumerate() {
-            let statement_target_type = if one_statement { target_type } else { None };
+            let statement_target_type = if i == statements_len - 1 { target_type } else { None };
             let (id, stmt_type) =
                 self.elaborate_statement_with_target_type(statement, statement_target_type);
             statements.push(id);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -500,7 +500,8 @@ impl<'context> Elaborator<'context> {
             | FunctionKind::Oracle
             | FunctionKind::TraitFunctionWithoutBody => (HirFunction::empty(), Type::Error),
             FunctionKind::Normal => {
-                let (block, body_type) = self.elaborate_block(body);
+                let return_type = func_meta.return_type();
+                let (block, body_type) = self.elaborate_block(body, Some(return_type));
                 let expr_id = self.intern_expr(block, body_span);
                 self.interner.push_expr_type(expr_id, body_type.clone());
                 (HirFunction::unchecked_from_expr(expr_id), body_type)

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -92,11 +92,12 @@ impl<'context> Elaborator<'context> {
         let_stmt: LetStatement,
         global_id: Option<GlobalId>,
     ) -> (HirStatement, Type) {
-        let expr_span = let_stmt.expression.span;
-        let (expression, expr_type) = self.elaborate_expression(let_stmt.expression);
-
         let type_contains_unspecified = let_stmt.r#type.contains_unspecified();
         let annotated_type = self.resolve_inferred_type(let_stmt.r#type);
+
+        let expr_span = let_stmt.expression.span;
+        let (expression, expr_type) =
+            self.elaborate_expression_with_target_type(let_stmt.expression, Some(&annotated_type));
 
         // Require the top-level of a global's type to be fully-specified
         if type_contains_unspecified && global_id.is_some() {

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -28,6 +28,14 @@ use super::{lints, Elaborator, Loop};
 
 impl<'context> Elaborator<'context> {
     fn elaborate_statement_value(&mut self, statement: Statement) -> (HirStatement, Type) {
+        self.elaborate_statement_value_with_target_type(statement, None)
+    }
+
+    fn elaborate_statement_value_with_target_type(
+        &mut self,
+        statement: Statement,
+        target_type: Option<&Type>,
+    ) -> (HirStatement, Type) {
         match statement.kind {
             StatementKind::Let(let_stmt) => self.elaborate_local_let(let_stmt),
             StatementKind::Constrain(constrain) => self.elaborate_constrain(constrain),
@@ -38,7 +46,7 @@ impl<'context> Elaborator<'context> {
             StatementKind::Continue => self.elaborate_jump(false, statement.span),
             StatementKind::Comptime(statement) => self.elaborate_comptime_statement(*statement),
             StatementKind::Expression(expr) => {
-                let (expr, typ) = self.elaborate_expression(expr);
+                let (expr, typ) = self.elaborate_expression_with_target_type(expr, target_type);
                 (HirStatement::Expression(expr), typ)
             }
             StatementKind::Semi(expr) => {
@@ -48,15 +56,24 @@ impl<'context> Elaborator<'context> {
             StatementKind::Interned(id) => {
                 let kind = self.interner.get_statement_kind(id);
                 let statement = Statement { kind: kind.clone(), span: statement.span };
-                self.elaborate_statement_value(statement)
+                self.elaborate_statement_value_with_target_type(statement, target_type)
             }
             StatementKind::Error => (HirStatement::Error, Type::Error),
         }
     }
 
     pub(crate) fn elaborate_statement(&mut self, statement: Statement) -> (StmtId, Type) {
+        self.elaborate_statement_with_target_type(statement, None)
+    }
+
+    pub(crate) fn elaborate_statement_with_target_type(
+        &mut self,
+        statement: Statement,
+        target_type: Option<&Type>,
+    ) -> (StmtId, Type) {
         let span = statement.span;
-        let (hir_statement, typ) = self.elaborate_statement_value(statement);
+        let (hir_statement, typ) =
+            self.elaborate_statement_value_with_target_type(statement, target_type);
         let id = self.interner.push_stmt(hir_statement);
         self.interner.push_stmt_location(id, span, self.file);
         (id, typ)

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4091,6 +4091,24 @@ fn infers_lambda_argument_from_function_return_type() {
 }
 
 #[test]
+fn infers_lambda_argument_from_function_return_type_multiple_statements() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    pub fn func() -> fn(Foo) -> Field {
+        let _ = 1;
+        |foo| foo.value
+    }
+
+    fn main() {
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn infers_lambda_argument_from_variable_type() {
     let src = r#"
     pub struct Foo {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4121,6 +4121,20 @@ fn infers_lambda_argument_from_variable_alias_type() {
 }
 
 #[test]
+fn infers_lambda_argument_from_variable_tuple_type() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    fn main() {
+      let _: (fn(Foo) -> Field, _) = (|foo| foo.value, 1);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn regression_7088() {
     // A test for code that initially broke when implementing inferring
     // lambda parameter types from the function type related to the call

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4054,6 +4054,26 @@ fn infers_lambda_argument_from_call_function_type_in_generic_call() {
 }
 
 #[test]
+fn infers_lambda_argument_from_call_function_type_as_alias() {
+    let src = r#"
+    struct Foo {
+        value: Field,
+    }
+
+    type MyFn = fn(Foo) -> Field;
+
+    fn call(f: MyFn) -> Field {
+        f(Foo { value: 1 })
+    }
+
+    fn main() {
+        let _ = call(|foo| foo.value);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn infers_lambda_argument_from_function_return_type() {
     let src = r#"
     pub struct Foo {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4054,6 +4054,23 @@ fn infers_lambda_argument_from_call_function_type_in_generic_call() {
 }
 
 #[test]
+fn infers_lambda_argument_from_function_return_type() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    pub fn func() -> fn(Foo) -> Field {
+        |foo| foo.value
+    }
+
+    fn main() {
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn regression_7088() {
     // A test for code that initially broke when implementing inferring
     // lambda parameter types from the function type related to the call

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4109,6 +4109,27 @@ fn infers_lambda_argument_from_function_return_type_multiple_statements() {
 }
 
 #[test]
+fn infers_lambda_argument_from_function_return_type_when_inside_if() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    pub fn func() -> fn(Foo) -> Field {
+        if true {
+            |foo| foo.value
+        } else {
+            |foo| foo.value
+        }
+    }
+
+    fn main() {
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn infers_lambda_argument_from_variable_type() {
     let src = r#"
     pub struct Foo {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4071,6 +4071,20 @@ fn infers_lambda_argument_from_function_return_type() {
 }
 
 #[test]
+fn infers_lambda_argument_from_variable_type() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    fn main() {
+      let _: fn(Foo) -> Field = |foo| foo.value;
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn regression_7088() {
     // A test for code that initially broke when implementing inferring
     // lambda parameter types from the function type related to the call

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4152,6 +4152,22 @@ fn infers_lambda_argument_from_variable_tuple_type() {
 }
 
 #[test]
+fn infers_lambda_argument_from_variable_tuple_type_aliased() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    type Alias = (fn(Foo) -> Field, Field);
+
+    fn main() {
+      let _: Alias = (|foo| foo.value, 1);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn regression_7088() {
     // A test for code that initially broke when implementing inferring
     // lambda parameter types from the function type related to the call

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4085,6 +4085,22 @@ fn infers_lambda_argument_from_variable_type() {
 }
 
 #[test]
+fn infers_lambda_argument_from_variable_alias_type() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    type FooFn = fn(Foo) -> Field;
+
+    fn main() {
+      let _: FooFn = |foo| foo.value;
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn regression_7088() {
     // A test for code that initially broke when implementing inferring
     // lambda parameter types from the function type related to the call

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4121,6 +4121,23 @@ fn infers_lambda_argument_from_variable_alias_type() {
 }
 
 #[test]
+fn infers_lambda_argument_from_variable_double_alias_type() {
+    let src = r#"
+    pub struct Foo {
+        value: Field,
+    }
+
+    type FooFn = fn(Foo) -> Field;
+    type FooFn2 = FooFn;
+
+    fn main() {
+      let _: FooFn2 = |foo| foo.value;
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn infers_lambda_argument_from_variable_tuple_type() {
     let src = r#"
     pub struct Foo {


### PR DESCRIPTION
# Description

## Problem

Follow up to https://github.com/noir-lang/noir/pull/7088 with more scenarios where we can infer the type of lambda parameters

## Summary

These are just for completeness. There are actually a couple of these cases in Aztec-Packages, but I just thought at this point it's relatively straight-forward to implement this, and it's also how it works in Rust (I mean semantically, not how it's implemented).

## Additional Context

It's fine if you think this isn't worth it, it's mostly experimental and for completeness.

I'm also unsure about how the code ended up looking like, though I tried to avoid modifying existing code as much as possible.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
