### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT a90f08e245add379fa0257c81f8e2819beb190cb
+define: &AZ_COMMIT 966982264a0da23546fb7695079e74b1234da790
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -35,19 +35,19 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/rollup-base-private
     num_runs: 5
     timeout: 15
-    compilation-timeout: 10
-    execution-timeout: 0.5
-    compilation-memory-limit: 1100
-    execution-memory-limit: 500
+    compilation-timeout: 20
+    execution-timeout: 1
+    compilation-memory-limit: 1500
+    execution-memory-limit: 650
   rollup-base-public:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-base-public
     num_runs: 5
     timeout: 15
-    compilation-timeout: 8
-    execution-timeout: 0.4
-    compilation-memory-limit: 1000
+    compilation-timeout: 15
+    execution-timeout: 0.75
+    compilation-memory-limit: 1300
     execution-memory-limit: 500
   rollup-block-root-empty:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT a90f08e245add379fa0257c81f8e2819beb190cb
+define: &AZ_COMMIT 966982264a0da23546fb7695079e74b1234da790
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
