### PR TITLE
fix: improve misleading error message when object type is unknown

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -521,7 +521,13 @@ impl Elaborator<'_> {
         let method_name_location = method_call.method_name.location();
         let method_name = method_call.method_name.as_str();
         let check_self_param = true;
-        match self.lookup_method(&object_type, method_name, location, check_self_param) {
+        match self.lookup_method(
+            &object_type,
+            method_name,
+            location,
+            object_location,
+            check_self_param,
+        ) {
             Some(method_ref) => {
                 // Automatically add `&mut` if the method expects a mutable reference and
                 // the object is not already one.

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -873,11 +873,17 @@ impl Elaborator<'_> {
 
     pub(super) fn elaborate_type_path(&mut self, path: TypePath) -> (ExprId, Type) {
         let location = path.item.location();
+        let object_location = path.typ.location;
         let typ = self.resolve_type(path.typ);
         let check_self_param = false;
 
-        let Some(method) = self.lookup_method(&typ, path.item.as_str(), location, check_self_param)
-        else {
+        let Some(method) = self.lookup_method(
+            &typ,
+            path.item.as_str(),
+            location,
+            object_location,
+            check_self_param,
+        ) else {
             let error = Expression::new(ExpressionKind::Error, location);
             return self.elaborate_expression(error);
         };

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1433,6 +1433,7 @@ impl Elaborator<'_> {
         object_type: &Type,
         method_name: &str,
         location: Location,
+        object_location: Location,
         check_self_param: bool,
     ) -> Option<HirMethodReference> {
         match object_type.follow_bindings() {
@@ -1446,14 +1447,21 @@ impl Elaborator<'_> {
                 });
                 None
             }
-            Type::NamedGeneric(_, _) => {
-                self.lookup_method_in_trait_constraints(object_type, method_name, location)
-            }
+            Type::NamedGeneric(_, _) => self.lookup_method_in_trait_constraints(
+                object_type,
+                method_name,
+                location,
+                object_location,
+            ),
             // References to another type should resolve to methods of their element type.
             // This may be a data type or a primitive type.
-            Type::Reference(element, _mutable) => {
-                self.lookup_method(&element, method_name, location, check_self_param)
-            }
+            Type::Reference(element, _mutable) => self.lookup_method(
+                &element,
+                method_name,
+                location,
+                object_location,
+                check_self_param,
+            ),
 
             // If we fail to resolve the object to a data type, we have no way of type
             // checking its arguments as we can't even resolve the name of the function
@@ -1469,6 +1477,7 @@ impl Elaborator<'_> {
                 &other,
                 method_name,
                 location,
+                object_location,
                 check_self_param,
             ),
         }
@@ -1479,6 +1488,7 @@ impl Elaborator<'_> {
         object_type: &Type,
         method_name: &str,
         location: Location,
+        object_location: Location,
         check_self_param: bool,
     ) -> Option<HirMethodReference> {
         // First search in the type methods. If there is one, that's the one.
@@ -1533,7 +1543,12 @@ impl Elaborator<'_> {
             // It could be that this type is a composite type that is bound to a trait,
             // for example `x: (T, U) ... where (T, U): SomeTrait`
             // (so this case is a generalization of the NamedGeneric case)
-            self.lookup_method_in_trait_constraints(object_type, method_name, location)
+            self.lookup_method_in_trait_constraints(
+                object_type,
+                method_name,
+                location,
+                object_location,
+            )
         }
     }
 
@@ -1649,6 +1664,7 @@ impl Elaborator<'_> {
         object_type: &Type,
         method_name: &str,
         location: Location,
+        object_location: Location,
     ) -> Option<HirMethodReference> {
         let func_id = match self.current_item {
             Some(DependencyId::Function(id)) => id,
@@ -1692,11 +1708,17 @@ impl Elaborator<'_> {
             }
         }
 
-        self.push_err(TypeCheckError::UnresolvedMethodCall {
-            method_name: method_name.to_string(),
-            object_type: object_type.clone(),
-            location,
-        });
+        if object_type.is_bindable() {
+            self.push_err(TypeCheckError::TypeAnnotationsNeededForMethodCall {
+                location: object_location,
+            });
+        } else {
+            self.push_err(TypeCheckError::UnresolvedMethodCall {
+                method_name: method_name.to_string(),
+                object_type: object_type.clone(),
+                location,
+            });
+        }
 
         None
     }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4188,9 +4188,8 @@ fn mutable_reference_to_array_element_as_func_arg() {
 fn object_type_must_be_known_in_method_call() {
     let src = r#"
     pub fn foo<let N: u32>() -> [Field; N] {
-        let mut bar = _;
-                      ^ in expressions, `_` can only be used on the left-hand side of an assignment
-                      ~ `_` not allowed here
+        let array = [];
+        let mut bar = array[0];
         let _ = bar.len();
                 ^^^ Object type is unknown in method call
                 ~~~ Type must be known by this point to know which method to call

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4183,3 +4183,21 @@ fn mutable_reference_to_array_element_as_func_arg() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn object_type_must_be_known_in_method_call() {
+    let src = r#"
+    pub fn foo<let N: u32>() -> [Field; N] {
+        let mut bar = _;
+                      ^ in expressions, `_` can only be used on the left-hand side of an assignment
+                      ~ `_` not allowed here
+        let _ = bar.len();
+                ^^^ Object type is unknown in method call
+                ~~~ Type must be known by this point to know which method to call
+        bar
+    }
+
+    fn main() {}
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #7798

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
