### PR TITLE
chore(refactor): Move resolved error structures out of acir crate

### DIFF
--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -135,16 +135,6 @@ pub enum ResolvedAssertionPayload<F> {
     Raw(RawAssertionPayload<F>),
 }
 
-#[derive(Debug, Copy, Clone)]
-/// The opcode location for a call to a separate ACIR circuit
-/// This includes the function index of the caller within a [program][Program]
-/// and the index in the callers ACIR to the specific call opcode.
-/// This is only resolved and set during circuit execution.
-pub struct ResolvedOpcodeLocation {
-    pub acir_function_index: usize,
-    pub opcode_location: OpcodeLocation,
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "arb", derive(proptest_derive::Arbitrary))]
 /// Opcodes are locatable so that callers can

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -123,18 +123,6 @@ impl<'de> Deserialize<'de> for ErrorSelector {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub struct RawAssertionPayload<F> {
-    pub selector: ErrorSelector,
-    pub data: Vec<F>,
-}
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum ResolvedAssertionPayload<F> {
-    String(String),
-    Raw(RawAssertionPayload<F>),
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "arb", derive(proptest_derive::Arbitrary))]
 /// Opcodes are locatable so that callers can

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -4,7 +4,7 @@ use acir::{
     AcirField,
     brillig::{ForeignCallParam, ForeignCallResult, Opcode as BrilligOpcode},
     circuit::{
-        ErrorSelector, OpcodeLocation, RawAssertionPayload, ResolvedAssertionPayload,
+        OpcodeLocation,
         brillig::{BrilligFunctionId, BrilligInputs, BrilligOutputs},
         opcodes::BlockId,
     },
@@ -16,7 +16,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{OpcodeResolutionError, pwg::OpcodeNotSolvable};
 
-use super::{get_value, insert_value, memory_op::MemoryOpSolver};
+use super::{
+    ErrorSelector, RawAssertionPayload, ResolvedAssertionPayload, get_value, insert_value,
+    memory_op::MemoryOpSolver,
+};
 
 #[derive(Debug)]
 pub enum BrilligSolverStatus<F> {

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -7,7 +7,6 @@ use acir::{
     brillig::ForeignCallResult,
     circuit::{
         AssertionPayload, ErrorSelector, ExpressionOrMemory, Opcode, OpcodeLocation,
-        RawAssertionPayload, ResolvedAssertionPayload,
         brillig::{BrilligBytecode, BrilligFunctionId},
         opcodes::{
             AcirFunctionId, BlockId, ConstantOrWitnessEnum, FunctionInput, InvalidInputBitSize,
@@ -34,6 +33,7 @@ mod memory_op;
 
 pub use self::brillig::{BrilligSolver, BrilligSolverStatus};
 pub use brillig::ForeignCallWaitInfo;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ACVMStatus<F> {
@@ -115,6 +115,18 @@ impl std::fmt::Display for ErrorLocation {
             }
         }
     }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct RawAssertionPayload<F> {
+    pub selector: ErrorSelector,
+    pub data: Vec<F>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ResolvedAssertionPayload<F> {
+    String(String),
+    Raw(RawAssertionPayload<F>),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Error)]

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -1,12 +1,11 @@
 use std::{future::Future, pin::Pin};
 
-use acvm::acir::circuit::ResolvedAssertionPayload;
 use acvm::acir::circuit::brillig::BrilligBytecode;
 use acvm::{BlackBoxFunctionSolver, FieldElement};
 use acvm::{
     acir::circuit::{Circuit, Program},
     acir::native_types::{WitnessMap, WitnessStack},
-    pwg::{ACVM, ACVMStatus, ErrorLocation, OpcodeResolutionError},
+    pwg::{ACVM, ACVMStatus, ErrorLocation, OpcodeResolutionError, ResolvedAssertionPayload},
 };
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 

--- a/acvm-repo/acvm_js/src/js_execution_error.rs
+++ b/acvm-repo/acvm_js/src/js_execution_error.rs
@@ -1,6 +1,7 @@
 use acvm::{
     FieldElement,
-    acir::circuit::{OpcodeLocation, RawAssertionPayload, brillig::BrilligFunctionId},
+    acir::circuit::{OpcodeLocation, brillig::BrilligFunctionId},
+    pwg::RawAssertionPayload,
 };
 use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{Array, Error, JsString, Reflect};

--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -2,11 +2,8 @@ use std::collections::BTreeMap;
 
 use acvm::{
     AcirField, FieldElement,
-    acir::circuit::{
-        ErrorSelector, OpcodeLocation, RawAssertionPayload, ResolvedAssertionPayload,
-        ResolvedOpcodeLocation, brillig::BrilligFunctionId,
-    },
-    pwg::{ErrorLocation, OpcodeResolutionError},
+    acir::circuit::{ErrorSelector, OpcodeLocation, brillig::BrilligFunctionId},
+    pwg::{ErrorLocation, OpcodeResolutionError, RawAssertionPayload, ResolvedAssertionPayload},
 };
 use noirc_abi::{Abi, AbiErrorType, display_abi_error};
 use noirc_errors::{CustomDiagnostic, debug_info::DebugInfo, reporter::ReportedErrors};
@@ -84,6 +81,16 @@ impl<F: AcirField> NargoError<F> {
             _ => None,
         }
     }
+}
+
+#[derive(Debug, Copy, Clone)]
+/// The opcode location for a call to a separate ACIR circuit
+/// This includes the function index of the caller within a [program][Program]
+/// and the index in the callers ACIR to the specific call opcode.
+/// This is only resolved and set during circuit execution.
+pub struct ResolvedOpcodeLocation {
+    pub acir_function_index: usize,
+    pub opcode_location: OpcodeLocation,
 }
 
 #[derive(Debug, Error)]

--- a/tooling/nargo/src/ops/execute.rs
+++ b/tooling/nargo/src/ops/execute.rs
@@ -1,16 +1,15 @@
 use acvm::acir::circuit::brillig::BrilligBytecode;
-use acvm::acir::circuit::{
-    OpcodeLocation, Program, ResolvedAssertionPayload, ResolvedOpcodeLocation,
-};
+use acvm::acir::circuit::{OpcodeLocation, Program};
 use acvm::acir::native_types::WitnessStack;
 use acvm::pwg::{
     ACVM, ACVMStatus, ErrorLocation, OpcodeNotSolvable, OpcodeResolutionError, ProfilingSamples,
+    ResolvedAssertionPayload,
 };
 use acvm::{AcirField, BlackBoxFunctionSolver};
 use acvm::{acir::circuit::Circuit, acir::native_types::WitnessMap};
 
 use crate::NargoError;
-use crate::errors::ExecutionError;
+use crate::errors::{ExecutionError, ResolvedOpcodeLocation};
 use crate::foreign_calls::ForeignCallExecutor;
 
 struct ProgramExecutor<'a, F: AcirField, B: BlackBoxFunctionSolver<F>, E: ForeignCallExecutor<F>> {

--- a/tooling/noirc_abi_wasm/src/lib.rs
+++ b/tooling/noirc_abi_wasm/src/lib.rs
@@ -7,10 +7,8 @@ use getrandom as _;
 
 use acvm::{
     FieldElement,
-    acir::{
-        circuit::RawAssertionPayload,
-        native_types::{WitnessMap, WitnessStack},
-    },
+    acir::native_types::{WitnessMap, WitnessStack},
+    pwg::RawAssertionPayload,
 };
 use iter_extended::try_btree_map;
 use noirc_abi::{


### PR DESCRIPTION
# Description

## Problem\*

No issue, just something I noticed while working on docs.

We have structures that are only created only for resolution of errors that live in the acir crate. This location feels unnatural.

## Summary\*

Move `ResolvedOpcodeLocation`, `RawAssertionPayload`, and `ResolvedAssertionPayload` out of the `acir` crate.  `RawAssertionPayload` and `ResolvedAssertionPayload` are part of the `acvm` crate where they are instantiated and `ResolvedOpcodeLocation` has been moved to `nargo`.

## Additional Context

I want to move `ErrorSelector` out of the `acir` crate as well as it has nothing to do with the circuit definition and is only used for resolving errors in the ABI. As we lean into the ABI for error resolution we should not need any error context as part of the `acir` definition. I didn't do it in this PR yet as it is used across more crates and would require some more refactors. 

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
