### PR TITLE
chore: bump `light-poseidon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,12 +2828,12 @@ dependencies = [
 
 [[package]]
 name = "light-poseidon"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
+checksum = "39e3d87542063daaccbfecd78b60f988079b6ec4e089249658b9455075c78d42"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.2",
+ "ark-bn254 0.5.0",
+ "ark-ff 0.5.0",
  "num-bigint",
  "thiserror",
 ]
@@ -3030,9 +3030,7 @@ name = "nargo_cli"
 version = "1.0.0-beta.3"
 dependencies = [
  "acvm",
- "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
- "ark-ff 0.4.2",
  "assert_cmd",
  "assert_fs",
  "async-lsp",

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -99,12 +99,7 @@ sha3.workspace = true
 iai = "0.1.1"
 test-case.workspace = true
 lazy_static.workspace = true
-light-poseidon = "0.2.0"
-
-ark-bn254-v04 = { package = "ark-bn254", version = "^0.4.0", default-features = false, features = [
-    "curve",
-] }
-ark-ff-v04 = { package = "ark-ff", version = "^0.4.0", default-features = false }
+light-poseidon = "0.3.0"
 
 [[bench]]
 name = "criterion"

--- a/tooling/nargo_cli/tests/stdlib-props.rs
+++ b/tooling/nargo_cli/tests/stdlib-props.rs
@@ -290,17 +290,13 @@ fn fuzz_poseidon2_equivalence() {
 
 #[test]
 fn fuzz_poseidon_equivalence() {
-    use ark_ff_v04::{BigInteger, PrimeField};
     use light_poseidon::{Poseidon, PoseidonHasher};
 
     let poseidon_hash = |inputs: &[FieldElement]| {
-        let mut poseidon = Poseidon::<ark_bn254_v04::Fr>::new_circom(inputs.len()).unwrap();
-        let frs: Vec<ark_bn254_v04::Fr> = inputs
-            .iter()
-            .map(|f| ark_bn254_v04::Fr::from_be_bytes_mod_order(&f.to_be_bytes()))
-            .collect::<Vec<_>>();
-        let hash = poseidon.hash(&frs).expect("failed to hash");
-        FieldElement::from_be_bytes_reduce(&hash.into_bigint().to_bytes_be())
+        let mut poseidon = Poseidon::<ark_bn254::Fr>::new_circom(inputs.len()).unwrap();
+        let frs: Vec<ark_bn254::Fr> = inputs.iter().map(|f| f.into_repr()).collect::<Vec<_>>();
+        let hash: ark_bn254::Fr = poseidon.hash(&frs).expect("failed to hash");
+        FieldElement::from_repr(hash)
     };
 
     // Noir has hashes up to length 16, but the reference library won't work with more than 12.


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Followup to https://github.com/noir-lang/noir/pull/6871. We can now remove arkworks v0.4 fully as our poseidon dependency accepts v0.5.0

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
