### PR TITLE
fix!: check abi integer input is within signed range

### DIFF
--- a/test_programs/execution_success/signed_cmp/Prover.toml
+++ b/test_programs/execution_success/signed_cmp/Prover.toml
@@ -1,1 +1,1 @@
-minus_one = "-1"
+minus_one = -1

--- a/test_programs/execution_success/signed_cmp/Prover.toml
+++ b/test_programs/execution_success/signed_cmp/Prover.toml
@@ -1,1 +1,1 @@
-minus_one = 255
+minus_one = "-1"

--- a/test_programs/execution_success/signed_div/Prover.toml
+++ b/test_programs/execution_success/signed_div/Prover.toml
@@ -1,51 +1,51 @@
 [[ops]]
 lhs = 4
-rhs = "-1"
-result = "-4"
+rhs = -1
+result = -4
 
 [[ops]]
 lhs = 4
-rhs = "-2"
-result = "-2"
+rhs = -2
+result = -2
 
 [[ops]]
 lhs = 4
-rhs = "-3"
-result = "-1"
+rhs = -3
+result = -1
 
 [[ops]]
 lhs = 4
-rhs = "-4"
-result = "-1"
+rhs = -4
+result = -1
 
 [[ops]]
 lhs = 4
-rhs = "-5"
+rhs = -5
 result = 0
 
 [[ops]]
-lhs = "-4"
-rhs = "-1"
+lhs = -4
+rhs = -1
 result = 4
 
 [[ops]]
-lhs = "-4"
-rhs = "-2"
+lhs = -4
+rhs = -2
 result = 2
 
 [[ops]]
-lhs = "-4"
-rhs = "-3"
+lhs = -4
+rhs = -3
 result = 1
 
 [[ops]]
-lhs = "-4"
-rhs = "-4"
+lhs = -4
+rhs = -4
 result = 1
 
 [[ops]]
-lhs = "-4"
-rhs = "-5"
+lhs = -4
+rhs = -5
 result = 0
 
 

--- a/test_programs/execution_success/signed_div/Prover.toml
+++ b/test_programs/execution_success/signed_div/Prover.toml
@@ -1,51 +1,51 @@
 [[ops]]
 lhs = 4
-rhs = 255    # -1
-result = 252 # -4
+rhs = "-1"
+result = "-4"
 
 [[ops]]
 lhs = 4
-rhs = 254    # -2
-result = 254 # -2
+rhs = "-2"
+result = "-2"
 
 [[ops]]
 lhs = 4
-rhs = 253    # -3
-result = 255 # -1
+rhs = "-3"
+result = "-1"
 
 [[ops]]
 lhs = 4
-rhs = 252    # -4
-result = 255 # -1
+rhs = "-4"
+result = "-1"
 
 [[ops]]
 lhs = 4
-rhs = 251  # -5
+rhs = "-5"
 result = 0
 
 [[ops]]
-lhs = 252  # -4
-rhs = 255  # -1
+lhs = "-4"
+rhs = "-1"
 result = 4
 
 [[ops]]
-lhs = 252  # -4
-rhs = 254  # -2
+lhs = "-4"
+rhs = "-2"
 result = 2
 
 [[ops]]
-lhs = 252  # -4
-rhs = 253  # -3
+lhs = "-4"
+rhs = "-3"
 result = 1
 
 [[ops]]
-lhs = 252  # -4
-rhs = 252  # -4
+lhs = "-4"
+rhs = "-4"
 result = 1
 
 [[ops]]
-lhs = 252  # -4
-rhs = 251  # -5
+lhs = "-4"
+rhs = "-5"
 result = 0
 
 

