### PR TITLE
chore: add workflow to publish rustdoc to github pages

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -57,6 +57,11 @@ jobs:
           name: rustdoc
           path: ./docs
 
+      - name: Configure git
+        run: |
+          git config --global user.email "rustdoc"
+          git config --global user.name "github@users.noreply.github.com"
+
       - name: Commit new docs
         run: |
           git add ./docs/*

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - tf/rustdoc
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
@@ -72,6 +71,8 @@ jobs:
 
       - name: Commit new docs
         run: |
+          # This could _potentially_ clash with pushing benchmarks to this branch at the same time.
+          # In practice, this will complete much sooner than the benchmarks are generated.
           git add ./docs/*
           git commit -m "update rustdoc"
           git push

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,64 @@
+name: Publish rustdoc
+
+on:
+  push:
+    branches:
+      - master
+      - tf/rustdoc
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Configure cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Clean docs folder
+        run: cargo clean --doc
+
+      - name: Build docs
+        run: cargo doc --no-deps --workspace
+
+      - name: Add redirect
+        run: echo '<meta http-equiv="refresh" content="0;url=aoc/index.html">' > target/doc/index.html
+
+      - name: Remove lock file
+        run: rm target/doc/.lock
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          name: rustdoc
+          path: target/doc
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Download rustdoc output
+        uses: actions/download-artifact@v4
+        with:
+          name: rustdoc
+          path: ./docs
+
+      - name: Commit new docs
+        run: |
+          git add ./docs/*
+          git commit -m "update rustdoc"
+          git push

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -31,7 +31,7 @@ jobs:
         run: cargo doc --no-deps --workspace
 
       - name: Add redirect
-        run: echo '<meta http-equiv="refresh" content="0;url=aoc/index.html">' > target/doc/index.html
+        run: echo '<meta http-equiv="refresh" content="0;url=nargo/index.html">' > target/doc/index.html
 
       - name: Remove lock file
         run: rm target/doc/.lock
@@ -59,8 +59,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --global user.email "rustdoc"
-          git config --global user.name "github@users.noreply.github.com"
+          git config --global user.name "rustdoc"
+          git config --global user.email "github@users.noreply.github.com"
 
       - name: Commit new docs
         run: |

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - master
-      - tf/rustdoc
+
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - tf/rustdoc
 
 # This will cancel previous runs when a branch or PR is updated
 concurrency:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -37,7 +37,7 @@ jobs:
         run: rm target/doc/.lock
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: rustdoc
           path: target/doc

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo clean --doc
 
       - name: Build docs
-        run: cargo doc --no-deps --workspace
+        run: cargo doc --no-deps --document-private-items --workspace
 
       - name: Add redirect
         run: echo '<meta http-equiv="refresh" content="0;url=nargo/index.html">' > target/doc/index.html

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           ref: gh-pages
 
+      - name: Clear old docs
+        run: rm -rf ./docs
+
       - name: Download rustdoc output
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7683 

## Summary\*

This PR sets up a build of rustdoc to be hosted at https://noir-lang.github.io/noir/docs. This is automatically update on each commit to master.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
