### PR TITLE
chore: avoid u128s in brillig memory

### DIFF
--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -312,16 +312,13 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
         }
         BlackBoxOp::ToRadix { input, radix, output_pointer, num_limbs, output_bits } => {
             let input: F = *memory.read(*input).extract_field().expect("ToRadix input not a field");
-            let radix = memory
-                .read(*radix)
-                .expect_integer_with_bit_size(IntegerBitSize::U32)
-                .expect("ToRadix opcode's radix bit size does not match expected bit size 32");
+            let MemoryValue::U32(radix) = memory.read(*radix) else {
+                panic!("ToRadix opcode's radix bit size does not match expected bit size 32")
+            };
             let num_limbs = memory.read(*num_limbs).to_usize();
-            let output_bits = !memory
-                .read(*output_bits)
-                .expect_integer_with_bit_size(IntegerBitSize::U1)
-                .expect("ToRadix opcode's output_bits size does not match expected bit size 1")
-                .is_zero();
+            let MemoryValue::U1(output_bits) = memory.read(*output_bits) else {
+                panic!("ToRadix opcode's output_bits size does not match expected bit size 1")
+            };
 
             let mut input = BigUint::from_bytes_be(&input.to_be_bytes());
             let radix = BigUint::from_bytes_be(&radix.to_be_bytes());

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -21,6 +21,7 @@ use black_box::{evaluate_black_box, BrilligBigIntSolver};
 
 // Re-export `brillig`.
 pub use acir::brillig;
+use memory::MemoryTypeError;
 pub use memory::{Memory, MemoryValue, MEMORY_ADDRESSING_BIT_SIZE};
 
 mod arithmetic;
@@ -248,7 +249,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
             }
             Opcode::Not { destination, source, bit_size } => {
                 if let Err(error) = self.process_not(*source, *destination, *bit_size) {
-                    self.fail(error)
+                    self.fail(error.to_string())
                 } else {
                     self.increment_program_counter()
                 }
@@ -775,63 +776,91 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
         source: MemoryAddress,
         destination: MemoryAddress,
         op_bit_size: IntegerBitSize,
-    ) -> Result<(), String> {
-        let (value, bit_size) = self
-            .memory
-            .read(source)
-            .extract_integer()
-            .ok_or("Not opcode source is not an integer")?;
+    ) -> Result<(), MemoryTypeError> {
+        let value = self.memory.read(source);
 
-        if bit_size != op_bit_size {
-            return Err(format!(
-                "Not opcode source bit size {} does not match expected bit size {}",
-                bit_size, op_bit_size
-            ));
-        }
-
-        let negated_value = if let IntegerBitSize::U128 = bit_size {
-            !value
-        } else {
-            let bit_size: u32 = bit_size.into();
-            let mask = (1_u128 << bit_size as u128) - 1;
-            (!value) & mask
+        let negated_value = match op_bit_size {
+            IntegerBitSize::U1 => MemoryValue::U32(!value.expect_u32()?),
+            IntegerBitSize::U8 => MemoryValue::U32(!value.expect_u32()?),
+            IntegerBitSize::U16 => MemoryValue::U32(!value.expect_u32()?),
+            IntegerBitSize::U32 => MemoryValue::U32(!value.expect_u32()?),
+            IntegerBitSize::U64 => MemoryValue::U32(!value.expect_u32()?),
+            IntegerBitSize::U128 => MemoryValue::U32(!value.expect_u32()?),
         };
-        self.memory.write(destination, MemoryValue::new_integer(negated_value, bit_size));
+        self.memory.write(destination, negated_value);
         Ok(())
     }
 
     /// Casts a value to a different bit size.
     fn cast(&self, target_bit_size: BitSize, source_value: MemoryValue<F>) -> MemoryValue<F> {
+        use MemoryValue::*;
+
         match (source_value, target_bit_size) {
-            // Field to field, no op
-            (MemoryValue::Field(_), BitSize::Field) => source_value,
             // Field downcast to u128
-            (MemoryValue::Field(field), BitSize::Integer(IntegerBitSize::U128)) => {
-                MemoryValue::Integer(field.to_u128(), IntegerBitSize::U128)
-            }
+            (Field(field), BitSize::Integer(IntegerBitSize::U128)) => U128(field.to_u128()),
             // Field downcast to arbitrary bit size
-            (MemoryValue::Field(field), BitSize::Integer(target_bit_size)) => {
+            (Field(field), BitSize::Integer(target_bit_size)) => {
                 let as_u128 = field.to_u128();
-                let target_bit_size_u32: u32 = target_bit_size.into();
-                let mask = (1_u128 << target_bit_size_u32) - 1;
-                MemoryValue::Integer(as_u128 & mask, target_bit_size)
+                match target_bit_size {
+                    IntegerBitSize::U1 => U1(as_u128 & 0x01 == 1),
+                    IntegerBitSize::U8 => U8(as_u128 as u8),
+                    IntegerBitSize::U16 => U16(as_u128 as u16),
+                    IntegerBitSize::U32 => U32(as_u128 as u32),
+                    IntegerBitSize::U64 => U64(as_u128 as u64),
+                    IntegerBitSize::U128 => unreachable!(),
+                }
             }
-            // Integer upcast to field
-            (MemoryValue::Integer(integer, _), BitSize::Field) => {
-                MemoryValue::new_field(integer.into())
-            }
-            // Integer upcast to integer
-            (MemoryValue::Integer(integer, source_bit_size), BitSize::Integer(target_bit_size))
-                if source_bit_size <= target_bit_size =>
-            {
-                MemoryValue::Integer(integer, target_bit_size)
-            }
-            // Integer downcast
-            (MemoryValue::Integer(integer, _), BitSize::Integer(target_bit_size)) => {
-                let target_bit_size_u32: u32 = target_bit_size.into();
-                let mask = (1_u128 << target_bit_size_u32) - 1;
-                MemoryValue::Integer(integer & mask, target_bit_size)
-            }
+
+            (U1(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value.into()),
+            (U1(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value.into()),
+            (U1(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
+            (U1(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+            (U1(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+            (U1(value), BitSize::Field) => Field(value.into()),
+
+            (U8(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+            (U8(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value.into()),
+            (U8(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
+            (U8(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+            (U8(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+            (U8(value), BitSize::Field) => Field((value as u128).into()),
+
+            (U16(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+            (U16(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+            (U16(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
+            (U16(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+            (U16(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+            (U16(value), BitSize::Field) => Field((value as u128).into()),
+
+            (U32(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+            (U32(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+            (U32(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
+            (U32(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+            (U32(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+            (U32(value), BitSize::Field) => Field((value as u128).into()),
+
+            (U64(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+            (U64(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+            (U64(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
+            (U64(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value as u32),
+            (U64(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+            (U64(value), BitSize::Field) => Field((value as u128).into()),
+
+            (U128(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+            (U128(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+            (U128(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
+            (U128(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value as u32),
+            (U128(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value as u64),
+            (U128(value), BitSize::Field) => Field(value.into()),
+
+            // no ops
+            (Field(_), BitSize::Field) => source_value,
+            (U1(_), BitSize::Integer(IntegerBitSize::U1)) => source_value,
+            (U8(_), BitSize::Integer(IntegerBitSize::U8)) => source_value,
+            (U16(_), BitSize::Integer(IntegerBitSize::U16)) => source_value,
+            (U32(_), BitSize::Integer(IntegerBitSize::U32)) => source_value,
+            (U64(_), BitSize::Integer(IntegerBitSize::U64)) => source_value,
+            (U128(_), BitSize::Integer(IntegerBitSize::U128)) => source_value,
         }
     }
 }
@@ -1127,10 +1156,9 @@ mod tests {
 
         let VM { memory, .. } = vm;
 
-        let (negated_value, _) = memory
-            .read(MemoryAddress::direct(1))
-            .extract_integer()
-            .expect("Expected integer as the output of Not");
+        let MemoryValue::U128(negated_value) = memory.read(MemoryAddress::direct(1)) else {
+            panic!("Expected integer as the output of Not");
+        };
         assert_eq!(negated_value, !1_u128);
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
