### PR TITLE
fix: Update deprecated rust-lang-nursery/rand repository URL to rust-random/rand

### DIFF
--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -552,8 +552,8 @@ mod tests {
         compiler_version = "*"
 
         [dependencies]
-        rand = { tag = "next", git = "https://github.com/rust-lang-nursery/rand"}
-        cool = { tag = "next", git = "https://github.com/rust-lang-nursery/rand"}
+        rand = { tag = "next", git = "https://github.com/rust-random/rand"}
+        cool = { tag = "next", git = "https://github.com/rust-random/rand"}
         hello = {path = "./noir_driver"}
     "#;
 


### PR DESCRIPTION
Updates the outdated repository URL in the test example from rust-lang-nursery/rand to the current rust-random/rand repository.