### PR TITLE
chore: add regression tests for PR #7570 from lambda interpreter test

### DIFF
--- a/test_programs/compile_success_empty/regression_7570_nested/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_7570_nested/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7570_nested"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_7570_nested/src/main.nr
+++ b/test_programs/compile_success_empty/regression_7570_nested/src/main.nr
@@ -1,0 +1,30 @@
+// Regression test for bug that appears to be fixed by https://github.com/noir-lang/noir/pull/7570
+pub enum Foo {
+    // at least three variants are required, i.e.
+    // if e.g. only `A` and `B` are included, the bug goes away
+    A,
+    B,
+    C,
+}
+
+fn main() {
+    // - the error occured with or without values in the array
+    // - the error goes away if `x` is directly defined as e.g. `Foo::A`
+    let arena: [Foo; 1] = [Foo::A];
+    let x = arena[0];
+
+    // this needs to be in a loop with a positive bound for the error to occur
+    for _ in 0..1 {
+        match x {
+            Foo::A => {
+                // the error goes away if this match is removed
+                match x {
+                    // the error goes away if we only match on Foo::A and/or '_'
+                    Foo::B => (),
+                    _ => (),
+                }
+            },
+            _ => (),
+        }
+    }
+}

--- a/test_programs/compile_success_empty/regression_7570_serial/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_7570_serial/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7570_serial"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_7570_serial/src/main.nr
+++ b/test_programs/compile_success_empty/regression_7570_serial/src/main.nr
@@ -1,0 +1,27 @@
+// Regression test for bug that appears to be fixed by https://github.com/noir-lang/noir/pull/7570
+pub enum Foo {
+    // at least three variants are required, i.e.
+    // if e.g. only `A` and `B` are included, the bug goes away
+    A,
+    B,
+    C,
+}
+
+fn main() {
+    // - the error occurs with or without values in the array
+    // - the error goes away if `x` is directly defined as e.g. `Foo::A`
+    let arena: [Foo; 1] = [Foo::A];
+    let x = arena[0];
+
+    match x {
+        Foo::A => (),
+        _ => (),
+    }
+
+    // the error goes away if this match is removed
+    match x {
+        // the error goes away if we only match on Foo::A and/or '_'
+        Foo::B => (),
+        _ => (),
+    }
+}


### PR DESCRIPTION
# Description

Two more tests for https://github.com/noir-lang/noir/pull/7570

## Problem\*

I found these failing (panicking) cases while implementing the new lambda calculus interpreter test.

## Summary\*

These cases aren't explicitly tested in https://github.com/noir-lang/noir/pull/7570, so adding them here.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
