### PR TITLE
fix: avoid stack overflow on many comments in a row

### DIFF
--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4364,3 +4364,9 @@ fn errors_on_if_without_else_type_mismatch() {
     };
     assert!(matches!(**err, TypeCheckError::TypeMismatch { .. }));
 }
+
+#[test]
+fn does_not_stack_overflow_on_many_comments_in_a_row() {
+    let src = "//\n".repeat(10_000);
+    assert_no_errors(&src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #6975

## Summary

Turns recursion into a loop for skipping comments.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
