### PR TITLE
chore: box `ParserError`s in `InterpreterError`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -150,7 +150,7 @@ pub enum InterpreterError {
         location: Location,
     },
     FailedToParseMacro {
-        error: ParserError,
+        error: Box<ParserError>,
         tokens: String,
         rule: &'static str,
         file: FileId,
@@ -539,7 +539,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
 
                 let push_the_problem_on_the_library_author = "To avoid this error in the future, try adding input validation to your macro. Erroring out early with an `assert` can be a good way to provide a user-friendly error message".into();
 
-                let mut diagnostic = CustomDiagnostic::from(error);
+                let mut diagnostic = CustomDiagnostic::from(error.as_ref());
                 // Swap the parser's primary note to become the secondary note so that it is
                 // more clear this error originates from failing to parse a macro.
                 let secondary = std::mem::take(&mut diagnostic.message);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -523,7 +523,7 @@ where
     F: FnOnce(&mut Parser<'a>) -> T,
 {
     Parser::for_tokens(quoted).parse_result(parsing_function).map_err(|mut errors| {
-        let error = errors.swap_remove(0);
+        let error = Box::new(errors.swap_remove(0));
         let tokens = tokens_to_string(tokens, interner);
         InterpreterError::FailedToParseMacro { error, tokens, rule, file: location.file }
     })

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -278,7 +278,7 @@ impl Value {
                         Ok(expr)
                     }
                     Err(mut errors) => {
-                        let error = errors.swap_remove(0);
+                        let error = Box::new(errors.swap_remove(0));
                         let file = location.file;
                         let rule = "an expression";
                         let tokens = tokens_to_string(tokens, elaborator.interner);
@@ -608,7 +608,7 @@ where
             Ok(expr)
         }
         Err(mut errors) => {
-            let error = errors.swap_remove(0);
+            let error = Box::new(errors.swap_remove(0));
             let file = location.file;
             let tokens = tokens_to_string(tokens, elaborator.interner);
             Err(InterpreterError::FailedToParseMacro { error, file, tokens, rule })


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

`InterpreterError` is currently 488 bytes (and so all of `IResults` are as well). Most of that size comes from it holding a `ParserError` inside one of its variants so I've boxed that which reduces the size of an `InterpreterError` to 192 bytes.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
