### PR TITLE
chore: update docs about integer overflows

### DIFF
--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -111,8 +111,9 @@ fn main(x: U128, y: U128) {
 Computations that exceed the type boundaries will result in overflow errors. This happens with both signed and unsigned integers. For example, attempting to prove:
 
 ```rust
-fn main(x: u8, y: u8) {
+fn main(x: u8, y: u8) -> pub u8 {
     let z = x + y;
+    z
 }
 ```
 
@@ -140,10 +141,20 @@ error: Assertion failed: 'attempt to add with overflow'
 A similar error would happen with signed integers:
 
 ```rust
-fn main() {
+fn main() -> i8 {
     let x: i8 = -118;
     let y: i8 = -11;
     let z = x + y;
+    z
+}
+```
+
+Note that if a computation ends up being unused the compiler might remove it and it won't end up producing an overflow:
+
+```rust
+fn main() {
+    // "255 + 1" would overflow, but `z` is unused so no computation happens
+    let z: u8 = 255 + 1;
 }
 ```
 


### PR DESCRIPTION
# Description

## Problem

Resolves #7367

## Summary

The code in the docs doesn't end up producing an overflow so here it's changed to do so. Also an explanation of when overflows might not be triggered is added.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
