### PR TITLE
feat: relate errors to macro built-ins errors

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -703,15 +703,22 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
 /// comptime call or macro "something" that eventually led to that error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComptimeError {
-    ErrorRunningAttribute { error: Box<CompilationError>, location: Location },
-    ErrorAddingItemToModule { error: Box<CompilationError>, location: Location },
+    ErrorRunningAttribute {
+        error: Box<CompilationError>,
+        location: Location,
+    },
+    ErrorEvaluatingComptimeCall {
+        method_name: &'static str,
+        error: Box<CompilationError>,
+        location: Location,
+    },
 }
 
 impl ComptimeError {
     pub fn location(&self) -> Location {
         match self {
             ComptimeError::ErrorRunningAttribute { location, .. }
-            | ComptimeError::ErrorAddingItemToModule { location, .. } => *location,
+            | ComptimeError::ErrorEvaluatingComptimeCall { location, .. } => *location,
         }
     }
 }
@@ -724,9 +731,9 @@ impl<'a> From<&'a ComptimeError> for CustomDiagnostic {
                 diagnostic.add_secondary("While running this function attribute".into(), *location);
                 diagnostic
             }
-            ComptimeError::ErrorAddingItemToModule { error, location } => {
+            ComptimeError::ErrorEvaluatingComptimeCall { method_name, error, location } => {
                 let mut diagnostic = CustomDiagnostic::from(&**error);
-                diagnostic.add_secondary("While interpreting `Module::add_item`".into(), *location);
+                diagnostic.add_secondary(format!("While evaluating `{method_name}`"), *location);
                 diagnostic
             }
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2426,7 +2426,9 @@ fn function_def_as_typed_expr(
     let hir_expr = HirExpression::Ident(hir_ident.clone(), generics.clone());
     let expr_id = interpreter.elaborator.interner.push_expr(hir_expr);
     interpreter.elaborator.interner.push_expr_location(expr_id, location);
-    let typ = interpreter.elaborator.type_check_variable(hir_ident, expr_id, generics);
+    let typ = interpreter.elaborate_in_function(interpreter.current_function, |elaborator| {
+        elaborator.type_check_variable(hir_ident, expr_id, generics)
+    });
     interpreter.elaborator.interner.push_expr_type(expr_id, typ);
     Ok(Value::TypedExpr(TypedExpr::ExprId(expr_id)))
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #7459

## Summary

Now this code:

```noir
fn main() {
    comptime {
        let x = quote { Hello };
        let _ = x.as_type();
    }
}
```

Gives this error:

```
error: Could not resolve 'Hello' in path
  ┌─ src/main.nr:3:25
  │
3 │         let x = quote { Hello };
  │                         -----
4 │         let _ = x.as_type();
  │                 ----------- While evaluating `Quoted::as_type`
```


## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
