### PR TITLE
fix: issue duplicate error on impl function without self

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -515,7 +515,8 @@ impl<'context> Elaborator<'context> {
 
         let method_name_location = method_call.method_name.location();
         let method_name = method_call.method_name.0.contents.as_str();
-        match self.lookup_method(&object_type, method_name, location, true) {
+        let check_self_param = true;
+        match self.lookup_method(&object_type, method_name, location, check_self_param) {
             Some(method_ref) => {
                 // Automatically add `&mut` if the method expects a mutable reference and
                 // the object is not already one.

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -885,8 +885,11 @@ impl<'context> Elaborator<'context> {
     pub(super) fn elaborate_type_path(&mut self, path: TypePath) -> (ExprId, Type) {
         let location = path.item.location();
         let typ = self.resolve_type(path.typ);
+        let check_self_param = false;
 
-        let Some(method) = self.lookup_method(&typ, &path.item.0.contents, location, false) else {
+        let Some(method) =
+            self.lookup_method(&typ, &path.item.0.contents, location, check_self_param)
+        else {
             let error = Expression::new(ExpressionKind::Error, location);
             return self.elaborate_expression(error);
         };

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1406,10 +1406,11 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
         let typ = object.get_type().follow_bindings();
         let method_name = &call.method.0.contents;
+        let check_self_param = true;
 
         let method = self
             .elaborator
-            .lookup_method(&typ, method_name, location, true)
+            .lookup_method(&typ, method_name, location, check_self_param)
             .and_then(|method| method.func_id(self.elaborator.interner));
 
         if let Some(method) = method {

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1402,7 +1402,8 @@ impl NodeInterner {
                 });
 
                 if trait_id.is_none() && matches!(self_type, Type::DataType(..)) {
-                    if let Some(existing) = self.lookup_direct_method(self_type, &method_name, true)
+                    if let Some(existing) =
+                        self.lookup_direct_method(self_type, &method_name, false)
                     {
                         return Some(existing);
                     }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1405,7 +1405,7 @@ impl NodeInterner {
                 });
 
                 if trait_id.is_none() && matches!(self_type, Type::DataType(..)) {
-                    let check_self_param = false;
+                    let check_self_param = true;
                     if let Some(existing) =
                         self.lookup_direct_method(self_type, &method_name, check_self_param)
                     {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4475,3 +4475,24 @@ fn errors_on_unspecified_unstable_match() {
 
     assert!(matches!(error.reason(), Some(ParserErrorReason::ExperimentalFeature(_))));
 }
+
+#[test]
+fn check_impl_duplicate_method_without_self() {
+    let src = "
+    pub struct Foo {}
+
+    impl Foo {
+        fn foo() {}
+        fn foo() {}
+    }
+
+    fn main() {}
+    ";
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(
+        errors[0].0,
+        CompilationError::ResolverError(ResolverError::DuplicateDefinition { .. })
+    ));
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #7483

## Summary

~The first commit has the fix. The second one is a refactor.~

It turned out the first commit fixed the bug but introduced another one. So there's a third (fourth, after merge) commit that fixes both. The idea is to always store the type methods are added to and later check this type against the type a method is being added to.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
