### PR TITLE
chore: deprecate `merkle` module of stdlib

### DIFF
--- a/noir_stdlib/src/merkle.nr
+++ b/noir_stdlib/src/merkle.nr
@@ -2,6 +2,7 @@
 // Currently we assume that it is a binary tree, so depth k implies a width of 2^k
 // XXX: In the future we can add an arity parameter
 // Returns the merkle root of the tree from the provided leaf, its hashpath, using a pedersen hash function.
+#[deprecated("This function will be removed from the stdlib in version 1.0.0-beta.4")]
 pub fn compute_merkle_root<let N: u32>(leaf: Field, index: Field, hash_path: [Field; N]) -> Field {
     let index_bits: [u1; N] = index.to_le_bits();
     let mut current = leaf;


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This function should really not be in the stdlib so I'm deprecating it so we can remove it after the next release goes out.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
