### PR TITLE
chore: remove some unused HIR code

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -307,7 +307,6 @@ fn can_return_without_recursing(interner: &NodeInterner, func_id: FuncId, expr_i
         HirExpression::Index(e) => check(e.collection) && check(e.index),
         HirExpression::MemberAccess(e) => check(e.lhs),
         HirExpression::Call(e) => check(e.func) && e.arguments.iter().cloned().all(check),
-        HirExpression::MethodCall(e) => check(e.object) && e.arguments.iter().cloned().all(check),
         HirExpression::Constrain(e) => check(e.0) && e.2.map(check).unwrap_or(true),
         HirExpression::Cast(e) => check(e.lhs),
         HirExpression::If(e) => {

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -322,7 +322,6 @@ fn can_return_without_recursing(interner: &NodeInterner, func_id: FuncId, expr_i
         | HirExpression::EnumConstructor(_)
         | HirExpression::Quote(_)
         | HirExpression::Unquote(_)
-        | HirExpression::Comptime(_)
         | HirExpression::Error => true,
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -185,9 +185,6 @@ impl HirExpression {
                 ExpressionKind::Lambda(Box::new(Lambda { parameters, return_type, body }))
             }
             HirExpression::Error => ExpressionKind::Error,
-            HirExpression::Comptime(block) => {
-                ExpressionKind::Comptime(block.to_display_ast(interner), location)
-            }
             HirExpression::Unsafe(block) => ExpressionKind::Unsafe(UnsafeExpression {
                 block: block.to_display_ast(interner),
                 unsafe_keyword_location: location,

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -6,8 +6,8 @@ use crate::ast::{
     ArrayLiteral, AssignStatement, BlockExpression, CallExpression, CastExpression, ConstrainKind,
     ConstructorExpression, ExpressionKind, ForLoopStatement, ForRange, GenericTypeArgs, Ident,
     IfExpression, IndexExpression, InfixExpression, LValue, Lambda, Literal, MatchExpression,
-    MemberAccessExpression, MethodCallExpression, Path, PathSegment, Pattern, PrefixExpression,
-    UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression, UnsafeExpression, WhileStatement,
+    MemberAccessExpression, Path, PathSegment, Pattern, PrefixExpression, UnresolvedType,
+    UnresolvedTypeData, UnresolvedTypeExpression, UnsafeExpression, WhileStatement,
 };
 use crate::ast::{ConstrainExpression, Expression, Statement, StatementKind};
 use crate::hir_def::expr::{
@@ -147,19 +147,6 @@ impl HirExpression {
                 let arguments = vecmap(call.arguments.clone(), |arg| arg.to_display_ast(interner));
                 let is_macro_call = false;
                 ExpressionKind::Call(Box::new(CallExpression { func, arguments, is_macro_call }))
-            }
-            HirExpression::MethodCall(method_call) => {
-                ExpressionKind::MethodCall(Box::new(MethodCallExpression {
-                    object: method_call.object.to_display_ast(interner),
-                    method_name: method_call.method.clone(),
-                    arguments: vecmap(method_call.arguments.clone(), |arg| {
-                        arg.to_display_ast(interner)
-                    }),
-                    generics: method_call.generics.clone().map(|option| {
-                        option.iter().map(|generic| generic.to_display_ast()).collect()
-                    }),
-                    is_macro_call: false,
-                }))
             }
             HirExpression::Constrain(constrain) => {
                 let expr = constrain.0.to_display_ast(interner);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -29,8 +29,7 @@ use crate::{
         expr::{
             HirArrayLiteral, HirBlockExpression, HirCallExpression, HirCastExpression,
             HirConstructorExpression, HirExpression, HirIdent, HirIfExpression, HirIndexExpression,
-            HirInfixExpression, HirLambda, HirLiteral, HirMemberAccess, HirMethodCallExpression,
-            HirPrefixExpression,
+            HirInfixExpression, HirLambda, HirLiteral, HirMemberAccess, HirPrefixExpression,
         },
         stmt::{
             HirAssignStatement, HirForStatement, HirLValue, HirLetStatement, HirPattern,
@@ -528,7 +527,6 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             HirExpression::Constructor(constructor) => self.evaluate_constructor(constructor, id),
             HirExpression::MemberAccess(access) => self.evaluate_access(access, id),
             HirExpression::Call(call) => self.evaluate_call(call, id),
-            HirExpression::MethodCall(call) => self.evaluate_method_call(call, id),
             HirExpression::Constrain(constrain) => self.evaluate_constrain(constrain),
             HirExpression::Cast(cast) => self.evaluate_cast(&cast, id),
             HirExpression::If(if_) => self.evaluate_if(if_, id),
@@ -1367,33 +1365,6 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 expr_location: location,
             }
         });
-    }
-
-    fn evaluate_method_call(
-        &mut self,
-        call: HirMethodCallExpression,
-        id: ExprId,
-    ) -> IResult<Value> {
-        let object = self.evaluate(call.object)?;
-        let arguments = try_vecmap(call.arguments, |arg| {
-            Ok((self.evaluate(arg)?, self.elaborator.interner.expr_location(&arg)))
-        })?;
-        let location = self.elaborator.interner.expr_location(&id);
-
-        let typ = object.get_type().follow_bindings();
-        let method_name = &call.method.0.contents;
-        let check_self_param = true;
-
-        let method = self
-            .elaborator
-            .lookup_method(&typ, method_name, location, check_self_param)
-            .and_then(|method| method.func_id(self.elaborator.interner));
-
-        if let Some(method) = method {
-            self.call_function(method, arguments, TypeBindings::new(), location)
-        } else {
-            Err(InterpreterError::NoMethodFound { name: method_name.clone(), typ, location })
-        }
     }
 
     fn evaluate_cast(&mut self, cast: &HirCastExpression, id: ExprId) -> IResult<Value> {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -534,7 +534,6 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             HirExpression::Tuple(tuple) => self.evaluate_tuple(tuple),
             HirExpression::Lambda(lambda) => self.evaluate_lambda(lambda, id),
             HirExpression::Quote(tokens) => self.evaluate_quote(tokens, id),
-            HirExpression::Comptime(block) => self.evaluate_block(block),
             HirExpression::Unsafe(block) => self.evaluate_block(block),
             HirExpression::EnumConstructor(constructor) => {
                 self.evaluate_enum_constructor(constructor, id)

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -42,7 +42,6 @@ pub enum HirExpression {
     Lambda(HirLambda),
     Quote(Tokens),
     Unquote(Tokens),
-    Comptime(HirBlockExpression),
     Unsafe(HirBlockExpression),
     Error,
 }

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -34,7 +34,6 @@ pub enum HirExpression {
     EnumConstructor(HirEnumConstructorExpression),
     MemberAccess(HirMemberAccess),
     Call(HirCallExpression),
-    MethodCall(HirMethodCallExpression),
     Constrain(HirConstrainExpression),
     Cast(HirCastExpression),
     If(HirIfExpression),

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -606,11 +606,6 @@ impl<'interner> Monomorphizer<'interner> {
 
             HirExpression::Lambda(lambda) => self.lambda(lambda, expr)?,
 
-            HirExpression::MethodCall(hir_method_call) => {
-                unreachable!(
-                    "Encountered HirExpression::MethodCall during monomorphization {hir_method_call:?}"
-                )
-            }
             HirExpression::Error => unreachable!("Encountered Error node during monomorphization"),
             HirExpression::Quote(_) => unreachable!("quote expression remaining in runtime code"),
             HirExpression::Unquote(_) => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -611,9 +611,6 @@ impl<'interner> Monomorphizer<'interner> {
             HirExpression::Unquote(_) => {
                 unreachable!("unquote expression remaining in runtime code")
             }
-            HirExpression::Comptime(_) => {
-                unreachable!("comptime expression remaining in runtime code")
-            }
             HirExpression::EnumConstructor(constructor) => {
                 self.enum_constructor(constructor, expr)?
             }


### PR DESCRIPTION
# Description

## Problem

I noticed this while working on #7613

## Summary

Another thing I noticed is that `HirExpression::Unquote` is created [here](https://github.com/noir-lang/noir/blob/1fa0dd95a95b01652332e94952ade14019a51fd1/compiler/noirc_frontend/src/hir/comptime/value.rs#L451) but I don't know if that should be `HirExpression::Quoted` (if so, `HirExpression::Unquote` could also be removed)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
