### PR TITLE
chore(docs): Document BlackBoxFuncCall enum

### DIFF
--- a/acvm-repo/acir/README.md
+++ b/acvm-repo/acir/README.md
@@ -214,7 +214,7 @@ The black box functions supported by ACIR are:
 
 Computes a recursive aggregation object internally when verifying a proof inside
 another circuit.
-This outputted aggregation object will then be either checked in a
+The outputted aggregation object will then be either checked in a
 top-level verifier or aggregated upon again.
 The aggregation object should be maintained by the backend implementer.
 

--- a/acvm-repo/acir/README.md
+++ b/acvm-repo/acir/README.md
@@ -211,27 +211,29 @@ The black box functions supported by ACIR are:
 **Sha256Compression**: SHA256 compression function
 
 **RecursiveAggregation**: verify a proof inside the circuit.
-**Warning: this opcode is subject to change.**
 
-This black box function does not fully verify a proof, what it does is verify
-that the provided `key_hash` is indeed a hash of `verification_key`, allowing
-the user to use the verification key as private inputs and only have the
-`key_hash` as public input, which is more performant.
+Computes a recursive aggregation object internally when verifying a proof inside
+another circuit.
+This outputted aggregation object will then be either checked in a
+top-level verifier or aggregated upon again.
+The aggregation object should be maintained by the backend implementer.
 
-Another thing that it does is preparing the verification of the proof. In order
-to fully verify a proof, some operations may still be required to be done by the
-final verifier. This is why this black box function does not say if verification
-is passing or not.
+This opcode prepares the verification of the final proof.
+In order to fully verify a recursive proof, some operations may still be required
+to be done by the final verifier (e.g. a pairing check).
+This is why this black box function does not say if verification is passing or not.
+It delays the expensive part of verification out of the SNARK
+and leaves it to the final verifier outside of the SNARK circuit.
 
-If you have several proofs to verify in one ACIR program, you would call
-`RecursiveAggregation()` multiple times while passing the
-`output_aggregation_object` as `input_aggregation_object` to the next
-`RecursiveAggregation()` call, except for the first call where you do not have
-any `input_aggregation_object`.
+This opcode also verifies that the key_hash is indeed a hash of verification_key,
+allowing the user to use the verification key as private inputs and only
+have the key_hash as public input, which is more performant.
 
-If one of the proof you verify with the black box function does not verify, then
-the verification of the proof of the main ACIR program will ultimately fail.
+**Warning: the key hash logic does not need to be part of the black box and subject to be removed.**
 
+If one of the recursive proofs you verify with the black box function fails to
+verify, then the verification of the final proof of the main ACIR program will
+ultimately fail.
 
 ### Brillig
 

