### PR TITLE
feat: cache argless comptime function values

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -98,6 +98,7 @@ impl<'context> Elaborator<'context> {
             self.debug_comptime_in_file,
             self.interpreter_call_stack.clone(),
             self.pedantic_solving,
+            self.cached_function_values,
         );
 
         elaborator.function_context.push(FunctionContext::default());


### PR DESCRIPTION
# Description

## Problem

I noticed that doing `nargo check` on "rollup-base-private" would take about 1.5 seconds. Profiling it turned out that a lot of that time (around 900ms) is spent in the comptime interpreter.

I know a tree-walk interpreter is slow but I wanted to know where the slowness happened so I printed expressions that took more than 10ms to evaluate. It turns out that there were many calls to `get_vk_merkle_tree` which builds a massive tree. Those are mainly used in tests so my first reaction was to change those `comptime`s to non-comptime because it would work the same.

## Summary

A second thought was that we could cache function return values if they have no arguments, which is a more general solution, so that's what this PR does.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
