### PR TITLE
chore: create a CI action to download nargo and add to path

### DIFF
--- a/.github/actions/download-nargo/action.yml
+++ b/.github/actions/download-nargo/action.yml
@@ -13,6 +13,6 @@ runs:
       - name: Set nargo on PATH
         shell: bash
         run: |
-          nargo_binary="./nargo/nargo"
+          nargo_binary="${{ github.workspace }}/nargo/nargo"
           chmod +x $nargo_binary
           echo "$(dirname $nargo_binary)" >> $GITHUB_PATH

--- a/.github/actions/download-nargo/action.yml
+++ b/.github/actions/download-nargo/action.yml
@@ -1,0 +1,18 @@
+name: Download Nargo
+description: Downloads the nargo binary from an artifact and adds it to the path
+
+runs:
+  using: composite
+  steps:
+      - name: Download nargo binary
+        uses: actions/download-artifact@v4
+        with:
+          name: nargo
+          path: ./nargo
+
+      - name: Set nargo on PATH
+        shell: bash
+        run: |
+          nargo_binary="./nargo/nargo"
+          chmod +x $nargo_binary
+          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -123,18 +123,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-            
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Format stdlib
         working-directory: ./noir_stdlib

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -280,9 +280,8 @@ jobs:
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-root, num_runs: 5 }
 
     name: External repo compilation and execution reports - ${{ matrix.project.repo }}/${{ matrix.project.path }}
-  
-        s:
-            - name: Download nargo binary
+    steps:
+      - name: Download nargo binary
         uses: ./.github/actions/download-nargo
 
       - uses: actions/checkout@v4

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -54,18 +54,7 @@ jobs:
           echo "$HOME/.bb/" >> $GITHUB_PATH
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Generate gates report
         working-directory: ./test_programs
@@ -100,18 +89,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Generate Brillig bytecode size report
         working-directory: ./test_programs
@@ -160,18 +138,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Generate Brillig execution report
         working-directory: ./test_programs
@@ -220,18 +187,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Generate Memory report
         working-directory: ./test_programs
@@ -272,18 +228,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Generate Compilation report
         working-directory: ./test_programs
@@ -335,20 +280,10 @@ jobs:
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-root, num_runs: 5 }
 
     name: External repo compilation and execution reports - ${{ matrix.project.repo }}/${{ matrix.project.path }}
-    steps:
-      - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+  
+        s:
+            - name: Download nargo binary
+        uses: ./.github/actions/download-nargo
 
       - uses: actions/checkout@v4
         with:
@@ -450,20 +385,10 @@ jobs:
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-root }
 
     name: External repo memory report - ${{ matrix.project.repo }}/${{ matrix.project.path }}
-    steps:
-      - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+  
+        s:
+            - name: Download nargo binary
+        uses: ./.github/actions/download-nargo
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -281,17 +281,18 @@ jobs:
 
     name: External repo compilation and execution reports - ${{ matrix.project.repo }}/${{ matrix.project.path }}
     steps:
-      - name: Download nargo binary
-        uses: ./.github/actions/download-nargo
-
       - uses: actions/checkout@v4
         with:
           path: scripts
           sparse-checkout: |
+            .github/actions/download-nargo/action.yml
             test_programs/compilation_report.sh
             test_programs/execution_report.sh
             test_programs/parse_time.sh
           sparse-checkout-cone-mode: false
+
+      - name: Download nargo binary
+        uses: scripts/.github/actions/download-nargo
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -389,7 +390,7 @@ jobs:
         with:
           path: scripts
           sparse-checkout: |
-            ./.github/actions/download-nargo
+            ./.github/actions/download-nargo/action.yml
             test_programs/memory_report.sh
             test_programs/parse_memory.sh
           sparse-checkout-cone-mode: false

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -395,7 +395,7 @@ jobs:
           sparse-checkout-cone-mode: false
       
       - name: Download nargo binary
-        uses: ./.github/actions/download-nargo
+        uses: ./scripts/.github/actions/download-nargo
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -384,18 +384,18 @@ jobs:
           - project: { repo: AztecProtocol/aztec-packages, path: noir-projects/noir-protocol-circuits/crates/rollup-root }
 
     name: External repo memory report - ${{ matrix.project.repo }}/${{ matrix.project.path }}
-  
-        s:
-            - name: Download nargo binary
-        uses: ./.github/actions/download-nargo
-
+    steps:
       - uses: actions/checkout@v4
         with:
           path: scripts
           sparse-checkout: |
+            ./.github/actions/download-nargo
             test_programs/memory_report.sh
             test_programs/parse_memory.sh
           sparse-checkout-cone-mode: false
