### PR TITLE
feat(debugging): Add `--count-array-copies` flag

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -144,6 +144,10 @@ pub struct CompileOptions {
     #[arg(long, hide = true)]
     pub enable_brillig_debug_assertions: bool,
 
+    /// Count the number of arrays that are copied in an unconstrained context for performance debugging
+    #[arg(long)]
+    pub count_array_copies: bool,
+
     /// Flag to turn on the lookback feature of the Brillig call constraints
     /// check, allowing tracking argument values before the call happens preventing
     /// certain rare false positives (leads to a slowdown on large rollout functions)
@@ -737,6 +741,7 @@ pub fn compile_no_check(
         brillig_options: BrilligOptions {
             enable_debug_trace: options.show_brillig,
             enable_debug_assertions: options.enable_brillig_debug_assertions,
+            enable_array_copy_counter: options.count_array_copies,
         },
         print_codegen_timings: options.benchmark_codegen,
         expression_width: if options.bounded_codegen {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -29,12 +29,10 @@ pub(crate) fn convert_ssa_function(
     options: &BrilligOptions,
     globals: &HashMap<ValueId, BrilligVariable>,
     hoisted_global_constants: &HashMap<(FieldElement, NumericType), BrilligVariable>,
-    globals_memory_size: Option<usize>,
+    is_entry_point: bool,
 ) -> BrilligArtifact<FieldElement> {
     let mut brillig_context = BrilligContext::new(options);
-    brillig_context.set_globals_memory_size(globals_memory_size);
-
-    let mut function_context = FunctionContext::new(func);
+    let mut function_context = FunctionContext::new(func, is_entry_point);
 
     brillig_context.enter_context(Label::function(func.id()));
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -29,8 +29,10 @@ pub(crate) fn convert_ssa_function(
     options: &BrilligOptions,
     globals: &HashMap<ValueId, BrilligVariable>,
     hoisted_global_constants: &HashMap<(FieldElement, NumericType), BrilligVariable>,
+    globals_memory_size: Option<usize>,
 ) -> BrilligArtifact<FieldElement> {
     let mut brillig_context = BrilligContext::new(options);
+    brillig_context.set_globals_memory_size(globals_memory_size);
 
     let mut function_context = FunctionContext::new(func);
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -137,7 +137,6 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // If this flag is set, also compile the array copy counter as a global
         if self.brillig_context.enable_debug_assertions() {
             let new_variable = allocate_value_with_type(self.brillig_context, Type::unsigned(32));
-            eprintln!("initializing array copy counter @ {:?}", new_variable.extract_register());
             self.brillig_context
                 .const_instruction(new_variable.extract_single_addr(), FieldElement::zero());
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -168,6 +168,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
 
         if self.brillig_context.count_array_copies()
             && matches!(terminator_instruction, TerminatorInstruction::Return { .. })
+            && self.brillig_context.in_entry_point_function()
         {
             self.brillig_context.emit_println_of_array_copy_counter();
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -133,6 +133,15 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 unreachable!("ICE: ({constant:?}, {typ:?}) was already in cache");
             }
         }
+
+        // If this flag is set, also compile the array copy counter as a global
+        if self.brillig_context.enable_debug_assertions() {
+            let new_variable = allocate_value_with_type(self.brillig_context, Type::unsigned(32));
+            eprintln!("initializing array copy counter @ {:?}", new_variable.extract_register());
+            self.brillig_context
+                .const_instruction(new_variable.extract_single_addr(), FieldElement::zero());
+        }
+
         new_hoisted_constants
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -168,7 +168,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
 
         if self.brillig_context.count_array_copies()
             && matches!(terminator_instruction, TerminatorInstruction::Return { .. })
-            && self.brillig_context.in_entry_point_function()
+            && self.function_context.is_entry_point
         {
             self.brillig_context.emit_println_of_array_copy_counter();
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -30,11 +30,13 @@ pub(crate) struct FunctionContext {
     pub(crate) liveness: VariableLiveness,
     /// Information on where to allocate constants
     pub(crate) constant_allocation: ConstantAllocation,
+    /// True if this function is a brillig entry point
+    pub(crate) is_entry_point: bool,
 }
 
 impl FunctionContext {
     /// Creates a new function context. It will allocate parameters for all blocks and compute the liveness of every variable.
-    pub(crate) fn new(function: &Function) -> Self {
+    pub(crate) fn new(function: &Function, is_entry_point: bool) -> Self {
         let id = function.id();
 
         let mut reverse_post_order = Vec::new();
@@ -49,6 +51,7 @@ impl FunctionContext {
             ssa_value_allocations: HashMap::default(),
             blocks: reverse_post_order,
             liveness,
+            is_entry_point,
             constant_allocation: constants,
         }
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
@@ -100,6 +100,10 @@ impl BrilligGlobals {
         }
     }
 
+    pub(crate) fn entry_points(&self) -> &BTreeMap<FunctionId, BTreeSet<FunctionId>> {
+        &self.brillig_entry_points
+    }
+
     /// Helper for marking that a constant was instantiated in a given function.
     /// For a given entry point, we want to determine which constants are shared across multiple functions.
     fn mark_globals_for_hoisting(

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_slice_ops.rs
@@ -190,7 +190,7 @@ mod tests {
         let mut brillig_context = create_context(ssa.main_id);
         brillig_context.enter_context(Label::block(ssa.main_id, Id::test_new(0)));
 
-        let function_context = FunctionContext::new(ssa.main());
+        let function_context = FunctionContext::new(ssa.main(), true);
         (ssa, function_context, brillig_context)
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -111,24 +111,18 @@ impl<F, R> BrilligContext<F, R> {
 
     /// Returns the address of the implicit debug variable containing the count of
     /// implicitly copied arrays as a result of RC's copy on write semantics.
-    /// This method assumes
     pub(crate) fn array_copy_counter_address(&self) -> MemoryAddress {
         assert!(
             self.count_arrays_copied,
             "`count_arrays_copied` is not set, so the array copy counter does not exist"
         );
 
-        let size = self.globals_memory_size.expect("Expected a globals memory size");
-        // The copy counter is always put in the last global slot
-        MemoryAddress::direct(GlobalSpace::start() + size - 1)
+        // The copy counter is always put in the first global slot
+        MemoryAddress::Direct(GlobalSpace::start())
     }
 
     pub(crate) fn count_array_copies(&self) -> bool {
         self.count_arrays_copied
-    }
-
-    pub(crate) fn get_globals_memory_size(&self) -> Option<usize> {
-        self.globals_memory_size
     }
 
     /// Set the globals memory size if it is not already set.

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -111,13 +111,36 @@ impl<F, R> BrilligContext<F, R> {
 
     /// Returns the address of the implicit debug variable containing the count of
     /// implicitly copied arrays as a result of RC's copy on write semantics.
-    /// This method assumes 
+    /// This method assumes
     pub(crate) fn array_copy_counter_address(&self) -> MemoryAddress {
-        assert!(self.count_arrays_copied, "`count_arrays_copied` is not set, so the array copy counter does not exist");
+        assert!(
+            self.count_arrays_copied,
+            "`count_arrays_copied` is not set, so the array copy counter does not exist"
+        );
 
         let size = self.globals_memory_size.expect("Expected a globals memory size");
         // The copy counter is always put in the last global slot
         MemoryAddress::direct(GlobalSpace::start() + size - 1)
+    }
+
+    pub(crate) fn count_array_copies(&self) -> bool {
+        self.count_arrays_copied
+    }
+
+    pub(crate) fn get_globals_memory_size(&self) -> Option<usize> {
+        self.globals_memory_size
+    }
+
+    /// Set the globals memory size if it is not already set.
+    /// If it is already set, this will assert that the two values must be equal.
+    pub(crate) fn set_globals_memory_size(&mut self, new_size: Option<usize>) {
+        if self.globals_memory_size.is_some() {
+            assert_eq!(
+                self.globals_memory_size, new_size,
+                "Tried to change globals_memory_size to a different value"
+            );
+        }
+        self.globals_memory_size = new_size;
     }
 }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -408,7 +408,7 @@ pub(crate) mod tests {
             let LabelType::Procedure(procedure_id) = unresolved_fn_label.label_type else {
                 panic!("Test functions cannot be linked with other functions");
             };
-            let procedure_artifact = compile_procedure(procedure_id, &options, None);
+            let procedure_artifact = compile_procedure(procedure_id, &options);
             entry_point_artifact.link_with(&procedure_artifact);
         }
         entry_point_artifact.finish()

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -136,15 +136,6 @@ impl<F, R> BrilligContext<F, R> {
         }
         self.globals_memory_size = new_size;
     }
-
-    /// True if we are currently in an entry point function. This is currently only
-    /// indirectly deduced by whether `globals_memory_size` is set. This is used
-    /// for the output of the array copy counter so that flag should be tested
-    /// if globals_memory_size is ever changed. Testing should be done with a low inliner
-    /// aggressiveness to more easily identify whether it is printing in multiple functions.
-    pub(crate) fn in_entry_point_function(&self) -> bool {
-        self.globals_memory_size.is_some()
-    }
 }
 
 /// Regular brillig context to codegen user defined functions

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -136,6 +136,15 @@ impl<F, R> BrilligContext<F, R> {
         }
         self.globals_memory_size = new_size;
     }
+
+    /// True if we are currently in an entry point function. This is currently only
+    /// indirectly deduced by whether `globals_memory_size` is set. This is used
+    /// for the output of the array copy counter so that flag should be tested
+    /// if globals_memory_size is ever changed. Testing should be done with a low inliner
+    /// aggressiveness to more easily identify whether it is printing in multiple functions.
+    pub(crate) fn in_entry_point_function(&self) -> bool {
+        self.globals_memory_size.is_some()
+    }
 }
 
 /// Regular brillig context to codegen user defined functions

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
@@ -207,7 +207,11 @@ mod tests {
     }
 
     pub(crate) fn create_context() -> BrilligContext<FieldElement, Stack> {
-        let options = BrilligOptions { enable_debug_trace: true, enable_debug_assertions: true };
+        let options = BrilligOptions {
+            enable_debug_trace: true,
+            enable_debug_assertions: true,
+            enable_array_copy_counter: false,
+        };
         let mut context = BrilligContext::new(&options);
         context.enter_context(Label::function(FunctionId::test_new(0)));
         context

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -23,10 +23,15 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         return_parameters: Vec<BrilligParameter>,
         target_function: FunctionId,
         globals_init: bool,
-        globals_memory_size: usize,
+        mut globals_memory_size: usize,
         options: &BrilligOptions,
     ) -> BrilligArtifact<F> {
         let mut context = BrilligContext::new(options);
+
+        if options.enable_debug_assertions {
+            // Reserve space for the array clone counter
+            globals_memory_size += 1;
+        }
 
         context.globals_memory_size = Some(globals_memory_size);
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -23,15 +23,10 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         return_parameters: Vec<BrilligParameter>,
         target_function: FunctionId,
         globals_init: bool,
-        mut globals_memory_size: usize,
+        globals_memory_size: usize,
         options: &BrilligOptions,
     ) -> BrilligArtifact<F> {
         let mut context = BrilligContext::new(options);
-
-        if options.enable_array_copy_counter {
-            // Reserve space for the array clone counter
-            globals_memory_size += 1;
-        }
 
         context.set_globals_memory_size(Some(globals_memory_size));
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -28,12 +28,12 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
     ) -> BrilligArtifact<F> {
         let mut context = BrilligContext::new(options);
 
-        if options.enable_debug_assertions {
+        if options.enable_array_copy_counter {
             // Reserve space for the array clone counter
             globals_memory_size += 1;
         }
 
-        context.globals_memory_size = Some(globals_memory_size);
+        context.set_globals_memory_size(Some(globals_memory_size));
 
         context.codegen_entry_point(&arguments, &return_parameters);
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
@@ -88,7 +88,6 @@ pub(super) fn compile_array_copy_procedure<F: AcirField + DebugToString>(
 
                 let counter_register = array_copy_counter.extract_register();
                 ctx.codegen_usize_op(counter_register, counter_register, BrilligBinaryOp::Add, 1);
-                ctx.emit_println_of_array_copy_counter();
             }
         }
     });
@@ -153,7 +152,7 @@ fn initialize_constant_string<F: AcirField + DebugToString, Registers: RegisterA
 
 impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
     /// emit: `println(f"Total arrays copied: {array_copy_counter}")`
-    fn emit_println_of_array_copy_counter(&mut self) {
+    pub(crate) fn emit_println_of_array_copy_counter(&mut self) {
         let array_copy_counter = BrilligVariable::SingleAddr(SingleAddrVariable {
             address: self.array_copy_counter_address(),
             bit_size: 32,
@@ -162,8 +161,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         let newline = ValueOrArray::MemoryAddress(ReservedRegisters::usize_one());
         let message = literal_string_to_value(ARRAY_COPY_COUNTER_MESSAGE, self);
         let item_count = ValueOrArray::MemoryAddress(ReservedRegisters::usize_one());
-        let value_to_print =
-            ValueOrArray::MemoryAddress(array_copy_counter.extract_register());
+        let value_to_print = ValueOrArray::MemoryAddress(array_copy_counter.extract_register());
         let type_string_metadata = literal_string_to_value(PRINT_U32_TYPE_STRING, self);
         let is_fmt_string = ValueOrArray::MemoryAddress(ReservedRegisters::usize_one());
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
@@ -1,13 +1,19 @@
 use std::vec;
 
-use acvm::{AcirField, acir::brillig::MemoryAddress};
+use acvm::{
+    AcirField,
+    acir::brillig::{BitSize, HeapValueType, IntegerBitSize, MemoryAddress, ValueOrArray},
+};
 
 use super::ProcedureId;
-use crate::brillig::brillig_ir::{
-    BRILLIG_MEMORY_ADDRESSING_BIT_SIZE, BrilligBinaryOp, BrilligContext,
-    brillig_variable::{BrilligArray, SingleAddrVariable},
-    debug_show::DebugToString,
-    registers::{RegisterAllocator, ScratchSpace},
+use crate::brillig::{
+    BrilligVariable, GlobalSpace,
+    brillig_ir::{
+        BRILLIG_MEMORY_ADDRESSING_BIT_SIZE, BrilligBinaryOp, BrilligContext, ReservedRegisters,
+        brillig_variable::{BrilligArray, SingleAddrVariable},
+        debug_show::DebugToString,
+        registers::{RegisterAllocator, ScratchSpace},
+    },
 };
 
 impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
@@ -69,8 +75,116 @@ pub(super) fn compile_array_copy_procedure<F: AcirField + DebugToString>(
                 BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
                 1_usize.into(),
             );
+
             // Decrease the original ref count now that this copy is no longer pointing to it
             ctx.codegen_usize_op(rc.address, rc.address, BrilligBinaryOp::Sub, 1);
+
+            // Increase our array copy counter if that flag is set
+            if ctx.enable_debug_assertions {
+                let size = ctx.globals_memory_size.expect("Expected a globals memory size");
+                // The copy counter is always put in the last global slot
+                let addr = GlobalSpace::start() + size - 1;
+
+                eprintln!("array clone counter @ address {}", addr);
+                let array_copy_counter = BrilligVariable::SingleAddr(SingleAddrVariable {
+                    address: MemoryAddress::direct(addr),
+                    bit_size: 32,
+                });
+
+                let counter_register = array_copy_counter.extract_register();
+                ctx.codegen_usize_op(counter_register, counter_register, BrilligBinaryOp::Add, 1);
+
+                let zero_register = SingleAddrVariable::new_usize(ctx.allocate_register());
+                ctx.const_instruction(zero_register, AcirField::zero());
+
+                let newline = ValueOrArray::MemoryAddress(ReservedRegisters::usize_one());
+                let is_fmt_string = ValueOrArray::MemoryAddress(zero_register.address);
+                let item_count = ValueOrArray::MemoryAddress(ReservedRegisters::usize_one());
+                let type_string_metadata = print_u32_type_string(ctx);
+                let value_to_print =
+                    ValueOrArray::MemoryAddress(array_copy_counter.extract_register());
+
+                let inputs =
+                    [newline, is_fmt_string, item_count, type_string_metadata, value_to_print];
+
+                let u8_type = HeapValueType::Simple(BitSize::Integer(IntegerBitSize::U8));
+                let u32_type = HeapValueType::Simple(BitSize::Integer(IntegerBitSize::U32));
+
+                let input_types = [
+                    u32_type.clone(), // newline
+                    u32_type.clone(), // is_fmt_string
+                    u32_type.clone(), // item_count
+                    HeapValueType::Array {
+                        value_types: vec![u8_type],
+                        size: PRINT_U32_TYPE_STRING.len(),
+                    },
+                    u32_type.clone(), // value_to_print
+                ];
+
+                ctx.foreign_call_instruction("print".to_string(), &inputs, &input_types, &[], &[]);
+            }
         }
     });
+}
+
+/// The metadata string needed to tell `print` to print out a u32
+const PRINT_U32_TYPE_STRING: &str = "{\"kind\":\"unsignedinteger\",\"width\":32}";
+// "{\"kind\":\"array\",\"length\":2,\"type\":{\"kind\":\"unsignedinteger\",\"width\":32}}";
+
+// Create and return the string `PRINT_U32_TYPE_STRING`
+fn print_u32_type_string<F: AcirField + DebugToString>(
+    brillig_context: &mut BrilligContext<F, ScratchSpace>,
+) -> ValueOrArray {
+    let target = PRINT_U32_TYPE_STRING;
+
+    let brillig_array =
+        BrilligArray { pointer: brillig_context.allocate_register(), size: target.len() };
+
+    brillig_context.codegen_initialize_array(brillig_array);
+
+    let items_pointer = brillig_context.codegen_make_array_items_pointer(brillig_array);
+
+    initialize_constant_string(brillig_context, target, items_pointer);
+    brillig_context.deallocate_register(items_pointer);
+
+    brillig_context.memory_op_instruction(
+        brillig_array.pointer,
+        ReservedRegisters::usize_one(),
+        brillig_array.pointer,
+        BrilligBinaryOp::Add,
+    );
+
+    ValueOrArray::HeapArray(acvm::acir::brillig::HeapArray {
+        pointer: brillig_array.pointer,
+        size: brillig_array.size,
+    })
+}
+
+// This function was adapted from `initialize_constant_array_comptime`
+fn initialize_constant_string<F: AcirField + DebugToString>(
+    brillig_context: &mut BrilligContext<F, ScratchSpace>,
+    data: &str,
+    pointer: MemoryAddress,
+) {
+    // Allocate a register for the iterator
+    let write_pointer_register = brillig_context.allocate_register();
+    brillig_context.mov_instruction(write_pointer_register, pointer);
+
+    for (element_idx, byte) in data.bytes().enumerate() {
+        let byte_field = AcirField::from_le_bytes_reduce(&[byte]);
+        // Store the item in memory
+        brillig_context.indirect_const_instruction(write_pointer_register, 32, byte_field);
+
+        if element_idx != data.len() - 1 {
+            // Increment the write_pointer_register
+            brillig_context.memory_op_instruction(
+                write_pointer_register,
+                ReservedRegisters::usize_one(),
+                write_pointer_register,
+                BrilligBinaryOp::Add,
+            );
+        }
+    }
+
+    brillig_context.deallocate_register(write_pointer_register);
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
@@ -117,7 +117,7 @@ pub(crate) fn compile_procedure<F: AcirField + DebugToString>(
 
     // If this flag is set, the array copy procedure needs to track when each array is cloned
     // through a global counter variable.
-    if brillig_context.enable_debug_assertions {
+    if brillig_context.count_arrays_copied {
         brillig_context.globals_memory_size = globals_memory_size;
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
@@ -111,16 +111,8 @@ impl std::fmt::Display for ProcedureId {
 pub(crate) fn compile_procedure<F: AcirField + DebugToString>(
     procedure_id: ProcedureId,
     options: &BrilligOptions,
-    globals_memory_size: Option<usize>,
 ) -> BrilligArtifact<F> {
     let mut brillig_context = BrilligContext::new_for_procedure(procedure_id.clone(), options);
-
-    // If this flag is set, the array copy procedure needs to track when each array is cloned
-    // through a global counter variable.
-    if brillig_context.count_arrays_copied {
-        brillig_context.set_globals_memory_size(globals_memory_size);
-    }
-
     brillig_context.enter_context(Label::procedure(procedure_id.clone()));
 
     match procedure_id {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
@@ -118,7 +118,7 @@ pub(crate) fn compile_procedure<F: AcirField + DebugToString>(
     // If this flag is set, the array copy procedure needs to track when each array is cloned
     // through a global counter variable.
     if brillig_context.count_arrays_copied {
-        brillig_context.globals_memory_size = globals_memory_size;
+        brillig_context.set_globals_memory_size(globals_memory_size);
     }
 
     brillig_context.enter_context(Label::procedure(procedure_id.clone()));

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
@@ -111,8 +111,16 @@ impl std::fmt::Display for ProcedureId {
 pub(crate) fn compile_procedure<F: AcirField + DebugToString>(
     procedure_id: ProcedureId,
     options: &BrilligOptions,
+    globals_memory_size: Option<usize>,
 ) -> BrilligArtifact<F> {
     let mut brillig_context = BrilligContext::new_for_procedure(procedure_id.clone(), options);
+
+    // If this flag is set, the array copy procedure needs to track when each array is cloned
+    // through a global counter variable.
+    if brillig_context.enable_debug_assertions {
+        brillig_context.globals_memory_size = globals_memory_size;
+    }
+
     brillig_context.enter_context(Label::procedure(procedure_id.clone()));
 
     match procedure_id {
@@ -142,6 +150,5 @@ pub(crate) fn compile_procedure<F: AcirField + DebugToString>(
     };
 
     brillig_context.return_instruction();
-
     brillig_context.artifact()
 }

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -54,15 +54,10 @@ impl Brillig {
         options: &BrilligOptions,
         globals: &HashMap<ValueId, BrilligVariable>,
         hoisted_global_constants: &HashMap<(FieldElement, NumericType), BrilligVariable>,
-        globals_memory_size: Option<usize>,
+        is_entry_point: bool,
     ) {
-        let obj = convert_ssa_function(
-            func,
-            options,
-            globals,
-            hoisted_global_constants,
-            globals_memory_size,
-        );
+        let obj =
+            convert_ssa_function(func, options, globals, hoisted_global_constants, is_entry_point);
         self.ssa_function_to_brillig.insert(func.id(), obj);
     }
 
@@ -138,14 +133,14 @@ impl Ssa {
                 .unwrap_or((&empty_allocations, &empty_const_allocations));
 
             let func = &self.functions[&brillig_function_id];
-            let globals_memory_size =
-                brillig.globals_memory_size.get(&brillig_function_id).copied();
+            let is_entry_point = brillig_globals.entry_points().contains_key(&brillig_function_id);
+
             brillig.compile(
                 func,
                 options,
                 globals_allocations,
                 hoisted_constant_allocations,
-                globals_memory_size,
+                is_entry_point,
             );
         }
 

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -33,6 +33,7 @@ pub use self::brillig_ir::procedures::ProcedureId;
 pub struct BrilligOptions {
     pub enable_debug_trace: bool,
     pub enable_debug_assertions: bool,
+    pub enable_array_copy_counter: bool,
 }
 
 /// Context structure for the brillig pass.

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -78,9 +78,7 @@ impl Brillig {
             }
             // Procedures are compiled as needed
             LabelType::Procedure(procedure_id) => {
-                let globals_size = (self.globals_memory_size.len() == 1)
-                    .then(|| *self.globals_memory_size.values().next().unwrap());
-                Some(Cow::Owned(compile_procedure(procedure_id, options, globals_size)))
+                Some(Cow::Owned(compile_procedure(procedure_id, options)))
             }
             LabelType::GlobalInit(function_id) => self.globals.get(&function_id).map(Cow::Borrowed),
             _ => unreachable!("ICE: Expected a function or procedure label"),

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -54,8 +54,15 @@ impl Brillig {
         options: &BrilligOptions,
         globals: &HashMap<ValueId, BrilligVariable>,
         hoisted_global_constants: &HashMap<(FieldElement, NumericType), BrilligVariable>,
+        globals_memory_size: Option<usize>,
     ) {
-        let obj = convert_ssa_function(func, options, globals, hoisted_global_constants);
+        let obj = convert_ssa_function(
+            func,
+            options,
+            globals,
+            hoisted_global_constants,
+            globals_memory_size,
+        );
         self.ssa_function_to_brillig.insert(func.id(), obj);
     }
 
@@ -133,7 +140,15 @@ impl Ssa {
                 .unwrap_or((&empty_allocations, &empty_const_allocations));
 
             let func = &self.functions[&brillig_function_id];
-            brillig.compile(func, options, globals_allocations, hoisted_constant_allocations);
+            let globals_memory_size =
+                brillig.globals_memory_size.get(&brillig_function_id).copied();
+            brillig.compile(
+                func,
+                options,
+                globals_allocations,
+                hoisted_constant_allocations,
+                globals_memory_size,
+            );
         }
 
         brillig

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -70,7 +70,9 @@ impl Brillig {
             }
             // Procedures are compiled as needed
             LabelType::Procedure(procedure_id) => {
-                Some(Cow::Owned(compile_procedure(procedure_id, options)))
+                let globals_size = (self.globals_memory_size.len() == 1)
+                    .then(|| *self.globals_memory_size.values().next().unwrap());
+                Some(Cow::Owned(compile_procedure(procedure_id, options, globals_size)))
             }
             LabelType::GlobalInit(function_id) => self.globals.get(&function_id).map(Cow::Borrowed),
             _ => unreachable!("ICE: Expected a function or procedure label"),

--- a/tooling/nargo/src/foreign_calls/print.rs
+++ b/tooling/nargo/src/foreign_calls/print.rs
@@ -108,11 +108,12 @@ fn convert_fmt_string_inputs<F: AcirField>(
         .ok_or(ForeignCallError::MissingForeignCallInputs)?;
 
     let mut output = Vec::new();
-    let num_values = num_values.unwrap_field().to_u128() as usize;
+    let num_values = dbg!(num_values.unwrap_field()).to_u128() as usize;
 
-    let types_start_at = input_and_printable_types.len() - num_values;
+    let types_start_at = dbg!(input_and_printable_types).len() - num_values;
+
     let mut input_iter =
-        input_and_printable_types[0..types_start_at].iter().flat_map(|param| param.fields());
+        input_and_printable_types[0..dbg!(types_start_at)].iter().flat_map(|param| param.fields());
     for printable_type in input_and_printable_types.iter().skip(types_start_at) {
         let printable_type = fetch_printable_type(printable_type)?;
         let value = decode_printable_value(&mut input_iter, &printable_type);
@@ -126,9 +127,9 @@ fn convert_fmt_string_inputs<F: AcirField>(
 fn fetch_printable_type<F: AcirField>(
     printable_type: &ForeignCallParam<F>,
 ) -> Result<PrintableType, ForeignCallError> {
-    let printable_type_as_fields = printable_type.fields();
+    let printable_type_as_fields = dbg!(printable_type.fields());
     let printable_type_as_string = decode_string_value(&printable_type_as_fields);
-    let printable_type: PrintableType = serde_json::from_str(&printable_type_as_string)?;
+    let printable_type: PrintableType = serde_json::from_str(dbg!(&printable_type_as_string))?;
 
     Ok(printable_type)
 }

--- a/tooling/nargo/src/foreign_calls/print.rs
+++ b/tooling/nargo/src/foreign_calls/print.rs
@@ -108,12 +108,12 @@ fn convert_fmt_string_inputs<F: AcirField>(
         .ok_or(ForeignCallError::MissingForeignCallInputs)?;
 
     let mut output = Vec::new();
-    let num_values = dbg!(num_values.unwrap_field()).to_u128() as usize;
+    let num_values = num_values.unwrap_field().to_u128() as usize;
 
-    let types_start_at = dbg!(input_and_printable_types).len() - num_values;
+    let types_start_at = input_and_printable_types.len() - num_values;
 
     let mut input_iter =
-        input_and_printable_types[0..dbg!(types_start_at)].iter().flat_map(|param| param.fields());
+        input_and_printable_types[0..types_start_at].iter().flat_map(|param| param.fields());
     for printable_type in input_and_printable_types.iter().skip(types_start_at) {
         let printable_type = fetch_printable_type(printable_type)?;
         let value = decode_printable_value(&mut input_iter, &printable_type);
@@ -127,9 +127,9 @@ fn convert_fmt_string_inputs<F: AcirField>(
 fn fetch_printable_type<F: AcirField>(
     printable_type: &ForeignCallParam<F>,
 ) -> Result<PrintableType, ForeignCallError> {
-    let printable_type_as_fields = dbg!(printable_type.fields());
+    let printable_type_as_fields = printable_type.fields();
     let printable_type_as_string = decode_string_value(&printable_type_as_fields);
-    let printable_type: PrintableType = serde_json::from_str(dbg!(&printable_type_as_string))?;
+    let printable_type: PrintableType = serde_json::from_str(&printable_type_as_string)?;
 
     Ok(printable_type)
 }


### PR DESCRIPTION
# Description

## Problem\*

Working towards https://github.com/noir-lang/noir/issues/7287 but this is also just a good debugging utility in general

## Summary\*

Adds a new flag `--count-array-copies` to count how many array copies are implicitly performed through brillig's copy on write semantics. This count is performed per brillig entry point so a program with multiple brillig entry points will also output multiple counts. Resultingly, this is easiest to use with `--force-brillig` or an entirely brillig program to see just one count.

This flag helps bring some hard data to the problem of array copies where we previously only had vague notions of "this program is too slow" or "this program seems fast enough." When passing this flag we output `Total arrays copied: {number}` after running each brillig entry point.

~~This is a draft because of a bug when counting the copies in `rollup-block-merge`~~

## Additional Context

Some data on array copy counts in existing programs. All of these are run with `nargo execute --force-brillig --count-array-copies`
- `private-kernel-init`: Total arrays copied: 136
- `private-kernel-tail`: Total arrays copied: 3
- `rollup-base-private`: Total arrays copied: 895
- `rollup-base-public`: Total arrays copied: 644
- `rollup-block-merge`: Total arrays copied: 902

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
