### PR TITLE
feat: add eq, gte, and lte functions to BN254 library

### DIFF
--- a/noir_stdlib/src/field/bn254.nr
+++ b/noir_stdlib/src/field/bn254.nr
@@ -122,9 +122,123 @@ pub fn lt(a: Field, b: Field) -> bool {
     gt(b, a)
 }
 
+pub fn eq(a: Field, b: Field) -> bool {
+    a == b
+}
+
+pub fn lte(a: Field, b: Field) -> bool {
+    if is_unconstrained() {
+        unsafe {
+            lte_hint(a, b)
+        }
+    } else {
+        if a == b {
+            true
+        } else {
+            unsafe {
+                if field_less_than(a, b) {
+                    assert_gt(b, a);
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+pub fn gte(a: Field, b: Field) -> bool {
+    if is_unconstrained() {
+        unsafe {
+            !field_less_than(a, b)
+        }
+    } else if a == b {
+        true
+    } else {
+        unsafe {
+            if field_less_than(a, b) {
+                false
+            } else {
+                assert_gt(a, b);
+                true
+            }
+        }
+    }
+}
+
+pub fn assert_lte(a: Field, b: Field) {
+    if is_unconstrained() {
+        unsafe {
+            assert(lte_hint(a, b));
+        }
+    } else {
+        if a != b {
+            unsafe {
+                if !field_less_than(a, b) {
+                    assert(false);
+                }
+                assert_gt(b, a);
+            }
+        }
+    }
+}
+
+pub fn assert_gte(a: Field, b: Field) {
+    if is_unconstrained() {
+        unsafe {
+            assert(!field_less_than(a, b));
+        }
+    } else {
+        if a != b {
+            unsafe {
+                if field_less_than(a, b) {
+                    assert(false);
+                }
+                assert_gt(a, b);
+            }
+        }
+    }
+}
+
 mod tests {
     // TODO: Allow imports from "super"
-    use crate::field::bn254::{assert_gt, decompose, gt, lte_hint, PHI, PLO, TWO_POW_128};
+    use super::{
+        assert_gt, assert_gte, assert_lte, decompose, gt, gte, lte, lte_hint, PHI, PLO, TWO_POW_128,
+    };
+
+    #[test]
+    fn check_assert_lte() {
+        assert_lte(0, 0);
+        assert_lte(0, 1);
+        assert_lte(100, 100);
+    }
+
+    #[test]
+    fn check_assert_gte() {
+        assert_gte(0, 0);
+        assert_gte(1, 0);
+        assert_gte(100, 100);
+    }
+
+    #[test]
+    fn check_lte() {
+        assert(lte(0, 0));
+        assert(lte(1, 1));
+        assert(lte(0, 1));
+        assert(!lte(1, 0));
+        assert(lte(0x99, 0x100));
+        assert(!lte(0x101, 0x100));
+    }
+
+    #[test]
+    fn check_gte() {
+        assert(gte(0, 0));
+        assert(gte(1, 1));
+        assert(gte(1, 0));
+        assert(!gte(0, 1));
+        assert(gte(0x100, 0x99));
+        assert(!gte(0x100, 0x101));
+    }
 
     #[test]
     fn check_decompose() {
@@ -146,7 +260,6 @@ mod tests {
         assert(lte_hint(0, 0x100));
         assert(lte_hint(0x100, TWO_POW_128 - 1));
         assert(!lte_hint(0 - 1, 0));
-
         assert(lte_hint(0, 0));
         assert(lte_hint(0x100, 0x100));
         assert(lte_hint(0 - 1, 0 - 1));


### PR DESCRIPTION
# Description

I was writing a circuit in noir the other day, and I really wished the `eq`, `gte`, and `lte` functions existed on the `bn254` field library as this would make my circuit cleaner.

## Problem\*

The `bn254` field library does not have `eq`, `gte`, nor `lte` functions. It is possible to compare equality of fields with `==` however, I believe the following syntax is useful: 
```rust
let a: Field = 1;
let b: Field = 1;
let is_equal = a.eq(b);
```

Also the syntax: 

```rust
let a: Field = 0;
let b: Field = 1;
let is_lte = a.lte(b);
```

```rust
let a: Field = 1;
let b: Field = 0;
let is_gte = a.gte(b);
```
would be super useful to have.

## Summary\*
Implemented these functions and added tests.


## Additional Context
I believe this simple PR will make circuit writing slightly easier. These abstractions are super useful.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
