### PR TITLE
chore: Add GITHUB_TOKEN for downloading prost_prebuilt to acvm.js build

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -202,6 +202,8 @@ jobs:
 
       - name: Build acvm_js
         run: ./.github/scripts/acvm_js-build.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

## Problem\*

Occasionally we get limited in https://github.com/noir-lang/noir/actions/runs/13932331691/job/38992290927#step:6:1

## Summary\*

Adds the `GITHUB_TOKEN` to the workflow to avoid getting rate limited.

## Additional Context

The build happens [here](https://github.com/noir-lang/noir/blob/24e2217347cf8a0021d419fa992e1c09316e77b0/acvm-repo/acvm_js/build.sh#L49).

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
