### PR TITLE
feat(performance): type-check program only once in `nargo test`

### DIFF
--- a/tooling/nargo/src/ops/mod.rs
+++ b/tooling/nargo/src/ops/mod.rs
@@ -7,7 +7,7 @@ pub use self::optimize::{optimize_contract, optimize_program};
 pub use self::transform::{transform_contract, transform_program};
 
 pub use self::execute::{execute_program, execute_program_with_profiling};
-pub use self::test::{run_test, TestStatus};
+pub use self::test::{run_compiled_test, run_test, test_status_program_compile_fail, TestStatus};
 
 mod check;
 mod compile;


### PR DESCRIPTION
# Description

## Problem

#7333 made running tests much slower. I think the compiler got slower, just not that much slower. However, I noticed that for running tests we type-check the entire program as many times as target tests there are. That's probably why with the compiler being just a bit more slower, multiplied by the number of tests ends up being much slower.

## Summary

This PR changes the test runner to only type-check the entire program once. Then each test function is compiled separately.

The effect is that when running `nargo test` there will be a small pause while it's type-checking things, but then it will run tests much faster than before.

For example, running `nargo test` on:
- the stdlib takes 1.2 seconds in master, 0.83 seconds with this PR
- `aztec-nr` takes 11.6 seconds in master, 1.77 seconds with this PR

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
