### PR TITLE
fix: always normalize ssa when priting at least one pass

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -494,6 +494,11 @@ impl SsaBuilder {
     }
 
     fn print(mut self, msg: &str) -> Self {
+        // Always normalize if we are going to print at least one of the passes
+        if !matches!(self.ssa_logging, SsaLogging::None) {
+            self.ssa.normalize_ids();
+        }
+
         let print_ssa_pass = match &self.ssa_logging {
             SsaLogging::None => false,
             SsaLogging::All => true,
@@ -505,7 +510,6 @@ impl SsaBuilder {
             }
         };
         if print_ssa_pass {
-            self.ssa.normalize_ids();
             println!("After {msg}:\n{}", self.ssa);
         }
         self


### PR DESCRIPTION
# Description

## Problem

If you used `--show-ssa-pass` it would sometimes crash depending on the program.

Resolves #7235

## Summary

I'm not sure why that is the case, but it works fine with `--show-ssa` which normalized the SSA after every pass. As a quick fix, we now also always normalize the SSA after every pass, but we just print the relevant pass(es) if we are told to do so.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
