### PR TITLE
fix(ssa): Do not deduplicate division by a zero constant

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -605,7 +605,7 @@ impl Instruction {
                     BinaryOp::Div | BinaryOp::Mod => {
                         // Div and Mod require a predicate if the RHS may be zero.
                         dfg.get_numeric_constant(binary.rhs)
-                            .map(|rhs| !rhs.is_zero())
+                            .map(|rhs| rhs.is_zero())
                             .unwrap_or(true)
                     }
                     BinaryOp::Add { unchecked: true }


### PR DESCRIPTION
# Description

## Problem\*

No issue just a bug I found while working on other tasks.

## Summary\*

If the rhs of a div/mod was a zero we would `false` from `requires_acir_gen_predicate`. This would also deduplicating a div/mod by a zero constant.
e.g. this SSA:
```
        acir(inline) fn main f0 {
          b0(v0: u32, v1: u32, v2: u1):
            enable_side_effects v2
            v4 = div v1, u32 0
            v5 = not v2
            enable_side_effects v5
            v6 = div v1, u32 0
            return
        }
```
would turn into this SSA:
```
        acir(inline) fn main f0 {
          b0(v0: u32, v1: u32, v2: u1):
            enable_side_effects v2
            v4 = div v1, u32 0
            v5 = not v2
            enable_side_effects v5
            return
        }
```
If `v2` was inactive and `v5` was active, we would miss needing to fail when processing the second division.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
