### PR TITLE
Start working on a tool to show code after macro expansions

### DIFF
--- a/tooling/nargo_cli/src/cli/expand_cmd.rs
+++ b/tooling/nargo_cli/src/cli/expand_cmd.rs
@@ -1,0 +1,251 @@
+use clap::Args;
+use fm::FileManager;
+use nargo::{
+    errors::CompileError, insert_all_files_for_workspace_into_file_manager, package::Package,
+    parse_all, prepare_package, workspace::Workspace,
+};
+use nargo_toml::PackageSelection;
+use noirc_driver::CompileOptions;
+use noirc_frontend::{
+    Generics, Type,
+    ast::{ItemVisibility, Visibility},
+    hir::{
+        Context, ParsedFiles,
+        def_map::{CrateDefMap, ModuleDefId, ModuleId},
+    },
+    hir_def::{expr::HirExpression, stmt::HirPattern},
+    node_interner::{FuncId, NodeInterner},
+};
+
+use crate::errors::CliError;
+
+use super::{LockType, PackageOptions, WorkspaceCommand, check_cmd::check_crate_and_report_errors};
+
+/// Expands macros
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ExpandCommand {
+    #[clap(flatten)]
+    pub(super) package_options: PackageOptions,
+
+    #[clap(flatten)]
+    compile_options: CompileOptions,
+}
+
+impl WorkspaceCommand for ExpandCommand {
+    fn package_selection(&self) -> PackageSelection {
+        self.package_options.package_selection()
+    }
+    fn lock_type(&self) -> LockType {
+        // Creates a `Prover.toml` template if it doesn't exist, otherwise only writes if `allow_overwrite` is true,
+        // so it shouldn't lead to accidental conflicts. Doesn't produce compilation artifacts.
+        LockType::None
+    }
+}
+
+pub(crate) fn run(args: ExpandCommand, workspace: Workspace) -> Result<(), CliError> {
+    let mut workspace_file_manager = workspace.new_file_manager();
+    insert_all_files_for_workspace_into_file_manager(&workspace, &mut workspace_file_manager);
+    let parsed_files = parse_all(&workspace_file_manager);
+
+    for package in &workspace {
+        check_package(&workspace_file_manager, &parsed_files, package, &args.compile_options)?;
+    }
+
+    Ok(())
+}
+
+fn check_package(
+    file_manager: &FileManager,
+    parsed_files: &ParsedFiles,
+    package: &Package,
+    compile_options: &CompileOptions,
+) -> Result<(), CompileError> {
+    let (mut context, crate_id) = prepare_package(file_manager, parsed_files, package);
+    check_crate_and_report_errors(&mut context, crate_id, compile_options)?;
+
+    let def_map = &context.def_maps[&crate_id];
+    let root_module_id = def_map.root();
+    let module_id = ModuleId { krate: crate_id, local_id: root_module_id };
+
+    let mut string = String::new();
+    show_module(module_id, &context, def_map, &mut string);
+    println!("{}", string);
+
+    Ok(())
+}
+
+fn show_module(module_id: ModuleId, context: &Context, def_map: &CrateDefMap, string: &mut String) {
+    let attributes = context.def_interner.try_module_attributes(&module_id);
+    let name =
+        attributes.map(|attributes| attributes.name.clone()).unwrap_or_else(|| String::new());
+
+    let module_data = &def_map.modules()[module_id.local_id.0];
+    let definitions = module_data.definitions();
+
+    for (name, scope) in definitions.types().iter().chain(definitions.values()) {
+        for (_trait_id, (module_def_id, visibility, _is_prelude)) in scope {
+            show_module_def_id(*module_def_id, *visibility, &context.def_interner, string);
+        }
+    }
+}
+
+fn show_module_def_id(
+    module_def_id: ModuleDefId,
+    visibility: ItemVisibility,
+    interner: &NodeInterner,
+    string: &mut String,
+) {
+    if visibility != ItemVisibility::Private {
+        string.push_str(&visibility.to_string());
+        string.push(' ');
+    };
+
+    match module_def_id {
+        ModuleDefId::ModuleId(module_id) => todo!("Show modules"),
+        ModuleDefId::FunctionId(func_id) => show_function(func_id, interner, string),
+        ModuleDefId::TypeId(_) => todo!("Show types"),
+        ModuleDefId::TypeAliasId(type_alias_id) => todo!("Show type aliases"),
+        ModuleDefId::TraitId(trait_id) => todo!("Show traits"),
+        ModuleDefId::GlobalId(global_id) => todo!("Show globals"),
+    }
+
+    string.push_str("\n\n");
+}
+
+fn show_function(func_id: FuncId, interner: &NodeInterner, string: &mut String) {
+    let modifiers = interner.function_modifiers(&func_id);
+    let func_meta = interner.function_meta(&func_id);
+    let name = &modifiers.name;
+
+    if modifiers.is_unconstrained {
+        string.push_str("unconstrained ");
+    }
+    if modifiers.is_comptime {
+        string.push_str("comptime ");
+    }
+
+    string.push_str("fn ");
+    string.push_str(name);
+
+    show_generics(&func_meta.direct_generics, string);
+
+    string.push('(');
+    let parameters = &func_meta.parameters;
+    for (index, (pattern, typ, visibility)) in parameters.iter().enumerate() {
+        let is_self = pattern_is_self(pattern, interner);
+
+        // `&mut self` is represented as a mutable reference type, not as a mutable pattern
+        if is_self && matches!(typ, Type::Reference(..)) {
+            string.push_str("&mut ");
+        }
+
+        show_pattern(pattern, interner, string);
+
+        // Don't add type for `self` param
+        if !is_self {
+            string.push_str(": ");
+            if matches!(visibility, Visibility::Public) {
+                string.push_str("pub ");
+            }
+            string.push_str(&format!("{}", typ));
+        }
+
+        if index != parameters.len() - 1 {
+            string.push_str(", ");
+        }
+    }
+    string.push(')');
+
+    let return_type = func_meta.return_type();
+    match return_type {
+        Type::Unit => (),
+        _ => {
+            string.push_str(" -> ");
+            string.push_str(&format!("{}", return_type));
+        }
+    }
+
+    string.push(' ');
+
+    let hir_function = interner.function(&func_id);
+    let block = hir_function.block(interner);
+    let block = HirExpression::Block(block);
+    let block = block.to_display_ast(interner, func_meta.location);
+    string.push_str(&block.to_string());
+}
+
+fn show_generics(generics: &Generics, string: &mut String) {
+    show_generics_impl(
+        generics, false, // only show names
+        string,
+    );
+}
+
+fn show_generic_names(generics: &Generics, string: &mut String) {
+    show_generics_impl(
+        generics, true, // only show names
+        string,
+    );
+}
+
+fn show_generics_impl(generics: &Generics, only_show_names: bool, string: &mut String) {
+    if generics.is_empty() {
+        return;
+    }
+
+    string.push('<');
+    for (index, generic) in generics.iter().enumerate() {
+        if index > 0 {
+            string.push_str(", ");
+        }
+
+        if only_show_names {
+            string.push_str(&generic.name);
+        } else {
+            match generic.kind() {
+                noirc_frontend::Kind::Any | noirc_frontend::Kind::Normal => {
+                    string.push_str(&generic.name);
+                }
+                noirc_frontend::Kind::IntegerOrField | noirc_frontend::Kind::Integer => {
+                    string.push_str("let ");
+                    string.push_str(&generic.name);
+                    string.push_str(": u32");
+                }
+                noirc_frontend::Kind::Numeric(typ) => {
+                    string.push_str("let ");
+                    string.push_str(&generic.name);
+                    string.push_str(": ");
+                    string.push_str(&typ.to_string());
+                }
+            }
+        }
+    }
+    string.push('>');
+}
+
+fn show_pattern(pattern: &HirPattern, interner: &NodeInterner, string: &mut String) {
+    match pattern {
+        HirPattern::Identifier(ident) => {
+            let definition = interner.definition(ident.id);
+            string.push_str(&definition.name);
+        }
+        HirPattern::Mutable(pattern, _) => {
+            string.push_str("mut ");
+            show_pattern(pattern, interner, string);
+        }
+        HirPattern::Tuple(..) | HirPattern::Struct(..) => {
+            string.push('_');
+        }
+    }
+}
+
+fn pattern_is_self(pattern: &HirPattern, interner: &NodeInterner) -> bool {
+    match pattern {
+        HirPattern::Identifier(ident) => {
+            let definition = interner.definition(ident.id);
+            definition.name == "self"
+        }
+        HirPattern::Mutable(pattern, _) => pattern_is_self(pattern, interner),
+        HirPattern::Tuple(..) | HirPattern::Struct(..) => false,
+    }
+}

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -19,6 +19,7 @@ mod compile_cmd;
 mod dap_cmd;
 mod debug_cmd;
 mod execute_cmd;
