### PR TITLE
chore: add tests for trait renaming in imports

### DIFF
--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1246,8 +1246,11 @@ fn as_trait_path_in_expression() {
     assert_no_errors(src);
 }
 
+// TODO: remove `should_panic` once fixed
 #[test]
+#[should_panic = "ResolverError(PathResolutionError(TraitMethodNotInScope { ident: Ident(Located { contents: \"foo\""]
 fn allows_renaming_trait_during_import() {
+    // Regression test for https://github.com/noir-lang/noir/issues/7632
     let src = r#"
     mod trait_mod {
         pub trait Foo {
@@ -1266,8 +1269,11 @@ fn allows_renaming_trait_during_import() {
     assert_no_errors(src);
 }
 
+// TODO: remove `should_panic` once fixed
 #[test]
+#[should_panic = "ResolverError(PathResolutionError(TraitMethodNotInScope { ident: Ident(Located { contents: \"foo\""]
 fn renaming_trait_avoids_name_collisions() {
+    // Regression test for https://github.com/noir-lang/noir/issues/7632
     let src = r#"
     mod trait_mod {
         pub trait Foo {
@@ -1279,7 +1285,7 @@ fn renaming_trait_avoids_name_collisions() {
 
     use trait_mod::Foo as FooTrait;
 
-    use pub struct Foo {}
+    pub struct Foo {}
 
     fn main(x: Field) {
         x.foo();

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1245,3 +1245,45 @@ fn as_trait_path_in_expression() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn allows_renaming_trait_during_import() {
+    let src = r#"
+    mod trait_mod {
+        pub trait Foo {
+            fn foo(_: Self) {}
+        }
+
+        impl Foo for Field {}
+    }
+
+    use trait_mod::Foo as FooTrait;
+
+    fn main(x: Field) {
+        x.foo();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn renaming_trait_avoids_name_collisions() {
+    let src = r#"
+    mod trait_mod {
+        pub trait Foo {
+            fn foo(_: Self) {}
+        }
+
+        impl Foo for Field {}
+    }
+
+    use trait_mod::Foo as FooTrait;
+
+    use pub struct Foo {}
+
+    fn main(x: Field) {
+        x.foo();
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1248,7 +1248,7 @@ fn as_trait_path_in_expression() {
 
 // TODO: remove `should_panic` once fixed
 #[test]
-#[should_panic = "ResolverError(PathResolutionError(TraitMethodNotInScope { ident: Ident(Located { contents: \"foo\""]
+#[should_panic = "Expected no errors"]
 fn allows_renaming_trait_during_import() {
     // Regression test for https://github.com/noir-lang/noir/issues/7632
     let src = r#"
@@ -1271,7 +1271,7 @@ fn allows_renaming_trait_during_import() {
 
 // TODO: remove `should_panic` once fixed
 #[test]
-#[should_panic = "ResolverError(PathResolutionError(TraitMethodNotInScope { ident: Ident(Located { contents: \"foo\""]
+#[should_panic = "Expected no errors"]
 fn renaming_trait_avoids_name_collisions() {
     // Regression test for https://github.com/noir-lang/noir/issues/7632
     let src = r#"


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds tests for the behaviour we want to implement for #7632. Once that issue is addressed we can remove the `should_panic` attributes.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
