### PR TITLE
chore(artifact_cli): Print circuit output to stdout

### DIFF
--- a/tooling/artifact_cli/src/execution.rs
+++ b/tooling/artifact_cli/src/execution.rs
@@ -89,7 +89,7 @@ pub fn save_and_check_witness(
     if let Some(witness_dir) = witness_dir {
         save_witness(&results.witness_stack, circuit_name, witness_dir, witness_name)?;
     }
-    check_witness(circuit, results.return_values)
+    check_witness(circuit, results.return_values, circuit_name)
 }
 
 /// Save the witness stack to a file.
@@ -109,6 +109,7 @@ pub fn save_witness(
 pub fn check_witness(
     circuit: &CompiledProgram,
     return_values: ReturnValues,
+    circuit_name: &str,
 ) -> Result<(), CliError> {
     // Check that the circuit returned a non-empty result if the ABI expects a return value.
     if let Some(ref expected) = circuit.abi.return_type {
@@ -127,6 +128,7 @@ pub fn check_witness(
                 if actual != expected {
                     return Err(CliError::UnexpectedReturn { expected, actual: Some(actual) });
                 }
+                println!("[{}] Circuit output: {actual:?}", circuit_name);
             }
         }
     }

--- a/tooling/artifact_cli/src/execution.rs
+++ b/tooling/artifact_cli/src/execution.rs
@@ -89,7 +89,10 @@ pub fn save_and_check_witness(
     if let Some(witness_dir) = witness_dir {
         save_witness(&results.witness_stack, circuit_name, witness_dir, witness_name)?;
     }
-    check_witness(circuit, results.return_values, circuit_name)
+    if let Some(ref return_value) = results.return_values.actual_return {
+        println!("[{}] Circuit output: {return_value:?}", circuit_name);
+    }
+    check_witness(circuit, results.return_values)
 }
 
 /// Save the witness stack to a file.
@@ -109,7 +112,6 @@ pub fn save_witness(
 pub fn check_witness(
     circuit: &CompiledProgram,
     return_values: ReturnValues,
-    circuit_name: &str,
 ) -> Result<(), CliError> {
     // Check that the circuit returned a non-empty result if the ABI expects a return value.
     if let Some(ref expected) = circuit.abi.return_type {
@@ -128,7 +130,6 @@ pub fn check_witness(
                 if actual != expected {
                     return Err(CliError::UnexpectedReturn { expected, actual: Some(actual) });
                 }
-                println!("[{}] Circuit output: {actual:?}", circuit_name);
             }
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue raised by aztec team wanting to extract the output from stdout

## Summary\*

In https://github.com/noir-lang/noir/pull/7406 we removed printing the return value of a program to stdout. 

This simply brings it back.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
