### PR TITLE
fix(experimental): Replace most remaining match panics with errors

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -571,7 +571,9 @@ impl Elaborator<'_> {
                             location,
                         );
                     }
-                    other => todo!("Value `{other:?}` is not an enum constant"),
+                    // We tried to resolve this value above so there must have been an error
+                    // in doing so. Avoid reporting an additional error.
+                    _ => return Pattern::Error,
                 };
 
                 let global_type = self.interner.definition_type(global.definition_id);

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -595,7 +595,7 @@ impl Elaborator<'_> {
             }
             PathResolutionItem::Method(_type_id, _type_turbofish, func_id) => {
                 // TODO(#7430): Take type_turbofish into account when instantiating the function's type
-                let meta = self.interner.function_meta(&func_id);
+                let meta = self.interner.function_meta(func_id);
                 let Some(variant_index) = meta.enum_variant_index else {
                     let item = resolution.description();
                     self.push_err(ResolverError::UnexpectedItemInPattern { location, item });

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1983,6 +1983,8 @@ impl<'context> Elaborator<'context> {
         let old_file = std::mem::replace(&mut self.file, global.file_id);
         let old_item = self.current_item.take();
 
+        eprintln!("Elaborating {global:?}");
+
         let global_id = global.global_id;
         self.current_item = Some(DependencyId::Global(global_id));
         let let_stmt = global.stmt_def;
@@ -2006,13 +2008,18 @@ impl<'context> Elaborator<'context> {
             self.push_err(ResolverError::MutableGlobal { span }, location.file);
         }
 
+        dbg!();
+
         let (let_statement, _typ) = self
             .elaborate_in_comptime_context(|this| this.elaborate_let(let_stmt, Some(global_id)));
+        dbg!();
 
         let statement_id = self.interner.get_global(global_id).let_statement;
         self.interner.replace_statement(statement_id, let_statement);
 
+        dbg!();
         self.elaborate_comptime_global(global_id);
+        dbg!();
 
         if let Some(name) = name {
             self.interner.register_global(
@@ -2034,22 +2041,27 @@ impl<'context> Elaborator<'context> {
             .interner
             .get_global_let_statement(global_id)
             .expect("Let statement of global should be set by elaborate_global_let");
+        dbg!();
 
         let global = self.interner.get_global(global_id);
         let definition_id = global.definition_id;
         let location = global.location;
         let mut interpreter = self.setup_interpreter();
+        dbg!();
 
         if let Err(error) = interpreter.evaluate_let(let_statement) {
+            dbg!(&error);
             let (error, file) = error.into_compilation_error_pair();
             self.push_err(error, file);
         } else {
+            dbg!();
             let value = interpreter
                 .lookup_id(definition_id, location)
                 .expect("The global should be defined since evaluate_let did not error");
 
             self.debug_comptime(location, |interner| value.display(interner).to_string());
 
+            eprintln!("  set {global_id:?}.value = Resolved({value:?})");
             self.interner.get_global_mut(global_id).value = GlobalValue::Resolved(value);
         }
     }
@@ -2057,9 +2069,11 @@ impl<'context> Elaborator<'context> {
     /// If the given global is unresolved, elaborate it and return true
     fn elaborate_global_if_unresolved(&mut self, global_id: &GlobalId) -> bool {
         if let Some(global) = self.unresolved_globals.remove(global_id) {
+            eprintln!("Elaborating {global_id:?}: {global:?}");
             self.elaborate_global(global);
             true
         } else {
+            eprintln!("Not elaborating {global_id:?}");
             false
         }
     }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -186,6 +186,8 @@ pub enum ResolverError {
     InvalidSyntaxInPattern { span: Span },
     #[error("Variable '{existing}' was already defined in the same match pattern")]
     VariableAlreadyDefinedInPattern { existing: Ident, new_span: Span },
+    #[error("Only integer globals can be used in match patterns")]
+    NonIntegerGlobalUsedInPattern { location: Location },
 }
 
 impl ResolverError {
@@ -708,6 +710,11 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 let mut error = Diagnostic::simple_error(message, secondary, *new_span);
                 error.add_secondary(format!("`{existing}` was previously defined here"), existing.span());
                 error
+            },
+            ResolverError::NonIntegerGlobalUsedInPattern { location } => {
+                let message = "Only integer or boolean globals can be used in match patterns".to_string();
+                let secondary = "This global is not an integer or boolean".to_string();
+                Diagnostic::simple_error(message, secondary, location.span)
             },
         }
     }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -188,6 +188,10 @@ pub enum ResolverError {
     VariableAlreadyDefinedInPattern { existing: Ident, new_span: Span },
     #[error("Only integer globals can be used in match patterns")]
     NonIntegerGlobalUsedInPattern { location: Location },
+    #[error("Cannot match on values of type `{typ}`")]
+    TypeUnsupportedInMatch { typ: Type, span: Span },
+    #[error("Expected a struct, enum, or literal value in pattern, but found a {item}")]
+    UnexpectedItemInPattern { span: noirc_errors::Span, item: &'static str },
 }
 
 impl ResolverError {
@@ -715,6 +719,20 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 let message = "Only integer or boolean globals can be used in match patterns".to_string();
                 let secondary = "This global is not an integer or boolean".to_string();
                 Diagnostic::simple_error(message, secondary, location.span)
+            },
+            ResolverError::TypeUnsupportedInMatch { typ, span } => {
+                Diagnostic::simple_error(
+                    format!("Cannot match on values of type `{typ}`"), 
+                    String::new(),
+                    *span,
+                )
+            },
+            ResolverError::UnexpectedItemInPattern { item, span } => {
+                Diagnostic::simple_error(
+                    format!("Expected a struct, enum, or literal pattern, but found a {item}"), 
+                    String::new(),
+                    *span,
+                )
             },
         }
     }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3,6 +3,7 @@
 mod aliases;
 mod arithmetic_generics;
 mod bound_checks;
+mod enums;
 mod imports;
 mod metaprogramming;
 mod name_shadowing;
@@ -4236,28 +4237,6 @@ fn regression_7088() {
 }
 
 #[test]
-fn error_with_duplicate_enum_variant() {
-    let src = r#"
-    enum Foo {
-        Bar(i32),
-        Bar(u8),
-    }
-
-    fn main() {}
-    "#;
-    let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 2);
-    assert!(matches!(
-        &errors[0].0,
-        CompilationError::DefinitionError(DefCollectorErrorKind::Duplicate { .. })
-    ));
-    assert!(matches!(
-        &errors[1].0,
-        CompilationError::ResolverError(ResolverError::UnusedItem { .. })
-    ));
-}
-
-#[test]
 fn errors_on_empty_loop_no_break() {
     let src = r#"
     fn main() {
@@ -4430,142 +4409,4 @@ fn errors_if_while_body_type_is_not_unit() {
     let CompilationError::TypeError(TypeCheckError::TypeMismatch { .. }) = &errors[0].0 else {
         panic!("Expected a TypeMismatch error");
     };
-}
-
-#[test]
-fn errors_on_unspecified_unstable_enum() {
-    // Enums are experimental - this will need to be updated when they are stabilized
-    let src = r#"
-    enum Foo { Bar }
-
-    fn main() {
-        let _x = Foo::Bar;
-    }
-    "#;
-
-    let no_features = &[];
-    let errors = get_program_using_features(src, no_features).2;
-    assert_eq!(errors.len(), 1);
-
-    let CompilationError::ParseError(error) = &errors[0].0 else {
-        panic!("Expected a ParseError experimental feature error");
-    };
-
-    assert!(matches!(error.reason(), Some(ParserErrorReason::ExperimentalFeature(_))));
-}
-
-#[test]
-fn errors_on_unspecified_unstable_match() {
-    // Enums are experimental - this will need to be updated when they are stabilized
-    let src = r#"
-    fn main() {
-        match 3 {
-            _ => (),
-        }
-    }
-    "#;
-
-    let no_features = &[];
-    let errors = get_program_using_features(src, no_features).2;
-    assert_eq!(errors.len(), 1);
-
-    let CompilationError::ParseError(error) = &errors[0].0 else {
-        panic!("Expected a ParseError experimental feature error");
-    };
-
-    assert!(matches!(error.reason(), Some(ParserErrorReason::ExperimentalFeature(_))));
-}
-
-#[test]
-fn errors_on_repeated_match_variables_in_pattern() {
-    let src = r#"
-    fn main() {
-        match (1, 2) {
-            (_x, _x) => (),
-        }
-    }
-    "#;
-
-    let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 1);
-
-    assert!(matches!(
-        &errors[0].0,
-        CompilationError::ResolverError(ResolverError::VariableAlreadyDefinedInPattern { .. })
-    ));
-}
-
-#[test]
-fn duplicate_field_in_match_struct_pattern() {
-    let src = r#"
-fn main() {
-    let foo = Foo { x: 10, y: 20 };
-    match foo {
-        Foo { x: _, x: _, y: _ } => {}
-    }
-}
-
-struct Foo {
-    x: i32,
-    y: Field,
-}
-    "#;
-
-    let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 1);
-
-    assert!(matches!(
-        &errors[0].0,
-        CompilationError::ResolverError(ResolverError::DuplicateField { .. })
-    ));
-}
-
-#[test]
-fn missing_field_in_match_struct_pattern() {
-    let src = r#"
-fn main() {
-    let foo = Foo { x: 10, y: 20 };
-    match foo {
-        Foo { x: _ } => {}
-    }
-}
-
-struct Foo {
-    x: i32,
-    y: Field,
-}
-    "#;
-
-    let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 1);
-
-    assert!(matches!(
-        &errors[0].0,
-        CompilationError::ResolverError(ResolverError::MissingFields { .. })
-    ));
-}
-
-#[test]
-fn no_such_field_in_match_struct_pattern() {
-    let src = r#"
-fn main() {
-    let foo = Foo { x: 10, y: 20 };
-    match foo {
-        Foo { x: _, y: _, z: _ } => {}
-    }
-}
-
-struct Foo {
-    x: i32,
-    y: Field,
-}
-    "#;
-
-    let errors = get_program_errors(src);
-    assert_eq!(errors.len(), 1);
-
-    assert!(matches!(
-        &errors[0].0,
-        CompilationError::ResolverError(ResolverError::NoSuchField { .. })
-    ));
 }

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -1,0 +1,228 @@
+use crate::{
+    hir::{
+        def_collector::{dc_crate::CompilationError, errors::DefCollectorErrorKind},
+        resolution::errors::ResolverError,
+        type_check::TypeCheckError,
+    },
+    parser::ParserErrorReason,
+    tests::{get_program_errors, get_program_using_features},
+};
+use CompilationError::*;
+use DefCollectorErrorKind::Duplicate;
+use ResolverError::*;
+use TypeCheckError::{ArityMisMatch, TypeMismatch};
+
+#[test]
+fn error_with_duplicate_enum_variant() {
+    let src = r#"
+        enum Foo {
+            Bar(i32),
+            Bar(u8),
+        }
+
+        fn main() {}
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 2);
+    assert!(matches!(&errors[0].0, DefinitionError(Duplicate { .. })));
+    assert!(matches!(&errors[1].0, ResolverError(UnusedItem { .. })));
+}
+
+#[test]
+fn errors_on_unspecified_unstable_enum() {
+    // Enums are experimental - this will need to be updated when they are stabilized
+    let src = r#"
+        enum Foo { Bar }
+
+        fn main() {
+            let _x = Foo::Bar;
+        }
+    "#;
+
+    let no_features = &[];
+    let errors = get_program_using_features(src, no_features).2;
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ParseError(error) = &errors[0].0 else {
+        panic!("Expected a ParseError experimental feature error");
+    };
+
+    assert!(matches!(error.reason(), Some(ParserErrorReason::ExperimentalFeature(_))));
+}
+
+#[test]
+fn errors_on_unspecified_unstable_match() {
+    // Enums are experimental - this will need to be updated when they are stabilized
+    let src = r#"
+        fn main() {
+            match 3 {
+                _ => (),
+            }
+        }
+    "#;
+
+    let no_features = &[];
+    let errors = get_program_using_features(src, no_features).2;
+    assert_eq!(errors.len(), 1);
+
+    let CompilationError::ParseError(error) = &errors[0].0 else {
+        panic!("Expected a ParseError experimental feature error");
+    };
+
+    assert!(matches!(error.reason(), Some(ParserErrorReason::ExperimentalFeature(_))));
+}
+
+#[test]
+fn errors_on_repeated_match_variables_in_pattern() {
+    let src = r#"
+        fn main() {
+            match (1, 2) {
+                (_x, _x) => (),
+            }
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(&errors[0].0, ResolverError(VariableAlreadyDefinedInPattern { .. })));
+}
+
+#[test]
+fn duplicate_field_in_match_struct_pattern() {
+    let src = r#"
+        fn main() {
+            let foo = Foo { x: 10, y: 20 };
+            match foo {
+                Foo { x: _, x: _, y: _ } => {}
+            }
+        }
+
+        struct Foo {
+            x: i32,
+            y: Field,
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(&errors[0].0, ResolverError(DuplicateField { .. })));
+}
+
+#[test]
+fn missing_field_in_match_struct_pattern() {
+    let src = r#"
+        fn main() {
+            let foo = Foo { x: 10, y: 20 };
+            match foo {
+                Foo { x: _ } => {}
+            }
+        }
+
+        struct Foo {
+            x: i32,
+            y: Field,
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(&errors[0].0, ResolverError(MissingFields { .. })));
+}
+
+#[test]
+fn no_such_field_in_match_struct_pattern() {
+    let src = r#"
+        fn main() {
+            let foo = Foo { x: 10, y: 20 };
+            match foo {
+                Foo { x: _, y: _, z: _ } => {}
+            }
+        }
+
+        struct Foo {
+            x: i32,
+            y: Field,
+        }
+    "#;
+
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(&errors[0].0, ResolverError(NoSuchField { .. })));
+}
+
+#[test]
+fn match_integer_type_mismatch_in_pattern() {
+    let src = r#"
+        fn main() {
+            match 2 {
+                Foo::One(_) => (),
+            }
+        }
+
+        enum Foo {
+            One(i32),
+        }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(&errors[0].0, TypeError(TypeMismatch { .. })));
+}
+
+#[test]
+fn match_shadow_global() {
+    let src = r#"
+        fn main() {
+            match 2 {
+                foo => assert_eq(foo, 2),
+            }
+        }
+
+        fn foo() {}
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn match_no_shadow_global() {
+    let src = r#"
+        fn main() {
+            match 2 {
+                crate::foo => (),
+            }
+        }
+
+        fn foo() {}
+    "#;
+    let errors = dbg!(get_program_errors(src));
+    assert_eq!(errors.len(), 1);
+
+    assert!(matches!(&errors[0].0, ResolverError(UnexpectedItemInPattern { .. })));
+}
+
+#[test]
+fn constructor_arg_arity_mismatch_in_pattern() {
+    let src = r#"
+        fn main() {
+            match Foo::One(1) {
+                Foo::One(_, _) => (), // too many
+                Foo::Two(_) => (),    // too few
+            }
+        }
+
+        enum Foo {
+            One(i32),
+            Two(i32, i32),
+        }
+    "#;
+    let errors = get_program_errors(src);
+    assert_eq!(errors.len(), 2);
+
+    assert!(matches!(&errors[0].0, TypeError(ArityMisMatch { .. })));
+    assert!(matches!(&errors[1].0, TypeError(ArityMisMatch { .. })));
+}

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -24,8 +24,8 @@ fn error_with_duplicate_enum_variant() {
     "#;
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 2);
-    assert!(matches!(&errors[0].0, DefinitionError(Duplicate { .. })));
-    assert!(matches!(&errors[1].0, ResolverError(UnusedItem { .. })));
+    assert!(matches!(&errors[0], DefinitionError(Duplicate { .. })));
+    assert!(matches!(&errors[1], ResolverError(UnusedItem { .. })));
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn errors_on_unspecified_unstable_enum() {
     let errors = get_program_using_features(src, no_features).2;
     assert_eq!(errors.len(), 1);
 
-    let CompilationError::ParseError(error) = &errors[0].0 else {
+    let CompilationError::ParseError(error) = &errors[0] else {
         panic!("Expected a ParseError experimental feature error");
     };
 
@@ -65,7 +65,7 @@ fn errors_on_unspecified_unstable_match() {
     let errors = get_program_using_features(src, no_features).2;
     assert_eq!(errors.len(), 1);
 
-    let CompilationError::ParseError(error) = &errors[0].0 else {
+    let CompilationError::ParseError(error) = &errors[0] else {
         panic!("Expected a ParseError experimental feature error");
     };
 
@@ -85,7 +85,7 @@ fn errors_on_repeated_match_variables_in_pattern() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 1);
 
-    assert!(matches!(&errors[0].0, ResolverError(VariableAlreadyDefinedInPattern { .. })));
+    assert!(matches!(&errors[0], ResolverError(VariableAlreadyDefinedInPattern { .. })));
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn duplicate_field_in_match_struct_pattern() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 1);
 
-    assert!(matches!(&errors[0].0, ResolverError(DuplicateField { .. })));
+    assert!(matches!(&errors[0], ResolverError(DuplicateField { .. })));
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn missing_field_in_match_struct_pattern() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 1);
 
-    assert!(matches!(&errors[0].0, ResolverError(MissingFields { .. })));
+    assert!(matches!(&errors[0], ResolverError(MissingFields { .. })));
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn no_such_field_in_match_struct_pattern() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 1);
 
-    assert!(matches!(&errors[0].0, ResolverError(NoSuchField { .. })));
+    assert!(matches!(&errors[0], ResolverError(NoSuchField { .. })));
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn match_integer_type_mismatch_in_pattern() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 1);
 
