### PR TITLE
fix: proper use of add_unsafe in unconstrained

### DIFF
--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -142,7 +142,13 @@ pub fn embedded_curve_add(
 ) -> EmbeddedCurvePoint {
     // docs:end:embedded_curve_add
     if crate::runtime::is_unconstrained() {
-        embedded_curve_add_unsafe(point1, point2)
+        if point1.is_infinite {
+            point2
+        } else if point2.is_infinite {
+            point1
+        } else {
+            embedded_curve_add_unsafe(point1, point2)
+        }
     } else {
         // In a constrained context we need to do some black magic in order to satisfy the backend's
         // expectations about the inputs to an `embedded_curve_add` opcode.

--- a/test_programs/execution_success/multi_scalar_mul/src/main.nr
+++ b/test_programs/execution_success/multi_scalar_mul/src/main.nr
@@ -1,6 +1,6 @@
 // This test provides a basic implementation of a MSM in Noir, that allows us to check
 // performance improvements and regressions.
-use std::embedded_curve_ops::embedded_curve_add_unsafe;
+use std::embedded_curve_ops::embedded_curve_add;
 use std::embedded_curve_ops::EmbeddedCurvePoint;
 
 // `main` must be marked unconstrained as the function uses `break` internally
@@ -40,14 +40,14 @@ unconstrained fn double_then_add_msm<let N: u32>(
         // traversing from second MSB to LSB
         for j in (index_of_msb + 1)..(254) {
             // Double
-            res = embedded_curve_add_unsafe(res, res);
+            res = embedded_curve_add(res, res);
             // Add
             if full_scalar_bits[j] == 1 {
-                res = embedded_curve_add_unsafe(res, temp);
+                res = embedded_curve_add(res, temp);
             }
         }
 
-        acc = embedded_curve_add_unsafe(acc, res);
+        acc = embedded_curve_add(acc, res);
     }
     acc
 }


### PR DESCRIPTION
# Description

## Problem\*

Small fix which makes sure to use embedded_curve_add_unsafe() properly in underconstrained mode. 

## Summary\*
Checking for infinity, it is easy to do in underconstrained function.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
