### PR TITLE
fix: fix a few cases where safety comment wasn't correctly identified

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -208,6 +208,9 @@ impl<'a> Parser<'a> {
             match self.tokens.next() {
                 Some(Ok(token)) => match token.token() {
                     Token::LineComment(comment, None) | Token::BlockComment(comment, None) => {
+                        if !last_comments.is_empty() {
+                            last_comments.push('\n');
+                        }
                         last_comments.push_str(comment);
                         continue;
                     }

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -398,7 +398,7 @@ impl Parser<'_> {
             if let Some(statement_comments) = &self.statement_comments {
                 statement_comments
             } else {
-                &""
+                ""
             }
         } else {
             &comments_before_unsafe

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -393,15 +393,17 @@ impl Parser<'_> {
             return None;
         }
 
-        if self.current_token_comments.is_empty() {
-            if let Some(statement_comments) = &mut self.statement_comments {
-                if !statement_comments.trim().to_lowercase().starts_with("safety:") {
-                    self.push_error(ParserErrorReason::MissingSafetyComment, start_location);
-                }
+        let comments: &str = if self.current_token_comments.is_empty() {
+            if let Some(statement_comments) = &self.statement_comments {
+                statement_comments
             } else {
-                self.push_error(ParserErrorReason::MissingSafetyComment, start_location);
+                &""
             }
-        } else if !self.current_token_comments.trim().to_lowercase().starts_with("safety:") {
+        } else {
+            &self.current_token_comments
+        };
+
+        if !comments.lines().any(|line| line.trim().to_lowercase().starts_with("safety:")) {
             self.push_error(ParserErrorReason::MissingSafetyComment, start_location);
         }
 

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -521,7 +521,9 @@ mod tests {
     fn parses_let_statement_with_unsafe() {
         let src = "// Safety: comment
         let x = unsafe { 1 };";
-        let statement = parse_statement_no_errors(src);
+        let mut parser = Parser::for_str_with_dummy_file(src);
+        let statement = parser.parse_statement_or_error();
+        assert!(parser.errors.is_empty());
         let StatementKind::Let(let_statement) = statement.kind else {
             panic!("Expected let statement");
         };
@@ -534,6 +536,20 @@ mod tests {
         let x = unsafe { 1 };";
         let mut parser = Parser::for_str_with_dummy_file(src);
         let (statement, _) = parser.parse_statement().unwrap();
+        let StatementKind::Let(let_statement) = statement.kind else {
+            panic!("Expected let statement");
+        };
+        assert_eq!(let_statement.pattern.to_string(), "x");
+    }
+
+    #[test]
+    fn parses_let_statement_with_unsafe_after_some_other_comment() {
+        let src = "// Top comment
+        // Safety: comment
+        let x = unsafe { 1 };";
+        let mut parser = Parser::for_str_with_dummy_file(src);
+        let statement = parser.parse_statement_or_error();
+        assert!(parser.errors.is_empty());
         let StatementKind::Let(let_statement) = statement.kind else {
             panic!("Expected let statement");
         };


### PR DESCRIPTION
# Description

## Problem

Resolves #7547

## Summary

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