--- a/tooling/noir_js/test/node/cjs.test.cjs
+++ b/tooling/noir_js/test/node/cjs.test.cjs
@@ -59,7 +59,7 @@ it('0x prefixed string input for inputs will throw', async () => {
 });
 
 describe('input validation', () => {
-  it('x should be a uint64 not a string', async () => {
+  it('x should be a int64 not a string', async () => {
     const inputs = {
       x: 'foo',
       y: '3',
@@ -67,7 +67,7 @@ describe('input validation', () => {
 
     try {
       await new Noir(assert_lt_json).execute(inputs);
-      chai.expect.fail('Expected generatedWitness to throw, due to x not being convertible to a uint64');
+      chai.expect.fail('Expected generatedWitness to throw, due to x not being convertible to a int64');
     } catch (error) {
       const knownError = error;
       chai

--- a/tooling/noir_js/test/node/cjs.test.cjs
+++ b/tooling/noir_js/test/node/cjs.test.cjs
@@ -73,7 +73,7 @@ describe('input validation', () => {
       chai
         .expect(knownError.message)
         .to.equal(
-          'The value passed for parameter `x` is invalid:\nExpected witness values to be integers, provided value causes `invalid digit found in string` error',
+          'The value passed for parameter `x` is invalid:\nExpected witness values to be integers, but `foo` failed with `invalid digit found in string`',
         );
     }
   });

--- a/tooling/noir_js/test/node/cjs.test.cjs
+++ b/tooling/noir_js/test/node/cjs.test.cjs
@@ -73,7 +73,7 @@ describe('input validation', () => {
       chai
         .expect(knownError.message)
         .to.equal(
-          'Expected witness values to be integers, provided value causes `invalid digit found in string` error',
+          'The value passed for parameter `x` is invalid:\nExpected witness values to be integers, provided value causes `invalid digit found in string` error',
         );
     }
   });

--- a/tooling/noir_js/test/node/smoke.test.ts
+++ b/tooling/noir_js/test/node/smoke.test.ts
@@ -58,7 +58,7 @@ it('0x prefixed string input for inputs will throw', async () => {
 });
 
 describe('input validation', () => {
-  it('x should be a uint64 not a string', async () => {
+  it('x should be a int64 not a string', async () => {
     const inputs = {
       x: 'foo',
       y: '3',
@@ -66,7 +66,7 @@ describe('input validation', () => {
 
     try {
       await new Noir(assert_lt_program).execute(inputs);
-      expect.fail('Expected generatedWitness to throw, due to x not being convertible to a uint64');
+      expect.fail('Expected generatedWitness to throw, due to x not being convertible to a int64');
     } catch (error) {
       const knownError = error as Error;
       expect(knownError.message).to.equal(

--- a/tooling/noir_js/test/node/smoke.test.ts
+++ b/tooling/noir_js/test/node/smoke.test.ts
@@ -70,7 +70,7 @@ describe('input validation', () => {
     } catch (error) {
       const knownError = error as Error;
       expect(knownError.message).to.equal(
-        'Expected witness values to be integers, provided value causes `invalid digit found in string` error',
+        'The value passed for parameter `x` is invalid:\nExpected witness values to be integers, provided value causes `invalid digit found in string` error',
       );
     }
   });

--- a/tooling/noir_js/test/node/smoke.test.ts
+++ b/tooling/noir_js/test/node/smoke.test.ts
@@ -70,7 +70,7 @@ describe('input validation', () => {
     } catch (error) {
       const knownError = error as Error;
       expect(knownError.message).to.equal(
-        'The value passed for parameter `x` is invalid:\nExpected witness values to be integers, provided value causes `invalid digit found in string` error',
+        'The value passed for parameter `x` is invalid:\nExpected witness values to be integers, but `foo` failed with `invalid digit found in string`',
       );
     }
   });

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -10,17 +10,17 @@ use thiserror::Error;
 pub enum InputParserError {
     #[error("input file is badly formed, could not parse, {0}")]
     ParseInputMap(String),
-    #[error("Expected witness values to be integers, provided value causes `{0}` error")]
-    ParseStr(String),
+    #[error("Expected witness values to be integers, provided value causes `{value}` error")]
+    ParseStr { value: String },
     #[error("Input {value} exceeds maximum value of {max}")]
     InputExceedsMaximum { value: u64, max: u64 },
     #[error("Input {value} outside of valid range. Value must fall within [{min}, {max}]")]
     InputOutsideOfRange { value: BigInt, min: BigInt, max: BigInt },
     #[error(
-        "Input {0} exceeds field modulus. Values must fall within [0, {})",
+        "Input {value} exceeds field modulus. Values must fall within [0, {})",
         FieldElement::modulus()
     )]
-    InputExceedsFieldModulus(String),
+    InputExceedsFieldModulus { value: String },
     #[error("cannot parse value into {0:?}")]
     AbiTypeMismatch(AbiType),
     #[error("Expected argument `{0}`, but none was found")]

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -10,17 +10,21 @@ use thiserror::Error;
 pub enum InputParserError {
     #[error("input file is badly formed, could not parse, {0}")]
     ParseInputMap(String),
-    #[error("Expected witness values to be integers, provided value causes `{value}` error")]
-    ParseStr { value: String },
-    #[error("Input {value} exceeds maximum value of {max}")]
-    InputExceedsMaximum { value: u64, max: u64 },
-    #[error("Input {value} outside of valid range. Value must fall within [{min}, {max}]")]
-    InputOutsideOfRange { value: BigInt, min: BigInt, max: BigInt },
     #[error(
-        "Input {value} exceeds field modulus. Values must fall within [0, {})",
+        "The value passed for parameter `{arg_name}` has an error:\nExpected witness values to be integers, provided value causes `{value}` error"
+    )]
+    ParseStr { arg_name: String, value: String },
+    #[error("The value passed for parameter `{arg_name}` has an error:\nValue {value} exceeds maximum value of {max}")]
+    InputExceedsMaximum { arg_name: String, value: u64, max: u64 },
+    #[error(
+        "The value passed for parameter `{arg_name}` has an error:\nValue {value} outside of valid range. Value must fall within [{min}, {max}]"
+    )]
+    InputOutsideOfRange { arg_name: String, value: BigInt, min: BigInt, max: BigInt },
+    #[error(
+        "The value passed for parameter `{arg_name}` has an error:\nValue {value} exceeds field modulus. Values must fall within [0, {})",
         FieldElement::modulus()
     )]
-    InputExceedsFieldModulus { value: String },
+    InputExceedsFieldModulus { arg_name: String, value: String },
     #[error("cannot parse value into {0:?}")]
     AbiTypeMismatch(AbiType),
     #[error("Expected argument `{0}`, but none was found")]

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -11,9 +11,9 @@ pub enum InputParserError {
     #[error("input file is badly formed, could not parse, {0}")]
     ParseInputMap(String),
     #[error(
-        "The value passed for parameter `{arg_name}` is invalid:\nExpected witness values to be integers, but `{value}` failed with `{error_str}`"
+        "The value passed for parameter `{arg_name}` is invalid:\nExpected witness values to be integers, but `{value}` failed with `{error}`"
     )]
-    ParseStr { arg_name: String, value: String },
+    ParseStr { arg_name: String, value: String, error: String },
     #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} is less than minimum allowed value of {min}")]
     InputExceedsMinimum { arg_name: String, value: String, min: String },
     #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds maximum allowed value of {max}")]

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -14,8 +14,10 @@ pub enum InputParserError {
         "The value passed for parameter `{arg_name}` is invalid:\nExpected witness values to be integers, provided value causes `{value}` error"
     )]
     ParseStr { arg_name: String, value: String },
-    #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds maximum value of {max}")]
-    InputExceedsMaximum { arg_name: String, value: u64, max: u64 },
+    #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} is less than minimum allowed value of {min}")]
+    InputExceedsMinimum { arg_name: String, value: String, min: String },
+    #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds maximum allowed value of {max}")]
+    InputExceedsMaximum { arg_name: String, value: String, max: String },
     #[error(
         "The value passed for parameter `{arg_name}` is invalid:\nValue {value} outside of valid range. Value must fall within [{min}, {max}]"
     )]

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -14,9 +14,9 @@ pub enum InputParserError {
     )]
     ParseStr { arg_name: String, value: String, error: String },
     #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} is less than minimum allowed value of {min}")]
-    InputExceedsMinimum { arg_name: String, value: String, min: String },
+    InputUnderflowsMinimum { arg_name: String, value: String, min: String },
     #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds maximum allowed value of {max}")]
-    InputExceedsMaximum { arg_name: String, value: String, max: String },
+    InputOverflowsMaximum { arg_name: String, value: String, max: String },
     #[error(
         "The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds field modulus. Values must fall within [0, {})",
         FieldElement::modulus()

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -11,17 +11,17 @@ pub enum InputParserError {
     #[error("input file is badly formed, could not parse, {0}")]
     ParseInputMap(String),
     #[error(
-        "The value passed for parameter `{arg_name}` has an error:\nExpected witness values to be integers, provided value causes `{value}` error"
+        "The value passed for parameter `{arg_name}` is invalid:\nExpected witness values to be integers, provided value causes `{value}` error"
     )]
     ParseStr { arg_name: String, value: String },
-    #[error("The value passed for parameter `{arg_name}` has an error:\nValue {value} exceeds maximum value of {max}")]
+    #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds maximum value of {max}")]
     InputExceedsMaximum { arg_name: String, value: u64, max: u64 },
     #[error(
-        "The value passed for parameter `{arg_name}` has an error:\nValue {value} outside of valid range. Value must fall within [{min}, {max}]"
+        "The value passed for parameter `{arg_name}` is invalid:\nValue {value} outside of valid range. Value must fall within [{min}, {max}]"
     )]
     InputOutsideOfRange { arg_name: String, value: BigInt, min: BigInt, max: BigInt },
     #[error(
-        "The value passed for parameter `{arg_name}` has an error:\nValue {value} exceeds field modulus. Values must fall within [0, {})",
+        "The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds field modulus. Values must fall within [0, {})",
         FieldElement::modulus()
     )]
     InputExceedsFieldModulus { arg_name: String, value: String },

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -11,7 +11,7 @@ pub enum InputParserError {
     #[error("input file is badly formed, could not parse, {0}")]
     ParseInputMap(String),
     #[error(
-        "The value passed for parameter `{arg_name}` is invalid:\nExpected witness values to be integers, provided value causes `{value}` error"
+        "The value passed for parameter `{arg_name}` is invalid:\nExpected witness values to be integers, but `{value}` failed with `{error_str}`"
     )]
     ParseStr { arg_name: String, value: String },
     #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} is less than minimum allowed value of {min}")]

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -2,7 +2,8 @@ use crate::{
     input_parser::{InputTypecheckingError, InputValue},
     AbiType,
 };
