### PR TITLE
fix: Log to `stderr`

### DIFF
--- a/tooling/acvm_cli/src/main.rs
+++ b/tooling/acvm_cli/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
     } else {
         tracing_subscriber::fmt()
             .with_span_events(FmtSpan::ACTIVE)
+            .with_writer(std::io::stderr)
             .with_ansi(true)
             .with_env_filter(EnvFilter::from_env("NOIR_LOG"))
             .init();

--- a/tooling/acvm_cli/src/main.rs
+++ b/tooling/acvm_cli/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
             .with_span_events(FmtSpan::ACTIVE)
             .with_writer(debug_file)
             .with_ansi(false)
-            .with_env_filter(EnvFilter::from_default_env())
+            .with_env_filter(EnvFilter::from_env("NOIR_LOG"))
             .init();
     } else {
         tracing_subscriber::fmt()

--- a/tooling/artifact_cli/src/bin/execute.rs
+++ b/tooling/artifact_cli/src/bin/execute.rs
@@ -35,6 +35,7 @@ pub fn start_cli() -> eyre::Result<()> {
 fn main() {
     tracing_subscriber::fmt()
         .with_span_events(FmtSpan::ACTIVE)
+        .with_writer(std::io::stderr)
         .with_ansi(true)
         .with_env_filter(EnvFilter::from_env("NOIR_LOG"))
         .init();

--- a/tooling/nargo_cli/src/main.rs
+++ b/tooling/nargo_cli/src/main.rs
@@ -42,6 +42,6 @@ fn setup_tracing() {
         let debug_file = rolling::daily(log_dir, "nargo-log");
         subscriber.with_writer(debug_file).with_ansi(false).json().init();
     } else {
-        subscriber.with_ansi(true).init();
+        subscriber.with_writer(std::io::stderr).with_ansi(true).init();
     }
 }

--- a/tooling/profiler/src/main.rs
+++ b/tooling/profiler/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
             .with_span_events(FmtSpan::ACTIVE)
             .with_writer(debug_file)
             .with_ansi(false)
-            .with_env_filter(EnvFilter::from_default_env())
+            .with_env_filter(EnvFilter::from_env("NOIR_LOG"))
             .init();
     } else {
         tracing_subscriber::fmt()

--- a/tooling/profiler/src/main.rs
+++ b/tooling/profiler/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
     } else {
         tracing_subscriber::fmt()
             .with_span_events(FmtSpan::ACTIVE)
+            .with_writer(std::io::stderr)
             .with_ansi(true)
             .with_env_filter(EnvFilter::from_env("NOIR_LOG"))
             .init();


### PR DESCRIPTION
# Description

## Problem\*

Resolves something I noticed while reviewing https://github.com/noir-lang/noir/pull/7578

## Summary\*

The `profiler` to `stdout`, while also aims to display information that the users should be able to pick up in scripting, which is made difficult if log messages and program output are mixed. The solution is to send all logs to `stderr`, in which case piping the output to another program ignores it unless it's redirected with `2>&1`. 

## Additional Context

I tested that the default behaviour of `tracing_subscriber` was indeed to log to `stdout` by adding a `tracing::info!(<msg>)` call and looking for the message with `| grep <msg>`, which was highlighted with red. If we apply the changes in this PR, it is no longer highlighted, as it appears on `stderr`.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
