### PR TITLE
chore: Resolve various rustdoc warnings

### DIFF
--- a/acvm-repo/acvm/src/compiler/transformers/csat.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/csat.rs
@@ -10,9 +10,9 @@ use indexmap::IndexMap;
 pub const MIN_EXPRESSION_WIDTH: usize = 3;
 
 /// A transformer which processes any [`Expression`]s to break them up such that they
-/// fit within the [`ProofSystemCompiler`][crate::ProofSystemCompiler]'s width.
+/// fit within the backend's width.
 ///
-/// This transformer is only used when targeting the [`Bounded`][crate::ExpressionWidth::Bounded] configuration.
+/// This transformer is only used when targeting the [`Bounded`][acir::circuit::ExpressionWidth::Bounded] configuration.
 ///
 /// This is done by creating intermediate variables to hold partial calculations and then combining them
 /// to calculate the original expression.

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -35,7 +35,7 @@ pub struct BrilligSolver<'b, F, B: BlackBoxFunctionSolver<F>> {
 }
 
 impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
-    /// Assigns the zero value to all outputs of the given [`Brillig`] bytecode.
+    /// Assigns the zero value to all outputs of a given [brillig call][acir::circuit::opcodes::Opcode::BrilligCall].
     pub(super) fn zero_out_brillig_outputs(
         initial_witness: &mut WitnessMap<F>,
         outputs: &[BrilligOutputs],

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -2827,7 +2827,7 @@ impl<'a> Context<'a> {
         Ok(())
     }
 
-    /// Convert a Vec<AcirVar> into a Vec<AcirValue> using the given result ids.
+    /// Convert a `Vec<AcirVar>` into a `Vec<AcirValue>` using the given result ids.
     /// If the type of a result id is an array, several acir vars are collected into
     /// a single AcirValue::Array of the same length.
     /// If the type of a result id is a slice, the slice length must precede it and we can

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
@@ -260,7 +260,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.deallocate_register(index_at_end_of_array);
     }
 
