### PR TITLE
fix: don't crash on broken impl syntax

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -2134,7 +2134,7 @@ impl<'context> Elaborator<'context> {
                     let span = location.span;
                     let found = trait_impl.r#trait.typ.to_string();
                     self.push_err(ResolverError::ExpectedTrait { span, found }, location.file);
-                    continue;
+                    (None, GenericTypeArgs::default(), location)
                 }
             };
 

--- a/test_programs/compile_failure/broken_impl/Nargo.toml
+++ b/test_programs/compile_failure/broken_impl/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "broken_impl"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.26.0"
+
+[dependencies]

--- a/test_programs/compile_failure/broken_impl/src/main.nr
+++ b/test_programs/compile_failure/broken_impl/src/main.nr
@@ -1,0 +1,2 @@
+// This used to crash the compiler
+impl< Foo for


### PR DESCRIPTION
# Description

## Problem

I noticed that LSP would crash whenever starting to write an impl's generics. It was because the compiler actually crashed.

## Summary

This PR prevents this crash.

## Additional Context

I'll try to fix LSP crashes as soon as I find them because I heard LSP crashes often.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
