### PR TITLE
Tf/remove plonk tests

### DIFF
--- a/compiler/integration-tests/scripts/codegen-verifiers.sh
+++ b/compiler/integration-tests/scripts/codegen-verifiers.sh
@@ -17,14 +17,14 @@ KEYS=$(mktemp -d)
 # Codegen verifier contract for 1_mul
 mul_dir=$repo_root/test_programs/execution_success/1_mul
 nargo --program-dir $mul_dir compile
-$NARGO_BACKEND_PATH OLD_API write_vk -b $mul_dir/target/1_mul.json -o $KEYS/1_mul
-$NARGO_BACKEND_PATH OLD_API contract -k $KEYS/1_mul -o $contracts_dir/1_mul.sol
+$NARGO_BACKEND_PATH write_vk -b $mul_dir/target/1_mul.json -o $KEYS --oracle_hash keccak
+$NARGO_BACKEND_PATH write_solidity_verifier -k $KEYS/vk -o $contracts_dir/1_mul.sol
 
 # Codegen verifier contract for assert_statement
 assert_statement_dir=$repo_root/test_programs/execution_success/assert_statement
 nargo --program-dir $assert_statement_dir compile
-$NARGO_BACKEND_PATH OLD_API write_vk -b $assert_statement_dir/target/assert_statement.json -o $KEYS/assert_statement
-$NARGO_BACKEND_PATH OLD_API contract -k $KEYS/assert_statement -o $contracts_dir/assert_statement.sol
+$NARGO_BACKEND_PATH write_vk -b $assert_statement_dir/target/assert_statement.json -o $KEYS --oracle_hash keccak
+$NARGO_BACKEND_PATH write_solidity_verifier -k $KEYS/vk -o $contracts_dir/assert_statement.sol
 
 # Codegen verifier contract for recursion
 recursion_dir=$repo_root/compiler/integration-tests/circuits/recursion

--- a/compiler/integration-tests/test/browser/compile_prove_verify.test.ts
+++ b/compiler/integration-tests/test/browser/compile_prove_verify.test.ts
@@ -4,7 +4,7 @@ import * as TOML from 'smol-toml';
 import { compile, createFileManager } from '@noir-lang/noir_wasm';
 import { Noir } from '@noir-lang/noir_js';
 import { InputMap } from '@noir-lang/noirc_abi';
-import { UltraPlonkBackend } from '@aztec/bb.js';
+import { UltraHonkBackend } from '@aztec/bb.js';
 
 import { getFile } from './utils.js';
 
