### PR TITLE
fix: rename q c field to constant in expression struct

### DIFF
--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -35,12 +35,12 @@ pub enum Opcode<F> {
     /// `w=(w_1,..w_n)` is a tuple of `n` witnesses, and `P` is a multi-variate
     /// polynomial of total degree at most `2`.
     ///
-    /// The coefficients `{q_M}_{i,j}, q_i,q_c` of the polynomial are known
+    /// The coefficients `{q_M}_{i,j}, q_i, constant` of the polynomial are known
     /// values which define the opcode.
     ///
     /// A general expression of assert-zero opcode is the following:
     /// ```text
-    /// \sum_{i,j} {q_M}_{i,j}w_iw_j + \sum_i q_iw_i +q_c = 0
+    /// \sum_{i,j} {q_M}_{i,j}w_iw_j + \sum_i q_iw_i + constant = 0
     /// ```
     ///
     /// An assert-zero opcode can be used to:
@@ -140,7 +140,7 @@ impl<F: AcirField> std::fmt::Display for Opcode<F> {
                 for i in &expr.linear_combinations {
                     write!(f, "({}, _{}) ", i.0, i.1.witness_index())?;
                 }
-                write!(f, "{}", expr.q_c)?;
+                write!(f, "{}", expr.constant)?;
 
                 write!(f, " ]")
             }

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -57,7 +57,7 @@ impl<F: AcirField> RangeOptimizer<F> {
                     // as a range opcode for the number of bits required to hold that value.
                     if expr.is_degree_one_univariate() {
                         let (k, witness) = expr.linear_combinations[0];
-                        let constant = expr.q_c;
+                        let constant = expr.constant;
                         let witness_value = -constant / k;
 
                         if witness_value.is_zero() {

--- a/acvm-repo/acvm/src/compiler/transformers/csat.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/csat.rs
@@ -242,7 +242,7 @@ impl CSatTransformer {
         // Add the rest of the elements back into the new_opcode
         new_opcode.mul_terms.extend(opcode.mul_terms);
         new_opcode.linear_combinations.extend(opcode.linear_combinations);
-        new_opcode.q_c = opcode.q_c;
+        new_opcode.constant = opcode.constant;
         new_opcode.sort();
         new_opcode
     }

--- a/acvm-repo/acvm/src/pwg/arithmetic.rs
+++ b/acvm-repo/acvm/src/pwg/arithmetic.rs
@@ -48,7 +48,7 @@ impl ExpressionSolver {
             (MulTerm::OneUnknown(q, w1), OpcodeStatus::OpcodeSolvable(a, (b, w2))) => {
                 if w1 == w2 {
                     // We have one unknown so we can solve the equation
-                    let total_sum = a + opcode.q_c;
+                    let total_sum = a + opcode.constant;
                     if (q + b).is_zero() {
                         if !total_sum.is_zero() {
                             Err(OpcodeResolutionError::UnsatisfiedConstrain {
@@ -77,7 +77,7 @@ impl ExpressionSolver {
                 // Hence the equation is solvable, since there is a single unknown
                 // The equation is: partial_prod * unknown_var + sum + qC = 0
 
-                let total_sum = sum + opcode.q_c;
+                let total_sum = sum + opcode.constant;
                 if partial_prod.is_zero() {
                     if !total_sum.is_zero() {
                         Err(OpcodeResolutionError::UnsatisfiedConstrain {
@@ -95,7 +95,7 @@ impl ExpressionSolver {
             (MulTerm::Solved(a), OpcodeStatus::OpcodeSatisfied(b)) => {
                 // All the variables in the MulTerm are solved and the Fan-in is also solved
                 // There is nothing to solve
-                if !(a + b + opcode.q_c).is_zero() {
+                if !(a + b + opcode.constant).is_zero() {
                     Err(OpcodeResolutionError::UnsatisfiedConstrain {
                         opcode_location: ErrorLocation::Unresolved,
                         payload: None,
@@ -111,7 +111,7 @@ impl ExpressionSolver {
                 // The variables in the MulTerm are solved nad there is one unknown in the Fan-in
                 // Hence the equation is solvable, since we have one unknown
                 // The equation is total_prod + partial_sum + coeff * unknown_var + q_C = 0
-                let total_sum = total_prod + partial_sum + opcode.q_c;
+                let total_sum = total_prod + partial_sum + opcode.constant;
                 if coeff.is_zero() {
                     if !total_sum.is_zero() {
                         Err(OpcodeResolutionError::UnsatisfiedConstrain {
@@ -233,17 +233,17 @@ impl ExpressionSolver {
                         result.mul_terms.push((c, w1, w2));
                     }
                 }
-                MulTerm::Solved(f) => result.q_c += f,
+                MulTerm::Solved(f) => result.constant += f,
             }
         }
         for &(c, w) in &expr.linear_combinations {
             if let Some(f) = ExpressionSolver::solve_fan_in_term_helper(&(c, w), initial_witness) {
-                result.q_c += f;
+                result.constant += f;
             } else if !c.is_zero() {
                 result.linear_combinations.push((c, w));
             }
         }
-        result.q_c += expr.q_c;
+        result.constant += expr.constant;
         result
     }
 }
@@ -261,7 +261,7 @@ mod tests {
         let opcode_a = Expression {
             mul_terms: vec![],
             linear_combinations: vec![(FieldElement::one(), a)],
-            q_c: -FieldElement::one(),
+            constant: -FieldElement::one(),
         };
 
         let mut values = WitnessMap::new();
@@ -285,7 +285,7 @@ mod tests {
                 (-FieldElement::one(), c),
                 (-FieldElement::one(), d),
             ],
-            q_c: FieldElement::zero(),
+            constant: FieldElement::zero(),
         };
 
         let mut values = WitnessMap::new();
@@ -314,7 +314,7 @@ mod tests {
                 (-FieldElement::one(), c),
                 (-FieldElement::one(), d),
             ],
-            q_c: FieldElement::zero(),
+            constant: FieldElement::zero(),
         };
 
         let e = Witness(4);
@@ -325,7 +325,7 @@ mod tests {
                 (-FieldElement::one(), a),
                 (-FieldElement::one(), b),
             ],
-            q_c: FieldElement::zero(),
+            constant: FieldElement::zero(),
         };
 
         let mut values = WitnessMap::new();


### PR DESCRIPTION
# Description

## Problem*

Resolves TODO comment in `acir/src/native_types/expression/mod.rs` about renaming the `q_c` field.

## Summary*

While exploring the codebase, I found a TODO comment suggesting to rename the `q_c` field to `constant` in the Expression struct and implemented this change.

## Additional Context

_

## Documentation*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.