### PR TITLE
fix: do not discard negative sign from field literals in comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -715,6 +715,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         let location = self.elaborator.interner.expr_location(&id);
 
         if let Type::FieldElement = &typ {
+            let value = if is_negative { -value } else { value };
             Ok(Value::Field(value))
         } else if let Type::Integer(sign, bit_size) = &typ {
             match (sign, bit_size) {

--- a/test_programs/compile_success_empty/regression_7433/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_7433/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7433"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_7433/src/main.nr
+++ b/test_programs/compile_success_empty/regression_7433/src/main.nr
@@ -1,0 +1,7 @@
+// These two globals should cancel out.
+global positive_global: Field = 17;
+global negative_global: Field = -17; // Previously the negative sign here would be dropped so this became 17.
+
+fn main() {
+    assert_eq(positive_global + negative_global, 0);
+}


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves #7433 

## Summary\*

We are currently throwing away the sign when evaluating `Field` type literals in the interpreter which causes nasty weird behaviour as seen in #7433. I've updated the interpreter to negate the field properly in this case.

A regression test has been added along with a sanity check test I wrote while debugging to ensure that we parse these correctly.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
