### PR TITLE
fix: mark field division and modulo as requiring predicate for all necessary types

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_variable.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_variable.rs
@@ -549,12 +549,12 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
         &mut self,
         lhs: AcirVar,
         rhs: AcirVar,
+        predicate: AcirVar,
         assert_message: Option<AssertionPayload<F>>,
     ) -> Result<(), RuntimeError> {
         let diff_var = self.sub_var(lhs, rhs)?;
 
-        let one = self.add_constant(F::one());
-        let _ = self.inv_var(diff_var, one)?;
+        let _ = self.inv_var(diff_var, predicate)?;
         if let Some(payload) = assert_message {
             self.acir_ir
                 .assertion_payloads
@@ -613,7 +613,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
             }
             NumericType::Signed { bit_size } => {
                 let (quotient_var, _remainder_var) =
-                    self.signed_division_var(lhs, rhs, bit_size)?;
+                    self.signed_division_var(lhs, rhs, bit_size, predicate)?;
                 Ok(quotient_var)
             }
         }
@@ -1050,6 +1050,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
         lhs: AcirVar,
         rhs: AcirVar,
         bit_size: u32,
+        predicate: AcirVar,
     ) -> Result<(AcirVar, AcirVar), RuntimeError> {
         // We derive the signed division from the unsigned euclidean division.
         // note that this is not euclidean division!
@@ -1079,7 +1080,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
 
         // Performs the division using the unsigned values of lhs and rhs
         let (q1, r1) =
-            self.euclidean_division_var(unsigned_lhs, unsigned_rhs, bit_size - 1, one)?;
+            self.euclidean_division_var(unsigned_lhs, unsigned_rhs, bit_size - 1, predicate)?;
 
         // Unsigned to signed: derive q and r from q1,r1 and the signs of lhs and rhs
         // Quotient sign is lhs sign * rhs sign, whose resulting sign bit is the XOR of the sign bits
@@ -1117,7 +1118,9 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
         };
 
         let (_, remainder_var) = match numeric_type {
-            NumericType::Signed { bit_size } => self.signed_division_var(lhs, rhs, bit_size)?,
+            NumericType::Signed { bit_size } => {
+                self.signed_division_var(lhs, rhs, bit_size, predicate)?
+            }
             _ => self.euclidean_division_var(lhs, rhs, bit_size, predicate)?,
         };
         Ok(remainder_var)

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -762,7 +762,12 @@ impl<'a> Context<'a> {
                     None
                 };
 
-                self.acir_context.assert_neq_var(lhs, rhs, assert_payload)?;
+                self.acir_context.assert_neq_var(
+                    lhs,
+                    rhs,
+                    self.current_side_effects_enabled_var,
+                    assert_payload,
+                )?;
             }
             Instruction::Cast(value_id, _) => {
                 let acir_var = self.convert_numeric_value(*value_id, dfg)?;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -595,12 +595,16 @@ impl Instruction {
                 match binary.operator {
                     BinaryOp::Add { unchecked: false }
                     | BinaryOp::Sub { unchecked: false }
-                    | BinaryOp::Mul { unchecked: false }
-                    | BinaryOp::Div
-                    | BinaryOp::Mod => {
+                    | BinaryOp::Mul { unchecked: false } => {
                         // Some binary math can overflow or underflow, but this is only the case
                         // for unsigned types (here we assume the type of binary.lhs is the same)
                         dfg.type_of_value(binary.rhs).is_unsigned()
+                    }
+                    BinaryOp::Div | BinaryOp::Mod => {
+                        // Div and Mod require a predicate if the RHS may be zero.
+                        dfg.get_numeric_constant(binary.rhs)
+                            .map(|rhs| !rhs.is_zero())
+                            .unwrap_or(true)
                     }
                     BinaryOp::Add { unchecked: true }
                     | BinaryOp::Sub { unchecked: true }

--- a/test_programs/execution_success/signed_inactive_division_by_zero/Nargo.toml
+++ b/test_programs/execution_success/signed_inactive_division_by_zero/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "signed_inactive_division_by_zero"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/signed_inactive_division_by_zero/Prover.toml
+++ b/test_programs/execution_success/signed_inactive_division_by_zero/Prover.toml
@@ -1,0 +1,3 @@
+a = "1"
+b = "0"
+condition = false

--- a/test_programs/execution_success/signed_inactive_division_by_zero/src/main.nr
+++ b/test_programs/execution_success/signed_inactive_division_by_zero/src/main.nr
@@ -1,0 +1,8 @@
+fn main(a : i32, b : i32, condition: bool) -> pub i32 {
+    if condition {
+        // If `condition` is not set then we should not trigger an assertion failure here.
+        a / b 
+    } else {
+        0
+    }
+}

--- a/test_programs/execution_success/signed_inactive_division_by_zero/src/main.nr
+++ b/test_programs/execution_success/signed_inactive_division_by_zero/src/main.nr
@@ -1,7 +1,7 @@
-fn main(a : i32, b : i32, condition: bool) -> pub i32 {
+fn main(a: i32, b: i32, condition: bool) -> pub i32 {
     if condition {
         // If `condition` is not set then we should not trigger an assertion failure here.
-        a / b 
+        a / b
     } else {
         0
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7283 

## Summary\*

This PR fixes an issue where division and modulo operations were marked as only requiring a predicate in the case where it's acting on an unsigned type. This is incorrect as we need to handle a zero denominator for field and signed integer types.

This showed that we weren't handling predicates related to signed division more generally so I've rolled that into this PR.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
