### PR TITLE
chore(docs): Extend stable documentation versions to build to cover multiple `beta.n` releases

### DIFF
--- a/docs/scripts/setStable.ts
+++ b/docs/scripts/setStable.ts
@@ -37,6 +37,9 @@ async function main() {
 
   console.log('Filtered down to stables: ', stables);
 
+  // Temporarily disable omission of patch versions, as it omits all 1.0.0-beta.n versions that are not the latest
+  // To restore when versioning scheme upgrades from 1.0.0-beta.n to 1.x.y
+  /*
   const onlyLatestPatches = [];
   const minorsSet = new Set(stables.map((el) => el.split('.')[1]));
   for (const minor of minorsSet) {
@@ -50,6 +53,10 @@ async function main() {
   console.log('Only latest patches: ', onlyLatestPatches);
 
   fs.writeFileSync(path.resolve(__dirname, '../versions.json'), JSON.stringify(onlyLatestPatches, null, 2));
+  */
+
+  // To delete when versioning scheme upgrades from 1.0.0-beta.n to 1.x.y
+  fs.writeFileSync(path.resolve(__dirname, '../versions.json'), JSON.stringify(stables, null, 2));
 }
 
 main();


### PR DESCRIPTION
# Description

## Problem\*

The _setStable.ts_ script currently omits building and serving documentations for older patch versions. It was and will be great for skipping largely redundant builds for multiple _y_ when Noir was on _0.x.y_ versioning and when Noir is on _1.x.y_ versioning.

As Noir is currently on _1.0.0-beta.n_ versioning though, this skips all _n_ version documentations except the latest, albeit them not necessarily being patches.

E.g. Only _1.0.0-beta.2_ docs are currently served:

<img width="247" alt="image" src="https://github.com/user-attachments/assets/96ce00b6-42b2-4361-8df4-a16f135cd3d0" />

## Summary\*

This PR:
- Comments out patch version omission logic in _setStable.ts_
- Add temporary command to generate _versions.json_ with just filtered stables instead

Which enables serving of docs for the two most-recent versions as intended for doc readers:

<img width="245" alt="image" src="https://github.com/user-attachments/assets/115f4750-ba82-4d45-aff0-e79c0a0837f5" />

## Additional Context

This PR should be reverted / the patch omission logic should be restored when Noir moves to _1.x.y_ versioning.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
