### PR TITLE
feat: faster `Field` decomposition

### DIFF
--- a/noir_stdlib/src/field/bn254.nr
+++ b/noir_stdlib/src/field/bn254.nr
@@ -12,7 +12,7 @@ fn compute_decomposition(mut x: Field) -> (Field, Field) {
     // Here's we're taking advantage of truncating 128 bit limbs from the input field
     // and then subtracting them from the input such the field division is equivalent to integer division.
     let low = (x as u128) as Field;
-    let high x = (x - low) / TWO_POW_128;
+    let high = (x - low) / TWO_POW_128;
     
     (low, high)
 }

--- a/noir_stdlib/src/field/bn254.nr
+++ b/noir_stdlib/src/field/bn254.nr
@@ -8,7 +8,7 @@ global PHI: Field = 64323764613183177041862057485226039389;
 pub(crate) global TWO_POW_128: Field = 0x100000000000000000000000000000000;
 
 // Decomposes a single field into two 16 byte fields.
-fn compute_decomposition(mut x: Field) -> (Field, Field) {
+fn compute_decomposition(x: Field) -> (Field, Field) {
     // Here's we're taking advantage of truncating 128 bit limbs from the input field
     // and then subtracting them from the input such the field division is equivalent to integer division.
     let low = (x as u128) as Field;

--- a/noir_stdlib/src/field/bn254.nr
+++ b/noir_stdlib/src/field/bn254.nr
@@ -6,19 +6,14 @@ global PLO: Field = 53438638232309528389504892708671455233;
 global PHI: Field = 64323764613183177041862057485226039389;
 
 pub(crate) global TWO_POW_128: Field = 0x100000000000000000000000000000000;
-global TWO_POW_64: Field = 0x10000000000000000;
 
 // Decomposes a single field into two 16 byte fields.
 fn compute_decomposition(mut x: Field) -> (Field, Field) {
-    // Here's we're taking advantage of truncating 64 bit limbs from the input field
+    // Here's we're taking advantage of truncating 128 bit limbs from the input field
     // and then subtracting them from the input such the field division is equivalent to integer division.
-    let low_lower_64 = (x as u64) as Field;
-    x = (x - low_lower_64) / TWO_POW_64;
-    let low_upper_64 = (x as u64) as Field;
-
-    let high = (x - low_upper_64) / TWO_POW_64;
-    let low = low_upper_64 * TWO_POW_64 + low_lower_64;
-
+    let low = (x as u128) as Field;
+    let high x = (x - low) / TWO_POW_128;
+    
     (low, high)
 }
 

--- a/noir_stdlib/src/field/bn254.nr
+++ b/noir_stdlib/src/field/bn254.nr
@@ -13,7 +13,7 @@ fn compute_decomposition(mut x: Field) -> (Field, Field) {
     // and then subtracting them from the input such the field division is equivalent to integer division.
     let low = (x as u128) as Field;
     let high = (x - low) / TWO_POW_128;
-    
+
     (low, high)
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I noticed that we hadn't updated this to take advantage of the native u128 type so I've done so.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