+mod expand_cmd;
 mod export_cmd;
 mod fmt_cmd;
 mod generate_completion_script_cmd;
@@ -106,6 +107,7 @@ enum NargoCommand {
     Lsp(lsp_cmd::LspCommand),
     #[command(hide = true)]
     Dap(dap_cmd::DapCommand),
+    Expand(expand_cmd::ExpandCommand),
     GenerateCompletionScript(generate_completion_script_cmd::GenerateCompletionScriptCommand),
 }
 
@@ -147,6 +149,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         NargoCommand::Lsp(_) => lsp_cmd::run(),
         NargoCommand::Dap(args) => dap_cmd::run(args),
         NargoCommand::Fmt(args) => with_workspace(args, config, fmt_cmd::run),
+        NargoCommand::Expand(args) => with_workspace(args, config, expand_cmd::run),
         NargoCommand::GenerateCompletionScript(args) => generate_completion_script_cmd::run(args),
     }?;
 


### PR DESCRIPTION
# Description

## Problem

Resolves #7552

## Summary

The idea I have for this is:
1. We type-check the code as usual
2. All code, that which exists in source files and that which is created by macros, is stored in "def maps" and the node interner, so we can use those sources to rebuild the final code

The output right now goes to the console, and just for the top-level module, and just for functions, as a way to experiment with this and get feedback from you all. Eventually a directory with all the expanded code could be created, with one file per module to match the original source code.

