### PR TITLE
chore: Add SSA security checks description

### DIFF
--- a/docs/docs/explainers/cspell.json
+++ b/docs/docs/explainers/cspell.json
@@ -1,5 +1,6 @@
 {
     "words": [
-        "Cryptdoku"
+        "Cryptdoku",
+        "lookback"
     ]
 }

--- a/docs/docs/tooling/cspell.json
+++ b/docs/docs/tooling/cspell.json
@@ -1,5 +1,5 @@
 {
     "words": [
-        "Cryptdoku"
+        "lookback"
     ]
 }

--- a/docs/docs/tooling/security.md
+++ b/docs/docs/tooling/security.md
@@ -5,7 +5,7 @@ keywords: [Nargo, Security, Brillig, Unconstrained]
 sidebar_position: 2
 ---
 
-# Securtiy checks
+# Security checks
 
 Two SSA security passes exist currently to ensure soundness of compiled code. Problems they catch are reported as bugs (as opposed to errors) in the compiler output. 
 

--- a/docs/docs/tooling/security.md
+++ b/docs/docs/tooling/security.md
@@ -1,0 +1,46 @@
+---
+title: Security checks
+description: Security checks currently provided by the compiler
+keywords: [Nargo, Security, Brillig, Unconstrained]
+sidebar_position: 2
+---
+
+# Securtiy checks
+
+Two SSA security passes exist currently to ensure soundness of compiled code. Problems they catch are reported as bugs (as opposed to errors) in the compiler output. 
+
+### Independent subgraph detection
+
+This pass examines the SSA to see if the final function would involve values that don't come from any provided inputs and don't result in the outputs. That would mean there are no constraints ensuring the required continuity.
+
+This check is enabled by default and can be disabled by passing the `--skip-underconstrained-check` option to `nargo`.
+
+### Brillig manual constraint coverage
+
+The results of a Brillig function call must be constrained to ensure security, adhering to these rules: every resulting value (including every array element of a resulting array) has to be involved in a following constraint (assert, range check) against either one of the arguments of the call, or a constant. In this context, involvement means that a descendant value (e.g. a result of a chain of operations over the value) of a result has to be checked against a descendant value of an argument.
+
+This pass checks if the constraint coverage of Brillig calls is sufficient in these terms.
+
+The check is at the moment disabled by default due to performance concerns and can be enabled by passing the `--enable-brillig-constraints-check` option to `nargo`.
+
+#### Lookback option
+
+Certain false positives of this check can be avoided by providing the `--enable-brillig-constraints-check-lookback` option to `nargo`, which can be slower but additionally ensures that descendants of call argument values coming from operations *preceding* the call itself would be followed. For example, consider this SSA case:
+
+```
+acir(inline) fn main f0 {
+  b0(v0: Field, v1: Field):
+    v3 = add v0, v1
+    v5 = call f1(v0, v1) -> Field
+    constrain v3 == v5
+    return v3
+}
+
+brillig(inline) fn foo f1 {
+  b0(v0: Field, v1: Field):
+    v2 = add v0, v1
+    return v2
+}
+```
+
+Normally, the `add` operation over `v0` and `v1` happening before the call itself would prevent the call from being (correctly) considered properly constrained. With lookback option, this false positive goes away at the cost of the check becoming somewhat less performant on large unrolled functions. 

--- a/docs/docs/tooling/security.md
+++ b/docs/docs/tooling/security.md
@@ -23,7 +23,7 @@ This pass checks if the constraint coverage of Brillig calls is sufficient in th
 
 The check is at the moment disabled by default due to performance concerns and can be enabled by passing the `--enable-brillig-constraints-check` option to `nargo`.
 
-#### Lookback option
+#### "Look back" option
 
 Certain false positives of this check can be avoided by providing the `--enable-brillig-constraints-check-lookback` option to `nargo`, which can be slower but additionally ensures that descendants of call argument values coming from operations *preceding* the call itself would be followed. For example, consider this SSA case:
 
