### PR TITLE
chore: redo typo PR by maximevtush

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -658,7 +658,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             }
             InterpreterError::GenericNameShouldBeAnIdent { name, location } => {
                 let msg =
-                    "Generic name needs to be a valid identifer (one word beginning with a letter)"
+                    "Generic name needs to be a valid identifier (one word beginning with a letter)"
                         .to_string();
                 let secondary = format!("`{name}` is not a valid identifier");
                 CustomDiagnostic::simple_error(msg, secondary, location.span)

--- a/test_programs/compile_failure/primary_attribute_struct/src/main.nr
+++ b/test_programs/compile_failure/primary_attribute_struct/src/main.nr
@@ -1,4 +1,4 @@
-// An primary attribute should not be able to be added to a struct defintion
+// An primary attribute should not be able to be added to a struct definition
 #[oracle(some_oracle)]
 struct SomeStruct{
     x: Field,

--- a/test_programs/compile_success_empty/trait_method_mut_self/src/main.nr
+++ b/test_programs/compile_success_empty/trait_method_mut_self/src/main.nr
@@ -71,7 +71,7 @@ where
 {
     // Check that we can call a trait method instead of a trait implementation
     // TODO: Need to remove the need for this type annotation
-    // TODO: Curently, without the annotation we will get `Expression type is ambiguous` when trying to use the `hasher`
+    // TODO: Currently, without the annotation we will get `Expression type is ambiguous` when trying to use the `hasher`
     let mut hasher: H = H::default();
     // Regression that the object is converted to a mutable reference type `&mut _`.
     // Otherwise will see `Expected type &mut _, found type H`.

--- a/test_programs/execution_success/brillig_conditional/src/main.nr
+++ b/test_programs/execution_success/brillig_conditional/src/main.nr
@@ -1,6 +1,6 @@
 // Tests a very simple program.
 //
-// The features being tested is basic conditonal on brillig
+// The features being tested is basic conditional on brillig
 fn main(x: Field) {
     // Safety: testing context
     unsafe {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1133,7 +1133,7 @@ impl<'a> NodeFinder<'a> {
 
     /// Try to suggest the name of a module to declare based on which
     /// files exist in the filesystem, excluding modules that are already declared.
-    fn complete_module_delcaration(&mut self, module: &ModuleDeclaration) -> Option<()> {
+    fn complete_module_declaration(&mut self, module: &ModuleDeclaration) -> Option<()> {
         let filename = self.files.get_absolute_name(self.file).ok()?.into_path_buf();
 
         let is_main_lib_or_mod = filename.ends_with("main.nr")
@@ -1869,7 +1869,7 @@ impl<'a> Visitor for NodeFinder<'a> {
             return;
         }
 
-        self.complete_module_delcaration(module);
+        self.complete_module_declaration(module);
     }
 }
 

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2345,7 +2345,7 @@ fn main() {
     }
 
     #[test]
-    async fn test_auto_import_suggests_private_function_if_visibile() {
+    async fn test_auto_import_suggests_private_function_if_visible() {
         let src = r#"
             mod foo {
                 fn qux() {


### PR DESCRIPTION
Thanks maximevtush for https://github.com/noir-lang/noir/pull/7420. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.