### PR TITLE
chore: unhide `nargo export` command from CLI docs

### DIFF
--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -98,7 +98,6 @@ enum NargoCommand {
     New(new_cmd::NewCommand),
     Init(init_cmd::InitCommand),
     Execute(execute_cmd::ExecuteCommand),
-    #[command(hide = true)] // Hidden while the feature is being built out
     Export(export_cmd::ExportCommand),
     Debug(debug_cmd::DebugCommand),
     Test(test_cmd::TestCommand),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Just noticed this was still hidden. I wouldn't say this is fully stabilised but we use it in various places in libraries so there's no reason for it to be hidden.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
