### PR TITLE
fix: allow referring to comptime locals at runtime

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -17,7 +17,9 @@ use crate::{
         expr::{HirExpression, HirIdent, HirMethodReference, ImplKind, TraitMethod},
         stmt::HirPattern,
     },
-    node_interner::{DefinitionId, DefinitionKind, ExprId, FuncId, GlobalId, TraitImplKind},
+    node_interner::{
+        DefinitionId, DefinitionInfo, DefinitionKind, ExprId, FuncId, GlobalId, TraitImplKind,
+    },
 };
 
 use super::{Elaborator, ResolverMeta, path_resolution::PathResolutionItem};
@@ -543,8 +545,8 @@ impl Elaborator<'_> {
         let type_generics = item.map(|item| self.resolve_item_turbofish(item)).unwrap_or_default();
 
         let definition = self.interner.try_definition(definition_id);
-        let is_comptime_local =
-            !self.in_comptime_context() && definition.map_or(false, |def| def.is_comptime_local());
+        let is_comptime_local = !self.in_comptime_context()
+            && definition.is_some_and(DefinitionInfo::is_comptime_local);
         let definition_kind = definition.as_ref().map(|definition| definition.kind.clone());
 
         let mut bindings = TypeBindings::new();

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -582,9 +582,16 @@ impl Elaborator<'_> {
         if is_comptime_local {
             let mut interpreter = self.setup_interpreter();
             let value = interpreter.evaluate(id);
-            let (id, typ) = self.inline_comptime_value(value, location);
-            self.debug_comptime(location, |interner| id.to_display_ast(interner).kind);
-            (id, typ)
+            // If the value is an error it means the variable already had an error, so don't report it here again
+            // (the error will make no sense, it will say that a non-comptime variable was referenced at runtime
+            // but that's not true)
+            if value.is_ok() {
+                let (id, typ) = self.inline_comptime_value(value, location);
+                self.debug_comptime(location, |interner| id.to_display_ast(interner).kind);
+                (id, typ)
+            } else {
+                (id, typ)
+            }
         } else {
             (id, typ)
         }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -573,6 +573,10 @@ impl DefinitionInfo {
     pub fn is_global(&self) -> bool {
         self.kind.is_global()
     }
+
+    pub fn is_comptime_local(&self) -> bool {
+        self.comptime && matches!(self.kind, DefinitionKind::Local(..))
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -32,6 +32,8 @@ fn comptime_code_rejects_dynamic_variable() {
                                ^ Non-comptime variable `x` referenced in comptime code
                                ~ Non-comptime variables can't be used in comptime code
         assert_eq(my_var, 2);
+                  ^^^^^^ Non-comptime variable `my_var` referenced in comptime code
+                  ~~~~~~ Non-comptime variables can't be used in comptime code
     }
     "#;
     check_errors(src);

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -32,8 +32,6 @@ fn comptime_code_rejects_dynamic_variable() {
                                ^ Non-comptime variable `x` referenced in comptime code
                                ~ Non-comptime variables can't be used in comptime code
         assert_eq(my_var, 2);
-                  ^^^^^^ Non-comptime variable `my_var` referenced in comptime code
-                  ~~~~~~ Non-comptime variables can't be used in comptime code
     }
     "#;
     check_errors(src);

--- a/test_programs/execution_success/comptime_variable_at_runtime/Nargo.toml
+++ b/test_programs/execution_success/comptime_variable_at_runtime/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "comptime_variable_at_runtime"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/comptime_variable_at_runtime/src/main.nr
+++ b/test_programs/execution_success/comptime_variable_at_runtime/src/main.nr
@@ -1,0 +1,11 @@
+fn main() {
+    comptime let mut x = 1;
+
+    println(x); // prints 1
+
+    comptime {
+        x += 1;
+    }
+
+    println(x); // prints 2
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #7550

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
