### PR TITLE
feat: allow `fn` returning `()` without having to write `-> ()`

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -314,7 +314,6 @@ impl Parser<'_> {
         let ret = if self.eat(Token::Arrow) {
             self.parse_type_or_error()
         } else {
-            self.expected_token(Token::Arrow);
             UnresolvedTypeData::Unit.with_location(self.location_at_previous_token_end())
         };
 
@@ -703,6 +702,16 @@ mod tests {
             panic!("Expected a function type")
         };
         assert_eq!(ret.typ.to_string(), "Field");
+    }
+
+    #[test]
+    fn parses_function_type_without_return_type() {
+        let src = "fn()";
+        let typ = parse_type_no_errors(src);
+        let UnresolvedTypeData::Function(_args, ret, _env, _unconstrained) = typ.typ else {
+            panic!("Expected a function type")
+        };
+        assert_eq!(ret.typ.to_string(), "()");
     }
 
     #[test]

--- a/test_programs/execution_success/reference_only_used_as_alias/src/main.nr
+++ b/test_programs/execution_success/reference_only_used_as_alias/src/main.nr
@@ -4,11 +4,11 @@ struct ExampleEvent0 {
 }
 
 trait EventInterface {
-    fn emit<Env>(self, _emit: fn[Env](Self) -> ());
+    fn emit<Env>(self, _emit: fn[Env](Self));
 }
 
 impl EventInterface for ExampleEvent0 {
-    fn emit<Env>(self: ExampleEvent0, _emit: fn[Env](Self) -> ()) {
+    fn emit<Env>(self: ExampleEvent0, _emit: fn[Env](Self)) {
         _emit(self);
     }
 }
@@ -56,7 +56,7 @@ where
 fn encode_event_with_randomness<Event>(
     context: &mut Context,
     randomness: Field,
-) -> fn[(&mut Context, Field)](Event) -> ()
+) -> fn[(&mut Context, Field)](Event)
 where
     Event: EventInterface,
 {

--- a/tooling/nargo_fmt/src/formatter/types.rs
+++ b/tooling/nargo_fmt/src/formatter/types.rs
@@ -305,6 +305,13 @@ mod tests {
     }
 
     #[test]
+    fn format_function_type_without_return_type() {
+        let src = "  fn   ( )  ";
+        let expected = "fn()";
+        assert_format_type(src, expected);
+    }
+
+    #[test]
     fn format_tuple_type_one_type() {
         let src = " ( Field , )";
         let expected = "(Field,)";


### PR DESCRIPTION
# Description

## Problem

Resolves #7703

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
