### PR TITLE
chore: use functions inside of test generation

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -209,25 +209,7 @@ fn generate_test_cases(
 fn test_{test_name}(force_brillig: ForceBrillig, inliner_aggressiveness: Inliner) {{
     let test_program_dir = PathBuf::from("{test_dir}");
 
-    let mut nargo = Command::cargo_bin("nargo").unwrap();
-    nargo.arg("--program-dir").arg(test_program_dir.clone());
-    nargo.arg("{test_command}").arg("--force");
-    nargo.arg("--inliner-aggressiveness").arg(inliner_aggressiveness.0.to_string());
-    // Check whether the test case is non-deterministic
-    nargo.arg("--check-non-determinism");
-    // Allow more bytecode in exchange to catch illegal states.
-    nargo.arg("--enable-brillig-debug-assertions");
-
-    // Enable enums as an unstable feature
-    nargo.arg("-Zenums");
-
-    if force_brillig.0 {{
-        nargo.arg("--force-brillig");
-
-        // Set the maximum increase so that part of the optimization is exercised (it might fail).
-        nargo.arg("--max-bytecode-increase-percent");
-        nargo.arg("50");
-    }}
+    let nargo = setup_nargo(&test_program_dir, "{test_command}", force_brillig, inliner_aggressiveness);
 
     {test_content}
 }}
@@ -275,54 +257,21 @@ fn generate_execution_success_tests(test_file: &mut File, test_data_dir: &Path) 
         test_file,
         "mod {test_type} {{
         use super::*;
-
-        fn remove_noise_lines(string: String) -> String {{
-            string.lines().filter(|line| 
-                !line.contains(\"Witness saved to\") && 
-                    !line.contains(\"Circuit witness successfully solved\") &&
-                    !line.contains(\"Waiting for lock\")
-            ).collect::<Vec<&str>>().join(\"\n\")
-        }}
     "
     )
     .unwrap();
     for (test_name, test_dir) in test_cases {
         let test_dir = test_dir.display();
 
-        let test_content = if TESTS_WITHOUT_STDOUT_CHECK.contains(&test_name.as_str()) {
-            "nargo.assert().success();"
-        } else {
-            r#"
-            nargo.assert().success();
-
-            let output = nargo.output().unwrap();
-            let stdout = String::from_utf8(output.stdout).unwrap();
-            let stdout = remove_noise_lines(stdout);
-
-            let stdout_path = test_program_dir.join("stdout.txt");
-            let expected_stdout = if stdout_path.exists() {
-                String::from_utf8(fs::read(stdout_path).unwrap()).unwrap()
-            } else {
-                String::new()
-            };
-
-            // Remove any trailing newlines added by some editors
-            let stdout = stdout.trim();
-            let expected_stdout = expected_stdout.trim();
-
-            if stdout != expected_stdout {
-                println!("stdout does not match expected output. Expected:\n{expected_stdout}\n\nActual:\n{stdout}");
-                assert_eq!(stdout, expected_stdout);
-            }
-            "#
-        };
-
         generate_test_cases(
             test_file,
             &test_name,
             &test_dir,
             "execute",
-            test_content,
+            &format!(
+                "execution_success(nargo, test_program_dir, {});",
+                !TESTS_WITHOUT_STDOUT_CHECK.contains(&test_name.as_str())
+            ),
             &MatrixConfig {
                 vary_brillig: !IGNORED_BRILLIG_TESTS.contains(&test_name.as_str()),
                 vary_inliner: true,
@@ -371,9 +320,7 @@ fn generate_execution_failure_tests(test_file: &mut File, test_data_dir: &Path) 
             &test_name,
             &test_dir,
             "execute",
-            r#"
-                nargo.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
-            "#,
+            "execution_failure(nargo);",
             &MatrixConfig::default(),
         );
     }
@@ -427,9 +374,7 @@ fn generate_noir_test_success_tests(test_file: &mut File, test_data_dir: &Path) 
             &test_name,
             &test_dir,
             "test",
-            r#"
-                nargo.assert().success();
-            "#,
+            "noir_test_success(nargo);",
             &MatrixConfig::default(),
         );
     }
@@ -454,9 +399,7 @@ fn generate_noir_test_failure_tests(test_file: &mut File, test_data_dir: &Path) 
             &test_name,
             &test_dir,
             "test",
-            r#"
-                nargo.assert().failure();
-            "#,
+            "noir_test_failure(nargo);",
             &MatrixConfig::default(),
         );
     }
@@ -477,39 +420,14 @@ fn generate_compile_success_empty_tests(test_file: &mut File, test_data_dir: &Pa
     for (test_name, test_dir) in test_cases {
         let test_dir = test_dir.display();
 
-        let mut assert_zero_opcodes = r#"
-        let output = nargo.output().expect("Failed to execute command");
-
-        if !output.status.success() {{
-            panic!("`nargo info` failed with: {}", String::from_utf8(output.stderr).unwrap_or_default());
-        }}
-        "#.to_string();
-
-        if !TESTS_WITH_EXPECTED_WARNINGS.contains(&test_name.as_str()) {
-            assert_zero_opcodes += r#"
-            nargo.assert().success().stderr(predicate::str::contains("warning:").not());
-            "#;
-        }
-
-        assert_zero_opcodes += r#"
-        // `compile_success_empty` tests should be able to compile down to an empty circuit.
-        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {{
-            panic!("JSON was not well-formatted {:?}\n\n{:?}", e, std::str::from_utf8(&output.stdout))
-        }});
-        let num_opcodes = &json["programs"][0]["functions"][0]["opcodes"];
-        assert_eq!(num_opcodes.as_u64().expect("number of opcodes should fit in a u64"), 0, "expected the number of opcodes to be 0");
-        "#;
-
         generate_test_cases(
             test_file,
             &test_name,
             &test_dir,
             "info",
             &format!(
-                r#"
-                nargo.arg("--json");
-                {assert_zero_opcodes}
-            "#,
+                "compile_success_empty(nargo, {})",
+                !TESTS_WITH_EXPECTED_WARNINGS.contains(&test_name.as_str())
             ),
             &MatrixConfig::default(),
         );
@@ -536,9 +454,7 @@ fn generate_compile_success_contract_tests(test_file: &mut File, test_data_dir: 
             &test_name,
             &test_dir,
             "compile",
-            r#"
-                nargo.assert().success().stderr(predicate::str::contains("warning:").not());
-            "#,
+            "compile_success_contract(nargo);",
             &MatrixConfig::default(),
         );
     }
@@ -565,9 +481,7 @@ fn generate_compile_success_no_bug_tests(test_file: &mut File, test_data_dir: &P
             &test_name,
             &test_dir,
             "compile",
-            r#"
-                nargo.assert().success().stderr(predicate::str::contains("bug:").not());
-            "#,
+            "compile_success_no_bug(nargo);",
             &MatrixConfig::default(),
         );
     }
