### PR TITLE
feat(experimental): Issue missing case error for match expressions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use fxhash::FxHashMap as HashMap;
 use iter_extended::{btree_map, try_vecmap, vecmap};
 use noirc_errors::Location;
+use rangemap::StepLite;
 
 use crate::{
     DataType, Kind, Shared, Type,
@@ -26,6 +27,8 @@ use crate::{
 };
 
 use super::Elaborator;
+
+const WILDCARD_PATTERN: &str = "_";
 
 struct MatchCompiler<'elab, 'ctx> {
     elaborator: &'elab mut Elaborator<'ctx>,
@@ -506,7 +509,7 @@ impl Elaborator<'_> {
 
         if let Some(existing) = variables_defined.iter().find(|elem| *elem == &name) {
             // Allow redefinition of `_` only, to ignore variables
-            if name.0.contents != "_" {
+            if name.0.contents != WILDCARD_PATTERN {
                 self.push_err(ResolverError::VariableAlreadyDefinedInPattern {
                     existing: existing.clone(),
                     new_location: name.location(),
@@ -793,8 +796,13 @@ impl Elaborator<'_> {
     ///
     /// This is an adaptation of https://github.com/yorickpeterse/pattern-matching-in-rust/tree/main/jacobs2021
     /// which is an implementation of https://julesjacobs.com/notes/patternmatching/patternmatching.pdf
-    pub(super) fn elaborate_match_rows(&mut self, rows: Vec<Row>, location: Location) -> HirMatch {
-        MatchCompiler::run(self, rows, location)
+    pub(super) fn elaborate_match_rows(
+        &mut self,
+        rows: Vec<Row>,
+        type_matched_on: &Type,
+        location: Location,
+    ) -> HirMatch {
+        MatchCompiler::run(self, rows, type_matched_on, location)
     }
 }
 
@@ -802,6 +810,7 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
     fn run(
         elaborator: &'elab mut Elaborator<'ctx>,
         rows: Vec<Row>,
+        type_matched_on: &Type,
         location: Location,
     ) -> HirMatch {
         let mut compiler = Self {
@@ -816,7 +825,7 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
         });
 
         if compiler.has_missing_cases {
-            compiler.issue_missing_cases_error(&hir_match, location);
+            compiler.issue_missing_cases_error(&hir_match, type_matched_on, location);
         }
 
         if !compiler.unreachable_cases.is_empty() {
@@ -1191,10 +1200,15 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
 
     /// Traverse the resulting HirMatch to build counter-examples of values which would
     /// not be covered by the match.
-    fn issue_missing_cases_error(&mut self, tree: &HirMatch, location: Location) {
+    fn issue_missing_cases_error(
+        &mut self,
+        tree: &HirMatch,
+        type_matched_on: &Type,
+        location: Location,
+    ) {
         let starting_id = match tree {
-            HirMatch::Switch(id, ..) => Some(*id),
-            _ => None,
+            HirMatch::Switch(id, ..) => *id,
+            _ => return self.issue_missing_cases_error_for_type(type_matched_on, location),
         };
 
         let mut cases = BTreeSet::new();
@@ -1203,12 +1217,28 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
         self.elaborator.push_err(TypeCheckError::MissingCases { cases, location });
     }
 
+    /// Issue a missing cases error if necessary for the given type, assuming that no
+    /// case of the type is covered. This is the case for empty matches `match foo {}`.
+    /// Note that this is expected not to error if the given type is an enum with zero variants.
+    fn issue_missing_cases_error_for_type(&mut self, type_matched_on: &Type, location: Location) {
+        let typ = type_matched_on.follow_bindings_shallow();
+        if let Type::DataType(shared, generics) = typ.as_ref() {
+            if let Some(variants) = shared.borrow().get_variants(generics) {
+                let cases = variants.into_iter().map(|(name, _)| name).collect();
+                self.elaborator.push_err(TypeCheckError::MissingCases { cases, location });
+                return;
+            }
+        }
+        let typ = typ.to_string();
+        self.elaborator.push_err(TypeCheckError::MissingManyCases { typ, location });
+    }
+
     fn find_missing_values(
         &self,
         tree: &HirMatch,
-        env: &mut HashMap<DefinitionId, Case>,
+        env: &mut HashMap<DefinitionId, (String, Vec<DefinitionId>)>,
         missing_cases: &mut BTreeSet<String>,
-        starting_id: Option<DefinitionId>,
+        starting_id: DefinitionId,
     ) {
         match tree {
             HirMatch::Success(_) | HirMatch::Failure { missing_case: false } => (),
@@ -1221,12 +1251,15 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
             }
             HirMatch::Switch(definition_id, cases, else_case) => {
                 for case in cases {
-                    env.insert(*definition_id, case.clone());
+                    let name = case.constructor.to_string();
+                    env.insert(*definition_id, (name, case.arguments.clone()));
                     self.find_missing_values(&case.body, env, missing_cases, starting_id);
                 }
 
                 if let Some(else_case) = else_case {
-                    for case in self.missing_cases(cases) {
+                    let typ = self.elaborator.interner.definition_type(*definition_id);
+
+                    for case in self.missing_cases(cases, &typ) {
                         env.insert(*definition_id, case);
                         self.find_missing_values(else_case, env, missing_cases, starting_id);
                     }
@@ -1237,10 +1270,14 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
         }
     }
 
-    fn missing_cases(&self, cases: &[Case]) -> Vec<Case> {
+    fn missing_cases(&self, cases: &[Case], typ: &Type) -> Vec<(String, Vec<DefinitionId>)> {
         // We expect `cases` to come from a `Switch` which should always have
         // at least 2 cases, otherwise it should be a Success or Failure node.
         let first = &cases[0];
+
+        if matches!(&first.constructor, Constructor::Int(_) | Constructor::Range(..)) {
+            return self.missing_integer_cases(cases, typ);
+        }
 
         let all_constructors = first.constructor.all_constructors();
         let mut all_constructors =
@@ -1254,28 +1291,65 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
             // Safety: this id should only be used in `env` of `find_missing_values` which
             //         only uses it for display and defaults to "_" on unknown ids.
             let args = vecmap(0..arg_count, |_| DefinitionId::dummy_id());
-            Case::new(constructor, args, HirMatch::Failure { missing_case: true })
+            (constructor.to_string(), args)
+        })
+    }
+
+    fn missing_integer_cases(
+        &self,
+        cases: &[Case],
+        typ: &Type,
+    ) -> Vec<(String, Vec<DefinitionId>)> {
+        // We could give missed cases for field ranges of `0 .. field_modulus` but since the field
+        // used in Noir may change we recommend a match-all pattern instead.
+        // If the type is a type variable, we don't know exactly which integer type this may
+        // resolve to so also just suggest a catch-all in that case.
+        if typ.is_field() || typ.is_bindable() {
+            return vec![(WILDCARD_PATTERN.to_string(), Vec::new())];
+        }
+
+        let mut missing_cases = rangemap::RangeInclusiveSet::new();
+
+        let int_max = SignedField::positive(typ.integral_maximum_size().unwrap());
+        let int_min = typ.integral_minimum_size().unwrap();
+        missing_cases.insert(int_min..=int_max);
+
+        for case in cases {
+            match &case.constructor {
+                Constructor::Int(signed_field) => {
+                    missing_cases.remove(*signed_field..=*signed_field)
+                }
+                Constructor::Range(start, end) => {
+                    // our ranges our exclusive, so adjust for that
+                    missing_cases.remove(*start..=end.sub_one());
+                }
+                _ => unreachable!(
+                    "missing_integer_cases should only be called with Int or Range constructors"
+                ),
+            }
+        }
+
+        vecmap(missing_cases, |range| {
+            if range.start() == range.end() {
+                (format!("{}", range.start()), Vec::new())
+            } else {
+                (format!("{}..={}", range.start(), range.end()), Vec::new())
+            }
         })
     }
 
     fn construct_missing_case(
-        starting_id: Option<DefinitionId>,
-        env: &HashMap<DefinitionId, Case>,
+        starting_id: DefinitionId,
+        env: &HashMap<DefinitionId, (String, Vec<DefinitionId>)>,
     ) -> String {
-        let Some(id) = starting_id else {
-            return "_".to_string();
+        let Some((constructor, arguments)) = env.get(&starting_id) else {
+            return WILDCARD_PATTERN.to_string();
         };
 
-        let Some(case) = env.get(&id) else {
-            return "_".to_string();
-        };
+        let no_arguments = arguments.is_empty();
 
-        let constructor = case.constructor.to_string();
-        let no_arguments = case.arguments.is_empty();
+        let args = vecmap(arguments, |arg| Self::construct_missing_case(*arg, env)).join(", ");
 
-        let args =
-            vecmap(&case.arguments, |arg| Self::construct_missing_case(Some(*arg), env)).join(", ");
-
-        if no_arguments { constructor } else { format!("{constructor}({args})") }
+        if no_arguments { constructor.clone() } else { format!("{constructor}({args})") }
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -1320,7 +1320,7 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
                     missing_cases.remove(*signed_field..=*signed_field);
                 }
                 Constructor::Range(start, end) => {
-                    // our ranges our exclusive, so adjust for that
+                    // Our ranges are exclusive, so adjust for that
                     missing_cases.remove(*start..=end.sub_one());
                 }
                 _ => unreachable!(

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -1317,7 +1317,7 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
         for case in cases {
             match &case.constructor {
                 Constructor::Int(signed_field) => {
-                    missing_cases.remove(*signed_field..=*signed_field)
+                    missing_cases.remove(*signed_field..=*signed_field);
                 }
                 Constructor::Range(start, end) => {
                     // our ranges our exclusive, so adjust for that

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1055,6 +1055,7 @@ impl Elaborator<'_> {
     ) -> (HirExpression, Type) {
         self.use_unstable_feature(super::UnstableFeature::Enums, location);
 
+        let expr_location = match_expr.expression.location;
         let (expression, typ) = self.elaborate_expression(match_expr.expression);
         let (let_, variable) = self.wrap_in_let(expression, typ);
 
@@ -1065,7 +1066,7 @@ impl Elaborator<'_> {
         // the match rows - it'll just lead to extra errors like `unreachable pattern`
         // warnings on branches which previously had type errors.
         let tree = HirExpression::Match(if !errored {
-            self.elaborate_match_rows(rows)
+            self.elaborate_match_rows(rows, expr_location)
         } else {
             HirMatch::Failure { missing_case: false }
         });

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1057,7 +1057,7 @@ impl Elaborator<'_> {
 
         let expr_location = match_expr.expression.location;
         let (expression, typ) = self.elaborate_expression(match_expr.expression);
-        let (let_, variable) = self.wrap_in_let(expression, typ);
+        let (let_, variable) = self.wrap_in_let(expression, typ.clone());
 
         let (errored, (rows, result_type)) =
             self.errors_occurred_in(|this| this.elaborate_match_rules(variable, match_expr.rules));
@@ -1066,7 +1066,7 @@ impl Elaborator<'_> {
         // the match rows - it'll just lead to extra errors like `unreachable pattern`
         // warnings on branches which previously had type errors.
         let tree = HirExpression::Match(if !errored {
-            self.elaborate_match_rows(rows, expr_location)
+            self.elaborate_match_rows(rows, &typ, expr_location)
         } else {
             HirMatch::Failure { missing_case: false }
         });

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::rc::Rc;
 
 use acvm::FieldElement;
@@ -14,6 +15,9 @@ use crate::hir_def::traits::TraitConstraint;
 use crate::hir_def::types::{BinaryTypeOperator, Kind, Type};
 use crate::node_interner::NodeInterner;
 use crate::signed_field::SignedField;
+
+/// Rust also only shows 3 maximum, even for short patterns.
+pub const MAX_MISSING_CASES: usize = 3;
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum Source {
@@ -237,6 +241,8 @@ pub enum TypeCheckError {
     NestedUnsafeBlock { location: Location },
     #[error("Unreachable match case")]
     UnreachableCase { location: Location },
+    #[error("Missing cases")]
+    MissingCases { cases: BTreeSet<String>, location: Location },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -324,6 +330,7 @@ impl TypeCheckError {
             | TypeCheckError::TypeAnnotationsNeededForIndex { location }
             | TypeCheckError::UnnecessaryUnsafeBlock { location }
             | TypeCheckError::UnreachableCase { location }
+            | TypeCheckError::MissingCases { location, .. }
             | TypeCheckError::NestedUnsafeBlock { location } => *location,
             TypeCheckError::DuplicateNamedTypeArg { name: ident, .. }
             | TypeCheckError::NoSuchNamedTypeArg { name: ident, .. } => ident.location(),
@@ -650,6 +657,24 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                     "This pattern is redundant with one or more prior patterns".into(),
                     *location,
                 )
+            },
+            TypeCheckError::MissingCases { cases, location } => {
+                let s = if cases.len() == 1 { "" } else { "s" };
+
+                let mut not_shown = String::new();
+                let mut shown_cases = cases.iter()
+                    .map(|s| format!("`{s}`"))
+                    .take(MAX_MISSING_CASES)
+                    .collect::<Vec<_>>();
+
+                if cases.len() > MAX_MISSING_CASES {
+                    shown_cases.truncate(MAX_MISSING_CASES);
+                    not_shown = format!(", and {} more not shown", cases.len() - MAX_MISSING_CASES);
+                }
+
+                let shown_cases = shown_cases.join(", ");
+                let msg = format!("Missing case{s}: {shown_cases}{not_shown}");
+                Diagnostic::simple_error(msg, String::new(), *location)
             },
         }
     }

--- a/compiler/noirc_frontend/src/hir/type_check/mod.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/mod.rs
@@ -2,4 +2,4 @@ mod errors;
 pub mod generics;
 
 pub use self::errors::Source;
-pub use errors::{NoMatchingImplFoundError, TypeCheckError};
+pub use errors::{MAX_MISSING_CASES, NoMatchingImplFoundError, TypeCheckError};

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -455,7 +455,7 @@ impl Constructor {
                 };
 
                 let def_ref = def.borrow();
-                if let Some(variants) = def_ref.get_variants(&generics) {
+                if let Some(variants) = def_ref.get_variants(generics) {
                     vecmap(variants.into_iter().enumerate(), |(i, (_, fields))| {
                         (Constructor::Variant(typ.clone(), i), fields.len())
                     })

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -14,6 +14,7 @@ use crate::{
     ast::{IntegerBitSize, ItemVisibility},
     hir::type_check::{TypeCheckError, generics::TraitGenerics},
     node_interner::{ExprId, NodeInterner, TraitId, TypeAliasId},
+    signed_field::{AbsU128, SignedField},
 };
 use iter_extended::vecmap;
 use noirc_errors::Location;
@@ -1156,15 +1157,15 @@ impl Type {
     }
 
     pub fn is_field(&self) -> bool {
-        matches!(self.follow_bindings(), Type::FieldElement)
+        matches!(self.follow_bindings_shallow().as_ref(), Type::FieldElement)
     }
 
     pub fn is_bool(&self) -> bool {
-        matches!(self.follow_bindings(), Type::Bool)
+        matches!(self.follow_bindings_shallow().as_ref(), Type::Bool)
     }
 
     pub fn is_integer(&self) -> bool {
-        matches!(self.follow_bindings(), Type::Integer(_, _))
+        matches!(self.follow_bindings_shallow().as_ref(), Type::Integer(_, _))
     }
 
     /// If value_level, only check for Type::FieldElement,
@@ -2759,6 +2760,36 @@ impl Type {
             | Type::Forall(..)
             | Type::Quoted(..)
             | Type::Error => None,
+        }
+    }
+
+    pub(crate) fn integral_minimum_size(&self) -> Option<SignedField> {
+        match self.follow_bindings_shallow().as_ref() {
+            Type::FieldElement => None,
+            Type::Integer(sign, num_bits) => {
+                if *sign == Signedness::Unsigned {
+                    return Some(SignedField::zero());
+                }
+
+                let max_bit_size = num_bits.bit_size() - 1;
+                Some(if max_bit_size == 128 {
+                    SignedField::negative(i128::MIN.abs_u128())
+                } else {
+                    SignedField::negative(1u128 << max_bit_size)
+                })
+            }
+            Type::Bool => Some(SignedField::zero()),
+            Type::TypeVariable(var) => {
+                let binding = &var.1;
+                match &*binding.borrow() {
+                    TypeBinding::Unbound(_, type_var_kind) => match type_var_kind {
+                        Kind::Any | Kind::Normal | Kind::Integer | Kind::IntegerOrField => None,
+                        Kind::Numeric(typ) => typ.integral_minimum_size(),
+                    },
+                    TypeBinding::Bound(typ) => typ.integral_minimum_size(),
+                }
+            }
+            _ => None,
         }
     }
 }

--- a/compiler/noirc_frontend/src/signed_field.rs
+++ b/compiler/noirc_frontend/src/signed_field.rs
@@ -19,6 +19,14 @@ impl SignedField {
         Self { field: field.into(), is_negative: true }
     }
 
+    pub fn zero() -> SignedField {
+        Self { field: FieldElement::zero(), is_negative: false }
+    }
+
+    pub fn one() -> SignedField {
+        Self { field: FieldElement::one(), is_negative: false }
+    }
+
     /// Convert a signed integer to a SignedField, carefully handling
     /// INT_MIN in the process. Note that to convert an unsigned integer
     /// you can call `SignedField::positive`.
@@ -122,6 +130,32 @@ impl std::fmt::Display for SignedField {
             write!(f, "-")?;
         }
         write!(f, "{}", self.field)
+    }
+}
+
+impl rangemap::StepLite for SignedField {
+    fn add_one(&self) -> Self {
+        if self.is_negative {
+            if self.field.is_one() {
+                Self::new(FieldElement::zero(), false)
+            } else {
+                Self::new(self.field - FieldElement::one(), self.is_negative)
+            }
+        } else {
+            Self::new(self.field + FieldElement::one(), self.is_negative)
+        }
+    }
+
+    fn sub_one(&self) -> Self {
+        if self.is_negative {
+            Self::new(self.field + FieldElement::one(), self.is_negative)
+        } else {
+            if self.field.is_zero() {
+                Self::new(FieldElement::one(), true)
+            } else {
+                Self::new(self.field - FieldElement::one(), self.is_negative)
+            }
+        }
     }
 }
 

--- a/compiler/noirc_frontend/src/signed_field.rs
+++ b/compiler/noirc_frontend/src/signed_field.rs
@@ -149,12 +149,10 @@ impl rangemap::StepLite for SignedField {
     fn sub_one(&self) -> Self {
         if self.is_negative {
             Self::new(self.field + FieldElement::one(), self.is_negative)
+        } else if self.field.is_zero() {
+            Self::new(FieldElement::one(), true)
         } else {
-            if self.field.is_zero() {
-                Self::new(FieldElement::one(), true)
-            } else {
-                Self::new(self.field - FieldElement::one(), self.is_negative)
-            }
+            Self::new(self.field - FieldElement::one(), self.is_negative)
         }
     }
 }

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -356,3 +356,14 @@ fn missing_integer_cases_with_empty_match() {
     ",
     );
 }
+
+#[test]
+fn match_on_empty_enum() {
+    check_errors(
+        "
+        pub fn foo(v: Void) {
+            match v {}
+        }
+        pub enum Void {}",
+    );
+}

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -250,3 +250,41 @@ fn match_reachability_errors_ignored_when_there_is_a_type_error() {
     ",
     );
 }
+
+#[test]
+fn missing_single_case() {
+    check_errors(
+        "
+        fn main() {
+            match Opt::Some(3) {
+                  ^^^^^^^^^^^^ Missing case: `Some(_)`
+                Opt::None => (),
+            }
+        }
+
+        enum Opt<T> {
+            None,
+            Some(T),
+        }
+    ",
+    );
+}
+
+#[test]
+fn missing_many_cases() {
+    check_errors(
+        "
+        fn main() {
+            match Abc::A {
+                  ^^^^^^ Missing cases: `C`, `D`, `E`, and 21 more not shown
+                Abc::A => (),
+                Abc::B => (),
+            }
+        }
+
+        enum Abc {
+            A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z
+        }
+    ",
+    );
+}

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -288,3 +288,54 @@ fn missing_many_cases() {
     ",
     );
 }
+
+#[test]
+fn missing_int_ranges() {
+    check_errors(
+        "
+        fn main() {
+            let x: i8 = 3;
+            match Opt::Some(x) {
+                  ^^^^^^^^^^^^ Missing cases: `None`, `Some(-128..=3)`, `Some(5)`, and 1 more not shown
+                Opt::Some(4) => (),
+                Opt::Some(6) => (),
+            }
+        }
+
+        enum Opt<T> {
+            None,
+            Some(T),
+        }
+    ",
+    );
+}
+
+#[test]
+fn missing_cases_with_empty_match() {
+    check_errors(
+        "
+        fn main() {
+            match Abc::A {}
+                  ^^^^^^ Missing cases: `A`, `B`, `C`, and 23 more not shown
+        }
+
+        enum Abc {
+            A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z
+        }
+    ",
+    );
+}
+
+#[test]
+fn missing_integer_cases_with_empty_match() {
+    check_errors(
+        "
+        fn main() {
+            let x: i8 = 3;
+            match x {}
+                  ^ Missing cases: `i8` is non-empty
+                  ~ Try adding a match-all pattern: `_`
+        }
+    ",
+    );
+}

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -311,6 +311,23 @@ fn missing_int_ranges() {
 }
 
 #[test]
+fn missing_int_ranges_with_negatives() {
+    check_errors(
+        "
+        fn main() {
+            let x: i32 = -4;
+            match x {
+                  ^ Missing cases: `-2147483648..=-6`, `-4..=-1`, `1..=2`, and 1 more not shown
+                -5 => (),
+                0 => (),
+                3 => (),
+            }
+        }
+    ",
+    );
+}
+
+#[test]
 fn missing_cases_with_empty_match() {
     check_errors(
         "


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Issues a missing case(s) error for match expressions missing any cases. This includes constructing an example of a value which fails to match.

## Additional Context

~~Limitation: if the match doesn't match on any cases such as `match foo {}` we don't issue a helpful error like `Missing cases Foo, Bar, Baz` and instead issue `Missing cases: _`. This could be fixed but it is the end of the week so I wanted to get this work out.~~ This has been implemented along with ranges for integers (see tests).

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
