### PR TITLE
chore: Increaes base64's allotted time

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -29,7 +29,7 @@ libraries:
     timeout: 330
   noir_base64:
     repo: noir-lang/noir_base64
-    timeout: 2
+    timeout: 3
   noir_string_search:
     repo: noir-lang/noir_string_search
     timeout: 2


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Unblock current PRs by bumping the time allowed to compile base64 by 1s.

## Additional Context

I elected not to lock us to a given commit in this PR since we have many external repos that may need to be locked to a commit for similar reasons. So I preferred consistency and unblocking current PRs quickly. We could maybe have a discussion in the future on whether more or all repos should be locked to a commit.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
