### PR TITLE
fix: TokensPrettyPrinter was missing some spaces between tokens

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -174,31 +174,31 @@ impl<'interner> TokenPrettyPrinter<'interner> {
         match token {
             Token::QuotedType(id) => {
                 let value = Value::Type(self.interner.get_quoted_type(*id).clone());
-                self.print_value(&value, f)
+                self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::InternedExpr(id) => {
                 let value = Value::expression(ExpressionKind::Interned(*id));
-                self.print_value(&value, f)
+                self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::InternedStatement(id) => {
                 let value = Value::statement(StatementKind::Interned(*id));
-                self.print_value(&value, f)
+                self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::InternedLValue(id) => {
                 let value = Value::lvalue(LValue::Interned(*id, Location::dummy()));
-                self.print_value(&value, f)
+                self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::InternedUnresolvedTypeData(id) => {
                 let value = Value::UnresolvedType(UnresolvedTypeData::Interned(*id));
-                self.print_value(&value, f)
+                self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::InternedPattern(id) => {
                 let value = Value::pattern(Pattern::Interned(*id, Location::dummy()));
-                self.print_value(&value, f)
+                self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::UnquoteMarker(id) => {
                 let value = Value::TypedExpr(TypedExpr::ExprId(*id));
-                self.print_value(&value, f)
+                self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::Keyword(..)
             | Token::Ident(..)
@@ -297,14 +297,18 @@ impl<'interner> TokenPrettyPrinter<'interner> {
         }
     }
 
-    fn print_value(&mut self, value: &Value, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn print_value(
+        &mut self,
+        value: &Value,
+        last_was_alphanumeric: bool,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
         let string = value.display(self.interner).to_string();
         if string.is_empty() {
             return Ok(());
         }
 
-        let starts_with_alphanumeric = string.bytes().next().unwrap().is_ascii_alphanumeric();
-        if starts_with_alphanumeric {
+        if last_was_alphanumeric && string.bytes().next().unwrap().is_ascii_alphanumeric() {
             write!(f, " ")?;
         }
 


### PR DESCRIPTION
# Description

## Problem

This is hard to test, but a code like this (regardless of its validity):

```noir
struct Foo {}

fn main() {
    comptime {
        let foo = quote { Foo }.as_type();
        let q = quote { impl $foo for $foo {} };
        println(q);
    }
}
```

printed this:

```
quote {
    implFooforFoo {
        
    }
    
}
```

## Summary

Now it prints:

```
quote {
    impl Foo for Foo {

    }

}
```

Three changes were made here:
1. Printing a quoted typed by wrapping it in a `Value`, then calling `print_value` which handles spaces
2. Adding a space before printing a value, if it's needed
3. Making `last_was_alphanumeric` take into account only the last byte, not the entire string (for example if a quoted expression had a space but still ended with an alphanumeric, we'd consider that as not ending in alphanumeric)


## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
