### PR TITLE
chore: remove Recoverable

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -4,8 +4,8 @@ use std::fmt::Display;
 use thiserror::Error;
 
 use crate::ast::{
-    Ident, ItemVisibility, Path, Pattern, Recoverable, Statement, StatementKind,
-    UnresolvedTraitConstraint, UnresolvedType, UnresolvedTypeData, Visibility,
+    Ident, ItemVisibility, Path, Pattern, Statement, StatementKind, UnresolvedTraitConstraint,
+    UnresolvedType, UnresolvedTypeData, Visibility,
 };
 use crate::node_interner::{
     ExprId, InternedExpressionKind, InternedStatementKind, QuotedTypeId, TypeId,
@@ -223,24 +223,6 @@ impl ExpressionKind {
             fields,
             struct_type: None,
         }))
-    }
-}
-
-impl Recoverable for ExpressionKind {
-    fn error(_: Span) -> Self {
-        ExpressionKind::Error
-    }
-}
-
-impl Recoverable for Expression {
-    fn error(span: Span) -> Self {
-        Expression::new(ExpressionKind::Error, span)
-    }
-}
-
-impl Recoverable for Option<Expression> {
-    fn error(span: Span) -> Self {
-        Some(Expression::new(ExpressionKind::Error, span))
     }
 }
 

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -253,12 +253,6 @@ pub enum UnresolvedTypeExpression {
     AsTraitPath(Box<AsTraitPath>),
 }
 
-impl Recoverable for UnresolvedType {
-    fn error(span: Span) -> Self {
-        UnresolvedType { typ: UnresolvedTypeData::Error, span }
-    }
-}
-
 impl std::fmt::Display for GenericTypeArg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -140,12 +140,6 @@ impl StatementKind {
     }
 }
 
-impl Recoverable for StatementKind {
-    fn error(_: Span) -> Self {
-        StatementKind::Error
-    }
-}
-
 impl StatementKind {
     pub fn new_let(
         pattern: Pattern,
@@ -284,25 +278,6 @@ impl Ident {
     }
 }
 
-impl Recoverable for Ident {
-    fn error(span: Span) -> Self {
-        Ident(Spanned::from(span, ERROR_IDENT.to_owned()))
-    }
-}
-
-impl<T> Recoverable for Vec<T> {
-    fn error(_: Span) -> Self {
-        vec![]
-    }
-}
-
-/// Trait for recoverable nodes during parsing.
-/// This is similar to Default but is expected
-/// to return an Error node of the appropriate type.
-pub trait Recoverable {
-    fn error(span: Span) -> Self;
-}
-
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ModuleDeclaration {
     pub visibility: ItemVisibility,
@@ -420,9 +395,6 @@ pub struct TypePath {
     pub turbofish: Option<GenericTypeArgs>,
 }
 
-// Note: Path deliberately doesn't implement Recoverable.
-// No matter which default value we could give in Recoverable::error,
-// it would most likely cause further errors during name resolution
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Path {
     pub segments: Vec<PathSegment>,
@@ -704,12 +676,6 @@ impl Pattern {
             }
             Pattern::Interned(id, _) => interner.get_pattern(*id).try_as_expression(interner),
         }
-    }
-}
-
-impl Recoverable for Pattern {
-    fn error(span: Span) -> Self {
-        Pattern::Identifier(Ident::error(span))
     }
 }
 


### PR DESCRIPTION
# Description

## Problem

I noticed `Recoverable` is unused, probably a left-over from the chumsky parser.

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
