### PR TITLE
chore: add trailing slash to link on docs homepage

### DIFF
--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -31,7 +31,7 @@ export default function Landing() {
 
           <div className="homepage_cta_header_container">
             <div className="homepage_cta_container">
-              <Link to="/docs">
+              <Link to="/docs/">
                 <button className="cta-button button button--primary button--lg homepage_cta">Read the Docs</button>
               </Link>
             </div>


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
