### PR TITLE
Convert frontend tests to compilation tests

### DIFF
--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -9,7 +9,7 @@ use noirc_abi::{
 use noirc_errors::Location;
 use noirc_evaluator::ErrorType;
 use noirc_frontend::TypeBinding;
-use noirc_frontend::ast::{Signedness, Visibility};
+use noirc_frontend::shared::{Signedness, Visibility};
 use noirc_frontend::{
     hir::Context,
     hir_def::{

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -31,7 +31,7 @@ use acvm::{
 use ir::instruction::ErrorType;
 use noirc_errors::debug_info::{DebugFunctions, DebugInfo, DebugTypes, DebugVariables};
 
-use noirc_frontend::ast::Visibility;
+use noirc_frontend::shared::Visibility;
 use noirc_frontend::{hir_def::function::FunctionSignature, monomorphization::ast::Program};
 use ssa_gen::Ssa;
 use tracing::{Level, span};

--- a/compiler/noirc_evaluator/src/ssa/function_builder/data_bus.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/data_bus.rs
@@ -7,8 +7,8 @@ use crate::ssa::ir::{
 };
 use acvm::FieldElement;
 use fxhash::FxHashMap as HashMap;
-use noirc_frontend::ast;
 use noirc_frontend::hir_def::function::FunctionSignature;
+use noirc_frontend::shared::Visibility;
 use serde::{Deserialize, Serialize};
 
 use super::FunctionBuilder;
@@ -48,9 +48,9 @@ impl DataBusBuilder {
 
         for param in &main_signature.0 {
             let is_databus = match param.2 {
-                ast::Visibility::Public | ast::Visibility::Private => DatabusVisibility::None,
-                ast::Visibility::CallData(id) => DatabusVisibility::CallData(id),
-                ast::Visibility::ReturnData => DatabusVisibility::ReturnData,
+                Visibility::Public | Visibility::Private => DatabusVisibility::None,
+                Visibility::CallData(id) => DatabusVisibility::CallData(id),
+                Visibility::ReturnData => DatabusVisibility::ReturnData,
             };
             let len = param.1.field_count(&param.0.location()) as usize;
             params_is_databus.extend(vec![is_databus; len]);

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -4,9 +4,11 @@ use std::sync::{Arc, Mutex, RwLock};
 use acvm::{FieldElement, acir::AcirField};
 use iter_extended::vecmap;
 use noirc_errors::Location;
-use noirc_frontend::ast::{BinaryOpKind, Signedness};
-use noirc_frontend::monomorphization::ast::{self, GlobalId, InlineType, LocalId, Parameters};
-use noirc_frontend::monomorphization::ast::{FuncId, Program};
+use noirc_frontend::ast::BinaryOpKind;
+use noirc_frontend::monomorphization::ast::{
+    self, FuncId, GlobalId, InlineType, LocalId, Parameters, Program,
+};
+use noirc_frontend::shared::Signedness;
 use noirc_frontend::signed_field::SignedField;
 
 use crate::errors::RuntimeError;

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -10,9 +10,10 @@ pub(crate) use program::Ssa;
 use context::{Loop, SharedContext};
 use iter_extended::{try_vecmap, vecmap};
 use noirc_errors::Location;
-use noirc_frontend::ast::{UnaryOp, Visibility};
+use noirc_frontend::ast::UnaryOp;
 use noirc_frontend::hir_def::types::Type as HirType;
 use noirc_frontend::monomorphization::ast::{self, Expression, MatchCase, Program, While};
+use noirc_frontend::shared::Visibility;
 
 use crate::{
     errors::RuntimeError,

--- a/compiler/noirc_frontend/rb.rb
+++ b/compiler/noirc_frontend/rb.rb
@@ -1,0 +1,26 @@
+require 'fileutils'
+require 'pathname'
+
+# for each file in tmp:
+# - make test in compile_success_empty
+# - use file name as crate name
+# - make crate w/ Nargo.toml
+# - put contents of file in main.nr
+Dir['tmp/*'].each do |tmp_path|
+  original_tmp_path = tmp_path
+  tmp_path = Pathname.new tmp_path
+  tmp_path = tmp_path.basename.to_s
+
+  # tests_dir = Pathname.new("../../test_programs/compile_success_empty")
+  tests_dir = Pathname.new("../../test_programs/compile_success_no_bug")
+  test_dir = tests_dir.join(tmp_path)
+  nargo_path = test_dir.join('Nargo.toml')
+  src_dir = test_dir.join('src')
+  main_path = src_dir.join('main.nr')
+  FileUtils.mkdir_p src_dir
+
+  p tmp_path
+  File.write(nargo_path, "[package]\nname = \"#{tmp_path}\"\ntype = \"bin\"\nauthors = [\"\"]\n\n[dependencies]\n")
+  File.write(main_path, File.read(original_tmp_path))
+end
+

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -5,9 +5,10 @@ use thiserror::Error;
 
 use crate::ast::{
     Ident, ItemVisibility, Path, Pattern, Statement, StatementKind, UnresolvedTraitConstraint,
-    UnresolvedType, UnresolvedTypeData, Visibility,
+    UnresolvedType, UnresolvedTypeData,
 };
 use crate::node_interner::{ExprId, InternedExpressionKind, InternedStatementKind, QuotedTypeId};
+use crate::shared::Visibility;
 use crate::signed_field::SignedField;
 use crate::token::{Attributes, FmtStrFragment, FunctionAttribute, Token, Tokens};
 use crate::{Kind, Type};

--- a/compiler/noirc_frontend/src/ast/function.rs
+++ b/compiler/noirc_frontend/src/ast/function.rs
@@ -3,7 +3,8 @@ use std::fmt::Display;
 use noirc_errors::{Location, Span};
 
 use crate::{
-    ast::{FunctionReturnType, Ident, Param, Visibility},
+    ast::{FunctionReturnType, Ident, Param},
+    shared::Visibility,
     token::{Attributes, FunctionAttribute, SecondaryAttribute},
 };
 

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -28,7 +28,6 @@ use acvm::FieldElement;
 pub use docs::*;
 pub use enumeration::*;
 use noirc_errors::Span;
-use serde::{Deserialize, Serialize};
 pub use statement::*;
 pub use structure::*;
 pub use traits::*;
@@ -38,8 +37,10 @@ use crate::{
     BinaryTypeOperator,
     node_interner::{InternedUnresolvedTypeData, QuotedTypeId},
     parser::{ParserError, ParserErrorReason},
+    shared::Signedness,
     token::IntType,
 };
+
 use acvm::acir::AcirField;
 use iter_extended::vecmap;
 
@@ -451,21 +452,6 @@ impl UnresolvedTypeData {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, PartialOrd, Ord)]
-pub enum Signedness {
-    Unsigned,
-    Signed,
-}
-
-impl Signedness {
-    pub fn is_signed(&self) -> bool {
-        match self {
-            Signedness::Unsigned => false,
-            Signedness::Signed => true,
-        }
-    }
-}
-
 impl UnresolvedTypeExpression {
     // This large error size is justified because it improves parsing speeds by around 40% in
     // release mode. See `ParserError` definition for further explanation.
@@ -583,32 +569,6 @@ impl std::fmt::Display for ItemVisibility {
             ItemVisibility::Public => write!(f, "pub"),
             ItemVisibility::Private => Ok(()),
             ItemVisibility::PublicCrate => write!(f, "pub(crate)"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-/// Represents whether the parameter is public or known only to the prover.
-pub enum Visibility {
-    Public,
-    // Constants are not allowed in the ABI for main at the moment.
-    // Constant,
-    #[default]
-    Private,
-    /// DataBus is public input handled as private input. We use the fact that return values are properly computed by the program to avoid having them as public inputs
-    /// it is useful for recursion and is handled by the proving system.
-    /// The u32 value is used to group inputs having the same value.
-    CallData(u32),
-    ReturnData,
-}
-
-impl std::fmt::Display for Visibility {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Public => write!(f, "pub"),
-            Self::Private => write!(f, "priv"),
-            Self::CallData(id) => write!(f, "calldata{id}"),
-            Self::ReturnData => write!(f, "returndata"),
         }
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -9,7 +9,7 @@ use crate::{
     DataType, Kind, Shared, Type,
     ast::{
         ConstructorExpression, EnumVariant, Expression, ExpressionKind, FunctionKind, Ident,
-        Literal, NoirEnumeration, StatementKind, UnresolvedType, Visibility,
+        Literal, NoirEnumeration, StatementKind, UnresolvedType,
     },
     elaborator::path_resolution::PathResolutionItem,
     hir::{comptime::Value, resolution::errors::ResolverError, type_check::TypeCheckError},
@@ -22,6 +22,7 @@ use crate::{
         stmt::{HirLetStatement, HirPattern, HirStatement},
     },
     node_interner::{DefinitionId, DefinitionKind, ExprId, FunctionModifiers, GlobalValue, TypeId},
+    shared::Visibility,
     signed_field::SignedField,
     token::Attributes,
 };

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -1,6 +1,6 @@
 use crate::{
     Type,
-    ast::{Ident, NoirFunction, Signedness, UnaryOp, Visibility},
+    ast::{Ident, NoirFunction, UnaryOp},
     graph::CrateId,
     hir::{
         resolution::errors::{PubPosition, ResolverError},
@@ -14,6 +14,7 @@ use crate::{
     node_interner::{
         DefinitionId, DefinitionKind, ExprId, FuncId, FunctionModifiers, NodeInterner,
     },
+    shared::{Signedness, Visibility},
 };
 
 use noirc_errors::Location;

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -599,11 +599,10 @@ impl Elaborator<'_> {
 
     /// Solve any generics that are part of the path before the function, for example:
     ///
-    /// ```rust
-    /// foo::Bar::<i32>::baz
-    ///           ^^^^^
-    ///         solve these
+    /// ```noir
+    /// foo::Bar::<i32>::baz   
     /// ```
+    /// Solve `<i32>` above
     fn resolve_item_turbofish(&mut self, item: PathResolutionItem) -> Vec<Type> {
         match item {
             PathResolutionItem::Method(struct_id, Some(generics), _func_id) => {

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -8,9 +8,9 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::{
     Generics, Kind, ResolvedGeneric, Type, TypeBinding, TypeBindings, UnificationError,
     ast::{
-        AsTraitPath, BinaryOpKind, GenericTypeArgs, Ident, IntegerBitSize, Path, PathKind,
-        Signedness, UnaryOp, UnresolvedGeneric, UnresolvedGenerics, UnresolvedType,
-        UnresolvedTypeData, UnresolvedTypeExpression, WILDCARD_TYPE,
+        AsTraitPath, BinaryOpKind, GenericTypeArgs, Ident, IntegerBitSize, Path, PathKind, UnaryOp,
+        UnresolvedGeneric, UnresolvedGenerics, UnresolvedType, UnresolvedTypeData,
+        UnresolvedTypeExpression, WILDCARD_TYPE,
     },
     elaborator::UnstableFeature,
     hir::{
@@ -35,6 +35,7 @@ use crate::{
         DependencyId, ExprId, FuncId, GlobalValue, ImplSearchErrorKind, TraitId, TraitImplKind,
         TraitMethodId,
     },
+    shared::Signedness,
     signed_field::SignedField,
     token::SecondaryAttribute,
 };

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -9,7 +9,7 @@ use noirc_errors::Location;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::TypeVariable;
-use crate::ast::{BinaryOpKind, FunctionKind, IntegerBitSize, Signedness, UnaryOp};
+use crate::ast::{BinaryOpKind, FunctionKind, IntegerBitSize, UnaryOp};
 use crate::elaborator::{ElaborateReason, Elaborator};
 use crate::graph::CrateId;
 use crate::hir::def_map::ModuleId;
@@ -21,6 +21,7 @@ use crate::monomorphization::{
     undo_instantiation_bindings,
 };
 use crate::node_interner::GlobalValue;
+use crate::shared::Signedness;
 use crate::signed_field::SignedField;
 use crate::token::{FmtStrFragment, Tokens};
 use crate::{

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -21,8 +21,8 @@ use crate::{
     ast::{
         ArrayLiteral, BlockExpression, ConstrainKind, Expression, ExpressionKind, ForRange,
         FunctionKind, FunctionReturnType, Ident, IntegerBitSize, ItemVisibility, LValue, Literal,
-        Pattern, Signedness, Statement, StatementKind, UnaryOp, UnresolvedType, UnresolvedTypeData,
-        UnsafeExpression, Visibility,
+        Pattern, Statement, StatementKind, UnaryOp, UnresolvedType, UnresolvedTypeData,
+        UnsafeExpression,
     },
     elaborator::{ElaborateReason, Elaborator},
     hir::{
@@ -44,6 +44,7 @@ use crate::{
     },
     node_interner::{DefinitionKind, NodeInterner, TraitImplKind, TraitMethodId},
     parser::{Parser, StatementOrExpressionOrLValue},
+    shared::{Signedness, Visibility},
     token::{Attribute, LocatedToken, Token},
 };
 
@@ -2912,7 +2913,7 @@ fn modulus_be_bits(arguments: Vec<(Value, Location)>, location: Location) -> IRe
     let bits = FieldElement::modulus().to_radix_be(2);
     let bits_vector = bits.into_iter().map(|bit| Value::U1(bit != 0)).collect();
 
-    let int_type = Type::Integer(crate::ast::Signedness::Unsigned, IntegerBitSize::One);
+    let int_type = Type::Integer(Signedness::Unsigned, IntegerBitSize::One);
     let typ = Type::Slice(Box::new(int_type));
     Ok(Value::Slice(bits_vector, typ))
 }
@@ -2923,7 +2924,7 @@ fn modulus_be_bytes(arguments: Vec<(Value, Location)>, location: Location) -> IR
     let bytes = FieldElement::modulus().to_bytes_be();
     let bytes_vector = bytes.into_iter().map(Value::U8).collect();
 
-    let int_type = Type::Integer(crate::ast::Signedness::Unsigned, IntegerBitSize::Eight);
+    let int_type = Type::Integer(Signedness::Unsigned, IntegerBitSize::Eight);
     let typ = Type::Slice(Box::new(int_type));
     Ok(Value::Slice(bytes_vector, typ))
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -16,8 +16,8 @@ use crate::{DataType, Kind, Shared};
 use crate::{
     QuotedType, Type,
     ast::{
-        BlockExpression, ExpressionKind, Ident, IntegerBitSize, LValue, Pattern, Signedness,
-        StatementKind, UnresolvedTypeData,
+        BlockExpression, ExpressionKind, Ident, IntegerBitSize, LValue, Pattern, StatementKind,
+        UnresolvedTypeData,
     },
     hir::{
         comptime::{
@@ -33,6 +33,7 @@ use crate::{
         stmt::HirPattern,
     },
     node_interner::{FuncId, NodeInterner, TraitId, TraitImplId, TypeId},
+    shared::Signedness,
     token::{SecondaryAttribute, Token, Tokens},
 };
 use rustc_hash::FxHashMap as HashMap;

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -10,8 +10,8 @@ use crate::{
     Kind, QuotedType, Shared, Type, TypeBindings,
     ast::{
         ArrayLiteral, BlockExpression, ConstructorExpression, Expression, ExpressionKind, Ident,
-        IntegerBitSize, LValue, Literal, Pattern, Signedness, Statement, StatementKind,
-        UnresolvedType, UnresolvedTypeData,
+        IntegerBitSize, LValue, Literal, Pattern, Statement, StatementKind, UnresolvedType,
+        UnresolvedTypeData,
     },
     elaborator::Elaborator,
     hir::{
@@ -24,6 +24,7 @@ use crate::{
     },
     node_interner::{ExprId, FuncId, NodeInterner, StmtId, TraitId, TraitImplId, TypeId},
     parser::{Item, Parser},
+    shared::Signedness,
     signed_field::SignedField,
     token::{LocatedToken, Token, Tokens},
 };

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -6,14 +6,13 @@ use noirc_errors::CustomDiagnostic as Diagnostic;
 use noirc_errors::Location;
 use thiserror::Error;
 
-use crate::ast::{
-    BinaryOpKind, ConstrainKind, FunctionReturnType, Ident, IntegerBitSize, Signedness,
-};
+use crate::ast::{BinaryOpKind, ConstrainKind, FunctionReturnType, Ident, IntegerBitSize};
 use crate::hir::resolution::errors::ResolverError;
 use crate::hir_def::expr::HirBinaryOp;
 use crate::hir_def::traits::TraitConstraint;
 use crate::hir_def::types::{BinaryTypeOperator, Kind, Type};
 use crate::node_interner::NodeInterner;
+use crate::shared::Signedness;
 use crate::signed_field::SignedField;
 
 /// Rust also only shows 3 maximum, even for short patterns.

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -5,10 +5,11 @@ use noirc_errors::{Location, Span};
 use super::expr::{HirBlockExpression, HirExpression, HirIdent};
 use super::stmt::HirPattern;
 use super::traits::TraitConstraint;
-use crate::ast::{BlockExpression, FunctionKind, FunctionReturnType, Visibility};
+use crate::ast::{BlockExpression, FunctionKind, FunctionReturnType};
 use crate::graph::CrateId;
 use crate::hir::def_map::LocalModuleId;
 use crate::node_interner::{ExprId, NodeInterner, TraitId, TraitImplId, TypeId};
+use crate::shared::Visibility;
 
 use crate::{ResolvedGeneric, Type};
 

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -20,10 +20,8 @@ use iter_extended::vecmap;
 use noirc_errors::Location;
 use noirc_printable_type::PrintableType;
 
-use crate::{
-    ast::{Ident, Signedness},
-    node_interner::TypeId,
-};
+use crate::shared::Signedness;
+use crate::{ast::Ident, node_interner::TypeId};
 
 use super::{
     expr::{HirCallExpression, HirExpression, HirIdent},

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -473,8 +473,9 @@ mod proptests {
     use proptest::result::maybe_ok;
     use proptest::strategy;
 
-    use crate::ast::{IntegerBitSize, Signedness};
+    use crate::ast::IntegerBitSize;
     use crate::hir_def::types::{BinaryTypeOperator, Kind, Type, TypeVariable, TypeVariableId};
+    use crate::shared::Signedness;
 
     prop_compose! {
         // maximum_size must be non-zero

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -24,6 +24,7 @@ pub mod monomorphization;
 pub mod node_interner;
 pub mod parser;
 pub mod resolve_locations;
+pub mod shared;
 pub mod signed_field;
 pub mod usage_tracker;
 

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -6,9 +6,11 @@ use noirc_errors::{
     debug_info::{DebugFunctions, DebugTypes, DebugVariables},
 };
 
+use crate::shared::Visibility;
 use crate::{
-    ast::{BinaryOpKind, IntegerBitSize, Signedness, Visibility},
+    ast::{BinaryOpKind, IntegerBitSize},
     hir_def::expr::Constructor,
+    shared::Signedness,
     signed_field::SignedField,
     token::{Attributes, FunctionAttribute},
 };

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -8,10 +8,11 @@
 //!
 //! The entry point to this pass is the `monomorphize` function which, starting from a given
 //! function, will monomorphize the entire reachable program.
-use crate::ast::{FunctionKind, IntegerBitSize, Signedness, UnaryOp, Visibility};
+use crate::ast::{FunctionKind, IntegerBitSize, UnaryOp};
 use crate::hir::comptime::InterpreterError;
 use crate::hir::type_check::{NoMatchingImplFoundError, TypeCheckError};
 use crate::node_interner::{ExprId, GlobalValue, ImplSearchErrorKind};
+use crate::shared::{Signedness, Visibility};
 use crate::signed_field::SignedField;
 use crate::token::FmtStrFragment;
 use crate::{
@@ -1726,7 +1727,7 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> ast::Expression {
         use ast::*;
 
-        let int_type = Type::Integer(crate::ast::Signedness::Unsigned, arr_elem_bits);
+        let int_type = Type::Integer(Signedness::Unsigned, arr_elem_bits);
 
         let bytes_as_expr = vecmap(bytes, |byte| {
             let value = SignedField::positive(byte as u32);
@@ -2131,7 +2132,7 @@ impl<'interner> Monomorphizer<'interner> {
                 }))
             }
             ast::Type::MutableReference(element) => {
-                use crate::ast::UnaryOp::Reference;
+                use UnaryOp::Reference;
                 let rhs = Box::new(self.zeroed_value_of_type(element, location));
                 let result_type = typ.clone();
                 ast::Expression::Unary(ast::Unary {

--- a/compiler/noirc_frontend/src/parser/parser/enums.rs
+++ b/compiler/noirc_frontend/src/parser/parser/enums.rs
@@ -120,12 +120,13 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{IntegerBitSize, NoirEnumeration, Signedness, UnresolvedGeneric, UnresolvedTypeData},
+        ast::{IntegerBitSize, NoirEnumeration, UnresolvedGeneric, UnresolvedTypeData},
         parse_program_with_dummy_file,
         parser::{
             ItemKind, ParserErrorReason,
             parser::tests::{expect_no_errors, get_source_with_error_span},
         },
+        shared::Signedness,
     };
 
     fn parse_enum_no_errors(src: &str) -> NoirEnumeration {

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -2,12 +2,13 @@ use crate::ast::{
     BlockExpression, GenericTypeArgs, Ident, Path, Pattern, UnresolvedTraitConstraint,
     UnresolvedType,
 };
+use crate::shared::Visibility;
 use crate::token::{Attribute, Attributes, Keyword, Token};
 use crate::{ast::UnresolvedGenerics, parser::labels::ParsingRuleLabel};
 use crate::{
     ast::{
         FunctionDefinition, FunctionReturnType, ItemVisibility, NoirFunction, Param,
-        UnresolvedTypeData, Visibility,
+        UnresolvedTypeData,
     },
     parser::ParserErrorReason,
 };
@@ -326,8 +327,8 @@ fn empty_body() -> BlockExpression {
 mod tests {
     use crate::{
         ast::{
-            ExpressionKind, IntegerBitSize, ItemVisibility, NoirFunction, Signedness,
-            StatementKind, UnresolvedTypeData, Visibility,
+            ExpressionKind, IntegerBitSize, ItemVisibility, NoirFunction, StatementKind,
+            UnresolvedTypeData,
         },
         parse_program_with_dummy_file,
         parser::{
@@ -337,6 +338,7 @@ mod tests {
                 get_source_with_error_span,
             },
         },
+        shared::{Signedness, Visibility},
     };
 
     fn parse_function_no_error(src: &str) -> NoirFunction {

--- a/compiler/noirc_frontend/src/parser/parser/generics.rs
+++ b/compiler/noirc_frontend/src/parser/parser/generics.rs
@@ -1,9 +1,10 @@
 use crate::{
     ast::{
-        GenericTypeArg, GenericTypeArgs, IntegerBitSize, Signedness, UnresolvedGeneric,
-        UnresolvedGenerics, UnresolvedType, UnresolvedTypeData,
+        GenericTypeArg, GenericTypeArgs, IntegerBitSize, UnresolvedGeneric, UnresolvedGenerics,
+        UnresolvedType, UnresolvedTypeData,
     },
     parser::{ParserErrorReason, labels::ParsingRuleLabel},
+    shared::Signedness,
     token::{Keyword, Token, TokenKind},
 };
 
@@ -165,13 +166,14 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{GenericTypeArgs, IntegerBitSize, Signedness, UnresolvedGeneric, UnresolvedTypeData},
+        ast::{GenericTypeArgs, IntegerBitSize, UnresolvedGeneric, UnresolvedTypeData},
         parser::{
             Parser, ParserErrorReason,
             parser::tests::{
                 expect_no_errors, get_single_error_reason, get_source_with_error_span,
             },
         },
+        shared::Signedness,
     };
 
     fn parse_generics_no_errors(src: &str) -> Vec<UnresolvedGeneric> {

--- a/compiler/noirc_frontend/src/parser/parser/global.rs
+++ b/compiler/noirc_frontend/src/parser/parser/global.rs
@@ -75,7 +75,7 @@ mod tests {
     use crate::{
         ast::{
             ExpressionKind, IntegerBitSize, ItemVisibility, LetStatement, Literal, Pattern,
-            Signedness, UnresolvedTypeData,
+            UnresolvedTypeData,
         },
         parse_program_with_dummy_file,
         parser::{
@@ -85,6 +85,7 @@ mod tests {
                 get_source_with_error_span,
             },
         },
+        shared::Signedness,
     };
 
     fn parse_global_no_errors(src: &str) -> (LetStatement, ItemVisibility) {

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -129,7 +129,7 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{IntegerBitSize, NoirStruct, Signedness, UnresolvedGeneric, UnresolvedTypeData},
+        ast::{IntegerBitSize, NoirStruct, UnresolvedGeneric, UnresolvedTypeData},
         parse_program_with_dummy_file,
         parser::{
             ItemKind, ParserErrorReason,
@@ -138,6 +138,7 @@ mod tests {
                 get_source_with_error_span,
             },
         },
+        shared::Signedness,
     };
 
     fn parse_struct_no_errors(src: &str) -> NoirStruct {

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -461,11 +461,12 @@ mod tests {
 
     use crate::{
         QuotedType,
-        ast::{IntegerBitSize, Signedness, UnresolvedType, UnresolvedTypeData},
+        ast::{IntegerBitSize, UnresolvedType, UnresolvedTypeData},
         parser::{
             Parser, ParserErrorReason,
             parser::tests::{expect_no_errors, get_single_error, get_source_with_error_span},
         },
+        shared::Signedness,
     };
 
     fn parse_type_no_errors(src: &str) -> UnresolvedType {

--- a/compiler/noirc_frontend/src/shared/mod.rs
+++ b/compiler/noirc_frontend/src/shared/mod.rs
@@ -1,0 +1,10 @@
+//! The `shared` module contains simple types which are using in multiple of Noir's IRs.
+//!
+//! This is done to avoid each IR from needing to have its own definition of elementary types
+//! while avoiding one IR being embedded within another.
+
+mod signedness;
+mod visibility;
+
+pub use signedness::Signedness;
+pub use visibility::Visibility;

--- a/compiler/noirc_frontend/src/shared/signedness.rs
+++ b/compiler/noirc_frontend/src/shared/signedness.rs
@@ -1,0 +1,14 @@
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, PartialOrd, Ord)]
+pub enum Signedness {
+    Unsigned,
+    Signed,
+}
+
+impl Signedness {
+    pub fn is_signed(&self) -> bool {
+        match self {
+            Signedness::Unsigned => false,
+            Signedness::Signed => true,
+        }
+    }
+}

--- a/compiler/noirc_frontend/src/shared/visibility.rs
+++ b/compiler/noirc_frontend/src/shared/visibility.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+/// Represents whether the parameter is public or known only to the prover.
+pub enum Visibility {
+    Public,
+    // Constants are not allowed in the ABI for main at the moment.
+    // Constant,
+    #[default]
+    Private,
+    /// DataBus is public input handled as private input. We use the fact that return values are properly computed by the program to avoid having them as public inputs
+    /// it is useful for recursion and is handled by the proving system.
+    /// The u32 value is used to group inputs having the same value.
+    CallData(u32),
+    ReturnData,
+}
+
+impl std::fmt::Display for Visibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Public => write!(f, "pub"),
+            Self::Private => write!(f, "priv"),
+            Self::CallData(id) => write!(f, "calldata{id}"),
+            Self::ReturnData => write!(f, "returndata"),
+        }
+    }
+}

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -121,6 +121,12 @@ pub(crate) fn get_program_with_options(
             options,
         ));
     }
+
+    // TODO emit to files
+    let env_emit_frontend_tests = std::env::var("NARGO_EMIT_FRONTEND_TESTS");
+    if errors.is_empty() && env_emit_frontend_tests.is_ok() {
+        dbg!(src);
+    }
     (program, context, errors)
 }
 

--- a/compiler/noirc_frontend/src/tests/name_shadowing.rs
+++ b/compiler/noirc_frontend/src/tests/name_shadowing.rs
@@ -408,8 +408,6 @@ fn test_name_shadowing() {
     for (i, x) in names_to_collapse.iter().enumerate() {
         for (j, y) in names_to_collapse.iter().enumerate().filter(|(j, _)| i < *j) {
             if !cases_to_skip.contains(&(i, j)) {
-                dbg!((i, j));
-
                 let modified_src = src.replace(x, y);
                 let errors = get_program_errors(&modified_src);
                 assert!(!errors.is_empty(), "Expected errors, got: {:?}", errors);

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -21,8 +21,8 @@ use noirc_frontend::{
         Expression, ExpressionKind, ForLoopStatement, GenericTypeArgs, Ident, IfExpression,
         IntegerBitSize, ItemVisibility, LValue, Lambda, LetStatement, MemberAccessExpression,
         MethodCallExpression, ModuleDeclaration, NoirFunction, NoirStruct, NoirTraitImpl, Path,
-        PathKind, Pattern, Signedness, Statement, TraitBound, TraitImplItemKind, TypeImpl,
-        TypePath, UnresolvedGeneric, UnresolvedGenerics, UnresolvedType, UnresolvedTypeData,
+        PathKind, Pattern, Statement, TraitBound, TraitImplItemKind, TypeImpl, TypePath,
+        UnresolvedGeneric, UnresolvedGenerics, UnresolvedType, UnresolvedTypeData,
         UnresolvedTypeExpression, UseTree, UseTreeKind, Visitor,
     },
     graph::{CrateId, Dependency},
@@ -35,6 +35,7 @@ use noirc_frontend::{
     hir_def::traits::Trait,
     node_interner::{FuncId, NodeInterner, ReferenceId, TypeId},
     parser::{Item, ItemKind, ParsedSubModule},
+    shared::Signedness,
     token::{MetaAttribute, Token, Tokens},
 };
 use sort_text::underscore_sort_text;

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -1,9 +1,10 @@
 use fm::{FileId, FileMap};
 use lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position};
+use noirc_frontend::shared::Visibility;
 use noirc_frontend::{
     DataType, EnumVariant, Generics, Shared, StructField, Type, TypeAlias, TypeBinding,
     TypeVariable,
-    ast::{ItemVisibility, Visibility},
+    ast::ItemVisibility,
     hir::def_map::ModuleId,
     hir_def::{
         expr::{HirArrayLiteral, HirExpression, HirLiteral},

--- a/tooling/lsp/src/requests/hover/from_visitor.rs
+++ b/tooling/lsp/src/requests/hover/from_visitor.rs
@@ -86,9 +86,7 @@ fn format_integer(typ: &Type, value: SignedField) -> String {
 #[cfg(test)]
 mod tests {
     use noirc_frontend::{
-        Type,
-        ast::{IntegerBitSize, Signedness},
-        signed_field::SignedField,
+        Type, ast::IntegerBitSize, shared::Signedness, signed_field::SignedField,
     };
 
     use super::format_integer;

--- a/tooling/nargo_fmt/src/formatter/function.rs
+++ b/tooling/nargo_fmt/src/formatter/function.rs
@@ -1,7 +1,8 @@
+use noirc_frontend::shared::Visibility;
 use noirc_frontend::{
     ast::{
         BlockExpression, FunctionReturnType, Ident, ItemVisibility, NoirFunction, Param,
-        UnresolvedGenerics, UnresolvedTraitConstraint, Visibility,
+        UnresolvedGenerics, UnresolvedTraitConstraint,
     },
     token::{Attributes, Keyword, Token},
 };

--- a/tooling/nargo_fmt/src/formatter/traits.rs
+++ b/tooling/nargo_fmt/src/formatter/traits.rs
@@ -1,6 +1,7 @@
 use noirc_errors::Location;
+use noirc_frontend::shared::Visibility;
 use noirc_frontend::{
-    ast::{NoirTrait, Param, Pattern, TraitItem, Visibility},
+    ast::{NoirTrait, Param, Pattern, TraitItem},
     token::{Attributes, Keyword, Token},
 };
 

--- a/tooling/nargo_fmt/src/formatter/visibility.rs
+++ b/tooling/nargo_fmt/src/formatter/visibility.rs
@@ -1,8 +1,6 @@
 use super::Formatter;
-use noirc_frontend::{
-    ast::{ItemVisibility, Visibility},
-    token::Keyword,
-};
+use noirc_frontend::shared::Visibility;
+use noirc_frontend::{ast::ItemVisibility, token::Keyword};
 
 impl Formatter<'_> {
     pub(super) fn format_item_visibility(&mut self, visibility: ItemVisibility) {


### PR DESCRIPTION
# Description

## Problem\*

Frontend tests are run in an environment that could become out of sync with `nargo compile`.

## Summary\*

During `get_program_with_options`, we can:
- Generate a crate name by hashing the source
- Use the source as the contents of `main.nr`
- Generate a simple `Nargo.toml`

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
