### PR TITLE
fix: compare Quoted by expanding interned values

### DIFF
--- a/test_programs/compile_success_empty/comptime_quoted/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_quoted/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_quoted"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_quoted/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_quoted/src/main.nr
@@ -1,0 +1,8 @@
+fn main() {
+    comptime {
+        let array = quote { [1, 2, 3] }.as_expr().unwrap();
+        let expr1 = quote { [1, 2, 3]};
+        let expr2 = quote { $array };
+        assert_eq(expr1, expr2);
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #5979

## Summary

Compares two Quoted values by turning them into strings, then comparing the strings.

Another way to do this would be to expand interned nodes to the nodes they represent, then turning those nodes into tokens, then finally comparing all tokens. However, that involves more code (or at least code that we currently don't have) while comparing strings works as well and might have more or less the same performance (we might need to allocate tokens with the other approach).

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