@@ -43,4 +43,4 @@ brillig(inline) fn foo f1 {
 }
 ```
 
-Normally, the `add` operation over `v0` and `v1` happening before the call itself would prevent the call from being (correctly) considered properly constrained. With lookback option, this false positive goes away at the cost of the check becoming somewhat less performant on large unrolled functions. 
+Normally, the `add` operation over `v0` and `v1` happening before the call itself would prevent the call from being (correctly) considered properly constrained. With this option enabled, the false positive goes away at the cost of the check becoming somewhat less performant on large unrolled functions. 

--- a/docs/docs/tooling/security.md
+++ b/docs/docs/tooling/security.md
@@ -7,7 +7,11 @@ sidebar_position: 2
 
 # Security checks
 
-Two compilation security passes exist currently to ensure soundness of compiled code. Problems they catch are reported as "bugs" (as opposed to errors) in the compiler output.
+Two compilation security passes exist currently to ensure soundness of compiled code. Problems they catch are reported as "bugs" (as opposed to errors) in the compiler output. For example:
+
+```
+**bug**: Brillig function call isn't properly covered by a manual constraint
+```
 
 ### Independent subgraph detection
 
@@ -17,7 +21,21 @@ This check is enabled by default and can be disabled by passing the `--skip-unde
 
 ### Brillig manual constraint coverage
 
-The results of a Brillig function call must be constrained to ensure security, adhering to these rules: every resulting value (including every array element of a resulting array) has to be involved in a later constraint (i.e. assert, range check) against either one of the arguments of the call, or a constant. In this context, involvement means that a descendant value (e.g. a result of a chain of operations over the value) of a result has to be checked against a descendant value of an argument.
+The results of a Brillig function call must be constrained to ensure security, adhering to these rules: every resulting value (including every array element of a resulting array) has to be involved in a later constraint (i.e. assert, range check) against either one of the arguments of the call, or a constant. In this context, involvement means that a descendant value (e.g. a result of a chain of operations over the value) of a result has to be checked against a descendant value of an argument. For example:
+
+```rust
+unconstrained fn factor(v0: Field) -> [Field; 2] {
+    ...
+}
+
+fn main f0 (foo: Field) -> [Field; 2] {
+    let factored = unsafe { factor(foo) };
+    assert(factored[0] * factored[1] == foo);
+    return factored
+}
+```
+
+Here, the results of `factor` are two elements of the returned array. The value `factored[0] * factored[1]` is a descendant of both of them, so both are involved in a constraint against the argument value in the `assert`. Hence, the call to an unconstrained function is properly covered.
 
 This pass checks if the constraint coverage of Brillig calls is sufficient in these terms.
 
@@ -27,14 +45,14 @@ The check is at the moment disabled by default due to performance concerns and c
 
 Certain false positives of this check can be avoided by providing the `--enable-brillig-constraints-check-lookback` option to `nargo`, which can be slower at compile-time but additionally ensures that descendants of call argument values coming from operations *preceding* the call itself would be followed. For example, consider this case:
 
-```
+```rust
 unconstrained fn unconstrained_add(v0: Field, v1: Field) -> Field {
     v0 + v1
 }
 
 fn main f0 (v0: Field, v1: Field) {
     let foo = v0 + v1;
-    let bar = unconstrained_add(v0, v1);
+    let bar = unsafe { unconstrained_add(v0, v1) };
     assert(foo == bar);
     return bar
 }

--- a/docs/docs/tooling/security.md
+++ b/docs/docs/tooling/security.md
@@ -7,40 +7,37 @@ sidebar_position: 2
 
 # Security checks
 
-Two SSA security passes exist currently to ensure soundness of compiled code. Problems they catch are reported as bugs (as opposed to errors) in the compiler output. 
+Two compilation security passes exist currently to ensure soundness of compiled code. Problems they catch are reported as "bugs" (as opposed to errors) in the compiler output.
 
 ### Independent subgraph detection
 