The downside of this approach is that comments and formatting is lost, though we could at least run the formatter at the end for formatting. Comments could be done in a follow-up where they would also be stored in the node interner, and just for this tool (maybe!).

For example, if you run it for this code:

```noir
fn main() {
    let _ = std::as_witness(1);
    println("Hello world");
}

#[foo]
comptime fn foo(f: FunctionDefinition) -> Quoted {
    quote {
        pub fn bar(x: i32) -> i32  {  
            let y = x + 1;
            y + 2
        }
    }
}

#[mutate_add_one]
fn add_one() {}

comptime fn mutate_add_one(f: FunctionDefinition) {
    f.set_parameters(&[(quote { x }, quote { Field }.as_type())]);
    f.set_return_type(quote { Field }.as_type());
    f.set_body(quote { x + 1 }.as_expr().unwrap());
}

```

we get this output:

```noir
fn main() {
    let _: () = as_witness(1)
    println("Hello world");
}

comptime fn foo(f: FunctionDefinition) -> Quoted {
    quote { pub fn bar ( x : i32 ) -> i32 { let y = x + 1 ; y + 2 } }
}

fn add_one(x: Field) -> Field {
    (x + 1)
}

comptime fn mutate_add_one(f: FunctionDefinition) {
    set_parameters(f, &[(quote { x }, as_type(quote { Field }))]);
    set_return_type(f, as_type(quote { Field }));
    set_body(f, unwrap(as_expr(quote { x + 1 })));
}

pub fn bar(x: i32) -> i32 {
    let y: i32 = (x + 1)
    (y + 2)
}
```

## Additional Context

Do you think this approach is good enough? What other ways we could tackle this?



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
