### PR TITLE
fix: lock git dependencies folder when resolving workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "toml",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,6 +3082,7 @@ version = "1.0.0-beta.1"
 dependencies = [
  "dirs",
  "fm",
+ "fs2",
  "nargo",
  "noirc_driver",
  "noirc_frontend",

--- a/tooling/nargo_toml/Cargo.toml
+++ b/tooling/nargo_toml/Cargo.toml
@@ -23,6 +23,7 @@ toml.workspace = true
 url.workspace = true
 noirc_driver.workspace = true
 semver = "1.0.20"
+fs2 = "0.4.3"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/tooling/nargo_toml/Cargo.toml
+++ b/tooling/nargo_toml/Cargo.toml
@@ -24,6 +24,7 @@ url.workspace = true
 noirc_driver.workspace = true
 semver = "1.0.20"
 fs2 = "0.4.3"
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/tooling/nargo_toml/src/flock.rs
+++ b/tooling/nargo_toml/src/flock.rs
@@ -1,0 +1,33 @@
+use fs2::FileExt;
+use std::{
+    fs::{File, OpenOptions},
+    path::Path,
+};
+
+// TODO: move this to some utils crate.
+
+pub(crate) struct FileLock {
+    file: File,
+}
+
+impl FileLock {
+    pub(crate) fn new(file_path: &Path, lock_name: &str) -> std::io::Result<Self> {
+        std::fs::create_dir_all(file_path.parent().expect("can't create lock on filesystem root"))?;
+        let file = OpenOptions::new().create(true).truncate(true).write(true).open(file_path)?;
+        if file.try_lock_exclusive().is_err() {
+            eprintln!("Waiting for lock on {lock_name}...");
+        }
+
+        file.lock_exclusive()?;
+
+        Ok(Self { file })
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        if let Err(e) = self.file.unlock() {
+            tracing::warn!("failed to release lock: {e:?}");
+        }
+    }
+}

--- a/tooling/nargo_toml/src/flock.rs
+++ b/tooling/nargo_toml/src/flock.rs
@@ -13,7 +13,7 @@ pub(crate) struct FileLock {
 impl FileLock {
     pub(crate) fn new(file_path: &Path, lock_name: &str) -> std::io::Result<Self> {
         std::fs::create_dir_all(file_path.parent().expect("can't create lock on filesystem root"))?;
-        let file = OpenOptions::new().create(true).truncate(true).write(true).open(file_path)?;
+        let file = OpenOptions::new().create(true).truncate(false).write(true).open(file_path)?;
         if file.try_lock_exclusive().is_err() {
             eprintln!("Waiting for lock on {lock_name}...");
         }

--- a/tooling/nargo_toml/src/git.rs
+++ b/tooling/nargo_toml/src/git.rs
@@ -1,8 +1,6 @@
-use fs2::FileExt;
-use std::{
-    fs::{File, OpenOptions},
-    path::PathBuf,
-};
+use std::path::PathBuf;
+
+use crate::flock::FileLock;
 
 /// Creates a unique folder name for a GitHub repo
 /// by using its URL and tag
@@ -27,17 +25,8 @@ fn git_dep_location(base: &url::Url, tag: &str) -> PathBuf {
     nargo_crates().join(folder_name)
 }
 
-pub(crate) fn lock_git_deps() -> std::io::Result<File> {
-    std::fs::create_dir_all(nargo_crates())?;
-    let file_path = nargo_crates().join(".package-cache");
-    let file = OpenOptions::new().create(true).truncate(true).write(true).open(file_path)?;
-    if file.try_lock_exclusive().is_err() {
-        eprintln!("Waiting for lock on git dependencies cache...");
-    }
-
-    file.lock_exclusive()?;
-
-    Ok(file)
+pub(crate) fn lock_git_deps() -> std::io::Result<FileLock> {
+    FileLock::new(&nargo_crates().join(".package-cache"), "git dependencies cache")
 }
 
 /// XXX: I'd prefer to use a GitHub library however, there

--- a/tooling/nargo_toml/src/git.rs
+++ b/tooling/nargo_toml/src/git.rs
@@ -28,6 +28,7 @@ fn git_dep_location(base: &url::Url, tag: &str) -> PathBuf {
 }
 
 pub(crate) fn lock_git_deps() -> std::io::Result<File> {
+    std::fs::create_dir_all(nargo_crates())?;
     let file_path = nargo_crates().join(".package-cache");
     let file = OpenOptions::new().create(true).truncate(true).write(true).open(file_path)?;
     if file.try_lock_exclusive().is_err() {

--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -10,7 +10,6 @@ use std::{
 
 use errors::SemverError;
 use fm::{NormalizePath, FILE_EXTENSION};
-use fs2::FileExt;
 use nargo::{
     package::{Dependency, Package, PackageType},
     workspace::Workspace,
@@ -20,6 +19,7 @@ use noirc_frontend::graph::CrateName;
 use serde::Deserialize;
 
 mod errors;
+mod flock;
 mod git;
 mod semver;
 
@@ -519,9 +519,8 @@ pub fn resolve_workspace_from_toml(
     current_compiler_version: Option<String>,
 ) -> Result<Workspace, ManifestError> {
     let nargo_toml = read_toml(toml_path)?;
-    let lock = lock_git_deps().expect("Failed to lock git dependencies cache");
+    let _lock = lock_git_deps().expect("Failed to lock git dependencies cache");
     let workspace = toml_to_workspace(nargo_toml, package_selection)?;
-    lock.unlock().expect("Failed to unlock git dependencies cache");
 
     if let Some(current_compiler_version) = current_compiler_version {
         semver::semver_check_workspace(&workspace, current_compiler_version)?;

--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -383,6 +383,7 @@ fn toml_to_workspace(
     package_selection: PackageSelection,
 ) -> Result<Workspace, ManifestError> {
     let mut resolved = Vec::new();
+    let _lock = lock_git_deps().expect("Failed to lock git dependencies cache");
     let workspace = match nargo_toml.config {
         Config::Package { package_config } => {
             let member = package_config.resolve_to_package(&nargo_toml.root_dir, &mut resolved)?;
@@ -519,7 +520,6 @@ pub fn resolve_workspace_from_toml(
     current_compiler_version: Option<String>,
 ) -> Result<Workspace, ManifestError> {
     let nargo_toml = read_toml(toml_path)?;
-    let _lock = lock_git_deps().expect("Failed to lock git dependencies cache");
     let workspace = toml_to_workspace(nargo_toml, package_selection)?;
 
     if let Some(current_compiler_version) = current_compiler_version {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a simple file lock on the `~/nargo` directory to prevent two instances of nargo attempting to download dependencies into the same folder at the same time.

This can't cause deadlock with the nargo.toml file lock.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
