### PR TITLE
chore: removed redundant `.clone()` in `insert_expr` function

### DIFF
--- a/tooling/fuzzer/src/dictionary/mod.rs
+++ b/tooling/fuzzer/src/dictionary/mod.rs
@@ -43,7 +43,7 @@ fn build_dictionary_from_circuit<F: AcirField>(circuit: &Circuit<F>) -> HashSet<
         let linear_coefficients = expr.linear_combinations.iter().map(|(k, _)| *k);
         let coefficients = linear_coefficients.chain(quad_coefficients);
 
-        dictionary.extend(coefficients.clone());
+        dictionary.extend(coefficients);
         dictionary.insert(expr.q_c);
 
         // We divide the constant term by any coefficients in the expression to aid solving constraints such as `2 * x - 4 == 0`.


### PR DESCRIPTION
# Description  
In the `insert_expr` function, I removed the unnecessary `.clone()` call on `coefficients` since `coefficients` is already an iterator. This change simplifies the code and avoids redundant cloning.

## Additional Context  
This change optimizes performance slightly by removing an unnecessary operation in the code. No logic was altered.

## Documentation  
Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [[Prettier](https://prettier.io/)](https://prettier.io/) and/or `cargo fmt` on default settings.