### PR TITLE
fix(performance): Remove redundant slice access check from brillig

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -768,7 +768,9 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 let index_variable = self.convert_ssa_single_addr_value(*index, dfg);
 
                 // Slice access checks are generated separately against the slice's dynamic length field.
-                if !dfg.is_safe_index(*index, *array) && matches!(dfg.type_of_value(*array), Type::Array(..))  {
+                if !dfg.is_safe_index(*index, *array)
+                    && matches!(dfg.type_of_value(*array), Type::Array(..))
+                {
                     self.validate_array_index(array_variable, index_variable);
                 }
 
@@ -797,7 +799,9 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 );
 
                 // Slice access checks are generated separately against the slice's dynamic length field.
-                if !dfg.is_safe_index(*index, *array) && matches!(dfg.type_of_value(*array), Type::Array(..)) {
+                if !dfg.is_safe_index(*index, *array)
+                    && matches!(dfg.type_of_value(*array), Type::Array(..))
+                {
                     self.validate_array_index(source_variable, index_register);
                 }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -767,7 +767,8 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
 
                 let index_variable = self.convert_ssa_single_addr_value(*index, dfg);
 
-                if !dfg.is_safe_index(*index, *array) {
+                // Slice access checks are generated separately against the slice's dynamic length field.
+                if !dfg.is_safe_index(*index, *array) && matches!(dfg.type_of_value(*array), Type::Array(..))  {
                     self.validate_array_index(array_variable, index_variable);
                 }
 
@@ -795,7 +796,8 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                     dfg,
                 );
 
-                if !dfg.is_safe_index(*index, *array) {
+                // Slice access checks are generated separately against the slice's dynamic length field.
+                if !dfg.is_safe_index(*index, *array) && matches!(dfg.type_of_value(*array), Type::Array(..)) {
                     self.validate_array_index(source_variable, index_register);
                 }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -768,8 +768,8 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 let index_variable = self.convert_ssa_single_addr_value(*index, dfg);
 
                 // Slice access checks are generated separately against the slice's dynamic length field.
-                if !dfg.is_safe_index(*index, *array)
-                    && matches!(dfg.type_of_value(*array), Type::Array(..))
+                if matches!(dfg.type_of_value(*array), Type::Array(..))
+                    && !dfg.is_safe_index(*index, *array)
                 {
                     self.validate_array_index(array_variable, index_variable);
                 }
@@ -799,8 +799,8 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 );
 
                 // Slice access checks are generated separately against the slice's dynamic length field.
-                if !dfg.is_safe_index(*index, *array)
-                    && matches!(dfg.type_of_value(*array), Type::Array(..))
+                if matches!(dfg.type_of_value(*array), Type::Array(..))
+                    && !dfg.is_safe_index(*index, *array)
                 {
                     self.validate_array_index(source_variable, index_register);
                 }


### PR DESCRIPTION
# Description

## Problem\*

No issue, small optimization I found while exploring other Brillig gen optimizations.

## Summary\*

For every slice access, we code gen a slice access check against its dynamic index: https://github.com/noir-lang/noir/blob/988adae231c1aca09fd4d08d5e7bf5e72deecf9d/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs#L475

In Brillig gen we use `!dfg.is_safe_index` to determine whether to code gen an array index. This always returns false for slice types as we cannot check against their length. However, we already have generated a check the precedes the array access. We should generate this validation code for array types in Brillig gen.

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