+      
+      - name: Download nargo binary
+        uses: ./.github/actions/download-nargo
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -13,6 +13,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  critical-library-list:
+    name: Load critical library list
+    runs-on: ubuntu-22.04
+    outputs:
+      libraries: ${{ steps.get_critical_libraries.outputs.libraries }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build list of libraries
+        id: get_critical_libraries
+        run: |
+          LIBRARIES=$(yq ./EXTERNAL_NOIR_LIBRARIES.yml -o json | jq -c '.libraries | map({ repo, path: (.path // ""), timeout:(.timeout // 2), nargo_args })')
+          echo "libraries=$LIBRARIES"
+          echo "libraries=$LIBRARIES" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   yarn-lock:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
@@ -465,25 +484,6 @@ jobs:
       - name: Run `codegen_verifier`
         working-directory: ./examples/codegen_verifier
         run: ./test.sh
-
-  critical-library-list:
-    name: Load critical library list
-    runs-on: ubuntu-22.04
-    outputs:
-      libraries: ${{ steps.get_critical_libraries.outputs.libraries }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build list of libraries
-        id: get_critical_libraries
-        run: |
-          LIBRARIES=$(yq ./EXTERNAL_NOIR_LIBRARIES.yml -o json | jq -c '.libraries | map({ repo, path: (.path // ""), timeout:(.timeout // 2), nargo_args })')
-          echo "libraries=$LIBRARIES"
-          echo "libraries=$LIBRARIES" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
 
   external-repo-checks:
     needs: [build-nargo, critical-library-list]

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -509,7 +509,7 @@ jobs:
           ref: ${{ matrix.project.ref }}
 
       - name: Download nargo binary
-        uses: ./.github/actions/download-nargo
+        uses: ./noir-repo/.github/actions/download-nargo
 
       - name: Remove requirements on compiler version
         working-directory: ./test-repo
@@ -570,11 +570,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          path: noir-repo
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
           repository: AztecProtocol/aztec-packages
           path: test-repo
 
       - name: Download nargo binary
-        uses: ./.github/actions/download-nargo
+        uses: ./noir-repo/.github/actions/download-nargo
 
       - name: Remove requirements on compiler version
         working-directory: ./test-repo

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -244,10 +244,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
+        uses: ./.github/actions/download-nargo
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -260,14 +257,6 @@ jobs:
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
@@ -300,17 +289,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
+        uses: ./.github/actions/download-nargo
 
       - name: Build fixtures
         run: yarn workspace @noir-lang/noir_wasm test:build_fixtures
@@ -335,10 +314,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
+        uses: ./.github/actions/download-nargo
 
       - name: Download acvm_js package artifact
         uses: actions/download-artifact@v4
@@ -351,14 +327,6 @@ jobs:
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
@@ -388,10 +356,7 @@ jobs:
           echo "$HOME/.bb/" >> $GITHUB_PATH
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
+        uses: ./.github/actions/download-nargo
 
       - name: Download acvm_js package artifact
         uses: actions/download-artifact@v4
@@ -410,14 +375,6 @@ jobs:
         with:
           name: noirc_abi_wasm
           path: ./tooling/noirc_abi_wasm
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
 
       - name: Install Yarn dependencies
         uses: ./.github/actions/setup
@@ -493,25 +450,13 @@ jobs:
         with:
           version: nightly-8660e5b941fe7f4d67e246cfd3dafea330fb53b1
 
-
       - name: Install `bb`
         run: |
           ./scripts/install_bb.sh
           echo "$HOME/.bb/" >> $GITHUB_PATH
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Run `prove_and_verify`
         working-directory: ./examples/prove_and_verify
@@ -564,18 +509,7 @@ jobs:
           ref: ${{ matrix.project.ref }}
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Remove requirements on compiler version
         working-directory: ./test-repo
@@ -588,7 +522,6 @@ jobs:
         id: test_report
         working-directory: ./test-repo/${{ matrix.project.path }}
         run: |
-
           output_file=${{ github.workspace }}/noir-repo/.github/critical_libraries_status/${{ matrix.project.repo }}/${{ matrix.project.path }}.actual.jsonl
           BEFORE=$SECONDS
           nargo test --silence-warnings --skip-brillig-constraints-check --format json ${{ matrix.project.nargo_args }} | tee $output_file
@@ -641,18 +574,7 @@ jobs:
           path: test-repo
 
       - name: Download nargo binary
-        uses: actions/download-artifact@v4
-        with:
-          name: nargo
-          path: ./nargo
-
-      - name: Set nargo on PATH
-        run: |
-          nargo_binary="${{ github.workspace }}/nargo/nargo"
-          chmod +x $nargo_binary
-          echo "$(dirname $nargo_binary)" >> $GITHUB_PATH
-          export PATH="$PATH:$(dirname $nargo_binary)"
-          nargo -V
+        uses: ./.github/actions/download-nargo
 
       - name: Remove requirements on compiler version
         working-directory: ./test-repo


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This adds an action which downloads nargo from an artifact and adds it to the path.

Unsure if this will work due to being in an action context. :shrug: 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
