### PR TITLE
feat: simplify consecutive arithemtic

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -156,7 +156,7 @@ impl Binary {
                     return SimplifyResult::SimplifiedTo(lhs);
                 }
                 if let Some(instruction) =
-                    self.simplify_consecutive(lhs, rhs, lhs_const, rhs_const, lhs_type, dfg)
+                    self.simplify_consecutive(lhs, lhs_const, rhs_const, lhs_type, dfg)
                 {
                     return SimplifyResult::SimplifiedToInstruction(instruction);
                 }
@@ -170,7 +170,7 @@ impl Binary {
                     return SimplifyResult::SimplifiedTo(lhs);
                 }
                 if let Some(instruction) =
-                    self.simplify_consecutive(lhs, rhs, lhs_const, rhs_const, lhs_type, dfg)
+                    self.simplify_consecutive(lhs, lhs_const, rhs_const, lhs_type, dfg)
                 {
                     return SimplifyResult::SimplifiedToInstruction(instruction);
                 }
@@ -219,7 +219,7 @@ impl Binary {
                     }
                 }
                 if let Some(instruction) =
-                    self.simplify_consecutive(lhs, rhs, lhs_const, rhs_const, lhs_type, dfg)
+                    self.simplify_consecutive(lhs, lhs_const, rhs_const, lhs_type, dfg)
                 {
                     return SimplifyResult::SimplifiedToInstruction(instruction);
                 }
@@ -383,7 +383,6 @@ impl Binary {
     fn simplify_consecutive(
         &self,
         lhs: ValueId,
-        _rhs: ValueId,
         lhs_const: Option<FieldElement>,
         rhs_const: Option<FieldElement>,
         typ: NumericType,

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -416,8 +416,7 @@ impl Binary {
         };
 
         let new_const = match self.operator {
-            BinaryOp::Add { .. } => rhs_const + rhs2_const,
-            BinaryOp::Sub { .. } => rhs_const + rhs2_const,
+            BinaryOp::Add { .. } | BinaryOp::Sub { .. } => rhs_const + rhs2_const,
             BinaryOp::Mul { .. } => rhs_const * rhs2_const,
             BinaryOp::Div
             | BinaryOp::Mod

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -415,6 +415,8 @@ impl Binary {
             return None;
         };
 
+        // TODO: perform the math in the target type, and don't simplify if there's an overflow
+        // (in the checked case)
         let new_const = match self.operator {
             BinaryOp::Add { .. } | BinaryOp::Sub { .. } => rhs_const + rhs2_const,
             BinaryOp::Mul { .. } => rhs_const * rhs2_const,


### PR DESCRIPTION
# Description

## Problem

Resolves #5707

## Summary

For now this just simplifies consecutive operations with the same operation (so "add 3", "sub 1" doesn't get simplified to "add 2" yet) but I wanted to see if just this change makes a different (I think it will, at least in the sha256 test program I noticed consecutive multiplications)

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
