### PR TITLE
fix: correctly format trait function with multiple where clauses

### DIFF
--- a/tooling/nargo_fmt/src/formatter/traits.rs
+++ b/tooling/nargo_fmt/src/formatter/traits.rs
@@ -301,6 +301,23 @@ mod tests {
     }
 
     #[test]
+    fn format_trait_with_function_with_multiple_where_clauses() {
+        let src = " mod moo { trait Foo { 
+            fn  foo<T> () where  A: B, C: D;
+         } }";
+        let expected = "mod moo {
+    trait Foo {
+        fn foo<T>()
+        where
+            A: B,
+            C: D;
+    }
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
     fn format_trait_with_function_with_visibility() {
         let src = " mod moo { trait Foo { 
     /// hello 

--- a/tooling/nargo_fmt/src/formatter/where_clause.rs
+++ b/tooling/nargo_fmt/src/formatter/where_clause.rs
@@ -23,7 +23,8 @@ impl<'a> Formatter<'a> {
         // To format it we'll have to skip the second type `F` if we find a `+` token.
         let mut write_type = true;
 
-        for constraint in constraints {
+        let constrains_len = constraints.len();
+        for (index, constraint) in constraints.into_iter().enumerate() {
             if write_type {
                 self.write_line();
                 self.write_indentation();
@@ -45,7 +46,9 @@ impl<'a> Formatter<'a> {
 
             write_type = true;
 
-            if self.is_at(Token::Comma) {
+            if index < constrains_len - 1 {
+                self.write_token(Token::Comma);
+            } else if self.is_at(Token::Comma) {
                 if write_trailing_comma_and_new_line {
                     self.write_token(Token::Comma);
                 } else {


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed while working on something else.

## Summary

The bug was that the comma separating the two where clauses was missing after formatting.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
