### PR TITLE
chore: remove FileDiagnostic

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -401,6 +401,7 @@ pub fn compile_main(
         // TODO(#2155): This error might be a better to exist in Nargo
         let err = CustomDiagnostic::from_message(
             "cannot compile crate into a program as it does not contain a `main` function",
+            FileId::default(),
         )
         .in_file(FileId::default());
         vec![err]
@@ -439,12 +440,16 @@ pub fn compile_contract(
     let mut errors = warnings;
 
     if contracts.len() > 1 {
-        let err = CustomDiagnostic::from_message("Packages are limited to a single contract")
-            .in_file(FileId::default());
+        let err = CustomDiagnostic::from_message(
+            "Packages are limited to a single contract",
+            FileId::default(),
+        )
+        .in_file(FileId::default());
         return Err(vec![err]);
     } else if contracts.is_empty() {
         let err = CustomDiagnostic::from_message(
             "cannot compile crate into a contract as it does not contain any contracts",
+            FileId::default(),
         )
         .in_file(FileId::default());
         return Err(vec![err]);

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -10,7 +10,7 @@ use clap::Args;
 use fm::{FileId, FileManager};
 use iter_extended::vecmap;
 use noirc_abi::{AbiParameter, AbiType, AbiValue};
-use noirc_errors::{CustomDiagnostic, DiagnosticKind, FileDiagnostic};
+use noirc_errors::{CustomDiagnostic, DiagnosticKind};
 use noirc_evaluator::brillig::BrilligOptions;
 use noirc_evaluator::create_program;
 use noirc_evaluator::errors::RuntimeError;
@@ -227,8 +227,8 @@ impl From<RuntimeError> for CompileError {
     }
 }
 
-impl From<CompileError> for FileDiagnostic {
-    fn from(error: CompileError) -> FileDiagnostic {
+impl From<CompileError> for CustomDiagnostic {
+    fn from(error: CompileError) -> CustomDiagnostic {
         match error {
             CompileError::RuntimeError(err) => err.into(),
             CompileError::MonomorphizationError(err) => err.into(),
@@ -237,10 +237,10 @@ impl From<CompileError> for FileDiagnostic {
 }
 
 /// Helper type used to signify where only warnings are expected in file diagnostics
-pub type Warnings = Vec<FileDiagnostic>;
+pub type Warnings = Vec<CustomDiagnostic>;
 
 /// Helper type used to signify where errors or warnings are expected in file diagnostics
-pub type ErrorsAndWarnings = Vec<FileDiagnostic>;
+pub type ErrorsAndWarnings = Vec<CustomDiagnostic>;
 
 /// Helper type for connecting a compilation artifact to the errors or warnings which were produced during compilation.
 pub type CompilationResult<T> = Result<(T, Warnings), ErrorsAndWarnings>;
@@ -350,20 +350,16 @@ pub fn check_crate(
 ) -> CompilationResult<()> {
     let diagnostics = CrateDefMap::collect_defs(crate_id, context, options.frontend_options());
     let crate_files = context.crate_files(&crate_id);
-    let warnings_and_errors: Vec<FileDiagnostic> = diagnostics
-        .into_iter()
-        .map(|error| {
-            let location = error.location();
-            let diagnostic = CustomDiagnostic::from(&error);
-            diagnostic.in_file(location.file)
-        })
+    let warnings_and_errors: Vec<CustomDiagnostic> = diagnostics
+        .iter()
+        .map(CustomDiagnostic::from)
         .filter(|diagnostic| {
             // We filter out any warnings if they're going to be ignored later on to free up memory.
-            !options.silence_warnings || diagnostic.diagnostic.kind != DiagnosticKind::Warning
+            !options.silence_warnings || diagnostic.kind != DiagnosticKind::Warning
         })
         .filter(|error| {
             // Only keep warnings from the crate we are checking
-            if error.diagnostic.is_warning() { crate_files.contains(&error.file_id) } else { true }
+            if error.is_warning() { crate_files.contains(&error.file) } else { true }
         })
         .collect();
 
@@ -402,16 +398,15 @@ pub fn compile_main(
         let err = CustomDiagnostic::from_message(
             "cannot compile crate into a program as it does not contain a `main` function",
             FileId::default(),
-        )
-        .in_file(FileId::default());
+        );
         vec![err]
     })?;
 
     let compiled_program =
         compile_no_check(context, options, main, cached_program, options.force_compile)
-            .map_err(FileDiagnostic::from)?;
+            .map_err(|error| vec![CustomDiagnostic::from(error)])?;
 
-    let compilation_warnings = vecmap(compiled_program.warnings.clone(), FileDiagnostic::from);
+    let compilation_warnings = vecmap(compiled_program.warnings.clone(), CustomDiagnostic::from);
     if options.deny_warnings && !compilation_warnings.is_empty() {
         return Err(compilation_warnings);
     }
@@ -443,15 +438,13 @@ pub fn compile_contract(
         let err = CustomDiagnostic::from_message(
             "Packages are limited to a single contract",
             FileId::default(),
-        )
-        .in_file(FileId::default());
+        );
         return Err(vec![err]);
     } else if contracts.is_empty() {
         let err = CustomDiagnostic::from_message(
             "cannot compile crate into a contract as it does not contain any contracts",
             FileId::default(),
-        )
-        .in_file(FileId::default());
+        );
         return Err(vec![err]);
     };
 
@@ -488,12 +481,8 @@ pub fn compile_contract(
 }
 
 /// True if there are (non-warning) errors present and we should halt compilation
-fn has_errors(errors: &[FileDiagnostic], deny_warnings: bool) -> bool {
-    if deny_warnings {
-        !errors.is_empty()
-    } else {
-        errors.iter().any(|error| error.diagnostic.is_error())
-    }
+fn has_errors(errors: &[CustomDiagnostic], deny_warnings: bool) -> bool {
+    if deny_warnings { !errors.is_empty() } else { errors.iter().any(|error| error.is_error()) }
 }
 
 /// Compile all of the functions associated with a Noir contract.
@@ -530,7 +519,7 @@ fn compile_contract_inner(
         let function = match compile_no_check(context, &options, function_id, None, true) {
             Ok(function) => function,
             Err(new_error) => {
-                errors.push(FileDiagnostic::from(new_error));
+                errors.push(new_error.into());
                 continue;
             }
         };

--- a/compiler/noirc_driver/tests/contracts.rs
+++ b/compiler/noirc_driver/tests/contracts.rs
@@ -33,13 +33,10 @@ contract Bar {}";
 
     assert_eq!(
         errors,
-        vec![
-            CustomDiagnostic::from_message(
-                "Packages are limited to a single contract",
-                FileId::default()
-            )
-            .in_file(FileId::default())
-        ],
+        vec![CustomDiagnostic::from_message(
+            "Packages are limited to a single contract",
+            FileId::default()
+        )],
         "stdlib is producing warnings"
     );
 

--- a/compiler/noirc_driver/tests/contracts.rs
+++ b/compiler/noirc_driver/tests/contracts.rs
@@ -34,8 +34,11 @@ contract Bar {}";
     assert_eq!(
         errors,
         vec![
-            CustomDiagnostic::from_message("Packages are limited to a single contract")
-                .in_file(FileId::default())
+            CustomDiagnostic::from_message(
+                "Packages are limited to a single contract",
+                FileId::default()
+            )
+            .in_file(FileId::default())
         ],
         "stdlib is producing warnings"
     );

--- a/compiler/noirc_errors/src/lib.rs
+++ b/compiler/noirc_errors/src/lib.rs
@@ -8,21 +8,3 @@ mod position;
 pub mod reporter;
 pub use position::{Located, Location, Position, Span, Spanned};
 pub use reporter::{CustomDiagnostic, DiagnosticKind};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FileDiagnostic {
-    pub file_id: fm::FileId,
-    pub diagnostic: CustomDiagnostic,
-}
-
-impl FileDiagnostic {
-    pub fn new(file_id: fm::FileId, diagnostic: CustomDiagnostic) -> FileDiagnostic {
-        FileDiagnostic { file_id, diagnostic }
-    }
-}
-
-impl From<FileDiagnostic> for Vec<FileDiagnostic> {
-    fn from(value: FileDiagnostic) -> Self {
-        vec![value]
-    }
-}

--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -8,6 +8,7 @@ use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CustomDiagnostic {
+    pub file: fm::FileId,
     pub message: String,
     pub secondaries: Vec<CustomLabel>,
     pub notes: Vec<String>,
@@ -35,8 +36,9 @@ pub struct ReportedErrors {
 }
 
 impl CustomDiagnostic {
-    pub fn from_message(msg: &str) -> CustomDiagnostic {
+    pub fn from_message(msg: &str, file: fm::FileId) -> CustomDiagnostic {
         Self {
+            file,
             message: msg.to_owned(),
             secondaries: Vec::new(),
             notes: Vec::new(),
@@ -54,6 +56,7 @@ impl CustomDiagnostic {
         kind: DiagnosticKind,
     ) -> CustomDiagnostic {
         CustomDiagnostic {
+            file: secondary_location.file,
             message: primary_message,
             secondaries: vec![CustomLabel::new(secondary_message, secondary_location)],
             notes: Vec::new(),
@@ -109,6 +112,7 @@ impl CustomDiagnostic {
         secondary_location: Location,
     ) -> CustomDiagnostic {
         CustomDiagnostic {
+            file: secondary_location.file,
             message: primary_message,
             secondaries: vec![CustomLabel::new(secondary_message, secondary_location)],
             notes: Vec::new(),

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -2,7 +2,6 @@ use crate::ast::{Ident, ItemVisibility, Path, UnsupportedNumericGenericType};
 use crate::hir::resolution::import::PathResolutionError;
 use crate::hir::type_check::generics::TraitGenerics;
 
-use noirc_errors::FileDiagnostic;
 use noirc_errors::{CustomDiagnostic as Diagnostic, Location};
 use thiserror::Error;
 
@@ -76,10 +75,6 @@ pub enum DefCollectorErrorKind {
 }
 
 impl DefCollectorErrorKind {
-    pub fn into_file_diagnostic(&self, file: fm::FileId) -> FileDiagnostic {
-        Diagnostic::from(self).in_file(file)
-    }
-
     pub fn location(&self) -> Location {
         match self {
             DefCollectorErrorKind::Duplicate { first_def: ident, .. }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -1,6 +1,6 @@
 use acvm::FieldElement;
 pub use noirc_errors::Span;
-use noirc_errors::{CustomDiagnostic as Diagnostic, FileDiagnostic, Location};
+use noirc_errors::{CustomDiagnostic as Diagnostic, Location};
 use thiserror::Error;
 
 use crate::{
@@ -195,10 +195,6 @@ pub enum ResolverError {
 }
 
 impl ResolverError {
-    pub fn into_file_diagnostic(&self, file: fm::FileId) -> FileDiagnostic {
-        Diagnostic::from(self).in_file(file)
-    }
-
     pub fn location(&self) -> Location {
         match self {
             ResolverError::DuplicateDefinition { first_location: location, .. }

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -648,15 +648,15 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
 impl<'a> From<&'a NoMatchingImplFoundError> for Diagnostic {
     fn from(error: &'a NoMatchingImplFoundError) -> Self {
         let constraints = &error.constraints;
-        let span = error.location;
+        let location = error.location;
 
         assert!(!constraints.is_empty());
         let msg =
             format!("No matching impl found for `{}: {}`", constraints[0].0, constraints[0].1);
-        let mut diagnostic = Diagnostic::from_message(&msg);
+        let mut diagnostic = Diagnostic::from_message(&msg, location.file);
 
         let secondary = format!("No impl for `{}: {}`", constraints[0].0, constraints[0].1);
-        diagnostic.add_secondary(secondary, span);
+        diagnostic.add_secondary(secondary, location);
 
         // These must be notes since secondaries are unordered
         for (typ, trait_name) in &constraints[1..] {

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -1,4 +1,4 @@
-use noirc_errors::{CustomDiagnostic, FileDiagnostic, Location};
+use noirc_errors::{CustomDiagnostic, Location};
 
 use crate::{
     Type,
@@ -34,18 +34,9 @@ impl MonomorphizationError {
     }
 }
 
-impl From<MonomorphizationError> for FileDiagnostic {
-    fn from(error: MonomorphizationError) -> FileDiagnostic {
-        let location = error.location();
-        let call_stack = vec![location];
-        let diagnostic = error.into_diagnostic();
-        diagnostic.with_call_stack(call_stack).in_file(location.file)
-    }
-}
-
-impl MonomorphizationError {
-    fn into_diagnostic(self) -> CustomDiagnostic {
-        let message = match &self {
+impl From<MonomorphizationError> for CustomDiagnostic {
+    fn from(error: MonomorphizationError) -> CustomDiagnostic {
+        let message = match &error {
             MonomorphizationError::UnknownArrayLength { length, err, .. } => {
                 format!("Could not determine array length `{length}`, encountered error: `{err}`")
             }
@@ -78,7 +69,7 @@ impl MonomorphizationError {
             }
         };
 
-        let location = self.location();
+        let location = error.location();
         CustomDiagnostic::simple_error(message, String::new(), location)
     }
 }

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -176,7 +176,7 @@ pub fn compile_program(
     let compiled_program =
         noirc_driver::compile_main(&mut context, crate_id, &compile_options, None)
             .map_err(|errs| {
-                CompileError::with_file_diagnostics(
+                CompileError::with_custom_diagnostics(
                     "Failed to compile program",
                     errs,
                     &context.file_manager,
@@ -186,7 +186,7 @@ pub fn compile_program(
 
     let optimized_program = nargo::ops::transform_program(compiled_program, expression_width);
     nargo::ops::check_program(&optimized_program).map_err(|errs| {
-        CompileError::with_file_diagnostics(
+        CompileError::with_custom_diagnostics(
             "Compiled program is not solvable",
             errs,
             &context.file_manager,
@@ -212,8 +212,8 @@ pub fn compile_contract(
 
     let compiled_contract =
         noirc_driver::compile_contract(&mut context, crate_id, &compile_options)
-            .map_err(|errs: Vec<noirc_errors::FileDiagnostic>| {
-                CompileError::with_file_diagnostics(
+            .map_err(|errs: Vec<noirc_errors::CustomDiagnostic>| {
+                CompileError::with_custom_diagnostics(
                     "Failed to compile contract",
                     errs,
                     &context.file_manager,

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -109,7 +109,7 @@ impl CompilerContext {
         let compiled_program =
             compile_main(&mut self.context, root_crate_id, &compile_options, None)
                 .map_err(|errs| {
-                    CompileError::with_file_diagnostics(
+                    CompileError::with_custom_diagnostics(
                         "Failed to compile program",
                         errs,
                         &self.context.file_manager,
@@ -119,7 +119,7 @@ impl CompilerContext {
 
         let optimized_program = nargo::ops::transform_program(compiled_program, expression_width);
         nargo::ops::check_program(&optimized_program).map_err(|errs| {
-            CompileError::with_file_diagnostics(
+            CompileError::with_custom_diagnostics(
                 "Compiled program is not solvable",
                 errs,
                 &self.context.file_manager,
@@ -148,7 +148,7 @@ impl CompilerContext {
         let compiled_contract =
             compile_contract(&mut self.context, root_crate_id, &compile_options)
                 .map_err(|errs| {
-                    CompileError::with_file_diagnostics(
+                    CompileError::with_custom_diagnostics(
                         "Failed to compile contract",
                         errs,
                         &self.context.file_manager,

--- a/compiler/wasm/src/errors.rs
+++ b/compiler/wasm/src/errors.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 use fm::FileManager;
-use noirc_errors::FileDiagnostic;
+use noirc_errors::CustomDiagnostic;
 
 #[wasm_bindgen(typescript_custom_section)]
 const DIAGNOSTICS: &'static str = r#"
@@ -87,8 +87,7 @@ pub struct Diagnostic {
 }
 
 impl Diagnostic {
-    fn new(file_diagnostic: &FileDiagnostic, file: String) -> Diagnostic {
-        let diagnostic = &file_diagnostic.diagnostic;
+    fn new(diagnostic: &CustomDiagnostic, file: String) -> Diagnostic {
         let message = diagnostic.message.clone();
 
         let secondaries = diagnostic
@@ -116,16 +115,16 @@ impl CompileError {
         CompileError { message: message.to_string(), diagnostics: vec![] }
     }
 
-    pub fn with_file_diagnostics(
+    pub fn with_custom_diagnostics(
         message: &str,
-        file_diagnostics: Vec<FileDiagnostic>,
+        custom_diagnostics: Vec<CustomDiagnostic>,
         file_manager: &FileManager,
     ) -> CompileError {
-        let diagnostics: Vec<_> = file_diagnostics
+        let diagnostics: Vec<_> = custom_diagnostics
             .iter()
             .map(|err| {
                 let file_path = file_manager
-                    .path(err.file_id)
+                    .path(err.file)
                     .expect("File must exist to have caused diagnostics");
                 Diagnostic::new(err, file_path.to_str().unwrap().to_string())
             })

--- a/tooling/lsp/src/requests/test_run.rs
+++ b/tooling/lsp/src/requests/test_run.rs
@@ -119,7 +119,7 @@ fn on_test_run_request_inner(
                 TestStatus::CompileError(diag) => NargoTestRunResult {
                     id: params.id.clone(),
                     result: "error".to_string(),
-                    message: Some(diag.diagnostic.message),
+                    message: Some(diag.message),
                 },
             };
             Ok(result)

--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -9,9 +9,7 @@ use acvm::{
     pwg::{ErrorLocation, OpcodeResolutionError},
 };
 use noirc_abi::{Abi, AbiErrorType, display_abi_error};
-use noirc_errors::{
-    CustomDiagnostic, FileDiagnostic, debug_info::DebugInfo, reporter::ReportedErrors,
-};
+use noirc_errors::{CustomDiagnostic, debug_info::DebugInfo, reporter::ReportedErrors};
 
 pub use noirc_errors::Location;
 
@@ -230,7 +228,7 @@ pub fn try_to_diagnose_runtime_error(
     nargo_err: &NargoError<FieldElement>,
     abi: &Abi,
     debug: &[DebugInfo],
-) -> Option<FileDiagnostic> {
+) -> Option<CustomDiagnostic> {
     let source_locations = match nargo_err {
         NargoError::ExecutionError(execution_error) => {
             extract_locations_from_error(execution_error, debug)?
@@ -242,5 +240,5 @@ pub fn try_to_diagnose_runtime_error(
     let location = *source_locations.last()?;
     let message = extract_message_from_error(&abi.error_types, nargo_err);
     let error = CustomDiagnostic::simple_error(message, String::new(), location);
-    Some(error.with_call_stack(source_locations).in_file(location.file))
+    Some(error.with_call_stack(source_locations))
 }

--- a/tooling/nargo/src/ops/check.rs
+++ b/tooling/nargo/src/ops/check.rs
@@ -1,6 +1,6 @@
 use acvm::compiler::CircuitSimulator;
 use noirc_driver::{CompiledProgram, ErrorsAndWarnings};
-use noirc_errors::{CustomDiagnostic, FileDiagnostic};
+use noirc_errors::CustomDiagnostic;
 
 /// Run each function through a circuit simulator to check that they are solvable.
 #[tracing::instrument(level = "trace", skip_all)]
@@ -8,13 +8,10 @@ pub fn check_program(compiled_program: &CompiledProgram) -> Result<(), ErrorsAnd
     for (i, circuit) in compiled_program.program.functions.iter().enumerate() {
         let mut simulator = CircuitSimulator::default();
         if !simulator.check_circuit(circuit) {
-            let diag = FileDiagnostic {
-                file_id: fm::FileId::dummy(),
-                diagnostic: CustomDiagnostic::from_message(&format!(
-                    "Circuit \"{}\" is not solvable",
-                    compiled_program.names[i]
-                )),
-            };
+            let diag = CustomDiagnostic::from_message(
+                &format!("Circuit \"{}\" is not solvable", compiled_program.names[i]),
+                fm::FileId::dummy(),
+            );
             return Err(vec![diag]);
         }
     }

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -8,7 +8,7 @@ use acvm::{
 };
 use noirc_abi::Abi;
 use noirc_driver::{CompileError, CompileOptions, DEFAULT_EXPRESSION_WIDTH, compile_no_check};
-use noirc_errors::{FileDiagnostic, debug_info::DebugInfo};
+use noirc_errors::{CustomDiagnostic, debug_info::DebugInfo};
 use noirc_frontend::hir::{Context, def_map::TestFunction};
 
 use crate::{
@@ -22,9 +22,9 @@ use super::execute_program;
 #[derive(Debug)]
 pub enum TestStatus {
     Pass,
-    Fail { message: String, error_diagnostic: Option<FileDiagnostic> },
+    Fail { message: String, error_diagnostic: Option<CustomDiagnostic> },
     Skipped,
-    CompileError(FileDiagnostic),
+    CompileError(CustomDiagnostic),
 }
 
 impl TestStatus {
@@ -218,7 +218,7 @@ fn test_status_program_compile_pass(
 fn check_expected_failure_message(
     test_function: &TestFunction,
     failed_assertion: Option<String>,
-    error_diagnostic: Option<FileDiagnostic>,
+    error_diagnostic: Option<CustomDiagnostic>,
 ) -> TestStatus {
     // Extract the expected failure message, if there was one
     //
@@ -235,9 +235,7 @@ fn check_expected_failure_message(
     // expected_failure_message
     let expected_failure_message_matches = failed_assertion
         .as_ref()
-        .or_else(|| {
-            error_diagnostic.as_ref().map(|file_diagnostic| &file_diagnostic.diagnostic.message)
-        })
+        .or_else(|| error_diagnostic.as_ref().map(|file_diagnostic| &file_diagnostic.message))
         .map(|message| message.contains(expected_failure_message))
         .unwrap_or(false);
     if expected_failure_message_matches {

--- a/tooling/nargo_cli/src/cli/export_cmd.rs
+++ b/tooling/nargo_cli/src/cli/export_cmd.rs
@@ -1,7 +1,7 @@
 use nargo::errors::CompileError;
 use nargo::ops::report_errors;
 use noir_artifact_cli::fs::artifact::save_program_to_file;
-use noirc_errors::FileDiagnostic;
+use noirc_errors::CustomDiagnostic;
 use noirc_frontend::hir::ParsedFiles;
 use rayon::prelude::*;
 
@@ -82,7 +82,7 @@ fn compile_exported_functions(
         |(function_name, function_id)| -> Result<(String, CompiledProgram), CompileError> {
             // TODO: We should to refactor how to deal with compilation errors to avoid this.
             let program = compile_no_check(&mut context, compile_options, function_id, None, false)
-                .map_err(|error| vec![FileDiagnostic::from(error)]);
+                .map_err(|error| vec![CustomDiagnostic::from(error)]);
 
             let program = report_errors(
                 program.map(|program| (program, Vec::new())),

--- a/tooling/nargo_cli/src/cli/fmt_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fmt_cmd.rs
@@ -56,11 +56,8 @@ pub(crate) fn run(args: FormatCommand, workspace: Workspace) -> Result<(), CliEr
             let is_all_warnings = errors.iter().all(ParserError::is_warning);
             if !is_all_warnings {
                 let errors = errors
-                    .into_iter()
-                    .map(|error| {
-                        let error = CustomDiagnostic::from(&error);
-                        error.in_file(file_id)
-                    })
+                    .iter()
+                    .map(CustomDiagnostic::from)
                     .collect();
 
                 let _ = report_errors::<()>(

--- a/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
@@ -2,7 +2,7 @@ use std::{io::Write, panic::RefUnwindSafe, time::Duration};
 
 use fm::FileManager;
 use nargo::ops::TestStatus;
-use noirc_errors::{FileDiagnostic, reporter::stack_trace};
+use noirc_errors::{CustomDiagnostic, reporter::stack_trace};
 use serde_json::{Map, json};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, StandardStreamLock, WriteColor};
 
@@ -438,7 +438,7 @@ impl Formatter for JsonFormatter {
                 stdout.push_str(message.trim());
 
                 if let Some(diagnostic) = error_diagnostic {
-                    if !(diagnostic.diagnostic.is_warning() && silence_warnings) {
+                    if !(diagnostic.is_warning() && silence_warnings) {
                         stdout.push('\n');
                         stdout.push_str(&diagnostic_to_string(diagnostic, file_manager));
                     }
@@ -450,7 +450,7 @@ impl Formatter for JsonFormatter {
             TestStatus::CompileError(diagnostic) => {
                 json.insert("event".to_string(), json!("failed"));
 
-                if !(diagnostic.diagnostic.is_warning() && silence_warnings) {
+                if !(diagnostic.is_warning() && silence_warnings) {
                     if !stdout.is_empty() {
                         stdout.push('\n');
                     }
@@ -515,12 +515,11 @@ fn package_start(package_name: &str, test_count: usize) -> std::io::Result<()> {
 }
 
 pub(crate) fn diagnostic_to_string(
-    file_diagnostic: &FileDiagnostic,
+    custom_diagnostic: &CustomDiagnostic,
     file_manager: &FileManager,
 ) -> String {
     let file_map = file_manager.as_file_map();
 
-    let custom_diagnostic = &file_diagnostic.diagnostic;
     let mut message = String::new();
     message.push_str(custom_diagnostic.message.trim());
 
@@ -529,7 +528,7 @@ pub(crate) fn diagnostic_to_string(
         message.push_str(note.trim());
     }
 
-    if let Ok(name) = file_map.get_name(file_diagnostic.file_id) {
+    if let Ok(name) = file_map.get_name(custom_diagnostic.file) {
         message.push('\n');
         message.push_str(&format!("at {name}"));
     }


### PR DESCRIPTION
# Description

## Problem

Addresses this comment: https://github.com/noir-lang/noir/pull/7486#discussion_r1967841707

## Summary

Now that `CustomDiagnostic` almost always carries a Location, I change it to also always carry a `file: FileId` so that we no longer need an extra `FileDiagnostic` type, and code becomes a bit simpler.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
