### PR TITLE
chore: Make embedded curve opcodes return embedded curve points

### DIFF
--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -1,4 +1,4 @@
-use acir::brillig::{BlackBoxOp, HeapArray, HeapVector, IntegerBitSize};
+use acir::brillig::{BlackBoxOp, HeapArray, HeapVector};
 use acir::{AcirField, BlackBoxFunc};
 use acvm_blackbox_solver::{
     BigIntSolverWithId, BlackBoxFunctionSolver, BlackBoxResolutionError, aes128_encrypt, blake2s,
@@ -173,7 +173,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 &[
                     MemoryValue::new_field(x),
                     MemoryValue::new_field(y),
-                    MemoryValue::new_integer(is_infinite.to_u128(), IntegerBitSize::U1),
+                    MemoryValue::U1(is_infinite != F::zero()),
                 ],
             );
             Ok(())
@@ -206,7 +206,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 &[
                     MemoryValue::new_field(x),
                     MemoryValue::new_field(y),
-                    MemoryValue::new_integer(infinite.to_u128(), IntegerBitSize::U1),
+                    MemoryValue::U1(infinite != F::zero()),
                 ],
             );
             Ok(())

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -1,4 +1,4 @@
-use acir::brillig::{BlackBoxOp, HeapArray, HeapVector};
+use acir::brillig::{BlackBoxOp, HeapArray, HeapVector, IntegerBitSize};
 use acir::{AcirField, BlackBoxFunc};
 use acvm_blackbox_solver::{
     BigIntSolverWithId, BlackBoxFunctionSolver, BlackBoxResolutionError, aes128_encrypt, blake2s,
@@ -173,7 +173,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 &[
                     MemoryValue::new_field(x),
                     MemoryValue::new_field(y),
-                    MemoryValue::new_field(is_infinite),
+                    MemoryValue::new_integer(is_infinite.to_u128(), IntegerBitSize::U1),
                 ],
             );
             Ok(())
