### PR TITLE
chore(docs): Minor fixes on local documentation development workflows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,25 +15,20 @@ Check out the contributing guide [here](../CONTRIBUTING.md).
 
 ### Installation
 
-This project requires recent versions of rust and cargo to be installed.
+This project requires recent versions of Rust and Cargo to be installed.
 Any build errors should indicate dependencies that need installing, and at what version.
 
-On the root folder of the repository, run:
+From the _noir_ root directory, run:
 
-```
+```sh
 yarn
-yarn build
 ```
 
 ### Local Development
 
-```
-yarn workspace docs version
-```
+From the _noir_ root directory, run:
 
-This command fetches and compiles the list of documentation versions to build with.
-
-```
+```sh
 yarn workspace docs dev
 ```
 
@@ -42,13 +37,25 @@ reflected live without having to restart the server.
 
 ### Build
 
+From the _noir_ root directory:
+
+1. Fetch and generate the list of recent stable documentation versions to build:
+
+```sh
+yarn workspace docs version::stables
 ```
+
+2. Build the docs:
+
+```sh
 yarn workspace docs build
 ```
 
-This command generates static content into the `build` directory and can be served using any static
-contents hosting service. You can see a preview by running:
+This command generates static content into the _build_ directory and can be served using any static
+contents hosting service.
 
-```
+3. Verify build by serve a preview of the docs locally:
+
+```sh
 yarn workspace docs serve
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,15 @@ yarn
 
 ### Local Development
 
-From the _noir_ root directory, run:
+From the _noir_ root directory:
+
+1. Fetch and generate the list of recent stable documentation versions to build:
+
+```sh
+yarn workspace docs version::stables
+```
+
+2. Start a development server serving docs preview:
 
 ```sh
 yarn workspace docs dev

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "preprocess": "yarn workspace @noir-lang/acvm_js build && ./scripts/codegen_nargo_reference.sh && yarn node ./scripts/preprocess/index.js",
-    "dev": "yarn preprocess && ENV=dev docusaurus start",
+    "dev": "yarn preprocess && yarn version::stables && ENV=dev docusaurus start",
     "build": "yarn preprocess && docusaurus build",
     "clean": "rm -rf ./processed-docs ./processed-docs ./build",
     "version::stables": "ts-node ./scripts/setStable.ts",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "preprocess": "yarn workspace @noir-lang/acvm_js build && ./scripts/codegen_nargo_reference.sh && yarn node ./scripts/preprocess/index.js",
-    "dev": "yarn preprocess && yarn version::stables && ENV=dev docusaurus start",
+    "dev": "yarn preprocess && ENV=dev docusaurus start",
     "build": "yarn preprocess && docusaurus build",
     "clean": "rm -rf ./processed-docs ./processed-docs-cache ./build",
     "version::stables": "ts-node ./scripts/setStable.ts",

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
     "preprocess": "yarn workspace @noir-lang/acvm_js build && ./scripts/codegen_nargo_reference.sh && yarn node ./scripts/preprocess/index.js",
     "dev": "yarn preprocess && yarn version::stables && ENV=dev docusaurus start",
     "build": "yarn preprocess && docusaurus build",
-    "clean": "rm -rf ./processed-docs ./processed-docs ./build",
+    "clean": "rm -rf ./processed-docs ./processed-docs-cache ./build",
     "version::stables": "ts-node ./scripts/setStable.ts",
     "serve": "serve build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## Summary\*

- Supplement missing step of generating `versions.json` in `yarn dev`
- Fix missing cache cleaning in `yarn clean`
- Trim unnecessary commands and supplement missing commands in README
- Improve readability of steps in README

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
