### PR TITLE
fix: let LSP read `noirfmt.toml` for formatting files

### DIFF
--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{collections::HashMap, future::Future};
 
 use crate::{insert_all_files_for_workspace_into_file_manager, parse_diff, PackageCacheData};
@@ -303,6 +303,7 @@ fn on_formatting_inner(
 ) -> Result<Option<Vec<lsp_types::TextEdit>>, ResponseError> {
     // The file_path might be Err/None if the action runs against an unsaved file
     let file_path = params.text_document.uri.to_file_path().ok();
+    let directory_path = file_path.as_ref().and_then(|path| path.parent());
 
     let path = params.text_document.uri.to_string();
 
@@ -313,7 +314,7 @@ fn on_formatting_inner(
             return Ok(None);
         }
 
-        let config = read_config(file_path);
+        let config = read_config(directory_path);
         let new_text = nargo_fmt::format(source, module, &config);
 
         let start_position = Position { line: 0, character: 0 };
@@ -331,9 +332,9 @@ fn on_formatting_inner(
     }
 }
 
-fn read_config(file_path: Option<PathBuf>) -> Config {
+fn read_config(file_path: Option<&Path>) -> Config {
     match file_path {
-        Some(file_path) => match Config::read(&file_path) {
+        Some(file_path) => match Config::read(file_path) {
             Ok(config) => config,
             Err(err) => {
                 eprintln!("Failed to parse noirfmt.toml: {}", err);

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -314,7 +314,7 @@ fn on_formatting_inner(
             return Ok(None);
         }
 
-        let config = read_config(directory_path);
+        let config = read_format_config(directory_path);
         let new_text = nargo_fmt::format(source, module, &config);
 
         let start_position = Position { line: 0, character: 0 };
@@ -332,7 +332,7 @@ fn on_formatting_inner(
     }
 }
 
-fn read_config(file_path: Option<&Path>) -> Config {
+fn read_format_config(file_path: Option<&Path>) -> Config {
     match file_path {
         Some(file_path) => match Config::read(file_path) {
             Ok(config) => config,

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -337,7 +337,7 @@ fn read_config(file_path: Option<&Path>) -> Config {
         Some(file_path) => match Config::read(file_path) {
             Ok(config) => config,
             Err(err) => {
-                eprintln!("Failed to parse noirfmt.toml: {}", err);
+                eprintln!("{}", err);
                 Config::default()
             }
         },

--- a/tooling/nargo_fmt/build.rs
+++ b/tooling/nargo_fmt/build.rs
@@ -62,7 +62,7 @@ fn generate_formatter_tests(test_file: &mut File, test_data_dir: &Path) {
 
         let (parsed_module, _errors) = noirc_frontend::parse_program(input);
 
-        let config = nargo_fmt::Config::default();
+        let config = nargo_fmt::Config::of("{config}", &std::path::PathBuf::new()).unwrap();
         let fmt_text = nargo_fmt::format(input, parsed_module, &config);
 
         if std::env::var("UPDATE_EXPECT").is_ok() {{

--- a/tooling/nargo_fmt/build.rs
+++ b/tooling/nargo_fmt/build.rs
@@ -62,7 +62,7 @@ fn generate_formatter_tests(test_file: &mut File, test_data_dir: &Path) {
 
         let (parsed_module, _errors) = noirc_frontend::parse_program(input);
 
-        let config = nargo_fmt::Config::of("{config}").unwrap();
+        let config = nargo_fmt::Config::default();
         let fmt_text = nargo_fmt::format(input, parsed_module, &config);
 
         if std::env::var("UPDATE_EXPECT").is_ok() {{
@@ -84,7 +84,7 @@ fn generate_formatter_tests(test_file: &mut File, test_data_dir: &Path) {
 
             let (parsed_module, _errors) = noirc_frontend::parse_program(expected_output);
 
-            let config = nargo_fmt::Config::of("{config}").unwrap();
+            let config = nargo_fmt::Config::of("{config}", &std::path::PathBuf::new()).unwrap();
             let fmt_text = nargo_fmt::format(expected_output, parsed_module, &config);
 
             similar_asserts::assert_eq!(fmt_text, expected_output);

--- a/tooling/nargo_fmt/src/config.rs
+++ b/tooling/nargo_fmt/src/config.rs
@@ -56,16 +56,24 @@ config! {
 }
 
 impl Config {
-    pub fn read(path: &Path) -> Result<Self, ConfigError> {
-        let config_path = path.join("noirfmt.toml");
+    /// Reads a Config starting at the given path and going through the path parents
+    /// until a `noirfmt.toml` file is found in one of them or the root is reached.
+    pub fn read(mut path: &Path) -> Result<Self, ConfigError> {
+        loop {
+            let config_path = path.join("noirfmt.toml");
+            if config_path.exists() {
+                match std::fs::read_to_string(&config_path) {
+                    Ok(input) => return Self::of(&input),
+                    Err(cause) => return Err(ConfigError::ReadFailed(config_path, cause)),
+                };
+            }
 
-        let input = match std::fs::read_to_string(&config_path) {
-            Ok(input) => input,
-            Err(cause) if cause.kind() == std::io::ErrorKind::NotFound => String::new(),
-            Err(cause) => return Err(ConfigError::ReadFailed(config_path, cause)),
-        };
+            let Some(parent_path) = path.parent() else {
+                return Ok(Config::default());
+            };
 
-        Self::of(&input)
+            path = parent_path;
+        }
     }
 
     pub fn of(s: &str) -> Result<Self, ConfigError> {

--- a/tooling/nargo_fmt/src/config.rs
+++ b/tooling/nargo_fmt/src/config.rs
@@ -63,7 +63,7 @@ impl Config {
             let config_path = path.join("noirfmt.toml");
             if config_path.exists() {
                 match std::fs::read_to_string(&config_path) {
-                    Ok(input) => return Self::of(&input),
+                    Ok(input) => return Self::of(&input, &config_path),
                     Err(cause) => return Err(ConfigError::ReadFailed(config_path, cause)),
                 };
             }
@@ -76,9 +76,10 @@ impl Config {
         }
     }
 
-    pub fn of(s: &str) -> Result<Self, ConfigError> {
+    pub fn of(s: &str, path: &Path) -> Result<Self, ConfigError> {
         let mut config = Self::default();
-        let toml = toml::from_str(s).map_err(ConfigError::MalformedFile)?;
+        let toml =
+            toml::from_str(s).map_err(|err| ConfigError::MalformedFile(path.to_path_buf(), err))?;
         config.fill_from_toml(toml);
         Ok(config)
     }

--- a/tooling/nargo_fmt/src/errors.rs
+++ b/tooling/nargo_fmt/src/errors.rs
@@ -7,6 +7,6 @@ pub enum ConfigError {
     #[error("Cannot read file {0} - {1}")]
     ReadFailed(PathBuf, std::io::Error),
 
-    #[error("noirfmt.toml is badly formed, could not parse.\n\n {0}")]
-    MalformedFile(#[from] toml::de::Error),
+    #[error("{0} is badly formed, could not parse.\n\n {1}")]
+    MalformedFile(PathBuf, toml::de::Error),
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #7340

## Summary

Also changes the logic of `nargo fmt` to try to find the configuration file in the current directory or parent directories.

## Additional Context

It seems `rustfmt` also allows the config file to be called ".rustfmt.toml", or for it to be placed in the global config directory (`.config/rustfmt/`) but those could be done in follow-up PRs.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
