### PR TITLE
chore: avoid doing all brillig integer arithmetic on u128s

### DIFF
--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -118,8 +118,7 @@ fn evaluate_binary_int_op_u1(
     rhs: bool,
 ) -> Result<bool, BrilligArithmeticError> {
     let result = match op {
-        BinaryIntOp::Add => lhs ^ rhs,
-        BinaryIntOp::Sub => lhs ^ rhs,
+        BinaryIntOp::Add | BinaryIntOp::Sub => lhs ^ rhs,
         BinaryIntOp::Mul => lhs & rhs,
         BinaryIntOp::Div => {
             if !rhs {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR replaces the current integer arithmetic functions in the brillig VM which treat all values as u128s with a proper generic function which allows us to simply cast down to the relevant type, do the operation and then cast back up to u128.

I've implemented the solver for `U1` as working on boolean types as rust doesn't have a u1 type, this could probably do with some scrutiny.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
