### PR TITLE
fix: error on if without else when type mismatch

### DIFF
--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4347,3 +4347,21 @@ fn call_function_alias_type() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn errors_on_if_without_else_type_mismatch() {
+    let src = r#"
+    fn main() {
+        if true { 
+            1 
+        }
+    }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::Context { err, .. }) = &errors[0].0 else {
+        panic!("Expected a Context error");
+    };
+    assert!(matches!(**err, TypeCheckError::TypeMismatch { .. }));
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #6846

## Summary

This now matches how Rust works.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
