### PR TITLE
feat(experimental): Always inline certain methods in sha

### DIFF
--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -349,6 +349,7 @@ fn update_block_item<Env>(
 }
 
 // Set the rightmost `zeros` number of bytes to 0.
+#[inline_always]
 fn set_item_zeros(item: u32, zeros: u8) -> u32 {
     lshift8(rshift8(item, zeros), zeros)
 }
@@ -374,6 +375,7 @@ fn get_item_byte(mut msg_item: u32, msg_byte_ptr: BLOCK_BYTE_PTR) -> u8 {
 // Project a byte into a position in a field based on the overall block pointer.
 // For example putting 1 into pointer 5 would be 100, because overall we would
 // have [____, 0100] with indexes [0123,4567].
+#[inline_always]
 fn byte_into_item(msg_byte: u8, msg_byte_ptr: BLOCK_BYTE_PTR) -> u32 {
     let mut msg_item = msg_byte as u32;
     // How many times do we have to shift to the left to get to the position we want?

--- a/noir_stdlib/src/hash/sha256.nr
+++ b/noir_stdlib/src/hash/sha256.nr
@@ -383,6 +383,7 @@ fn byte_into_item(msg_byte: u8, msg_byte_ptr: BLOCK_BYTE_PTR) -> u32 {
 }
 
 // Construct a field out of 4 bytes.
+#[inline_always]
 fn make_item(b0: u8, b1: u8, b2: u8, b3: u8) -> u32 {
     let mut item = b0 as u32;
     item = lshift8(item, 1) + b1 as u32;
@@ -394,6 +395,7 @@ fn make_item(b0: u8, b1: u8, b2: u8, b3: u8) -> u32 {
 // Shift by 8 bits to the left between 0 and 4 times.
 // Checks `is_unconstrained()` to just use a bitshift if we're running in an unconstrained context,
 // otherwise multiplies by 256.
+#[inline_always]
 fn lshift8(item: u32, shifts: u8) -> u32 {
     if is_unconstrained() {
         if item == 0 {


### PR DESCRIPTION
# Description

## Problem\*

Optimizing bytecode sizes and execution traces in Brillig

## Summary\*

I know we are deprecating sha256 in the stdlib and moving to use noir-lang/sha256. I have replicated this PR here https://github.com/noir-lang/sha256/pull/13. I am just pushing this draft for now as we have more complete benchmarking and visualization on this repo.  

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
