### PR TITLE
feat(LSP): auto-import via visible reexport

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -3,7 +3,7 @@ use super::errors::{DefCollectorErrorKind, DuplicateType};
 use crate::elaborator::Elaborator;
 use crate::graph::CrateId;
 use crate::hir::comptime::InterpreterError;
-use crate::hir::def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId};
+use crate::hir::def_map::{CrateDefMap, LocalModuleId, ModuleId};
 use crate::hir::resolution::errors::ResolverError;
 use crate::hir::type_check::TypeCheckError;
 use crate::locations::ReferencesTracker;
@@ -431,14 +431,12 @@ impl DefCollector {
                                     Some(defining_module),
                                 );
 
-                                if let ModuleDefId::TraitId(trait_id) = module_def_id {
-                                    context.def_interner.add_trait_reexport(
-                                        trait_id,
-                                        defining_module,
-                                        name.clone(),
-                                        visibility,
-                                    );
-                                }
+                                context.def_interner.add_reexport(
+                                    module_def_id,
+                                    defining_module,
+                                    name.clone(),
+                                    visibility,
+                                );
                             }
                         }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -961,7 +961,14 @@ fn push_child_module(
         );
 
         if interner.is_in_lsp_mode() {
-            interner.register_module(mod_id, visibility, mod_name.0.contents.clone());
+            let parent_module_id = ModuleId { krate: def_map.krate, local_id: parent };
+            interner.register_module(
+                mod_id,
+                location,
+                visibility,
+                mod_name.0.contents.clone(),
+                parent_module_id,
+            );
         }
     }
 

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -55,6 +55,13 @@ impl<'a> ReferencesTracker<'a> {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+pub struct AutoImportEntry {
+    pub module_def_id: ModuleDefId,
+    pub visibility: ItemVisibility,
+    pub defining_module: Option<ModuleId>,
+}
+
 impl NodeInterner {
     pub fn reference_location(&self, reference: ReferenceId) -> Location {
         match reference {
@@ -381,13 +388,11 @@ impl NodeInterner {
         }
 
         let entry = self.auto_import_names.entry(name).or_default();
-        entry.push((module_def_id, visibility, defining_module));
+        entry.push(AutoImportEntry { module_def_id, visibility, defining_module });
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn get_auto_import_names(
-        &self,
-    ) -> &HashMap<String, Vec<(ModuleDefId, ItemVisibility, Option<ModuleId>)>> {
+    pub fn get_auto_import_names(&self) -> &HashMap<String, Vec<AutoImportEntry>> {
         &self.auto_import_names
     }
 }

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -55,10 +55,27 @@ impl<'a> ReferencesTracker<'a> {
     }
 }
 
+/// A `ModuleDefId` captured to be offered in LSP's auto-import feature.
+///
+/// The name of the item is stored in the key of the `auto_import_names` map in the `NodeInterner`.
 #[derive(Debug, Copy, Clone)]
 pub struct AutoImportEntry {
+    /// The item to import.
     pub module_def_id: ModuleDefId,
+    /// The item's visibility.
     pub visibility: ItemVisibility,
+    /// If the item is available via a re-export, this contains the module where it's defined.
+    /// For example:
+    ///
+    /// ```noir
+    /// mod foo { // <- this is the defining module
+    ///     mod bar {
+    ///         pub struct Baz {} // This is the item
+    ///     }
+    ///     
+    ///     pub use bar::Baz; // Here's the visibility
+    /// }
+    /// ```
     pub defining_module: Option<ModuleId>,
 }
 

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -333,9 +333,12 @@ impl NodeInterner {
     pub(crate) fn register_module(
         &mut self,
         id: ModuleId,
+        location: Location,
         visibility: ItemVisibility,
         name: String,
+        parent_module_id: ModuleId,
     ) {
+        self.add_definition_location(ReferenceId::Module(id), location, Some(parent_module_id));
         self.register_name_for_auto_import(name, ModuleDefId::ModuleId(id), visibility, None);
     }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -24,6 +24,7 @@ use crate::hir::def_map::{LocalModuleId, ModuleDefId, ModuleId};
 use crate::hir::type_check::generics::TraitGenerics;
 use crate::hir_def::traits::NamedType;
 use crate::hir_def::traits::ResolvedTraitBound;
+use crate::locations::AutoImportEntry;
 use crate::QuotedType;
 
 use crate::ast::{BinaryOpKind, FunctionDefinition, ItemVisibility};
@@ -254,8 +255,7 @@ pub struct NodeInterner {
     // The third value in the tuple is the module where the definition is (only for pub use).
     // These include top-level functions, global variables and types, but excludes
     // impl and trait-impl methods.
-    pub(crate) auto_import_names:
-        HashMap<String, Vec<(ModuleDefId, ItemVisibility, Option<ModuleId>)>>,
+    pub(crate) auto_import_names: HashMap<String, Vec<AutoImportEntry>>,
 
     /// Each value currently in scope in the comptime interpreter.
     /// Each element of the Vec represents a scope with every scope together making

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -2278,8 +2278,15 @@ impl NodeInterner {
         self.reexports.entry(module_def_id).or_default().push((module_id, name, visibility));
     }
 
+    pub fn get_reexports(
+        &self,
+        module_def_id: ModuleDefId,
+    ) -> &[(ModuleId, Ident, ItemVisibility)] {
+        self.reexports.get(&module_def_id).map_or(&[], |exports| exports)
+    }
+
     pub fn get_trait_reexports(&self, trait_id: TraitId) -> &[(ModuleId, Ident, ItemVisibility)] {
-        self.reexports.get(&ModuleDefId::TraitId(trait_id)).map_or(&[], |exports| exports)
+        self.get_reexports(ModuleDefId::TraitId(trait_id))
     }
 }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -268,10 +268,10 @@ pub struct NodeInterner {
     /// Captures the documentation comments for each module, struct, trait, function, etc.
     pub(crate) doc_comments: HashMap<ReferenceId, Vec<String>>,
 
-    /// Only for LSP: a map of trait ID to each module that pub or pub(crate) exports it.
-    /// In LSP this is used to offer importing the trait via one of these exports if
-    /// the trait is not visible where it's defined.
-    trait_reexports: HashMap<TraitId, Vec<(ModuleId, Ident, ItemVisibility)>>,
+    /// Only for LSP: a map of ModuleDefId to each module that pub or pub(crate) exports it.
+    /// In LSP this is used to offer importing the item via one of these exports if
+    /// the item is not visible where it's defined.
+    reexports: HashMap<ModuleDefId, Vec<(ModuleId, Ident, ItemVisibility)>>,
 }
 
 /// A dependency in the dependency graph may be a type or a definition.
@@ -686,7 +686,7 @@ impl Default for NodeInterner {
             comptime_scopes: vec![HashMap::default()],
             trait_impl_associated_types: HashMap::default(),
             doc_comments: HashMap::default(),
-            trait_reexports: HashMap::default(),
+            reexports: HashMap::default(),
         }
     }
 }
@@ -2268,18 +2268,18 @@ impl NodeInterner {
         }
     }
 
-    pub fn add_trait_reexport(
+    pub fn add_reexport(
         &mut self,
-        trait_id: TraitId,
+        module_def_id: ModuleDefId,
         module_id: ModuleId,
         name: Ident,
         visibility: ItemVisibility,
     ) {
-        self.trait_reexports.entry(trait_id).or_default().push((module_id, name, visibility));
+        self.reexports.entry(module_def_id).or_default().push((module_id, name, visibility));
     }
 
     pub fn get_trait_reexports(&self, trait_id: TraitId) -> &[(ModuleId, Ident, ItemVisibility)] {
-        self.trait_reexports.get(&trait_id).map_or(&[], |exports| exports)
+        self.reexports.get(&ModuleDefId::TraitId(trait_id)).map_or(&[], |exports| exports)
     }
 }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -648,7 +648,7 @@ pub struct InternedPattern(noirc_arena::Index);
 /// }
 /// ```
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Reexport {
     pub module_id: ModuleId,
     pub name: Ident,

--- a/tooling/lsp/src/modules.rs
+++ b/tooling/lsp/src/modules.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use noirc_frontend::{
-    ast::Ident,
+    ast::{Ident, ItemVisibility},
     graph::{CrateId, Dependency},
     hir::def_map::{CrateDefMap, ModuleDefId, ModuleId},
     node_interner::{NodeInterner, Reexport, ReferenceId},
@@ -169,6 +169,7 @@ pub(crate) fn module_full_path(
 /// Finds a visible reexport for any ancestor module of the given ModuleDefId,
 pub(crate) fn get_ancestor_module_reexport(
     module_def_id: ModuleDefId,
+    visibility: ItemVisibility,
     current_module_id: ModuleId,
     interner: &NodeInterner,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
@@ -194,11 +195,25 @@ pub(crate) fn get_ancestor_module_reexport(
     // Try searching in the parent's parent module.
     let mut grandparent_module_reexport = get_ancestor_module_reexport(
         ModuleDefId::ModuleId(parent_module),
+        visibility,
         current_module_id,
         interner,
         def_maps,
         dependencies,
     )?;
+
+    // If we can find one, we need to check if ModuleDefId is actually visible from the grandparent module
+    if !module_def_id_is_visible(
+        module_def_id,
+        grandparent_module_reexport.module_id,
+        visibility,
+        None,
+        interner,
+        def_maps,
+        dependencies,
+    ) {
+        return None;
+    }
 
     // If we can find one we need to adjust the exported name a bit.
     let parent_module_name = &interner.try_module_attributes(&parent_module)?.name;

--- a/tooling/lsp/src/modules.rs
+++ b/tooling/lsp/src/modules.rs
@@ -205,9 +205,9 @@ pub(crate) fn get_ancestor_module_reexport(
     // If we can find one, we need to check if ModuleDefId is actually visible from the grandparent module
     if !module_def_id_is_visible(
         module_def_id,
-        grandparent_module_reexport.module_id,
+        current_module_id,
         visibility,
-        None,
+        Some(grandparent_module_reexport.module_id),
         interner,
         def_maps,
         dependencies,

--- a/tooling/lsp/src/requests/code_action.rs
+++ b/tooling/lsp/src/requests/code_action.rs
@@ -17,7 +17,7 @@ use noirc_frontend::{
         Path, UseTree, Visitor,
     },
     graph::CrateId,
-    hir::def_map::{CrateDefMap, LocalModuleId, ModuleId},
+    hir::def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId},
     node_interner::NodeInterner,
     usage_tracker::UsageTracker,
 };
@@ -26,7 +26,10 @@ use noirc_frontend::{
     ParsedModule,
 };
 
-use crate::{use_segment_positions::UseSegmentPositions, utils, LspState};
+use crate::{
+    use_segment_positions::UseSegmentPositions, utils, visibility::module_def_id_is_visible,
+    LspState,
+};
 
 use super::{process_request, to_lsp_location};
 
@@ -186,6 +189,22 @@ impl<'a> CodeActionFinder<'a> {
             disabled: None,
             data: None,
         }
+    }
+
+    fn module_def_id_is_visible(
+        &self,
+        module_def_id: ModuleDefId,
+        visibility: ItemVisibility,
+        defining_module: Option<ModuleId>,
+    ) -> bool {
+        module_def_id_is_visible(
+            module_def_id,
+            self.module_id,
+            visibility,
+            defining_module,
+            self.interner,
+            self.def_maps,
+        )
     }
 
     fn includes_span(&self, span: Span) -> bool {

--- a/tooling/lsp/src/requests/code_action.rs
+++ b/tooling/lsp/src/requests/code_action.rs
@@ -13,8 +13,8 @@ use lsp_types::{
 use noirc_errors::Span;
 use noirc_frontend::{
     ast::{
-        CallExpression, ConstructorExpression, ItemVisibility, MethodCallExpression, NoirTraitImpl,
-        Path, UseTree, Visitor,
+        CallExpression, ConstructorExpression, Ident, ItemVisibility, MethodCallExpression,
+        NoirTraitImpl, Path, UseTree, Visitor,
     },
     graph::{CrateId, Dependency},
     hir::def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId},
@@ -27,8 +27,8 @@ use noirc_frontend::{
 };
 
 use crate::{
-    use_segment_positions::UseSegmentPositions, utils, visibility::module_def_id_is_visible,
-    LspState,
+    modules::get_parent_module_reexport, use_segment_positions::UseSegmentPositions, utils,
+    visibility::module_def_id_is_visible, LspState,
 };
 
 use super::{process_request, to_lsp_location};
@@ -206,6 +206,16 @@ impl<'a> CodeActionFinder<'a> {
             self.module_id,
             visibility,
             defining_module,
+            self.interner,
+            self.def_maps,
+            self.dependencies,
+        )
+    }
+
+    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<(ModuleId, Ident)> {
+        get_parent_module_reexport(
+            module_def_id,
+            self.module_id,
             self.interner,
             self.def_maps,
             self.dependencies,

--- a/tooling/lsp/src/requests/code_action.rs
+++ b/tooling/lsp/src/requests/code_action.rs
@@ -27,7 +27,7 @@ use noirc_frontend::{
 };
 
 use crate::{
-    modules::get_parent_module_reexport, use_segment_positions::UseSegmentPositions, utils,
+    modules::get_ancestor_module_reexport, use_segment_positions::UseSegmentPositions, utils,
     visibility::module_def_id_is_visible, LspState,
 };
 
@@ -212,8 +212,8 @@ impl<'a> CodeActionFinder<'a> {
         )
     }
 
-    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<&Reexport> {
-        get_parent_module_reexport(
+    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<Reexport> {
+        get_ancestor_module_reexport(
             module_def_id,
             self.module_id,
             self.interner,

--- a/tooling/lsp/src/requests/code_action.rs
+++ b/tooling/lsp/src/requests/code_action.rs
@@ -212,9 +212,14 @@ impl<'a> CodeActionFinder<'a> {
         )
     }
 
-    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<Reexport> {
+    fn get_ancestor_module_reexport(
+        &self,
+        module_def_id: ModuleDefId,
+        visibility: ItemVisibility,
+    ) -> Option<Reexport> {
         get_ancestor_module_reexport(
             module_def_id,
+            visibility,
             self.module_id,
             self.interner,
             self.def_maps,

--- a/tooling/lsp/src/requests/code_action.rs
+++ b/tooling/lsp/src/requests/code_action.rs
@@ -16,7 +16,7 @@ use noirc_frontend::{
         CallExpression, ConstructorExpression, ItemVisibility, MethodCallExpression, NoirTraitImpl,
         Path, UseTree, Visitor,
     },
-    graph::CrateId,
+    graph::{CrateId, Dependency},
     hir::def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId},
     node_interner::NodeInterner,
     usage_tracker::UsageTracker,
@@ -66,6 +66,7 @@ pub(crate) fn on_code_action_request(
                     byte_range,
                     args.crate_id,
                     args.def_maps,
+                    args.dependencies,
                     args.interner,
                     args.usage_tracker,
                 );
@@ -87,6 +88,7 @@ struct CodeActionFinder<'a> {
     /// if we are analyzing something inside an inline module declaration.
     module_id: ModuleId,
     def_maps: &'a BTreeMap<CrateId, CrateDefMap>,
+    dependencies: &'a Vec<Dependency>,
     interner: &'a NodeInterner,
     usage_tracker: &'a UsageTracker,
     /// How many nested `mod` we are in deep
@@ -109,6 +111,7 @@ impl<'a> CodeActionFinder<'a> {
         byte_range: Range<usize>,
         krate: CrateId,
         def_maps: &'a BTreeMap<CrateId, CrateDefMap>,
+        dependencies: &'a Vec<Dependency>,
         interner: &'a NodeInterner,
         usage_tracker: &'a UsageTracker,
     ) -> Self {
@@ -131,6 +134,7 @@ impl<'a> CodeActionFinder<'a> {
             byte_range,
             module_id,
             def_maps,
+            dependencies,
             interner,
             usage_tracker,
             nesting: 0,
@@ -204,6 +208,7 @@ impl<'a> CodeActionFinder<'a> {
             defining_module,
             self.interner,
             self.def_maps,
+            self.dependencies,
         )
     }
 

--- a/tooling/lsp/src/requests/code_action.rs
+++ b/tooling/lsp/src/requests/code_action.rs
@@ -13,12 +13,12 @@ use lsp_types::{
 use noirc_errors::Span;
 use noirc_frontend::{
     ast::{
-        CallExpression, ConstructorExpression, Ident, ItemVisibility, MethodCallExpression,
-        NoirTraitImpl, Path, UseTree, Visitor,
+        CallExpression, ConstructorExpression, ItemVisibility, MethodCallExpression, NoirTraitImpl,
+        Path, UseTree, Visitor,
     },
     graph::{CrateId, Dependency},
     hir::def_map::{CrateDefMap, LocalModuleId, ModuleDefId, ModuleId},
-    node_interner::NodeInterner,
+    node_interner::{NodeInterner, Reexport},
     usage_tracker::UsageTracker,
 };
 use noirc_frontend::{
@@ -212,7 +212,7 @@ impl<'a> CodeActionFinder<'a> {
         )
     }
 
-    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<(ModuleId, Ident)> {
+    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<&Reexport> {
         get_parent_module_reexport(
             module_def_id,
             self.module_id,

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -44,6 +44,8 @@ impl<'a> CodeActionFinder<'a> {
                 let module_def_id = entry.module_def_id;
                 let visibility = entry.visibility;
                 let mut defining_module = entry.defining_module.as_ref().cloned();
+
+                // If the item is offered via a re-export of it's parent module, this holds the name of the reexport.
                 let mut intermediate_name = None;
 
                 let is_visible =

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -48,7 +48,9 @@ impl<'a> CodeActionFinder<'a> {
                 let is_visible =
                     self.module_def_id_is_visible(module_def_id, visibility, defining_module);
                 if !is_visible {
-                    if let Some(reexport) = self.get_parent_module_reexport(module_def_id) {
+                    if let Some(reexport) =
+                        self.get_ancestor_module_reexport(module_def_id, visibility)
+                    {
                         defining_module = Some(reexport.module_id);
                         intermediate_name = Some(reexport.name);
                     } else {

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -40,15 +40,17 @@ impl<'a> CodeActionFinder<'a> {
                 continue;
             }
 
-            for (module_def_id, visibility, defining_module) in entries {
-                let mut defining_module = defining_module.as_ref().cloned();
+            for entry in entries {
+                let module_def_id = entry.module_def_id;
+                let visibility = entry.visibility;
+                let mut defining_module = entry.defining_module.as_ref().cloned();
                 let mut intermediate_name = None;
 
                 let is_visible =
-                    self.module_def_id_is_visible(*module_def_id, *visibility, defining_module);
+                    self.module_def_id_is_visible(module_def_id, visibility, defining_module);
                 if !is_visible {
                     if let Some((parent_module_reexport, reexport_name)) =
-                        self.get_parent_module_reexport(*module_def_id)
+                        self.get_parent_module_reexport(module_def_id)
                     {
                         defining_module = Some(parent_module_reexport);
                         intermediate_name = Some(reexport_name);
@@ -66,7 +68,7 @@ impl<'a> CodeActionFinder<'a> {
                     )
                 } else {
                     let Some(module_full_path) = relative_module_full_path(
-                        *module_def_id,
+                        module_def_id,
                         self.module_id,
                         current_module_parent_id,
                         self.interner,

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -50,7 +50,7 @@ impl<'a> CodeActionFinder<'a> {
                 if !is_visible {
                     if let Some(reexport) = self.get_parent_module_reexport(module_def_id) {
                         defining_module = Some(reexport.module_id);
-                        intermediate_name = Some(reexport.name.clone());
+                        intermediate_name = Some(reexport.name);
                     } else {
                         continue;
                     }

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -49,11 +49,9 @@ impl<'a> CodeActionFinder<'a> {
                 let is_visible =
                     self.module_def_id_is_visible(module_def_id, visibility, defining_module);
                 if !is_visible {
-                    if let Some((parent_module_reexport, reexport_name)) =
-                        self.get_parent_module_reexport(module_def_id)
-                    {
-                        defining_module = Some(parent_module_reexport);
-                        intermediate_name = Some(reexport_name);
+                    if let Some(reexport) = self.get_parent_module_reexport(module_def_id) {
+                        defining_module = Some(reexport.module_id);
+                        intermediate_name = Some(reexport.name.clone());
                     } else {
                         continue;
                     }

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -11,7 +11,6 @@ use crate::{
     use_segment_positions::{
         use_completion_item_additional_text_edits, UseCompletionItemAdditionTextEditsRequest,
     },
-    visibility::module_def_id_is_visible,
 };
 
 use super::CodeActionFinder;
@@ -42,14 +41,7 @@ impl<'a> CodeActionFinder<'a> {
             }
 
             for (module_def_id, visibility, defining_module) in entries {
-                if !module_def_id_is_visible(
-                    *module_def_id,
-                    self.module_id,
-                    *visibility,
-                    *defining_module,
-                    self.interner,
-                    self.def_maps,
-                ) {
+                if !self.module_def_id_is_visible(*module_def_id, *visibility, *defining_module) {
                     continue;
                 }
 

--- a/tooling/lsp/src/requests/code_action/import_trait.rs
+++ b/tooling/lsp/src/requests/code_action/import_trait.rs
@@ -56,6 +56,8 @@ impl<'a> CodeActionFinder<'a> {
         let visibility = trait_.visibility;
         let module_def_id = ModuleDefId::TraitId(trait_id);
         let mut trait_reexport = None;
+
+        // If the item is offered via a re-export of it's parent module, this holds the name of the reexport.
         let mut intermediate_name = None;
 
         if !self.module_def_id_is_visible(module_def_id, visibility, None) {

--- a/tooling/lsp/src/requests/code_action/import_trait.rs
+++ b/tooling/lsp/src/requests/code_action/import_trait.rs
@@ -13,7 +13,6 @@ use crate::{
     use_segment_positions::{
         use_completion_item_additional_text_edits, UseCompletionItemAdditionTextEditsRequest,
     },
-    visibility::module_def_id_is_visible,
 };
 
 use super::CodeActionFinder;
@@ -58,27 +57,13 @@ impl<'a> CodeActionFinder<'a> {
         let module_def_id = ModuleDefId::TraitId(trait_id);
         let mut trait_reexport = None;
 
-        if !module_def_id_is_visible(
-            module_def_id,
-            self.module_id,
-            visibility,
-            None,
-            self.interner,
-            self.def_maps,
-        ) {
+        if !self.module_def_id_is_visible(module_def_id, visibility, None) {
             // If it's not, try to find a visible reexport of the trait
             // that is visible from the current module
             let Some((visible_module_id, name, _)) =
                 self.interner.get_trait_reexports(trait_id).iter().find(
                     |(module_id, _, visibility)| {
-                        module_def_id_is_visible(
-                            module_def_id,
-                            self.module_id,
-                            *visibility,
-                            Some(*module_id),
-                            self.interner,
-                            self.def_maps,
-                        )
+                        self.module_def_id_is_visible(module_def_id, *visibility, Some(*module_id))
                     },
                 )
             else {

--- a/tooling/lsp/src/requests/code_action/import_trait.rs
+++ b/tooling/lsp/src/requests/code_action/import_trait.rs
@@ -76,7 +76,9 @@ impl<'a> CodeActionFinder<'a> {
                     module_id: reexport.module_id,
                     name: reexport.name.clone(),
                 });
-            } else if let Some(reexport) = self.get_parent_module_reexport(module_def_id) {
+            } else if let Some(reexport) =
+                self.get_ancestor_module_reexport(module_def_id, visibility)
+            {
                 trait_reexport = Some(TraitReexport {
                     module_id: reexport.module_id,
                     name: trait_.name.clone(),

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -686,26 +686,20 @@ impl<'a> NodeFinder<'a> {
                     let modifiers = self.interner.function_modifiers(&func_id);
                     let visibility = modifiers.visibility;
                     let module_def_id = ModuleDefId::TraitId(trait_id);
-                    if !module_def_id_is_visible(
+                    if !self.module_def_id_is_visible(
                         module_def_id,
-                        self.module_id,
                         visibility,
                         None, // defining module
-                        self.interner,
-                        self.def_maps,
                     ) {
                         // Try to find a visible reexport of the trait
                         // that is visible from the current module
                         let Some((visible_module_id, name, _)) =
                             self.interner.get_trait_reexports(trait_id).iter().find(
                                 |(module_id, _, visibility)| {
-                                    module_def_id_is_visible(
+                                    self.module_def_id_is_visible(
                                         module_def_id,
-                                        self.module_id,
                                         *visibility,
                                         Some(*module_id),
-                                        self.interner,
-                                        self.def_maps,
                                     )
                                 },
                             )
@@ -1179,6 +1173,22 @@ impl<'a> NodeFinder<'a> {
         }
 
         Some(())
+    }
+
+    fn module_def_id_is_visible(
+        &self,
+        module_def_id: ModuleDefId,
+        visibility: ItemVisibility,
+        defining_module: Option<ModuleId>,
+    ) -> bool {
+        module_def_id_is_visible(
+            module_def_id,
+            self.module_id,
+            visibility,
+            defining_module,
+            self.interner,
+            self.def_maps,
+        )
     }
 
     fn includes_span(&self, span: Span) -> bool {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -686,30 +686,29 @@ impl<'a> NodeFinder<'a> {
                     let modifiers = self.interner.function_modifiers(&func_id);
                     let visibility = modifiers.visibility;
                     let module_def_id = ModuleDefId::TraitId(trait_id);
-                    if !self.module_def_id_is_visible(
+                    let is_visible = self.module_def_id_is_visible(
                         module_def_id,
                         visibility,
                         None, // defining module
-                    ) {
+                    );
+                    if !is_visible {
                         // Try to find a visible reexport of the trait
                         // that is visible from the current module
-                        let Some((visible_module_id, name, _)) =
-                            self.interner.get_trait_reexports(trait_id).iter().find(
-                                |(module_id, _, visibility)| {
-                                    self.module_def_id_is_visible(
-                                        module_def_id,
-                                        *visibility,
-                                        Some(*module_id),
-                                    )
-                                },
-                            )
+                        let Some(reexport) =
+                            self.interner.get_trait_reexports(trait_id).iter().find(|reexport| {
+                                self.module_def_id_is_visible(
+                                    module_def_id,
+                                    reexport.visibility,
+                                    Some(reexport.module_id),
+                                )
+                            })
                         else {
                             continue;
                         };
 
                         trait_reexport = Some(TraitReexport {
-                            module_id: *visible_module_id,
-                            name: name.clone(),
+                            module_id: reexport.module_id,
+                            name: reexport.name.clone(),
                         });
                     }
                 }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -707,7 +707,10 @@ impl<'a> NodeFinder<'a> {
                             continue;
                         };
 
-                        trait_reexport = Some(TraitReexport { module_id: visible_module_id, name });
+                        trait_reexport = Some(TraitReexport {
+                            module_id: *visible_module_id,
+                            name: name.clone(),
+                        });
                     }
                 }
 

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1188,6 +1188,7 @@ impl<'a> NodeFinder<'a> {
             defining_module,
             self.interner,
             self.def_maps,
+            self.dependencies,
         )
     }
 

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -1,7 +1,7 @@
 use noirc_frontend::{hir::def_map::ModuleDefId, node_interner::Reexport};
 
 use crate::{
-    modules::{get_parent_module_reexport, module_def_id_relative_path},
+    modules::{get_ancestor_module_reexport, module_def_id_relative_path},
     use_segment_positions::{
         use_completion_item_additional_text_edits, UseCompletionItemAdditionTextEditsRequest,
     },
@@ -45,7 +45,7 @@ impl<'a> NodeFinder<'a> {
                 if !is_visible {
                     if let Some(reexport) = self.get_parent_module_reexport(module_def_id) {
                         defining_module = Some(reexport.module_id);
-                        intermediate_name = Some(reexport.name.clone());
+                        intermediate_name = Some(reexport.name);
                     } else {
                         continue;
                     }
@@ -101,8 +101,8 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
-    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<&Reexport> {
-        get_parent_module_reexport(
+    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<Reexport> {
+        get_ancestor_module_reexport(
             module_def_id,
             self.module_id,
             self.interner,

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -4,7 +4,7 @@ use noirc_frontend::{
 };
 
 use crate::{
-    modules::{get_parent_module, relative_module_full_path, relative_module_id_path},
+    modules::{get_parent_module_reexport, relative_module_full_path, relative_module_id_path},
     use_segment_positions::{
         use_completion_item_additional_text_edits, UseCompletionItemAdditionTextEditsRequest,
     },
@@ -121,17 +121,13 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
-    /// Finds a visible reexport for the parent module of the given ModuleDefId.
     fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<(ModuleId, Ident)> {
-        let parent_module = get_parent_module(self.interner, module_def_id)?;
-        let (parent_module_reexport, name, _) = self
-            .interner
-            .get_reexports(ModuleDefId::ModuleId(parent_module))
-            .iter()
-            .find(|(module_id, _, visibility)| {
-                self.module_def_id_is_visible(ModuleDefId::ModuleId(*module_id), *visibility, None)
-            })?;
-
-        Some((*parent_module_reexport, name.clone()))
+        get_parent_module_reexport(
+            module_def_id,
+            self.module_id,
+            self.interner,
+            self.def_maps,
+            self.dependencies,
+        )
     }
 }

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -5,7 +5,6 @@ use crate::{
     use_segment_positions::{
         use_completion_item_additional_text_edits, UseCompletionItemAdditionTextEditsRequest,
     },
-    visibility::module_def_id_is_visible,
 };
 
 use super::{
@@ -34,14 +33,7 @@ impl<'a> NodeFinder<'a> {
                     continue;
                 }
 
-                if !module_def_id_is_visible(
-                    *module_def_id,
-                    self.module_id,
-                    *visibility,
-                    *defining_module,
-                    self.interner,
-                    self.def_maps,
-                ) {
+                if !self.module_def_id_is_visible(*module_def_id, *visibility, *defining_module) {
                     continue;
                 }
 

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -36,6 +36,8 @@ impl<'a> NodeFinder<'a> {
 
                 let visibility = entry.visibility;
                 let mut defining_module = entry.defining_module.as_ref().cloned();
+
+                // If the item is offered via a re-export of it's parent module, this holds the name of the reexport.
                 let mut intermediate_name = None;
 
                 let is_visible =

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -1,7 +1,7 @@
 use noirc_frontend::{hir::def_map::ModuleDefId, node_interner::Reexport};
 
 use crate::{
-    modules::{get_parent_module_reexport, relative_module_full_path, relative_module_id_path},
+    modules::{get_parent_module_reexport, module_def_id_relative_path},
     use_segment_positions::{
         use_completion_item_additional_text_edits, UseCompletionItemAdditionTextEditsRequest,
     },
@@ -66,35 +66,16 @@ impl<'a> NodeFinder<'a> {
                 self.suggested_module_def_ids.insert(module_def_id);
 
                 for mut completion_item in completion_items {
-                    let module_full_path = if let Some(defining_module) = defining_module {
-                        relative_module_id_path(
-                            defining_module,
-                            &self.module_id,
-                            current_module_parent_id,
-                            self.interner,
-                        )
-                    } else {
-                        let Some(module_full_path) = relative_module_full_path(
-                            module_def_id,
-                            self.module_id,
-                            current_module_parent_id,
-                            self.interner,
-                        ) else {
-                            continue;
-                        };
-                        module_full_path
-                    };
-
-                    let full_path = if defining_module.is_some()
-                        || !matches!(module_def_id, ModuleDefId::ModuleId(..))
-                    {
-                        if let Some(reexport_name) = &intermediate_name {
-                            format!("{}::{}::{}", module_full_path, reexport_name, name)
-                        } else {
-                            format!("{}::{}", module_full_path, name)
-                        }
-                    } else {
-                        module_full_path
+                    let Some(full_path) = module_def_id_relative_path(
+                        module_def_id,
+                        name,
+                        self.module_id,
+                        current_module_parent_id,
+                        defining_module,
+                        &intermediate_name,
+                        self.interner,
+                    ) else {
+                        continue;
                     };
 
                     let mut label_details = completion_item.label_details.unwrap();

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -31,19 +31,21 @@ impl<'a> NodeFinder<'a> {
                 continue;
             }
 
-            for (module_def_id, visibility, defining_module) in entries {
-                if self.suggested_module_def_ids.contains(module_def_id) {
+            for entry in entries {
+                let module_def_id = entry.module_def_id;
+                if self.suggested_module_def_ids.contains(&module_def_id) {
                     continue;
                 }
 
-                let mut defining_module = defining_module.as_ref().cloned();
+                let visibility = entry.visibility;
+                let mut defining_module = entry.defining_module.as_ref().cloned();
                 let mut intermediate_name = None;
 
                 let is_visible =
-                    self.module_def_id_is_visible(*module_def_id, *visibility, defining_module);
+                    self.module_def_id_is_visible(module_def_id, visibility, defining_module);
                 if !is_visible {
                     if let Some((parent_module_reexport, reexport_name)) =
-                        self.get_parent_module_reexport(*module_def_id)
+                        self.get_parent_module_reexport(module_def_id)
                     {
                         defining_module = Some(parent_module_reexport);
                         intermediate_name = Some(reexport_name);
@@ -53,7 +55,7 @@ impl<'a> NodeFinder<'a> {
                 }
 
                 let completion_items = self.module_def_id_completion_items(
-                    *module_def_id,
+                    module_def_id,
                     name.clone(),
                     function_completion_kind,
                     FunctionKind::Any,
@@ -64,7 +66,7 @@ impl<'a> NodeFinder<'a> {
                     continue;
                 };
 
-                self.suggested_module_def_ids.insert(*module_def_id);
+                self.suggested_module_def_ids.insert(module_def_id);
 
                 for mut completion_item in completion_items {
                     let module_full_path = if let Some(defining_module) = defining_module {
@@ -76,7 +78,7 @@ impl<'a> NodeFinder<'a> {
                         )
                     } else {
                         let Some(module_full_path) = relative_module_full_path(
-                            *module_def_id,
+                            module_def_id,
                             self.module_id,
                             current_module_parent_id,
                             self.interner,

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -1,7 +1,4 @@
-use noirc_frontend::{
-    ast::Ident,
-    hir::def_map::{ModuleDefId, ModuleId},
-};
+use noirc_frontend::{hir::def_map::ModuleDefId, node_interner::Reexport};
 
 use crate::{
     modules::{get_parent_module_reexport, relative_module_full_path, relative_module_id_path},
@@ -44,11 +41,9 @@ impl<'a> NodeFinder<'a> {
                 let is_visible =
                     self.module_def_id_is_visible(module_def_id, visibility, defining_module);
                 if !is_visible {
-                    if let Some((parent_module_reexport, reexport_name)) =
-                        self.get_parent_module_reexport(module_def_id)
-                    {
-                        defining_module = Some(parent_module_reexport);
-                        intermediate_name = Some(reexport_name);
+                    if let Some(reexport) = self.get_parent_module_reexport(module_def_id) {
+                        defining_module = Some(reexport.module_id);
+                        intermediate_name = Some(reexport.name.clone());
                     } else {
                         continue;
                     }
@@ -123,7 +118,7 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
-    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<(ModuleId, Ident)> {
+    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<&Reexport> {
         get_parent_module_reexport(
             module_def_id,
             self.module_id,

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -1,4 +1,4 @@
-use noirc_frontend::{hir::def_map::ModuleDefId, node_interner::Reexport};
+use noirc_frontend::{ast::ItemVisibility, hir::def_map::ModuleDefId, node_interner::Reexport};
 
 use crate::{
     modules::{get_ancestor_module_reexport, module_def_id_relative_path},
@@ -43,7 +43,9 @@ impl<'a> NodeFinder<'a> {
                 let is_visible =
                     self.module_def_id_is_visible(module_def_id, visibility, defining_module);
                 if !is_visible {
-                    if let Some(reexport) = self.get_parent_module_reexport(module_def_id) {
+                    if let Some(reexport) =
+                        self.get_ancestor_module_reexport(module_def_id, visibility)
+                    {
                         defining_module = Some(reexport.module_id);
                         intermediate_name = Some(reexport.name);
                     } else {
@@ -101,9 +103,14 @@ impl<'a> NodeFinder<'a> {
         }
     }
 
-    fn get_parent_module_reexport(&self, module_def_id: ModuleDefId) -> Option<Reexport> {
+    fn get_ancestor_module_reexport(
+        &self,
+        module_def_id: ModuleDefId,
+        visibility: ItemVisibility,
+    ) -> Option<Reexport> {
         get_ancestor_module_reexport(
             module_def_id,
+            visibility,
             self.module_id,
             self.interner,
             self.def_maps,

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -395,15 +395,15 @@ impl<'a> NodeFinder<'a> {
         let (trait_id, trait_reexport) = trait_info?;
 
         let trait_name = if let Some(trait_reexport) = trait_reexport {
-            trait_reexport.name
+            trait_reexport.name.clone()
         } else {
             let trait_ = self.interner.get_trait(trait_id);
-            &trait_.name
+            trait_.name.clone()
         };
 
         let module_data =
             &self.def_maps[&self.module_id.krate].modules()[self.module_id.local_id.0];
-        if !module_data.scope().find_name(trait_name).is_none() {
+        if !module_data.scope().find_name(&trait_name).is_none() {
             return None;
         }
 
@@ -411,7 +411,7 @@ impl<'a> NodeFinder<'a> {
         let current_module_parent_id = self.module_id.parent(self.def_maps);
         let module_full_path = if let Some(reexport_data) = trait_reexport {
             relative_module_id_path(
-                *reexport_data.module_id,
+                reexport_data.module_id,
                 &self.module_id,
                 current_module_parent_id,
                 self.interner,

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -412,7 +412,7 @@ impl<'a> NodeFinder<'a> {
         let module_full_path = if let Some(reexport_data) = trait_reexport {
             relative_module_id_path(
                 reexport_data.module_id,
-                &self.module_id,
+                self.module_id,
                 current_module_parent_id,
                 self.interner,
             )

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3308,4 +3308,26 @@ fn main() {
             apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
         assert_eq!(changed, expected);
     }
+
+    #[test]
+    async fn does_not_autocomplete_nested_type_via_parent_module_reexport_if_it_is_not_visible() {
+        let src = r#"mod aztec {
+    mod deps {
+        pub mod protocol_types {
+            pub mod nested {
+                struct SomeStruct {}
+            }
+        }
+    }
+
+    pub use deps::protocol_types;
+}
+
+fn main() {
+    SomeStru>|<
+}"#;
+
+        let items = get_completions(src).await;
+        assert_eq!(items.len(), 0);
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3157,4 +3157,102 @@ fn main() {
         let item = &items[0];
         assert_eq!(item.kind, Some(CompletionItemKind::ENUM));
     }
+
+    #[test]
+    async fn autocompletes_via_parent_module_reexport() {
+        let src = r#"mod aztec {
+    mod deps {
+        pub mod protocol_types {
+            pub struct SomeStruct {}
+        }
+    }
+
+    pub use deps::protocol_types;
+}
+
+fn main() {
+    SomeStru>|<
+}"#;
+
+        let mut items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = items.remove(0);
+        assert_eq!(
+            item.label_details,
+            Some(CompletionItemLabelDetails {
+                detail: Some("(use aztec::protocol_types::SomeStruct)".to_string()),
+                description: Some("SomeStruct".to_string()),
+            })
+        );
+
+        let expected = r#"use aztec::protocol_types::SomeStruct;
+
+mod aztec {
+    mod deps {
+        pub mod protocol_types {
+            pub struct SomeStruct {}
+        }
+    }
+
+    pub use deps::protocol_types;
+}
+
+fn main() {
+    SomeStru
+}"#;
+
+        let changed =
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
+        assert_eq!(changed, expected);
+    }
+
+    #[test]
+    async fn autocompletes_via_renamed_parent_module_reexport() {
+        let src = r#"mod aztec {
+    mod deps {
+        pub mod protocol_types {
+            pub struct SomeStruct {}
+        }
+    }
+
+    pub use deps::protocol_types as export;
+}
+
+fn main() {
+    SomeStru>|<
+}"#;
+
+        let mut items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = items.remove(0);
+        assert_eq!(
+            item.label_details,
+            Some(CompletionItemLabelDetails {
+                detail: Some("(use aztec::export::SomeStruct)".to_string()),
+                description: Some("SomeStruct".to_string()),
+            })
+        );
+
+        let expected = r#"use aztec::export::SomeStruct;
+
+mod aztec {
+    mod deps {
+        pub mod protocol_types {
+            pub struct SomeStruct {}
+        }
+    }
+
+    pub use deps::protocol_types as export;
+}
+
+fn main() {
+    SomeStru
+}"#;
+
+        let changed =
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
+        assert_eq!(changed, expected);
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3330,4 +3330,61 @@ fn main() {
         let items = get_completions(src).await;
         assert_eq!(items.len(), 0);
     }
+
+    #[test]
+    async fn autocompletes_deeply_nested_type_via_parent_module_reexport() {
+        let src = r#"mod aztec {
+    mod deps {
+        pub mod protocol_types {
+            pub mod deeply {
+                pub mod nested {
+                    pub struct SomeStruct {}
+                }
+            }
+        }
+    }
+
+    pub use deps::protocol_types;
+}
+
+fn main() {
+    SomeStru>|<
+}"#;
+
+        let mut items = get_completions(src).await;
+        assert_eq!(items.len(), 1);
+
+        let item = items.remove(0);
+        assert_eq!(
+            item.label_details,
+            Some(CompletionItemLabelDetails {
+                detail: Some("(use aztec::protocol_types::deeply::nested::SomeStruct)".to_string()),
+                description: Some("SomeStruct".to_string()),
+            })
+        );
+
+        let expected = r#"use aztec::protocol_types::deeply::nested::SomeStruct;
+
+mod aztec {
+    mod deps {
+        pub mod protocol_types {
+            pub mod deeply {
+                pub mod nested {
+                    pub struct SomeStruct {}
+                }
+            }
+        }
+    }
+
+    pub use deps::protocol_types;
+}
+
+fn main() {
+    SomeStru
+}"#;
+
+        let changed =
+            apply_text_edits(&src.replace(">|<", ""), &item.additional_text_edits.unwrap());
+        assert_eq!(changed, expected);
+    }
 }

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -657,9 +657,9 @@ pub(crate) fn find_all_references(
 }
 
 /// Represents a trait reexported from a given module with a name.
-pub(crate) struct TraitReexport<'a> {
-    pub(super) module_id: &'a ModuleId,
-    pub(super) name: &'a Ident,
+pub(crate) struct TraitReexport {
+    pub(super) module_id: ModuleId,
+    pub(super) name: Ident,
 }
 
 #[cfg(test)]

--- a/tooling/lsp/src/trait_impl_method_stub_generator.rs
+++ b/tooling/lsp/src/trait_impl_method_stub_generator.rs
@@ -204,7 +204,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
 
                 let relative_path = relative_module_id_path(
                     parent_module_id,
-                    &self.module_id,
+                    self.module_id,
                     current_module_parent_id,
                     self.interner,
                 );
@@ -241,7 +241,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
 
                 let relative_path = relative_module_id_path(
                     *parent_module_id,
-                    &self.module_id,
+                    self.module_id,
                     current_module_parent_id,
                     self.interner,
                 );
@@ -278,7 +278,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
 
                 let relative_path = relative_module_id_path(
                     *parent_module_id,
-                    &self.module_id,
+                    self.module_id,
                     current_module_parent_id,
                     self.interner,
                 );

--- a/tooling/lsp/src/visibility.rs
+++ b/tooling/lsp/src/visibility.rs
@@ -23,7 +23,7 @@ pub(super) fn module_def_id_is_visible(
     mut defining_module: Option<ModuleId>,
     interner: &NodeInterner,
     def_maps: &BTreeMap<CrateId, CrateDefMap>,
-    dependencies: &Vec<Dependency>,
+    dependencies: &[Dependency],
 ) -> bool {
     // First find out which module we need to check.
     // If a module is trying to be referenced, it's that module. Otherwise it's the module that contains the item.


### PR DESCRIPTION
# Description

## Problem

Resolves #7378

## Summary

This is a new feature but also a bug fix.

The bug was that if a type was directly visible from the current module it was offered for autocompletion. However, that didn't take into account if the type was actually in a crate that's in one of the current crate's dependencies. That's why in the original issue `protocol_types::traits::Packable` was offered: if it were a dependency it's good to suggest that... but it's not!

Then the feature is that we now track all of an item's reexports (not just traits). Then, if the item isn't directly visible we search for that item's parent module's reexports. If there's one visible, we can suggest importing the item via the parent module's reexport. This is done recursively so that if the parent doesn't have a reexport but the grandparent module has one, that's used instead.

Here's how `Packable` is imported now:

![lsp-import-via-reexport](https://github.com/user-attachments/assets/7bc8e697-8335-4f9c-84e6-6f22d156fc06)

## Additional Context

The changes here are bigger than just the above things because I also took the time to refactor and remove some code duplication that existed, and that now would have gotten even bigger. I tried to document the code as much as possible because the logic is getting more and more complex by the minute.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
