### PR TITLE
chore(ci): Missing dash in profiler command argument

### DIFF
--- a/docs/docs/tooling/profiler.md
+++ b/docs/docs/tooling/profiler.md
@@ -41,7 +41,7 @@ The program on its own is quite high-level. Let's get a more granular look at wh
 
 After compiling the program, run the following:
 ```sh
-noir-profiler opcodes --artifact-path ./target/program.json -output ./target/
+noir-profiler opcodes --artifact-path ./target/program.json --output ./target/
 ```
 Below you can see an example flamegraph with a total 387 opcodes (using `nargo` version 1.0.0-beta.2):
 <picture>


### PR DESCRIPTION
# Description

## Problem\*

No issue just something I noticed in https://github.com/noir-lang/noir/pull/7457. If someone were to copy-paste the command they would get an error, which is quite confusing.

## Summary\*

Specify the command arguments correctly.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
