### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -66,7 +66,7 @@ projects:
     num_runs: 1
     timeout: 60
     compilation-timeout: 100
-    compilation-memory-limit: 7000
+    compilation-memory-limit: 8000
   rollup-block-root:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
@@ -75,7 +75,7 @@ projects:
     timeout: 60
     compilation-timeout: 110
     execution-timeout: 40
-    compilation-memory-limit: 7000
+    compilation-memory-limit: 8000
     execution-memory-limit: 1500
   rollup-merge:
     repo: AztecProtocol/aztec-packages

--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT f7a8f6be5c4b9c9aa9f59b4b99104b30b7bbff4c
+define: &AZ_COMMIT 17e79f42c0a1895dc87a74e4155591e38c45f09b
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -23,10 +23,10 @@ libraries:
     timeout: 2
   noir-bignum:
     repo: noir-lang/noir-bignum
-    timeout: 380
+    timeout: 90
   noir_bigcurve:
     repo: noir-lang/noir_bigcurve
-    timeout: 330
+    timeout: 250
   noir_base64:
     repo: noir-lang/noir_base64
     timeout: 2

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT f7a8f6be5c4b9c9aa9f59b4b99104b30b7bbff4c
+define: &AZ_COMMIT 17e79f42c0a1895dc87a74e4155591e38c45f09b
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
