### PR TITLE
chore(ci): Exclude enum tests from Brillig reports

### DIFF
--- a/test_programs/gates_report_brillig.sh
+++ b/test_programs/gates_report_brillig.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-# These tests are incompatible with gas reporting
-excluded_dirs=("workspace" "workspace_default_member" "double_verify_nested_proof" "overlapping_dep_and_mod" "comptime_println")
+# These tests are incompatible with artifact size reporting
+excluded_dirs=(
+  "workspace" 
+  "workspace_default_member" 
+  "double_verify_nested_proof" 
+  "overlapping_dep_and_mod" 
+  "comptime_println" 
+  # This test utilizes enums which are experimental
+  "regression_7323"
+)
 
 current_dir=$(pwd)
 base_path="$current_dir/execution_success"

--- a/test_programs/gates_report_brillig_execution.sh
+++ b/test_programs/gates_report_brillig_execution.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
-# These tests are incompatible with gas reporting
+# These tests are incompatible with execution trace reporting
 excluded_dirs=(
   "workspace"
   "workspace_default_member"
   "double_verify_nested_proof"
   "overlapping_dep_and_mod"
   "comptime_println"
-  #  bit sizes for bigint operation doesn't match up.
+  # bit sizes for bigint operation doesn't match up.
   "bigint"
-  #  Expected to fail as test asserts on which runtime it is in.
+  # Expected to fail as test asserts on which runtime it is in.
   "is_unconstrained"
+  # This test utilizes enums which are experimental
+  "regression_7323"
 )
 
 current_dir=$(pwd)


### PR DESCRIPTION
# Description

## Problem\*

In https://github.com/noir-lang/noir/pull/7660 I was not getting an opcode diff that I am getting locally.

Although the CI jobs for the Brillig opcode reports are passing, we are getting this failure:
```
error: This requires the unstable feature 'enums' which is not enabled
   ┌─ execution_success/regression_7323/src/main.nr:5:5
   │  
 5 │ ╭     match x {
 6 │ │         1 => panic(f"Branch 1 should not be taken"),
 7 │ │         2 => panic(f"Branch 2 should not be taken"),
 8 │ │         3 => panic(f"Branch 3 should not be taken"),
 9 │ │         _ => (),
10 │ │     }
   │ ╰─────' Pass -Zenums to nargo to enable this feature at your own risk.
   │  
```

Here is an example from an entirely unrelated PR where we see the same failure: https://github.com/noir-lang/noir/actions/runs/13788593062/job/38562554298?pr=7659

## Summary\*

Exclude tests that use enums from the Brillig reports. Right now this is just `regression_7323`.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
