### PR TITLE
fix: Allow `INT_MIN` globals

### DIFF
--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -226,7 +226,9 @@ pub(super) fn value_from_hir_expression(context: &Context, expression: HirExpres
             },
             HirLiteral::Bool(value) => AbiValue::Boolean { value },
             HirLiteral::Str(value) => AbiValue::String { value },
-            HirLiteral::Integer(field, sign) => AbiValue::Integer { value: field.to_hex(), sign },
+            HirLiteral::Integer(value) => {
+                AbiValue::Integer { value: value.field.to_hex(), sign: value.is_negative }
+            }
             _ => unreachable!("Literal cannot be used in the abi"),
         },
         _ => unreachable!("Type cannot be used in the abi {:?}", expression),

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -7,9 +7,9 @@
 //! An Error of the former is a user Error
 //!
 //! An Error of the latter is an error in the implementation of the compiler
-use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_errors::{CustomDiagnostic as Diagnostic, FileDiagnostic};
+use noirc_frontend::signed_field::SignedField;
 use thiserror::Error;
 
 use crate::ssa::ir::{call_stack::CallStack, types::NumericType};
@@ -23,7 +23,7 @@ pub enum RuntimeError {
     InvalidRangeConstraint { num_bits: u32, call_stack: CallStack },
     #[error("The value `{value:?}` cannot fit into `{typ}` which has range `{range}`")]
     IntegerOutOfBounds {
-        value: FieldElement,
+        value: SignedField,
         typ: NumericType,
         range: String,
         call_stack: CallStack,

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -1,3 +1,4 @@
+use noirc_frontend::signed_field::SignedField;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -58,18 +59,14 @@ impl NumericType {
     /// Returns None if the given Field value is within the numeric limits
     /// for the current NumericType. Otherwise returns a string describing
     /// the limits, as a range.
-    pub(crate) fn value_is_outside_limits(
-        self,
-        field: FieldElement,
-        negative: bool,
-    ) -> Option<String> {
+    pub(crate) fn value_is_outside_limits(self, value: SignedField) -> Option<String> {
         match self {
             NumericType::Unsigned { bit_size } => {
                 let max = if bit_size == 128 { u128::MAX } else { 2u128.pow(bit_size) - 1 };
-                if negative {
+                if value.is_negative {
                     return Some(format!("0..={}", max));
                 }
-                if field <= max.into() {
+                if value.field <= max.into() {
                     None
                 } else {
                     Some(format!("0..={}", max))
@@ -78,8 +75,8 @@ impl NumericType {
             NumericType::Signed { bit_size } => {
                 let min = 2u128.pow(bit_size - 1);
                 let max = 2u128.pow(bit_size - 1) - 1;
-                let target_max = if negative { min } else { max };
-                if field <= target_max.into() {
+                let target_max = if value.is_negative { min } else { max };
+                if value.field <= target_max.into() {
                     None
                 } else {
                     Some(format!("-{}..={}", min, max))
@@ -307,19 +304,19 @@ mod tests {
     #[test]
     fn test_u8_value_is_outside_limits() {
         let u8 = NumericType::Unsigned { bit_size: 8 };
-        assert!(u8.value_is_outside_limits(FieldElement::from(1_i128), true).is_some());
-        assert!(u8.value_is_outside_limits(FieldElement::from(0_i128), false).is_none());
-        assert!(u8.value_is_outside_limits(FieldElement::from(255_i128), false).is_none());
-        assert!(u8.value_is_outside_limits(FieldElement::from(256_i128), false).is_some());
+        assert!(u8.value_is_outside_limits(SignedField::new(1_i128.into(), true)).is_some());
+        assert!(u8.value_is_outside_limits(SignedField::positive(0_i128)).is_none());
+        assert!(u8.value_is_outside_limits(SignedField::positive(255_i128)).is_none());
+        assert!(u8.value_is_outside_limits(SignedField::positive(256_i128)).is_some());
     }
 
     #[test]
     fn test_i8_value_is_outside_limits() {
         let i8 = NumericType::Signed { bit_size: 8 };
-        assert!(i8.value_is_outside_limits(FieldElement::from(129_i128), true).is_some());
-        assert!(i8.value_is_outside_limits(FieldElement::from(128_i128), true).is_none());
-        assert!(i8.value_is_outside_limits(FieldElement::from(0_i128), false).is_none());
-        assert!(i8.value_is_outside_limits(FieldElement::from(127_i128), false).is_none());
-        assert!(i8.value_is_outside_limits(FieldElement::from(128_i128), false).is_some());
+        assert!(i8.value_is_outside_limits(SignedField::new(129_i128.into(), true)).is_some());
+        assert!(i8.value_is_outside_limits(SignedField::new(128_i128.into(), true)).is_none());
+        assert!(i8.value_is_outside_limits(SignedField::positive(0_i128)).is_none());
+        assert!(i8.value_is_outside_limits(SignedField::positive(127_i128)).is_none());
+        assert!(i8.value_is_outside_limits(SignedField::positive(128_i128)).is_some());
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -7,6 +7,7 @@ use noirc_errors::Location;
 use noirc_frontend::ast::{BinaryOpKind, Signedness};
 use noirc_frontend::monomorphization::ast::{self, GlobalId, InlineType, LocalId, Parameters};
 use noirc_frontend::monomorphization::ast::{FuncId, Program};
+use noirc_frontend::signed_field::SignedField;
 
 use crate::errors::RuntimeError;
 use crate::ssa::function_builder::FunctionBuilder;
@@ -289,33 +290,30 @@ impl<'a> FunctionContext<'a> {
     /// otherwise values like 2^128 can be assigned to a u8 without error or wrapping.
     pub(super) fn checked_numeric_constant(
         &mut self,
-        value: impl Into<FieldElement>,
-        negative: bool,
+        value: SignedField,
         numeric_type: NumericType,
     ) -> Result<ValueId, RuntimeError> {
-        let value = value.into();
-
-        if let Some(range) = numeric_type.value_is_outside_limits(value, negative) {
+        if let Some(range) = numeric_type.value_is_outside_limits(value) {
             let call_stack = self.builder.get_call_stack();
             return Err(RuntimeError::IntegerOutOfBounds {
-                value: if negative { -value } else { value },
+                value,
                 typ: numeric_type,
                 range,
                 call_stack,
             });
         }
 
-        let value = if negative {
+        let value = if value.is_negative {
             match numeric_type {
-                NumericType::NativeField => -value,
+                NumericType::NativeField => -value.field,
                 NumericType::Signed { bit_size } | NumericType::Unsigned { bit_size } => {
                     assert!(bit_size < 128);
                     let base = 1_u128 << bit_size;
-                    FieldElement::from(base) - value
+                    FieldElement::from(base) - value.field
                 }
             }
         } else {
-            value
+            value.field
         };
 
         Ok(self.builder.numeric_constant(value, numeric_type))

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -233,10 +233,10 @@ impl<'a> FunctionContext<'a> {
                     _ => unreachable!("ICE: unexpected slice literal type, got {}", array.typ),
                 })
             }
-            ast::Literal::Integer(value, negative, typ, location) => {
+            ast::Literal::Integer(value, typ, location) => {
                 self.builder.set_location(*location);
                 let typ = Self::convert_non_tuple_type(typ).unwrap_numeric();
-                self.checked_numeric_constant(*value, *negative, typ).map(Into::into)
+                self.checked_numeric_constant(*value, typ).map(Into::into)
             }
             ast::Literal::Bool(value) => {
                 // Don't need to call checked_numeric_constant here since `value` can only be true or false
@@ -820,9 +820,7 @@ impl<'a> FunctionContext<'a> {
         typ: NumericType,
     ) -> Result<ValueId, RuntimeError> {
         match constructor {
-            Constructor::Int(value) => {
-                self.checked_numeric_constant(value.field, value.is_negative, typ)
-            }
+            Constructor::Int(value) => self.checked_numeric_constant(*value, typ),
             other => Ok(self.builder.numeric_constant(other.variant_index(), typ)),
         }
     }

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -7,10 +7,11 @@ use crate::ast::{
     Ident, ItemVisibility, Path, Pattern, Statement, StatementKind, UnresolvedTraitConstraint,
     UnresolvedType, UnresolvedTypeData, Visibility,
 };
+use crate::hir_def::expr::SignedField;
 use crate::node_interner::{ExprId, InternedExpressionKind, InternedStatementKind, QuotedTypeId};
 use crate::token::{Attributes, FmtStrFragment, FunctionAttribute, Token, Tokens};
 use crate::{Kind, Type};
-use acvm::{acir::AcirField, FieldElement};
+use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_errors::{Located, Location, Span};
 
@@ -170,8 +171,8 @@ impl ExpressionKind {
         match (operator, &rhs) {
             (
                 UnaryOp::Minus,
-                Expression { kind: ExpressionKind::Literal(Literal::Integer(field, sign)), .. },
-            ) => ExpressionKind::Literal(Literal::Integer(*field, !sign)),
+                Expression { kind: ExpressionKind::Literal(Literal::Integer(field)), .. },
+            ) => ExpressionKind::Literal(Literal::Integer(-*field)),
             _ => ExpressionKind::Prefix(Box::new(PrefixExpression { operator, rhs })),
         }
     }
@@ -199,7 +200,7 @@ impl ExpressionKind {
     }
 
     pub fn integer(contents: FieldElement) -> ExpressionKind {
-        ExpressionKind::Literal(Literal::Integer(contents, false))
+        ExpressionKind::Literal(Literal::Integer(SignedField::positive(contents)))
     }
 
     pub fn boolean(contents: bool) -> ExpressionKind {
@@ -409,7 +410,7 @@ pub enum Literal {
     Array(ArrayLiteral),
     Slice(ArrayLiteral),
     Bool(bool),
-    Integer(FieldElement, /*sign*/ bool), // false for positive integer and true for negative
+    Integer(SignedField),
     Str(String),
     RawStr(String, u8),
     FmtStr(Vec<FmtStrFragment>, u32 /* length */),
@@ -686,12 +687,8 @@ impl Display for Literal {
                 write!(f, "&[{repeated_element}; {length}]")
             }
             Literal::Bool(boolean) => write!(f, "{}", if *boolean { "true" } else { "false" }),
-            Literal::Integer(integer, sign) => {
-                if *sign {
-                    write!(f, "-{}", integer.to_u128())
-                } else {
-                    write!(f, "{}", integer.to_u128())
-                }
+            Literal::Integer(signed_field) => {
+                write!(f, "{signed_field}")
             }
             Literal::Str(string) => write!(f, "\"{string}\""),
             Literal::RawStr(string, num_hashes) => {

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -7,8 +7,8 @@ use crate::ast::{
     Ident, ItemVisibility, Path, Pattern, Statement, StatementKind, UnresolvedTraitConstraint,
     UnresolvedType, UnresolvedTypeData, Visibility,
 };
-use crate::hir_def::expr::SignedField;
 use crate::node_interner::{ExprId, InternedExpressionKind, InternedStatementKind, QuotedTypeId};
+use crate::signed_field::SignedField;
 use crate::token::{Attributes, FmtStrFragment, FunctionAttribute, Token, Tokens};
 use crate::{Kind, Type};
 use acvm::FieldElement;

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -492,7 +492,7 @@ impl UnresolvedTypeExpression {
 
     fn from_expr_helper(expr: Expression) -> Result<UnresolvedTypeExpression, Expression> {
         match expr.kind {
-            ExpressionKind::Literal(Literal::Integer(int, _)) => match int.try_to_u32() {
+            ExpressionKind::Literal(Literal::Integer(int)) => match int.try_to_unsigned::<u32>() {
                 Some(int) => Ok(UnresolvedTypeExpression::Constant(int.into(), expr.location)),
                 None => Err(expr),
             },

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -1,4 +1,3 @@
-use acvm::FieldElement;
 use noirc_errors::Span;
 
 use crate::{
@@ -16,6 +15,7 @@ use crate::{
         InternedUnresolvedTypeData, QuotedTypeId,
     },
     parser::{Item, ItemKind, ParsedSubModule},
+    signed_field::SignedField,
     token::{FmtStrFragment, MetaAttribute, SecondaryAttribute, Tokens},
     ParsedModule, QuotedType,
 };
@@ -172,7 +172,7 @@ pub trait Visitor {
 
     fn visit_literal_bool(&mut self, _: bool, _: Span) {}
 
-    fn visit_literal_integer(&mut self, _value: FieldElement, _negative: bool, _: Span) {}
+    fn visit_literal_integer(&mut self, _value: SignedField, _: Span) {}
 
     fn visit_literal_str(&mut self, _: &str, _: Span) {}
 
@@ -948,8 +948,8 @@ impl Literal {
                 }
             }
             Literal::Bool(value) => visitor.visit_literal_bool(*value, span),
-            Literal::Integer(value, negative) => {
-                visitor.visit_literal_integer(*value, *negative, span);
+            Literal::Integer(value) => {
+                visitor.visit_literal_integer(*value, span);
             }
             Literal::Str(str) => visitor.visit_literal_str(str, span),
             Literal::RawStr(str, length) => visitor.visit_literal_raw_str(str, *length, span),

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -1,6 +1,7 @@
 use crate::ast::PathSegment;
 use crate::parse_program;
 use crate::parser::ParsedModule;
+use crate::signed_field::SignedField;
 use crate::{
     ast,
     ast::{Path, PathKind},
@@ -777,11 +778,13 @@ fn id_expr(id: &ast::Ident) -> ast::Expression {
 }
 
 fn uint_expr(x: u128, location: Location) -> ast::Expression {
-    let kind = ast::ExpressionKind::Literal(ast::Literal::Integer(x.into(), false));
+    let value = SignedField::positive(x);
+    let kind = ast::ExpressionKind::Literal(ast::Literal::Integer(value));
     ast::Expression { kind, location }
 }
 
 fn sint_expr(x: i128, location: Location) -> ast::Expression {
-    let kind = ast::ExpressionKind::Literal(ast::Literal::Integer(x.abs().into(), x < 0));
+    let value = SignedField::from_signed(x);
+    let kind = ast::ExpressionKind::Literal(ast::Literal::Integer(value));
     ast::Expression { kind, location }
 }

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -15,12 +15,13 @@ use crate::{
     hir_def::{
         expr::{
             Case, Constructor, HirBlockExpression, HirEnumConstructorExpression, HirExpression,
-            HirIdent, HirMatch, SignedField,
+            HirIdent, HirMatch,
         },
         function::{FuncMeta, FunctionBody, HirFunction, Parameters},
         stmt::{HirLetStatement, HirPattern, HirStatement},
     },
     node_interner::{DefinitionId, DefinitionKind, ExprId, FunctionModifiers, GlobalValue, TypeId},
+    signed_field::SignedField,
     token::Attributes,
     DataType, Kind, Shared, Type,
 };
@@ -322,10 +323,10 @@ impl Elaborator<'_> {
         };
 
         match expression.kind {
-            ExpressionKind::Literal(Literal::Integer(value, negative)) => {
+            ExpressionKind::Literal(Literal::Integer(value)) => {
                 let actual = self.interner.next_type_variable_with_kind(Kind::IntegerOrField);
                 unify_with_expected_type(self, &actual);
-                Pattern::Int(SignedField::new(value, negative))
+                Pattern::Int(value)
             }
             ExpressionKind::Literal(Literal::Bool(value)) => {
                 unify_with_expected_type(self, &Type::Bool);

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -227,9 +227,8 @@ impl<'context> Elaborator<'context> {
         match literal {
             Literal::Unit => (Lit(HirLiteral::Unit), Type::Unit),
             Literal::Bool(b) => (Lit(HirLiteral::Bool(b)), Type::Bool),
-            Literal::Integer(integer, sign) => {
-                let int = HirLiteral::Integer(integer, sign);
-                (Lit(int), self.polymorphic_integer_or_field())
+            Literal::Integer(integer) => {
+                (Lit(HirLiteral::Integer(integer)), self.polymorphic_integer_or_field())
             }
             Literal::Str(str) | Literal::RawStr(str, _) => {
                 let len = Type::Constant(str.len().into(), Kind::u32());

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -202,13 +202,13 @@ pub(crate) fn overflowing_int(
 
     let mut errors = Vec::with_capacity(2);
     match expr {
-        HirExpression::Literal(HirLiteral::Integer(value, negative)) => match annotated_type {
+        HirExpression::Literal(HirLiteral::Integer(value)) => match annotated_type {
             Type::Integer(Signedness::Unsigned, bit_size) => {
                 let bit_size: u32 = (*bit_size).into();
                 let max = if bit_size == 128 { u128::MAX } else { 2u128.pow(bit_size) - 1 };
-                if value > max.into() || negative {
+                if value.field > max.into() || value.is_negative {
                     errors.push(TypeCheckError::OverflowingAssignment {
-                        expr: if negative { -value } else { value },
+                        expr: value,
                         ty: annotated_type.clone(),
                         range: format!("0..={}", max),
                         span,
@@ -219,9 +219,11 @@ pub(crate) fn overflowing_int(
                 let bit_count: u32 = (*bit_count).into();
                 let min = 2u128.pow(bit_count - 1);
                 let max = 2u128.pow(bit_count - 1) - 1;
-                if (negative && value > min.into()) || (!negative && value > max.into()) {
+                if (value.is_negative && value.field > min.into())
+                    || (!value.is_negative && value.field > max.into())
+                {
                     errors.push(TypeCheckError::OverflowingAssignment {
-                        expr: if negative { -value } else { value },
+                        expr: value,
                         ty: annotated_type.clone(),
                         range: format!("-{}..={}", min, max),
                         span,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -34,6 +34,7 @@ use crate::{
         DependencyId, ExprId, FuncId, GlobalValue, ImplSearchErrorKind, NodeInterner, TraitId,
         TraitImplKind, TraitMethodId,
     },
+    signed_field::SignedField,
     token::SecondaryAttribute,
     Generics, Kind, ResolvedGeneric, Type, TypeBinding, TypeBindings, UnificationError,
 };
@@ -1016,8 +1017,9 @@ impl<'context> Elaborator<'context> {
         let file = location.file;
         let from_follow_bindings = from.follow_bindings();
 
+        use HirExpression::Literal;
         let from_value_opt = match self.interner.expression(from_expr_id) {
-            HirExpression::Literal(HirLiteral::Integer(int, false)) => Some(int),
+            Literal(HirLiteral::Integer(SignedField { field, is_negative: false })) => Some(field),
 
             // TODO(https://github.com/noir-lang/noir/issues/6247):
             // handle negative literals

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -697,7 +697,7 @@ fn remove_interned_in_literal(interner: &NodeInterner, literal: Literal) -> Lite
             Literal::Array(remove_interned_in_array_literal(interner, array_literal))
         }
         Literal::Bool(_)
-        | Literal::Integer(_, _)
+        | Literal::Integer(_)
         | Literal::Str(_)
         | Literal::RawStr(_, _)
         | Literal::FmtStr(_, _)

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -7,10 +7,11 @@ use crate::{
         def_collector::dc_crate::CompilationError,
         type_check::{NoMatchingImplFoundError, TypeCheckError},
     },
+    hir_def::expr::SignedField,
     parser::ParserError,
     Type,
 };
-use acvm::{acir::AcirField, BlackBoxResolutionError, FieldElement};
+use acvm::BlackBoxResolutionError;
 use fm::FileId;
 use noirc_errors::{CustomDiagnostic, Location};
 
@@ -35,7 +36,7 @@ pub enum InterpreterError {
         location: Location,
     },
     IntegerOutOfRangeForType {
-        value: FieldElement,
+        value: SignedField,
         typ: Type,
         location: Location,
     },
@@ -394,11 +395,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 CustomDiagnostic::simple_error(msg, secondary, location.span)
             }
             InterpreterError::IntegerOutOfRangeForType { value, typ, location } => {
-                let int = match value.try_into_u128() {
-                    Some(int) => int.to_string(),
-                    None => value.to_string(),
-                };
-                let msg = format!("{int} is outside the range of the {typ} type");
+                let msg = format!("{value} is outside the range of the {typ} type");
                 CustomDiagnostic::simple_error(msg, String::new(), location.span)
             }
             InterpreterError::ErrorNodeEncountered { location } => {

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -7,8 +7,8 @@ use crate::{
         def_collector::dc_crate::CompilationError,
         type_check::{NoMatchingImplFoundError, TypeCheckError},
     },
-    hir_def::expr::SignedField,
     parser::ParserError,
+    signed_field::SignedField,
     Type,
 };
 use acvm::BlackBoxResolutionError;

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -16,6 +16,7 @@ use crate::hir_def::expr::{
 use crate::hir_def::stmt::{HirLValue, HirPattern, HirStatement};
 use crate::hir_def::types::{Type, TypeBinding};
 use crate::node_interner::{DefinitionId, ExprId, NodeInterner, StmtId};
+use crate::signed_field::SignedField;
 
 // TODO:
 // - Full path for idents & types
@@ -98,8 +99,8 @@ impl HirExpression {
             HirExpression::Literal(HirLiteral::Bool(value)) => {
                 ExpressionKind::Literal(Literal::Bool(*value))
             }
-            HirExpression::Literal(HirLiteral::Integer(value, sign)) => {
-                ExpressionKind::Literal(Literal::Integer(*value, *sign))
+            HirExpression::Literal(HirLiteral::Integer(value)) => {
+                ExpressionKind::Literal(Literal::Integer(*value))
             }
             HirExpression::Literal(HirLiteral::Str(string)) => {
                 ExpressionKind::Literal(Literal::Str(string.clone()))
@@ -284,9 +285,7 @@ impl Constructor {
             Constructor::True => ExpressionKind::Literal(Literal::Bool(true)),
             Constructor::False => ExpressionKind::Literal(Literal::Bool(false)),
             Constructor::Unit => ExpressionKind::Literal(Literal::Unit),
-            Constructor::Int(value) => {
-                ExpressionKind::Literal(Literal::Integer(value.field, value.is_negative))
-            }
+            Constructor::Int(value) => ExpressionKind::Literal(Literal::Integer(*value)),
             Constructor::Tuple(_) => ExpressionKind::Tuple(arguments),
             Constructor::Variant(typ, index) => {
                 let typ = typ.follow_bindings_shallow();
@@ -539,7 +538,7 @@ impl HirArrayLiteral {
                 let repeated_element = Box::new(repeated_element.to_display_ast(interner));
                 let length = match length {
                     Type::Constant(length, _kind) => {
-                        let literal = Literal::Integer(*length, false);
+                        let literal = Literal::Integer(SignedField::positive(*length));
                         let expr_kind = ExpressionKind::Literal(literal);
                         Box::new(Expression::new(expr_kind, location))
                     }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -14,7 +14,9 @@ use crate::elaborator::Elaborator;
 use crate::graph::CrateId;
 use crate::hir::def_map::ModuleId;
 use crate::hir::type_check::TypeCheckError;
-use crate::hir_def::expr::{HirConstrainExpression, HirEnumConstructorExpression, ImplKind};
+use crate::hir_def::expr::{
+    HirConstrainExpression, HirEnumConstructorExpression, ImplKind, SignedField,
+};
 use crate::hir_def::function::FunctionBody;
 use crate::monomorphization::{
     perform_impl_bindings, perform_instantiation_bindings, resolve_trait_method,
@@ -631,7 +633,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                     }
                 }?;
 
-                self.evaluate_integer(value, false, id)
+                self.evaluate_integer(value.into(), id)
             }
         }
     }
@@ -640,9 +642,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         match literal {
             HirLiteral::Unit => Ok(Value::Unit),
             HirLiteral::Bool(value) => Ok(Value::Bool(value)),
-            HirLiteral::Integer(value, is_negative) => {
-                self.evaluate_integer(value, is_negative, id)
-            }
+            HirLiteral::Integer(value) => self.evaluate_integer(value, id),
             HirLiteral::Str(string) => Ok(Value::String(Rc::new(string))),
             HirLiteral::FmtStr(fragments, captures, _length) => {
                 self.evaluate_format_string(fragments, captures, id)
@@ -702,113 +702,85 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         Ok(Value::FormatString(Rc::new(result), typ))
     }
 
-    fn evaluate_integer(
-        &self,
-        value: FieldElement,
-        is_negative: bool,
-        id: ExprId,
-    ) -> IResult<Value> {
+    fn evaluate_integer(&self, value: SignedField, id: ExprId) -> IResult<Value> {
         let typ = self.elaborator.interner.id_type(id).follow_bindings();
         let location = self.elaborator.interner.expr_location(&id);
 
         if let Type::FieldElement = &typ {
-            let value = if is_negative { -value } else { value };
-            Ok(Value::Field(value))
+            Ok(Value::Field(value.into()))
         } else if let Type::Integer(sign, bit_size) = &typ {
             match (sign, bit_size) {
                 (Signedness::Unsigned, IntegerBitSize::One) => {
                     return Err(InterpreterError::TypeUnsupported { typ, location });
                 }
                 (Signedness::Unsigned, IntegerBitSize::Eight) => {
-                    let value: u8 =
-                        value.try_to_u64().and_then(|value| value.try_into().ok()).ok_or(
-                            InterpreterError::IntegerOutOfRangeForType { value, typ, location },
-                        )?;
-                    let value = if is_negative { 0u8.wrapping_sub(value) } else { value };
+                    let value = value.try_to_unsigned().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::U8(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::Sixteen) => {
-                    let value: u16 =
-                        value.try_to_u64().and_then(|value| value.try_into().ok()).ok_or(
-                            InterpreterError::IntegerOutOfRangeForType { value, typ, location },
-                        )?;
-                    let value = if is_negative { 0u16.wrapping_sub(value) } else { value };
+                    let value = value.try_to_unsigned().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::U16(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::ThirtyTwo) => {
-                    let value: u32 =
-                        value.try_to_u32().ok_or(InterpreterError::IntegerOutOfRangeForType {
-                            value,
-                            typ,
-                            location,
-                        })?;
-                    let value = if is_negative { 0u32.wrapping_sub(value) } else { value };
+                    let value = value.try_to_unsigned().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::U32(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::SixtyFour) => {
-                    let value: u64 =
-                        value.try_to_u64().ok_or(InterpreterError::IntegerOutOfRangeForType {
-                            value,
-                            typ,
-                            location,
-                        })?;
-                    let value = if is_negative { 0u64.wrapping_sub(value) } else { value };
+                    let value = value.try_to_unsigned().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::U64(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::HundredTwentyEight) => {
-                    let value: u128 = value.try_into_u128().ok_or(
+                    let value: u128 = value.try_to_unsigned().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
-                    let value = if is_negative { 0u128.wrapping_sub(value) } else { value };
                     Ok(Value::U128(value))
                 }
                 (Signedness::Signed, IntegerBitSize::One) => {
                     return Err(InterpreterError::TypeUnsupported { typ, location });
                 }
                 (Signedness::Signed, IntegerBitSize::Eight) => {
-                    let value: i8 =
-                        value.try_to_u64().and_then(|value| value.try_into().ok()).ok_or(
-                            InterpreterError::IntegerOutOfRangeForType { value, typ, location },
-                        )?;
-                    let value = if is_negative { -value } else { value };
+                    let value = value.try_to_signed().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::I8(value))
                 }
                 (Signedness::Signed, IntegerBitSize::Sixteen) => {
-                    let value: i16 =
-                        value.try_to_u64().and_then(|value| value.try_into().ok()).ok_or(
-                            InterpreterError::IntegerOutOfRangeForType { value, typ, location },
-                        )?;
-                    let value = if is_negative { -value } else { value };
+                    let value = value.try_to_signed().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::I16(value))
                 }
                 (Signedness::Signed, IntegerBitSize::ThirtyTwo) => {
-                    let value: i32 =
-                        value.try_to_u64().and_then(|value| value.try_into().ok()).ok_or(
-                            InterpreterError::IntegerOutOfRangeForType { value, typ, location },
-                        )?;
-                    let value = if is_negative { -value } else { value };
+                    let value = value.try_to_signed().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::I32(value))
                 }
                 (Signedness::Signed, IntegerBitSize::SixtyFour) => {
-                    let value: i64 =
-                        value.try_to_u64().and_then(|value| value.try_into().ok()).ok_or(
-                            InterpreterError::IntegerOutOfRangeForType { value, typ, location },
-                        )?;
-                    let value = if is_negative { -value } else { value };
+                    let value = value.try_to_signed().ok_or(
+                        InterpreterError::IntegerOutOfRangeForType { value, typ, location },
+                    )?;
                     Ok(Value::I64(value))
                 }
                 (Signedness::Signed, IntegerBitSize::HundredTwentyEight) => {
-                    todo!()
+                    return Err(InterpreterError::TypeUnsupported { typ, location });
                 }
             }
         } else if let Type::TypeVariable(variable) = &typ {
             if variable.is_integer_or_field() {
-                Ok(Value::Field(value))
+                Ok(Value::Field(value.into()))
             } else if variable.is_integer() {
-                let value: u64 = value
-                    .try_to_u64()
+                let value = value
+                    .try_to_unsigned()
                     .ok_or(InterpreterError::IntegerOutOfRangeForType { value, typ, location })?;
-                let value = if is_negative { 0u64.wrapping_sub(value) } else { value };
                 Ok(Value::U64(value))
             } else {
                 Err(InterpreterError::NonIntegerIntegerLiteral { typ, location })
@@ -1255,6 +1227,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             Value::Field(value) => {
                 value.try_to_u64().and_then(|value| value.try_into().ok()).ok_or_else(|| {
                     let typ = Type::default_int_type();
+                    let value = SignedField::new(value, false);
                     InterpreterError::IntegerOutOfRangeForType { value, typ, location }
                 })?
             }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -14,15 +14,14 @@ use crate::elaborator::Elaborator;
 use crate::graph::CrateId;
 use crate::hir::def_map::ModuleId;
 use crate::hir::type_check::TypeCheckError;
-use crate::hir_def::expr::{
-    HirConstrainExpression, HirEnumConstructorExpression, ImplKind, SignedField,
-};
+use crate::hir_def::expr::{HirConstrainExpression, HirEnumConstructorExpression, ImplKind};
 use crate::hir_def::function::FunctionBody;
 use crate::monomorphization::{
     perform_impl_bindings, perform_instantiation_bindings, resolve_trait_method,
     undo_instantiation_bindings,
 };
 use crate::node_interner::GlobalValue;
+use crate::signed_field::SignedField;
 use crate::token::{FmtStrFragment, Tokens};
 use crate::TypeVariable;
 use crate::{
@@ -706,6 +705,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         let typ = self.elaborator.interner.id_type(id).follow_bindings();
         let location = self.elaborator.interner.expr_location(&id);
 
+        dbg!(("evaluate_integer", value));
+
         if let Type::FieldElement = &typ {
             Ok(Value::Field(value.into()))
         } else if let Type::Integer(sign, bit_size) = &typ {
@@ -714,30 +715,35 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                     return Err(InterpreterError::TypeUnsupported { typ, location });
                 }
                 (Signedness::Unsigned, IntegerBitSize::Eight) => {
+                    dbg!("u8");
                     let value = value.try_to_unsigned().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
                     Ok(Value::U8(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::Sixteen) => {
+                    dbg!("u16");
                     let value = value.try_to_unsigned().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
                     Ok(Value::U16(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::ThirtyTwo) => {
+                    dbg!("u32");
                     let value = value.try_to_unsigned().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
                     Ok(Value::U32(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::SixtyFour) => {
+                    dbg!("u64");
                     let value = value.try_to_unsigned().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
                     Ok(Value::U64(value))
                 }
                 (Signedness::Unsigned, IntegerBitSize::HundredTwentyEight) => {
+                    dbg!("u128");
                     let value: u128 = value.try_to_unsigned().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
@@ -747,24 +753,28 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                     return Err(InterpreterError::TypeUnsupported { typ, location });
                 }
                 (Signedness::Signed, IntegerBitSize::Eight) => {
+                    dbg!("i8");
                     let value = value.try_to_signed().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
                     Ok(Value::I8(value))
                 }
                 (Signedness::Signed, IntegerBitSize::Sixteen) => {
+                    dbg!("i16");
                     let value = value.try_to_signed().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
                     Ok(Value::I16(value))
                 }
                 (Signedness::Signed, IntegerBitSize::ThirtyTwo) => {
+                    dbg!("i32");
                     let value = value.try_to_signed().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;
                     Ok(Value::I32(value))
                 }
                 (Signedness::Signed, IntegerBitSize::SixtyFour) => {
+                    dbg!("i64");
                     let value = value.try_to_signed().ok_or(
                         InterpreterError::IntegerOutOfRangeForType { value, typ, location },
                     )?;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1924,14 +1924,12 @@ fn expr_as_integer(
     location: Location,
 ) -> IResult<Value> {
     expr_as(interner, arguments, return_type.clone(), location, |expr| match expr {
-        ExprValue::Expression(ExpressionKind::Literal(Literal::Integer(field, sign))) => {
-            Some(Value::Tuple(vec![Value::Field(field), Value::Bool(sign)]))
+        ExprValue::Expression(ExpressionKind::Literal(Literal::Integer(field))) => {
+            Some(Value::Tuple(vec![Value::Field(field.field), Value::Bool(field.is_negative)]))
         }
         ExprValue::Expression(ExpressionKind::Resolved(id)) => {
-            if let HirExpression::Literal(HirLiteral::Integer(field, sign)) =
-                interner.expression(&id)
-            {
-                Some(Value::Tuple(vec![Value::Field(field), Value::Bool(sign)]))
+            if let HirExpression::Literal(HirLiteral::Integer(field)) = interner.expression(&id) {
+                Some(Value::Tuple(vec![Value::Field(field.field), Value::Bool(field.is_negative)]))
             } else {
                 None
             }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     hir_def::expr::{
         HirArrayLiteral, HirConstructorExpression, HirEnumConstructorExpression, HirExpression,
-        HirIdent, HirLambda, HirLiteral, ImplKind,
+        HirIdent, HirLambda, HirLiteral, ImplKind, SignedField,
     },
     node_interner::{ExprId, FuncId, NodeInterner, StmtId, TraitId, TraitImplId, TypeId},
     parser::{Item, Parser},
@@ -180,47 +180,39 @@ impl Value {
         let kind = match self {
             Value::Unit => ExpressionKind::Literal(Literal::Unit),
             Value::Bool(value) => ExpressionKind::Literal(Literal::Bool(value)),
-            Value::Field(value) => ExpressionKind::Literal(Literal::Integer(value, false)),
+            Value::Field(value) => {
+                ExpressionKind::Literal(Literal::Integer(SignedField::positive(value)))
+            }
             Value::I8(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                ExpressionKind::Literal(Literal::Integer(value, negative))
+                ExpressionKind::Literal(Literal::Integer(SignedField::from_signed(value)))
             }
             Value::I16(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                ExpressionKind::Literal(Literal::Integer(value, negative))
+                ExpressionKind::Literal(Literal::Integer(SignedField::from_signed(value)))
             }
             Value::I32(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                ExpressionKind::Literal(Literal::Integer(value, negative))
+                ExpressionKind::Literal(Literal::Integer(SignedField::from_signed(value)))
             }
             Value::I64(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                ExpressionKind::Literal(Literal::Integer(value, negative))
+                ExpressionKind::Literal(Literal::Integer(SignedField::from_signed(value)))
             }
             Value::U1(value) => {
-                ExpressionKind::Literal(Literal::Integer((value as u128).into(), false))
+                ExpressionKind::Literal(Literal::Integer(SignedField::positive(value)))
             }
             Value::U8(value) => {
-                ExpressionKind::Literal(Literal::Integer((value as u128).into(), false))
+                ExpressionKind::Literal(Literal::Integer(SignedField::positive(value as u128)))
             }
             Value::U16(value) => {
-                ExpressionKind::Literal(Literal::Integer((value as u128).into(), false))
+                ExpressionKind::Literal(Literal::Integer(SignedField::positive(value as u128)))
             }
             Value::U32(value) => {
-                ExpressionKind::Literal(Literal::Integer((value as u128).into(), false))
+                ExpressionKind::Literal(Literal::Integer(SignedField::positive(value)))
             }
             Value::U64(value) => {
-                ExpressionKind::Literal(Literal::Integer((value as u128).into(), false))
+                ExpressionKind::Literal(Literal::Integer(SignedField::positive(value)))
             }
-            Value::U128(value) => ExpressionKind::Literal(Literal::Integer(value.into(), false)),
+            Value::U128(value) => {
+                ExpressionKind::Literal(Literal::Integer(SignedField::positive(value)))
+            }
             Value::String(value) | Value::CtString(value) => {
                 ExpressionKind::Literal(Literal::Str(unwrap_rc(value)))
             }
@@ -358,47 +350,37 @@ impl Value {
         let expression = match self {
             Value::Unit => HirExpression::Literal(HirLiteral::Unit),
             Value::Bool(value) => HirExpression::Literal(HirLiteral::Bool(value)),
-            Value::Field(value) => HirExpression::Literal(HirLiteral::Integer(value, false)),
+            Value::Field(value) => HirExpression::Literal(HirLiteral::Integer(value.into())),
             Value::I8(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                HirExpression::Literal(HirLiteral::Integer(value, negative))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::from_signed(value)))
             }
             Value::I16(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                HirExpression::Literal(HirLiteral::Integer(value, negative))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::from_signed(value)))
             }
             Value::I32(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                HirExpression::Literal(HirLiteral::Integer(value, negative))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::from_signed(value)))
             }
             Value::I64(value) => {
-                let negative = value < 0;
-                let value = value.abs();
-                let value = (value as u128).into();
-                HirExpression::Literal(HirLiteral::Integer(value, negative))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::from_signed(value)))
             }
             Value::U1(value) => {
-                HirExpression::Literal(HirLiteral::Integer((value as u128).into(), false))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::positive(value)))
             }
             Value::U8(value) => {
-                HirExpression::Literal(HirLiteral::Integer((value as u128).into(), false))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::positive(value as u128)))
             }
             Value::U16(value) => {
-                HirExpression::Literal(HirLiteral::Integer((value as u128).into(), false))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::positive(value as u128)))
             }
             Value::U32(value) => {
-                HirExpression::Literal(HirLiteral::Integer((value as u128).into(), false))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::positive(value)))
             }
             Value::U64(value) => {
-                HirExpression::Literal(HirLiteral::Integer((value as u128).into(), false))
+                HirExpression::Literal(HirLiteral::Integer(SignedField::positive(value)))
             }
-            Value::U128(value) => HirExpression::Literal(HirLiteral::Integer(value.into(), false)),
+            Value::U128(value) => {
+                HirExpression::Literal(HirLiteral::Integer(SignedField::positive(value)))
+            }
             Value::String(value) | Value::CtString(value) => {
                 HirExpression::Literal(HirLiteral::Str(unwrap_rc(value)))
             }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -19,10 +19,11 @@ use crate::{
     },
     hir_def::expr::{
         HirArrayLiteral, HirConstructorExpression, HirEnumConstructorExpression, HirExpression,
-        HirIdent, HirLambda, HirLiteral, ImplKind, SignedField,
+        HirIdent, HirLambda, HirLiteral, ImplKind,
     },
     node_interner::{ExprId, FuncId, NodeInterner, StmtId, TraitId, TraitImplId, TypeId},
     parser::{Item, Parser},
+    signed_field::SignedField,
     token::{LocatedToken, Token, Tokens},
     Kind, QuotedType, Shared, Type, TypeBindings,
 };

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -13,6 +13,7 @@ use crate::hir_def::expr::HirBinaryOp;
 use crate::hir_def::traits::TraitConstraint;
 use crate::hir_def::types::{BinaryTypeOperator, Kind, Type};
 use crate::node_interner::NodeInterner;
+use crate::signed_field::SignedField;
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum Source {
@@ -42,8 +43,8 @@ pub enum TypeCheckError {
     DivisionByZero { lhs: FieldElement, rhs: FieldElement, span: Span },
     #[error("Modulo on Field elements: {lhs} % {rhs}")]
     ModuloOnFields { lhs: FieldElement, rhs: FieldElement, span: Span },
-    #[error("The value `{expr:?}` cannot fit into `{ty}` which has range `{range}`")]
-    OverflowingAssignment { expr: FieldElement, ty: Type, range: String, span: Span },
+    #[error("The value `{expr}` cannot fit into `{ty}` which has range `{range}`")]
+    OverflowingAssignment { expr: SignedField, ty: Type, range: String, span: Span },
     #[error(
         "The value `{value}` cannot fit into `{kind}` which has a maximum size of `{maximum_size}`"
     )]

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -20,6 +20,7 @@ pub mod monomorphization;
 pub mod node_interner;
 pub mod parser;
 pub mod resolve_locations;
+pub mod signed_field;
 pub mod usage_tracker;
 
 pub mod hir;

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, fmt::Display};
 
-use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_errors::{
     debug_info::{DebugFunctions, DebugTypes, DebugVariables},
@@ -10,6 +9,7 @@ use noirc_errors::{
 use crate::{
     ast::{BinaryOpKind, IntegerBitSize, Signedness, Visibility},
     hir_def::expr::Constructor,
+    signed_field::SignedField,
     token::{Attributes, FunctionAttribute},
 };
 use crate::{hir_def::function::FunctionSignature, token::FmtStrFragment};
@@ -123,7 +123,7 @@ pub struct While {
 pub enum Literal {
     Array(ArrayLiteral),
     Slice(ArrayLiteral),
-    Integer(FieldElement, /*sign*/ bool, Type, Location), // false for positive integer and true for negative
+    Integer(SignedField, Type, Location),
     Bool(bool),
     Unit,
     Str(String),

--- a/compiler/noirc_frontend/src/monomorphization/debug.rs
+++ b/compiler/noirc_frontend/src/monomorphization/debug.rs
@@ -7,6 +7,7 @@ use noirc_printable_type::PrintableType;
 use crate::debug::{SourceFieldId, SourceVarId};
 use crate::hir_def::expr::*;
 use crate::node_interner::ExprId;
+use crate::signed_field::SignedField;
 
 use super::ast::{Expression, Ident};
 use super::{MonomorphizationError, Monomorphizer};
@@ -68,14 +69,14 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> Result<(), MonomorphizationError> {
         let hir_arguments = vecmap(&call.arguments, |id| self.interner.expression(id));
         let var_id_arg = hir_arguments.get(DEBUG_VAR_ID_ARG_SLOT);
-        let Some(HirExpression::Literal(HirLiteral::Integer(source_var_id, _))) = var_id_arg else {
+        let Some(HirExpression::Literal(HirLiteral::Integer(source_var_id))) = var_id_arg else {
             unreachable!("Missing source_var_id in __debug_var_assign call");
         };
 
         // instantiate tracked variable for the value type and associate it with
         // the ID used by the injected instrumentation code
         let var_type = self.interner.id_type(call.arguments[DEBUG_VALUE_ARG_SLOT]);
-        let source_var_id = source_var_id.to_u128().into();
+        let source_var_id = source_var_id.field.to_u128().into();
         // then update the ID used for tracking at runtime
         let var_id = self.debug_type_tracker.insert_var(source_var_id, &var_type);
         let interned_var_id = self.intern_var_id(var_id, &call.location);
@@ -93,11 +94,11 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> Result<(), MonomorphizationError> {
         let hir_arguments = vecmap(&call.arguments, |id| self.interner.expression(id));
         let var_id_arg = hir_arguments.get(DEBUG_VAR_ID_ARG_SLOT);
-        let Some(HirExpression::Literal(HirLiteral::Integer(source_var_id, _))) = var_id_arg else {
+        let Some(HirExpression::Literal(HirLiteral::Integer(source_var_id))) = var_id_arg else {
             unreachable!("Missing source_var_id in __debug_var_drop call");
         };
         // update variable ID for tracked drops (ie. when the var goes out of scope)
-        let source_var_id = source_var_id.to_u128().into();
+        let source_var_id = source_var_id.field.to_u128().into();
         let var_id = self
             .debug_type_tracker
             .get_var_id(source_var_id)
@@ -121,11 +122,11 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> Result<(), MonomorphizationError> {
         let hir_arguments = vecmap(&call.arguments, |id| self.interner.expression(id));
         let var_id_arg = hir_arguments.get(DEBUG_VAR_ID_ARG_SLOT);
-        let Some(HirExpression::Literal(HirLiteral::Integer(source_var_id, _))) = var_id_arg else {
+        let Some(HirExpression::Literal(HirLiteral::Integer(source_var_id))) = var_id_arg else {
             unreachable!("Missing source_var_id in __debug_member_assign call");
         };
         // update variable member assignments
-        let source_var_id = source_var_id.to_u128().into();
+        let source_var_id = source_var_id.field.to_u128().into();
 
         let var_type = self
             .debug_type_tracker
@@ -134,11 +135,11 @@ impl<'interner> Monomorphizer<'interner> {
             .clone();
         let mut cursor_type = &var_type;
         for i in 0..arity {
-            if let Some(HirExpression::Literal(HirLiteral::Integer(fe_i, i_neg))) =
+            if let Some(HirExpression::Literal(HirLiteral::Integer(fe_i))) =
                 hir_arguments.get(DEBUG_MEMBER_FIELD_INDEX_ARG_SLOT + i)
             {
-                let index = fe_i.to_i128().unsigned_abs();
-                if *i_neg {
+                let index = fe_i.field.to_i128().unsigned_abs();
+                if fe_i.is_negative {
                     // We use negative indices at instrumentation time to indicate
                     // and reference member accesses by name which cannot be
                     // resolved until we have a type. This strategy is also used
@@ -152,9 +153,8 @@ impl<'interner> Monomorphizer<'interner> {
                         });
 
                     cursor_type = element_type_at_index(cursor_type, field_index);
-                    let index_id = self.interner.push_expr(HirExpression::Literal(
-                        HirLiteral::Integer(field_index.into(), false),
-                    ));
+                    let integer = HirLiteral::Integer(SignedField::positive(field_index));
+                    let index_id = self.interner.push_expr(HirExpression::Literal(integer));
                     self.interner.push_expr_type(index_id, crate::Type::FieldElement);
                     self.interner.push_expr_location(index_id, call.location);
                     arguments[DEBUG_MEMBER_FIELD_INDEX_ARG_SLOT + i] = self.expr(index_id)?;
@@ -178,7 +178,8 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     fn intern_var_id(&mut self, var_id: DebugVarId, location: &Location) -> ExprId {
-        let var_id_literal = HirLiteral::Integer((var_id.0 as u128).into(), false);
+        let value = SignedField::positive(var_id.0);
+        let var_id_literal = HirLiteral::Integer(value);
         let expr_id = self.interner.push_expr(HirExpression::Literal(var_id_literal));
         self.interner.push_expr_type(expr_id, crate::Type::FieldElement);
         self.interner.push_expr_location(expr_id, *location);

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -105,7 +105,7 @@ impl AstPrinter {
                 self.print_comma_separated(&array.contents, f)?;
                 write!(f, "]")
             }
-            super::ast::Literal::Integer(x, _, _, _) => x.fmt(f),
+            super::ast::Literal::Integer(x, _, _) => x.fmt(f),
             super::ast::Literal::Bool(x) => x.fmt(f),
             super::ast::Literal::Str(s) => write!(f, "\"{s}\""),
             super::ast::Literal::FmtStr(fragments, _, _) => {

--- a/compiler/noirc_frontend/src/signed_field.rs
+++ b/compiler/noirc_frontend/src/signed_field.rs
@@ -1,0 +1,157 @@
+use acvm::{AcirField, FieldElement};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct SignedField {
+    pub field: FieldElement,
+    pub is_negative: bool,
+}
+
+impl SignedField {
+    pub fn new(field: FieldElement, is_negative: bool) -> Self {
+        Self { field, is_negative }
+    }
+
+    pub fn positive(field: impl Into<FieldElement>) -> Self {
+        Self { field: field.into(), is_negative: false }
+    }
+
+    /// Convert a signed integer to a SignedField, carefully handling
+    /// INT_MIN in the process. Note that to convert an unsigned integer
+    /// you can call `SignedField::positive`.
+    pub fn from_signed<T>(value: T) -> Self
+    where
+        T: num_traits::Signed + AbsU128,
+    {
+        let negative = value.is_negative();
+        let value = value.abs_u128();
+        SignedField::new(value.into(), negative)
+    }
+
+    /// Convert a SignedField into an unsigned integer type (up to u128),
+    /// returning None if the value does not fit (e.g. if it is negative).
+    pub fn try_to_unsigned<T: TryFrom<u128>>(self) -> Option<T> {
+        if self.is_negative {
+            return None;
+        }
+
+        assert!(std::mem::size_of::<T>() <= std::mem::size_of::<u128>());
+        let u128_value = self.field.try_into_u128()?;
+        u128_value.try_into().ok()
+    }
+
+    /// Convert a SignedField into a signed integer type (up to i128),
+    /// returning None if the value does not fit. This function is more complex
+    /// for handling negative values, specifically INT_MIN which we can't cast from
+    /// a u128 to i128 without wrapping it.
+    pub fn try_to_signed<T>(self) -> Option<T>
+    where
+        T: TryFrom<u128> + TryFrom<i128> + num_traits::Signed + num_traits::Bounded + AbsU128,
+        u128: TryFrom<T>,
+    {
+        let u128_value = self.field.try_into_u128()?;
+
+        if self.is_negative {
+            // The positive version of the minimum value of this type.
+            // E.g. 128 for i8.
+            let positive_min = T::min_value().abs_u128();
+
+            // If it is the min value, we can't negate it without overflowing
+            // so test for it and return it directly
+            if u128_value == positive_min {
+                Some(T::min_value())
+            } else {
+                let i128_value = -(u128_value as i128);
+                T::try_from(i128_value).ok()
+            }
+        } else {
+            T::try_from(u128_value).ok()
+        }
+    }
+}
+
+impl std::ops::Neg for SignedField {
+    type Output = Self;
+
+    fn neg(mut self) -> Self::Output {
+        self.is_negative = !self.is_negative;
+        self
+    }
+}
+
+impl Ord for SignedField {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if self.is_negative != other.is_negative {
+            if self.is_negative {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        } else {
+            self.field.cmp(&other.field)
+        }
+    }
+}
+
+impl PartialOrd for SignedField {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl From<FieldElement> for SignedField {
+    fn from(value: FieldElement) -> Self {
+        Self::new(value, false)
+    }
+}
+
+impl From<SignedField> for FieldElement {
+    fn from(value: SignedField) -> Self {
+        if value.is_negative {
+            -value.field
+        } else {
+            value.field
+        }
+    }
+}
+
+impl std::fmt::Display for SignedField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_negative {
+            write!(f, "-")?;
+        }
+        write!(f, "{}", self.field)
+    }
+}
+
+pub trait AbsU128 {
+    /// Necessary to handle casting to unsigned generically without overflowing on INT_MIN.
+    fn abs_u128(self) -> u128;
+}
+
+macro_rules! impl_unsigned_abs_for {
+    ($typ:ty) => {
+        impl AbsU128 for $typ {
+            fn abs_u128(self) -> u128 {
+                self.unsigned_abs() as u128
+            }
+        }
+    };
+}
+
+impl_unsigned_abs_for!(i8);
+impl_unsigned_abs_for!(i16);
+impl_unsigned_abs_for!(i32);
+impl_unsigned_abs_for!(i64);
+impl_unsigned_abs_for!(i128);
+
+#[cfg(test)]
+mod tests {
+    use super::SignedField;
+
+    #[test]
+    fn int_min_to_signed_field_roundtrip() {
+        let x = i128::MIN;
+        let field = SignedField::from_signed(x);
+        assert_eq!(field.try_to_signed(), Some(x));
+    }
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4590,3 +4590,33 @@ struct Foo {
         CompilationError::ResolverError(ResolverError::NoSuchField { .. })
     ));
 }
+
+#[test]
+fn int_min_global() {
+    let src = r#"
+        global MIN: i8 = -128;
+        fn main() {
+            let _x = MIN;
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn subtract_to_int_min() {
+    // This would cause an integer underflow panic before
+    let src = r#"
+        fn main() {
+            let _x: i8 = comptime {
+                let y: i8 = -127;
+                let z = y - 1;
+                z
+            };
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 0);
+}

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -318,7 +318,7 @@ fn get_global_value(interner: &NodeInterner, expr: ExprId) -> Option<String> {
                 get_global_array_value(interner, hir_array_literal, true)
             }
             HirLiteral::Bool(value) => Some(value.to_string()),
-            HirLiteral::Integer(field_element, _) => Some(field_element.to_string()),
+            HirLiteral::Integer(value) => Some(value.to_string()),
             HirLiteral::Str(string) => Some(format!("{:?}", string)),
             HirLiteral::FmtStr(..) => None,
             HirLiteral::Unit => Some("()".to_string()),

--- a/tooling/lsp/src/requests/hover/from_visitor.rs
+++ b/tooling/lsp/src/requests/hover/from_visitor.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 
-use acvm::FieldElement;
 use fm::{FileId, FileMap};
 use lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position};
 use noirc_errors::{Location, Span};
-use noirc_frontend::{ast::Visitor, node_interner::NodeInterner, parse_program, Type};
+use noirc_frontend::{
+    ast::Visitor, node_interner::NodeInterner, parse_program, signed_field::SignedField, Type,
+};
 use num_bigint::BigInt;
 
 use crate::{
@@ -51,7 +52,7 @@ impl<'a> HoverFinder<'a> {
 }
 
 impl<'a> Visitor for HoverFinder<'a> {
-    fn visit_literal_integer(&mut self, value: FieldElement, negative: bool, span: Span) {
+    fn visit_literal_integer(&mut self, value: SignedField, span: Span) {
         if !self.intersects_span(span) {
             return;
         }
@@ -63,19 +64,19 @@ impl<'a> Visitor for HoverFinder<'a> {
             return;
         };
 
-        let value = format_integer(typ, value, negative);
+        let value = format_integer(typ, value);
         let contents = HoverContents::Markup(MarkupContent { kind: MarkupKind::Markdown, value });
         self.hover = Some(Hover { contents, range });
     }
 }
 
-fn format_integer(typ: Type, value: FieldElement, negative: bool) -> String {
-    let value_base_10 = value.to_string();
+fn format_integer(typ: Type, value: SignedField) -> String {
+    let value_base_10 = value.field.to_string();
 
     // For simplicity we parse the value as a BigInt to convert it to hex
     // because `FieldElement::to_hex` will include many leading zeros.
     let value_big_int = BigInt::from_str(&value_base_10).unwrap();
-    let negative = if negative { "-" } else { "" };
+    let negative = if value.is_negative { "-" } else { "" };
 
     format!("    {typ}\n---\nvalue of literal: `{negative}{value_base_10} ({negative}0x{value_big_int:02x})`")
 }
@@ -84,6 +85,7 @@ fn format_integer(typ: Type, value: FieldElement, negative: bool) -> String {
 mod tests {
     use noirc_frontend::{
         ast::{IntegerBitSize, Signedness},
+        signed_field::SignedField,
         Type,
     };
 
@@ -92,27 +94,24 @@ mod tests {
     #[test]
     fn format_integer_zero() {
         let typ = Type::FieldElement;
-        let value = 0_u128.into();
-        let negative = false;
+        let value = SignedField::positive(0_u128);
         let expected = "    Field\n---\nvalue of literal: `0 (0x00)`";
-        assert_eq!(format_integer(typ, value, negative), expected);
+        assert_eq!(format_integer(typ, value), expected);
     }
 
     #[test]
     fn format_positive_integer() {
         let typ = Type::Integer(Signedness::Unsigned, IntegerBitSize::ThirtyTwo);
-        let value = 123456_u128.into();
-        let negative = false;
+        let value = SignedField::positive(123456_u128);
         let expected = "    u32\n---\nvalue of literal: `123456 (0x1e240)`";
-        assert_eq!(format_integer(typ, value, negative), expected);
+        assert_eq!(format_integer(typ, value), expected);
     }
 
     #[test]
     fn format_negative_integer() {
         let typ = Type::Integer(Signedness::Signed, IntegerBitSize::SixtyFour);
-        let value = 987654_u128.into();
-        let negative = true;
+        let value = SignedField::new(987654_u128.into(), true);
         let expected = "    i64\n---\nvalue of literal: `-987654 (-0xf1206)`";
-        assert_eq!(format_integer(typ, value, negative), expected);
+        assert_eq!(format_integer(typ, value), expected);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/7506
Resolves https://github.com/noir-lang/noir/issues/7324

## Summary\*

Allow INT_MIN globals by properly handling negatives by refactoring the frontend to use `SignedField` instead of `FieldElement, bool` pairs.

## Additional Context

One advantage I noticed while using SignedField was that I was able to refactor several separate conversion functions we had (mostly in the interpreter) from SignedField to various signed and unsigned integer types into one place. Before we had written these conversions several times and some handled INT_MIN properly while others did not. Now there are conversion methods on `SignedField` itself.

Some future improvements we could do that I did not tackle in this PR:
- `Type::Constant` still holds a `FIeldElement` rather than a `SignedField`. I think refactoring it to handle negatives was beyond the scope of this PR, although theoretically it should be easier in the future once we have the following point.
- We have several repeated methods for checking if a field value fits in a desired type. We could refactor these to just one method. (There is at least one in SSA and one for `Type::Constant` although the later is only on Fields). This feels like something that should be on SignedField itself (sans error reporting).

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
