### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT f15942770bc391a4d66fe9c23262b755de77f71d
+define: &AZ_COMMIT b764a9a48a19c4803671876f9df8b7af53fe3e49
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT f15942770bc391a4d66fe9c23262b755de77f71d
+define: &AZ_COMMIT b764a9a48a19c4803671876f9df8b7af53fe3e49
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
