### PR TITLE
fix(ci): Exclude inliner specific reference count tests from Brillig trace report

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -65,7 +65,7 @@ projects:
     cannot_execute: true
     num_runs: 1
     timeout: 60
-    compilation-timeout: 135
+    compilation-timeout: 150
     compilation-memory-limit: 8000
   rollup-block-root:
     repo: AztecProtocol/aztec-packages
@@ -73,7 +73,7 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/rollup-block-root
     num_runs: 1
     timeout: 60
-    compilation-timeout: 135
+    compilation-timeout: 150
     execution-timeout: 40
     compilation-memory-limit: 8000
     execution-memory-limit: 1500

--- a/test_programs/gates_report_brillig_execution.sh
+++ b/test_programs/gates_report_brillig_execution.sh
@@ -14,6 +14,11 @@ excluded_dirs=(
   "is_unconstrained"
   # This test utilizes enums which are experimental
   "regression_7323"
+  # These tests fail with different inliner settings, while this script
+  # assumes that a test can pass with all inliner settings.
+  "reference_counts_inliner_min"
+  "reference_counts_inliner_0"
+  "reference_counts_inliner_max"
 )
 
 current_dir=$(pwd)


### PR DESCRIPTION
# Description

## Problem\*

Resolves the failures seen under `Generate Brillig execution report` in https://github.com/noir-lang/noir/actions/runs/13971802272/job/39115494211

## Summary\*

In https://github.com/noir-lang/noir/pull/7629 we added reference count tests that only work with specific inliner settings. This causes our Brillig trace reports to fail. 

I excluded `reference_counts_inliner_min`, `reference_counts_inliner_0`, and `reference_counts_inliner_max` from the brillig trace report. 

## Additional Context


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