@@ -59,7 +59,7 @@ test_cases.forEach((testInfo) => {
     const program = new Noir(noir_program);
     const { witness } = await program.execute(inputs);
 
-    const backend = new UltraPlonkBackend(noir_program.bytecode);
+    const backend = new UltraHonkBackend(noir_program.bytecode);
     const proof = await backend.generateProof(witness);
 
     // JS verification

--- a/compiler/integration-tests/test/node/prove_and_verify.test.ts
+++ b/compiler/integration-tests/test/node/prove_and_verify.test.ts
@@ -2,158 +2,15 @@ import { expect } from 'chai';
 import assert_lt_json from '../../circuits/assert_lt/target/assert_lt.json' assert { type: 'json' };
 import fold_fibonacci_json from '../../circuits/fold_fibonacci/target/fold_fibonacci.json' assert { type: 'json' };
 import { Noir } from '@noir-lang/noir_js';
-import { BarretenbergVerifier, UltraPlonkBackend, UltraHonkBackend } from '@aztec/bb.js';
+import { BarretenbergVerifier, UltraHonkBackend } from '@aztec/bb.js';
 import { CompiledCircuit } from '@noir-lang/types';
 
 const assert_lt_program = assert_lt_json as CompiledCircuit;
 const fold_fibonacci_program = fold_fibonacci_json as CompiledCircuit;
 
-const backend = new UltraPlonkBackend(assert_lt_program.bytecode);
-
-it('end-to-end proof creation and verification (outer)', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '2',
-    y: '3',
-  };
-
-  const program = new Noir(assert_lt_program);
-
-  const { witness } = await program.execute(inputs);
-
-  // bb.js part
-  //
-  // Proof creation
-  const proof = await backend.generateProof(witness);
-
-  // Proof verification
-  const isValid = await backend.verifyProof(proof);
-  expect(isValid).to.be.true;
-});
-
-it('end-to-end proof creation and verification (outer) -- Verifier API', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '2',
-    y: '3',
-  };
-
-  // Execute program
-  const program = new Noir(assert_lt_program);
-  const { witness } = await program.execute(inputs);
-
-  // Generate proof
-  const proof = await backend.generateProof(witness);
-
-  const verificationKey = await backend.getVerificationKey();
-
-  // Proof verification
-  const verifier = new BarretenbergVerifier();
-  const isValid = await verifier.verifyUltraPlonkProof(proof, verificationKey);
-  expect(isValid).to.be.true;
-});
-
-// TODO: maybe switch to using assert_statement_recursive here to test both options
-it('end-to-end proof creation and verification (inner)', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '2',
-    y: '3',
-  };
-
-  const program = new Noir(assert_lt_program);
-
-  const { witness } = await program.execute(inputs);
-
-  // bb.js part
-  //
-  // Proof creation
-  const proof = await backend.generateProof(witness);
-
-  // Proof verification
-  const isValid = await backend.verifyProof(proof);
-  expect(isValid).to.be.true;
-});
-
-it('end-to-end proving and verification with different instances', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '2',
-    y: '3',
-  };
-
-  const program = new Noir(assert_lt_program);
-
-  const { witness } = await program.execute(inputs);
-
-  // bb.js part
-  const proof = await backend.generateProof(witness);
-
-  const verifier = new UltraPlonkBackend(assert_lt_program.bytecode);
-  const proof_is_valid = await verifier.verifyProof(proof);
-  expect(proof_is_valid).to.be.true;
-});
-
-// This bug occurs when we use the same backend to create an inner proof and then an outer proof
-// and then try to verify either one of them.
-//
-// The panic occurs when we try to verify the outer/inner proof that was created.
-// If we only create one type of proof, then this works as expected.
-//
-// If we do not create an inner proof, then this will work as expected.
-it('[BUG] -- bb.js null function or function signature mismatch (outer-inner) ', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '2',
-    y: '3',
-  };
-
-  const program = new Noir(assert_lt_program);
-
-  const { witness } = await program.execute(inputs);
-
-  // bb.js part
-  //
-  // Proof creation
-  //
-  // Create a proof using both proving systems, the majority of the time
-  // one would only use outer proofs.
-  const proofOuter = await backend.generateProof(witness);
-  const _proofInner = await backend.generateProof(witness);
-
-  // Proof verification
-  //
-  const isValidOuter = await backend.verifyProof(proofOuter);
-  expect(isValidOuter).to.be.true;
-  // We can also try verifying an inner proof and it will fail.
-  const isValidInner = await backend.verifyProof(_proofInner);
-  expect(isValidInner).to.be.true;
-});
-
-it('end-to-end proof creation and verification for multiple ACIR circuits (inner)', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '10',
-  };
-
-  const program = new Noir(fold_fibonacci_program);
-
-  const { witness } = await program.execute(inputs);
-
-  // bb.js part
-  //
-  // Proof creation
-  const backend = new UltraPlonkBackend(fold_fibonacci_program.bytecode);
-  const proof = await backend.generateProof(witness);
-
-  // Proof verification
-  const isValid = await backend.verifyProof(proof);
-  expect(isValid).to.be.true;
-});
-
 const honkBackend = new UltraHonkBackend(assert_lt_program.bytecode);
 
