### PR TITLE
fix: require loop/for/while body to be unit

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -245,6 +245,45 @@ impl Expression {
     pub fn new(kind: ExpressionKind, span: Span) -> Expression {
         Expression { kind, span }
     }
+
+    /// Returns the innermost span that gives this expression its type.
+    pub fn type_span(&self) -> Span {
+        match &self.kind {
+            ExpressionKind::Block(block_expression)
+            | ExpressionKind::Comptime(block_expression, _)
+            | ExpressionKind::Unsafe(block_expression, _) => {
+                if let Some(statement) = block_expression.statements.last() {
+                    statement.type_span()
+                } else {
+                    self.span
+                }
+            }
+            ExpressionKind::Parenthesized(expression) => expression.type_span(),
+            ExpressionKind::Literal(..)
+            | ExpressionKind::Prefix(..)
+            | ExpressionKind::Index(..)
+            | ExpressionKind::Call(..)
+            | ExpressionKind::MethodCall(..)
+            | ExpressionKind::Constrain(..)
+            | ExpressionKind::Constructor(..)
+            | ExpressionKind::MemberAccess(..)
+            | ExpressionKind::Cast(..)
+            | ExpressionKind::Infix(..)
+            | ExpressionKind::If(..)
+            | ExpressionKind::Match(..)
+            | ExpressionKind::Variable(..)
+            | ExpressionKind::Tuple(..)
+            | ExpressionKind::Lambda(..)
+            | ExpressionKind::Quote(..)
+            | ExpressionKind::Unquote(..)
+            | ExpressionKind::AsTraitPath(..)
+            | ExpressionKind::TypePath(..)
+            | ExpressionKind::Resolved(..)
+            | ExpressionKind::Interned(..)
+            | ExpressionKind::InternedStatement(..)
+            | ExpressionKind::Error => self.span,
+        }
+    }
 }
 
 pub type BinaryOp = Spanned<BinaryOpKind>;

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -73,6 +73,24 @@ impl Statement {
         self.kind = self.kind.add_semicolon(semi, span, last_statement_in_block, emit_error);
         self
     }
+
+    /// Returns the innermost span that gives this statement its type.
+    pub fn type_span(&self) -> Span {
+        match &self.kind {
+            StatementKind::Expression(expression) => expression.type_span(),
+            StatementKind::Comptime(statement) => statement.type_span(),
+            StatementKind::Let(..)
+            | StatementKind::Assign(..)
+            | StatementKind::For(..)
+            | StatementKind::Loop(..)
+            | StatementKind::While(..)
+            | StatementKind::Break
+            | StatementKind::Continue
+            | StatementKind::Semi(..)
+            | StatementKind::Interned(..)
+            | StatementKind::Error => self.span,
+        }
+    }
 }
 
 impl StatementKind {

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -274,7 +274,7 @@ impl Elaborator<'_> {
             let columns = vec![Column::new(variable_to_match, pattern)];
 
             let guard = None;
-            let body_span = branch.span;
+            let body_span = branch.type_span();
             let (body, body_type) = self.elaborate_expression(branch);
 
             self.unify(&body_type, &result_type, || TypeCheckError::TypeMismatch {
@@ -291,7 +291,7 @@ impl Elaborator<'_> {
 
     /// Convert an expression into a Pattern, defining any variables within.
     fn expression_to_pattern(&mut self, expression: Expression, expected_type: &Type) -> Pattern {
-        let expr_span = expression.span;
+        let expr_span = expression.type_span();
         let unify_with_expected_type = |this: &mut Self, actual| {
             this.unify(actual, expected_type, || TypeCheckError::TypeMismatch {
                 expected_typ: expected_type.to_string(),

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -971,8 +971,8 @@ impl<'context> Elaborator<'context> {
         if_expr: IfExpression,
         target_type: Option<&Type>,
     ) -> (HirExpression, Type) {
-        let expr_span = if_expr.condition.span;
-        let consequence_span = if_expr.consequence.span;
+        let expr_span = if_expr.condition.type_span();
+        let consequence_span = if_expr.consequence.type_span();
         let (condition, cond_type) = self.elaborate_expression(if_expr.condition);
         let (consequence, mut ret_type) =
             self.elaborate_expression_with_target_type(if_expr.consequence, target_type);
@@ -984,7 +984,7 @@ impl<'context> Elaborator<'context> {
         });
 
         let (alternative, else_type, error_span) = if let Some(alternative) = if_expr.alternative {
-            let alternative_span = alternative.span;
+            let alternative_span = alternative.type_span();
             let (else_, else_type) =
                 self.elaborate_expression_with_target_type(alternative, target_type);
             (Some(else_), else_type, alternative_span)

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -984,9 +984,10 @@ impl<'context> Elaborator<'context> {
         });
 
         let (alternative, else_type, error_span) = if let Some(alternative) = if_expr.alternative {
+            let alternative_span = alternative.span;
             let (else_, else_type) =
                 self.elaborate_expression_with_target_type(alternative, target_type);
-            (Some(else_), else_type, expr_span)
+            (Some(else_), else_type, alternative_span)
         } else {
             (None, Type::Unit, consequence_span)
         };

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4371,3 +4371,56 @@ fn does_not_stack_overflow_on_many_comments_in_a_row() {
     let src = "//\n".repeat(10_000);
     assert_no_errors(&src);
 }
+
+#[test]
+fn errors_if_for_body_type_is_not_unit() {
+    let src = r#"
+    fn main() {
+        for _ in 0..1 {
+            1
+        }
+    }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::TypeMismatch { .. }) = &errors[0].0 else {
+        panic!("Expected a TypeMismatch error");
+    };
+}
+
+#[test]
+fn errors_if_loop_body_type_is_not_unit() {
+    let src = r#"
+    unconstrained fn main() {
+        loop {
+            if false { break; }
+
+            1
+        }
+    }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::TypeMismatch { .. }) = &errors[0].0 else {
+        panic!("Expected a TypeMismatch error");
+    };
+}
+
+#[test]
+fn errors_if_while_body_type_is_not_unit() {
+    let src = r#"
+    unconstrained fn main() {
+        while 1 == 1 {
+            1
+        }
+    }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::TypeError(TypeCheckError::TypeMismatch { .. }) = &errors[0].0 else {
+        panic!("Expected a TypeMismatch error");
+    };
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #7408

## Summary

In addition to that:
1. It fixes an issue where the error span when the "then" and "else" branches of an "if" didn't match was wrong (I introduced that bug some weeks ago)
2. A new feature where some type errors will now point to more precise spans

For point 2, here's the error you got when the branches of an "if" didn't match:

![image](https://github.com/user-attachments/assets/46467383-036a-4137-8ac5-5f0ce26a3497)

And this is how it looks now:

![image](https://github.com/user-attachments/assets/942b15c6-00ed-4c0a-a1ae-b6f57f3c1af2)

That is, for a given expression we now point the type mismatch in the innermost expression that gives it its type.

The same is done for loops:

![image](https://github.com/user-attachments/assets/8402948c-0b16-41ca-be84-729facda45b0)

I made this change in places where a block usually happens. We could eventually do it in other places (prefix expression, index expressions, call arguments, etc.) as we find them, though using blocks there is pretty rare.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
