### PR TITLE
chore: allow opting in to displaying benchmark comments

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -552,6 +552,7 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/master' }}
           alert-threshold: "120%"
           comment-on-alert: true
+          comment-always: ${{ contains( github.event.pull_request.labels.*.name, 'bench-show') }}
           fail-on-alert: false
           alert-comment-cc-users: "@TomAFrench"
           max-items-in-chart: 50
@@ -601,6 +602,7 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/master' }}
           alert-threshold: "120%"
           comment-on-alert: true
+          comment-always: ${{ contains( github.event.pull_request.labels.*.name, 'bench-show') }}
           fail-on-alert: false
           alert-comment-cc-users: "@TomAFrench"
           max-items-in-chart: 50
@@ -650,6 +652,7 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/master' }}
           alert-threshold: "120%"
           comment-on-alert: true
+          comment-always: ${{ contains( github.event.pull_request.labels.*.name, 'bench-show') }}
           fail-on-alert: false
           alert-comment-cc-users: "@TomAFrench"
           max-items-in-chart: 50
@@ -700,6 +703,7 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/master' }}
           alert-threshold: "120%"
           comment-on-alert: true
+          comment-always: ${{ contains( github.event.pull_request.labels.*.name, 'bench-show') }}
           fail-on-alert: false
           alert-comment-cc-users: "@TomAFrench"
           max-items-in-chart: 50

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -637,6 +637,7 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/master' }}
           alert-threshold: "120%"
           comment-on-alert: true
+          comment-always: ${{ contains( github.event.pull_request.labels.*.name, 'bench-show') }}
           fail-on-alert: false
           alert-comment-cc-users: "@TomAFrench"
           max-items-in-chart: 50


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

See https://github.com/noir-lang/noir/pull/7388#issuecomment-2660017557

This PR allows printing of the benchmarks into the PR comments if the `bench-show` label is set.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
