### PR TITLE
chore(ssa): Do not print entire functions in underconstrained values check trace

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -316,7 +316,12 @@ impl DependencyContext {
         function: &Function,
         all_functions: &BTreeMap<FunctionId, Function>,
     ) {
-        trace!("processing instructions of block {} of function {} {}", block, function.name(), function.id());
+        trace!(
+            "processing instructions of block {} of function {} {}",
+            block,
+            function.name(),
+            function.id()
+        );
 
         // First, gather information on all Brillig calls in the block
         // to be able to follow their arguments first appearing in the

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -316,7 +316,7 @@ impl DependencyContext {
         function: &Function,
         all_functions: &BTreeMap<FunctionId, Function>,
     ) {
-        trace!("processing instructions of block {} of function {}", block, function.id());
+        trace!("processing instructions of block {} of function {} {}", block, function.name(), function.id());
 
         // First, gather information on all Brillig calls in the block
         // to be able to follow their arguments first appearing in the
@@ -548,8 +548,9 @@ impl DependencyContext {
 
         if !self.tainted.is_empty() {
             trace!(
-                "number of Brillig calls in function {} left unchecked: {}",
-                function,
+                "number of Brillig calls in function {} {} left unchecked: {}",
+                function.name(),
+                function.id(),
                 self.tainted.len()
             );
         }
@@ -573,9 +574,10 @@ impl DependencyContext {
             .collect();
 
         trace!(
-            "making {} reports on underconstrained Brillig calls for function {}",
+            "making {} reports on underconstrained Brillig calls for function {} {}",
             warnings.len(),
-            function.name()
+            function.name(),
+            function.id()
         );
         warnings
     }


### PR DESCRIPTION
# Description

## Problem\*

No issue just something I noticed while running a Noir program with a trace activated.

## Summary\*

We should not be printing the entire function where we may have tainted Brillig calls. A function's SSA could potentially be massive. This litters the trace and also most likely affects our compilation timing reports (which have `NOIR_LOG=trace` activated) as we are printing much more than necessary. 

This was initially done here https://github.com/noir-lang/noir/pull/6814 but looks like a trace was missed. We now use a combo of function name and id. 

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