@@ -594,9 +508,7 @@ fn generate_compile_success_with_bug_tests(test_file: &mut File, test_data_dir: 
             &test_name,
             &test_dir,
             "compile",
-            r#"
-                nargo.assert().success().stderr(predicate::str::contains("bug:"));
-            "#,
+            "compile_success_with_bug(nargo);",
             &MatrixConfig::default(),
         );
     }
@@ -622,9 +534,7 @@ fn generate_compile_failure_tests(test_file: &mut File, test_data_dir: &Path) {
             &test_name,
             &test_dir,
             "compile",
-            r#"
-                nargo.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
-            "#,
+            "compile_failure(nargo);",
             &MatrixConfig::default(),
         );
     }

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -7,7 +7,7 @@ mod tests {
 
     use std::collections::BTreeMap;
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
     use super::*;
@@ -17,6 +17,149 @@ mod tests {
     struct ForceBrillig(pub bool);
     #[derive(Debug, Clone, Copy)]
     struct Inliner(pub i64);
+
+    fn setup_nargo(
+        test_program_dir: &Path,
+        test_command: &str,
+        force_brillig: ForceBrillig,
+        inliner_aggressiveness: Inliner,
+    ) -> Command {
+        let mut nargo = Command::cargo_bin("nargo").unwrap();
+        nargo.arg("--program-dir").arg(test_program_dir);
+        nargo.arg(test_command).arg("--force");
+        nargo.arg("--inliner-aggressiveness").arg(inliner_aggressiveness.0.to_string());
+        // Check whether the test case is non-deterministic
+        nargo.arg("--check-non-determinism");
+        // Allow more bytecode in exchange to catch illegal states.
+        nargo.arg("--enable-brillig-debug-assertions");
+
+        // Enable enums as an unstable feature
+        nargo.arg("-Zenums");
+
+        if force_brillig.0 {
+            {
+                nargo.arg("--force-brillig");
+
+                // Set the maximum increase so that part of the optimization is exercised (it might fail).
+                nargo.arg("--max-bytecode-increase-percent");
+                nargo.arg("50");
+            }
+        }
+
+        nargo
+    }
+
+    fn remove_noise_lines(string: String) -> String {
+        string
+            .lines()
+            .filter(|line| {
+                !line.contains("Witness saved to")
+                    && !line.contains("Circuit witness successfully solved")
+                    && !line.contains("Waiting for lock")
+            })
+            .collect::<Vec<&str>>()
+            .join("\n")
+    }
+
+    fn execution_success(mut nargo: Command, test_program_dir: PathBuf, check_stdout: bool) {
+        nargo.assert().success();
+
+        if check_stdout {
+            let output = nargo.output().unwrap();
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            let stdout = remove_noise_lines(stdout);
+
+            let stdout_path = test_program_dir.join("stdout.txt");
+            let expected_stdout = if stdout_path.exists() {
+                String::from_utf8(fs::read(stdout_path).unwrap()).unwrap()
+            } else {
+                String::new()
+            };
+
+            // Remove any trailing newlines added by some editors
+            let stdout = stdout.trim();
+            let expected_stdout = expected_stdout.trim();
+
+            if stdout != expected_stdout {
+                println!(
+                    "stdout does not match expected output. Expected:\n{expected_stdout}\n\nActual:\n{stdout}"
+                );
+                assert_eq!(stdout, expected_stdout);
+            }
+        }
+    }
+
+    fn execution_failure(mut nargo: Command) {
+        nargo
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("The application panicked (crashed).").not());
+    }
+
+    fn noir_test_success(mut nargo: Command) {
+        nargo.assert().success();
+    }
+
+    fn noir_test_failure(mut nargo: Command) {
+        nargo
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("The application panicked (crashed).").not());
+    }
+
+    fn compile_success_empty(mut nargo: Command, no_warnings: bool) {
+        nargo.arg("--json");
+        let output = nargo.output().expect("Failed to execute command");
+
+        if !output.status.success() {
+            {
+                panic!(
+                    "`nargo info` failed with: {}",
+                    String::from_utf8(output.stderr).unwrap_or_default()
+                );
+            }
+        }
+
+        if no_warnings {
+            nargo.assert().success().stderr(predicate::str::contains("warning:").not());
+        }
+
+        // `compile_success_empty` tests should be able to compile down to an empty circuit.
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+            {
+                panic!(
+                    "JSON was not well-formatted {:?}\n\n{:?}",
+                    e,
+                    std::str::from_utf8(&output.stdout)
+                )
+            }
+        });
+        let num_opcodes = &json["programs"][0]["functions"][0]["opcodes"];
+        assert_eq!(
+            num_opcodes.as_u64().expect("number of opcodes should fit in a u64"),
+            0,
+            "expected the number of opcodes to be 0"
+        );
+    }
+
+    fn compile_success_contract(mut nargo: Command) {
+        nargo.assert().success().stderr(predicate::str::contains("warning:").not());
+    }
+
+    fn compile_success_no_bug(mut nargo: Command) {
+        nargo.assert().success().stderr(predicate::str::contains("bug:").not());
+    }
+
+    fn compile_success_with_bug(mut nargo: Command) {
+        nargo.assert().success().stderr(predicate::str::contains("bug:"));
+    }
+
+    fn compile_failure(mut nargo: Command) {
+        nargo
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("The application panicked (crashed).").not());
+    }
 
     // include tests generated by `build.rs`
     include!(concat!(env!("OUT_DIR"), "/execute.rs"));


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The generated `execute.rs` file is currently ~23k lines long due to a lot of repeated code which we're generating. This seemed a bit wasteful so I did some research and Rust has this nifty feature called "functions".

Turns out we can move a lot of the logic into these "functions" which then sit in `execute.rs` so we get type checking and all that nice stuff in our test code.

This ends up cutting the file size down to ~6k lines

## Additional Context

I have no idea why I didn't write it this way originally but :shrug:.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
