### PR TITLE
fix: update error message to display 128 bits as valid bit size

### DIFF
--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -43,8 +43,11 @@ use crate::{
 use acvm::acir::AcirField;
 use iter_extended::vecmap;
 
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd, EnumIter)]
 pub enum IntegerBitSize {
     One,
     Eight,
@@ -69,7 +72,7 @@ impl IntegerBitSize {
 
 impl IntegerBitSize {
     pub fn allowed_sizes() -> Vec<Self> {
-        vec![Self::One, Self::Eight, Self::ThirtyTwo, Self::SixtyFour]
+        IntegerBitSize::iter().collect()
     }
 }
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4146,3 +4146,15 @@ fn immutable_references_without_ownership_feature() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn errors_on_invalid_integer_bit_size() {
+    let src = r#"
+    fn main() {
+        let _: u42 = 4;
+               ^^^ Use of invalid bit size 42
+               ~~~ Allowed bit sizes for integers are 1, 8, 16, 32, 64, 128
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is a leftover from #7301.

We're not showing 128 bits as a valid size if someone provides an invalid bit size for an integer type. This PR updates this logic so it'll remain up to date on future updates to the supported bitsizes.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
