### PR TITLE
feat(ci): Release noir-inspector in binaries

### DIFF
--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -60,12 +60,14 @@ jobs:
         run: |
           cargo build --package nargo_cli --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
           cargo build --package noir_profiler --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
+          cargo build --package noir_inspector --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
       
       - name: Package artifacts
         run: |
           mkdir dist
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           cp ./target/${{ matrix.target }}/release/noir-profiler ./dist/noir-profiler
+          cp ./target/${{ matrix.target }}/release/noir-inspector ./dist/noir-inspector
 
           # TODO(https://github.com/noir-lang/noir/issues/7445): Remove the separate nargo binary
           7z a -ttar -so -an ./dist/nargo | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
@@ -168,12 +170,14 @@ jobs:
         run: |
           cross build --package nargo_cli --release --target=${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
           cross build --package noir_profiler --release --target=${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
+          cargo build --package noir_inspector --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
 
       - name: Package artifacts
         run: |
           mkdir dist
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           cp ./target/${{ matrix.target }}/release/noir-profiler ./dist/noir-profiler
+          cp ./target/${{ matrix.target }}/release/noir-inspector ./dist/noir-inspector
 
           # TODO(https://github.com/noir-lang/noir/issues/7445): Remove the separate nargo binary
           tar -czf nargo-${{ matrix.target }}.tar.gz -C dist nargo

--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           cross build --package nargo_cli --release --target=${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
           cross build --package noir_profiler --release --target=${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
-          cargo build --package noir_inspector --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
+          cross build --package noir_inspector --release --target ${{ matrix.target }} --no-default-features --features "${{ inputs.features }}"
 
       - name: Package artifacts
         run: |


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7438 

I was thinking we could resolve the above issue and then make individual issues for new binaries we are ready to add to our releases (e.g. the artifact_cli)

## Summary\*

Add `noir-inspector` binary to our releases.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
