### PR TITLE
fix: Reserve memory slots for debugging at the start of the global space

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
@@ -235,6 +235,8 @@ pub(crate) type BrilligGlobalsArtifact = (
     HashMap<(FieldElement, NumericType), BrilligVariable>,
 );
 
+// pub(crate) type GlobalsCompi
+
 pub(crate) fn convert_ssa_globals(
     options: &BrilligOptions,
     globals_dfg: &DataFlowGraph,

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -111,24 +111,18 @@ impl<F, R> BrilligContext<F, R> {
 
     /// Returns the address of the implicit debug variable containing the count of
     /// implicitly copied arrays as a result of RC's copy on write semantics.
-    /// This method assumes
     pub(crate) fn array_copy_counter_address(&self) -> MemoryAddress {
         assert!(
             self.count_arrays_copied,
             "`count_arrays_copied` is not set, so the array copy counter does not exist"
         );
 
-        let size = self.globals_memory_size.expect("Expected a globals memory size");
-        // The copy counter is always put in the last global slot
-        MemoryAddress::direct(GlobalSpace::start() + size - 1)
+        // The copy counter is always put in the first global slot
+        MemoryAddress::Direct(GlobalSpace::start())
     }
 
     pub(crate) fn count_array_copies(&self) -> bool {
         self.count_arrays_copied
-    }
-
-    pub(crate) fn get_globals_memory_size(&self) -> Option<usize> {
-        self.globals_memory_size
     }
 
     /// Set the globals memory size if it is not already set.

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -23,15 +23,10 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         return_parameters: Vec<BrilligParameter>,
         target_function: FunctionId,
         globals_init: bool,
-        mut globals_memory_size: usize,
+        globals_memory_size: usize,
         options: &BrilligOptions,
     ) -> BrilligArtifact<F> {
         let mut context = BrilligContext::new(options);
-
-        if options.enable_array_copy_counter {
-            // Reserve space for the array clone counter
-            globals_memory_size += 1;
-        }
 
         context.set_globals_memory_size(Some(globals_memory_size));
 


### PR DESCRIPTION
# Description

## Problem\*

Bug from https://github.com/noir-lang/noir/pull/7789

rollup-block-merge: Total arrays copied: 42812 (seems to be a bug here, the count starts at 41911 for this test for some reason meaning the real count would be 901)


## Summary\*

Keeping track of memory slots can become muddled 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
