### PR TITLE
chore(profiler): Add option to only get the total sample count for the `execution-opcodes` command

### DIFF
--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -30,13 +30,22 @@ pub(crate) struct ExecutionFlamegraphCommand {
 
     /// The output folder for the flamegraph svg files
     #[clap(long, short)]
-    output: PathBuf,
+    output: Option<PathBuf>,
 
     /// Use pedantic ACVM solving, i.e. double-check some black-box function
     /// assumptions when solving.
     /// This is disabled by default.
     #[clap(long, default_value = "false")]
     pedantic_solving: bool,
+
+    /// A single number representing the total opcodes executed.
+    /// Outputs to stdout and skips generating a flamegraph.
+    #[clap(long, default_value = "false")]
+    sample_count: bool,
+
+    /// Enables additional logging
+    #[clap(long, default_value = "false")]
+    verbose: bool,
 }
 
 pub(crate) fn run(args: ExecutionFlamegraphCommand) -> eyre::Result<()> {
@@ -46,6 +55,8 @@ pub(crate) fn run(args: ExecutionFlamegraphCommand) -> eyre::Result<()> {
         &InfernoFlamegraphGenerator { count_name: "samples".to_string() },
         &args.output,
         args.pedantic_solving,
+        args.sample_count,
+        args.verbose,
     )
 }
 
@@ -53,20 +64,29 @@ fn run_with_generator(
     artifact_path: &Path,
     prover_toml_path: &Path,
     flamegraph_generator: &impl FlamegraphGenerator,
-    output_path: &Path,
+    output_path: &Option<PathBuf>,
     pedantic_solving: bool,
+    print_sample_count: bool,
+    verbose: bool,
 ) -> eyre::Result<()> {
     let program =
         read_program_from_file(artifact_path).context("Error reading program from file")?;
 
     ensure_brillig_entry_point(&program)?;
 
+    if !print_sample_count && output_path.is_none() {
+        return report_error("Missing --output <OUTPUT> argument for when building a flamegraph")
+            .map_err(Into::into);
+    }
+
     let (inputs_map, _) =
         read_inputs_from_file(&prover_toml_path.with_extension("toml"), &program.abi)?;
 
     let initial_witness = program.abi.encode(&inputs_map, None)?;
 
-    println!("Executing...");
+    if verbose {
+        println!("Executing...");
+    }
 
     let solved_witness_stack_err = nargo::ops::execute_program_with_profiling(
         &program.bytecode,
@@ -94,9 +114,25 @@ fn run_with_generator(
         }
     };
 
-    println!("Executed");
+    if verbose {
+        println!("Executed");
+        println!("{} samples", profiling_samples.len());
+    }
 
-    println!("Collecting {} samples", profiling_samples.len());
+    if print_sample_count {
+        // We avoid redundantly printing the sample count when in verbose mode.
+        if !verbose {
+            println!("{}", profiling_samples.len());
+        }
+        return Ok(());
+    }
+
+    // We place this logging output before the transforming and collection of the samples.
+    // This is done because large traces can take some time, and can make it look
+    // as if the profiler has stalled.
+    if verbose {
+        println!("Generating flamegraph...");
+    }
 
     let profiling_samples: Vec<BrilligExecutionSample> = profiling_samples
         .iter_mut()
@@ -118,24 +154,28 @@ fn run_with_generator(
         })
         .collect();
 
+    let output_path =
+        output_path.as_ref().expect("Should have already checked for the output path");
+
     let debug_artifact: DebugArtifact = program.into();
-
-    println!("Generating flamegraph with {} samples", profiling_samples.len());
-
     flamegraph_generator.generate_flamegraph(
         profiling_samples,
         &debug_artifact.debug_symbols[0],
         &debug_artifact,
         artifact_path.to_str().unwrap(),
         "main",
-        &Path::new(&output_path).join(Path::new(&format!("{}_brillig_trace.svg", "main"))),
+        &Path::new(output_path).join(Path::new(&format!("{}_brillig_trace.svg", "main"))),
     )?;
+
+    if verbose {
+        println!("Generated flamegraph");
+    }
 
     Ok(())
 }
 
 fn ensure_brillig_entry_point(artifact: &ProgramArtifact) -> Result<(), CliError> {
-    let err_msg = "Command only supports fully unconstrained Noir programs e.g. `unconstrained fn main() { .. }".to_owned();
+    let err_msg = "Command only supports fully unconstrained Noir programs e.g. `unconstrained fn main() { .. }";
     let program = &artifact.bytecode;
     if program.functions.len() != 1 || program.unconstrained_functions.len() != 1 {
         return report_error(err_msg);

--- a/tooling/profiler/src/errors.rs
+++ b/tooling/profiler/src/errors.rs
@@ -1,5 +1,5 @@
-use fm::FileMap;
-use noirc_errors::{CustomDiagnostic, Location};
+use fm::{FileId, FileMap};
+use noirc_errors::CustomDiagnostic;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -9,8 +9,8 @@ pub(crate) enum CliError {
 }
 
 /// Report an error from the CLI that is not reliant on a stack trace.
-pub(crate) fn report_error(message: String) -> Result<(), CliError> {
-    let error = CustomDiagnostic::simple_error(message.clone(), String::new(), Location::dummy());
+pub(crate) fn report_error(message: &str) -> Result<(), CliError> {
+    let error = CustomDiagnostic::from_message(message, FileId::dummy());
     noirc_errors::reporter::report(&FileMap::default(), &error, false);
     Err(CliError::Generic)
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7499 

## Summary\*

1. I added a `--sample-count` command. This command returns a single number to stdout of the total number of opcodes executed. I went with this name as "sample" felt clearer to re-iterate that we are profiling over something like `--opcode-count`. I initially was going to do JSON output, but as the profiler works with a single artifact I felt it was easier for consumers to simply work with a single number.
2. I added a `--verbose` flag to hide logging that is outputted by `execution-opcodes`. This flag could be expanded to all the profiler commands. I only did it here as it is convenient for consumers of the `noir-profiler` to fetch output from stdout.
3. We must have updated versions as I was getting errors from the reporter that did not exist before about missing files. I switched the `CustomDiagnostic` constructor to one that does not use secondary labels. Before this PR we were passing dummy information about the secondary labels. Now error reporting acts as expected.

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