-use acvm::acir::native_types::Witness;
+use acvm::{acir::native_types::Witness, AcirField, FieldElement};
+use num_bigint::BigInt;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,8 +12,15 @@ pub enum InputParserError {
     ParseInputMap(String),
     #[error("Expected witness values to be integers, provided value causes `{0}` error")]
     ParseStr(String),
-    #[error("Could not parse hex value {0}")]
-    ParseHexStr(String),
+    #[error("Input {value} exceeds maximum value of {max}")]
+    InputExceedsMaximum { value: u64, max: u64 },
+    #[error("Input {value} outside of valid range. Value must fall within [{min}, {max}]")]
+    InputOutsideOfRange { value: BigInt, min: BigInt, max: BigInt },
+    #[error(
+        "Input {0} exceeds field modulus. Values must fall within [0, {})",
+        FieldElement::modulus()
+    )]
+    InputExceedsFieldModulus(String),
     #[error("cannot parse value into {0:?}")]
     AbiTypeMismatch(AbiType),
     #[error("Expected argument `{0}`, but none was found")]

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -3,7 +3,6 @@ use crate::{
     AbiType,
 };
 use acvm::{acir::native_types::Witness, AcirField, FieldElement};
-use num_bigint::BigInt;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,10 +17,6 @@ pub enum InputParserError {
     InputExceedsMinimum { arg_name: String, value: String, min: String },
     #[error("The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds maximum allowed value of {max}")]
     InputExceedsMaximum { arg_name: String, value: String, max: String },
-    #[error(
-        "The value passed for parameter `{arg_name}` is invalid:\nValue {value} outside of valid range. Value must fall within [{min}, {max}]"
-    )]
-    InputOutsideOfRange { arg_name: String, value: BigInt, min: BigInt, max: BigInt },
     #[error(
         "The value passed for parameter `{arg_name}` is invalid:\nValue {value} exceeds field modulus. Values must fall within [0, {})",
         FieldElement::modulus()

