### PR TITLE
fix: field zero division in brillig

### DIFF
--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -43,7 +43,13 @@ pub(crate) fn evaluate_binary_field_op<F: AcirField>(
         BinaryFieldOp::Add => MemoryValue::new_field(a + b),
         BinaryFieldOp::Sub => MemoryValue::new_field(a - b),
         BinaryFieldOp::Mul => MemoryValue::new_field(a * b),
-        BinaryFieldOp::Div => MemoryValue::new_field(a / b),
+        BinaryFieldOp::Div => {
+            if b.is_zero() {
+                return Err(BrilligArithmeticError::DivisionByZero);
+            } else {
+                MemoryValue::new_field(a / b)
+            }
+        }
         BinaryFieldOp::IntegerDiv => {
             if b.is_zero() {
                 return Err(BrilligArithmeticError::DivisionByZero);

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -2437,6 +2437,14 @@ mod tests {
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
         let status = vm.process_opcode();
-        assert_eq!(status, VMStatus::Failure {reason: FailureReason::RuntimeError { message: "Attempted to divide by zero".into() }, call_stack: vec![2]} );
+        assert_eq!(
+            status,
+            VMStatus::Failure {
+                reason: FailureReason::RuntimeError {
+                    message: "Attempted to divide by zero".into()
+                },
+                call_stack: vec![2]
+            }
+        );
     }
 }

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -2408,9 +2408,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn field_zero_division_regression() {
-        let calldata: Vec<FieldElement> = vec![(1u128).into(), (0u128).into()];
+        let calldata: Vec<FieldElement> = vec![];
 
         let opcodes = &[
             Opcode::Const {
@@ -2438,9 +2437,6 @@ mod tests {
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
         let status = vm.process_opcode();
-        assert_eq!(status, VMStatus::Finished { return_data_offset: 0, return_data_size: 0 });
-        let VM { memory, .. } = vm;
-        let output_value = memory.read(MemoryAddress::direct(2));
-        assert_eq!(output_value.to_field(), (0u128).into());
+        assert_eq!(status, VMStatus::Failure {reason: FailureReason::RuntimeError { message: "Attempted to divide by zero".into() }, call_stack: vec![2]} );
     }
 }

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -2409,7 +2409,7 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn zero_division_regression() {
+    fn field_zero_division_regression() {
         let calldata: Vec<FieldElement> = vec![(1u128).into(), (0u128).into()];
 
         let opcodes = &[


### PR DESCRIPTION
# Description

## Problem\*
Brillig VM allowed division by zero for field operations

## Summary\*
Added validation to prevent division by zero in field operations, with a regression test to verify the fix. 


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