--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -6,155 +6,31 @@
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
+/// Representation of available black box function names.
+/// This enum should be used to represent a black box before we have set up the
+/// appropriate inputs and outputs. At which point it should be converted to a [crate::circuit::opcodes::BlackBoxFuncCall]
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Hash, Copy, PartialEq, Eq, Serialize, Deserialize, EnumIter)]
 pub enum BlackBoxFunc {
-    /// Ciphers (encrypts) the provided plaintext using AES128 in CBC mode,
-    /// padding the input using PKCS#7.
-    /// - inputs: byte array `[u8; N]`
-    /// - iv: initialization vector `[u8; 16]`
-    /// - key: user key `[u8; 16]`
-    /// - outputs: byte vector `[u8]` of length `input.len() + (16 - input.len() % 16)`
     AES128Encrypt,
-
-    /// Performs the bitwise AND of `lhs` and `rhs`. `bit_size` must be the same for
-    /// both inputs.
-    /// - lhs: (witness, bit_size)
-    /// - rhs: (witness, bit_size)
-    /// - output: a witness whose value is constrained to be lhs AND rhs, as
-    ///   bit_size bit integers
     AND,
-
-    /// Performs the bitwise XOR of `lhs` and `rhs`. `bit_size` must be the same for
-    /// both inputs.
-    /// - lhs: (witness, bit_size)
-    /// - rhs: (witness, bit_size)
-    /// - output: a witness whose value is constrained to be lhs XOR rhs, as
-    ///   bit_size bit integers
     XOR,
-
-    /// Range constraint to ensure that a witness
-    /// can be represented in the specified number of bits.
-    /// - input: (witness, bit_size)
     RANGE,
-
-    /// Computes the Blake2s hash of the inputs, as specified in
-    /// https://tools.ietf.org/html/rfc7693
-    /// - inputs are a byte array, i.e a vector of (witness, 8)
-    /// - output is a byte array of length 32, i.e. an array of 32
-    ///   (witness, 8), constrained to be the blake2s of the inputs.
     Blake2s,
-
-    /// Computes the Blake3 hash of the inputs
-    /// - inputs are a byte array, i.e a vector of (witness, 8)
-    /// - output is a byte array of length 32, i.e an array of 32
-    ///   (witness, 8), constrained to be the blake3 of the inputs.
     Blake3,
-
-    /// Verifies a ECDSA signature over the secp256k1 curve.
-    /// - inputs:
-    ///     - x coordinate of public key as 32 bytes
-    ///     - y coordinate of public key as 32 bytes
-    ///     - the signature, as a 64 bytes array
-    ///     - the hash of the message, as a vector of bytes
-    /// - output: 0 for failure and 1 for success
     EcdsaSecp256k1,
-
-    /// Verifies a ECDSA signature over the secp256r1 curve.
-    ///
-    /// Same as EcdsaSecp256k1, but done over another curve.
     EcdsaSecp256r1,
-
-    /// Multiple scalar multiplication (MSM) with a variable base/input point
-    /// (P) of the embedded curve. An MSM multiplies the points and scalars and
-    /// sums the results.
-    /// - input:
-    ///     points (witness, N) a vector of x and y coordinates of input
-    ///     points `[x1, y1, x2, y2,...]`.
-    ///     scalars (witness, N) a vector of low and high limbs of input
-    ///     scalars `[s1_low, s1_high, s2_low, s2_high, ...]`. (witness, N)
-    ///     For Barretenberg, they must both be less than 128 bits.
-    /// - output:
-    ///     a tuple of `x` and `y` coordinates of output.
-    ///     Points computed as `s_low*P+s_high*2^{128}*P`
-    ///
-    /// Because the Grumpkin scalar field is bigger than the ACIR field, we
-    /// provide 2 ACIR fields representing the low and high parts of the Grumpkin
-    /// scalar $a$: `a=low+high*2^{128}`, with `low, high < 2^{128}`
     MultiScalarMul,
-
-    /// Keccak Permutation function of width 1600
-    /// - inputs: An array of 25 64-bit Keccak lanes that represent a keccak sponge of 1600 bits
-    /// - outputs: The result of a keccak f1600 permutation on the input state. Also an array of 25 Keccak lanes.
     Keccakf1600,
-
-    /// Compute a recursive aggregation object when verifying a proof inside
-    /// another circuit.
-    /// This outputted aggregation object will then be either checked in a
-    /// top-level verifier or aggregated upon again.
-    ///
-    /// **Warning: this opcode is subject to change.**
-    /// Note that the `254` in `(witness, 254)` refers to the upper bound of
-    /// the `witness`.
-    /// - verification_key: Vector of (witness, 254) representing the
-    ///   verification key of the circuit being verified
-    /// - public_inputs: Vector of (witness, 254)  representing the public
-    ///   inputs corresponding to the proof being verified
-    /// - key_hash: one (witness, 254). It should be the hash of the
-    ///   verification key. Barretenberg expects the Pedersen hash of the
-    ///   verification key
-    ///
-    /// Another thing that it does is preparing the verification of the proof.
-    /// In order to fully verify a proof, some operations may still be required
-    /// to be done by the final verifier. This is why this black box function
-    /// does not say if verification is passing or not.
-    ///
-    /// This black box function does not fully verify a proof, what it does is
-    /// verifying that the key_hash is indeed a hash of verification_key,
-    /// allowing the user to use the verification key as private inputs and only
-    /// have the key_hash as public input, which is more performant.
-    ///
-    /// If one of the recursive proofs you verify with the black box function does not
-    /// verify, then the verification of the proof of the main ACIR program will
-    /// ultimately fail.
     RecursiveAggregation,
-
-    /// Addition over the embedded curve on which the witness is defined
-    /// The opcode makes the following assumptions but does not enforce them because
-    /// it is more efficient to do it only when required. For instance, adding two
-    /// points that are on the curve it guarantee to give a point on the curve.
-    ///
-    /// It assumes that the points are on the curve.
-    /// If the inputs are the same witnesses index, it will perform a doubling,
-    /// If not, it assumes that the points' x-coordinates are not equal.
-    /// It also assumes neither point is the infinity point.
     EmbeddedCurveAdd,
-
-    /// BigInt addition
     BigIntAdd,
-
-    /// BigInt subtraction
     BigIntSub,
-
-    /// BigInt multiplication
     BigIntMul,
-
-    /// BigInt division
     BigIntDiv,
-
-    /// BigInt from le bytes
     BigIntFromLeBytes,
-
-    /// BigInt to le bytes
     BigIntToLeBytes,
-
-    /// Permutation function of Poseidon2
     Poseidon2Permutation,
-
-    /// SHA256 compression function
-    /// - input: [(witness, 32); 16]
-    /// - state: [(witness, 32); 8]
-    /// - output: [(witness, 32); 8]
     Sha256Compression,
 }
 

