### PR TITLE
fix: doc comments on functions warn unexpectedly

### DIFF
--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -44,6 +44,8 @@ pub enum ParserErrorReason {
     InvalidPattern,
     #[error("Documentation comment does not document anything")]
     DocCommentDoesNotDocumentAnything,
+    #[error("Documentation comments cannot be applied to function parameters")]
+    DocCommentCannotBeAppliedToFunctionParameters,
 
     #[error("Missing type for function parameter")]
     MissingTypeForFunctionParameter,

--- a/compiler/noirc_frontend/src/parser/parser/doc_comments.rs
+++ b/compiler/noirc_frontend/src/parser/parser/doc_comments.rs
@@ -35,13 +35,20 @@ impl Parser<'_> {
 
     /// Skips any outer doc comments but produces a warning saying that they don't document anything.
     pub(super) fn warn_on_outer_doc_comments(&mut self) {
+        self.skip_doc_comments_with_reason(ParserErrorReason::DocCommentDoesNotDocumentAnything);
+    }
+
+    /// Skips any outer doc comments but produces an error saying that they can't be applied to parameters
+    pub(super) fn error_on_outer_doc_comments_on_parameter(&mut self) {
+        let reason = ParserErrorReason::DocCommentCannotBeAppliedToFunctionParameters;
+        self.skip_doc_comments_with_reason(reason);
+    }
+
+    fn skip_doc_comments_with_reason(&mut self, reason: ParserErrorReason) {
         let location_before_doc_comments = self.current_token_location;
         let doc_comments = self.parse_outer_doc_comments();
         if !doc_comments.is_empty() {
-            self.push_error(
-                ParserErrorReason::DocCommentDoesNotDocumentAnything,
-                location_before_doc_comments,
-            );
+            self.push_error(reason, self.location_since(location_before_doc_comments));
         }
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/doc_comments.rs
+++ b/compiler/noirc_frontend/src/parser/parser/doc_comments.rs
@@ -19,12 +19,13 @@ impl Parser<'_> {
         })
     }
 
-    /// OuterDocComments = outer_doc_comments*
+    /// OuterDocComments = OuterDocComment*
     pub(super) fn parse_outer_doc_comments(&mut self) -> Vec<String> {
         self.parse_many("outer doc comments", without_separator(), Self::parse_outer_doc_comment)
     }
 
-    fn parse_outer_doc_comment(&mut self) -> Option<String> {
+    /// OuterDocComment = outer_doc_comment
+    pub(super) fn parse_outer_doc_comment(&mut self) -> Option<String> {
         self.eat_kind(TokenKind::OuterDocComment).map(|token| match token.into_token() {
             Token::LineComment(comment, Some(DocStyle::Outer))
             | Token::BlockComment(comment, Some(DocStyle::Outer)) => comment,

--- a/noir_stdlib/src/ecdsa_secp256k1.nr
+++ b/noir_stdlib/src/ecdsa_secp256k1.nr
@@ -1,21 +1,20 @@
-// TODO(https://github.com/noir-lang/noir/issues/7711): Switch the regular comments to doc comments once they do not trigger a warning anymore
 #[foreign(ecdsa_secp256k1)]
 // docs:start:ecdsa_secp256k1
-// Verifies a ECDSA signature over the secp256k1 curve.
-// - inputs:
-//     - x coordinate of public key as 32 bytes
-//     - y coordinate of public key as 32 bytes
-//     - the signature, as a 64 bytes array
-//       The signature internally will be represented as `(r, s)`,
-//       where `r` and `s` are fixed-sized big endian scalar values.
-//       As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
-//       while `r` and `s` will both be 32 bytes.
-//       We expect `s` to be normalized. This means given the curve's order,
-//       `s` should be less than or equal to `order / 2`.
-//       This is done to prevent malleability.
-//       For more context regarding malleability you can reference BIP 0062.
-//     - the hash of the message, as a vector of bytes
-// - output: false for failure and true for success
+/// Verifies a ECDSA signature over the secp256k1 curve.
+/// - inputs:
+///     - x coordinate of public key as 32 bytes
+///     - y coordinate of public key as 32 bytes
+///     - the signature, as a 64 bytes array
+///       The signature internally will be represented as `(r, s)`,
+///       where `r` and `s` are fixed-sized big endian scalar values.
+///       As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
+///       while `r` and `s` will both be 32 bytes.
+///       We expect `s` to be normalized. This means given the curve's order,
+///       `s` should be less than or equal to `order / 2`.
+///       This is done to prevent malleability.
+///       For more context regarding malleability you can reference BIP 0062.
+///     - the hash of the message, as a vector of bytes
+/// - output: false for failure and true for success
 pub fn verify_signature<let N: u32>(
     public_key_x: [u8; 32],
     public_key_y: [u8; 32],

--- a/tooling/nargo_fmt/src/formatter/attribute.rs
+++ b/tooling/nargo_fmt/src/formatter/attribute.rs
@@ -15,9 +15,14 @@ impl Formatter<'_> {
         if let Some((function_attribute, index)) = attributes.function {
             all_attributes.insert(index, Attribute::Function(function_attribute));
         }
+
+        // Attributes and doc comments can be mixed, so between each attribute
+        // we format potential doc comments
         for attribute in all_attributes {
+            self.format_outer_doc_comments();
             self.format_attribute(attribute);
         }
+        self.format_outer_doc_comments();
     }
 
     pub(super) fn format_secondary_attributes(&mut self, attributes: Vec<SecondaryAttribute>) {

--- a/tooling/nargo_fmt/src/formatter/item.rs
+++ b/tooling/nargo_fmt/src/formatter/item.rs
@@ -179,3 +179,28 @@ struct ImportGroup {
     visibility: ItemVisibility,
     span_end: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::assert_format;
+
+    #[test]
+    fn formats_item_with_mixed_attributes_and_doc_comments() {
+        let src = "
+        /// One
+        #[one]
+        /// Two
+        #[two]
+        /// Three
+        fn  foo( ) { }
+        ";
+        let expected = "/// One
+#[one]
+/// Two
+#[two]
+/// Three
+fn foo() {}
+";
+        assert_format(src, expected);
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #7711

## Summary

Two things:
1. Doc comments and attributes can now be intermixed, like in Rust
2. Trying to document a function parameter will result in an error, like in Rust (and this error is clearer than the previous warning)

For point 2, I considered whether to produce a warning, given that we produce warnings for stray doc comments in other places. However, I think it should be an error to make it clear that that doc comment does nothing there (Rust will sometimes warn, sometimes error too, and it's not clear why).

Error here:

![image](https://github.com/user-attachments/assets/dfe1be41-5352-4a08-9b81-36e5f78995fa)

No warnings here:

![image](https://github.com/user-attachments/assets/7d04e382-3e7a-4c1c-8851-a3b2c6415318)


## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
