### PR TITLE
chore: remove some unused types and functions in the AST

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -16,7 +16,7 @@ use acvm::{acir::AcirField, FieldElement};
 use iter_extended::vecmap;
 use noirc_errors::{Span, Spanned};
 
-use super::{AsTraitPath, TypePath, UnaryRhsMemberAccess};
+use super::{AsTraitPath, TypePath};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ExpressionKind {
@@ -244,49 +244,6 @@ impl PartialEq<Expression> for Expression {
 impl Expression {
     pub fn new(kind: ExpressionKind, span: Span) -> Expression {
         Expression { kind, span }
-    }
-
-    pub fn member_access_or_method_call(
-        lhs: Expression,
-        rhs: UnaryRhsMemberAccess,
-        span: Span,
-    ) -> Expression {
-        let kind = match rhs.method_call {
-            None => {
-                let rhs = rhs.method_or_field;
-                ExpressionKind::MemberAccess(Box::new(MemberAccessExpression { lhs, rhs }))
-            }
-            Some(method_call) => ExpressionKind::MethodCall(Box::new(MethodCallExpression {
-                object: lhs,
-                method_name: rhs.method_or_field,
-                generics: method_call.turbofish,
-                arguments: method_call.args,
-                is_macro_call: method_call.macro_call,
-            })),
-        };
-        Expression::new(kind, span)
-    }
-
-    pub fn index(collection: Expression, index: Expression, span: Span) -> Expression {
-        let kind = ExpressionKind::Index(Box::new(IndexExpression { collection, index }));
-        Expression::new(kind, span)
-    }
-
-    pub fn cast(lhs: Expression, r#type: UnresolvedType, span: Span) -> Expression {
-        let kind = ExpressionKind::Cast(Box::new(CastExpression { lhs, r#type }));
-        Expression::new(kind, span)
-    }
-
-    pub fn call(
-        lhs: Expression,
-        is_macro_call: bool,
-        arguments: Vec<Expression>,
-        span: Span,
-    ) -> Expression {
-        let func = Box::new(lhs);
-        let kind =
-            ExpressionKind::Call(Box::new(CallExpression { func, is_macro_call, arguments }));
-        Expression::new(kind, span)
     }
 }
 

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -225,18 +225,6 @@ impl From<Vec<GenericTypeArg>> for GenericTypeArgs {
     }
 }
 
-/// Type wrapper for a member access
-pub struct UnaryRhsMemberAccess {
-    pub method_or_field: Ident,
-    pub method_call: Option<UnaryRhsMethodCall>,
-}
-
-pub struct UnaryRhsMethodCall {
-    pub turbofish: Option<Vec<UnresolvedType>>,
-    pub macro_call: bool,
-    pub args: Vec<Expression>,
-}
-
 /// The precursor to TypeExpression, this is the type that the parser allows
 /// to be used in the length position of an array type. Only constant integers, variables,
 /// and numeric binary operators are allowed here.

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -154,30 +154,6 @@ impl StatementKind {
             attributes,
         })
     }
-
-    /// Create a Statement::Assign value, desugaring any combined operators like += if needed.
-    pub fn assign(
-        lvalue: LValue,
-        operator: Token,
-        mut expression: Expression,
-        span: Span,
-    ) -> StatementKind {
-        // Desugar `a <op>= b` to `a = a <op> b`. This relies on the evaluation of `a` having no side effects,
-        // which is currently enforced by the restricted syntax of LValues.
-        if operator != Token::Assign {
-            let lvalue_expr = lvalue.as_expression();
-            let error_msg = "Token passed to Statement::assign is not a binary operator";
-
-            let infix = crate::ast::InfixExpression {
-                lhs: lvalue_expr,
-                operator: operator.try_into_binary_op(span).expect(error_msg),
-                rhs: expression,
-            };
-            expression = Expression::new(ExpressionKind::Infix(Box::new(infix)), span);
-        }
-
-        StatementKind::Assign(AssignStatement { lvalue, expression })
-    }
 }
 
 #[derive(Eq, Debug, Clone, Default)]

--- a/compiler/noirc_frontend/src/ast/type_alias.rs
+++ b/compiler/noirc_frontend/src/ast/type_alias.rs
@@ -13,18 +13,6 @@ pub struct NoirTypeAlias {
     pub span: Span,
 }
 
-impl NoirTypeAlias {
-    pub fn new(
-        name: Ident,
-        generics: UnresolvedGenerics,
-        typ: UnresolvedType,
-        visibility: ItemVisibility,
-        span: Span,
-    ) -> NoirTypeAlias {
-        NoirTypeAlias { name, generics, typ, visibility, span }
-    }
-}
-
 impl Display for NoirTypeAlias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let generics = vecmap(&self.generics, |generic| generic.to_string());


### PR DESCRIPTION
# Description

## Problem



## Summary

While working on #7333 I noticed some types and functions were never called. They are probably a left-over from the old parser.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
