### PR TITLE
chore(docs): Avoid colliding filenames

### DIFF
--- a/tooling/acvm_cli/Cargo.toml
+++ b/tooling/acvm_cli/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [[bin]]
 name = "acvm"
 path = "src/main.rs"
+doc = false # Avoid conflicts with the `acvm` library when documenting. We just want to document the `acvm` library.
 
 [dependencies]
 color-eyre.workspace = true

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [[bin]]
 name = "nargo"
 path = "src/main.rs"
+doc = false # Avoid conflicts with the `nargo` library when documenting. We just want to document the `nargo` library.
 
 [build-dependencies]
 build-data.workspace = true


### PR DESCRIPTION
# Description

## Problem\*

No issue, just something I noticed when working on documentation. 

I would get this failure sometimes https://github.com/noir-lang/noir/actions/runs/13975109215/job/39126812422. It looks to be due to colliding filenames as `nargo_cli` and `nargo` both have the same package name. 

The same happens for `acvm_cli` and `acvm`. We see these warnings when running `cargo doc`:
```
warning: output filename collision.
The bin target `acvm` in package `acvm_cli v0.40.0 (/mnt/user-data/maxim/noir-lang/noir/tooling/acvm_cli)` has the same output filename as the lib target `acvm` in package `acvm v1.0.0-beta.3 (/mnt/user-data/maxim/noir-lang/noir/acvm-repo/acvm)`.
Colliding filename is: /mnt/user-data/maxim/noir-lang/noir/target/doc/acvm/index.html
The targets should have unique names.
This is a known bug where multiple crates with the same name use
the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
warning: output filename collision.
The bin target `nargo` in package `nargo_cli v1.0.0-beta.3 (/mnt/user-data/maxim/noir-lang/noir/tooling/nargo_cli)` has the same output filename as the lib target `nargo` in package `nargo v1.0.0-beta.3 (/mnt/user-data/maxim/noir-lang/noir/tooling/nargo)`.
Colliding filename is: /mnt/user-data/maxim/noir-lang/noir/target/doc/nargo/index.html
The targets should have unique names.
This is a known bug where multiple crates with the same name use
the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
```

## Summary\*

I set `doc = false` for both the `acvm_cli` and `nargo_cli`. I chose this solution as it required minimal changes and is what cargo itself does to handle conflicting documentation names:

https://github.com/rust-lang/cargo/blob/8364f7b687b8dd4c4fb52629a3732e4aa5ecb503/Cargo.toml#L265

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