@@ -206,7 +206,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 &[
                     MemoryValue::new_field(x),
                     MemoryValue::new_field(y),
-                    MemoryValue::new_field(infinite),
+                    MemoryValue::new_integer(infinite.to_u128(), IntegerBitSize::U1),
                 ],
             );
             Ok(())

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -2188,7 +2188,7 @@ impl<'a> Context<'a> {
                 let inputs = vecmap(&arguments_no_slice_len, |arg| self.convert_value(*arg, dfg));
 
                 let output_count = result_ids.iter().fold(0usize, |sum, result_id| {
-                    sum + dfg.try_get_array_length(*result_id).unwrap_or(1) as usize
+                    sum + dfg.type_of_value(*result_id).flattened_size() as usize
                 });
 
                 let vars = self.acir_context.black_box_function(black_box, inputs, output_count)?;

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/call/blackbox.rs
@@ -52,10 +52,9 @@ pub(super) fn simplify_ec_add(
 
             let result_x = dfg.make_constant(result_x, NumericType::NativeField);
             let result_y = dfg.make_constant(result_y, NumericType::NativeField);
-            let result_is_infinity =
-                dfg.make_constant(result_is_infinity, NumericType::NativeField);
+            let result_is_infinity = dfg.make_constant(result_is_infinity, NumericType::bool());
 
-            let typ = Type::Array(Arc::new(vec![Type::field()]), 3);
+            let typ = Type::Array(Arc::new(vec![Type::field(), Type::field(), Type::bool()]), 1);
 
             let elements = im::vector![result_x, result_y, result_is_infinity];
             let instruction = Instruction::MakeArray { elements, typ };
@@ -148,11 +147,11 @@ pub(super) fn simplify_msm(
             if var_scalars.is_empty() {
                 let result_x = dfg.make_constant(result_x, NumericType::NativeField);
                 let result_y = dfg.make_constant(result_y, NumericType::NativeField);
-                let result_is_infinity =
-                    dfg.make_constant(result_is_infinity, NumericType::NativeField);
+                let result_is_infinity = dfg.make_constant(result_is_infinity, NumericType::bool());
 
                 let elements = im::vector![result_x, result_y, result_is_infinity];
-                let typ = Type::Array(Arc::new(vec![Type::field()]), 3);
+                let typ =
+                    Type::Array(Arc::new(vec![Type::field(), Type::field(), Type::bool()]), 1);
                 let instruction = Instruction::MakeArray { elements, typ };
                 let result_array =
                     dfg.insert_instruction_and_results(instruction, block, None, call_stack);
@@ -370,7 +369,7 @@ mod multi_scalar_mul {
               b0():
                 v0 = make_array [Field 2, Field 3, Field 5, Field 5] : [Field; 4]
                 v1 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 6]
-                v2 = call multi_scalar_mul (v1, v0) -> [Field; 3]
+                v2 = call multi_scalar_mul (v1, v0) -> [(Field, Field, u1); 1]
                 return v2
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
@@ -380,7 +379,7 @@ mod multi_scalar_mul {
               b0():
                 v3 = make_array [Field 2, Field 3, Field 5, Field 5] : [Field; 4]
                 v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 6]
-                v10 = make_array [Field 1478523918288173385110236399861791147958001875200066088686689589556927843200, Field 700144278551281040379388961242974992655630750193306467120985766322057145630, Field 0] : [Field; 3]
+                v10 = make_array [Field 1478523918288173385110236399861791147958001875200066088686689589556927843200, Field 700144278551281040379388961242974992655630750193306467120985766322057145630, u1 0] : [(Field, Field, u1); 1]
                 return v10
             }
             "#;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -645,15 +645,6 @@ pub(crate) fn to_byte_slice(values: &[u8]) -> Value {
     Value::Slice(values.iter().copied().map(Value::U8).collect(), byte_slice_type())
 }
 
-/// Create a `Value::Array` from fields.
-pub(crate) fn to_field_array(values: &[FieldElement]) -> Value {
-    let typ = Type::Array(
-        Box::new(Type::Constant(values.len().into(), Kind::u32())),
-        Box::new(Type::FieldElement),
-    );
-    Value::Array(values.iter().copied().map(Value::Field).collect(), typ)
-}
-
 /// Create a `Value::Struct` from fields and the expected return type.
 pub(crate) fn to_struct(
     fields: impl IntoIterator<Item = (&'static str, Value)>,

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -289,6 +289,10 @@ fn embedded_curve_add(
     let (p1x, p1y, p1inf) = get_embedded_curve_point(point1)?;
     let (p2x, p2y, p2inf) = get_embedded_curve_point(point2)?;
 
+    let (x, y, inf) = Bn254BlackBoxSolver(pedantic_solving)
+        .ec_add(&p1x, &p1y, &p1inf.into(), &p2x, &p2y, &p2inf.into())
+        .map_err(|e| InterpreterError::BlackBoxError(e, location))?;
+
     let embedded_curve_point_typ = match &return_type {
         Type::Array(_, item_type) => item_type.as_ref().clone(),
         _ => {
@@ -302,10 +306,6 @@ fn embedded_curve_add(
             });
         }
     };
-
-    let (x, y, inf) = Bn254BlackBoxSolver(pedantic_solving)
-        .ec_add(&p1x, &p1y, &p1inf.into(), &p2x, &p2y, &p2inf.into())
-        .map_err(|e| InterpreterError::BlackBoxError(e, location))?;
 
     Ok(Value::Array(
         vector![to_embedded_curve_point(x, y, inf > 0_usize.into(), embedded_curve_point_typ)],
@@ -339,6 +339,10 @@ fn multi_scalar_mul(
         scalars_hi.push(hi);
     }
 
+    let (x, y, inf) = Bn254BlackBoxSolver(pedantic_solving)
+        .multi_scalar_mul(&points, &scalars_lo, &scalars_hi)
+        .map_err(|e| InterpreterError::BlackBoxError(e, location))?;
+
     let embedded_curve_point_typ = match &return_type {
         Type::Array(_, item_type) => item_type.as_ref().clone(),
         _ => {
@@ -352,10 +356,6 @@ fn multi_scalar_mul(
             });
         }
     };
-
-    let (x, y, inf) = Bn254BlackBoxSolver(pedantic_solving)
-        .multi_scalar_mul(&points, &scalars_lo, &scalars_hi)
-        .map_err(|e| InterpreterError::BlackBoxError(e, location))?;
 
     Ok(Value::Array(
         vector![to_embedded_curve_point(x, y, inf > 0_usize.into(), embedded_curve_point_typ)],

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -4,11 +4,11 @@ use acvm::{
     blackbox_solver::{BigIntSolverWithId, BlackBoxFunctionSolver},
 };
 use bn254_blackbox_solver::Bn254BlackBoxSolver; // Currently locked to only bn254!
-use im::Vector;
+use im::{Vector, vector};
 use noirc_errors::Location;
 
 use crate::{
-    Type,
+    Kind, Type,
     hir::comptime::{
         InterpreterError, Value, errors::IResult,
         interpreter::builtin::builtin_helpers::to_byte_array,
@@ -21,7 +21,7 @@ use super::{
     builtin::builtin_helpers::{
         check_arguments, check_one_argument, check_three_arguments, check_two_arguments,
         get_array_map, get_bool, get_field, get_fixed_array_map, get_slice_map, get_struct_field,
-        get_struct_fields, get_u8, get_u32, get_u64, to_byte_slice, to_field_array, to_struct,
+        get_struct_fields, get_u8, get_u32, get_u64, to_byte_slice, to_struct,
     },
 };
 
@@ -81,8 +81,12 @@ fn call_foreign(
             location,
             acvm::blackbox_solver::ecdsa_secp256r1_verify,
         ),
-        "embedded_curve_add" => embedded_curve_add(args, location, pedantic_solving),
-        "multi_scalar_mul" => multi_scalar_mul(interner, args, location, pedantic_solving),
+        "embedded_curve_add" => {
+            embedded_curve_add(interner, args, return_type, location, pedantic_solving)
+        }
+        "multi_scalar_mul" => {
+            multi_scalar_mul(interner, args, return_type, location, pedantic_solving)
+        }
         "poseidon2_permutation" => {
             poseidon2_permutation(interner, args, location, pedantic_solving)
         }
@@ -271,10 +275,12 @@ fn ecdsa_secp256_verify(
 /// fn embedded_curve_add(
 ///     point1: EmbeddedCurvePoint,
 ///     point2: EmbeddedCurvePoint,
-/// ) -> [Field; 3]
+/// ) -> [EmbeddedCurvePoint; 1]
 /// ```
 fn embedded_curve_add(
+    interner: &mut NodeInterner,
     arguments: Vec<(Value, Location)>,
+    return_type: Type,
     location: Location,
     pedantic_solving: bool,
 ) -> IResult<Value> {
@@ -283,22 +289,40 @@ fn embedded_curve_add(
     let (p1x, p1y, p1inf) = get_embedded_curve_point(point1)?;
     let (p2x, p2y, p2inf) = get_embedded_curve_point(point2)?;
 
+    let embedded_curve_point_typ = match &return_type {
+        Type::Array(_, item_type) => item_type.as_ref().clone(),
+        _ => {
+            return Err(InterpreterError::TypeMismatch {
+                expected: Type::Array(
+                    Box::new(Type::Constant(1_usize.into(), Kind::u32())),
+                    Box::new(interner.next_type_variable()), // EmbeddedCurvePoint
+                ),
+                actual: return_type.clone(),
+                location,
+            });
+        }
+    };
+
     let (x, y, inf) = Bn254BlackBoxSolver(pedantic_solving)
         .ec_add(&p1x, &p1y, &p1inf.into(), &p2x, &p2y, &p2inf.into())
         .map_err(|e| InterpreterError::BlackBoxError(e, location))?;
 
-    Ok(to_field_array(&[x, y, inf]))
+    Ok(Value::Array(
+        vector![to_embedded_curve_point(x, y, inf > 0_usize.into(), embedded_curve_point_typ)],
+        return_type,
+    ))
 }
 
 /// ```text
 /// pub fn multi_scalar_mul<let N: u32>(
 ///     points: [EmbeddedCurvePoint; N],
 ///     scalars: [EmbeddedCurveScalar; N],
-/// ) -> [Field; 3]
+/// ) -> [EmbeddedCurvePoint; 1]
 /// ```
 fn multi_scalar_mul(
     interner: &mut NodeInterner,
     arguments: Vec<(Value, Location)>,
+    return_type: Type,
     location: Location,
     pedantic_solving: bool,
 ) -> IResult<Value> {
@@ -315,11 +339,28 @@ fn multi_scalar_mul(
         scalars_hi.push(hi);
     }
 
+    let embedded_curve_point_typ = match &return_type {
+        Type::Array(_, item_type) => item_type.as_ref().clone(),
+        _ => {
+            return Err(InterpreterError::TypeMismatch {
+                expected: Type::Array(
+                    Box::new(Type::Constant(1_usize.into(), Kind::u32())),
+                    Box::new(interner.next_type_variable()), // EmbeddedCurvePoint
+                ),
+                actual: return_type.clone(),
+                location,
+            });
+        }
+    };
+
     let (x, y, inf) = Bn254BlackBoxSolver(pedantic_solving)
         .multi_scalar_mul(&points, &scalars_lo, &scalars_hi)
         .map_err(|e| InterpreterError::BlackBoxError(e, location))?;
 
-    Ok(to_field_array(&[x, y, inf]))
+    Ok(Value::Array(
+        vector![to_embedded_curve_point(x, y, inf > 0_usize.into(), embedded_curve_point_typ)],
+        return_type,
+    ))
 }
 
 /// `poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32) -> [Field; N]`
@@ -414,6 +455,18 @@ fn get_embedded_curve_scalar(
 
 fn to_bigint(id: u32, typ: Type) -> Value {
     to_struct([("pointer", Value::U32(id)), ("modulus", Value::U32(id))], typ)
+}
+
+fn to_embedded_curve_point(
+    x: FieldElement,
+    y: FieldElement,
+    is_infinite: bool,
+    typ: Type,
+) -> Value {
+    to_struct(
+        [("x", Value::Field(x)), ("y", Value::Field(y)), ("is_infinite", Value::Bool(is_infinite))],
+        typ,
+    )
 }
 
 #[cfg(test)]

--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -117,15 +117,14 @@ pub fn multi_scalar_mul<let N: u32>(
 ) -> EmbeddedCurvePoint
 // docs:end:multi_scalar_mul
 {
-    let point_array = multi_scalar_mul_array_return(points, scalars);
-    EmbeddedCurvePoint { x: point_array[0], y: point_array[1], is_infinite: point_array[2] as bool }
+    multi_scalar_mul_array_return(points, scalars)[0]
 }
 
 #[foreign(multi_scalar_mul)]
 pub(crate) fn multi_scalar_mul_array_return<let N: u32>(
     points: [EmbeddedCurvePoint; N],
     scalars: [EmbeddedCurveScalar; N],
-) -> [Field; 3] {}
+) -> [EmbeddedCurvePoint; 1] {}
 
 // docs:start:fixed_base_scalar_mul
 pub fn fixed_base_scalar_mul(scalar: EmbeddedCurveScalar) -> EmbeddedCurvePoint
@@ -184,7 +183,7 @@ pub fn embedded_curve_add(
 fn embedded_curve_add_array_return(
     _point1: EmbeddedCurvePoint,
     _point2: EmbeddedCurvePoint,
-) -> [Field; 3] {}
+) -> [EmbeddedCurvePoint; 1] {}
 
 /// This function assumes that:
 /// The points are on the curve, and
@@ -211,9 +210,5 @@ pub fn embedded_curve_add_unsafe(
     point1: EmbeddedCurvePoint,
     point2: EmbeddedCurvePoint,
 ) -> EmbeddedCurvePoint {
-    let point_array = embedded_curve_add_array_return(point1, point2);
-    let x = point_array[0];
-    let y = point_array[1];
-
-    EmbeddedCurvePoint { x, y, is_infinite: false }
+    embedded_curve_add_array_return(point1, point2)[0]
 }

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -80,7 +80,7 @@ pub fn pedersen_hash_with_separator<let N: u32>(input: [Field; N], separator: u3
     let length_generator: [EmbeddedCurvePoint; 1] =
         derive_generators("pedersen_hash_length".as_bytes(), 0);
     generators[N] = length_generator[0];
-    multi_scalar_mul_array_return(generators, scalars)[0]
+    multi_scalar_mul_array_return(generators, scalars)[0].x
 }
 
 #[field(bn254)]


### PR DESCRIPTION
# Description

## Problem\*

Embedded curve opcodes returned 3 fields on noir land, but on barretenberg side is_infinite is a boolean. This mismatch is problematic for the AVM.

## Summary\*

I've changed ecadd and msm to return an array of 1 EmbeddedCurvePoint. I can't return an EmbeddedCurvePoint directly since the AVM doesn't handle proving opcodes with more than one return register. By making it an array, we just have one pointer in the opcode, which also makes it smaller. This quirk is not exposed since the opcode is wrapped in the stdlib. No change should happen for users.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