-it('UltraHonk end-to-end proof creation and verification (outer)', async () => {
+it('end-to-end proof creation and verification', async () => {
   // Noir.Js part
   const inputs = {
     x: '2',
@@ -174,7 +31,7 @@ it('UltraHonk end-to-end proof creation and verification (outer)', async () => {
   expect(isValid).to.be.true;
 });
 
-it('UltraHonk end-to-end proof creation and verification (outer) -- Verifier API', async () => {
+it('end-to-end proof creation and verification -- Verifier API', async () => {
   // Noir.Js part
   const inputs = {
     x: '2',
@@ -196,28 +53,7 @@ it('UltraHonk end-to-end proof creation and verification (outer) -- Verifier API
   expect(isValid).to.be.true;
 });
 
-it('UltraHonk end-to-end proof creation and verification (inner)', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '2',
-    y: '3',
-  };
-
-  const program = new Noir(assert_lt_program);
-
-  const { witness } = await program.execute(inputs);
-
-  // bb.js part
-  //
-  // Proof creation
-  const proof = await honkBackend.generateProof(witness);
-
-  // Proof verification
-  const isValid = await honkBackend.verifyProof(proof);
-  expect(isValid).to.be.true;
-});
-
-it('UltraHonk end-to-end proving and verification with different instances', async () => {
+it('end-to-end proving and verification with different instances', async () => {
   // Noir.Js part
   const inputs = {
     x: '2',
@@ -236,36 +72,7 @@ it('UltraHonk end-to-end proving and verification with different instances', asy
   expect(proof_is_valid).to.be.true;
 });
 
-it('[BUG] -- UltraHonk bb.js null function or function signature mismatch (outer-inner) ', async () => {
-  // Noir.Js part
-  const inputs = {
-    x: '2',
-    y: '3',
-  };
-
-  const program = new Noir(assert_lt_program);
-
-  const { witness } = await program.execute(inputs);
-
-  // bb.js part
-  //
-  // Proof creation
-  //
-  // Create a proof using both proving systems, the majority of the time
-  // one would only use outer proofs.
-  const proofOuter = await honkBackend.generateProof(witness);
-  const _proofInner = await honkBackend.generateProof(witness);
-
-  // Proof verification
-  //
-  const isValidOuter = await honkBackend.verifyProof(proofOuter);
-  expect(isValidOuter).to.be.true;
-  // We can also try verifying an inner proof and it will fail.
-  const isValidInner = await honkBackend.verifyProof(_proofInner);
-  expect(isValidInner).to.be.true;
-});
-
-it('UltraHonk end-to-end proof creation and verification for multiple ACIR circuits (inner)', async () => {
+it('end-to-end proof creation and verification for multiple ACIR circuits', async () => {
   // Noir.Js part
   const inputs = {
     x: '10',

--- a/compiler/integration-tests/test/node/smart_contract_verifier.test.ts
+++ b/compiler/integration-tests/test/node/smart_contract_verifier.test.ts
@@ -6,7 +6,7 @@ import { resolve } from 'path';
 import toml from 'toml';
 
 import { Noir } from '@noir-lang/noir_js';
-import { UltraPlonkBackend } from '@aztec/bb.js';
+import { UltraHonkBackend } from '@aztec/bb.js';
 
 import { compile, createFileManager } from '@noir-lang/noir_wasm';
 
@@ -46,7 +46,7 @@ test_cases.forEach((testInfo) => {
     const inputs = toml.parse(prover_toml);
     const { witness } = await program.execute(inputs);
 
-    const backend = new UltraPlonkBackend(noir_program.bytecode, {}, { recursive: false });
+    const backend = new UltraHonkBackend(noir_program.bytecode, {}, { recursive: false });
     const proofData = await backend.generateProof(witness);
 
     // JS verification


### PR DESCRIPTION
# Description

## Problem\*

Part of #7628 
## Summary\*

This PR removes most of the ultraplonk tests from the repository. I've kept the test which verifies a recursive proof onchain pending support for this using ultrahonk.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
