### PR TITLE
feat(ssa): Dominance frontiers

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -282,7 +282,7 @@ impl DominatorTree {
 
     /// Computes the dominance frontier for all blocks in the dominator tree.
     ///
-    /// This method uses the algorithm specified under Cooper, Keith D. et al. “A Simple, Fast Dominance Algorithm.” (1999).
+    /// This method uses the algorithm specified in Cooper, Keith D. et al. “A Simple, Fast Dominance Algorithm.” (1999).
     /// As referenced in the paper a dominance frontier is the set of all CFG nodes, y, such that
     /// b dominates a predecessor of y but does not strictly dominate y.
     ///

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use super::{
     basic_block::BasicBlockId, cfg::ControlFlowGraph, function::Function, post_order::PostOrder,
 };
-use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use fxhash::FxHashMap as HashMap;
 
 /// Dominator tree node. We keep one of these per reachable block.
 #[derive(Clone, Default)]
@@ -287,6 +287,7 @@ impl DominatorTree {
     /// a dominator tree (standard CFG) or a post-dominator tree (reversed CFG).
     /// Calling this method on a dominator tree will return a function's dominance frontiers,
     /// while on a post-dominator tree the method will return the function's reverse (or post) dominance frontiers.
+    #[cfg(test)]
     pub(crate) fn compute_dominance_frontiers(
         &mut self,
         cfg: &ControlFlowGraph,
@@ -333,8 +334,17 @@ mod tests {
     use crate::ssa::{
         function_builder::FunctionBuilder,
         ir::{
-            basic_block::{BasicBlock, BasicBlockId}, call_stack::CallStackId, cfg::ControlFlowGraph, dom::DominatorTree, function::Function, instruction::TerminatorInstruction, map::Id, post_order::PostOrder, types::Type
-        }, ssa_gen::Ssa,
+            basic_block::{BasicBlock, BasicBlockId},
+            call_stack::CallStackId,
+            cfg::ControlFlowGraph,
+            dom::DominatorTree,
+            function::Function,
+            instruction::TerminatorInstruction,
+            map::Id,
+            post_order::PostOrder,
+            types::Type,
+        },
+        ssa_gen::Ssa,
     };
 
     #[test]
@@ -690,7 +700,7 @@ mod tests {
         let post_order = PostOrder::with_cfg(&reversed_cfg);
 
         let mut post_dom = DominatorTree::with_cfg_and_post_order(&reversed_cfg, &post_order);
-        
+
         let blocks = vecmap(0..6, |index| Id::<BasicBlock>::test_new(index));
 
         // Post-dominance matrix:
@@ -723,7 +733,6 @@ mod tests {
         assert!(!post_dom.dominates(blocks[1], blocks[3]));
         assert!(post_dom.dominates(blocks[1], blocks[4]));
         assert!(post_dom.dominates(blocks[1], blocks[5]));
-        
 
         // Starting from the exit node b3 which should be the root of the post-dominator tree
         assert!(post_dom.dominates(blocks[3], blocks[0]));

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -652,7 +652,7 @@ mod tests {
         let main = ssa.main();
         let mut dt = DominatorTree::with_function(&main);
 
-        let blocks = vecmap(0..6, |index| Id::<BasicBlock>::test_new(index));
+        let blocks = vecmap(0..6, Id::<BasicBlock>::test_new);
         // Dominance matrix:
         // ✓: Row item dominates column item
         //    b0  b1  b2  b3  b4  b5
@@ -703,7 +703,7 @@ mod tests {
 
         let mut post_dom = DominatorTree::with_cfg_and_post_order(&reversed_cfg, &post_order);
 
-        let blocks = vecmap(0..6, |index| Id::<BasicBlock>::test_new(index));
+        let blocks = vecmap(0..6, Id::<BasicBlock>::test_new);
 
         // Post-dominance matrix:
         // ✓: Row item post-dominates column item
@@ -765,7 +765,7 @@ mod tests {
         let mut dt = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
         let dom_frontiers = dt.compute_dominance_frontiers(&cfg);
 
-        let blocks = vecmap(0..6, |index| Id::<BasicBlock>::test_new(index));
+        let blocks = vecmap(0..6, Id::<BasicBlock>::test_new);
 
         // b0 is the entry block which dominates all other blocks
         // Thus, it has an empty set for its dominance frontier
@@ -796,7 +796,7 @@ mod tests {
         let mut post_dom = DominatorTree::with_cfg_and_post_order(&reversed_cfg, &post_order);
         let post_dom_frontiers = post_dom.compute_dominance_frontiers(&reversed_cfg);
 
-        let blocks = vecmap(0..6, |index| Id::<BasicBlock>::test_new(index));
+        let blocks = vecmap(0..6, Id::<BasicBlock>::test_new);
 
         // Another way to think about the post-dominator frontier (PDF) for a node n,
         // is that we can reach a block in the PDF during execution without going through n.

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -650,7 +650,7 @@ mod tests {
     fn dom_loop_with_cond() {
         let ssa = loop_with_cond();
         let main = ssa.main();
-        let mut dt = DominatorTree::with_function(&main);
+        let mut dt = DominatorTree::with_function(main);
 
         let blocks = vecmap(0..6, Id::<BasicBlock>::test_new);
         // Dominance matrix:

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -775,8 +775,8 @@ mod tests {
         // b3 is the exit block which does not dominate any blocks
         assert!(!dom_frontiers.contains_key(&blocks[3]));
 
-        // b4 has DF { b5 } because b4 jumps to b5 (thus being a predecessor to b5)
-        // b4 dominates itself but b5 is not strictly dominated by b4.
+        // b4 has DF { b5 } because b4 jumps to b5, thus being a predecessor to b5.
+        // b5 dominates itself but b5 does not strictly dominate b4.
         let b4_df = &dom_frontiers[&blocks[4]];
         assert_eq!(b4_df.len(), 1);
         assert!(b4_df.contains(&blocks[5]));
@@ -798,13 +798,13 @@ mod tests {
 
         let blocks = vecmap(0..6, |index| Id::<BasicBlock>::test_new(index));
 
-        // Another way to think about the post-dominator frontier for a node n,
+        // Another way to think about the post-dominator frontier (PDF) for a node n,
         // is that we can reach a block in the PDF during execution without going through n.
 
         // b0 is the entry node of the program and the exit block of the post-dominator tree.
-        // Thus, it has an empty set for its post-dominance frontier (PDF)
+        // Thus, it has an empty set for its PDF
         assert!(!post_dom_frontiers.contains_key(&blocks[0]));
-        // We must go through b1 and b2 to reach the exist node
+        // We must go through b1 and b2 to reach the exit node
         assert!(!post_dom_frontiers.contains_key(&blocks[1]));
         assert!(!post_dom_frontiers.contains_key(&blocks[2]));
 

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -503,10 +503,22 @@ mod tests {
         func
     }
 
+    fn check_dom_matrix(
+        mut dom_tree: DominatorTree,
+        blocks: Vec<BasicBlockId>,
+        dominance_matrix: Vec<Vec<bool>>,
+    ) {
+        for (i, row) in dominance_matrix.into_iter().enumerate() {
+            for (j, expected) in row.into_iter().enumerate() {
+                assert_eq!(dom_tree.dominates(blocks[i], blocks[j]), expected);
+            }
+        }
+    }
+
     #[test]
     fn backwards_layout() {
         let func = backwards_layout_setup();
-        let mut dt = DominatorTree::with_function(&func);
+        let dt = DominatorTree::with_function(&func);
 
         // Expected dominance tree:
         // block0 {
@@ -543,17 +555,13 @@ mod tests {
         let dominance_matrix =
             vec![vec![true, true, true], vec![false, true, false], vec![false, true, true]];
 
-        for (i, row) in dominance_matrix.into_iter().enumerate() {
-            for (j, expected) in row.into_iter().enumerate() {
-                assert_eq!(dt.dominates(blocks[i], blocks[j]), expected);
-            }
-        }
+        check_dom_matrix(dt, blocks, dominance_matrix);
     }
 
     #[test]
     fn post_dom_backwards_layout() {
         let func = backwards_layout_setup();
-        let mut post_dom = DominatorTree::with_function_post_dom(&func);
+        let post_dom = DominatorTree::with_function_post_dom(&func);
 
         // Expected post-dominator tree:
         // block1 {
@@ -590,11 +598,7 @@ mod tests {
         let post_dominance_matrix =
             vec![vec![true, false, false], vec![true, true, true], vec![true, false, true]];
 
-        for (i, row) in post_dominance_matrix.into_iter().enumerate() {
-            for (j, expected) in row.into_iter().enumerate() {
-                assert_eq!(post_dom.dominates(blocks[i], blocks[j]), expected);
-            }
-        }
+        check_dom_matrix(post_dom, blocks, post_dominance_matrix);
     }
 
     #[test]
@@ -646,7 +650,7 @@ mod tests {
     fn dom_loop_with_cond() {
         let ssa = loop_with_cond();
         let main = ssa.main();
-        let mut dt = DominatorTree::with_function(main);
+        let dt = DominatorTree::with_function(main);
 
         let blocks = vecmap(0..6, Id::<BasicBlock>::test_new);
         // Dominance matrix:
@@ -668,11 +672,7 @@ mod tests {
             vec![false, false, false, false, false, true],
         ];
 
-        for (i, row) in dominance_matrix.into_iter().enumerate() {
-            for (j, expected) in row.into_iter().enumerate() {
-                assert_eq!(dt.dominates(blocks[i], blocks[j]), expected);
-            }
-        }
+        check_dom_matrix(dt, blocks, dominance_matrix);
     }
 
     #[test]
@@ -684,7 +684,7 @@ mod tests {
         let reversed_cfg = cfg.reverse();
         let post_order = PostOrder::with_cfg(&reversed_cfg);
 
-        let mut post_dom = DominatorTree::with_cfg_and_post_order(&reversed_cfg, &post_order);
+        let post_dom = DominatorTree::with_cfg_and_post_order(&reversed_cfg, &post_order);
 
         let blocks = vecmap(0..6, Id::<BasicBlock>::test_new);
 
@@ -720,11 +720,7 @@ mod tests {
             vec![false, false, true, false, true, true],
         ];
 
-        for (i, row) in post_dominance_matrix.into_iter().enumerate() {
-            for (j, expected) in row.into_iter().enumerate() {
-                assert_eq!(post_dom.dominates(blocks[i], blocks[j]), expected);
-            }
-        }
+        check_dom_matrix(post_dom, blocks, post_dominance_matrix);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -543,9 +543,9 @@ mod tests {
         let dominance_matrix =
             vec![vec![true, true, true], vec![false, true, false], vec![false, true, true]];
 
-        for (i, row) in dominance_matrix.iter().enumerate() {
-            for (j, &expected_dominates) in row.iter().enumerate() {
-                assert_eq!(dt.dominates(blocks[i], blocks[j]), expected_dominates);
+        for (i, row) in dominance_matrix.into_iter().enumerate() {
+            for (j, expected) in row.into_iter().enumerate() {
+                assert_eq!(dt.dominates(blocks[i], blocks[j]), expected);
             }
         }
     }
@@ -590,8 +590,8 @@ mod tests {
         let post_dominance_matrix =
             vec![vec![true, false, false], vec![true, true, true], vec![true, false, true]];
 
-        for (i, row) in post_dominance_matrix.iter().enumerate() {
-            for (j, &expected) in row.iter().enumerate() {
+        for (i, row) in post_dominance_matrix.into_iter().enumerate() {
+            for (j, expected) in row.into_iter().enumerate() {
                 assert_eq!(post_dom.dominates(blocks[i], blocks[j]), expected);
             }
         }
@@ -668,9 +668,9 @@ mod tests {
             vec![false, false, false, false, false, true],
         ];
 
-        for (i, row) in dominance_matrix.iter().enumerate() {
-            for (j, &expected_dominates) in row.iter().enumerate() {
-                assert_eq!(dt.dominates(blocks[i], blocks[j]), expected_dominates);
+        for (i, row) in dominance_matrix.into_iter().enumerate() {
+            for (j, expected) in row.into_iter().enumerate() {
+                assert_eq!(dt.dominates(blocks[i], blocks[j]), expected);
             }
         }
     }
@@ -720,8 +720,8 @@ mod tests {
             vec![false, false, true, false, true, true],
         ];
 
-        for (i, row) in post_dominance_matrix.iter().enumerate() {
-            for (j, &expected) in row.iter().enumerate() {
+        for (i, row) in post_dominance_matrix.into_iter().enumerate() {
+            for (j, expected) in row.into_iter().enumerate() {
                 assert_eq!(post_dom.dominates(blocks[i], blocks[j]), expected);
             }
         }

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -9,7 +9,10 @@ use std::cmp::Ordering;
 use super::{
     basic_block::BasicBlockId, cfg::ControlFlowGraph, function::Function, post_order::PostOrder,
 };
+
 use fxhash::FxHashMap as HashMap;
+#[allow(unused_imports)]
+use fxhash::FxHashSet as HashSet;
 
 /// Dominator tree node. We keep one of these per reachable block.
 #[derive(Clone, Default)]

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -328,7 +328,6 @@ impl DominatorTree {
 mod tests {
     use std::cmp::Ordering;
 
-    use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
     use iter_extended::vecmap;
 
     use crate::ssa::{


### PR DESCRIPTION
# Description

## Problem\*

Working towards handling control dependence 

This work was originally part of https://github.com/noir-lang/noir/pull/7660, but I decided to split it out for easier separation of concerns and reviewing. 

## Summary\*

Implements the algorithm in [Cooper, Keith D. et al. “A Simple, Fast Dominance Algorithm.” (1999).](https://www.cs.tufts.edu/comp/150FP/archive/keith-cooper/dom14.pdf). The algorithm is under the "Dominance Frontiers" section, but earlier sections are useful to have the full context. 

I also added tests for a simple loop with a conditional inside. I added additional dom/post-dom tree tests as well as dom/post-dom frontiers tests. 

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