--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -12,25 +12,45 @@ use strum_macros::EnumIter;
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Hash, Copy, PartialEq, Eq, Serialize, Deserialize, EnumIter)]
 pub enum BlackBoxFunc {
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::AES128Encrypt]
     AES128Encrypt,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::AND]
     AND,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::XOR]
     XOR,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::RANGE]
     RANGE,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::Blake2s]
     Blake2s,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::Blake3]
     Blake3,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::EcdsaSecp256k1]
     EcdsaSecp256k1,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::EcdsaSecp256r1]
     EcdsaSecp256r1,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::MultiScalarMul]
     MultiScalarMul,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::Keccakf1600]
     Keccakf1600,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::RecursiveAggregation]
     RecursiveAggregation,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::EmbeddedCurveAdd]
     EmbeddedCurveAdd,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::BigIntAdd]
     BigIntAdd,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::BigIntSub]
     BigIntSub,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::BigIntMul]
     BigIntMul,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::BigIntDiv]
     BigIntDiv,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::BigIntFromLeBytes]
     BigIntFromLeBytes,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::BigIntToLeBytes]
     BigIntToLeBytes,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::Poseidon2Permutation]
     Poseidon2Permutation,
+    /// More details can be found at [crate::circuit::opcodes::BlackBoxFuncCall::Sha256Compression]
     Sha256Compression,
 }
 

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -82,9 +82,6 @@ impl<F: std::fmt::Display> std::fmt::Display for FunctionInput<F> {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-// woooo
-/// i like doc comments
-/// haha
 pub enum BlackBoxFuncCall<F> {
     /// Ciphers (encrypts) the provided plaintext using AES128 in CBC mode,
     /// padding the input using PKCS#7.

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -205,7 +205,7 @@ pub enum BlackBoxFuncCall<F> {
     Keccakf1600 { inputs: Box<[FunctionInput<F>; 25]>, outputs: Box<[Witness; 25]> },
     /// Computes a recursive aggregation object when verifying a proof inside
     /// another circuit.
-    /// This outputted aggregation object will then be either checked in a
+    /// The outputted aggregation object will then be either checked in a
     /// top-level verifier or aggregated upon again.
     /// The aggregation object should be maintained by the backend implementer.
     ///

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -83,33 +83,54 @@ impl<F: std::fmt::Display> std::fmt::Display for FunctionInput<F> {
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BlackBoxFuncCall<F> {
+    /// Ciphers (encrypts) the provided plaintext using AES128 in CBC mode,
+    /// padding the input using PKCS#7.
+    /// - inputs: byte array `[u8; N]`
+    /// - iv: initialization vector `[u8; 16]`
+    /// - key: user key `[u8; 16]`
+    /// - outputs: byte vector `[u8]` of length `input.len() + (16 - input.len() % 16)`
     AES128Encrypt {
         inputs: Vec<FunctionInput<F>>,
         iv: Box<[FunctionInput<F>; 16]>,
         key: Box<[FunctionInput<F>; 16]>,
         outputs: Vec<Witness>,
     },
-    AND {
-        lhs: FunctionInput<F>,
-        rhs: FunctionInput<F>,
-        output: Witness,
-    },
-    XOR {
-        lhs: FunctionInput<F>,
-        rhs: FunctionInput<F>,
-        output: Witness,
-    },
-    RANGE {
-        input: FunctionInput<F>,
-    },
-    Blake2s {
-        inputs: Vec<FunctionInput<F>>,
-        outputs: Box<[Witness; 32]>,
-    },
-    Blake3 {
-        inputs: Vec<FunctionInput<F>>,
-        outputs: Box<[Witness; 32]>,
-    },
+    /// Performs the bitwise AND of `lhs` and `rhs`. `bit_size` must be the same for
+    /// both inputs.
+    /// - lhs: (witness, bit_size)
+    /// - rhs: (witness, bit_size)
+    /// - output: a witness whose value is constrained to be lhs AND rhs, as
+    ///   bit_size bit integers
+    AND { lhs: FunctionInput<F>, rhs: FunctionInput<F>, output: Witness },
+    /// Performs the bitwise XOR of `lhs` and `rhs`. `bit_size` must be the same for
+    /// both inputs.
+    /// - lhs: (witness, bit_size)
+    /// - rhs: (witness, bit_size)
+    /// - output: a witness whose value is constrained to be lhs XOR rhs, as
+    ///   bit_size bit integers
+    XOR { lhs: FunctionInput<F>, rhs: FunctionInput<F>, output: Witness },
+    /// Range constraint to ensure that a witness
+    /// can be represented in the specified number of bits.
+    /// - input: (witness, bit_size)
+    RANGE { input: FunctionInput<F> },
+    /// Computes the Blake2s hash of the inputs, as specified in
+    /// https://tools.ietf.org/html/rfc7693
+    /// - inputs are a byte array, i.e a vector of (witness, 8)
+    /// - output is a byte array of length 32, i.e. an array of 32
+    ///   (witness, 8), constrained to be the blake2s of the inputs.
+    Blake2s { inputs: Vec<FunctionInput<F>>, outputs: Box<[Witness; 32]> },
+    /// Computes the Blake3 hash of the inputs
+    /// - inputs are a byte array, i.e a vector of (witness, 8)
+    /// - output is a byte array of length 32, i.e an array of 32
+    ///   (witness, 8), constrained to be the blake3 of the inputs.
+    Blake3 { inputs: Vec<FunctionInput<F>>, outputs: Box<[Witness; 32]> },
+    /// Verifies a ECDSA signature over the secp256k1 curve.
+    /// - inputs:
+    ///     - x coordinate of public key as 32 bytes
+    ///     - y coordinate of public key as 32 bytes
+    ///     - the signature, as a 64 bytes array
+    ///     - the hash of the message, as a vector of bytes
+    /// - output: 0 for failure and 1 for success
     EcdsaSecp256k1 {
         public_key_x: Box<[FunctionInput<F>; 32]>,
         public_key_y: Box<[FunctionInput<F>; 32]>,
@@ -121,6 +142,9 @@ pub enum BlackBoxFuncCall<F> {
         hashed_message: Box<[FunctionInput<F>; 32]>,
         output: Witness,
     },
+    /// Verifies a ECDSA signature over the secp256r1 curve.
+    ///
+    /// Same as EcdsaSecp256k1, but done over another curve.
     EcdsaSecp256r1 {
         public_key_x: Box<[FunctionInput<F>; 32]>,
         public_key_y: Box<[FunctionInput<F>; 32]>,
@@ -132,21 +156,69 @@ pub enum BlackBoxFuncCall<F> {
         hashed_message: Box<[FunctionInput<F>; 32]>,
         output: Witness,
     },
+    /// Multiple scalar multiplication (MSM) with a variable base/input point
+    /// (P) of the embedded curve. An MSM multiplies the points and scalars and
+    /// sums the results.
+    /// - input:
+    ///     points (witness, N) a vector of x and y coordinates of input
+    ///     points `[x1, y1, x2, y2,...]`.
+    ///     scalars (witness, N) a vector of low and high limbs of input
+    ///     scalars `[s1_low, s1_high, s2_low, s2_high, ...]`. (witness, N)
+    ///     For Barretenberg, they must both be less than 128 bits.
+    /// - output:
+    ///     a tuple of `x` and `y` coordinates of output.
+    ///     Points computed as `s_low*P+s_high*2^{128}*P`
+    ///
+    /// Because the Grumpkin scalar field is bigger than the ACIR field, we
+    /// provide 2 ACIR fields representing the low and high parts of the Grumpkin
+    /// scalar $a$: `a=low+high*2^{128}`, with `low, high < 2^{128}`
     MultiScalarMul {
         points: Vec<FunctionInput<F>>,
         scalars: Vec<FunctionInput<F>>,
         outputs: (Witness, Witness, Witness),
     },
+    /// Addition over the embedded curve on which the witness is defined
+    /// The opcode makes the following assumptions but does not enforce them because
+    /// it is more efficient to do it only when required. For instance, adding two
+    /// points that are on the curve it guarantee to give a point on the curve.
+    ///
+    /// It assumes that the points are on the curve.
+    /// If the inputs are the same witnesses index, it will perform a doubling,
+    /// If not, it assumes that the points' x-coordinates are not equal.
+    /// It also assumes neither point is the infinity point.
     EmbeddedCurveAdd {
         input1: Box<[FunctionInput<F>; 3]>,
         input2: Box<[FunctionInput<F>; 3]>,
         outputs: (Witness, Witness, Witness),
     },
-    Keccakf1600 {
-        inputs: Box<[FunctionInput<F>; 25]>,
-        outputs: Box<[Witness; 25]>,
-    },
+    /// Keccak Permutation function of width 1600
+    /// - inputs: An array of 25 64-bit Keccak lanes that represent a keccak sponge of 1600 bits
+    /// - outputs: The result of a keccak f1600 permutation on the input state. Also an array of 25 Keccak lanes.
+    Keccakf1600 { inputs: Box<[FunctionInput<F>; 25]>, outputs: Box<[Witness; 25]> },
+    /// Computes a recursive aggregation object when verifying a proof inside
+    /// another circuit.
+    /// This outputted aggregation object will then be either checked in a
+    /// top-level verifier or aggregated upon again.
+    /// The aggregation object should be maintained by the backend implementer.
+    ///
+    /// This opcode prepares the verification of the final proof.
+    /// In order to fully verify a recursive proof, some operations may still be required
+    /// to be done by the final verifier (e.g. a pairing check).
+    /// This is why this black box function does not say if verification is passing or not.
+    /// It delays the expensive part of verification out of the SNARK
+    /// and leaves it to the final verifier outside of the SNARK circuit.
+    ///
+    /// This opcode also verifies that the key_hash is indeed a hash of verification_key,
+    /// allowing the user to use the verification key as private inputs and only
+    /// have the key_hash as public input, which is more performant.
+    ///
+    /// **Warning: the key hash logic does not need to be part of the black box and subject to be removed.**
+    ///
+    /// If one of the recursive proofs you verify with the black box function fails to
+    /// verify, then the verification of the final proof of the main ACIR program will
+    /// ultimately fail.
     RecursiveAggregation {
+        /// Verification key of the circuit being verified
         verification_key: Vec<FunctionInput<F>>,
         proof: Vec<FunctionInput<F>>,
         /// These represent the public inputs of the proof we are verifying
@@ -157,37 +229,26 @@ pub enum BlackBoxFuncCall<F> {
         /// The circuit implementing this opcode can use this hash to ensure that the
         /// key provided to the circuit matches the key produced by the circuit creator
         key_hash: FunctionInput<F>,
+        /// Backend-specific proof type constant.
+        /// The proof field is agnostic and can come from witness inputs.
+        /// However, a backend may have many different verifiers which affect
+        /// the circuit construction.
+        /// In order for a backend to construct the correct recursive verifier
+        /// it expects the user to specify a proof type.
         proof_type: u32,
     },
-    BigIntAdd {
-        lhs: u32,
-        rhs: u32,
-        output: u32,
-    },
-    BigIntSub {
-        lhs: u32,
-        rhs: u32,
-        output: u32,
-    },
-    BigIntMul {
-        lhs: u32,
-        rhs: u32,
-        output: u32,
-    },
-    BigIntDiv {
-        lhs: u32,
-        rhs: u32,
-        output: u32,
-    },
-    BigIntFromLeBytes {
-        inputs: Vec<FunctionInput<F>>,
-        modulus: Vec<u8>,
-        output: u32,
-    },
-    BigIntToLeBytes {
-        input: u32,
-        outputs: Vec<Witness>,
-    },
+    /// BigInt addition
+    BigIntAdd { lhs: u32, rhs: u32, output: u32 },
+    /// BigInt subtraction
+    BigIntSub { lhs: u32, rhs: u32, output: u32 },
+    /// BigInt multiplication
+    BigIntMul { lhs: u32, rhs: u32, output: u32 },
+    /// BigInt division
+    BigIntDiv { lhs: u32, rhs: u32, output: u32 },
+    /// BigInt from le bytes
+    BigIntFromLeBytes { inputs: Vec<FunctionInput<F>>, modulus: Vec<u8>, output: u32 },
+    /// BigInt to le bytes
+    BigIntToLeBytes { input: u32, outputs: Vec<Witness> },
     /// Applies the Poseidon2 permutation function to the given state,
     /// outputting the permuted state.
     Poseidon2Permutation {

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -136,7 +136,7 @@ pub enum BlackBoxFuncCall<F> {
     ///       where `r` and `s` are fixed-sized big endian scalar values.
     ///       As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
     ///       while `r` and `s` will both be 32 bytes.
-    ///       We expect `s` to be normalized. This means given an the curve's order,
+    ///       We expect `s` to be normalized. This means given the curve's order,
     ///       `s` should be less than or equal to `order / 2`.
     ///       This is done to prevent malleability.
     ///       For more context regarding malleability you can reference BIP 0062.

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -82,6 +82,9 @@ impl<F: std::fmt::Display> std::fmt::Display for FunctionInput<F> {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+// woooo
+/// i like doc comments
+/// haha
 pub enum BlackBoxFuncCall<F> {
     /// Ciphers (encrypts) the provided plaintext using AES128 in CBC mode,
     /// padding the input using PKCS#7.
@@ -129,6 +132,14 @@ pub enum BlackBoxFuncCall<F> {
     ///     - x coordinate of public key as 32 bytes
     ///     - y coordinate of public key as 32 bytes
     ///     - the signature, as a 64 bytes array
+    ///       The signature internally will be represented as `(r, s)`,
+    ///       where `r` and `s` are fixed-sized big endian scalar values.
+    ///       As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
+    ///       while `r` and `s` will both be 32 bytes.
+    ///       We expect `s` to be normalized. This means given an the curve's order,
+    ///       `s` should be less than or equal to `order / 2`.
+    ///       This is done to prevent malleability.
+    ///       For more context regarding malleability you can reference BIP 0062.
     ///     - the hash of the message, as a vector of bytes
     /// - output: 0 for failure and 1 for success
     EcdsaSecp256k1 {

--- a/cspell.json
+++ b/cspell.json
@@ -180,6 +180,7 @@
         "pedersen",
         "peekable",
         "petgraph",
+        "PKCS",
         "plonkc",
         "PLONKish",
         "pprof",

--- a/noir_stdlib/src/ecdsa_secp256k1.nr
+++ b/noir_stdlib/src/ecdsa_secp256k1.nr
@@ -1,8 +1,17 @@
+// TODO(https://github.com/noir-lang/noir/issues/7711): Switch the regular comments to doc comments once they do not trigger a warning anymore
 #[foreign(ecdsa_secp256k1)]
 // docs:start:ecdsa_secp256k1
 pub fn verify_signature<let N: u32>(
     public_key_x: [u8; 32],
     public_key_y: [u8; 32],
+    // The signature internally will be represented as `(r, s)`,
+    // where `r` and `s` are fixed-sized big endian scalar values.
+    // As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
+    // while `r` and `s` will both be 32 bytes.
+    // We expect `s` to be normalized. This means given an the curve's order,
+    // `s` should be less than or equal to `order / 2`.
+    // This is done to prevent malleability.
+    // For more context regarding malleability you can reference BIP 0062.
     signature: [u8; 64],
     message_hash: [u8; N],
 ) -> bool

--- a/noir_stdlib/src/ecdsa_secp256k1.nr
+++ b/noir_stdlib/src/ecdsa_secp256k1.nr
@@ -1,14 +1,21 @@
 // TODO(https://github.com/noir-lang/noir/issues/7711): Switch the regular comments to doc comments once they do not trigger a warning anymore
 #[foreign(ecdsa_secp256k1)]
 // docs:start:ecdsa_secp256k1
-// The signature internally will be represented as `(r, s)`,
-// where `r` and `s` are fixed-sized big endian scalar values.
-// As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
-// while `r` and `s` will both be 32 bytes.
-// We expect `s` to be normalized. This means given an the curve's order,
-// `s` should be less than or equal to `order / 2`.
-// This is done to prevent malleability.
-// For more context regarding malleability you can reference BIP 0062.
+// Verifies a ECDSA signature over the secp256k1 curve.
+// - inputs:
+//     - x coordinate of public key as 32 bytes
+//     - y coordinate of public key as 32 bytes
+//     - the signature, as a 64 bytes array
+//       The signature internally will be represented as `(r, s)`,
+//       where `r` and `s` are fixed-sized big endian scalar values.
+//       As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
+//       while `r` and `s` will both be 32 bytes.
+//       We expect `s` to be normalized. This means given an the curve's order,
+//       `s` should be less than or equal to `order / 2`.
+//       This is done to prevent malleability.
+//       For more context regarding malleability you can reference BIP 0062.
+//     - the hash of the message, as a vector of bytes
+// - output: false for failure and true for success
 pub fn verify_signature<let N: u32>(
     public_key_x: [u8; 32],
     public_key_y: [u8; 32],

--- a/noir_stdlib/src/ecdsa_secp256k1.nr
+++ b/noir_stdlib/src/ecdsa_secp256k1.nr
@@ -10,7 +10,7 @@
 //       where `r` and `s` are fixed-sized big endian scalar values.
 //       As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
 //       while `r` and `s` will both be 32 bytes.
-//       We expect `s` to be normalized. This means given an the curve's order,
+//       We expect `s` to be normalized. This means given the curve's order,
 //       `s` should be less than or equal to `order / 2`.
 //       This is done to prevent malleability.
 //       For more context regarding malleability you can reference BIP 0062.

--- a/noir_stdlib/src/ecdsa_secp256k1.nr
+++ b/noir_stdlib/src/ecdsa_secp256k1.nr
@@ -1,17 +1,17 @@
 // TODO(https://github.com/noir-lang/noir/issues/7711): Switch the regular comments to doc comments once they do not trigger a warning anymore
 #[foreign(ecdsa_secp256k1)]
 // docs:start:ecdsa_secp256k1
+// The signature internally will be represented as `(r, s)`,
+// where `r` and `s` are fixed-sized big endian scalar values.
+// As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
+// while `r` and `s` will both be 32 bytes.
+// We expect `s` to be normalized. This means given an the curve's order,
+// `s` should be less than or equal to `order / 2`.
+// This is done to prevent malleability.
+// For more context regarding malleability you can reference BIP 0062.
 pub fn verify_signature<let N: u32>(
     public_key_x: [u8; 32],
     public_key_y: [u8; 32],
-    // The signature internally will be represented as `(r, s)`,
-    // where `r` and `s` are fixed-sized big endian scalar values.
-    // As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
-    // while `r` and `s` will both be 32 bytes.
-    // We expect `s` to be normalized. This means given an the curve's order,
-    // `s` should be less than or equal to `order / 2`.
-    // This is done to prevent malleability.
-    // For more context regarding malleability you can reference BIP 0062.
     signature: [u8; 64],
     message_hash: [u8; N],
 ) -> bool

--- a/test_programs/execution_success/brillig_arrays/src/main.nr
+++ b/test_programs/execution_success/brillig_arrays/src/main.nr
@@ -9,17 +9,7 @@ fn main(x: [Field; 3]) {
     }
 }
 
-unconstrained fn read_array(
-    /// The signature internally will be represented as `(r, s)`
-    /// where `r` and `s` are fixed-sized big endian scalar values.
-    /// As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
-    /// while `r` and `s` will both be 32 bytes.
-    /// We expect `s` to be normalized. This means given an the curve's order,
-    /// `s` should be less than or equal to `order / 2`. 
-    /// This is done to prevent malleability. 
-    /// For more context regarding malleability you can reference BIP 0062.
-    x: [Field; 3]
-) {
+unconstrained fn read_array(x: [Field; 3]) {
     assert(x[0] == 1);
     let y = [1, 5, 27];
 

--- a/test_programs/execution_success/brillig_arrays/src/main.nr
+++ b/test_programs/execution_success/brillig_arrays/src/main.nr
@@ -9,7 +9,17 @@ fn main(x: [Field; 3]) {
     }
 }
 
-unconstrained fn read_array(x: [Field; 3]) {
+unconstrained fn read_array(
+    /// The signature internally will be represented as `(r, s)`
+    /// where `r` and `s` are fixed-sized big endian scalar values.
+    /// As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
+    /// while `r` and `s` will both be 32 bytes.
+    /// We expect `s` to be normalized. This means given an the curve's order,
+    /// `s` should be less than or equal to `order / 2`. 
+    /// This is done to prevent malleability. 
+    /// For more context regarding malleability you can reference BIP 0062.
+    x: [Field; 3]
+) {
     assert(x[0] == 1);
     let y = [1, 5, 27];
 


### PR DESCRIPTION
# Description

## Problem\*

Towards general documentation effort

## Summary\*

I was looking at the rust docs [here](https://noir-lang.github.io/noir/docs/acir/circuit/opcodes/enum.BlackBoxFuncCall.html) and I was expecting to see documentation on `BlackBoxFuncCall` as that is the actual circuit opcode. The black box func docs live on `BlackBoxFunc`, but that enum is basically a naming wrapper used internally by the compiler. The actual opcode is `BlackBoxFuncCall`.

1. New doc comments on `RecursiveAggregation` black box func call
2. Moved doc comments from `BlackBoxFunc` enum to `BlackBoxFuncCall` enum

## Additional Context

I think we could consider removing `BlackBoxFunc` from the `acir` crate entirely. I have not fully checked how annoying this would be, but it seems like it should live inside of the compiler. It looks to only be used in `OpcodeResolutionError<F>::BlackBoxFunctionFailed` where it is [ultimately unused when we resolve errors](https://github.com/noir-lang/noir/blob/c30bcd7e753d835442187bb27a6c14231041ed77/tooling/nargo/src/errors.rs#L77).

## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
