### PR TITLE
feat: use relative paths in "Call stack" and "Witness saved to"

### DIFF
--- a/tooling/artifact_cli/src/execution.rs
+++ b/tooling/artifact_cli/src/execution.rs
@@ -105,7 +105,7 @@ pub fn save_witness(
     let witness_name = witness_name.unwrap_or(circuit_name);
     let mut witness_path = save_witness_to_dir(witness_stack, witness_name, witness_dir)?;
 
-    // See if we can make the file name a bit shorter/easier to read if it starts with the current directory
+    // See if we can make the file path a bit shorter/easier to read if it starts with the current directory
     if let Ok(current_dir) = std::env::current_dir() {
         if let Ok(name_without_prefix) = witness_path.strip_prefix(current_dir) {
             witness_path = name_without_prefix.to_path_buf();

--- a/tooling/artifact_cli/src/execution.rs
+++ b/tooling/artifact_cli/src/execution.rs
@@ -103,7 +103,15 @@ pub fn save_witness(
     witness_name: Option<&str>,
 ) -> Result<(), CliError> {
     let witness_name = witness_name.unwrap_or(circuit_name);
-    let witness_path = save_witness_to_dir(witness_stack, witness_name, witness_dir)?;
+    let mut witness_path = save_witness_to_dir(witness_stack, witness_name, witness_dir)?;
+
+    // See if we can make the file name a bit shorter/easier to read if it starts with the current directory
+    if let Ok(current_dir) = std::env::current_dir() {
+        if let Ok(name_without_prefix) = witness_path.strip_prefix(current_dir) {
+            witness_path = name_without_prefix.to_path_buf();
+        }
+    }
+
     println!("[{}] Witness saved to {}", circuit_name, witness_path.display());
     Ok(())
 }

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -214,8 +214,15 @@ fn run_async(
             }
 
             if let Some(witness_name) = witness_name {
-                let witness_path =
+                let mut witness_path =
                     save_witness_to_dir(&solved_witness_stack, witness_name, target_dir)?;
+
+                // See if we can make the file name a bit shorter/easier to read if it starts with the current directory
+                if let Ok(current_dir) = std::env::current_dir() {
+                    if let Ok(name_without_prefix) = witness_path.strip_prefix(current_dir) {
+                        witness_path = name_without_prefix.to_path_buf();
+                    }
+                }
 
                 println!("[{}] Witness saved to {}", package.name, witness_path.display());
             }

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -217,7 +217,7 @@ fn run_async(
                 let mut witness_path =
                     save_witness_to_dir(&solved_witness_stack, witness_name, target_dir)?;
 
-                // See if we can make the file name a bit shorter/easier to read if it starts with the current directory
+                // See if we can make the file path a bit shorter/easier to read if it starts with the current directory
                 if let Ok(current_dir) = std::env::current_dir() {
                     if let Ok(name_without_prefix) = witness_path.strip_prefix(current_dir) {
                         witness_path = name_without_prefix.to_path_buf();

--- a/tooling/noirc_artifacts/src/debug.rs
+++ b/tooling/noirc_artifacts/src/debug.rs
@@ -177,7 +177,18 @@ impl<'a> Files<'a> for DebugArtifact {
     type Source = &'a str;
 
     fn name(&self, file_id: Self::FileId) -> Result<Self::Name, Error> {
-        self.file_map.get(&file_id).ok_or(Error::FileMissing).map(|file| file.path.clone().into())
+        let name = self.file_map.get(&file_id).ok_or(Error::FileMissing);
+        let name: Self::Name = name.map(|file| file.path.clone().into())?;
+
+        // See if we can make the file name a bit shorter/easier to read if it starts with the current directory
+        if let Ok(current_dir) = std::env::current_dir() {
+            if let Ok(name_without_prefix) = name.clone().into_path_buf().strip_prefix(current_dir)
+            {
+                return Ok(PathString::from_path(name_without_prefix.to_path_buf()));
+            }
+        }
+
+        Ok(name)
     }
 
     fn source(&'a self, file_id: Self::FileId) -> Result<Self::Source, Error> {

--- a/tooling/noirc_artifacts/src/debug.rs
+++ b/tooling/noirc_artifacts/src/debug.rs
@@ -180,7 +180,7 @@ impl<'a> Files<'a> for DebugArtifact {
         let name = self.file_map.get(&file_id).ok_or(Error::FileMissing);
         let name: Self::Name = name.map(|file| file.path.clone().into())?;
 
-        // See if we can make the file name a bit shorter/easier to read if it starts with the current directory
+        // See if we can make the file path a bit shorter/easier to read if it starts with the current directory
         if let Ok(current_dir) = std::env::current_dir() {
             if let Ok(name_without_prefix) = name.clone().into_path_buf().strip_prefix(current_dir)
             {


### PR DESCRIPTION
# Description

## Problem

No issue, just something I wanted to do for some time now.

## Summary

For example, an output before this PR looked like this:

```
error: Failed constraint
  ┌─ /Users/asterite/Sandbox/one/src/main.nr:9:16
  │
9 │         assert(array[index - 1].counter < 3);
  │                ----------------------------
  │
  = Call stack:
    1. /Users/asterite/Sandbox/one/src/main.nr:9:16
 ```

Now it's:

```
error: Failed constraint
  ┌─ src/main.nr:9:16
  │
9 │         assert(array[index - 1].counter < 3);
  │                ----------------------------
  │
  = Call stack:
    1. src/main.nr:9:16
```

Similarly, if the program executes fine it would show:

```
[one] Circuit witness successfully solved
[one] Witness saved to /Users/asterite/Sandbox/one/target/one.gz
```

Now it shows:

```
[one] Circuit witness successfully solved
[one] Witness saved to target/one.gz
```

## Additional Context

There's a bit of code duplication here but it's just a couple of lines. We could extract these to a helper function but I don't know where we'd put them. There's also a Go proverb I like: ["A little copying is better than a little dependency"](https://go-proverbs.github.io/)

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
