### PR TITLE
fix(performance): Accurately mark safe constant indices for arrays of complex types

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -658,7 +658,11 @@ impl DataFlowGraph {
     pub(crate) fn is_safe_index(&self, index: ValueId, array: ValueId) -> bool {
         #[allow(clippy::match_like_matches_macro)]
         match (self.type_of_value(array), self.get_numeric_constant(index)) {
-            (Type::Array(elements, len), Some(index)) if index.to_u128() < (len as u128 * elements.len() as u128) => true,
+            (Type::Array(elements, len), Some(index))
+                if index.to_u128() < (len as u128 * elements.len() as u128) =>
+            {
+                true
+            }
             _ => false,
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -658,7 +658,7 @@ impl DataFlowGraph {
     pub(crate) fn is_safe_index(&self, index: ValueId, array: ValueId) -> bool {
         #[allow(clippy::match_like_matches_macro)]
         match (self.type_of_value(array), self.get_numeric_constant(index)) {
-            (Type::Array(_, len), Some(index)) if index.to_u128() < (len as u128) => true,
+            (Type::Array(elements, len), Some(index)) if index.to_u128() < (len as u128 * elements.len() as u128) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

No issue but something I noticed while working towards Brillig execution trace optimizations. 

We flatten complex types within arrays. 
For example this program:
```noir
struct Foo {
    bar: Field,
    baz: Field,
}

fn main(foos: [Foo; 3]) -> pub Field {
    foos[2].bar + foos[2].baz
}
```
Will have the following SSA:
```
brillig(inline) fn main f0 {
  b0(v0: [(Field, Field); 3]):
    v2 = array_get v0, index u32 4 -> Field
    v4 = array_get v0, index u32 5 -> Field
    v5 = array_get v0, index u32 4 -> Field
    v6 = array_get v0, index u32 5 -> Field
    v7 = add v2, v6
    return v7
}
```
When it comes times to generate Brillig we will check whether to generate bytecode for array index validation by checking this method:
 https://github.com/noir-lang/noir/blob/8e68ce6403e99ff5af4fb9973b203070d8a9898c/compiler/noirc_evaluator/src/ssa/ir/dfg.rs#L658

We are only checkling the `len` from `Type::Array(..)`. Calling this method will thus fail for all of the above array gets. Even though we know the array index is safe.

## Summary\*

Use the elements array in `Type::Array(elements, len)` and check the index against `elements.len() * len`. 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
