### PR TITLE
chore: make brillig vm's `cast` implementation pure.

### DIFF
--- a/acvm-repo/brillig_vm/src/cast.rs
+++ b/acvm-repo/brillig_vm/src/cast.rs
@@ -13,8 +13,6 @@ pub(crate) fn cast<F: AcirField>(
     use MemoryValue::*;
 
     match (source_value, target_bit_size) {
-        // Field downcast to u128
-        (Field(field), BitSize::Integer(IntegerBitSize::U128)) => U128(field.to_u128()),
         // Field downcast to arbitrary bit size
         (Field(field), BitSize::Integer(target_bit_size)) => {
             let as_u128 = field.to_u128();
@@ -24,7 +22,7 @@ pub(crate) fn cast<F: AcirField>(
                 IntegerBitSize::U16 => U16(as_u128 as u16),
                 IntegerBitSize::U32 => U32(as_u128 as u32),
                 IntegerBitSize::U64 => U64(as_u128 as u64),
-                IntegerBitSize::U128 => unreachable!(),
+                IntegerBitSize::U128 => U128(as_u128),
             }
         }
 

--- a/acvm-repo/brillig_vm/src/cast.rs
+++ b/acvm-repo/brillig_vm/src/cast.rs
@@ -1,0 +1,82 @@
+use acir::{
+    AcirField,
+    brillig::{BitSize, IntegerBitSize},
+};
+
+use crate::MemoryValue;
+
+/// Casts a value to a different bit size.
+pub(crate) fn cast<F: AcirField>(
+    source_value: MemoryValue<F>,
+    target_bit_size: BitSize,
+) -> MemoryValue<F> {
+    use MemoryValue::*;
+
+    match (source_value, target_bit_size) {
+        // Field downcast to u128
+        (Field(field), BitSize::Integer(IntegerBitSize::U128)) => U128(field.to_u128()),
+        // Field downcast to arbitrary bit size
+        (Field(field), BitSize::Integer(target_bit_size)) => {
+            let as_u128 = field.to_u128();
+            match target_bit_size {
+                IntegerBitSize::U1 => U1(as_u128 & 0x01 == 1),
+                IntegerBitSize::U8 => U8(as_u128 as u8),
+                IntegerBitSize::U16 => U16(as_u128 as u16),
+                IntegerBitSize::U32 => U32(as_u128 as u32),
+                IntegerBitSize::U64 => U64(as_u128 as u64),
+                IntegerBitSize::U128 => unreachable!(),
+            }
+        }
+
+        (U1(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value.into()),
+        (U1(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value.into()),
+        (U1(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
+        (U1(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+        (U1(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+        (U1(value), BitSize::Field) => Field(value.into()),
+
+        (U8(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+        (U8(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value.into()),
+        (U8(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
+        (U8(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+        (U8(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+        (U8(value), BitSize::Field) => Field((value as u128).into()),
+
+        (U16(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+        (U16(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+        (U16(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
+        (U16(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+        (U16(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+        (U16(value), BitSize::Field) => Field((value as u128).into()),
+
+        (U32(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+        (U32(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+        (U32(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
+        (U32(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
+        (U32(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+        (U32(value), BitSize::Field) => Field((value as u128).into()),
+
+        (U64(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+        (U64(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+        (U64(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
+        (U64(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value as u32),
+        (U64(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
+        (U64(value), BitSize::Field) => Field((value as u128).into()),
+
+        (U128(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
+        (U128(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
+        (U128(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
+        (U128(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value as u32),
+        (U128(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value as u64),
+        (U128(value), BitSize::Field) => Field(value.into()),
+
+        // no ops
+        (Field(_), BitSize::Field) => source_value,
+        (U1(_), BitSize::Integer(IntegerBitSize::U1)) => source_value,
+        (U8(_), BitSize::Integer(IntegerBitSize::U8)) => source_value,
+        (U16(_), BitSize::Integer(IntegerBitSize::U16)) => source_value,
+        (U32(_), BitSize::Integer(IntegerBitSize::U32)) => source_value,
+        (U64(_), BitSize::Integer(IntegerBitSize::U64)) => source_value,
+        (U128(_), BitSize::Integer(IntegerBitSize::U128)) => source_value,
+    }
+}

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -26,6 +26,7 @@ pub use memory::{MEMORY_ADDRESSING_BIT_SIZE, Memory, MemoryValue};
 
 mod arithmetic;
 mod black_box;
+mod cast;
 mod memory;
 
 /// The error call stack contains the opcode indexes of the call stack at the time of failure, plus the index of the opcode that failed.
@@ -256,7 +257,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
             }
             Opcode::Cast { destination: destination_address, source: source_address, bit_size } => {
                 let source_value = self.memory.read(*source_address);
-                let casted_value = self.cast(*bit_size, source_value);
+                let casted_value = cast::cast(source_value, *bit_size);
                 self.memory.write(*destination_address, casted_value);
                 self.increment_program_counter()
             }
@@ -819,79 +820,6 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
         };
         self.memory.write(destination, negated_value);
         Ok(())
-    }
-
-    /// Casts a value to a different bit size.
-    fn cast(&self, target_bit_size: BitSize, source_value: MemoryValue<F>) -> MemoryValue<F> {
-        use MemoryValue::*;
-
-        match (source_value, target_bit_size) {
-            // Field downcast to u128
-            (Field(field), BitSize::Integer(IntegerBitSize::U128)) => U128(field.to_u128()),
-            // Field downcast to arbitrary bit size
-            (Field(field), BitSize::Integer(target_bit_size)) => {
-                let as_u128 = field.to_u128();
-                match target_bit_size {
-                    IntegerBitSize::U1 => U1(as_u128 & 0x01 == 1),
-                    IntegerBitSize::U8 => U8(as_u128 as u8),
-                    IntegerBitSize::U16 => U16(as_u128 as u16),
-                    IntegerBitSize::U32 => U32(as_u128 as u32),
-                    IntegerBitSize::U64 => U64(as_u128 as u64),
-                    IntegerBitSize::U128 => unreachable!(),
-                }
-            }
-
-            (U1(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value.into()),
-            (U1(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value.into()),
-            (U1(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
-            (U1(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
-            (U1(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
-            (U1(value), BitSize::Field) => Field(value.into()),
-
-            (U8(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
-            (U8(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value.into()),
-            (U8(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
-            (U8(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
-            (U8(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
-            (U8(value), BitSize::Field) => Field((value as u128).into()),
-
-            (U16(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
-            (U16(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
-            (U16(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value.into()),
-            (U16(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
-            (U16(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
-            (U16(value), BitSize::Field) => Field((value as u128).into()),
-
-            (U32(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
-            (U32(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
-            (U32(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
-            (U32(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value.into()),
-            (U32(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
-            (U32(value), BitSize::Field) => Field((value as u128).into()),
-
-            (U64(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
-            (U64(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
-            (U64(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
-            (U64(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value as u32),
-            (U64(value), BitSize::Integer(IntegerBitSize::U128)) => U128(value.into()),
-            (U64(value), BitSize::Field) => Field((value as u128).into()),
-
-            (U128(value), BitSize::Integer(IntegerBitSize::U1)) => U1(value & 0x01 == 1),
-            (U128(value), BitSize::Integer(IntegerBitSize::U8)) => U8(value as u8),
-            (U128(value), BitSize::Integer(IntegerBitSize::U16)) => U16(value as u16),
-            (U128(value), BitSize::Integer(IntegerBitSize::U32)) => U32(value as u32),
-            (U128(value), BitSize::Integer(IntegerBitSize::U64)) => U64(value as u64),
-            (U128(value), BitSize::Field) => Field(value.into()),
-
-            // no ops
-            (Field(_), BitSize::Field) => source_value,
-            (U1(_), BitSize::Integer(IntegerBitSize::U1)) => source_value,
-            (U8(_), BitSize::Integer(IntegerBitSize::U8)) => source_value,
-            (U16(_), BitSize::Integer(IntegerBitSize::U16)) => source_value,
-            (U32(_), BitSize::Integer(IntegerBitSize::U32)) => source_value,
-            (U64(_), BitSize::Integer(IntegerBitSize::U64)) => source_value,
-            (U128(_), BitSize::Integer(IntegerBitSize::U128)) => source_value,
-        }
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Small refactoring PR as part of casting work. the `cast` method in the brillig VM is actually pure so I've pulled it out so that we can run tests in isolation.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
