### PR TITLE
chore: Remove rust analyzer toolchain override

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,5 @@
     },
     "[yaml]": {
         "files.trimTrailingWhitespace": true
-    },
-    "rust-analyzer.server.extraEnv": { "RUSTUP_TOOLCHAIN": "stable" }
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

No issue but failures I am getting locally with rust-analyzer post the MSRV bump in https://github.com/noir-lang/noir/pull/7530.

With the repo as it is on master, rust-analyzer fails to start with like such:
```
2025-03-04T14:11:12.770492256Z ERROR FetchWorkspaceError: rust-analyzer failed to load workspace: Failed to load the project at /mnt/user-data/maxim/noir/Cargo.toml: Failed to read Cargo metadata from Cargo.toml file /mnt/user-data/maxim/noir/Cargo.toml, Some(Version { major: 1, minor: 84, patch: 1 }): Failed to run `cd "/mnt/user-data/maxim/noir" && RUSTUP_TOOLCHAIN="/opt/rust/rustup/toolchains/stable-x86_64-unknown-linux-gnu" "/mnt/user-data/maxim/.cargo/bin/cargo" "metadata" "--format-version" "1" "--manifest-path" "/mnt/user-data/maxim/noir/Cargo.toml" "--filter-platform" "x86_64-unknown-linux-gnu"`: `cargo metadata` exited with an error: error: failed to load manifest for workspace member `/mnt/user-data/maxim/noir/compiler/noirc_arena`
referenced by workspace at `/mnt/user-data/maxim/noir/Cargo.toml`

Caused by:
  failed to parse manifest at `/mnt/user-data/maxim/noir/compiler/noirc_arena/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.


[Error - 2:11:25 PM] Server process exited with code 0.
```

It looks that the stable toolchain from `"rust-analyzer.server.extraEnv": { "RUSTUP_TOOLCHAIN": "stable" }` is actually 1.84.1 and not 1.85.0. 

## Summary\*

Turning off the above setting got rust-analyzer working normally again.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
