### PR TITLE
fix: FunctionDefinition::as_typed_expr didn't work well for trait imp…

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -34,13 +34,15 @@ use crate::{
         },
         def_collector::dc_crate::CollectedItems,
         def_map::ModuleDefId,
+        type_check::generics::TraitGenerics,
     },
     hir_def::{
         self,
-        expr::{HirExpression, HirIdent, HirLiteral},
+        expr::{HirExpression, HirIdent, HirLiteral, ImplKind, TraitMethod},
         function::FunctionBody,
+        traits::{ResolvedTraitBound, TraitConstraint},
     },
-    node_interner::{DefinitionKind, NodeInterner, TraitImplKind},
+    node_interner::{DefinitionKind, NodeInterner, TraitImplKind, TraitMethodId},
     parser::{Parser, StatementOrExpressionOrLValue},
     token::{Attribute, LocatedToken, Token},
 };
@@ -2421,8 +2423,27 @@ fn function_def_as_typed_expr(
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
     let func_id = get_function_def(self_argument)?;
+    let trait_impl_id = interpreter.elaborator.interner.function_meta(&func_id).trait_impl;
     let definition_id = interpreter.elaborator.interner.function_definition_id(func_id);
-    let hir_ident = HirIdent::non_trait_method(definition_id, location);
+    let hir_ident = if let Some(trait_impl_id) = trait_impl_id {
+        let trait_impl = interpreter.elaborator.interner.get_trait_implementation(trait_impl_id);
+        let trait_impl = trait_impl.borrow();
+        let ordered = trait_impl.trait_generics.clone();
+        let named =
+            interpreter.elaborator.interner.get_associated_types_for_impl(trait_impl_id).to_vec();
+        let trait_generics = TraitGenerics { ordered, named };
+        let trait_bound =
+            ResolvedTraitBound { trait_id: trait_impl.trait_id, trait_generics, location };
+        let constraint = TraitConstraint { typ: trait_impl.typ.clone(), trait_bound };
+        let method_index = trait_impl.methods.iter().position(|id| *id == func_id);
+        let method_index = method_index.expect("Expected to find the method");
+        let method_id = TraitMethodId { trait_id: trait_impl.trait_id, method_index };
+        let trait_method = TraitMethod { method_id, constraint, assumed: true };
+        let id = interpreter.elaborator.interner.trait_method_id(trait_method.method_id);
+        HirIdent { location, id, impl_kind: ImplKind::TraitMethod(trait_method) }
+    } else {
+        HirIdent::non_trait_method(definition_id, location)
+    };
     let generics = None;
     let hir_expr = HirExpression::Ident(hir_ident.clone(), generics.clone());
     let expr_id = interpreter.elaborator.interner.push_expr(hir_expr);

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -208,3 +208,33 @@ mod test_as_typed_expr_4 {
         }
     }
 }
+
+mod test_as_typed_expr_5 {
+    trait Trait {}
+
+    impl Trait for i32 {}
+
+    trait Packable<let N: u32> {
+        fn pack(self);
+    }
+
+    pub struct Foo<T> {}
+
+    impl<T> Packable<10> for Foo<T>
+    where
+        T: Trait,
+    {
+        fn pack(self) {}
+    }
+
+    fn foo() {
+        comptime {
+            let foo = quote { Foo<i32> }.as_type();
+            let t = quote { Packable<10> }.as_trait_constraint();
+            let _ = foo.get_trait_impl(t).unwrap().methods().filter(|method| {
+                method.name() == quote { pack }
+            })[0]
+                .as_typed_expr();
+        }
+    }
+}


### PR DESCRIPTION
…l methods

# Description

## Problem

Resolves #7610

## Summary

The logic to type a function call when it belongs to a trait impl for a given type is similar (or probably exactly the same) as solving "as trait path". I checked what the code does there (`elaborate_as_trait_path`) and it also calls `type_check_variable` but the `HirIdent` is for a trait method. So now this is also done in `FunctionDefinition::as_typed_expr` if the underlying function is a trait impl method.

## Additional Context

A lot of code is required to build that HirIdent, I don't know if there's a shorter way.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
