### PR TITLE
feat: warn if array index type is not u32

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -414,6 +414,8 @@ impl Elaborator<'_> {
 
         let (index, index_type) = self.elaborate_expression(index_expr.index);
 
+        self.push_index_to_check(index);
+
         let expected = self.polymorphic_integer_or_field();
         self.unify(&index_type, &expected, || TypeCheckError::TypeMismatch {
             expected_typ: "an integer".to_owned(),

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -244,8 +244,10 @@ struct FunctionContext {
 
     /// List of expressions that are at an index position:
     ///
+    /// ```noir
     /// foo[index]
     ///     ^^^^^
+    /// ```
     ///
     /// After each function we'll check that the type of those indexes
     /// is u32 and, if not, produce a deprecation warning.

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -427,6 +427,8 @@ impl Elaborator<'_> {
                 let expr_location = index.location;
                 let (index, index_type) = self.elaborate_expression(index);
 
+                self.push_index_to_check(index);
+
                 let expected = self.polymorphic_integer_or_field();
                 self.unify(&index_type, &expected, || TypeCheckError::TypeMismatch {
                     expected_typ: "an integer".to_owned(),

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2068,6 +2068,12 @@ impl Elaborator<'_> {
         context.trait_constraints.push((constraint, expr_id, select_impl));
     }
 
+    pub(super) fn push_index_to_check(&mut self, index: ExprId) {
+        let context = self.function_context.last_mut();
+        let context = context.expect("The function_context stack should always be non-empty");
+        context.indexes_to_check.push(index);
+    }
+
     pub fn bind_generics_from_trait_constraint(
         &self,
         constraint: &TraitConstraint,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -40,7 +40,9 @@ use crate::{
     token::SecondaryAttribute,
 };
 
-use super::{Elaborator, UnsafeBlockStatus, lints, path_resolution::PathResolutionItem};
+use super::{
+    Elaborator, FunctionContext, UnsafeBlockStatus, lints, path_resolution::PathResolutionItem,
+};
 
 pub const SELF_TYPE_NAME: &str = "Self";
 
@@ -2050,9 +2052,7 @@ impl Elaborator<'_> {
     /// Push a type variable into the current FunctionContext to be defaulted if needed
     /// at the end of the earlier of either the current function or the current comptime scope.
     fn push_type_variable(&mut self, typ: Type) {
-        let context = self.function_context.last_mut();
-        let context = context.expect("The function_context stack should always be non-empty");
-        context.type_variables.push(typ);
+        self.get_function_context().type_variables.push(typ);
     }
 
     /// Push a trait constraint into the current FunctionContext to be solved if needed
@@ -2063,15 +2063,16 @@ impl Elaborator<'_> {
         expr_id: ExprId,
         select_impl: bool,
     ) {
-        let context = self.function_context.last_mut();
-        let context = context.expect("The function_context stack should always be non-empty");
-        context.trait_constraints.push((constraint, expr_id, select_impl));
+        self.get_function_context().trait_constraints.push((constraint, expr_id, select_impl));
     }
 
     pub(super) fn push_index_to_check(&mut self, index: ExprId) {
+        self.get_function_context().indexes_to_check.push(index);
+    }
+
+    fn get_function_context(&mut self) -> &mut FunctionContext {
         let context = self.function_context.last_mut();
-        let context = context.expect("The function_context stack should always be non-empty");
-        context.indexes_to_check.push(index);
+        context.expect("The function_context stack should always be non-empty")
     }
 
     pub fn bind_generics_from_trait_constraint(

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -1990,6 +1990,7 @@ fn numeric_generics_value_kind_mismatch_u32_u64() {
             assert(self.len < MaxLen, "push out of bounds");
                    ^^^^^^^^^^^^^^^^^ Integers must have the same bit width LHS is 64, RHS is 32
             self.storage[self.len] = elem;
+                         ^^^^^^^^ Indexing an array or slice with a type other than `u32` is deprecated and will soon be an error
             self.len += 1;
         }
     }
@@ -4197,6 +4198,56 @@ fn object_type_must_be_known_in_method_call() {
     }
 
     fn main() {}
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn indexing_array_with_default_numeric_type_does_not_produce_a_warning() {
+    let src = r#"
+    fn main() {
+        let index = 0;
+        let array = [1, 2, 3];
+        let _ = array[index];
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn indexing_array_with_u32_does_not_produce_a_warning() {
+    let src = r#"
+    fn main() {
+        let index: u32 = 0;
+        let array = [1, 2, 3];
+        let _ = array[index];
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn indexing_array_with_non_u32_produces_a_warning() {
+    let src = r#"
+    fn main() {
+        let index: Field = 0;
+        let array = [1, 2, 3];
+        let _ = array[index];
+                      ^^^^^ Indexing an array or slice with a type other than `u32` is deprecated and will soon be an error
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn indexing_array_with_non_u32_on_lvalue_produces_a_warning() {
+    let src = r#"
+    fn main() {
+        let index: Field = 0;
+        let mut array = [1, 2, 3];
+        array[index] = 0;
+              ^^^^^ Indexing an array or slice with a type other than `u32` is deprecated and will soon be an error
+    }
     "#;
     check_errors(src);
 }

--- a/test_programs/compile_success_empty/numeric_generics/src/main.nr
+++ b/test_programs/compile_success_empty/numeric_generics/src/main.nr
@@ -27,7 +27,7 @@ impl<let S: u32> MyStruct<S> {
         // Regression test for numeric generics on impls
         assert(index as u64 < S as u64);
 
-        self.data[index] = elem;
+        self.data[index as u32] = elem;
         self
     }
 }

--- a/test_programs/compile_success_empty/numeric_generics_explicit/src/main.nr
+++ b/test_programs/compile_success_empty/numeric_generics_explicit/src/main.nr
@@ -43,7 +43,7 @@ impl<let S: u32> MyStruct<S> {
         // Regression test for numeric generics on impls
         assert(index as u32 < S);
 
-        self.data[index] = elem;
+        self.data[index as u32] = elem;
         self
     }
 }


### PR DESCRIPTION
# Description

## Problem

Part of #7795

## Summary

This PR only changes test programs that would fail to pass if this warning isn't fixed. Other than that, the stdlib and other test programs aren't modified here (the stdlib produces warnings, but these can't be seen from outside the stdlib).

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
