### PR TITLE
chore: parse `!=` in SSA parser

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/parser/ast.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/ast.rs
@@ -111,6 +111,7 @@ pub(crate) enum ParsedInstruction {
     },
     Constrain {
         lhs: ParsedValue,
+        equals: bool,
         rhs: ParsedValue,
         assert_message: Option<AssertMessage>,
     },

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -264,7 +264,7 @@ impl Translator {
                 let value_id = self.builder.insert_cast(lhs, typ.unwrap_numeric());
                 self.define_variable(target, value_id)?;
             }
-            ParsedInstruction::Constrain { lhs, rhs, assert_message } => {
+            ParsedInstruction::Constrain { lhs, equals, rhs, assert_message } => {
                 let lhs = self.translate_value(lhs)?;
                 let rhs = self.translate_value(rhs)?;
                 let assert_message = match assert_message {
@@ -282,7 +282,12 @@ impl Translator {
                     }
                     None => None,
                 };
-                self.builder.insert_constrain(lhs, rhs, assert_message);
+                if equals {
+                    self.builder.insert_constrain(lhs, rhs, assert_message);
+                } else {
+                    let instruction = Instruction::ConstrainNotEqual(lhs, rhs, assert_message);
+                    self.builder.insert_instruction(instruction, None);
+                }
             }
             ParsedInstruction::DecrementRc { value } => {
                 let value = self.translate_value(value)?;

--- a/compiler/noirc_evaluator/src/ssa/parser/lexer.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/lexer.rs
@@ -49,6 +49,7 @@ impl<'a> Lexer<'a> {
             }
             Some('=') if self.peek_char() == Some('=') => self.double_char_token(Token::Equal),
             Some('=') => self.single_char_token(Token::Assign),
+            Some('!') if self.peek_char() == Some('=') => self.double_char_token(Token::NotEqual),
             Some(',') => self.single_char_token(Token::Comma),
             Some(':') => self.single_char_token(Token::Colon),
             Some(';') => self.single_char_token(Token::Semicolon),

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -383,7 +383,14 @@ impl<'a> Parser<'a> {
         }
 
         let lhs = self.parse_value_or_error()?;
-        self.eat_or_error(Token::Equal)?;
+        let equals = if self.eat(Token::Equal)? {
+            true
+        } else if self.eat(Token::NotEqual)? {
+            false
+        } else {
+            return self.expected_one_of_tokens(&[Token::Equal, Token::NotEqual]);
+        };
+
         let rhs = self.parse_value_or_error()?;
 
         let assert_message = if self.eat(Token::Comma)? {
@@ -398,7 +405,7 @@ impl<'a> Parser<'a> {
             None
         };
 
-        Ok(Some(ParsedInstruction::Constrain { lhs, rhs, assert_message }))
+        Ok(Some(ParsedInstruction::Constrain { lhs, equals, rhs, assert_message }))
     }
 
     fn parse_decrement_rc(&mut self) -> ParseResult<Option<ParsedInstruction>> {

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -293,6 +293,18 @@ fn test_constrain_with_dynamic_message() {
 }
 
 #[test]
+fn test_constrain_not_equal() {
+    let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            constrain v0 != Field 1
+            return
+        }
+        ";
+    assert_ssa_roundtrip(src);
+}
+
+#[test]
 fn test_enable_side_effects() {
     let src = "
         acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/parser/token.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/token.rs
@@ -57,6 +57,8 @@ pub(crate) enum Token {
     Arrow,
     /// ==
     Equal,
+    /// !=
+    NotEqual,
     /// &
     Ampersand,
     /// -
@@ -95,6 +97,7 @@ impl Display for Token {
             Token::Semicolon => write!(f, ";"),
             Token::Arrow => write!(f, "->"),
             Token::Equal => write!(f, "=="),
+            Token::NotEqual => write!(f, "!="),
             Token::Ampersand => write!(f, "&"),
             Token::Dash => write!(f, "-"),
             Token::Eof => write!(f, "(end of stream)"),


### PR DESCRIPTION
# Description

## Problem

While taking a look at #7770 and trying to write a test for it I noticed the SSA parser doesn't parse `constrain v0 != v1` so this is what this PR does.

## Summary

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
