### PR TITLE
fix: allow method call after block, if and match

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -147,6 +147,25 @@ impl Parser<'_> {
         self.parse_index(atom, start_location)
     }
 
+    pub(super) fn parse_member_accesses_or_method_calls_after_expression(
+        &mut self,
+        mut atom: Expression,
+        start_location: Location,
+    ) -> Expression {
+        let mut parsed;
+
+        loop {
+            (atom, parsed) = self.parse_member_access_or_method_call(atom, start_location);
+            if parsed {
+                continue;
+            } else {
+                break;
+            }
+        }
+
+        atom
+    }
+
     /// CallExpression = Atom CallArguments
     fn parse_call(&mut self, atom: Expression, start_location: Location) -> (Expression, bool) {
         if let Some(call_arguments) = self.parse_call_arguments() {

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -324,8 +324,8 @@ fn empty_body() -> BlockExpression {
 mod tests {
     use crate::{
         ast::{
-            IntegerBitSize, ItemVisibility, NoirFunction, Signedness, UnresolvedTypeData,
-            Visibility,
+            ExpressionKind, IntegerBitSize, ItemVisibility, NoirFunction, Signedness,
+            StatementKind, UnresolvedTypeData, Visibility,
         },
         parse_program_with_dummy_file,
         parser::{
@@ -569,5 +569,43 @@ mod tests {
             params[1].typ.typ,
             UnresolvedTypeData::Integer(Signedness::Signed, IntegerBitSize::SixtyFour)
         );
+    }
+
+    #[test]
+    fn parses_block_followed_by_call() {
+        let src = "fn foo() { { 1 }.bar() }";
+        let noir_function = parse_function_no_error(src);
+        let statements = &noir_function.def.body.statements;
+        assert_eq!(statements.len(), 1);
+
+        let StatementKind::Expression(expr) = &statements[0].kind else {
+            panic!("Expected expression statement");
+        };
+
+        let ExpressionKind::MethodCall(call) = &expr.kind else {
+            panic!("Expected method call expression");
+        };
+
+        assert!(matches!(call.object.kind, ExpressionKind::Block(_)));
+        assert_eq!(call.method_name.to_string(), "bar");
+    }
+
+    #[test]
+    fn parses_if_followed_by_call() {
+        let src = "fn foo() { if 1 { 2 } else { 3 }.bar() }";
+        let noir_function = parse_function_no_error(src);
+        let statements = &noir_function.def.body.statements;
+        assert_eq!(statements.len(), 1);
+
+        let StatementKind::Expression(expr) = &statements[0].kind else {
+            panic!("Expected expression statement");
+        };
+
+        let ExpressionKind::MethodCall(call) = &expr.kind else {
+            panic!("Expected method call expression");
+        };
+
+        assert!(matches!(call.object.kind, ExpressionKind::If(_)));
+        assert_eq!(call.method_name.to_string(), "bar");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -146,21 +146,12 @@ impl Parser<'_> {
             return Some(StatementKind::While(while_));
         }
 
-        if let Some(kind) = self.parse_if_expr() {
+        if let Some(kind) = self.parse_block_like() {
             let location = self.location_since(start_location);
-            return Some(StatementKind::Expression(Expression { kind, location }));
-        }
-
-        if let Some(kind) = self.parse_match_expr() {
-            let location = self.location_since(start_location);
-            return Some(StatementKind::Expression(Expression { kind, location }));
-        }
-
-        if let Some(block) = self.parse_block() {
-            return Some(StatementKind::Expression(Expression {
-                kind: ExpressionKind::Block(block),
-                location: self.location_since(start_location),
-            }));
+            let expression = Expression { kind, location };
+            let expression = self
+                .parse_member_accesses_or_method_calls_after_expression(expression, start_location);
+            return Some(StatementKind::Expression(expression));
         }
 
         if let Some(token) = self.eat_kind(TokenKind::InternedLValue) {
@@ -212,6 +203,24 @@ impl Parser<'_> {
         }
 
         Some(StatementKind::Expression(expression))
+    }
+
+    /// Parses an expression that looks like a block (ends with '}'):
+    /// `{ ... }`, `if { ... }` and `match { ... }`.
+    fn parse_block_like(&mut self) -> Option<ExpressionKind> {
+        if let Some(kind) = self.parse_if_expr() {
+            return Some(kind);
+        }
+
+        if let Some(kind) = self.parse_match_expr() {
+            return Some(kind);
+        }
+
+        if let Some(block) = self.parse_block() {
+            return Some(ExpressionKind::Block(block));
+        }
+
+        None
     }
 
     fn next_is_op_assign(&mut self) -> Option<BinaryOp> {


### PR DESCRIPTION
# Description

## Problem

Resolves #7654

## Summary

It's a minor thing, but with #7613 generating code it can sometimes happen that the code ends up like this, and then it's not valid code.

## Additional Context

In reality Rust also allows the same for `for`, `loop` and `while`. I think, like in Rust, they should be expressions that return `()` (except `loop` which could have a `break`) but as it's very rare to do a call after these (they are usually `()`) and because it implies a larger change, I didn't do it.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
