### PR TITLE
feat(ssa): Post dominator tree

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/cfg.rs
@@ -140,11 +140,7 @@ impl ControlFlowGraph {
     }
 
     pub(crate) fn compute_entry_blocks(&self) -> Vec<BasicBlockId> {
-        self.data
-            .keys()
-            .filter(|&&block| self.predecessors(block).len() == 0)
-            .cloned()
-            .collect()
+        self.data.keys().filter(|&&block| self.predecessors(block).len() == 0).cloned().collect()
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -501,17 +501,17 @@ mod tests {
         assert_eq!(post_dom.immediate_dominator(block2_id), Some(block1_id));
         assert_eq!(post_dom.immediate_dominator(block0_id), Some(block2_id));
 
-        assert_eq!(post_dom.reverse_post_order_cmp(block1_id, block1_id), Ordering::Equal);
-        assert_eq!(post_dom.reverse_post_order_cmp(block1_id, block2_id), Ordering::Less);
-        assert_eq!(post_dom.reverse_post_order_cmp(block1_id, block0_id), Ordering::Less);
-
-        assert_eq!(post_dom.reverse_post_order_cmp(block2_id, block1_id), Ordering::Greater);
-        assert_eq!(post_dom.reverse_post_order_cmp(block2_id, block2_id), Ordering::Equal);
-        assert_eq!(post_dom.reverse_post_order_cmp(block1_id, block0_id), Ordering::Less);
-
+        assert_eq!(post_dom.reverse_post_order_cmp(block0_id, block0_id), Ordering::Equal);
         assert_eq!(post_dom.reverse_post_order_cmp(block0_id, block1_id), Ordering::Greater);
         assert_eq!(post_dom.reverse_post_order_cmp(block0_id, block2_id), Ordering::Greater);
-        assert_eq!(post_dom.reverse_post_order_cmp(block0_id, block0_id), Ordering::Equal);
+
+        assert_eq!(post_dom.reverse_post_order_cmp(block1_id, block0_id), Ordering::Less);
+        assert_eq!(post_dom.reverse_post_order_cmp(block1_id, block1_id), Ordering::Equal);
+        assert_eq!(post_dom.reverse_post_order_cmp(block1_id, block2_id), Ordering::Less);
+
+        assert_eq!(post_dom.reverse_post_order_cmp(block2_id, block0_id), Ordering::Less);
+        assert_eq!(post_dom.reverse_post_order_cmp(block2_id, block1_id), Ordering::Greater);
+        assert_eq!(post_dom.reverse_post_order_cmp(block2_id, block2_id), Ordering::Equal);
 
         // Post-dominance matrix:
         // ✓: Row item post-dominates column item
@@ -520,17 +520,17 @@ mod tests {
         // b1 ✓   ✓   ✓
         // b2 ✓       ✓
 
-        assert!(post_dom.dominates(block1_id, block1_id));
-        assert!(post_dom.dominates(block1_id, block2_id));
-        assert!(post_dom.dominates(block1_id, block0_id));
-
-        assert!(!post_dom.dominates(block2_id, block1_id));
-        assert!(post_dom.dominates(block2_id, block2_id));
-        assert!(post_dom.dominates(block2_id, block0_id));
-
+        assert!(post_dom.dominates(block0_id, block0_id));
         assert!(!post_dom.dominates(block0_id, block1_id));
         assert!(!post_dom.dominates(block0_id, block2_id));
-        assert!(post_dom.dominates(block0_id, block0_id));
+
+        assert!(post_dom.dominates(block1_id, block0_id));
+        assert!(post_dom.dominates(block1_id, block1_id));
+        assert!(post_dom.dominates(block1_id, block2_id));
+
+        assert!(post_dom.dominates(block2_id, block0_id));
+        assert!(!post_dom.dominates(block2_id, block1_id));
+        assert!(post_dom.dominates(block2_id, block2_id));
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
@@ -27,59 +27,23 @@ impl PostOrder {
 impl PostOrder {
     /// Allocate and compute a function's block post-order.
     pub(crate) fn with_function(func: &Function) -> Self {
-        PostOrder(Self::compute_post_order(func))
+        let cfg = ControlFlowGraph::with_function(func);
+        PostOrder(Self::compute_post_order(&cfg))
     }
 
     /// Allocate and compute a function's block post-order.
     pub(crate) fn with_cfg(cfg: &ControlFlowGraph) -> Self {
-        PostOrder(Self::compute_post_order_cfg(cfg))
+        PostOrder(Self::compute_post_order(cfg))
     }
 
     pub(crate) fn into_vec(self) -> Vec<BasicBlockId> {
         self.0
     }
 
-    // Computes the post-order of the function by doing a depth-first traversal of the
-    // function's entry block's previously unvisited children. Each block is sequenced according
-    // to when the traversal exits it.
-    fn compute_post_order(func: &Function) -> Vec<BasicBlockId> {
-        let mut stack = vec![(Visit::First, func.entry_block())];
-        let mut visited: HashSet<BasicBlockId> = HashSet::new();
-        let mut post_order: Vec<BasicBlockId> = Vec::new();
-
-        while let Some((visit, block_id)) = stack.pop() {
-            match visit {
-                Visit::First => {
-                    if !visited.contains(&block_id) {
-                        // This is the first time we pop the block, so we need to scan its
-                        // successors and then revisit it.
-                        visited.insert(block_id);
-                        stack.push((Visit::Last, block_id));
-                        // Stack successors for visiting. Because items are taken from the top of the
-                        // stack, we push the item that's due for a visit first to the top.
-                        for successor_id in func.dfg[block_id].successors().rev() {
-                            if !visited.contains(&successor_id) {
-                                // This not visited check would also be cover by the next
-                                // iteration, but checking here two saves an iteration per successor.
-                                stack.push((Visit::First, successor_id));
-                            }
-                        }
-                    }
-                }
-
-                Visit::Last => {
-                    // We've finished all this node's successors.
-                    post_order.push(block_id);
-                }
-            }
-        }
-        post_order
-    }
-
     // Computes the post-order of the CFG by doing a depth-first traversal of the
     // function's entry block's previously unvisited children. Each block is sequenced according
     // to when the traversal exits it.
-    fn compute_post_order_cfg(cfg: &ControlFlowGraph) -> Vec<BasicBlockId> {
+    fn compute_post_order(cfg: &ControlFlowGraph) -> Vec<BasicBlockId> {
         let mut stack = vec![];
         let mut visited: HashSet<BasicBlockId> = HashSet::new();
         let mut post_order: Vec<BasicBlockId> = Vec::new();
@@ -128,7 +92,7 @@ impl PostOrder {
 mod tests {
     use crate::ssa::{
         function_builder::FunctionBuilder,
-        ir::{cfg::{self, ControlFlowGraph}, function::Function, map::Id, post_order::PostOrder, types::Type},
+        ir::{function::Function, map::Id, post_order::PostOrder, types::Type},
     };
 
     #[test]
@@ -137,10 +101,6 @@ mod tests {
         let func = Function::new("func".into(), func_id);
         let post_order = PostOrder::with_function(&func);
         assert_eq!(post_order.0, [func.entry_block()]);
-
-        let cfg = ControlFlowGraph::with_function(&func);
-        let post_order_from_cfg = PostOrder::with_cfg(&cfg);
-        assert_eq!(post_order, post_order_from_cfg);
     }
 
     #[test]
@@ -205,9 +165,5 @@ mod tests {
         let post_order = PostOrder::with_function(func);
         let block_a_id = func.entry_block();
         assert_eq!(post_order.0, [block_d_id, block_f_id, block_e_id, block_b_id, block_a_id]);
-
-        let cfg = ControlFlowGraph::with_function(&func);
-        let post_order_from_cfg = PostOrder::with_cfg(&cfg);
-        assert_eq!(post_order, post_order_from_cfg);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
@@ -7,13 +7,15 @@ use std::collections::HashSet;
 
 use crate::ssa::ir::{basic_block::BasicBlockId, function::Function};
 
+use super::cfg::ControlFlowGraph;
+
 /// Depth-first traversal stack state marker for computing the cfg post-order.
 enum Visit {
     First,
     Last,
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq, Eq, Debug)]
 pub(crate) struct PostOrder(Vec<BasicBlockId>);
 
 impl PostOrder {
@@ -26,6 +28,11 @@ impl PostOrder {
     /// Allocate and compute a function's block post-order.
     pub(crate) fn with_function(func: &Function) -> Self {
         PostOrder(Self::compute_post_order(func))
+    }
+
+    /// Allocate and compute a function's block post-order.
+    pub(crate) fn with_cfg(cfg: &ControlFlowGraph) -> Self {
+        PostOrder(Self::compute_post_order_cfg(cfg))
     }
 
     pub(crate) fn into_vec(self) -> Vec<BasicBlockId> {
@@ -68,13 +75,60 @@ impl PostOrder {
         }
         post_order
     }
+
+    // Computes the post-order of the CFG by doing a depth-first traversal of the
+    // function's entry block's previously unvisited children. Each block is sequenced according
+    // to when the traversal exits it.
+    fn compute_post_order_cfg(cfg: &ControlFlowGraph) -> Vec<BasicBlockId> {
+        let mut stack = vec![];
+        let mut visited: HashSet<BasicBlockId> = HashSet::new();
+        let mut post_order: Vec<BasicBlockId> = Vec::new();
+
+        // Determine root blocks
+        let root_blocks: Vec<BasicBlockId> = cfg.compute_entry_blocks();
+
+        // Start traversal from detected root blocks
+        for root in root_blocks {
+            if !visited.contains(&root) {
+                stack.push((Visit::First, root));
+            }
+        }
+
+        while let Some((visit, block_id)) = stack.pop() {
+            match visit {
+                Visit::First => {
+                    if !visited.contains(&block_id) {
+                        // This is the first time we pop the block, so we need to scan its
+                        // successors and then revisit it.
+                        visited.insert(block_id);
+                        stack.push((Visit::Last, block_id));
+                        // Stack successors for visiting. Because items are taken from the top of the
+                        // stack, we push the item that's due for a visit first to the top.
+                        for successor_id in cfg.successors(block_id).rev() {
+                            if !visited.contains(&successor_id) {
+                                // This not visited check would also be cover by the next
+                                // iteration, but checking here two saves an iteration per successor.
+                                stack.push((Visit::First, successor_id));
+                            }
+                        }
+                    }
+                }
+
+                Visit::Last => {
+                    // We've finished all this node's successors.
+                    post_order.push(block_id);
+                }
+            }
+        }
+        post_order
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::ssa::{
         function_builder::FunctionBuilder,
-        ir::{function::Function, map::Id, post_order::PostOrder, types::Type},
+        ir::{cfg::{self, ControlFlowGraph}, function::Function, map::Id, post_order::PostOrder, types::Type},
     };
 
     #[test]
@@ -83,6 +137,10 @@ mod tests {
         let func = Function::new("func".into(), func_id);
         let post_order = PostOrder::with_function(&func);
         assert_eq!(post_order.0, [func.entry_block()]);
+
+        let cfg = ControlFlowGraph::with_function(&func);
+        let post_order_from_cfg = PostOrder::with_cfg(&cfg);
+        assert_eq!(post_order, post_order_from_cfg);
     }
 
     #[test]
@@ -147,5 +205,9 @@ mod tests {
         let post_order = PostOrder::with_function(func);
         let block_a_id = func.entry_block();
         assert_eq!(post_order.0, [block_d_id, block_f_id, block_e_id, block_b_id, block_a_id]);
+
+        let cfg = ControlFlowGraph::with_function(&func);
+        let post_order_from_cfg = PostOrder::with_cfg(&cfg);
+        assert_eq!(post_order, post_order_from_cfg);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
@@ -28,7 +28,7 @@ impl PostOrder {
     /// Allocate and compute a function's block post-order.
     pub(crate) fn with_function(func: &Function) -> Self {
         let cfg = ControlFlowGraph::with_function(func);
-        PostOrder(Self::compute_post_order(&cfg))
+        Self::with_cfg(&cfg)
     }
 
     /// Allocate and compute a function's block post-order.


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7571 

## Summary\*

This PR is mostly contained to tests as it will be the basis for further control dependence analysis.

1. Logic for reversing the CFG
2. Switched post order computation to use the CFG rather than the function definition
3. Add a test to show using the the reversed CFG and updated post order provides an accurate post-dominator tree

## Additional Context

The new `reverse` and `with_function_post_dom` methods are only used in tests. The `#[cfg(test)]` attribute will be removed as these methods are used by later work.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
