### PR TITLE
chore(profiler): Use brillig names for outputted flamegraphs 

### DIFF
--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -127,7 +127,7 @@ fn run_with_generator(
         &debug_artifact,
         artifact_path.to_str().unwrap(),
         "main",
-        &Path::new(&output_path).join(Path::new(&format!("{}.svg", "main"))),
+        &Path::new(&output_path).join(Path::new(&format!("{}_brillig_trace.svg", "main"))),
     )?;
 
     Ok(())

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -100,9 +100,9 @@ fn run_with_provider<Provider: GatesProvider, Generator: FlamegraphGenerator>(
             .collect();
 
         let output_filename = if let Some(output_filename) = &output_filename {
-            format!("{}::{}::gates.svg", output_filename, func_name)
+            format!("{}_{}_gates.svg", output_filename, func_name)
         } else {
-            format!("{}::gates.svg", func_name)
+            format!("{}_gates.svg", func_name)
         };
         flamegraph_generator.generate_flamegraph(
             samples,

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -212,7 +212,7 @@ mod tests {
         .expect("should run without errors");
 
         // Check that the output file was written to
-        let output_file = temp_dir.path().join("test_filename::main::gates.svg");
+        let output_file = temp_dir.path().join("test_filename_main_gates.svg");
         assert!(output_file.exists());
     }
 }

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -274,7 +274,7 @@ mod tests {
         super::run_with_generator(&artifact_path, &flamegraph_generator, temp_dir.path(), false)
             .expect("should run without errors");
 
-        // Check that the output files that were written
+        // Check that the output files were written
         let output_file = temp_dir.path().join("main_acir_opcodes.svg");
         assert!(output_file.exists());
 

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -81,7 +81,8 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
             &debug_artifact,
             artifact_path.to_str().unwrap(),
             &function_name,
-            &Path::new(&output_path).join(Path::new(&format!("{}_acir_opcodes.svg", &function_name))),
+            &Path::new(&output_path)
+                .join(Path::new(&format!("{}_acir_opcodes.svg", &function_name))),
         )?;
     }
 
@@ -99,7 +100,8 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
 
         // We can have repeated names if there are functions with the same name in different
         // modules or functions that use generics. Thus, add the unique function index as a suffix.
-        let function_name = format!("{}_{}", brillig_names[brillig_fn_index].as_str(), brillig_fn_index);
+        let function_name =
+            format!("{}_{}", brillig_names[brillig_fn_index].as_str(), brillig_fn_index);
 
         println!("Opcode count for {}_brillig: {}", function_name, brillig_bytecode.bytecode.len());
 

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -235,12 +235,20 @@ mod tests {
 
         let artifact_path = temp_dir.path().join("test.json");
 
-        let acir: Vec<Opcode<FieldElement>> = vec![Opcode::BrilligCall {
-            id: BrilligFunctionId(0),
-            inputs: vec![],
-            outputs: vec![],
-            predicate: None,
-        }];
+        let acir: Vec<Opcode<FieldElement>> = vec![
+            Opcode::BrilligCall {
+                id: BrilligFunctionId(0),
+                inputs: vec![],
+                outputs: vec![],
+                predicate: None,
+            },
+            Opcode::BrilligCall {
+                id: BrilligFunctionId(1),
+                inputs: vec![],
+                outputs: vec![],
+                predicate: None,
+            },
+        ];
 
         let artifact = ProgramArtifact {
             noir_version: "0.0.0".to_string(),
@@ -248,12 +256,15 @@ mod tests {
             abi: noirc_abi::Abi::default(),
             bytecode: Program {
                 functions: vec![Circuit { opcodes: acir, ..Circuit::default() }],
-                unconstrained_functions: vec![BrilligBytecode::default()],
+                unconstrained_functions: vec![
+                    BrilligBytecode::default(),
+                    BrilligBytecode::default(),
+                ],
             },
             debug_symbols: ProgramDebugInfo { debug_infos: vec![DebugInfo::default()] },
             file_map: BTreeMap::default(),
             names: vec!["main".to_string()],
-            brillig_names: vec!["main".to_string()],
+            brillig_names: vec!["main".to_string(), "main".to_string()],
         };
 
         // Write the artifact to a file
@@ -265,11 +276,14 @@ mod tests {
         super::run_with_generator(&artifact_path, &flamegraph_generator, temp_dir.path(), false)
             .expect("should run without errors");
 
-        // Check that the output files ware written to
+        // Check that the output files that were written
         let output_file = temp_dir.path().join("main_acir_opcodes.svg");
         assert!(output_file.exists());
 
         let output_file = temp_dir.path().join("main_brillig_opcodes.svg");
+        assert!(output_file.exists());
+
+        let output_file = temp_dir.path().join("main_1_brillig_opcodes.svg");
         assert!(output_file.exists());
     }
 }

--- a/tooling/profiler/src/flamegraph.rs
+++ b/tooling/profiler/src/flamegraph.rs
@@ -112,7 +112,7 @@ impl FlamegraphGenerator for InfernoFlamegraphGenerator {
         let mut options = Options::default();
         options.hash = true;
         options.deterministic = true;
-        options.title = format!("{}-{}", artifact_name, function_name);
+        options.title = format!("Artifact: {}, Function: {}", artifact_name, function_name);
         options.frame_height = 24;
         options.color_diffusion = true;
         options.min_width = 0.0;


### PR DESCRIPTION
# Description

## Problem\*

No issue, just a QOL improvement I found while doing other documentation.

## Summary\*

We are using the brillig function index when writing a flamegraph file. 
e.g. Running `noir-profiler opcodes` on this program:
```noir
fn main(ptr: pub u32, mut array: [u32; 5]) -> pub [u32; 5] {
    // Safety: Sets all elements after `ptr` in `array` to zero.
    let new_array = unsafe { write_to_array(ptr, array) };
    for i in 0..5 {
        if i > ptr {
            assert_eq(new_array[i], 0);
        } else {
            assert_eq(new_array[i], array[i]);
        }
    }
    new_array
}
unconstrained fn write_to_array(ptr: u32, mut array: [u32; 5]) -> [u32; 5] {
    for i in 0..5 {
        if i > ptr {
            array[i] = 0;
        }
    }
    array
}
```
Will result in the following flamegraph files: `main_opcodes.svg`, `0_brillig_opcodes.svg`, `1_brillig_opcodes.svg`, `2_brillig_opcodes.svg`. The indices are pretty meaningless without a good amount extra context that is not reasonable to place on users.

Here is how the output directory looks after this PR:
<img width="329" alt="Screenshot 2025-02-20 at 3 50 19 PM" src="https://github.com/user-attachments/assets/7b79ac81-c20e-40bb-a2c3-186f55f34028" />

I also changed the flamegraph title:
<img width="1218" alt="Screenshot 2025-02-20 at 3 51 24 PM" src="https://github.com/user-attachments/assets/c8be75d9-a799-48aa-bcda-d03b3c799785" />

Before this PR the title would have just been `./target/program.json-brillig_0`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [X] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
