### PR TITLE
feat: add `EmbeddedCurvePoint::generator()` to return generator point

### DIFF
--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -24,9 +24,10 @@ impl EmbeddedCurvePoint {
 
     /// Returns the curve's generator point.
     pub fn generator() -> EmbeddedCurvePoint {
+        // Generator point for the grumpkin curve (y^2 = x^3 - 17)
         EmbeddedCurvePoint {
             x: 1,
-            y: 17631683881184975370165255887551781615748388533673675138860,
+            y: 17631683881184975370165255887551781615748388533673675138860, // sqrt(-16)
             is_infinite: false,
         }
     }

--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -21,6 +21,15 @@ impl EmbeddedCurvePoint {
     pub fn point_at_infinity() -> EmbeddedCurvePoint {
         EmbeddedCurvePoint { x: 0, y: 0, is_infinite: true }
     }
+
+    /// Returns the curve's generator point.
+    pub fn generator() -> EmbeddedCurvePoint {
+        EmbeddedCurvePoint {
+            x: 1,
+            y: 17631683881184975370165255887551781615748388533673675138860,
+            is_infinite: false,
+        }
+    }
 }
 
 impl Add for EmbeddedCurvePoint {
@@ -121,12 +130,7 @@ pub(crate) fn multi_scalar_mul_array_return<let N: u32>(
 pub fn fixed_base_scalar_mul(scalar: EmbeddedCurveScalar) -> EmbeddedCurvePoint
 // docs:end:fixed_base_scalar_mul
 {
-    let g1 = EmbeddedCurvePoint {
-        x: 1,
-        y: 17631683881184975370165255887551781615748388533673675138860,
-        is_infinite: false,
-    };
-    multi_scalar_mul([g1], [scalar])
+    multi_scalar_mul([EmbeddedCurvePoint::generator()], [scalar])
 }
 
 /// This function only assumes that the points are on the curve

--- a/test_programs/compile_success_empty/embedded_curve_add_simplification/src/main.nr
+++ b/test_programs/compile_success_empty/embedded_curve_add_simplification/src/main.nr
@@ -2,11 +2,7 @@ use std::embedded_curve_ops::EmbeddedCurvePoint;
 
 fn main() {
     let zero = EmbeddedCurvePoint::point_at_infinity();
-    let g1 = EmbeddedCurvePoint {
-        x: 1,
-        y: 17631683881184975370165255887551781615748388533673675138860,
-        is_infinite: false,
-    };
+    let g1 = EmbeddedCurvePoint::generator();
 
     assert(g1 + zero == g1);
     assert(g1 - g1 == zero);

--- a/test_programs/compile_success_empty/embedded_curve_msm_simplification/src/main.nr
+++ b/test_programs/compile_success_empty/embedded_curve_msm_simplification/src/main.nr
@@ -2,8 +2,7 @@ fn main() {
     let pub_x = 0x0000000000000000000000000000000000000000000000000000000000000001;
     let pub_y = 0x0000000000000002cf135e7506a45d632d270d45f1181294833fc48d823f272c;
 
-    let g1_y = 17631683881184975370165255887551781615748388533673675138860;
-    let g1 = std::embedded_curve_ops::EmbeddedCurvePoint { x: 1, y: g1_y, is_infinite: false };
+    let g1 = std::embedded_curve_ops::EmbeddedCurvePoint::generator();
     let scalar = std::embedded_curve_ops::EmbeddedCurveScalar { lo: 1, hi: 0 };
     // Test that multi_scalar_mul correctly derives the public key
     let res = std::embedded_curve_ops::multi_scalar_mul([g1], [scalar]);

--- a/test_programs/execution_success/embedded_curve_ops/src/main.nr
+++ b/test_programs/execution_success/embedded_curve_ops/src/main.nr
@@ -1,8 +1,7 @@
 use std::ops::Add;
 
 fn main(priv_key: Field, pub_x: pub Field, pub_y: pub Field) {
-    let g1_y = 17631683881184975370165255887551781615748388533673675138860;
-    let g1 = std::embedded_curve_ops::EmbeddedCurvePoint { x: 1, y: g1_y, is_infinite: false };
+    let g1 = std::embedded_curve_ops::EmbeddedCurvePoint::generator();
     let scalar = std::embedded_curve_ops::EmbeddedCurveScalar { lo: priv_key, hi: 0 };
     // Test that multi_scalar_mul correctly derives the public key
     let res = std::embedded_curve_ops::multi_scalar_mul([g1], [scalar]);

--- a/test_programs/noir_test_success/comptime_blackbox/src/main.nr
+++ b/test_programs/noir_test_success/comptime_blackbox/src/main.nr
@@ -135,11 +135,7 @@ fn test_embedded_curve_ops() {
     let (sum, mul) = comptime {
         let s1 = EmbeddedCurveScalar { lo: 1, hi: 0 };
         let s2 = EmbeddedCurveScalar { lo: 2, hi: 0 };
-        let g1 = EmbeddedCurvePoint {
-            x: 1,
-            y: 17631683881184975370165255887551781615748388533673675138860,
-            is_infinite: false,
-        };
+        let g1 = EmbeddedCurvePoint::generator();
         let g2 = multi_scalar_mul([g1], [s2]);
         let sum = g1 + g2;
         let mul = multi_scalar_mul([g1, g2], [s1, s1]);

--- a/test_programs/noir_test_success/embedded_curve_ops/src/main.nr
+++ b/test_programs/noir_test_success/embedded_curve_ops/src/main.nr
@@ -4,11 +4,7 @@ use std::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar, multi_sca
 
 fn test_infinite_point() {
     let zero = EmbeddedCurvePoint::point_at_infinity();
-    let g1 = EmbeddedCurvePoint {
-        x: 1,
-        y: 17631683881184975370165255887551781615748388533673675138860,
-        is_infinite: false,
-    };
+    let g1 = EmbeddedCurvePoint::generator();
     let g2 = g1 + g1;
 
     let s1 = EmbeddedCurveScalar { lo: 1, hi: 0 };
@@ -18,14 +14,7 @@ fn test_infinite_point() {
     assert(g1 - g1 == zero);
     assert(g1 - zero == g1);
     assert(zero + zero == zero);
-    assert(
-        multi_scalar_mul([g1], [s1])
-            == EmbeddedCurvePoint {
-                x: 1,
-                y: 17631683881184975370165255887551781615748388533673675138860,
-                is_infinite: false,
-            },
-    );
+    assert(multi_scalar_mul([g1], [s1]) == EmbeddedCurvePoint::generator());
     assert(multi_scalar_mul([g1, g1], [s1, s1]) == g2);
     assert(
         multi_scalar_mul(

--- a/test_programs/noir_test_success/embedded_curve_ops/src/main.nr
+++ b/test_programs/noir_test_success/embedded_curve_ops/src/main.nr
@@ -14,7 +14,7 @@ fn test_infinite_point() {
     assert(g1 - g1 == zero);
     assert(g1 - zero == g1);
     assert(zero + zero == zero);
-    assert(multi_scalar_mul([g1], [s1]) == EmbeddedCurvePoint::generator());
+    assert(multi_scalar_mul([g1], [s1]) == g1);
     assert(multi_scalar_mul([g1, g1], [s1, s1]) == g2);
     assert(
         multi_scalar_mul(


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/7707

## Summary\*

This PR adds a method to `EmbeddedCurvePoint` so that we can quickly get the generator point.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
