### PR TITLE
fix: handle predicate value reduction in array get also for the databus

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -1392,22 +1392,21 @@ impl<'a> Context<'a> {
         // Get operations to call-data parameters are replaced by a get to the call-data-bus array
         let call_data =
             self.data_bus.call_data.iter().find(|cd| cd.index_map.contains_key(&array)).cloned();
-        let mut value;
-        if let Some(call_data) = call_data {
+        let value = if let Some(call_data) = call_data {
             let call_data_block = self.ensure_array_is_initialized(call_data.array_id, dfg)?;
             let bus_index = self
                 .acir_context
                 .add_constant(FieldElement::from(call_data.index_map[&array] as i128));
             let mut current_index = self.acir_context.add_var(bus_index, var_index)?;
-            value = self.get_from_call_data(&mut current_index, call_data_block, &res_typ)?;
+            self.get_from_call_data(&mut current_index, call_data_block, &res_typ)?
         } else {
             // Compiler sanity check
             assert!(
                 !res_typ.contains_slice_element(),
                 "ICE: Nested slice result found during ACIR generation"
             );
-            value = self.array_get_value(&res_typ, block_id, &mut var_index)?;
-        }
+            self.array_get_value(&res_typ, block_id, &mut var_index)?
+        };
 
         if let AcirValue::Var(value_var, typ) = &value {
             let array_typ = dfg.type_of_value(array);

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -1392,22 +1392,22 @@ impl<'a> Context<'a> {
         // Get operations to call-data parameters are replaced by a get to the call-data-bus array
         let call_data =
             self.data_bus.call_data.iter().find(|cd| cd.index_map.contains_key(&array)).cloned();
+        let mut value;
         if let Some(call_data) = call_data {
             let call_data_block = self.ensure_array_is_initialized(call_data.array_id, dfg)?;
             let bus_index = self
                 .acir_context
                 .add_constant(FieldElement::from(call_data.index_map[&array] as i128));
             let mut current_index = self.acir_context.add_var(bus_index, var_index)?;
-            let result = self.get_from_call_data(&mut current_index, call_data_block, &res_typ)?;
-            self.define_result(dfg, instruction, result.clone());
-            return Ok(result);
+            value = self.get_from_call_data(&mut current_index, call_data_block, &res_typ)?;
+        } else {
+            // Compiler sanity check
+            assert!(
+                !res_typ.contains_slice_element(),
+                "ICE: Nested slice result found during ACIR generation"
+            );
+            value = self.array_get_value(&res_typ, block_id, &mut var_index)?;
         }
-        // Compiler sanity check
-        assert!(
-            !res_typ.contains_slice_element(),
-            "ICE: Nested slice result found during ACIR generation"
-        );
-        let mut value = self.array_get_value(&res_typ, block_id, &mut var_index)?;
 
         if let AcirValue::Var(value_var, typ) = &value {
             let array_typ = dfg.type_of_value(array);

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -1392,7 +1392,7 @@ impl<'a> Context<'a> {
         // Get operations to call-data parameters are replaced by a get to the call-data-bus array
         let call_data =
             self.data_bus.call_data.iter().find(|cd| cd.index_map.contains_key(&array)).cloned();
-        let value = if let Some(call_data) = call_data {
+        let mut value = if let Some(call_data) = call_data {
             let call_data_block = self.ensure_array_is_initialized(call_data.array_id, dfg)?;
             let bus_index = self
                 .acir_context

--- a/test_programs/execution_success/regression_7612/Nargo.toml
+++ b/test_programs/execution_success/regression_7612/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7612"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_7612/Prover.toml
+++ b/test_programs/execution_success/regression_7612/Prover.toml
@@ -1,0 +1,2 @@
+array = [{ counter = 8, fields = ["0x200000000"] }]
+x = true

--- a/test_programs/execution_success/regression_7612/src/main.nr
+++ b/test_programs/execution_success/regression_7612/src/main.nr
@@ -1,0 +1,11 @@
+pub struct Data {
+    fields: [Field; 1],
+    counter: u32,
+}
+
+fn main(array: call_data(0) [Data; 1], x: bool) {
+    let index = if x { 0 } else { 1 };
+    if index != 0 {
+        assert(array[index - 1].counter < 3);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7612

## Summary\*
The databus redirect usage of call data parameters to reads into the call data array, but these reads where not reducing the returned value in case a false predicate makes use of an incompatible type.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
