### PR TITLE
chore(ci): Add Vecs and vecs to cspell

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -246,6 +246,8 @@
         "vararg",
         "varargs",
         "vecmap",
+        "vecs",
+        "Vecs",
         "vitkov",
         "walkdir",
         "wasi",


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/actions/runs/13248973880/job/36982121704?pr=7341.

I'm getting cspell errors on various PRs after merging master. I guess it no longer accepts `Vecs` and `vecs.

## Summary\*

Add Vecs and vecs to cspell.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
