### PR TITLE
fix: add missing inputs to `BlackBoxFuncCall::get_inputs_vec` for EcAdd

### DIFF
--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -394,7 +394,7 @@ impl<F: Copy> BlackBoxFuncCall<F> {
                 inputs
             }
             BlackBoxFuncCall::EmbeddedCurveAdd { input1, input2, .. } => {
-                vec![input1[0], input1[1], input2[0], input2[1]]
+                vec![input1[0], input1[1], input1[2], input2[0], input2[1], input2[2]]
             }
             BlackBoxFuncCall::RANGE { input } => vec![*input],
             BlackBoxFuncCall::EcdsaSecp256k1 {

--- a/test_programs/compile_success_empty/regression_7749/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_7749/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7744"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_7749/src/main.nr
+++ b/test_programs/compile_success_empty/regression_7749/src/main.nr
@@ -1,0 +1,9 @@
+// https://github.com/noir-lang/noir/issues/7749
+
+fn main() {
+    let pt_y = 17631683881184975370165255887551781615748388533673675138860;
+    let pt = std::embedded_curve_ops::EmbeddedCurvePoint { x: 1, y: pt_y, is_infinite: false };
+    let pt_2x = pt.double();
+    let pt_4x = pt_2x.double();
+    assert(pt_2x != pt_4x);
+}

--- a/test_programs/execution_success/regression_7744/Nargo.toml
+++ b/test_programs/execution_success/regression_7744/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_7744"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_7744/Prover.toml
+++ b/test_programs/execution_success/regression_7744/Prover.toml
@@ -1,0 +1,1 @@
+is_active=false

--- a/test_programs/execution_success/regression_7744/src/main.nr
+++ b/test_programs/execution_success/regression_7744/src/main.nr
@@ -1,6 +1,6 @@
 // https://github.com/noir-lang/noir/issues/7744
 
-use std::embedded_curve_ops::{EmbeddedCurvePoint, embedded_curve_add_unsafe};
+use std::embedded_curve_ops::{embedded_curve_add_unsafe, EmbeddedCurvePoint};
 
 // is_active = false
 fn main(is_active: bool) -> pub EmbeddedCurvePoint {

--- a/test_programs/execution_success/regression_7744/src/main.nr
+++ b/test_programs/execution_success/regression_7744/src/main.nr
@@ -1,0 +1,13 @@
+// https://github.com/noir-lang/noir/issues/7744
+
+use std::embedded_curve_ops::{EmbeddedCurvePoint, embedded_curve_add_unsafe};
+
+// is_active = false
+fn main(is_active: bool) -> pub EmbeddedCurvePoint {
+    let bad = EmbeddedCurvePoint { x: 0, y: 5, is_infinite: false };
+    if is_active {
+        embedded_curve_add_unsafe(bad, bad)
+    } else {
+        bad
+    }
+}

--- a/test_programs/execution_success/regression_7744/stdout.txt
+++ b/test_programs/execution_success/regression_7744/stdout.txt
@@ -1,3 +1,1 @@
-[regression_7744] Circuit witness successfully solved
-[regression_7744] Witness saved to /mnt/user-data/tom/noir/test_programs/execution_success/regression_7744/target/regression_7744.gz
 [regression_7744] Circuit output: Struct({"is_infinite": Field(0), "x": Field(0), "y": Field(5)})

--- a/test_programs/execution_success/regression_7744/stdout.txt
+++ b/test_programs/execution_success/regression_7744/stdout.txt
@@ -1,0 +1,3 @@
+[regression_7744] Circuit witness successfully solved
+[regression_7744] Witness saved to /mnt/user-data/tom/noir/test_programs/execution_success/regression_7744/target/regression_7744.gz
+[regression_7744] Circuit output: Struct({"is_infinite": Field(0), "x": Field(0), "y": Field(5)})

--- a/test_programs/format.sh
+++ b/test_programs/format.sh
@@ -25,6 +25,12 @@ function collect_dirs {
       continue
     fi
 
+    if [[ ! -f "$current_dir/$1/$dir/Nargo.toml" ]]; then
+      echo "No Nargo.toml found in $dir. Removing directory."
+      rm -rf "$current_dir/$1/$dir"
+      echo "$dir: skipped (no Nargo.toml)"
+    fi
+
     echo "  \"$1/$dir\"," >> Nargo.toml
 done
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7744
Resolves #7749

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
