### PR TITLE
chore: include `eddsa` test in format check

### DIFF
--- a/test_programs/format.sh
+++ b/test_programs/format.sh
@@ -4,8 +4,6 @@ set -e
 # These tests are incompatible with gas reporting
 excluded_dirs=("workspace" "overlapping_dep_and_mod" "overlapping_dep_and_mod_fix" "workspace_default_member" "workspace_reexport_bug")
 
-# These tests cause failures in CI with a stack overflow for some reason.
-ci_excluded_dirs=("eddsa")
 
 current_dir=$(pwd)
 
@@ -18,10 +16,6 @@ function collect_dirs {
 
   for dir in $test_dirs; do
     if [[ " ${excluded_dirs[@]} " =~ " ${dir} " ]]; then
-      continue
-    fi
-
-    if [[ ${CI-false} = "true" ]] && [[ " ${ci_excluded_dirs[@]} " =~ " ${dir} " ]]; then
       continue
     fi
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/7790

## Summary\*

I'm not sure if this was intended to be applied to format.sh in the first place tbh.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
