### PR TITLE
fix: format last statement in block with optional semicolon

### DIFF
--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -2476,4 +2476,43 @@ global y = 1;
 }\n";
         assert_format(src, expected);
     }
+
+    #[test]
+    fn format_last_assignment_in_block_without_semicoln() {
+        let src = "fn main() {
+    let mut x: Field = 0;
+    {
+        x = 1
+    }
+    assert_eq(x, 1);
+}
+";
+        assert_format(src, src);
+    }
+
+    #[test]
+    fn format_last_break_in_block_without_semicoln() {
+        let src = "fn main() {
+    let mut x: Field = 0;
+    {
+        break
+    }
+    assert_eq(x, 1);
+}
+";
+        assert_format(src, src);
+    }
+
+    #[test]
+    fn format_last_continue_in_block_without_semicoln() {
+        let src = "fn main() {
+    let mut x: Field = 0;
+    {
+        continue
+    }
+    assert_eq(x, 1);
+}
+";
+        assert_format(src, src);
+    }
 }

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -2478,7 +2478,7 @@ global y = 1;
     }
 
     #[test]
-    fn format_last_assignment_in_block_without_semicoln() {
+    fn format_last_assignment_in_block_without_semicolon() {
         let src = "fn main() {
     let mut x: Field = 0;
     {
@@ -2491,7 +2491,7 @@ global y = 1;
     }
 
     #[test]
-    fn format_last_break_in_block_without_semicoln() {
+    fn format_last_break_in_block_without_semicolon() {
         let src = "fn main() {
     let mut x: Field = 0;
     {
@@ -2504,7 +2504,7 @@ global y = 1;
     }
 
     #[test]
-    fn format_last_continue_in_block_without_semicoln() {
+    fn format_last_continue_in_block_without_semicolon() {
         let src = "fn main() {
     let mut x: Field = 0;
     {

--- a/tooling/nargo_fmt/src/formatter/statement.rs
+++ b/tooling/nargo_fmt/src/formatter/statement.rs
@@ -81,13 +81,19 @@ impl ChunkFormatter<'_, '_> {
             StatementKind::Break => {
                 group.text(self.chunk(|formatter| {
                     formatter.write_keyword(Keyword::Break);
-                    formatter.write_semicolon();
+                    formatter.skip_comments_and_whitespace();
+                    if formatter.is_at(Token::Semicolon) {
+                        formatter.write_semicolon();
+                    }
                 }));
             }
             StatementKind::Continue => {
                 group.text(self.chunk(|formatter| {
                     formatter.write_keyword(Keyword::Continue);
-                    formatter.write_semicolon();
+                    formatter.skip_comments_and_whitespace();
+                    if formatter.is_at(Token::Semicolon) {
+                        formatter.write_semicolon();
+                    }
                 }));
             }
             StatementKind::Comptime(statement) => {
@@ -209,7 +215,13 @@ impl ChunkFormatter<'_, '_> {
         } else {
             self.format_expression(assign_statement.expression, &mut value_group);
         }
-        value_group.semicolon(self);
+
+        value_group.text(self.chunk(|formatter| {
+            formatter.skip_comments_and_whitespace();
+        }));
+        if self.is_at(Token::Semicolon) {
+            value_group.semicolon(self);
+        }
         group.group(value_group);
 
         group


### PR DESCRIPTION
# Description

## Problem

Resolves #7735

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
