### PR TITLE
fix: allow omitting ';' after last block statement if it's an assignment

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -104,14 +104,21 @@ impl StatementKind {
             ParserError::with_reason(ParserErrorReason::MissingSeparatingSemi, location);
 
         match self {
-            StatementKind::Let(_)
-            | StatementKind::Assign(_)
+            StatementKind::Let(_) => {
+                // To match rust, a let statement always requires a semicolon, even at the end of a block
+                if semi.is_none() {
+                    let reason = ParserErrorReason::MissingSemicolonAfterLet;
+                    emit_error(ParserError::with_reason(reason, location));
+                }
+                self
+            }
+            StatementKind::Assign(_)
             | StatementKind::Semi(_)
             | StatementKind::Break
             | StatementKind::Continue
             | StatementKind::Error => {
-                // To match rust, statements always require a semicolon, even at the end of a block
-                if semi.is_none() {
+                // These statements can omit the semicolon if they are the last statement in a block
+                if !last_statement_in_block && semi.is_none() {
                     emit_error(missing_semicolon);
                 }
                 self

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -60,6 +60,8 @@ pub enum ParserErrorReason {
     ExpectedPatternButFoundType(Token),
     #[error("Expected a ; separating these two statements")]
     MissingSeparatingSemi,
+    #[error("Expected a ; after `let` statement")]
+    MissingSemicolonAfterLet,
     #[error("constrain keyword is deprecated")]
     ConstrainDeprecated,
     #[error(

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -1101,6 +1101,39 @@ mod tests {
     }
 
     #[test]
+    fn parses_block_expression_with_a_single_assignment() {
+        let src = "{ x = 1 }";
+        let _ = parse_expression_no_errors(src);
+    }
+
+    #[test]
+    fn parses_block_expression_with_a_single_break() {
+        let src = "{ break }";
+        let _ = parse_expression_no_errors(src);
+    }
+
+    #[test]
+    fn parses_block_expression_with_a_single_continue() {
+        let src = "{ continue }";
+        let _ = parse_expression_no_errors(src);
+    }
+
+    #[test]
+    fn parses_block_expression_with_a_single_let() {
+        let src = "
+        { let x = 1 }
+                  ^
+        ";
+        let (src, span) = get_source_with_error_span(src);
+        let mut parser = Parser::for_str_with_dummy_file(&src);
+        parser.parse_expression();
+        let reason = get_single_error_reason(&parser.errors, span);
+        let ParserErrorReason::MissingSemicolonAfterLet = reason else {
+            panic!("Expected a different error");
+        };
+    }
+
+    #[test]
     fn parses_unsafe_expression() {
         let src = "
         // Safety: test


### PR DESCRIPTION
# Description

## Problem

Resolves #7704

## Summary

Our comments said "To match Rust" but they didn't, maybe because Rust then changed.

With this PR:
- assignments, `break` and `continue` are allowed to appear without a semicolon if they are the last statement in a block (this matches Rust)
- `let` still requires a semicolon if it's the last statement in a block, and the error message in this case is improved

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
