### PR TITLE
chore: hide Ident fields

### DIFF
--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -198,7 +198,7 @@ pub(super) fn value_from_hir_expression(context: &Context, expression: HirExpres
                 .iter()
                 .map(|(ident, expr_id)| {
                     (
-                        ident.0.contents.to_string(),
+                        ident.to_string(),
                         value_from_hir_expression(
                             context,
                             context.def_interner.expression(expr_id),

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -88,7 +88,7 @@ pub struct UnsupportedNumericGenericType {
 impl UnresolvedGeneric {
     pub fn location(&self) -> Location {
         match self {
-            UnresolvedGeneric::Variable(ident) => ident.0.location(),
+            UnresolvedGeneric::Variable(ident) => ident.location(),
             UnresolvedGeneric::Numeric { ident, typ } => ident.location().merge(typ.location),
             UnresolvedGeneric::Resolved(_, location) => *location,
         }

--- a/compiler/noirc_frontend/src/ast/function.rs
+++ b/compiler/noirc_frontend/src/ast/function.rs
@@ -72,7 +72,7 @@ impl NoirFunction {
         }
     }
     pub fn name(&self) -> &str {
-        &self.name_ident().0.contents
+        self.name_ident().as_str()
     }
     pub fn name_ident(&self) -> &Ident {
         &self.def.name

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -100,7 +100,7 @@ impl DebugInstrumenter {
     }
 
     fn walk_fn(&mut self, func: &mut ast::FunctionDefinition) {
-        let func_name = func.name.0.contents.clone();
+        let func_name = func.name.to_string();
         let func_args =
             func.parameters.iter().map(|param| pattern_to_string(&param.pattern)).collect();
         let fn_id = self.insert_function(func_name, func_args);
@@ -114,7 +114,7 @@ impl DebugInstrumenter {
                 pattern_vars(&param.pattern)
                     .iter()
                     .filter_map(|(id, _is_mut)| {
-                        let var_id = self.insert_var(&id.0.contents)?;
+                        let var_id = self.insert_var(id.as_str())?;
                         Some(build_assign_var_stmt(var_id, id_expr(id)))
                     })
                     .collect::<Vec<_>>()
@@ -242,7 +242,7 @@ impl DebugInstrumenter {
                 // We don't want to generate an expression to read from "_".
                 // And since this expression is going to be assigned to "_" so it doesn't matter
                 // what it is, we can use `()` for it.
-                if id.0.contents == "_" {
+                if id.as_str() == "_" {
                     ast::Expression {
                         kind: ast::ExpressionKind::Literal(ast::Literal::Unit),
                         location: id.location(),
@@ -256,7 +256,7 @@ impl DebugInstrumenter {
         let mut block_stmts =
             vec![ast::Statement { kind: ast::StatementKind::Let(let_stmt.clone()), location }];
         block_stmts.extend(vars.iter().filter_map(|(id, _)| {
-            let var_id = self.insert_var(&id.0.contents)?;
+            let var_id = self.insert_var(id.as_str())?;
             Some(build_assign_var_stmt(var_id, id_expr(id)))
         }));
         block_stmts.push(ast::Statement {
@@ -309,8 +309,8 @@ impl DebugInstrumenter {
         let new_assign_stmt = match &assign_stmt.lvalue {
             ast::LValue::Ident(id) => {
                 let var_id = self
-                    .lookup_var(&id.0.contents)
-                    .unwrap_or_else(|| panic!("var lookup failed for var_name={}", &id.0.contents));
+                    .lookup_var(id.as_str())
+                    .unwrap_or_else(|| panic!("var lookup failed for var_name={}", id.as_str()));
                 build_assign_var_stmt(var_id, id_expr(&ident("__debug_expr", id.location())))
             }
             ast::LValue::Dereference(_lv, location) => {
@@ -329,14 +329,14 @@ impl DebugInstrumenter {
                 loop {
                     match cursor {
                         ast::LValue::Ident(id) => {
-                            var_id = self.lookup_var(&id.0.contents).unwrap_or_else(|| {
-                                panic!("var lookup failed for var_name={}", &id.0.contents)
+                            var_id = self.lookup_var(id.as_str()).unwrap_or_else(|| {
+                                panic!("var lookup failed for var_name={}", id.as_str())
                             });
                             break;
                         }
                         ast::LValue::MemberAccess { object, field_name, location } => {
                             cursor = object;
-                            let field_name_id = self.insert_field_name(&field_name.0.contents);
+                            let field_name_id = self.insert_field_name(field_name.as_str());
                             indexes.push(sint_expr(-(field_name_id.0 as i128), *location));
                         }
                         ast::LValue::Index { index, array, location: _ } => {
@@ -445,7 +445,7 @@ impl DebugInstrumenter {
     }
 
     fn walk_for(&mut self, for_stmt: &mut ast::ForLoopStatement) {
-        let var_name = &for_stmt.identifier.0.contents;
+        let var_name = for_stmt.identifier.as_str();
         let var_id = self.insert_var(var_name);
 
         let set_and_drop_stmt = var_id.map(|var_id| {
@@ -731,7 +731,7 @@ fn pattern_vars(pattern: &ast::Pattern) -> Vec<(ast::Ident, bool)> {
 
 fn pattern_to_string(pattern: &ast::Pattern) -> String {
     match pattern {
-        ast::Pattern::Identifier(id) => id.0.contents.clone(),
+        ast::Pattern::Identifier(id) => id.to_string(),
         ast::Pattern::Mutable(mpat, _, _) => format!("mut {}", pattern_to_string(mpat.as_ref())),
         ast::Pattern::Tuple(elements, _) => format!(
             "({})",
@@ -744,7 +744,7 @@ fn pattern_to_string(pattern: &ast::Pattern) -> String {
                 fields
                     .iter()
                     .map(|(field_ident, field_pattern)| {
-                        format!("{}: {}", &field_ident.0.contents, pattern_to_string(field_pattern))
+                        format!("{}: {}", field_ident, pattern_to_string(field_pattern))
                     })
                     .collect::<Vec<_>>()
                     .join(", "),

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -509,7 +509,7 @@ impl Elaborator<'_> {
 
         if let Some(existing) = variables_defined.iter().find(|elem| *elem == &name) {
             // Allow redefinition of `_` only, to ignore variables
-            if name.0.contents != WILDCARD_PATTERN {
+            if name.as_str() != WILDCARD_PATTERN {
                 self.push_err(ResolverError::VariableAlreadyDefinedInPattern {
                     existing: existing.clone(),
                     new_location: name.location(),
@@ -541,9 +541,9 @@ impl Elaborator<'_> {
         let mut fields = BTreeMap::default();
         for (field_name, field) in constructor.fields {
             let Some(field_index) =
-                expected_field_types.iter().position(|(name, _)| *name == field_name.0.contents)
+                expected_field_types.iter().position(|(name, _)| *name == field_name.as_str())
             else {
-                let error = if fields.contains_key(&field_name.0.contents) {
+                let error = if fields.contains_key(field_name.as_str()) {
                     ResolverError::DuplicateField { field: field_name }
                 } else {
                     let struct_definition = struct_name.clone();

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -519,7 +519,7 @@ impl Elaborator<'_> {
         object_type = object_type.follow_bindings();
 
         let method_name_location = method_call.method_name.location();
-        let method_name = method_call.method_name.0.contents.as_str();
+        let method_name = method_call.method_name.as_str();
         let check_self_param = true;
         match self.lookup_method(&object_type, method_name, location, check_self_param) {
             Some(method_ref) => {
@@ -856,7 +856,7 @@ impl Elaborator<'_> {
             let expected_field_with_index = field_types
                 .iter()
                 .enumerate()
-                .find(|(_, (name, _, _))| name == &field_name.0.contents);
+                .find(|(_, (name, _, _))| name == field_name.as_str());
             let expected_index_and_visibility =
                 expected_field_with_index.map(|(index, (_, visibility, _))| (index, visibility));
             let expected_type =
@@ -894,7 +894,7 @@ impl Elaborator<'_> {
             if let Some((index, visibility)) = expected_index_and_visibility {
                 let struct_type = struct_type.borrow();
                 let field_location = field_name.location();
-                let field_name = &field_name.0.contents;
+                let field_name = field_name.as_str();
                 self.check_struct_field_visibility(
                     &struct_type,
                     field_name,
@@ -1380,7 +1380,7 @@ impl Elaborator<'_> {
         let constraint = TraitConstraint { typ, trait_bound };
 
         let the_trait = self.interner.get_trait(constraint.trait_bound.trait_id);
-        let Some(method) = the_trait.find_method(&path.impl_item.0.contents) else {
+        let Some(method) = the_trait.find_method(path.impl_item.as_str()) else {
             let trait_name = the_trait.name.to_string();
             let method_name = path.impl_item.to_string();
             let location = path.impl_item.location();

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-use noirc_errors::{Located, Location};
+use noirc_errors::Location;
 
 pub(super) fn deprecated_function(interner: &NodeInterner, expr: ExprId) -> Option<TypeCheckError> {
     let HirExpression::Ident(HirIdent { location, id, impl_kind: _ }, _) =
@@ -251,7 +251,7 @@ pub(crate) fn overflowing_int(
 }
 
 fn func_meta_name_ident(func: &FuncMeta, modifiers: &FunctionModifiers) -> Ident {
-    Ident(Located::from(func.name.location, modifiers.name.clone()))
+    Ident::new(modifiers.name.clone(), func.name.location)
 }
 
 /// Check that a recursive function *can* return without endlessly calling itself.

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -478,10 +478,10 @@ impl<'context> Elaborator<'context> {
 
         // Check arg and return-value visibility of standalone functions.
         if self.should_check_function_visibility(&func_meta, &modifiers) {
-            let name = Ident(Located::from(
-                func_meta.name.location,
+            let name = Ident::new(
                 self.interner.definition_name(func_meta.name.id).to_string(),
-            ));
+                func_meta.name.location,
+            );
             for (_, typ, _) in func_meta.parameters.iter() {
                 self.check_type_is_not_more_private_then_item(
                     &name,
@@ -688,7 +688,7 @@ impl<'context> Elaborator<'context> {
                 let kind = self.resolve_generic_kind(generic);
                 let typevar = TypeVariable::unbound(id, kind);
                 let ident = generic.ident();
-                let name = Rc::new(ident.0.contents.clone());
+                let name = Rc::new(ident.to_string());
                 Ok((typevar, name))
             }
             // An already-resolved generic is only possible if it is the result of a
@@ -842,7 +842,7 @@ impl<'context> Elaborator<'context> {
                     .trait_generics
                     .named_args
                     .iter()
-                    .any(|(name, _)| name.0.contents == *associated_type.name.as_ref())
+                    .any(|(name, _)| name.as_str() == *associated_type.name.as_ref())
                 {
                     // This generic isn't contained in the bound's named arguments,
                     // so add it by creating a fresh type variable.
@@ -1000,7 +1000,7 @@ impl<'context> Elaborator<'context> {
 
         let direct_generics = func.def.generics.iter();
         let direct_generics = direct_generics
-            .filter_map(|generic| self.find_generic(&generic.ident().0.contents).cloned())
+            .filter_map(|generic| self.find_generic(generic.ident().as_str()).cloned())
             .collect();
 
         let statements = std::mem::take(&mut func.def.body.statements);

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -272,7 +272,7 @@ impl Elaborator<'_> {
 
         for (field, pattern) in fields {
             let (field_type, visibility) = expected_type
-                .get_field_type_and_visibility(&field.0.contents)
+                .get_field_type_and_visibility(field.as_str())
                 .unwrap_or((Type::Error, ItemVisibility::Public));
             let resolved = self.elaborate_pattern_mut(
                 pattern,
@@ -289,7 +289,7 @@ impl Elaborator<'_> {
 
                 self.check_struct_field_visibility(
                     &struct_type.borrow(),
-                    &field.0.contents,
+                    field.as_str(),
                     visibility,
                     field.location(),
                 );
@@ -331,7 +331,7 @@ impl Elaborator<'_> {
         }
 
         let location = name.location();
-        let name = name.0.contents;
+        let name = name.into_string();
         let comptime = self.in_comptime_context();
         let id =
             self.interner.push_definition(name.clone(), mutable, comptime, definition, location);
@@ -385,12 +385,12 @@ impl Elaborator<'_> {
         let resolver_meta =
             ResolverMeta { num_times_used: 0, ident: ident.clone(), warn_if_unused: true };
 
-        let old_global_value = scope.add_key_value(name.0.contents.clone(), resolver_meta);
+        let old_global_value = scope.add_key_value(name.to_string(), resolver_meta);
         if let Some(old_global_value) = old_global_value {
             self.push_err(ResolverError::DuplicateDefinition {
                 first_location: old_global_value.ident.location,
                 second_location: name.location(),
-                name: name.0.contents,
+                name: name.into_string(),
             });
         }
         ident
@@ -405,7 +405,7 @@ impl Elaborator<'_> {
     ) -> Result<(HirIdent, usize), ResolverError> {
         // Find the definition for this Ident
         let scope_tree = self.scopes.current_scope_tree();
-        let variable = scope_tree.find(&name.0.contents);
+        let variable = scope_tree.find(name.as_str());
 
         let location = name.location();
         if let Some((variable_found, scope)) = variable {
@@ -414,8 +414,8 @@ impl Elaborator<'_> {
             Ok((HirIdent::non_trait_method(id, location), scope))
         } else {
             Err(ResolverError::VariableNotDeclared {
-                name: name.0.contents.clone(),
-                location: name.0.location(),
+                name: name.to_string(),
+                location: name.location(),
             })
         }
     }
@@ -454,7 +454,7 @@ impl Elaborator<'_> {
         let kinds = vecmap(&struct_type.generics, |generic| generic.kind());
         self.resolve_item_turbofish_generics(
             "struct",
-            &struct_type.name.0.contents,
+            struct_type.name.as_str(),
             kinds,
             generics,
             unresolved_turbofish,
@@ -490,7 +490,7 @@ impl Elaborator<'_> {
         let kinds = vecmap(&type_alias.generics, |generic| generic.kind());
         self.resolve_item_turbofish_generics(
             "alias",
-            &type_alias.name.0.contents,
+            type_alias.name.as_str(),
             kinds,
             generics,
             unresolved_turbofish,
@@ -875,8 +875,7 @@ impl Elaborator<'_> {
         let typ = self.resolve_type(path.typ);
         let check_self_param = false;
 
-        let Some(method) =
-            self.lookup_method(&typ, &path.item.0.contents, location, check_self_param)
+        let Some(method) = self.lookup_method(&typ, path.item.as_str(), location, check_self_param)
         else {
             let error = Expression::new(ExpressionKind::Error, location);
             return self.elaborate_expression(error);

--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -1,5 +1,3 @@
-use noirc_errors::Located;
-
 use crate::ast::{ERROR_IDENT, Ident, Path};
 use crate::hir::def_map::{LocalModuleId, ModuleId};
 
@@ -121,7 +119,7 @@ impl Elaborator<'_> {
             if let Some(definition_info) = self.interner.try_definition(unused_var.id) {
                 let name = &definition_info.name;
                 if name != ERROR_IDENT && !definition_info.is_global() {
-                    let ident = Ident(Located::from(unused_var.location, name.to_owned()));
+                    let ident = Ident::new(name.to_owned(), unused_var.location);
                     self.push_err(ResolverError::UnusedVariable { ident });
                 }
             }

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -359,7 +359,7 @@ impl Elaborator<'_> {
             LValue::Ident(ident) => {
                 let mut mutable = true;
                 let location = ident.location();
-                let path = Path::from_single(ident.0.contents, location);
+                let path = Path::from_single(ident.to_string(), location);
                 let ((ident, scope_index), _) = self.get_ident_from_path(path);
 
                 self.resolve_local_variable(ident.clone(), scope_index);
@@ -407,7 +407,7 @@ impl Elaborator<'_> {
                     *mutable_ref = true;
                 };
 
-                let name = &field_name.0.contents;
+                let name = field_name.as_str();
                 let (object_type, field_index) = self
                     .check_field_access(
                         &lhs_type,

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -49,7 +49,7 @@ impl Elaborator<'_> {
                 .methods
                 .functions
                 .iter()
-                .filter(|(_, _, f)| f.name() == method.name.0.contents)
+                .filter(|(_, _, f)| f.name() == method.name.as_str())
                 .collect();
 
             if overrides.is_empty() {
@@ -202,10 +202,10 @@ impl Elaborator<'_> {
                     self.interner.get_trait(override_trait_constraint.trait_bound.trait_id);
                 self.push_err(DefCollectorErrorKind::ImplIsStricterThanTrait {
                     constraint_typ: override_trait_constraint.typ,
-                    constraint_name: the_trait.name.0.contents.clone(),
+                    constraint_name: the_trait.name.to_string(),
                     constraint_generics: override_trait_constraint.trait_bound.trait_generics,
                     constraint_location: override_trait_constraint.trait_bound.location,
-                    trait_method_name: method.name.0.contents.clone(),
+                    trait_method_name: method.name.to_string(),
                     trait_method_location: method.location,
                 });
             }

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -128,7 +128,7 @@ impl Elaborator<'_> {
                         },
                     );
 
-                    let func_id = unresolved_trait.method_ids[&name.0.contents];
+                    let func_id = unresolved_trait.method_ids[name.as_str()];
                     let mut where_clause = where_clause.to_vec();
 
                     // Attach any trait constraints on the trait to the function,
@@ -164,7 +164,7 @@ impl Elaborator<'_> {
                         .fns_with_default_impl
                         .functions
                         .iter()
-                        .filter(|(_, _, q)| q.name() == name.0.contents)
+                        .filter(|(_, _, q)| q.name() == name.as_str())
                         .collect();
 
                     let default_impl = if default_impl_list.len() == 1 {
@@ -353,7 +353,7 @@ pub(crate) fn check_trait_impl_method_matches_declaration(
             &meta.return_type,
             noir_function,
             meta.name.location,
-            &trait_info.name.0.contents,
+            trait_info.name.as_str(),
             &mut errors,
         );
     }

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -328,7 +328,7 @@ impl HirPattern {
                 let name = match typ.follow_bindings() {
                     Type::DataType(struct_def, _) => {
                         let struct_def = struct_def.borrow();
-                        struct_def.name.0.contents.clone()
+                        struct_def.name.to_string()
                     }
                     // This pass shouldn't error so if the type isn't a struct we just get a string
                     // representation of any other type and use that. We're relying on name
@@ -347,7 +347,7 @@ impl HirIdent {
     /// Convert to AST for display (some details lost)
     fn to_display_ast(&self, interner: &NodeInterner) -> Ident {
         let name = interner.definition_name(self.id).to_owned();
-        Ident(Located::from(self.location, name))
+        Ident::new(name, self.location)
     }
 
     fn to_display_expr(

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -427,10 +427,10 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 let res = match argument {
                     Value::Struct(fields, struct_type) if fields.len() == pattern_fields.len() => {
                         for (field_name, field_pattern) in pattern_fields {
-                            let field = fields.get(&field_name.0.contents).ok_or_else(|| {
+                            let field = fields.get(field_name.as_string()).ok_or_else(|| {
                                 InterpreterError::ExpectedStructToHaveField {
                                     typ: struct_type.clone(),
-                                    field_name: field_name.0.contents.clone(),
+                                    field_name: field_name.to_string(),
                                     location,
                                 }
                             })?;
@@ -1262,7 +1262,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             .into_iter()
             .map(|(name, expr)| {
                 let field_value = self.evaluate(expr)?;
-                Ok((Rc::new(name.0.contents), field_value))
+                Ok((Rc::new(name.into_string()), field_value))
             })
             .collect::<Result<_, _>>()?;
 
@@ -1302,10 +1302,10 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             }
         };
 
-        fields.get(&access.rhs.0.contents).cloned().ok_or_else(|| {
+        fields.get(access.rhs.as_string()).cloned().ok_or_else(|| {
             let location = self.elaborator.interner.expr_location(&id);
             let value = Value::Struct(fields, struct_type);
-            let field_name = access.rhs.0.contents;
+            let field_name = access.rhs.into_string();
             let typ = value.get_type().into_owned();
             InterpreterError::ExpectedStructToHaveField { typ, field_name, location }
         })
@@ -1612,7 +1612,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                         self.store_lvalue(*object, Value::Tuple(fields))
                     }
                     Value::Struct(mut fields, typ) => {
-                        fields.insert(Rc::new(field_name.0.contents), rhs);
+                        fields.insert(Rc::new(field_name.into_string()), rhs);
                         self.store_lvalue(*object, Value::Struct(fields, typ.follow_bindings()))
                     }
                     value => {
@@ -1667,7 +1667,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
                 match object_value {
                     Value::Tuple(mut values) => Ok(values.swap_remove(index)),
-                    Value::Struct(fields, _) => Ok(fields[&field_name.0.contents].clone()),
+                    Value::Struct(fields, _) => Ok(fields[field_name.as_string()].clone()),
                     value => Err(InterpreterError::NonTupleOrStructInMemberAccess {
                         typ: value.get_type().into_owned(),
                         location: *location,

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1790,7 +1790,7 @@ fn expr_as_for(
     expr_as(interner, arguments, return_type, location, |expr| {
         if let ExprValue::Statement(StatementKind::For(for_statement)) = expr {
             if let ForRange::Array(array) = for_statement.range {
-                let token = Token::Ident(for_statement.identifier.0.contents);
+                let token = Token::Ident(for_statement.identifier.into_string());
                 let token = LocatedToken::new(token, location);
                 let identifier = Value::Quoted(Rc::new(vec![token]));
                 let array = Value::expression(array.kind);
@@ -1816,7 +1816,7 @@ fn expr_as_for_range(
         if let ExprValue::Statement(StatementKind::For(for_statement)) = expr {
             if let ForRange::Range(bounds) = for_statement.range {
                 let (from, to) = bounds.into_half_open();
-                let token = Token::Ident(for_statement.identifier.0.contents);
+                let token = Token::Ident(for_statement.identifier.into_string());
                 let token = LocatedToken::new(token, location);
                 let identifier = Value::Quoted(Rc::new(vec![token]));
                 let from = Value::expression(from.kind);
@@ -3009,7 +3009,7 @@ pub(crate) fn extract_option_generic_type(typ: Type) -> Type {
     };
 
     let struct_type = struct_type.borrow();
-    assert_eq!(struct_type.name.0.contents, "Option");
+    assert_eq!(struct_type.name.as_str(), "Option");
 
     generics.pop().expect("Expected Option to have a T generic type")
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -448,7 +448,7 @@ fn gather_hir_pattern_tokens(
                     tokens.push(Token::Comma);
                 }
 
-                let field_name = &field_name.0.contents;
+                let field_name = field_name.as_str();
                 tokens.push(Token::Ident(field_name.to_string()));
 
                 // If we have a pattern like `Foo { x }`, that's internally represented as `Foo { x: x }` so
@@ -591,7 +591,7 @@ pub(super) fn quote_ident(ident: &Ident, location: Location) -> Value {
 }
 
 fn ident_to_tokens(ident: &Ident, location: Location) -> Rc<Vec<LocatedToken>> {
-    let token = Token::Ident(ident.0.contents.clone());
+    let token = Token::Ident(ident.to_string());
     let token = LocatedToken::new(token, location);
     Rc::new(vec![token])
 }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -512,7 +512,7 @@ impl Value {
                 vec![Token::InternedUnresolvedTypeData(interner.push_unresolved_type_data(typ))]
             }
             Value::TraitConstraint(trait_id, generics) => {
-                let name = Rc::new(interner.get_trait(trait_id).name.0.contents.clone());
+                let name = Rc::new(interner.get_trait(trait_id).name.to_string());
                 let typ = Type::TraitAsType(trait_id, name, generics);
                 vec![Token::QuotedType(interner.push_quoted_type(typ))]
             }

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -509,7 +509,7 @@ impl ModCollector<'_> {
                         is_comptime,
                     } => {
                         let func_id = context.def_interner.push_empty_fn();
-                        if !method_ids.contains_key(&name.0.contents) {
+                        if !method_ids.contains_key(name.as_str()) {
                             method_ids.insert(name.to_string(), func_id);
                         }
 
@@ -944,7 +944,7 @@ fn push_child_module(
         interner.add_module_attributes(
             mod_id,
             ModuleAttributes {
-                name: mod_name.0.contents.clone(),
+                name: mod_name.to_string(),
                 location: mod_location,
                 parent: Some(parent),
                 visibility,
@@ -957,7 +957,7 @@ fn push_child_module(
                 mod_id,
                 location,
                 visibility,
-                mod_name.0.contents.clone(),
+                mod_name.to_string(),
                 parent_module_id,
             );
         }
@@ -1258,7 +1258,7 @@ fn find_module(
 
     // Assuming anchor is called "anchor.nr" and we are looking up a module named "mod_name"...
     // This is "mod_name"
-    let mod_name_str = &mod_name.0.contents;
+    let mod_name_str = mod_name.as_str();
 
     // If we are in a special name like "main.nr", "lib.nr", "mod.nr" or "{mod_name}.nr",
     // the search starts at the same directory, otherwise it starts in a nested directory.

--- a/compiler/noirc_frontend/src/hir/def_map/mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/mod.rs
@@ -277,7 +277,7 @@ impl CrateDefMap {
                 .children
                 .iter()
                 .find(|(_, id)| id.0 == child_id)
-                .map(|(name, _)| &name.0.contents)
+                .map(|(name, _)| name.as_str())
                 .expect("Child module was not a child of the given parent module");
 
             let parent_name = self.get_module_path_with_separator(id.0, parent.parent, separator);

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -241,10 +241,10 @@ impl Context<'_, '_> {
             });
             let type_var = TypeVariable::unbound(id, type_var_kind);
             let ident = generic.ident();
-            let location = ident.0.location();
+            let location = ident.location();
 
             // Check for name collisions of this generic
-            let name = Rc::new(ident.0.contents.clone());
+            let name = Rc::new(ident.to_string());
 
             ResolvedGeneric { name, type_var, location }
         })

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -297,10 +297,8 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 diag
             }
             ResolverError::UnusedVariable { ident } => {
-                let name = &ident.0.contents;
-
                 let mut diagnostic = Diagnostic::simple_warning(
-                    format!("unused variable {name}"),
+                    format!("unused variable {ident}"),
                     "unused variable".to_string(),
                     ident.location(),
                 );
@@ -308,19 +306,18 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 diagnostic
             }
             ResolverError::UnusedItem { ident, item} => {
-                let name = &ident.0.contents;
                 let item_type = item.item_type();
 
                 let mut diagnostic =
                     if let UnusedItem::Struct(..) = item {
                         Diagnostic::simple_warning(
-                            format!("{item_type} `{name}` is never constructed"),
+                            format!("{item_type} `{ident}` is never constructed"),
                             format!("{item_type} is never constructed"),
                             ident.location(),
                         )
                     } else {
                         Diagnostic::simple_warning(
-                            format!("unused {item_type} {name}"),
+                            format!("unused {item_type} {ident}"),
                             format!("unused {item_type}"),
                             ident.location(),
                         )
@@ -408,24 +405,20 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 error
             }
             ResolverError::UnnecessaryPub { ident, position } => {
-                let name = &ident.0.contents;
-
                 let mut diag = Diagnostic::simple_error(
-                    format!("unnecessary pub keyword on {position} for function {name}"),
+                    format!("unnecessary pub keyword on {position} for function {ident}"),
                     format!("unnecessary pub {position}"),
-                    ident.0.location(),
+                    ident.location(),
                 );
 
                 diag.add_note("The `pub` keyword only has effects on arguments to the entry-point function of a program. Thus, adding it to other function parameters can be deceiving and should be removed".to_owned());
                 diag
             }
             ResolverError::NecessaryPub { ident } => {
-                let name = &ident.0.contents;
-
                 let mut diag = Diagnostic::simple_error(
-                    format!("missing pub keyword on return type of function {name}"),
+                    format!("missing pub keyword on return type of function {ident}"),
                     "missing pub on return type".to_string(),
-                    ident.0.location(),
+                    ident.location(),
                 );
 
                 diag.add_note("The `pub` keyword is mandatory for the entry-point function return type because the verifier cannot retrieve private witness and thus the function will not be able to return a 'priv' value".to_owned());
@@ -610,24 +603,20 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 )
             },
             ResolverError::NoPredicatesAttributeOnUnconstrained { ident } => {
-                let name = &ident.0.contents;
-
                 let mut diag = Diagnostic::simple_error(
-                    format!("misplaced #[no_predicates] attribute on unconstrained function {name}. Only allowed on constrained functions"),
+                    format!("misplaced #[no_predicates] attribute on unconstrained function {ident}. Only allowed on constrained functions"),
                     "misplaced #[no_predicates] attribute".to_string(),
-                    ident.0.location(),
+                    ident.location(),
                 );
 
                 diag.add_note("The `#[no_predicates]` attribute specifies to the compiler whether it should diverge from auto-inlining constrained functions".to_owned());
                 diag
             }
             ResolverError::FoldAttributeOnUnconstrained { ident } => {
-                let name = &ident.0.contents;
-
                 let mut diag = Diagnostic::simple_error(
-                    format!("misplaced #[fold] attribute on unconstrained function {name}. Only allowed on constrained functions"),
+                    format!("misplaced #[fold] attribute on unconstrained function {ident}. Only allowed on constrained functions"),
                     "misplaced #[fold] attribute".to_string(),
-                    ident.0.location(),
+                    ident.location(),
                 );
 
                 diag.add_note("The `#[fold]` attribute specifies whether a constrained function should be treated as a separate circuit rather than inlined into the program entry point".to_owned());

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -234,7 +234,7 @@ impl PathResolutionTargetResolver<'_, '_> {
         let crate_name = &path.segments.first().unwrap().ident;
         let dep_module = current_def_map
             .extern_prelude
-            .get(&crate_name.0.contents)
+            .get(crate_name.as_str())
             .ok_or_else(|| PathResolutionError::Unresolved(crate_name.to_owned()))?;
 
         if let Some(references_tracker) = &mut self.references_tracker {

--- a/compiler/noirc_frontend/src/hir_def/stmt.rs
+++ b/compiler/noirc_frontend/src/hir_def/stmt.rs
@@ -100,9 +100,9 @@ impl HirPattern {
     /// Panics if the type is not a struct or tuple.
     pub fn iter_fields<'a>(&'a self) -> Box<dyn Iterator<Item = (String, &'a HirPattern)> + 'a> {
         match self {
-            HirPattern::Struct(_, fields, _) => Box::new(
-                fields.iter().map(move |(name, pattern)| (name.0.contents.clone(), pattern)),
-            ),
+            HirPattern::Struct(_, fields, _) => {
+                Box::new(fields.iter().map(move |(name, pattern)| (name.to_string(), pattern)))
+            }
             HirPattern::Tuple(fields, _) => {
                 Box::new(fields.iter().enumerate().map(|(i, field)| (i.to_string(), field)))
             }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -508,7 +508,7 @@ impl DataType {
         assert_eq!(self.generics.len(), generic_args.len());
 
         let mut fields = self.fields_raw()?.iter().enumerate();
-        fields.find(|(_, field)| field.name.0.contents == field_name).map(|(i, field)| {
+        fields.find(|(_, field)| field.name.as_str() == field_name).map(|(i, field)| {
             let generics = self.generics.iter().zip(generic_args);
             let substitutions = generics
                 .map(|(old, new)| {
@@ -529,7 +529,7 @@ impl DataType {
         let substitutions = self.get_fields_substitutions(generic_args);
 
         Some(vecmap(self.fields_raw()?, |field| {
-            let name = field.name.0.contents.clone();
+            let name = field.name.to_string();
             (name, field.visibility, field.typ.substitute(&substitutions))
         }))
     }
@@ -539,7 +539,7 @@ impl DataType {
         let substitutions = self.get_fields_substitutions(generic_args);
 
         Some(vecmap(self.fields_raw()?, |field| {
-            let name = field.name.0.contents.clone();
+            let name = field.name.to_string();
             (name, field.typ.substitute(&substitutions))
         }))
     }

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -362,24 +362,24 @@ pub struct LocatedToken(Located<Token>);
 
 impl PartialEq<LocatedToken> for Token {
     fn eq(&self, other: &LocatedToken) -> bool {
-        self == &other.0.contents
+        self == other.token()
     }
 }
 impl PartialEq<Token> for LocatedToken {
     fn eq(&self, other: &Token) -> bool {
-        &self.0.contents == other
+        self.token() == other
     }
 }
 
 impl From<LocatedToken> for Token {
     fn from(spt: LocatedToken) -> Self {
-        spt.0.contents
+        spt.into_token()
     }
 }
 
 impl<'a> From<&'a LocatedToken> for &'a Token {
     fn from(spt: &'a LocatedToken) -> Self {
-        &spt.0.contents
+        spt.token()
     }
 }
 
@@ -419,24 +419,24 @@ pub struct SpannedToken(Spanned<Token>);
 
 impl PartialEq<SpannedToken> for Token {
     fn eq(&self, other: &SpannedToken) -> bool {
-        self == &other.0.contents
+        self == other.token()
     }
 }
 impl PartialEq<Token> for SpannedToken {
     fn eq(&self, other: &Token) -> bool {
-        &self.0.contents == other
+        self.token() == other
     }
 }
 
 impl From<SpannedToken> for Token {
     fn from(spt: SpannedToken) -> Self {
-        spt.0.contents
+        spt.into_token()
     }
 }
 
 impl<'a> From<&'a SpannedToken> for &'a Token {
     fn from(spt: &'a SpannedToken) -> Self {
-        &spt.0.contents
+        spt.token()
     }
 }
 

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -389,7 +389,7 @@ impl NodeInterner {
     }
 
     pub(crate) fn register_function(&mut self, id: FuncId, func_def: &FunctionDefinition) {
-        let name = func_def.name.0.contents.clone();
+        let name = func_def.name.to_string();
         let id = ModuleDefId::FunctionId(id);
         self.register_name_for_auto_import(name, id, func_def.visibility, None);
     }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -450,8 +450,7 @@ impl<'interner> Monomorphizer<'interner> {
                 let struct_field_types = unwrap_struct_type(typ, *location)?;
                 assert_eq!(struct_field_types.len(), fields.len());
 
-                let mut fields =
-                    btree_map(fields, |(name, field)| (name.0.contents.clone(), field));
+                let mut fields = btree_map(fields, |(name, field)| (name.to_string(), field));
 
                 // Iterate over `struct_field_types` since `unwrap_struct_type` will always
                 // return the fields in the order defined by the struct type.
@@ -750,17 +749,17 @@ impl<'interner> Monomorphizer<'interner> {
 
         for (field_name, expr_id) in constructor.fields {
             let new_id = self.next_local_id();
-            let field_type = field_type_map.get(&field_name.0.contents).unwrap();
+            let field_type = field_type_map.get(field_name.as_str()).unwrap();
             let location = self.interner.expr_location(&expr_id);
             let typ = Self::convert_type(field_type, location)?;
 
-            field_vars.insert(field_name.0.contents.clone(), (new_id, typ));
+            field_vars.insert(field_name.to_string(), (new_id, typ));
             let expression = Box::new(self.expr(expr_id)?);
 
             new_exprs.push(ast::Expression::Let(ast::Let {
                 id: new_id,
                 mutable: false,
-                name: field_name.0.contents,
+                name: field_name.into_string(),
                 expression,
             }));
         }
@@ -862,7 +861,7 @@ impl<'interner> Monomorphizer<'interner> {
                 assert_eq!(patterns.len(), fields.len());
 
                 let mut patterns =
-                    btree_map(patterns, |(name, pattern)| (name.0.contents, pattern));
+                    btree_map(patterns, |(name, pattern)| (name.into_string(), pattern));
 
                 // We iterate through the type's fields to match the order defined in the struct type
                 let patterns_iter = fields.into_iter().map(|(field_name, field_type)| {
@@ -1500,7 +1499,7 @@ impl<'interner> Monomorphizer<'interner> {
             definition: Definition::Function(func_id),
             mutable: false,
             location: None,
-            name: the_trait.methods[method.method_index].name.0.contents.clone(),
+            name: the_trait.methods[method.method_index].name.to_string(),
             typ: Self::convert_type(&function_type, location)?,
         }))
     }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -6,7 +6,6 @@ use std::marker::Copy;
 use fm::FileId;
 use iter_extended::vecmap;
 use noirc_arena::{Arena, Index};
-use noirc_errors::Located;
 use noirc_errors::{Location, Span};
 use petgraph::algo::tarjan_scc;
 use petgraph::prelude::DiGraph;
@@ -1016,7 +1015,7 @@ impl NodeInterner {
     ) -> DefinitionId {
         let name_location = Location::new(function.name.span(), location.file);
         let modifiers = FunctionModifiers {
-            name: function.name.0.contents.clone(),
+            name: function.name.to_string(),
             visibility: function.visibility,
             attributes: function.attributes.clone(),
             is_unconstrained: function.is_unconstrained,
@@ -1107,7 +1106,7 @@ impl NodeInterner {
     pub fn function_ident(&self, func_id: &FuncId) -> crate::ast::Ident {
         let name = self.function_name(func_id).to_owned();
         let location = self.function_meta(func_id).name.location;
-        crate::ast::Ident(Located::from(location, name))
+        crate::ast::Ident::new(name, location)
     }
 
     pub fn function_name(&self, func_id: &FuncId) -> &str {
@@ -1398,7 +1397,7 @@ impl NodeInterner {
     pub fn trait_method_id(&self, trait_method: TraitMethodId) -> DefinitionId {
         let the_trait = self.get_trait(trait_method.trait_id);
         let method_name = &the_trait.methods[trait_method.method_index].name;
-        let function_id = the_trait.method_ids[&method_name.0.contents];
+        let function_id = the_trait.method_ids[method_name.as_str()];
         self.function_definition_id(function_id)
     }
 
@@ -1928,7 +1927,7 @@ impl NodeInterner {
     pub fn try_add_infix_operator_trait(&mut self, trait_id: TraitId) {
         let the_trait = self.get_trait(trait_id);
 
-        let operator = match the_trait.name.0.contents.as_str() {
+        let operator = match the_trait.name.as_str() {
             "Add" => BinaryOpKind::Add,
             "Sub" => BinaryOpKind::Subtract,
             "Mul" => BinaryOpKind::Multiply,
@@ -1974,7 +1973,7 @@ impl NodeInterner {
     pub fn try_add_prefix_operator_trait(&mut self, trait_id: TraitId) {
         let the_trait = self.get_trait(trait_id);
 
-        let operator = match the_trait.name.0.contents.as_str() {
+        let operator = match the_trait.name.as_str() {
             "Neg" => UnaryOp::Minus,
             "Not" => UnaryOp::Not,
             _ => return,
@@ -2123,9 +2122,7 @@ impl NodeInterner {
             DependencyId::Alias(id) => {
                 Cow::Owned(self.get_type_alias(id).borrow().name.to_string())
             }
-            DependencyId::Global(id) => {
-                Cow::Borrowed(self.get_global(id).ident.0.contents.as_ref())
-            }
+            DependencyId::Global(id) => Cow::Borrowed(self.get_global(id).ident.as_str()),
             DependencyId::Trait(id) => Cow::Owned(self.get_trait(id).name.to_string()),
             DependencyId::Variable(loc) => {
                 unreachable!("Variable used at location {loc:?} caught in a dependency cycle")
@@ -2249,7 +2246,7 @@ impl NodeInterner {
         type_name: &str,
     ) -> Option<&Type> {
         let types = self.trait_impl_associated_types.get(&impl_id)?;
-        types.iter().find(|typ| typ.name.0.contents == type_name).map(|typ| &typ.typ)
+        types.iter().find(|typ| typ.name.as_str() == type_name).map(|typ| &typ.typ)
     }
 
     /// Return a set of TypeBindings to bind types from the parent trait to those from the trait impl.

--- a/compiler/noirc_frontend/src/parser/parser/attributes.rs
+++ b/compiler/noirc_frontend/src/parser/parser/attributes.rs
@@ -140,7 +140,7 @@ impl Parser<'_> {
             self.parse_meta_attribute(path, start_location)
         } else if let Some(path) = self.parse_path_no_turbofish() {
             if let Some(ident) = path.as_ident() {
-                if ident.0.contents == "test" {
+                if ident.as_str() == "test" {
                     // The test attribute is the only secondary attribute that has `a = b` in its syntax
                     // (`should_fail_with = "..."``) so we parse it differently.
                     self.parse_test_attribute(start_location)
@@ -175,7 +175,7 @@ impl Parser<'_> {
     ) -> Attribute {
         let arguments = self.parse_arguments().unwrap_or_default();
         self.skip_until_right_bracket();
-        match ident.0.contents.as_str() {
+        match ident.as_str() {
             "abi" => self.parse_single_name_attribute(ident, arguments, start_location, |name| {
                 Attribute::Secondary(SecondaryAttribute::Abi(name))
             }),
@@ -274,7 +274,7 @@ impl Parser<'_> {
     fn parse_test_attribute(&mut self, start_location: Location) -> Attribute {
         let scope = if self.eat_left_paren() {
             let scope = if let Some(ident) = self.eat_ident() {
-                match ident.0.contents.as_str() {
+                match ident.as_str() {
                     "should_fail" => Some(TestScope::ShouldFailWith { reason: None }),
                     "should_fail_with" => {
                         self.eat_or_error(Token::Assign);

--- a/compiler/noirc_frontend/src/resolve_locations.rs
+++ b/compiler/noirc_frontend/src/resolve_locations.rs
@@ -172,9 +172,9 @@ impl NodeInterner {
         let struct_type = lhs_self_struct.borrow();
         let field_names = struct_type.field_names()?;
 
-        field_names.iter().find(|field_name| field_name.0 == expr_rhs.0).map(|found_field_name| {
-            Location::new(found_field_name.span(), struct_type.location.file)
-        })
+        field_names.iter().find(|field_name| field_name.as_str() == expr_rhs.as_str()).map(
+            |found_field_name| Location::new(found_field_name.span(), struct_type.location.file),
+        )
     }
 
     /// Attempts to resolve [Location] of [Trait] based on [Location] of [TraitImpl]
@@ -221,7 +221,7 @@ impl NodeInterner {
 
                 let mut methods = self.traits.get(&trait_id)?.methods.iter();
                 let method =
-                    methods.find(|method| method.name.0.contents == self.function_name(func_id));
+                    methods.find(|method| method.name.as_str() == self.function_name(func_id));
                 method.map(|method| method.location)
             })
     }

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -1,7 +1,4 @@
-use noirc_errors::Located;
-
 use crate::{
-    ast::Ident,
     hir::{
         comptime::ComptimeError,
         def_collector::{
@@ -145,16 +142,16 @@ fn errors_if_macros_inject_functions_with_name_collisions() {
         panic!("Expected a ComptimeError, got {:?}", errors[0]);
     };
 
-    assert!(matches!(
-        *error,
-        CompilationError::DefinitionError(
-            DefCollectorErrorKind::Duplicate {
-                typ: DuplicateType::Function,
-                first_def: Ident(Located { contents, .. }),
-                ..
-            },
-        ) if contents == "foo"
-    ));
+    let CompilationError::DefinitionError(DefCollectorErrorKind::Duplicate {
+        typ: DuplicateType::Function,
+        first_def,
+        ..
+    }) = *error
+    else {
+        panic!("Expected a duplicate error");
+    };
+
+    assert_eq!(first_def.as_str(), "foo");
 }
 
 #[test]

--- a/tooling/lsp/src/modules.rs
+++ b/tooling/lsp/src/modules.rs
@@ -217,8 +217,10 @@ pub(crate) fn get_ancestor_module_reexport(
 
     // If we can find one we need to adjust the exported name a bit.
     let parent_module_name = &interner.try_module_attributes(&parent_module)?.name;
-    grandparent_module_reexport.name.0.contents =
-        format!("{}::{}", grandparent_module_reexport.name.0.contents, parent_module_name);
+    grandparent_module_reexport.name = Ident::new(
+        format!("{}::{}", grandparent_module_reexport.name, parent_module_name),
+        grandparent_module_reexport.name.location(),
+    );
 
     Some(grandparent_module_reexport)
 }

--- a/tooling/lsp/src/requests/code_action/fill_struct_fields.rs
+++ b/tooling/lsp/src/requests/code_action/fill_struct_fields.rs
@@ -34,7 +34,7 @@ impl CodeActionFinder<'_> {
 
         // Remove the ones that already exists in the constructor
         for (constructor_field, _) in &constructor.fields {
-            fields.retain(|field| field.name.0.contents != constructor_field.0.contents);
+            fields.retain(|field| field.name.as_str() != constructor_field.as_str());
         }
 
         // Some fields are missing. Let's suggest a quick fix that adds them.
@@ -101,7 +101,7 @@ impl CodeActionFinder<'_> {
                     new_text.push(' ');
                 }
             }
-            new_text.push_str(&field.name.0.contents);
+            new_text.push_str(field.name.as_str());
             new_text.push_str(": ()");
         }
 

--- a/tooling/lsp/src/requests/code_action/implement_missing_members.rs
+++ b/tooling/lsp/src/requests/code_action/implement_missing_members.rs
@@ -52,7 +52,7 @@ impl CodeActionFinder<'_> {
                     if let UnresolvedTypeData::Unspecified = alias.typ {
                         continue;
                     }
-                    associated_types.remove(&name.0.contents);
+                    associated_types.remove(name.as_string());
                 }
             }
         }
@@ -60,7 +60,7 @@ impl CodeActionFinder<'_> {
         // Also remove default methods
         for trait_function in &trait_.methods {
             if trait_function.default_impl.is_some() {
-                method_ids.remove(&trait_function.name.0.contents);
+                method_ids.remove(trait_function.name.as_string());
             }
         }
 

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -33,7 +33,7 @@ impl CodeActionFinder<'_> {
         // The Path doesn't resolve to anything so it means it's an error and maybe we
         // can suggest an import or to fully-qualify the path.
         for (name, entries) in self.interner.get_auto_import_names() {
-            if name != &ident.0.contents {
+            if name != ident.as_str() {
                 continue;
             }
 

--- a/tooling/lsp/src/requests/code_action/import_trait.rs
+++ b/tooling/lsp/src/requests/code_action/import_trait.rs
@@ -42,7 +42,7 @@ impl CodeActionFinder<'_> {
         };
 
         let trait_methods =
-            self.interner.lookup_trait_methods(typ, &method_call.method_name.0.contents, true);
+            self.interner.lookup_trait_methods(typ, method_call.method_name.as_str(), true);
         let trait_ids: HashSet<_> = trait_methods.iter().map(|(_, trait_id)| *trait_id).collect();
 
         for trait_id in trait_ids {
@@ -108,7 +108,7 @@ impl CodeActionFinder<'_> {
 
         let Some(full_path) = module_def_id_relative_path(
             module_def_id,
-            &trait_name.0.contents,
+            trait_name.as_str(),
             self.module_id,
             current_module_parent_id,
             defining_module,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -216,13 +216,13 @@ impl<'a> NodeFinder<'a> {
 
         // Remove the ones that already exists in the constructor
         for (used_name, _) in &constructor_expression.fields {
-            fields.retain(|(_, field)| field.name.0.contents != used_name.0.contents);
+            fields.retain(|(_, field)| field.name.as_str() != used_name.as_str());
         }
 
         let self_prefix = false;
         for (field_index, field) in &fields {
             self.completion_items.push(self.struct_field_completion_item(
-                &field.name.0.contents,
+                field.name.as_str(),
                 &field.typ,
                 data_type.id,
                 *field_index,
@@ -265,7 +265,7 @@ impl<'a> NodeFinder<'a> {
                 // If so, take the substring and push that as the list of idents
                 // we'll do autocompletion for
                 let offset = self.byte_index - ident.span().start() as usize;
-                let substring = ident.0.contents[0..offset].to_string();
+                let substring = ident.as_str()[0..offset].to_string();
                 let ident = Ident::new(
                     substring,
                     Location::new(
@@ -805,7 +805,7 @@ impl<'a> NodeFinder<'a> {
 
         for (index, variant) in variants.iter().enumerate() {
             // Variants with parameters are represented as functions and are suggested in `complete_type_methods`
-            if variant.is_function || !name_matches(&variant.name.0.contents, prefix) {
+            if variant.is_function || !name_matches(variant.name.as_str(), prefix) {
                 continue;
             }
 
@@ -893,7 +893,7 @@ impl<'a> NodeFinder<'a> {
         let function_kind = FunctionKind::Any;
 
         for ident in module_data.scope().names() {
-            let name = &ident.0.contents;
+            let name = ident.as_str();
 
             if name_matches(name, prefix) {
                 let per_ns = module_data.find_name(ident);
@@ -906,7 +906,7 @@ impl<'a> NodeFinder<'a> {
                     ) {
                         let completion_items = self.module_def_id_completion_items(
                             module_def_id,
-                            name.clone(),
+                            name.to_string(),
                             function_completion_kind,
                             function_kind,
                             requested_items,
@@ -927,7 +927,7 @@ impl<'a> NodeFinder<'a> {
                     ) {
                         let completion_items = self.module_def_id_completion_items(
                             module_def_id,
-                            name.clone(),
+                            name.to_string(),
                             function_completion_kind,
                             function_kind,
                             requested_items,
@@ -1089,7 +1089,7 @@ impl<'a> NodeFinder<'a> {
     fn try_set_self_type(&mut self, pattern: &Pattern) {
         match pattern {
             Pattern::Identifier(ident) => {
-                if ident.0.contents == "self" {
+                if ident.as_str() == "self" {
                     let location = Location::new(ident.span(), self.file);
                     if let Some(ReferenceId::Local(definition_id)) =
                         self.interner.find_referenced(location)
@@ -1119,7 +1119,7 @@ impl<'a> NodeFinder<'a> {
             }
             LValue::MemberAccess { object, field_name, .. } => {
                 let typ = self.get_lvalue_type(object)?;
-                get_field_type(&typ, &field_name.0.contents)
+                get_field_type(&typ, field_name.as_str())
             }
             LValue::Index { array, .. } => {
                 let typ = self.get_lvalue_type(array)?;
@@ -1580,7 +1580,7 @@ impl Visitor for NodeFinder<'_> {
         // then suggest methods of the resulting type.
         if self.byte == Some(b'.') && span.end() as usize == self.byte_index - 1 {
             if let Some(typ) = self.get_lvalue_type(object) {
-                if let Some(typ) = get_field_type(&typ, &field_name.0.contents) {
+                if let Some(typ) = get_field_type(&typ, field_name.as_str()) {
                     let prefix = "";
                     let self_prefix = false;
                     self.complete_type_fields_and_methods(
@@ -1822,7 +1822,7 @@ impl Visitor for NodeFinder<'_> {
         };
 
         if let Some(typ) = typ {
-            let prefix = &type_path.item.0.contents;
+            let prefix = type_path.item.as_str();
             self.complete_type_methods(
                 &typ,
                 prefix,

--- a/tooling/lsp/src/requests/document_symbol.rs
+++ b/tooling/lsp/src/requests/document_symbol.rs
@@ -66,7 +66,7 @@ impl<'a> DocumentSymbolCollector<'a> {
     }
 
     fn collect_in_type(&mut self, name: &Ident, typ: Option<&UnresolvedType>) {
-        if name.0.contents.is_empty() {
+        if name.is_empty() {
             return;
         }
 
@@ -103,7 +103,7 @@ impl<'a> DocumentSymbolCollector<'a> {
         typ: &UnresolvedType,
         default_value: Option<&Expression>,
     ) {
-        if name.0.contents.is_empty() {
+        if name.is_empty() {
             return;
         }
 
@@ -145,7 +145,7 @@ impl<'a> DocumentSymbolCollector<'a> {
 
 impl Visitor for DocumentSymbolCollector<'_> {
     fn visit_noir_function(&mut self, noir_function: &NoirFunction, span: Span) -> bool {
-        if noir_function.def.name.0.contents.is_empty() {
+        if noir_function.def.name.is_empty() {
             return false;
         }
 
@@ -174,7 +174,7 @@ impl Visitor for DocumentSymbolCollector<'_> {
     }
 
     fn visit_noir_struct(&mut self, noir_struct: &NoirStruct, span: Span) -> bool {
-        if noir_struct.name.0.contents.is_empty() {
+        if noir_struct.name.is_empty() {
             return false;
         }
 
@@ -229,7 +229,7 @@ impl Visitor for DocumentSymbolCollector<'_> {
     }
 
     fn visit_noir_trait(&mut self, noir_trait: &NoirTrait, span: Span) -> bool {
-        if noir_trait.name.0.contents.is_empty() {
+        if noir_trait.name.is_empty() {
             return false;
         }
 
@@ -275,7 +275,7 @@ impl Visitor for DocumentSymbolCollector<'_> {
         _where_clause: &[noirc_frontend::ast::UnresolvedTraitConstraint],
         body: &Option<noirc_frontend::ast::BlockExpression>,
     ) -> bool {
-        if name.0.contents.is_empty() {
+        if name.is_empty() {
             return false;
         }
 
@@ -332,7 +332,7 @@ impl Visitor for DocumentSymbolCollector<'_> {
         typ: &UnresolvedType,
         default_value: &Option<Expression>,
     ) -> bool {
-        if name.0.contents.is_empty() {
+        if name.is_empty() {
             return false;
         }
 
@@ -448,7 +448,7 @@ impl Visitor for DocumentSymbolCollector<'_> {
     }
 
     fn visit_parsed_submodule(&mut self, parsed_sub_module: &ParsedSubModule, span: Span) -> bool {
-        if parsed_sub_module.name.0.contents.is_empty() {
+        if parsed_sub_module.name.is_empty() {
             return false;
         }
 

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -137,12 +137,12 @@ fn format_struct(
     }
     string.push_str("    ");
     string.push_str("struct ");
-    string.push_str(&typ.name.0.contents);
+    string.push_str(typ.name.as_str());
     format_generics(&typ.generics, &mut string);
     string.push_str(" {\n");
     for field in fields {
         string.push_str("        ");
-        string.push_str(&field.name.0.contents);
+        string.push_str(field.name.as_str());
         string.push_str(": ");
         string.push_str(&format!("{}", field.typ));
         string.push_str(",\n");
@@ -165,12 +165,12 @@ fn format_enum(
     }
     string.push_str("    ");
     string.push_str("enum ");
-    string.push_str(&typ.name.0.contents);
+    string.push_str(typ.name.as_str());
     format_generics(&typ.generics, &mut string);
     string.push_str(" {\n");
     for field in variants {
         string.push_str("        ");
-        string.push_str(&field.name.0.contents);
+        string.push_str(field.name.as_str());
 
         if !field.params.is_empty() {
             let types = field.params.iter().map(ToString::to_string).collect::<Vec<_>>();
@@ -201,10 +201,10 @@ fn format_struct_member(
     if format_parent_module(ReferenceId::Type(id), args, &mut string) {
         string.push_str("::");
     }
-    string.push_str(&struct_type.name.0.contents);
+    string.push_str(struct_type.name.as_str());
     string.push('\n');
     string.push_str("    ");
-    string.push_str(&field.name.0.contents);
+    string.push_str(field.name.as_str());
     string.push_str(": ");
     string.push_str(&format!("{}", field.typ));
     string.push_str(&go_to_type_links(&field.typ, args.interner, args.files));
@@ -227,10 +227,10 @@ fn format_enum_variant(
     if format_parent_module(ReferenceId::Type(id), args, &mut string) {
         string.push_str("::");
     }
-    string.push_str(&enum_type.name.0.contents);
+    string.push_str(enum_type.name.as_str());
     string.push('\n');
     string.push_str("    ");
-    string.push_str(&variant.name.0.contents);
+    string.push_str(variant.name.as_str());
     if !variant.params.is_empty() {
         let types = variant.params.iter().map(ToString::to_string).collect::<Vec<_>>();
         string.push('(');
@@ -256,7 +256,7 @@ fn format_trait(id: TraitId, args: &ProcessRequestCallbackArgs) -> String {
     }
     string.push_str("    ");
     string.push_str("trait ");
-    string.push_str(&a_trait.name.0.contents);
+    string.push_str(a_trait.name.as_str());
     format_generics(&a_trait.generics, &mut string);
 
     append_doc_comments(args.interner, ReferenceId::Trait(id), &mut string);
@@ -292,7 +292,7 @@ fn format_global(id: GlobalId, args: &ProcessRequestCallbackArgs) -> String {
         string.push_str("mut ");
     }
     string.push_str("global ");
-    string.push_str(&global_info.ident.0.contents);
+    string.push_str(global_info.ident.as_str());
     string.push_str(": ");
     string.push_str(&format!("{}", typ));
 
@@ -413,7 +413,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
         }
 
         string.push(' ');
-        string.push_str(&trait_.name.0.contents);
+        string.push_str(trait_.name.as_str());
         if !trait_impl.trait_generics.is_empty() {
             string.push('<');
             for (index, generic) in trait_impl.trait_generics.iter().enumerate() {
@@ -433,7 +433,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
         let trait_ = args.interner.get_trait(trait_id);
         string.push('\n');
         string.push_str("    trait ");
-        string.push_str(&trait_.name.0.contents);
+        string.push_str(trait_.name.as_str());
         format_generics(&trait_.generics, &mut string);
 
         true
@@ -443,7 +443,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
         if formatted_parent_module {
             string.push_str("::");
         }
-        string.push_str(&data_type.name.0.contents);
+        string.push_str(data_type.name.as_str());
         if enum_variant.is_none() {
             string.push('\n');
             string.push_str("    ");
@@ -458,7 +458,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
             format_generics(&impl_generics, &mut string);
 
             string.push(' ');
-            string.push_str(&data_type.name.0.contents);
+            string.push_str(data_type.name.as_str());
             format_generic_names(&impl_generics, &mut string);
         }
 
@@ -593,7 +593,7 @@ fn format_alias(id: TypeAliasId, args: &ProcessRequestCallbackArgs) -> String {
     string.push('\n');
     string.push_str("    ");
     string.push_str("type ");
-    string.push_str(&type_alias.name.0.contents);
+    string.push_str(type_alias.name.as_str());
     string.push_str(" = ");
     string.push_str(&format!("{}", &type_alias.typ));
 

--- a/tooling/lsp/src/requests/signature_help.rs
+++ b/tooling/lsp/src/requests/signature_help.rs
@@ -132,7 +132,7 @@ impl<'a> SignatureFinder<'a> {
 
         if let Some(enum_type_id) = enum_type_id {
             label.push_str("enum ");
-            label.push_str(&self.interner.get_type(enum_type_id).borrow().name.0.contents);
+            label.push_str(self.interner.get_type(enum_type_id).borrow().name.as_str());
             label.push_str("::");
         } else {
             label.push_str("fn ");

--- a/tooling/lsp/src/trait_impl_method_stub_generator.rs
+++ b/tooling/lsp/src/trait_impl_method_stub_generator.rs
@@ -98,7 +98,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                 self.append_type(&constraint.typ);
                 self.string.push_str(": ");
                 let trait_ = self.interner.get_trait(constraint.trait_bound.trait_id);
-                self.string.push_str(&trait_.name.0.contents);
+                self.string.push_str(trait_.name.as_str());
                 self.append_trait_generics(&constraint.trait_bound.trait_generics);
             }
         }
@@ -147,7 +147,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                     if index > 0 {
                         self.string.push_str(", ");
                     }
-                    self.string.push_str(&name.0.contents);
+                    self.string.push_str(name.as_str());
                 }
                 self.string.push_str(" }");
                 true
@@ -190,7 +190,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                 let per_ns = current_module_data.find_name(&struct_type.name);
                 if let Some((module_def_id, _, _)) = per_ns.types {
                     if module_def_id == ModuleDefId::TypeId(struct_type.id) {
-                        self.string.push_str(&struct_type.name.0.contents);
+                        self.string.push_str(struct_type.name.as_str());
                         self.append_generics(generics);
                         return;
                     }
@@ -212,7 +212,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                     self.string.push_str(&relative_path);
                     self.string.push_str("::");
                 }
-                self.string.push_str(&struct_type.name.0.contents);
+                self.string.push_str(struct_type.name.as_str());
                 self.append_generics(generics);
             }
             Type::Alias(type_alias, generics) => {
@@ -225,7 +225,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                 let per_ns = current_module_data.find_name(&type_alias.name);
                 if let Some((module_def_id, _, _)) = per_ns.types {
                     if module_def_id == ModuleDefId::TypeAliasId(type_alias.id) {
-                        self.string.push_str(&type_alias.name.0.contents);
+                        self.string.push_str(type_alias.name.as_str());
                         self.append_generics(generics);
                         return;
                     }
@@ -249,7 +249,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                     self.string.push_str(&relative_path);
                     self.string.push_str("::");
                 }
-                self.string.push_str(&type_alias.name.0.contents);
+                self.string.push_str(type_alias.name.as_str());
                 self.append_generics(generics);
             }
             Type::TraitAsType(trait_id, _, trait_generics) => {
@@ -259,7 +259,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                 let current_module_data =
                     &self.def_maps[&self.module_id.krate].modules()[self.module_id.local_id.0];
                 if current_module_data.find_trait_in_scope(*trait_id).is_some() {
-                    self.string.push_str(&trait_.name.0.contents);
+                    self.string.push_str(trait_.name.as_str());
                     self.append_trait_generics(trait_generics);
                     return;
                 }
@@ -282,7 +282,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
                     self.string.push_str(&relative_path);
                     self.string.push_str("::");
                 }
-                self.string.push_str(&trait_.name.0.contents);
+                self.string.push_str(trait_.name.as_str());
                 self.append_trait_generics(trait_generics);
             }
             Type::TypeVariable(typevar) => {
@@ -419,7 +419,7 @@ impl<'a> TraitImplMethodStubGenerator<'a> {
             if index > 0 {
                 self.string.push_str(", ");
             }
-            self.string.push_str(&named_type.name.0.contents);
+            self.string.push_str(named_type.name.as_str());
             self.string.push_str(" = ");
             self.append_type(&named_type.typ);
             index += 1;

--- a/tooling/lsp/src/use_segment_positions.rs
+++ b/tooling/lsp/src/use_segment_positions.rs
@@ -111,7 +111,7 @@ impl UseSegmentPositions {
             if !prefix.is_empty() {
                 prefix.push_str("::");
             };
-            prefix.push_str(&ident.0.contents);
+            prefix.push_str(ident.as_str());
 
             if index < prefix_segments_len - 1 {
                 self.insert_use_segment_position(
@@ -133,7 +133,7 @@ impl UseSegmentPositions {
                 if !prefix.is_empty() {
                     prefix.push_str("::");
                 }
-                prefix.push_str(&ident.0.contents);
+                prefix.push_str(ident.as_str());
 
                 if alias.is_none() {
                     self.insert_use_segment_position(

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -563,7 +563,7 @@ fn generic_type_args_with_file(generics: GenericTypeArgs, file: FileId) -> Gener
 
 fn ident_with_file(ident: Ident, file: FileId) -> Ident {
     let location = location_with_file(ident.location(), file);
-    Ident::new(ident.0.contents, location)
+    Ident::new(ident.into_string(), location)
 }
 
 fn secondary_attributes_with_file(

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -125,7 +125,7 @@ impl<'a> Formatter<'a> {
         let Token::Ident(..) = self.token else {
             panic!("Expected identifier, got {:?}", self.token);
         };
-        self.write(&ident.0.contents);
+        self.write(ident.as_str());
         self.bump();
     }
 
@@ -135,7 +135,7 @@ impl<'a> Formatter<'a> {
         if !matches!(self.token, Token::Ident(..) | Token::Int(..)) {
             panic!("Expected identifier or integer, got {:?}", self.token);
         }
-        self.write(&ident.0.contents);
+        self.write(ident.as_str());
         self.bump();
     }
 

--- a/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
@@ -279,7 +279,7 @@ fn merge_imports_in_tree(imports: Vec<UseTree>, mut tree: &mut ImportTree) {
                 if let Some(alias) = alias {
                     tree = tree.insert(Segment::Plain(format!("{} as {}", ident, alias)));
                     tree.insert(Segment::SelfReference);
-                } else if ident.0.contents == "self" {
+                } else if ident.as_str() == "self" {
                     tree.insert(Segment::SelfReference);
                 } else {
                     tree = tree.insert(Segment::Plain(ident.to_string()));


### PR DESCRIPTION
# Description

## Problem

## Summary

Just a refactor to avoid using `.0.contents` and prefer `as_str()` or other options, which are shorter and also maybe a bit clearer.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
