### PR TITLE
chore(ci): private-kernel-inner timeout bump

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -5,7 +5,7 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/private-kernel-inner
     num_runs: 5
-    compilation-timeout: 2.5
+    compilation-timeout: 3.0
     execution-timeout: 0.08
     compilation-memory-limit: 350
     execution-memory-limit: 250


### PR DESCRIPTION
# Description

## Problem\*

No issue, this just keeps being flake-y for me. On my docs PRs that do not touch any compiler logic I keep timing out https://github.com/noir-lang/noir/actions/runs/13909635066/job/38920891470?pr=7731.

## Summary\*

Bump `private-kernel-inner` timeout from 2.5s to 3s.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
