### PR TITLE
feat: add `std::warn::warn`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -256,6 +256,10 @@ pub enum InterpreterError {
     LoopHaltedForUiResponsiveness {
         location: Location,
     },
+    Warning {
+        message: String,
+        location: Location,
+    },
 
     // These cases are not errors, they are just used to prevent us from running more code
     // until the loop can be resumed properly. These cases will never be displayed to users.
@@ -331,7 +335,8 @@ impl InterpreterError {
             | InterpreterError::UnknownArrayLength { location, .. }
             | InterpreterError::CannotInterpretFormatStringWithErrors { location }
             | InterpreterError::GlobalsDependencyCycle { location }
-            | InterpreterError::LoopHaltedForUiResponsiveness { location } => *location,
+            | InterpreterError::LoopHaltedForUiResponsiveness { location }
+            | InterpreterError::Warning { location, .. } => *location,
 
             InterpreterError::FailedToParseMacro { error, .. } => error.location(),
             InterpreterError::NoMatchingImplFound { error } => error.location,
@@ -694,6 +699,9 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 let secondary =
                     "This error doesn't happen in normal executions of `nargo`".to_string();
                 CustomDiagnostic::simple_warning(msg, secondary, *location)
+            }
+            InterpreterError::Warning { message, location } => {
+                CustomDiagnostic::simple_warning(message.into(), String::new(), *location)
             }
         }
     }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -248,6 +248,7 @@ impl Interpreter<'_, '_> {
             "unresolved_type_is_bool" => unresolved_type_is_bool(interner, arguments, location),
             "unresolved_type_is_field" => unresolved_type_is_field(interner, arguments, location),
             "unresolved_type_is_unit" => unresolved_type_is_unit(interner, arguments, location),
+            "warn" => warn(self.elaborator, arguments, location),
             "zeroed" => Ok(zeroed(return_type, location)),
             _ => {
                 let item = format!("Comptime evaluation for builtin function '{name}'");
@@ -1401,6 +1402,18 @@ where
 
     let option_value = f(typ);
     Ok(option(return_type, option_value, location))
+}
+
+// fn warn<T, let N: u32>(message: fmtstr<N, T>) {}
+fn warn(
+    elaborator: &mut Elaborator,
+    arguments: Vec<(Value, Location)>,
+    location: Location,
+) -> IResult<Value> {
+    let message = check_one_argument(arguments, location)?;
+    let (message, _) = get_format_string(elaborator.interner, message)?;
+    elaborator.push_err(InterpreterError::Warning { message: message.to_string(), location });
+    Ok(Value::Unit)
 }
 
 // fn zeroed<T>() -> T

--- a/noir_stdlib/src/lib.nr
+++ b/noir_stdlib/src/lib.nr
@@ -22,6 +22,7 @@ pub mod append;
 pub mod mem;
 pub mod panic;
 pub mod hint;
+pub mod warn;
 
 use convert::AsPrimitive;
 

--- a/noir_stdlib/src/warn.nr
+++ b/noir_stdlib/src/warn.nr
@@ -1,0 +1,5 @@
+/// Produces a warning during compilation.
+///
+/// Note: this function cannot be used at runtime.
+#[builtin(warn)]
+pub comptime fn warn<T, let N: u32>(message: fmtstr<N, T>) {}


### PR DESCRIPTION
# Description

## Problem

Resolves #7714

## Summary

There's some special code here to produce an error if `warn` is used at runtime. Eventually we could control this with another attribute, maybe, though I don't know if we'll have many functions that can only be called at compile-time...

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
