### PR TITLE
fix: give "correct" error when trying to use AsTraitPath

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -91,7 +91,7 @@ impl<'context> Elaborator<'context> {
                 (HirExpression::Error, Type::Error)
             }
             ExpressionKind::AsTraitPath(_) => {
-                self.push_err(ResolverError::UnquoteUsedOutsideQuote { span: expr.span });
+                self.push_err(ResolverError::AsTraitPathNotYetImplemented { span: expr.span });
                 (HirExpression::Error, Type::Error)
             }
             ExpressionKind::TypePath(path) => return self.elaborate_type_path(path),

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -128,6 +128,8 @@ pub enum ResolverError {
     ArrayLengthInterpreter { error: InterpreterError },
     #[error("The unquote operator '$' can only be used within a quote expression")]
     UnquoteUsedOutsideQuote { span: Span },
+    #[error("\"as trait path\" not yet implemented")]
+    AsTraitPathNotYetImplemented { span: Span },
     #[error("Invalid syntax in macro call")]
     InvalidSyntaxInMacroCall { span: Span },
     #[error("Macros must be comptime functions")]
@@ -544,6 +546,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
             ResolverError::UnquoteUsedOutsideQuote { span } => {
                 Diagnostic::simple_error(
                     "The unquote operator '$' can only be used within a quote expression".into(),
+                    "".into(),
+                    *span,
+                )
+            },
+            ResolverError::AsTraitPathNotYetImplemented { span } => {
+                Diagnostic::simple_error(
+                    "\"as trait path\" not yet implemented".into(),
                     "".into(),
                     *span,
                 )


### PR DESCRIPTION
# Description

## Problem

Resolves #7080

## Summary

The issue seems to have been fixed in a past PR (I can't remember which one) but with a misleading error about using unquote. This PR changes the error to something more accurate.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
