### PR TITLE
chore: box `Closure` in `comptime::Value` enum

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 use super::errors::{IResult, InterpreterError};
-use super::value::{unwrap_rc, Value};
+use super::value::{unwrap_rc, Closure, Value};
 
 mod builtin;
 mod foreign;
@@ -264,7 +264,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
     fn call_closure(
         &mut self,
-        closure: HirLambda,
+        lambda: HirLambda,
         environment: Vec<Value>,
         arguments: Vec<(Value, Location)>,
         function_scope: Option<FuncId>,
@@ -275,7 +275,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         let old_module = self.elaborator.replace_module(module_scope);
         let old_function = std::mem::replace(&mut self.current_function, function_scope);
 
-        let result = self.call_closure_inner(closure, environment, arguments, call_location);
+        let result = self.call_closure_inner(lambda, environment, arguments, call_location);
 
         self.current_function = old_function;
         self.elaborator.replace_module(old_module);
@@ -1359,9 +1359,14 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 }
                 Ok(result)
             }
-            Value::Closure(closure, env, _, function_scope, module_scope) => {
-                self.call_closure(closure, env, arguments, function_scope, module_scope, location)
-            }
+            Value::Closure(closure) => self.call_closure(
+                closure.lambda,
+                closure.env,
+                arguments,
+                closure.function_scope,
+                closure.module_scope,
+                location,
+            ),
             value => {
                 let typ = value.get_type().into_owned();
                 Err(InterpreterError::NonFunctionCalled { typ, location })
@@ -1544,12 +1549,14 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
     fn evaluate_lambda(&mut self, lambda: HirLambda, id: ExprId) -> IResult<Value> {
         let location = self.elaborator.interner.expr_location(&id);
-        let environment =
+        let env =
             try_vecmap(&lambda.captures, |capture| self.lookup_id(capture.ident.id, location))?;
 
         let typ = self.elaborator.interner.id_type(id).follow_bindings();
-        let module = self.elaborator.module_id();
-        Ok(Value::Closure(lambda, environment, typ, self.current_function, module))
+        let module_scope = self.elaborator.module_id();
+        let closure =
+            Closure { lambda, env, typ, function_scope: self.current_function, module_scope };
+        Ok(Value::Closure(Box::new(closure)))
     }
 
     fn evaluate_quote(&mut self, mut tokens: Tokens, expr_id: ExprId) -> IResult<Value> {


### PR DESCRIPTION
# Description

## Problem

Follow-up to #7388

## Summary

This makes `Value` go from 280 to 152 bytes. Doing `nargo check` on `rollup-base-private` I notice a slight improvement, maybe not much but this is an easy change.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
