### PR TITLE
fix: perform SSA constraints check on final SSA

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -104,6 +104,28 @@ pub(crate) fn optimize_into_acir(
 
     let mut ssa_level_warnings = vec![];
 
+    drop(ssa_gen_span_guard);
+
+    let used_globals_map = std::mem::take(&mut ssa.used_globals);
+    let brillig = time("SSA to Brillig", options.print_codegen_timings, || {
+        ssa.to_brillig_with_globals(options.enable_brillig_logging, used_globals_map)
+    });
+
+    let ssa_gen_span = span!(Level::TRACE, "ssa_generation");
+    let ssa_gen_span_guard = ssa_gen_span.enter();
+
+    let mut ssa = SsaBuilder {
+        ssa,
+        ssa_logging: options.ssa_logging.clone(),
+        print_codegen_timings: options.print_codegen_timings,
+    }
+    .run_pass(|ssa| ssa.fold_constants_with_brillig(&brillig), "Inlining Brillig Calls Inlining")
+    // It could happen that we inlined all calls to a given brillig function.
+    // In that case it's unused so we can remove it. This is what we check next.
+    .run_pass(Ssa::remove_unreachable_functions, "Removing Unreachable Functions (3rd)")
+    .run_pass(Ssa::dead_instruction_elimination, "Dead Instruction Elimination (2nd)")
+    .finish();
+
     if !options.skip_underconstrained_check {
         ssa_level_warnings.extend(time(
             "After Check for Underconstrained Values",
@@ -119,28 +141,6 @@ pub(crate) fn optimize_into_acir(
             || ssa.check_for_missing_brillig_constraints(),
         ));
     };
-
-    drop(ssa_gen_span_guard);
-
-    let used_globals_map = std::mem::take(&mut ssa.used_globals);
-    let brillig = time("SSA to Brillig", options.print_codegen_timings, || {
-        ssa.to_brillig_with_globals(options.enable_brillig_logging, used_globals_map)
-    });
-
-    let ssa_gen_span = span!(Level::TRACE, "ssa_generation");
-    let ssa_gen_span_guard = ssa_gen_span.enter();
-
-    let ssa = SsaBuilder {
-        ssa,
-        ssa_logging: options.ssa_logging.clone(),
-        print_codegen_timings: options.print_codegen_timings,
-    }
-    .run_pass(|ssa| ssa.fold_constants_with_brillig(&brillig), "Inlining Brillig Calls Inlining")
-    // It could happen that we inlined all calls to a given brillig function.
-    // In that case it's unused so we can remove it. This is what we check next.
-    .run_pass(Ssa::remove_unreachable_functions, "Removing Unreachable Functions (3rd)")
-    .run_pass(Ssa::dead_instruction_elimination, "Dead Instruction Elimination (2nd)")
-    .finish();
 
     drop(ssa_gen_span_guard);
 

--- a/test_programs/compile_success_no_bug/regression_7292/Nargo.toml
+++ b/test_programs/compile_success_no_bug/regression_7292/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7292"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_no_bug/regression_7292/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_7292/src/main.nr
@@ -1,0 +1,10 @@
+unconstrained fn foo<T>(_x: T) -> Field {
+    0
+}
+
+fn main() {
+    /// Safety: test
+    unsafe {
+        assert(foo(0) == 0);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7292 

## Summary\*

We're currently performing the safety checks on the SSA before we do constant folding with brillig calls. This prevents bugs being shown for unconstrained calls which are optimized out. 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