-    /// Converts a BrilligArray (pointer to [RC, ...items]) to a HeapArray (pointer to [items])
+    /// Converts a BrilligArray (pointer to `[RC, ...items]`) to a HeapArray (pointer to `[items]`)
     pub(crate) fn codegen_brillig_array_to_heap_array(&mut self, array: BrilligArray) -> HeapArray {
         let heap_array = HeapArray { pointer: self.allocate_register(), size: array.size };
         self.codegen_usize_op(array.pointer, heap_array.pointer, BrilligBinaryOp::Add, 1);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -25,7 +25,7 @@ use super::{
 impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
     /// Processes a binary instruction according `operation`.
     ///
-    /// This method will compute lhs <operation> rhs
+    /// This method will compute lhs `<operation>` rhs
     /// and store the result in the `result` register.
     pub(crate) fn binary_instruction(
         &mut self,

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -32,7 +32,7 @@ use serde_with::serde_as;
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub(crate) struct DataFlowGraph {
-    /// Runtime of the [Function] that owns this [DataFlowGraph].
+    /// Runtime of the [function][super::function::Function] that owns this [DataFlowGraph].
     /// This might change during the `runtime_separation` pass where
     /// ACIR functions are cloned as Brillig functions.
     runtime: RuntimeType,

--- a/compiler/noirc_evaluator/src/ssa/ir/map.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/map.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 /// A unique ID corresponding to a value of type T.
 /// This type can be used to retrieve a value of type T from
-/// either a DenseMap<T> or SparseMap<T>.
+/// either a `DenseMap<T>` or `SparseMap<T>`.
 ///
 /// Note that there is nothing in an Id binding it to a particular
 /// DenseMap or SparseMap. If an Id was created to correspond to one
@@ -123,7 +123,7 @@ pub(crate) enum IdDisplayFromStrErr {
     InvalidId(String),
 }
 
-/// The implementation of display and FromStr allows serializing and deserializing an Id<T> to a string.
+/// The implementation of display and FromStr allows serializing and deserializing an `Id<T>` to a string.
 /// This is useful when used as key in a map that has to be serialized to JSON/TOML.
 impl FromStr for Id<super::basic_block::BasicBlock> {
     type Err = IdDisplayFromStrErr;

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -132,7 +132,7 @@ impl Type {
         Type::unsigned(8)
     }
 
-    /// Creates the str<N> type, of the given length N
+    /// Creates the `str<N>` type, of the given length N
     pub(crate) fn str(length: u32) -> Type {
         Type::Array(Arc::new(vec![Type::char()]), length)
     }

--- a/compiler/noirc_evaluator/src/ssa/ir/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/value.rs
@@ -15,7 +15,7 @@ use super::{
 pub(crate) type ValueId = Id<Value>;
 
 /// Value is the most basic type allowed in the IR.
-/// Transition Note: A Id<Value> is similar to `NodeId` in our previous IR.
+/// Transition Note: A `Id<Value>` is similar to `NodeId` in our previous IR.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub(crate) enum Value {
     /// This value was created due to an instruction

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -13,9 +13,8 @@
 //! without the need for multiple passes.
 //!
 //! Other passes perform a certain amount of constant folding automatically as they insert instructions
-//! into the [`DataFlowGraph`] but this pass can become needed if [`DataFlowGraph::set_value`] or
-//! [`DataFlowGraph::set_value_from_id`] are used on a value which enables instructions dependent on the value to
-//! now be simplified.
+//! into the [`DataFlowGraph`] but this pass can become needed if [`DataFlowGraph::set_value_from_id`]
+//! is used on a value which enables instructions dependent on the value to now be simplified.
 //!
 //! This is the only pass which removes duplicated pure [`Instruction`]s however and so is needed when
 //! different blocks are merged, i.e. after the [`flatten_cfg`][super::flatten_cfg] pass.

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining/inline_info.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining/inline_info.rs
@@ -41,7 +41,7 @@ pub(crate) type InlineInfos = BTreeMap<FunctionId, InlineInfo>;
 ///  - main
 ///  - Any Brillig function called from Acir
 ///  - Some Brillig functions depending on aggressiveness and some metrics
-///  - Any Acir functions with a [fold inline type][InlineType::Fold],
+///  - Any Acir functions with a [fold inline type][noirc_frontend::monomorphization::ast::InlineType],
 ///
 /// The returned `InlineInfos` won't have every function in it, only the ones which the algorithm visited.
 pub(crate) fn compute_inline_infos(

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -2,12 +2,13 @@
 //! instructions such that they cover the minimum number of instructions possible.
 //!
 //! The pass works as follows:
-//! - Insert instructions until an [Instruction::EnableSideEffectsIf] is encountered, save this [InstructionId].
+//! - Insert instructions until an [Instruction::EnableSideEffectsIf] is encountered, save this [InstructionId][crate::ssa::ir::instruction::InstructionId].
 //! - Continue inserting instructions until either
-//!     - Another [Instruction::EnableSideEffectsIf] is encountered, if so then drop the previous [InstructionId] in favour
+//!     - Another [Instruction::EnableSideEffectsIf] is encountered, if so then drop the previous [InstructionId][crate::ssa::ir::instruction::InstructionId] in favour
 //!       of this one.
 //!     - An [Instruction] with side-effects is encountered, if so then insert the currently saved [Instruction::EnableSideEffectsIf]
 //!       before the [Instruction]. Continue inserting instructions until the next [Instruction::EnableSideEffectsIf] is encountered.
+//!
 use std::collections::HashSet;
 
 use acvm::{FieldElement, acir::AcirField};

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -597,7 +597,7 @@ impl<'a> FunctionContext<'a> {
     /// Inserts a call instruction at the end of the current block and returns the results
     /// of the call.
     ///
-    /// Compared to self.builder.insert_call, this version will reshape the returned Vec<ValueId>
+    /// Compared to self.builder.insert_call, this version will reshape the returned `Vec<ValueId>`
     /// back into a Values tree of the proper shape.
     pub(super) fn insert_call(
         &mut self,
@@ -728,10 +728,12 @@ impl<'a> FunctionContext<'a> {
     /// Method: First `extract_current_value` must recurse on the lvalue to extract the current
     ///         value contained:
     ///
+    /// ```text
     /// v0 = foo.bar                 ; allocate instruction for bar
     /// v1 = load v0                 ; loading the bar array
     /// v2 = add i1, baz_index       ; field offset for index i1, field baz
     /// v3 = array_get v1, index v2  ; foo.bar[i1].baz
+    /// ```
     ///
     /// Method (part 2): Then, `assign_new_value` will recurse in the opposite direction to
     ///                  construct the larger value as needed until we can `store` to the nearest
@@ -790,7 +792,7 @@ impl<'a> FunctionContext<'a> {
     }
 
     /// Compile the given `array[index]` expression as a reference.
-    /// This will return a triple of (array, index, lvalue_ref, Option<length>) where the lvalue_ref records the
+    /// This will return a triple of (array, index, lvalue_ref, `Option<length>`) where the lvalue_ref records the
     /// structure of the lvalue expression for use by `assign_new_value`.
     /// The optional length is for indexing slices rather than arrays since slices
     /// are represented as a tuple in the form: (length, slice contents).

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/value.rs
@@ -98,7 +98,7 @@ impl<T> Tree<T> {
 
     /// Calls the given function on each leaf node, mapping this tree into a new one.
     ///
-    /// Because the given function returns a Tree<U> rather than a U, it is possible
+    /// Because the given function returns a `Tree<U>` rather than a U, it is possible
     /// to use this function to turn Leaf nodes into either other Leaf nodes or even Branch nodes.
     pub(super) fn map<U>(self, mut f: impl FnMut(T) -> Tree<U>) -> Tree<U> {
         self.map_helper(&mut f)
@@ -173,7 +173,7 @@ impl Tree<Type> {
 }
 
 impl Tree<Value> {
-    /// Flattens and evaluates this Tree<Value> into a list of ir values
+    /// Flattens and evaluates this `Tree<Value>` into a list of ir values
     /// for return statements, branching instructions, or function parameters.
     pub(super) fn into_value_list(self, ctx: &mut FunctionContext) -> Vec<IrValueId> {
         vecmap(self.flatten(), |value| value.eval(ctx))

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -798,6 +798,7 @@ impl ForRange {
     /// Create a 'for' expression taking care of desugaring a 'for e in array' loop
     /// into the following if needed:
     ///
+    /// ```text
     /// {
     ///     let fresh1 = array;
     ///     for fresh2 in 0 .. std::array::len(fresh1) {
@@ -805,6 +806,7 @@ impl ForRange {
     ///         ...
     ///     }
     /// }
+    /// ````
     pub(crate) fn into_for(
         self,
         identifier: Ident,

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -794,8 +794,8 @@ impl Elaborator<'_> {
 
     /// Compiles the rows of a match expression, outputting a decision tree for the match.
     ///
-    /// This is an adaptation of https://github.com/yorickpeterse/pattern-matching-in-rust/tree/main/jacobs2021
-    /// which is an implementation of https://julesjacobs.com/notes/patternmatching/patternmatching.pdf
+    /// This is an adaptation of <https://github.com/yorickpeterse/pattern-matching-in-rust/tree/main/jacobs2021>
+    /// which is an implementation of <https://julesjacobs.com/notes/patternmatching/patternmatching.pdf>
     pub(super) fn elaborate_match_rows(
         &mut self,
         rows: Vec<Row>,

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -599,9 +599,11 @@ impl Elaborator<'_> {
 
     /// Solve any generics that are part of the path before the function, for example:
     ///
+    /// ```rust
     /// foo::Bar::<i32>::baz
     ///           ^^^^^
     ///         solve these
+    /// ```
     fn resolve_item_turbofish(&mut self, item: PathResolutionItem) -> Vec<Type> {
         match item {
             PathResolutionItem::Method(struct_id, Some(generics), _func_id) => {

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -260,7 +260,7 @@ impl Elaborator<'_> {
 /// `impl<C> Foo<D> for Bar<E> { fn foo<F>(...); } `
 ///
 /// We have to substitute:
-/// - Self for Bar<E>
+/// - Self for `Bar<E>`
 /// - A for D
 /// - B for F
 ///

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -260,9 +260,9 @@ impl Elaborator<'_> {
 /// `impl<C> Foo<D> for Bar<E> { fn foo<F>(...); } `
 ///
 /// We have to substitute:
-/// - Self for `Bar<E>`
-/// - A for D
-/// - B for F
+/// - `Self` for `Bar<E>`
+/// - `A` for `D`
+/// - `B` for `F`
 ///
 /// Before we can type check. Finally, we must also check that the unification
 /// result does not introduce any new bindings. This can happen if the impl

--- a/compiler/noirc_frontend/src/graph/mod.rs
+++ b/compiler/noirc_frontend/src/graph/mod.rs
@@ -117,7 +117,7 @@ impl CrateGraph {
     /// Tries to find the requested crate in the current one's dependencies,
     /// otherwise walks down the crate dependency graph from crate_id until we reach it.
     /// This is needed in case a library (lib1) re-export a structure defined in another library (lib2)
-    /// In that case, we will get [lib1,lib2] when looking for a struct defined in lib2,
+    /// In that case, we will get `[lib1,lib2]` when looking for a struct defined in lib2,
     /// re-exported by lib1 and used by the main crate.
     /// Returns the path from crate_id to target_crate_id
     pub(crate) fn find_dependencies(

--- a/compiler/noirc_frontend/src/graph/mod.rs
+++ b/compiler/noirc_frontend/src/graph/mod.rs
@@ -116,7 +116,7 @@ pub struct CrateGraph {
 impl CrateGraph {
     /// Tries to find the requested crate in the current one's dependencies,
     /// otherwise walks down the crate dependency graph from crate_id until we reach it.
-    /// This is needed in case a library (lib1) re-export a structure defined in another library (lib2)
+    /// This is needed in case a library (`lib1`) re-export a structure defined in another library (`lib2`)
     /// In that case, we will get `[lib1,lib2]` when looking for a struct defined in lib2,
     /// re-exported by lib1 and used by the main crate.
     /// Returns the path from crate_id to target_crate_id

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -471,7 +471,7 @@ fn type_def_as_type(
     Ok(Value::Type(Type::DataType(type_def_rc, generics)))
 }
 
-/// fn generics(self) -> [(Type, Option<Type>)]
+/// fn generics(self) -> [(Type, `Option<Type>`)]
 fn type_def_generics(
     interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,
@@ -3002,7 +3002,7 @@ pub(crate) fn option(option_type: Type, value: Option<Value>, location: Location
     Value::Struct(fields, option_type)
 }
 
-/// Given a type, assert that it's an Option<T> and return the Type for T
+/// Given a type, assert that it's an `Option<T>` and return the Type for T
 pub(crate) fn extract_option_generic_type(typ: Type) -> Type {
     let Type::DataType(struct_type, mut generics) = typ else {
         panic!("Expected type to be a struct");

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -196,7 +196,7 @@ pub struct NodeInterner {
     func_id_to_trait: HashMap<FuncId, (Type, TraitId)>,
 
     /// A list of all type aliases that are referenced in the program.
-    /// Searched by LSP to resolve [Location]s of [TypeAliasType]s
+    /// Searched by LSP to resolve [Location]s of [TypeAlias]s
     pub(crate) type_alias_ref: Vec<(TypeAliasId, Location)>,
 
     /// Stores the [Location] of a [Type] reference

--- a/compiler/noirc_frontend/src/resolve_locations.rs
+++ b/compiler/noirc_frontend/src/resolve_locations.rs
@@ -177,7 +177,7 @@ impl NodeInterner {
         )
     }
 
-    /// Attempts to resolve [Location] of [Trait] based on [Location] of [TraitImpl]
+    /// Attempts to resolve [Location] of [Trait][crate::hir_def::traits::Trait] based on [Location] of [TraitImpl][crate::hir_def::traits::TraitImpl]
     /// This is used by LSP to resolve the location of a trait based on the location of a trait impl.
     ///
     /// Example:
@@ -195,7 +195,7 @@ impl NodeInterner {
             })
     }
 
-    /// Attempts to resolve [Location] of [Trait]'s [TraitFunction] declaration based on [Location] of [TraitFunction] call.
+    /// Attempts to resolve [Location] of [Trait][crate::hir_def::traits::Trait]'s [TraitFunction][crate::hir_def::traits::TraitFunction] declaration based on the [Location] of a [TraitFunction][crate::hir_def::traits::TraitFunction] call.
     ///
     /// This is used by LSP to resolve the location.
     ///

--- a/tooling/fuzzer/src/dictionary/mod.rs
+++ b/tooling/fuzzer/src/dictionary/mod.rs
@@ -18,7 +18,7 @@ use acvm::{
     brillig_vm::brillig::Opcode as BrilligOpcode,
 };
 
-/// Constructs a [HashSet<F>] of values pulled from a [Program<F>] which are likely to be correspond
+/// Constructs a [`HashSet<F>`] of values pulled from a [`Program<F>`] which are likely to be correspond
 /// to significant inputs during fuzzing.
 pub(super) fn build_dictionary_from_program<F: AcirField>(program: &Program<F>) -> HashSet<F> {
     let constrained_dictionaries = program.functions.iter().map(build_dictionary_from_circuit);

--- a/tooling/fuzzer/src/strategies/mod.rs
+++ b/tooling/fuzzer/src/strategies/mod.rs
@@ -81,7 +81,7 @@ pub(super) fn arb_value_from_abi_type(
     }
 }
 
-/// Given the [Abi] description of a [ProgramArtifact], generate random [InputValue]s for each circuit parameter.
+/// Given the [Abi] description of a [program artifact][noirc_artifacts::program::ProgramArtifact], generate random [InputValue]s for each circuit parameter.
 ///
 /// Use the `dictionary` to draw values from for numeric types.
 pub(super) fn arb_input_map(


### PR DESCRIPTION
# Description

## Problem\*

No issue, part of general documentation drive

## Summary\*

I was generating docs locally with `cargo doc`. Resolving a bunch of various warnings.

One example of an issue that currently exists: text such as Tree<T> is seen as an unclosed html tag. It needs to be wrapped in a source code block `Tree<T>`. In this case it caused unnecessary underlining:
<img width="1012" alt="Screenshot 2025-03-14 at 3 58 16 PM" src="https://github.com/user-attachments/assets/f1110528-5261-4740-aed3-e47f4c1dccc9" />

## Additional Context


## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X]  I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
