### PR TITLE
chore(ssa): Do not run passes on Brillig functions post Brillig gen

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -132,7 +132,7 @@ pub(crate) fn optimize_into_acir(
     // It could happen that we inlined all calls to a given brillig function.
     // In that case it's unused so we can remove it. This is what we check next.
     .run_pass(Ssa::remove_unreachable_functions, "Removing Unreachable Functions (4th)")
-    .run_pass(Ssa::dead_instruction_elimination, "Dead Instruction Elimination (3rd)")
+    .run_pass(Ssa::dead_instruction_elimination_acir, "Dead Instruction Elimination (3rd)")
     .finish();
 
     if !options.skip_underconstrained_check {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -95,6 +95,11 @@ impl Ssa {
         let brillig_info = Some(BrilligInfo { brillig, brillig_functions: &brillig_functions });
 
         for function in self.functions.values_mut() {
+            // We have already performed our final Brillig generation, so constant folding
+            // Brillig functions is unnecessary work.
+            if function.dfg.runtime().is_brillig() {
+                continue;
+            }
             function.constant_fold(false, brillig_info);
         }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
@@ -59,7 +59,7 @@ impl Ssa {
             // Try to reduce the number of blocks.
             function.simplify_function();
             // Remove leftover instructions.
-            function.dead_instruction_elimination(true, false);
+            function.dead_instruction_elimination(true, false, false);
 
             // Put it back into the SSA, so the next functions can pick it up.
             self.functions.insert(id, function);


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7157 

A small chore I noticed while working on https://github.com/noir-lang/noir/pull/7522, but looks like it should resolve the linked issue as well. 

Post Brillig gen we have generated our final Brillig artifacts. They are not going to be altered again. 

## Summary\*

Run constant folding and DIE only on ACIR functions post Brillig gen. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
