### PR TITLE
chore!: make `ResolverError::UnnecessaryPub` a hard error

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -410,7 +410,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
             ResolverError::UnnecessaryPub { ident, position } => {
                 let name = &ident.0.contents;
 
-                let mut diag = Diagnostic::simple_warning(
+                let mut diag = Diagnostic::simple_error(
                     format!("unnecessary pub keyword on {position} for function {name}"),
                     format!("unnecessary pub {position}"),
                     ident.0.location(),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is never meaningful so we should reject it rather than ignoring this which allows confusing syntax.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
