### PR TITLE
feat: add `wrap_comments` and `comment_width` options to `nargo fmt`

### DIFF
--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -1065,7 +1065,7 @@ impl<'a> Formatter<'a> {
             }
 
             if is_line_comment && self.config.wrap_comments {
-                if starts_with_space {
+                if starts_with_space && !self.buffer.ends_with_space() {
                     self.write(" ");
                 }
                 self.write_comment_with_prefix(
@@ -1074,7 +1074,7 @@ impl<'a> Formatter<'a> {
                 );
             } else if (is_block_comment || inside_block_comment) && self.config.wrap_comments {
                 // Only append a space if it's the start of a block comment (no leading spaces in following lines)
-                if starts_with_space && is_block_comment {
+                if starts_with_space && is_block_comment && !self.buffer.ends_with_space() {
                     self.write(" ");
                 }
                 self.write_comment_with_prefix(line, "");

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -1068,7 +1068,10 @@ impl<'a> Formatter<'a> {
                 if starts_with_space {
                     self.write(" ");
                 }
-                self.write_line_comment(line.trim_start().strip_prefix("//").unwrap_or(line));
+                self.write_comment_with_prefix(
+                    line.trim_start().strip_prefix("//").unwrap_or(line),
+                    "//",
+                );
             } else if (is_block_comment || inside_block_comment) && self.config.wrap_comments {
                 // Only append a space if it's the start of a block comment (no leading spaces in following lines)
                 if starts_with_space && is_block_comment {

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -863,7 +863,10 @@ impl<'a> Formatter<'a> {
                 Chunk::Text(text_chunk) | Chunk::Verbatim(text_chunk) => {
                     self.write(&text_chunk.string);
                 }
-                Chunk::TrailingComment(text_chunk, _) | Chunk::LeadingComment(text_chunk) => {
+                Chunk::TrailingComment(text_chunk, _) => {
+                    self.write(&text_chunk.string);
+                }
+                Chunk::LeadingComment(text_chunk) => {
                     self.write(&text_chunk.string);
                     self.write_space_without_skipping_whitespace_and_comments();
                 }

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -251,7 +251,7 @@ impl ChunkGroup {
         }
     }
 
-    /// Similar to `trailing_comment` but won't appent a newline+indentation after the chunk.
+    /// Similar to `trailing_comment` but won't append a newline+indentation after the chunk.
     pub(crate) fn trailing_comment_without_final_indentation(&mut self, chunk: TextChunk) {
         if chunk.width > 0 {
             self.push(Chunk::TrailingComment(chunk, false));

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -725,7 +725,7 @@ impl<'a> Formatter<'a> {
             return;
         }
 
-        // Check if the group first in the remainder of the current line.
+        // Check if the group fits in the remainder of the current line.
         if total_width > self.max_width {
             // If this chunk is the value of an assignment (either a normal assignment or a let statement)
             // and it doesn't fit the current line, we check if it fits the next line with an increased

--- a/tooling/nargo_fmt/src/config.rs
+++ b/tooling/nargo_fmt/src/config.rs
@@ -54,6 +54,7 @@ config! {
     imports_granularity: ImportsGranularity, ImportsGranularity::Preserve, "How imports should be grouped into use statements.";
     reorder_imports: bool, true, "Reorder imports alphabetically";
     wrap_comments: bool, false, "Break comments to fit on the line";
+    comment_width: usize, 100, "Maximum length of comments. No effect unless `wrap_comments = true`"
 }
 
 impl Config {

--- a/tooling/nargo_fmt/src/config.rs
+++ b/tooling/nargo_fmt/src/config.rs
@@ -53,6 +53,7 @@ config! {
     single_line_if_else_max_width: usize, 50, "Maximum line length for single line if-else expressions";
     imports_granularity: ImportsGranularity, ImportsGranularity::Preserve, "How imports should be grouped into use statements.";
     reorder_imports: bool, true, "Reorder imports alphabetically";
+    wrap_comments: bool, false, "Break comments to fit on the line";
 }
 
 impl Config {

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -76,6 +76,9 @@ pub(crate) struct Formatter<'a> {
 
     /// This is the buffer where we write the formatted code.
     pub(crate) buffer: Buffer,
+
+    /// Is the formatter inside a chunk?
+    pub(crate) in_chunk: bool,
 }
 
 impl<'a> Formatter<'a> {
@@ -94,6 +97,7 @@ impl<'a> Formatter<'a> {
             group_tag_counter: 0,
             max_width: config.max_width,
             buffer: Buffer::default(),
+            in_chunk: false,
         };
         formatter.bump();
         formatter

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -71,7 +71,7 @@ pub(crate) struct Formatter<'a> {
     pub(crate) group_tag_counter: usize,
 
     /// We keep a copy of the config's max width because when we format chunk groups
-    /// we somethings change this so that a group has less space to write to.
+    /// we sometimes change this so that a group has less space to write to.
     pub(crate) max_width: usize,
 
     /// This is the buffer where we write the formatted code.

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -210,13 +210,6 @@ impl<'a> Formatter<'a> {
         self.bump();
     }
 
-    /// Writes the current token trimming its end but doesn't advance to the next one.
-    /// Mainly used when writing comment lines, because we never want trailing spaces
-    /// inside comments.
-    pub(crate) fn write_current_token_trimming_end(&mut self) {
-        self.write(self.token.to_string().trim_end());
-    }
-
     /// Writes the current token but without turning it into a string using `to_string()`.
     /// Instead, we check the token's span and format what's in the original source there
     /// (useful when formatting integer tokens, because a token like 0xFF ends up being an

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -201,9 +201,7 @@ impl<'a> Formatter<'a> {
         self.write("//");
         for word in comment.split_inclusive([' ', '\n', '\t']) {
             if self.current_line_width() + word.trim().chars().count() >= self.max_width {
-                self.trim_spaces();
-                self.write_line_without_skipping_whitespace_and_comments();
-                self.write_indentation();
+                self.start_new_line();
                 self.write("// ");
             }
 
@@ -222,22 +220,17 @@ impl<'a> Formatter<'a> {
         self.write("/*");
 
         if comment.trim_start_matches([' ', '\t']).starts_with('\n') {
-            self.write_line_without_skipping_whitespace_and_comments();
-            self.write_indentation();
+            self.start_new_line();
         }
 
         for (index, line) in comment.lines().enumerate() {
             if index > 0 {
-                self.trim_spaces();
-                self.write_line_without_skipping_whitespace_and_comments();
-                self.write_indentation();
+                self.start_new_line();
             }
 
             for word in line.split_inclusive([' ', '\n', '\t']) {
                 if self.current_line_width() + word.trim().chars().count() >= self.max_width {
-                    self.trim_spaces();
-                    self.write_line_without_skipping_whitespace_and_comments();
-                    self.write_indentation();
+                    self.start_new_line();
                 }
 
                 self.write(word);
@@ -245,15 +238,11 @@ impl<'a> Formatter<'a> {
         }
 
         if comment.ends_with('\n') {
-            self.trim_spaces();
-            self.write_line_without_skipping_whitespace_and_comments();
-            self.write_indentation();
+            self.start_new_line();
         }
 
         if self.current_line_width() + 2 >= self.max_width {
-            self.trim_spaces();
-            self.write_line_without_skipping_whitespace_and_comments();
-            self.write_indentation();
+            self.start_new_line();
         }
 
         self.write("*/");
@@ -302,6 +291,12 @@ impl<'a> Formatter<'a> {
             self.write(NEWLINE);
             self.write(NEWLINE);
         }
+    }
+
+    pub(crate) fn start_new_line(&mut self) {
+        self.trim_spaces();
+        self.write_line_without_skipping_whitespace_and_comments();
+        self.write_indentation();
     }
 
     /// Trim spaces from the end of the buffer.

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -190,7 +190,7 @@ impl<'a> Formatter<'a> {
         if !self.config.wrap_comments
             || self.in_chunk
             || comment.trim_start().starts_with('#')
-            || self.current_line_width() + comment.chars().count() + 2 < self.max_width
+            || self.current_line_width() + comment.chars().count() + 2 < self.config.comment_width
         {
             // +2 for "//"
             self.write("//");
@@ -204,7 +204,8 @@ impl<'a> Formatter<'a> {
     pub(crate) fn write_comment_with_prefix(&mut self, comment: &str, prefix: &str) {
         self.write(prefix);
         for word in comment.split_inclusive([' ', '\n', '\t']) {
-            if self.current_line_width() + word.trim().chars().count() >= self.max_width {
+            if self.current_line_width() + word.trim().chars().count() >= self.config.comment_width
+            {
                 self.start_new_line();
                 if !prefix.is_empty() {
                     self.write(prefix);
@@ -236,7 +237,9 @@ impl<'a> Formatter<'a> {
             }
 
             for word in line.split_inclusive([' ', '\n', '\t']) {
-                if self.current_line_width() + word.trim().chars().count() >= self.max_width {
+                if self.current_line_width() + word.trim().chars().count()
+                    >= self.config.comment_width
+                {
                     self.start_new_line();
                 }
 
@@ -248,7 +251,7 @@ impl<'a> Formatter<'a> {
             self.start_new_line();
         }
 
-        if self.current_line_width() + 2 >= self.max_width {
+        if self.current_line_width() + 2 >= self.config.comment_width {
             self.start_new_line();
         }
 
@@ -321,8 +324,8 @@ impl<'a> Formatter<'a> {
 mod tests {
     use crate::{assert_format, assert_format_with_config, assert_format_with_max_width, Config};
 
-    fn assert_format_wrapping_comments(src: &str, expected: &str, max_width: usize) {
-        let config = Config { wrap_comments: true, max_width, ..Config::default() };
+    fn assert_format_wrapping_comments(src: &str, expected: &str, comment_width: usize) {
+        let config = Config { wrap_comments: true, comment_width, ..Config::default() };
         assert_format_with_config(src, expected, config);
     }
 

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -183,7 +183,10 @@ impl<'a> Formatter<'a> {
     }
 
     fn write_line_comment(&mut self, comment: String) {
+        // We don't wrap lines that start with '#' because these might be
+        // markdown headers and wrapping those would actually break them.
         if !self.config.wrap_comments
+            || comment.trim_start().starts_with('#')
             || self.current_line_width() + comment.chars().count() + 2 < self.max_width
         {
             // +2 for "//"
@@ -914,6 +917,19 @@ global x: Field = 1;
     // to be wrapped.
     global x: Field = 1;
 }
+";
+        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
+        assert_format_with_config(src, expected, config);
+    }
+
+    #[test]
+    fn does_not_wrap_line_comment_if_it_starts_with_pound() {
+        let src = "
+        // # This is a long comment that's not going to be wrapped.
+        global x: Field = 1;
+        ";
+        let expected = "// # This is a long comment that's not going to be wrapped.
+global x: Field = 1;
 ";
         let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
         assert_format_with_config(src, expected, config);

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -1168,4 +1168,20 @@ global x: Field = 1;
 ";
         assert_format_wrapping_comments(src, expected, 29);
     }
+
+    #[test]
+    fn wraps_line_comments_at_block_end() {
+        let src = "fn foo() {
+        let x = 1;
+        // This is a very long comment
+    }
+        ";
+        let expected = "fn foo() {
+    let x = 1;
+    // This is a very long
+    // comment
+}
+";
+        assert_format_wrapping_comments(src, expected, 29);
+    }
 }

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -969,4 +969,24 @@ global x: Field = 1;
         let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
         assert_format_with_config(src, expected, config);
     }
+
+    #[test]
+    fn wraps_line_comments_in_argument_trailing_position() {
+        let src = "fn foo() {
+        bar(
+        1, // This is a long comment that's going to be wrapped.
+    )}
+        ";
+        let expected = "fn foo() {
+    bar(
+        1, // This is a long
+        // comment that's
+        // going to be
+        // wrapped.
+    )
+}
+";
+        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
+        assert_format_with_config(src, expected, config);
+    }
 }

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -162,7 +162,8 @@ impl<'a> Formatter<'a> {
                         // will never write two consecutive spaces.
                         self.write_space_without_skipping_whitespace_and_comments();
                     }
-                    self.write_current_token_and_bump();
+                    self.write_current_token();
+                    self.bump();
                     passed_whitespace = false;
                     last_was_block_comment = true;
                     self.written_comments_count += 1;
@@ -237,7 +238,7 @@ impl<'a> Formatter<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{assert_format, assert_format_with_max_width};
+    use crate::{assert_format, assert_format_with_config, assert_format_with_max_width, Config};
 
     #[test]
     fn format_array_in_global_with_line_comments() {
@@ -857,5 +858,21 @@ global x = 1;
 global x = 1;
 ";
         assert_format(src, expected);
+    }
+
+    #[test]
+    fn wraps_comments() {
+        let src = "
+        // This is a long comment that's going to be wrapped.
+        global x : Field = 1;
+        ";
+        let expected = "
+        // This is a long comment
+        // that's going to be 
+        // wrapped.
+        global x : Field = 1;
+        ";
+        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
+        assert_format_with_config(src, expected, config);
     }
 }

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -269,6 +269,11 @@ impl<'a> Formatter<'a> {
 mod tests {
     use crate::{assert_format, assert_format_with_config, assert_format_with_max_width, Config};
 
+    fn assert_format_wrapping_comments(src: &str, expected: &str, max_width: usize) {
+        let config = Config { wrap_comments: true, max_width, ..Config::default() };
+        assert_format_with_config(src, expected, config);
+    }
+
     #[test]
     fn format_array_in_global_with_line_comments() {
         let src = "global x = [ // hello
@@ -900,8 +905,7 @@ global x = 1;
 // wrapped.
 global x: Field = 1;
 ";
-        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
-        assert_format_with_config(src, expected, config);
+        assert_format_wrapping_comments(src, expected, 29);
     }
 
     #[test]
@@ -919,8 +923,7 @@ global x: Field = 1;
     global x: Field = 1;
 }
 ";
-        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
-        assert_format_with_config(src, expected, config);
+        assert_format_wrapping_comments(src, expected, 29);
     }
 
     #[test]
@@ -932,8 +935,7 @@ global x: Field = 1;
         let expected = "// # This is a long comment that's not going to be wrapped.
 global x: Field = 1;
 ";
-        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
-        assert_format_with_config(src, expected, config);
+        assert_format_wrapping_comments(src, expected, 29);
     }
 
     #[test]
@@ -950,8 +952,7 @@ global x: Field = 1;
     let x = 1;
 }
 ";
-        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
-        assert_format_with_config(src, expected, config);
+        assert_format_wrapping_comments(src, expected, 29);
     }
 
     #[test]
@@ -966,8 +967,7 @@ global x: Field = 1;
     // going to be wrapped.
 }
 ";
-        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
-        assert_format_with_config(src, expected, config);
+        assert_format_wrapping_comments(src, expected, 29);
     }
 
     #[test]
@@ -986,7 +986,6 @@ global x: Field = 1;
     )
 }
 ";
-        let config = Config { wrap_comments: true, max_width: 29, ..Config::default() };
-        assert_format_with_config(src, expected, config);
+        assert_format_wrapping_comments(src, expected, 29);
     }
 }

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -40,14 +40,12 @@ impl<'a> Formatter<'a> {
                     let comment = comment.clone();
                     self.write_indentation();
                     self.write_line_comment(&comment, "///");
-                    self.bump();
                     self.write_line();
                 }
                 Token::BlockComment(comment, Some(DocStyle::Outer)) => {
                     let comment = comment.clone();
                     self.write_indentation();
                     self.write_block_comment(&comment, "/**");
-                    self.bump();
                     self.write_line();
                 }
                 _ => unreachable!("Expected an outer doc comment"),
@@ -147,5 +145,19 @@ that's going to be wrapped.
 global x: Field = 1;
 ";
         assert_format_wrapping_comments(src, expected, 29);
+    }
+
+    #[test]
+    fn doc_comment_followed_by_comment() {
+        let src = "
+        /// Some doc comment
+        // Some comment
+        global x: Field = 1;
+        ";
+        let expected = "/// Some doc comment
+// Some comment
+global x: Field = 1;
+";
+        assert_format(src, expected);
     }
 }

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -1,4 +1,4 @@
-use noirc_frontend::token::{DocStyle, Token};
+use noirc_frontend::token::{DocStyle, Token, TokenKind};
 
 use super::Formatter;
 
@@ -7,22 +7,22 @@ impl<'a> Formatter<'a> {
         loop {
             self.skip_comments_and_whitespace();
 
-            match &self.token {
+            if self.token.kind() != TokenKind::InnerDocComment {
+                break;
+            }
+
+            match self.bump() {
                 Token::LineComment(comment, Some(DocStyle::Inner)) => {
-                    let comment = comment.clone();
                     self.write_indentation();
                     self.write_line_comment(&comment, "//!");
-                    self.bump();
                     self.write_line();
                 }
                 Token::BlockComment(comment, Some(DocStyle::Inner)) => {
-                    let comment = comment.clone();
                     self.write_indentation();
                     self.write_block_comment(&comment, "/*!");
-                    self.bump();
                     self.write_line();
                 }
-                _ => break,
+                _ => unreachable!("Expected an inner doc comment"),
             }
         }
     }
@@ -31,7 +31,11 @@ impl<'a> Formatter<'a> {
         loop {
             self.skip_comments_and_whitespace();
 
-            match &self.token {
+            if self.token.kind() != TokenKind::OuterDocComment {
+                break;
+            }
+
+            match self.bump() {
                 Token::LineComment(comment, Some(DocStyle::Outer)) => {
                     let comment = comment.clone();
                     self.write_indentation();
@@ -46,7 +50,7 @@ impl<'a> Formatter<'a> {
                     self.bump();
                     self.write_line();
                 }
-                _ => break,
+                _ => unreachable!("Expected an outer doc comment"),
             }
         }
     }

--- a/tooling/nargo_fmt/src/formatter/enums.rs
+++ b/tooling/nargo_fmt/src/formatter/enums.rs
@@ -77,7 +77,7 @@ impl<'a> Formatter<'a> {
                 self.chunk_formatter().skip_comments_and_whitespace_chunk();
             comments_and_whitespace_chunk.string =
                 comments_and_whitespace_chunk.string.trim_end().to_string();
-            group.text(comments_and_whitespace_chunk);
+            group.trailing_comment_without_final_indentation(comments_and_whitespace_chunk);
 
             if self.is_at(Token::Comma) {
                 self.bump();

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -545,7 +545,7 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
             group.trailing_comma();
         }
 
-        group.text(chunk);
+        group.trailing_comment_without_final_indentation(chunk);
 
         if force_trailing_comma {
             group.text(TextChunk::new(",".to_string()));

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -1269,7 +1269,7 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
         }
 
         // Finally format the comment, if any
-        group.text(self.chunk(|formatter| {
+        group.trailing_comment_without_final_indentation(self.chunk(|formatter| {
             formatter.skip_comments_and_whitespace_writing_multiple_lines_if_found();
         }));
 

--- a/tooling/nargo_fmt/src/formatter/statement.rs
+++ b/tooling/nargo_fmt/src/formatter/statement.rs
@@ -21,19 +21,24 @@ impl<'a, 'b> ChunkFormatter<'a, 'b> {
         }));
 
         // Now write any leading comment respecting multiple newlines after them
+
+        if self.token.kind() == TokenKind::OuterDocComment {
+            group.leading_comment(self.chunk(|formatter| {
+                // Doc comments for a let statement could come before a potential non-doc comment
+                formatter.format_outer_doc_comments();
+            }));
+        }
+
         group.leading_comment(self.chunk(|formatter| {
-            // Doc comments for a let statement could come before a potential non-doc comment
-            if formatter.token.kind() == TokenKind::OuterDocComment {
-                formatter.format_outer_doc_comments();
-            }
-
             formatter.skip_comments_and_whitespace_writing_multiple_lines_if_found();
-
-            // Or doc comments could come after a potential non-doc comment
-            if formatter.token.kind() == TokenKind::OuterDocComment {
-                formatter.format_outer_doc_comments();
-            }
         }));
+
+        // Or doc comments could come after a potential non-doc comment
+        if self.token.kind() == TokenKind::OuterDocComment {
+            group.leading_comment(self.chunk(|formatter| {
+                formatter.format_outer_doc_comments();
+            }));
+        }
 
         ignore_next |= self.ignore_next;
 


### PR DESCRIPTION
# Description

## Problem

Resolves #7332

## Summary

This is an opt-in feature, just like in `rustfmt`.

## Additional Context

I tried to make sure this covers most scenarios though I'm sure I missed some. We could enhance things as we find them.

I also thought about enabling comment wrapping in the stdlib and test programs (things become easier to read) but I'll leave that for an (optional) PR.

Question: should the default `comment_width` be 100 or 80? It's 80 in `rustfmt`, which is different than the default `max_width` of 100 and I don't know why. Maybe comments are easier to read if they are shorter (compared to code)? 

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
