### PR TITLE
feat: simplify assertions that squared values are equal to zero

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/constrain.rs
@@ -177,3 +177,31 @@ pub(super) fn decompose_constrain(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa};
+
+    #[test]
+    fn simplifies_assertions_that_squared_values_are_equal_to_zero() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = mul v0, v0
+            constrain v1 == Field 0
+            return
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+
+        let expected = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = mul v0, v0
+            constrain v0 == Field 0
+            return
+        }
+        ";
+        assert_normalized_ssa_equals(ssa, expected);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Something I noticed when reviewing #7301 

## Summary\*

We currently don't simplify 

```
 v1 = mul v0, v0
constrain v1 == u1 0
```

into

```
constrain v0 == u1 0
```

I've then added this as an optimization when decomposing constraints.

This looks like it should be safe to me due to us using a prime field so there's no nonzero solutions to `v0 * v0 == 0`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
