### PR TITLE
fix: incorrect secondary file in LSP errors

### DIFF
--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -300,7 +300,7 @@ fn secondary_to_related_information(
     let secondary_file = secondary.file.unwrap_or(file_id);
     let path = fm.path(secondary_file)?;
     let uri = Url::from_file_path(path).ok()?;
-    let range = byte_span_to_range(files, file_id, secondary.span.into())?;
+    let range = byte_span_to_range(files, secondary_file, secondary.span.into())?;
     let message = secondary.message;
     Some(DiagnosticRelatedInformation { location: lsp_types::Location { uri, range }, message })
 }


### PR DESCRIPTION
# Description

## Problem

While working on #7333 I noticed secondary errors land on an incorrect file, so I extracted just this change here.

## Summary

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