-    assert!(matches!(&errors[0].0, TypeError(TypeMismatch { .. })));
+    assert!(matches!(&errors[0], TypeError(TypeMismatch { .. })));
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn match_no_shadow_global() {
     let errors = dbg!(get_program_errors(src));
     assert_eq!(errors.len(), 1);
 
-    assert!(matches!(&errors[0].0, ResolverError(UnexpectedItemInPattern { .. })));
+    assert!(matches!(&errors[0], ResolverError(UnexpectedItemInPattern { .. })));
 }
 
 #[test]
@@ -223,6 +223,6 @@ fn constructor_arg_arity_mismatch_in_pattern() {
     let errors = get_program_errors(src);
     assert_eq!(errors.len(), 2);
 
-    assert!(matches!(&errors[0].0, TypeError(ArityMisMatch { .. })));
-    assert!(matches!(&errors[1].0, TypeError(ArityMisMatch { .. })));
+    assert!(matches!(&errors[0], TypeError(ArityMisMatch { .. })));
+    assert!(matches!(&errors[1], TypeError(ArityMisMatch { .. })));
 }

--- a/test_programs/compile_success_empty/enums/src/main.nr
+++ b/test_programs/compile_success_empty/enums/src/main.nr
@@ -20,7 +20,19 @@ fn primitive_tests() {
         false => fail(),
         true => (),
     }
+
+    // Ensure we can match on MIN and use globals as constants
+    let i64_min = I64_MIN;
+    match i64_min {
+        9_223_372_036_854_775_807 => fail(),
+        -9_223_372_036_854_775_807 => fail(),
+        0 => fail(),
+        I64_MIN => (),
+        _ => fail(),
+    }
 }
+
+global I64_MIN: i64 = -9_223_372_036_854_775_808;
 
 enum Foo<T> {
     A(Field, Field),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Replaces most remaining panic/println cases in the match compiler with friendly user errors.

The only two remaining errors are what I consider to be the meatier ones: redundant cases & unhandled cases since these require more analysis of the match tree itself. The later also typically requires constructing an example of a value that wouldn't be matched as part of the error message.

## Additional Context

I've moved the frontend tests which deal with enums & matches to a new `tests/enums.rs` file since the frontend tests file is quite large. I'll add a comment noting where the new tests in this file are - the old ones are unchanged.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
