### PR TITLE
chore(ci): enforce rustdoc lints

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -65,6 +65,32 @@ jobs:
       - name: Run `cargo fmt`
         run: cargo fmt --all --check
 
+  rustdoc:
+    name: cargo fmt
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@1.85.0
+        with:
+          targets: x86_64-unknown-linux-gnu
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: x86_64-unknown-linux-gnu
+          cache-on-failure: true
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: Run `cargo doc`
+        run: cargo doc --no-deps --document-private-items --workspace
+
   eslint:
     name: eslint
     runs-on: ubuntu-22.04
@@ -143,6 +169,7 @@ jobs:
     needs:
       - clippy
       - rustfmt
+      - rustdoc
       - eslint
       - nargo_fmt
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -66,7 +66,7 @@ jobs:
         run: cargo fmt --all --check
 
   rustdoc:
-    name: cargo fmt
+    name: cargo doc
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:

--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -85,7 +85,7 @@ impl<F: AcirField> NargoError<F> {
 
 #[derive(Debug, Copy, Clone)]
 /// The opcode location for a call to a separate ACIR circuit
-/// This includes the function index of the caller within a [program][Program]
+/// This includes the function index of the caller within a [program][acvm::acir::circuit::Program]
 /// and the index in the callers ACIR to the specific call opcode.
 /// This is only resolved and set during circuit execution.
 pub struct ResolvedOpcodeLocation {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR enforces that we don't trigger any rustdoc lints due to broken links and the such in future.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
