### PR TITLE
chore: address recurring typo in docs

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -64,6 +64,7 @@
         "cpus",
         "cranelift",
         "critesjosh",
+        "crypdoku",
         "csat",
         "ctstring",
         "curvegroup",

--- a/docs/docs/explainers/explainer-writing-noir.md
+++ b/docs/docs/explainers/explainer-writing-noir.md
@@ -70,7 +70,7 @@ A few things to do when converting Rust code to Noir:
 - No early `return` in function. Use constrain via assertion instead
 - No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
-- No type `usize`. Use types `u8`, `u32`, `u64`, ... 
+- No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
 - No `const`, use `global`
 - Noir's LSP is your friend, so error message should be informative enough to resolve syntax issues.
@@ -203,6 +203,5 @@ The compiler will mostly be correct and optimal, but this may help some near ter
 Note: When used incorrectly it will create **less** efficient circuits (higher gate count).
 
 ## References
-- Guillaume's ["`Cryptdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
-- Tips from Tom, Jake and Zac.
+- Guillaume's ["`Crypdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
 - [Idiomatic Noir](https://www.vlayer.xyz/blog/idiomatic-noir-part-1-collections) blog post

--- a/docs/versioned_docs/version-v0.36.0/explainers/explainer-writing-noir.md
+++ b/docs/versioned_docs/version-v0.36.0/explainers/explainer-writing-noir.md
@@ -70,7 +70,7 @@ A few things to do when converting Rust code to Noir:
 - No early `return` in function. Use constrain via assertion instead
 - No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
-- No type `usize`. Use types `u8`, `u32`, `u64`, ... 
+- No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
 - No `const`, use `global`
 - Noir's LSP is your friend, so error message should be informative enough to resolve syntax issues.
@@ -172,6 +172,5 @@ The compiler will mostly be correct and optimal, but this may help some near ter
 Note: When used incorrectly it will create **less** efficient circuits (higher gate count).
 
 ## References
-- Guillaume's ["`Cryptdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
-- Tips from Tom, Jake and Zac.
+- Guillaume's ["`Crypdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
 - [Idiomatic Noir](https://www.vlayer.xyz/blog/idiomatic-noir-part-1-collections) blog post

--- a/docs/versioned_docs/version-v1.0.0-beta.0/explainers/explainer-writing-noir.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.0/explainers/explainer-writing-noir.md
@@ -70,7 +70,7 @@ A few things to do when converting Rust code to Noir:
 - No early `return` in function. Use constrain via assertion instead
 - No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
-- No type `usize`. Use types `u8`, `u32`, `u64`, ... 
+- No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
 - No `const`, use `global`
 - Noir's LSP is your friend, so error message should be informative enough to resolve syntax issues.
@@ -172,6 +172,5 @@ The compiler will mostly be correct and optimal, but this may help some near ter
 Note: When used incorrectly it will create **less** efficient circuits (higher gate count).
 
 ## References
-- Guillaume's ["`Cryptdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
-- Tips from Tom, Jake and Zac.
+- Guillaume's ["`Crypdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
 - [Idiomatic Noir](https://www.vlayer.xyz/blog/idiomatic-noir-part-1-collections) blog post

--- a/docs/versioned_docs/version-v1.0.0-beta.1/explainers/explainer-writing-noir.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.1/explainers/explainer-writing-noir.md
@@ -70,7 +70,7 @@ A few things to do when converting Rust code to Noir:
 - No early `return` in function. Use constrain via assertion instead
 - No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
-- No type `usize`. Use types `u8`, `u32`, `u64`, ... 
+- No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
 - No `const`, use `global`
 - Noir's LSP is your friend, so error message should be informative enough to resolve syntax issues.
@@ -172,6 +172,5 @@ The compiler will mostly be correct and optimal, but this may help some near ter
 Note: When used incorrectly it will create **less** efficient circuits (higher gate count).
 
 ## References
-- Guillaume's ["`Cryptdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
-- Tips from Tom, Jake and Zac.
+- Guillaume's ["`Crypdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
 - [Idiomatic Noir](https://www.vlayer.xyz/blog/idiomatic-noir-part-1-collections) blog post

--- a/docs/versioned_docs/version-v1.0.0-beta.2/explainers/explainer-writing-noir.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.2/explainers/explainer-writing-noir.md
@@ -70,7 +70,7 @@ A few things to do when converting Rust code to Noir:
 - No early `return` in function. Use constrain via assertion instead
 - No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
-- No type `usize`. Use types `u8`, `u32`, `u64`, ... 
+- No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
 - No `const`, use `global`
 - Noir's LSP is your friend, so error message should be informative enough to resolve syntax issues.
@@ -203,6 +203,5 @@ The compiler will mostly be correct and optimal, but this may help some near ter
 Note: When used incorrectly it will create **less** efficient circuits (higher gate count).
 
 ## References
-- Guillaume's ["`Cryptdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
-- Tips from Tom, Jake and Zac.
+- Guillaume's ["`Crypdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
 - [Idiomatic Noir](https://www.vlayer.xyz/blog/idiomatic-noir-part-1-collections) blog post

--- a/docs/versioned_docs/version-v1.0.0-beta.3/explainers/explainer-writing-noir.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.3/explainers/explainer-writing-noir.md
@@ -70,7 +70,7 @@ A few things to do when converting Rust code to Noir:
 - No early `return` in function. Use constrain via assertion instead
 - No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
-- No type `usize`. Use types `u8`, `u32`, `u64`, ... 
+- No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
 - No `const`, use `global`
 - Noir's LSP is your friend, so error message should be informative enough to resolve syntax issues.
@@ -203,6 +203,5 @@ The compiler will mostly be correct and optimal, but this may help some near ter
 Note: When used incorrectly it will create **less** efficient circuits (higher gate count).
 
 ## References
-- Guillaume's ["`Cryptdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
-- Tips from Tom, Jake and Zac.
+- Guillaume's ["`Crypdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
 - [Idiomatic Noir](https://www.vlayer.xyz/blog/idiomatic-noir-part-1-collections) blog post


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR deals with a recurring cspell issue which pops up in the release PRs. where Guillaume's talk name throws an error.

I've also removed the "Tips from Tom, Jake and Zac." reference as this is non-actionable by readers.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
