### PR TITLE
chore: run `noir_wasm` over `test_programs`

### DIFF
--- a/compiler/wasm/test/compiler/browser/compile.test.ts
+++ b/compiler/wasm/test/compiler/browser/compile.test.ts
@@ -24,6 +24,7 @@ async function getPrecompiledSource(path: string): Promise<any> {
 
 describe('noir-compiler/browser', () => {
   shouldCompileProgramIdentically(
+    'simple',
     async () => {
       const { simpleScriptExpectedArtifact } = paths;
       const fm = createFileManager('/');
@@ -42,6 +43,7 @@ describe('noir-compiler/browser', () => {
   );
 
   shouldCompileProgramIdentically(
+    'deps',
     async () => {
       const { depsScriptExpectedArtifact } = paths;
       const fm = createFileManager('/');
@@ -60,6 +62,7 @@ describe('noir-compiler/browser', () => {
   );
 
   shouldCompileContractIdentically(
+    'noir-contract',
     async () => {
       const { contractExpectedArtifact } = paths;
       const fm = createFileManager('/');

--- a/compiler/wasm/test/compiler/node/compile.test.ts
+++ b/compiler/wasm/test/compiler/node/compile.test.ts
@@ -5,12 +5,25 @@ import { expect } from 'chai';
 import { compile_program, compile_contract, createFileManager } from '@noir-lang/noir_wasm';
 import { readFile } from 'fs/promises';
 import { ContractArtifact, ProgramArtifact } from '../../../src/types/noir_artifact';
-import { shouldCompileContractIdentically, shouldCompileProgramIdentically } from '../shared/compile.test';
+import {
+  shouldCompileContractIdentically,
+  shouldCompileProgramIdentically,
+  shouldCompileProgramSuccessfully,
+} from '../shared/compile.test';
+import { readdirSync } from 'fs';
 
+const testProgramsDir = resolve(join(__dirname, '../../../../../test_programs'));
 const basePath = resolve(join(__dirname, '../../'));
+
+function getSubdirs(path: string): string[] {
+  return readdirSync(path, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+}
 
 describe('noir-compiler/node', () => {
   shouldCompileProgramIdentically(
+    'simple',
     async () => {
       const { simpleScriptProjectPath, simpleScriptExpectedArtifact } = getPaths(basePath);
 
@@ -24,6 +37,7 @@ describe('noir-compiler/node', () => {
   );
 
   shouldCompileProgramIdentically(
+    'deps',
     async () => {
       const { depsScriptProjectPath, depsScriptExpectedArtifact } = getPaths(basePath);
 
@@ -37,6 +51,7 @@ describe('noir-compiler/node', () => {
   );
 
   shouldCompileContractIdentically(
+    'noir-contract',
     async () => {
       const { contractProjectPath, contractExpectedArtifact } = getPaths(basePath);
 
@@ -48,4 +63,42 @@ describe('noir-compiler/node', () => {
     expect,
     /*30 second timeout*/ 30000,
   );
+
+  getSubdirs(join(testProgramsDir, 'compile_success_empty')).forEach((name: string) => {
+    shouldCompileProgramSuccessfully(
+      name,
+      async () => {
+        const programDir = join(testProgramsDir, 'compile_success_empty', name);
+        const fm = createFileManager(programDir);
+        const noirWasmArtifact = await compile_program(
+          fm,
+          undefined,
+          (_) => {},
+          (_) => {},
+        );
+        return noirWasmArtifact;
+      },
+      expect,
+      /*30 second timeout*/ 30000,
+    );
+  });
+
+  getSubdirs(join(testProgramsDir, 'execution_success')).forEach((name: string) => {
+    shouldCompileProgramSuccessfully(
+      name,
+      async () => {
+        const programDir = join(testProgramsDir, 'execution_success', name);
+        const fm = createFileManager(programDir);
+        const noirWasmArtifact = await compile_program(
+          fm,
+          undefined,
+          (_) => {},
+          (_) => {},
+        );
+        return noirWasmArtifact;
+      },
+      expect,
+      /*30 second timeout*/ 30000,
+    );
+  });
 });

--- a/compiler/wasm/test/compiler/node/compile.test.ts
+++ b/compiler/wasm/test/compiler/node/compile.test.ts
@@ -64,40 +64,38 @@ describe('noir-compiler/node', () => {
     /*30 second timeout*/ 30000,
   );
 
-  getSubdirs(join(testProgramsDir, 'compile_success_empty')).forEach((name: string) => {
-    shouldCompileProgramSuccessfully(
-      name,
-      async () => {
-        const programDir = join(testProgramsDir, 'compile_success_empty', name);
-        const fm = createFileManager(programDir);
-        const noirWasmArtifact = await compile_program(
-          fm,
-          undefined,
-          (_) => {},
-          (_) => {},
-        );
-        return noirWasmArtifact;
-      },
-      expect,
-      /*30 second timeout*/ 30000,
-    );
-  });
-
-  const filteredTests = [
+  const filteredCompileSuccessEmptyTests = [
     'comptime_enums',
     'enums',
-    'overlapping_dep_and_mod',
     'regression_7570_nested',
     'regression_7570_serial',
     'workspace_reexport_bug',
-    'custom_entry',
     'overlapping_dep_and_mod',
-    'regression_7323',
-    'workspace',
-    'workspace_default_member',
   ];
+  getSubdirs(join(testProgramsDir, 'compile_success_empty'))
+    .filter((name) => !filteredCompileSuccessEmptyTests.includes(name))
+    .forEach((name: string) => {
+      shouldCompileProgramSuccessfully(
+        name,
+        async () => {
+          const programDir = join(testProgramsDir, 'compile_success_empty', name);
+          const fm = createFileManager(programDir);
+          const noirWasmArtifact = await compile_program(
+            fm,
+            undefined,
+            (_) => {},
+            (_) => {},
+          );
+          return noirWasmArtifact;
+        },
+        expect,
+        /*30 second timeout*/ 30000,
+      );
+    });
+
+  const filteredExecutionSuccessTests = ['custom_entry', 'regression_7323', 'workspace', 'workspace_default_member'];
   getSubdirs(join(testProgramsDir, 'execution_success'))
-    .filter((name) => !filteredTests.includes(name))
+    .filter((name) => !filteredExecutionSuccessTests.includes(name))
     .forEach((name: string) => {
       shouldCompileProgramSuccessfully(
         name,

--- a/compiler/wasm/test/compiler/node/compile.test.ts
+++ b/compiler/wasm/test/compiler/node/compile.test.ts
@@ -93,7 +93,13 @@ describe('noir-compiler/node', () => {
       );
     });
 
-  const filteredExecutionSuccessTests = ['custom_entry', 'regression_7323', 'workspace', 'workspace_default_member'];
+  const filteredExecutionSuccessTests = [
+    'custom_entry',
+    'overlapping_dep_and_mod',
+    'regression_7323',
+    'workspace',
+    'workspace_default_member',
+  ];
   getSubdirs(join(testProgramsDir, 'execution_success'))
     .filter((name) => !filteredExecutionSuccessTests.includes(name))
     .forEach((name: string) => {

--- a/compiler/wasm/test/compiler/node/compile.test.ts
+++ b/compiler/wasm/test/compiler/node/compile.test.ts
@@ -83,22 +83,37 @@ describe('noir-compiler/node', () => {
     );
   });
 
-  getSubdirs(join(testProgramsDir, 'execution_success')).forEach((name: string) => {
-    shouldCompileProgramSuccessfully(
-      name,
-      async () => {
-        const programDir = join(testProgramsDir, 'execution_success', name);
-        const fm = createFileManager(programDir);
-        const noirWasmArtifact = await compile_program(
-          fm,
-          undefined,
-          (_) => {},
-          (_) => {},
-        );
-        return noirWasmArtifact;
-      },
-      expect,
-      /*30 second timeout*/ 30000,
-    );
-  });
+  const filteredTests = [
+    'comptime_enums',
+    'enums',
+    'overlapping_dep_and_mod',
+    'regression_7570_nested',
+    'regression_7570_serial',
+    'workspace_reexport_bug',
+    'custom_entry',
+    'overlapping_dep_and_mod',
+    'regression_7323',
+    'workspace',
+    'workspace_default_member',
+  ];
+  getSubdirs(join(testProgramsDir, 'execution_success'))
+    .filter((name) => !filteredTests.includes(name))
+    .forEach((name: string) => {
+      shouldCompileProgramSuccessfully(
+        name,
+        async () => {
+          const programDir = join(testProgramsDir, 'execution_success', name);
+          const fm = createFileManager(programDir);
+          const noirWasmArtifact = await compile_program(
+            fm,
+            undefined,
+            (_) => {},
+            (_) => {},
+          );
+          return noirWasmArtifact;
+        },
+        expect,
+        /*30 second timeout*/ 30000,
+      );
+    });
 });

--- a/compiler/wasm/test/compiler/shared/compile.test.ts
+++ b/compiler/wasm/test/compiler/shared/compile.test.ts
@@ -12,11 +12,12 @@ import {
 } from '../../../src/types/noir_artifact';
 
 export function shouldCompileProgramIdentically(
+  name: string,
   compileFn: () => Promise<{ nargoArtifact: ProgramArtifact; noirWasmArtifact: ProgramCompilationArtifacts }>,
   expect: typeof Expect,
   timeout = 5000,
 ) {
-  it('both nargo and noir_wasm should compile program identically', async () => {
+  it(`both nargo and noir_wasm should compile program ${name} identically`, async () => {
     // Compile!
     const { nargoArtifact, noirWasmArtifact } = await compileFn();
 
@@ -48,12 +49,31 @@ export function shouldCompileProgramIdentically(
   }).timeout(timeout);
 }
 
+export function shouldCompileProgramSuccessfully(
+  name: string,
+  compileFn: () => Promise<ProgramCompilationArtifacts>,
+  expect: typeof Expect,
+  timeout = 5000,
+) {
+  it(`program ${name} should compile successfully`, async () => {
+    // Compile!
+    const noirWasmArtifact = await compileFn();
+
+    // Prepare noir-wasm artifact
+    const noirWasmProgram = noirWasmArtifact.program;
+    expect(noirWasmProgram).not.to.be.undefined;
+    const [_noirWasmDebugInfos, _] = deleteProgramDebugMetadata(noirWasmProgram);
+    normalizeVersion(noirWasmProgram);
+  }).timeout(timeout);
+}
+
 export function shouldCompileContractIdentically(
+  name: string,
   compileFn: () => Promise<{ nargoArtifact: ContractArtifact; noirWasmArtifact: ContractCompilationArtifacts }>,
   expect: typeof Expect,
   timeout = 5000,
 ) {
-  it('both nargo and noir_wasm should compile contract identically', async () => {
+  it(`both nargo and noir_wasm should compile contract ${name} identically`, async () => {
     // Compile!
     const { nargoArtifact, noirWasmArtifact } = await compileFn();
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates `noir_wasm` tests to run over the `execution_success` and `compile_success_empty` test programs. We currently basically just check that the compiler doesn't throw an exception on these but we can beef up those checks later.

I've had to ignore a few cases where the tests fail which seem to fall into two categories:
- Using workspaces
- using experimental features, i.e. enums.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
