### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT fd9f1458557f2d67bcf2d58ba4194e000f58600c
+define: &AZ_COMMIT f15942770bc391a4d66fe9c23262b755de77f71d
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT fd9f1458557f2d67bcf2d58ba4194e000f58600c
+define: &AZ_COMMIT f15942770bc391a4d66fe9c23262b755de77f71d
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