--- a/tooling/noirc_abi/src/input_parser/json.rs
+++ b/tooling/noirc_abi/src/input_parser/json.rs
@@ -270,7 +270,7 @@ mod test {
         assert!(InputValue::try_from_json(input, &typ, "foo").is_err());
 
         let typ = AbiType::Integer { sign: crate::Sign::Signed, width: 16 };
-        let input = JsonTypes::Integer(32767);
+        let input = JsonTypes::Integer(32768);
         assert!(InputValue::try_from_json(input, &typ, "foo").is_err());
     }
 }

--- a/tooling/noirc_abi/src/input_parser/json.rs
+++ b/tooling/noirc_abi/src/input_parser/json.rs
@@ -72,9 +72,9 @@ pub enum JsonTypes {
     // Just a regular integer, that can fit in 64 bits.
     //
     // The JSON spec does not specify any limit on the size of integer number types,
-    // however we restrict the allowable size. Values which do not fit in a u64 should be passed
+    // however we restrict the allowable size. Values which do not fit in a i64 should be passed
     // as a string.
-    Integer(u64),
+    Integer(i64),
     // Simple boolean flag
     Bool(bool),
     // Array of JsonTypes
@@ -221,6 +221,7 @@ impl InputValue {
 
 #[cfg(test)]
 mod test {
+    use acvm::FieldElement;
     use proptest::prelude::*;
 
     use crate::{
@@ -265,5 +266,16 @@ mod test {
         let typ = AbiType::Integer { sign: crate::Sign::Signed, width: 16 };
         let input = JsonTypes::Integer(32768);
         assert!(InputValue::try_from_json(input, &typ, "foo").is_err());
+    }
+
+    #[test]
+    fn try_from_json_negative_integer() {
+        let typ = AbiType::Integer { sign: crate::Sign::Signed, width: 8 };
+        let input = JsonTypes::Integer(-1);
+        let InputValue::Field(field) = InputValue::try_from_json(input, &typ, "foo").unwrap()
+        else {
+            panic!("Expected field");
+        };
+        assert_eq!(field, FieldElement::from(255_u128));
     }
 }

--- a/tooling/noirc_abi/src/input_parser/json.rs
+++ b/tooling/noirc_abi/src/input_parser/json.rs
@@ -160,10 +160,7 @@ impl InputValue {
             ) => {
                 let max = 1 << (width - 1) - 1;
                 if integer > max {
-                    return Err(InputParserError::ParseStr(format!(
-                        "Value {} exceeds maximum value of {}",
-                        integer, max
-                    )));
+                    return Err(InputParserError::InputExceedsMaximum { value: integer, max });
                 }
 
                 let new_value = FieldElement::from(i128::from(integer));

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -313,7 +313,8 @@ fn parse_str_to_field(value: &str, arg_name: &str) -> Result<FieldElement, Input
     big_num
         .map_err(|err_msg| InputParserError::ParseStr {
             arg_name: arg_name.into(),
-            value: err_msg.to_string(),
+            value: value.into(),
+            error: err_msg.to_string(),
         })
         .and_then(|bigint| {
             if bigint < FieldElement::modulus() {
@@ -343,7 +344,8 @@ fn parse_str_to_signed(
     big_num
         .map_err(|err_msg| InputParserError::ParseStr {
             arg_name: arg_name.into(),
-            value: err_msg.to_string(),
+            value: value.into(),
+            error: err_msg.to_string(),
         })
         .and_then(|bigint| {
             let max = BigInt::from(2_u128.pow(width - 1) - 1);
@@ -485,14 +487,31 @@ mod test {
         let value = parse_str_to_signed("-1", 16, "arg_name").unwrap();
         assert_eq!(value, FieldElement::from(65535_u128));
 
-        assert_eq!(parse_str_to_signed("127", 8, "arg_name"), Ok(FieldElement::from(127_i128)));
+        assert_eq!(
+            parse_str_to_signed("127", 8, "arg_name").unwrap(),
+            FieldElement::from(127_i128)
+        );
         assert!(parse_str_to_signed("128", 8, "arg_name").is_err());
-        assert!(parse_str_to_signed("-128", 8, "arg_name").is_ok());
+        assert_eq!(
+            parse_str_to_signed("-128", 8, "arg_name").unwrap(),
+            FieldElement::from(128_i128)
+        );
+        assert_eq!(parse_str_to_signed("-1", 8, "arg_name").unwrap(), FieldElement::from(255_i128));
         assert!(parse_str_to_signed("-129", 8, "arg_name").is_err());
 
-        assert_eq!(parse_str_to_signed("32767", 8, "arg_name"), Ok(FieldElement::from(32767_i128)));
+        assert_eq!(
+            parse_str_to_signed("32767", 16, "arg_name").unwrap(),
+            FieldElement::from(32767_i128)
+        );
         assert!(parse_str_to_signed("32768", 16, "arg_name").is_err());
-        assert_eq!(parse_str_to_signed("-32768", 16, "arg_name"), Ok(FieldElement::from(-32768_i128)));
+        assert_eq!(
+            parse_str_to_signed("-32768", 16, "arg_name").unwrap(),
+            FieldElement::from(32768_i128)
+        );
+        assert_eq!(
+            parse_str_to_signed("-1", 16, "arg_name").unwrap(),
+            FieldElement::from(65535_i128)
+        );
         assert!(parse_str_to_signed("-32769", 16, "arg_name").is_err());
     }
 }

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -492,7 +492,7 @@ mod test {
 
         assert_eq!(parse_str_to_signed("32767", 8, "arg_name"), Ok(FieldElement::from(32767_i128)));
         assert!(parse_str_to_signed("32768", 16, "arg_name").is_err());
-        assert!(parse_str_to_signed("-32768", 16, "arg_name").is_ok());
+        assert_eq!(parse_str_to_signed("-32768", 16, "arg_name"), Ok(FieldElement::from(-32768_i128)));
         assert!(parse_str_to_signed("-32769", 16, "arg_name").is_err());
     }
 }

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -314,10 +314,7 @@ fn parse_str_to_field(value: &str) -> Result<FieldElement, InputParserError> {
         if bigint < FieldElement::modulus() {
             Ok(field_from_big_uint(bigint))
         } else {
-            Err(InputParserError::ParseStr(format!(
-                "Input exceeds field modulus. Values must fall within [0, {})",
-                FieldElement::modulus(),
-            )))
+            Err(InputParserError::InputExceedsFieldModulus(value.to_string()))
         }
     })
 }
@@ -336,10 +333,7 @@ fn parse_str_to_signed(value: &str, width: u32) -> Result<FieldElement, InputPar
         let min = BigInt::from(-(2_i128.pow(width - 1)));
 
         if bigint < min || bigint > max {
-            return Err(InputParserError::ParseStr(format!(
-                "Value {} outside of valid range. Values must fall within [{}, {}]",
-                bigint, min, max
-            )));
+            return Err(InputParserError::InputOutsideOfRange { value: bigint, min, max });
         }
 
         let modulus: BigInt = FieldElement::modulus().into();
@@ -351,10 +345,7 @@ fn parse_str_to_signed(value: &str, width: u32) -> Result<FieldElement, InputPar
         if bigint.is_zero() || (bigint.sign() == num_bigint::Sign::Plus && bigint < modulus) {
             Ok(field_from_big_int(bigint))
         } else {
-            Err(InputParserError::ParseStr(format!(
-                "Input exceeds field modulus. Values must fall within [0, {})",
-                FieldElement::modulus(),
-            )))
+            Err(InputParserError::InputExceedsFieldModulus(value.to_string()))
         }
     })
 }

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -399,12 +399,8 @@ fn parse_integer_to_signed(
         });
     }
 
-    let field = if integer < 0 {
-        field_from_big_int(BigInt::from(2).pow(width) + BigInt::from(integer))
-    } else {
-        FieldElement::from(integer as u128)
-    };
-    Ok(field)
+    let integer = if integer < 0 { (1 << width) + integer } else { integer };
+    Ok(FieldElement::from(integer as u128))
 }
 
 fn field_from_big_uint(bigint: BigUint) -> FieldElement {

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -485,7 +485,7 @@ mod test {
         let value = parse_str_to_signed("-1", 16, "arg_name").unwrap();
         assert_eq!(value, FieldElement::from(65535_u128));
 
-        assert!(parse_str_to_signed("127", 8, "arg_name").is_ok());
+        assert_eq!(parse_str_to_signed("127", 8, "arg_name"), Ok(FieldElement::from(127_i128)));
         assert!(parse_str_to_signed("128", 8, "arg_name").is_err());
         assert!(parse_str_to_signed("-128", 8, "arg_name").is_ok());
         assert!(parse_str_to_signed("-129", 8, "arg_name").is_err());

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -351,12 +351,19 @@ fn parse_str_to_signed(
             let max = BigInt::from(2_u128.pow(width - 1) - 1);
             let min = BigInt::from(-(2_i128.pow(width - 1)));
 
-            if bigint < min || bigint > max {
-                return Err(InputParserError::InputOutsideOfRange {
+            if bigint < min {
+                return Err(InputParserError::InputExceedsMinimum {
                     arg_name: arg_name.into(),
-                    value: bigint,
-                    min,
-                    max,
+                    value: bigint.to_string(),
+                    min: min.to_string(),
+                });
+            }
+
+            if bigint > max {
+                return Err(InputParserError::InputExceedsMaximum {
+                    arg_name: arg_name.into(),
+                    value: bigint.to_string(),
+                    max: max.to_string(),
                 });
             }
 

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -490,7 +490,7 @@ mod test {
         assert!(parse_str_to_signed("-128", 8, "arg_name").is_ok());
         assert!(parse_str_to_signed("-129", 8, "arg_name").is_err());
 
-        assert!(parse_str_to_signed("32767", 16, "arg_name").is_ok());
+        assert_eq!(parse_str_to_signed("32767", 8, "arg_name"), Ok(FieldElement::from(32767_i128)));
         assert!(parse_str_to_signed("32768", 16, "arg_name").is_err());
         assert!(parse_str_to_signed("-32768", 16, "arg_name").is_ok());
         assert!(parse_str_to_signed("-32769", 16, "arg_name").is_err());

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -352,7 +352,7 @@ fn parse_str_to_signed(
             let min = BigInt::from(-(2_i128.pow(width - 1)));
 
             if bigint < min {
-                return Err(InputParserError::InputExceedsMinimum {
+                return Err(InputParserError::InputUnderflowsMinimum {
                     arg_name: arg_name.into(),
                     value: bigint.to_string(),
                     min: min.to_string(),
@@ -360,7 +360,7 @@ fn parse_str_to_signed(
             }
 
             if bigint > max {
-                return Err(InputParserError::InputExceedsMaximum {
+                return Err(InputParserError::InputOverflowsMaximum {
                     arg_name: arg_name.into(),
                     value: bigint.to_string(),
                     max: max.to_string(),
@@ -393,7 +393,7 @@ fn parse_integer_to_signed(
     let max = (1 << (width - 1)) - 1;
 
     if integer < min {
-        return Err(InputParserError::InputExceedsMinimum {
+        return Err(InputParserError::InputUnderflowsMinimum {
             arg_name: arg_name.into(),
             value: integer.to_string(),
             min: min.to_string(),
@@ -401,7 +401,7 @@ fn parse_integer_to_signed(
     }
 
     if integer > max {
-        return Err(InputParserError::InputExceedsMaximum {
+        return Err(InputParserError::InputOverflowsMaximum {
             arg_name: arg_name.into(),
             value: integer.to_string(),
             max: max.to_string(),

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -379,7 +379,7 @@ fn field_from_big_uint(bigint: BigUint) -> FieldElement {
     FieldElement::from_be_bytes_reduce(&bigint.to_bytes_be())
 }
 
-fn field_from_big_int(bigint: BigInt) -> FieldElement {
+pub(crate) fn field_from_big_int(bigint: BigInt) -> FieldElement {
     match bigint.sign() {
         num_bigint::Sign::Minus => {
             unreachable!(

--- a/tooling/noirc_abi/src/input_parser/toml.rs
+++ b/tooling/noirc_abi/src/input_parser/toml.rs
@@ -255,7 +255,7 @@ mod test {
         assert!(InputValue::try_from_toml(input, &typ, "foo").is_err());
 
         let typ = AbiType::Integer { sign: crate::Sign::Signed, width: 16 };
-        let input = TomlTypes::Integer(32767);
+        let input = TomlTypes::Integer(32768);
         assert!(InputValue::try_from_toml(input, &typ, "foo").is_err());
     }
 }

--- a/tooling/noirc_abi/src/input_parser/toml.rs
+++ b/tooling/noirc_abi/src/input_parser/toml.rs
@@ -145,10 +145,7 @@ impl InputValue {
             ) => {
                 let max = 1 << (width - 1) - 1;
                 if integer > max {
-                    return Err(InputParserError::ParseStr(format!(
-                        "Value {} exceeds maximum value of {}",
-                        integer, max
-                    )));
+                    return Err(InputParserError::InputExceedsMaximum { value: integer, max });
                 }
 
                 let new_value = FieldElement::from(u128::from(integer));

--- a/tooling/noirc_abi/src/input_parser/toml.rs
+++ b/tooling/noirc_abi/src/input_parser/toml.rs
@@ -1,10 +1,10 @@
 use super::{
-    field_from_big_int, field_to_signed_hex, parse_str_to_field, parse_str_to_signed, InputValue,
+    field_to_signed_hex, parse_integer_to_signed, parse_str_to_field, parse_str_to_signed,
+    InputValue,
 };
 use crate::{errors::InputParserError, Abi, AbiType, MAIN_RETURN_NAME};
 use acvm::{AcirField, FieldElement};
 use iter_extended::{try_btree_map, try_vecmap};
-use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -146,31 +146,7 @@ impl InputValue {
                 TomlTypes::Integer(integer),
                 AbiType::Integer { sign: crate::Sign::Signed, width },
             ) => {
-                let min = -(1 << (width - 1));
-                let max = (1 << (width - 1)) - 1;
-
-                if integer < min {
-                    return Err(InputParserError::InputExceedsMinimum {
-                        arg_name: arg_name.into(),
-                        value: integer.to_string(),
-                        min: min.to_string(),
-                    });
-                }
-
-                if integer > max {
-                    return Err(InputParserError::InputExceedsMaximum {
-                        arg_name: arg_name.into(),
-                        value: integer.to_string(),
-                        max: max.to_string(),
-                    });
-                }
-
-                let new_value = if integer < 0 {
-                    field_from_big_int(BigInt::from(2).pow(*width) + BigInt::from(integer))
-                } else {
-                    FieldElement::from(integer as u128)
-                };
-
+                let new_value = parse_integer_to_signed(integer as i128, *width, arg_name)?;
                 InputValue::Field(new_value)
             }
 


### PR DESCRIPTION
# Description

## Problem

Resolves #7304

## Summary

I accidentally started fixing this when parsing strings, but I think that's also good to have. (edit: it turns out the original issue was about strings 😅)

Then I added a similar check for integers... though here we only need to check the maximum value because input values are always unsigned (~is there a reason for this?~ -> this PR now also allows negative integers in at least Prover.toml (I hope that's fine!)).

Finally, I noticed that the error message produced in this case was very barebones: it didn't mention which parameter name errored. So now that's shown, and also if the value is inside an array, that index is shown (a similar thing is done for tables where we show which field we are in).

The error shown for the program in #7304 is now this:

```
The value passed for parameter `x` is invalid:
Value 200 exceeds maximum value of 127
```

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