-This pass examines the SSA to see if the final function would involve values that don't come from any provided inputs and don't result in the outputs. That would mean there are no constraints ensuring the required continuity.
+This pass examines the instruction flow graph to see if the final function would involve values that don't come from any provided inputs and don't result in the outputs. That would mean there are no constraints ensuring the required continuity.
 
 This check is enabled by default and can be disabled by passing the `--skip-underconstrained-check` option to `nargo`.
 
 ### Brillig manual constraint coverage
 
-The results of a Brillig function call must be constrained to ensure security, adhering to these rules: every resulting value (including every array element of a resulting array) has to be involved in a following constraint (assert, range check) against either one of the arguments of the call, or a constant. In this context, involvement means that a descendant value (e.g. a result of a chain of operations over the value) of a result has to be checked against a descendant value of an argument.
+The results of a Brillig function call must be constrained to ensure security, adhering to these rules: every resulting value (including every array element of a resulting array) has to be involved in a later constraint (i.e. assert, range check) against either one of the arguments of the call, or a constant. In this context, involvement means that a descendant value (e.g. a result of a chain of operations over the value) of a result has to be checked against a descendant value of an argument.
 
 This pass checks if the constraint coverage of Brillig calls is sufficient in these terms.
 
 The check is at the moment disabled by default due to performance concerns and can be enabled by passing the `--enable-brillig-constraints-check` option to `nargo`.
 
-#### "Look back" option
+#### Lookback option
 
-Certain false positives of this check can be avoided by providing the `--enable-brillig-constraints-check-lookback` option to `nargo`, which can be slower but additionally ensures that descendants of call argument values coming from operations *preceding* the call itself would be followed. For example, consider this SSA case:
+Certain false positives of this check can be avoided by providing the `--enable-brillig-constraints-check-lookback` option to `nargo`, which can be slower at compile-time but additionally ensures that descendants of call argument values coming from operations *preceding* the call itself would be followed. For example, consider this case:
 
 ```
-acir(inline) fn main f0 {
-  b0(v0: Field, v1: Field):
-    v3 = add v0, v1
-    v5 = call f1(v0, v1) -> Field
-    constrain v3 == v5
-    return v3
+unconstrained fn unconstrained_add(v0: Field, v1: Field) -> Field {
+    v0 + v1
 }
 
-brillig(inline) fn foo f1 {
-  b0(v0: Field, v1: Field):
-    v2 = add v0, v1
-    return v2
+fn main f0 (v0: Field, v1: Field) {
+    let foo = v0 + v1;
+    let bar = unconstrained_add(v0, v1);
+    assert(foo == bar);
+    return bar
 }
 ```
 
-Normally, the `add` operation over `v0` and `v1` happening before the call itself would prevent the call from being (correctly) considered properly constrained. With this option enabled, the false positive goes away at the cost of the check becoming somewhat less performant on large unrolled functions. 
+Normally, the addition operation over `v0` and `v1` happening before the call itself would prevent the call from being (correctly) considered properly constrained. With this option enabled, the false positive goes away at the cost of the check becoming somewhat less performant on large unrolled functions. 

--- a/docs/docs/tooling/security.md
+++ b/docs/docs/tooling/security.md
@@ -58,4 +58,4 @@ fn main f0 (v0: Field, v1: Field) {
 }
 ```
 
-Normally, the addition operation over `v0` and `v1` happening before the call itself would prevent the call from being (correctly) considered properly constrained. With this option enabled, the false positive goes away at the cost of the check becoming somewhat less performant on large unrolled functions. 
+Normally, the addition operation over `v0` and `v1` happening before the call itself would prevent the call from being (correctly) considered properly constrained. With this option enabled, the false positive goes away at the cost of the check becoming somewhat less performant on large unrolled loops. 


### PR DESCRIPTION
# Description

Adds a short description of the SSA security passes in `docs/docs/tooling/security.md` (per @Rumata888's suggestion).

## Problem

Resolves #6707 

## Summary



## Additional Context



## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
