### PR TITLE
chore: normalize path displayed by `nargo new`

### DIFF
--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -120,6 +120,7 @@ enum NargoCommand {
 pub(crate) fn start_cli() -> eyre::Result<()> {
     use std::fs::File;
 
+    use fm::NormalizePath;
     use fs2::FileExt as _;
     use nargo_toml::get_package_manifest;
 
@@ -127,7 +128,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
 
     // If the provided `program_dir` is relative, make it absolute by joining it to the current directory.
     if !config.program_dir.is_absolute() {
-        config.program_dir = std::env::current_dir().unwrap().join(config.program_dir);
+        config.program_dir = std::env::current_dir().unwrap().join(config.program_dir).normalize();
     }
 
     // Search through parent directories to find package root if necessary.

--- a/tooling/nargo_cli/tests/hello_world.rs
+++ b/tooling/nargo_cli/tests/hello_world.rs
@@ -19,7 +19,10 @@ fn hello_world_example() {
     // `nargo new hello_world`
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("new").arg(project_name);
-    cmd.assert().success().stdout(predicate::str::contains("Project successfully created!"));
+    cmd.assert().success().stdout(predicate::str::contains(format!(
+        "Project successfully created! It is located at {}",
+        project_dir.display()
+    )));
 
     project_dir.child("src").assert(predicate::path::is_dir());
     project_dir.child("Nargo.toml").assert(predicate::path::is_file());


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This removes a `./` from within the printed path which was bugging me.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
