### PR TITLE
feat: use resolved type instead of needing Constructor.struct_type

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -7,9 +7,7 @@ use crate::ast::{
     Ident, ItemVisibility, Path, Pattern, Statement, StatementKind, UnresolvedTraitConstraint,
     UnresolvedType, UnresolvedTypeData, Visibility,
 };
-use crate::node_interner::{
-    ExprId, InternedExpressionKind, InternedStatementKind, QuotedTypeId, TypeId,
-};
+use crate::node_interner::{ExprId, InternedExpressionKind, InternedStatementKind, QuotedTypeId};
 use crate::token::{Attributes, FmtStrFragment, FunctionAttribute, Token, Tokens};
 use crate::{Kind, Type};
 use acvm::{acir::AcirField, FieldElement};
@@ -223,11 +221,7 @@ impl ExpressionKind {
     pub fn constructor(
         (typ, fields): (UnresolvedType, Vec<(Ident, Expression)>),
     ) -> ExpressionKind {
-        ExpressionKind::Constructor(Box::new(ConstructorExpression {
-            typ,
-            fields,
-            struct_type: None,
-        }))
+        ExpressionKind::Constructor(Box::new(ConstructorExpression { typ, fields }))
     }
 }
 
@@ -545,11 +539,6 @@ pub struct MethodCallExpression {
 pub struct ConstructorExpression {
     pub typ: UnresolvedType,
     pub fields: Vec<(Ident, Expression)>,
-
-    /// This may be filled out during macro expansion
-    /// so that we can skip re-resolving the type name since it
-    /// would be lost at that point.
-    pub struct_type: Option<TypeId>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -623,7 +623,6 @@ impl Pattern {
                     kind: ExpressionKind::Constructor(Box::new(ConstructorExpression {
                         typ: UnresolvedType::from_path(path.clone()),
                         fields,
-                        struct_type: None,
                     })),
                     location: *location,
                 })

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -760,9 +760,8 @@ impl<'context> Elaborator<'context> {
 
         let last_segment = path.last_segment();
 
-        let typ = match self.lookup_type_or_error(path) {
-            Some(typ) => typ,
-            None => return (HirExpression::Error, Type::Error),
+        let Some(typ) = self.lookup_type_or_error(path) else {
+            return (HirExpression::Error, Type::Error);
         };
 
         self.elaborate_constructor_with_type(typ, constructor.fields, location, Some(last_segment))

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -760,15 +760,9 @@ impl<'context> Elaborator<'context> {
 
         let last_segment = path.last_segment();
 
-        let typ = if let Some(struct_id) = constructor.struct_type {
-            let typ = self.interner.get_type(struct_id);
-            let generics = typ.borrow().instantiate(self.interner);
-            Type::DataType(typ, generics)
-        } else {
-            match self.lookup_type_or_error(path) {
-                Some(typ) => typ,
-                None => return (HirExpression::Error, Type::Error),
-            }
+        let typ = match self.lookup_type_or_error(path) {
+            Some(typ) => typ,
+            None => return (HirExpression::Error, Type::Error),
         };
 
         self.elaborate_constructor_with_type(typ, constructor.fields, location, Some(last_segment))

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -129,12 +129,10 @@ impl HirExpression {
                 let fields = vecmap(constructor.fields.clone(), |(name, expr): (Ident, ExprId)| {
                     (name, expr.to_display_ast(interner))
                 });
-                let struct_type = None;
 
                 ExpressionKind::Constructor(Box::new(ConstructorExpression {
                     typ: UnresolvedType::from_path(type_name),
                     fields,
-                    struct_type,
                 }))
             }
             HirExpression::MemberAccess(access) => {

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -440,11 +440,7 @@ impl<'a> Parser<'a> {
             Self::parse_constructor_field,
         );
 
-        ExpressionKind::Constructor(Box::new(ConstructorExpression {
-            typ,
-            fields,
-            struct_type: None,
-        }))
+        ExpressionKind::Constructor(Box::new(ConstructorExpression { typ, fields }))
     }
 
     fn parse_constructor_field(&mut self) -> Option<(Ident, Expression)> {

--- a/test_programs/compile_success_empty/unquote_struct/src/main.nr
+++ b/test_programs/compile_success_empty/unquote_struct/src/main.nr
@@ -29,7 +29,7 @@ comptime fn output_struct(f: FunctionDefinition) -> Quoted {
 
 pub struct Bar<T> {}
 
-fn main() {
+pub fn bar() {
     let _ = comptime {
         let x = quote { Bar::<i32> };
         let q = quote { $x {} };

--- a/test_programs/compile_success_empty/unquote_struct/src/main.nr
+++ b/test_programs/compile_success_empty/unquote_struct/src/main.nr
@@ -1,3 +1,5 @@
+use std::meta::unquote;
+
 fn main() {
     let foo = Foo { x: 4, y: 4 };
     foo.assert_equal();
@@ -20,4 +22,17 @@ comptime fn output_struct(f: FunctionDefinition) -> Quoted {
             }
         }
     }
+}
+
+// The following code proves that `Bar::<i32>` can be unquoted
+// into a constructor position without losing its generic types.
+
+pub struct Bar<T> {}
+
+fn main() {
+    let _ = comptime {
+        let x = quote { Bar::<i32> };
+        let q = quote { $x {} };
+        unquote!(q)
+    };
 }

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -783,7 +783,6 @@ fn constructor_expression_with_file(
         fields: vecmap(expr.fields, |(ident, expression)| {
             (ident_with_file(ident, file), expression_with_file(expression, file))
         }),
-        struct_type: expr.struct_type,
     }
 }
 


### PR DESCRIPTION
# Description

## Problem

Something I noticed while reviewing https://github.com/noir-lang/noir/pull/7489

## Summary

`ConstructorExpression` has a field, `struct_type`, that stores a resolved type from macro expansion. Instead of it we can use `Type::Resolved` for the actual type inside an unresolved type. This works the same way but there's one less field needed.

Additionally, this actually allows more valid programs to compile. For example this one:

```noir
use std::meta::unquote;

struct Foo<T> {}

fn main() {
    let x = comptime {
        let x = quote { Foo::<i32> };
        let q = quote { $x {} };
        unquote!(q)
    };
}
```

Previously when unquoting `Foo::<i32>` as `$x` the generics were lost, so the above program errored with "Type annotation needed". Now the above program compiles fine.

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
