### PR TITLE
feat: type path for any type

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -877,6 +877,8 @@ impl Elaborator<'_> {
         let typ = self.resolve_type(path.typ);
         let check_self_param = false;
 
+        self.interner.push_type_ref_location(typ.clone(), object_location);
+
         let Some(method) = self.lookup_method(
             &typ,
             path.item.as_str(),

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -877,7 +877,7 @@ impl Elaborator<'_> {
         let typ = self.resolve_type(path.typ);
         let check_self_param = false;
 
-        self.interner.push_type_ref_location(typ.clone(), object_location);
+        self.interner.push_type_ref_location(&typ, object_location);
 
         let Some(method) = self.lookup_method(
             &typ,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -164,7 +164,7 @@ impl Elaborator<'_> {
         match resolved_type {
             Type::DataType(ref data_type, _) => {
                 // Record the location of the type reference
-                self.interner.push_type_ref_location(resolved_type.clone(), location);
+                self.interner.push_type_ref_location(&resolved_type, location);
                 if !is_synthetic {
                     self.interner.add_type_reference(
                         data_type.borrow().id,

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -876,8 +876,12 @@ impl NodeInterner {
     }
 
     /// Store [Location] of [Type] reference
-    pub fn push_type_ref_location(&mut self, typ: Type, location: Location) {
-        self.type_ref_locations.push((typ, location));
+    pub fn push_type_ref_location(&mut self, typ: &Type, location: Location) {
+        if !self.is_in_lsp_mode() {
+            return;
+        }
+
+        self.type_ref_locations.push((typ.clone(), location));
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -119,6 +119,8 @@ pub enum ParserErrorReason {
     MissingParametersForFunctionDefinition,
     #[error("`StructDefinition` is deprecated. It has been renamed to `TypeDefinition`")]
     StructDefinitionDeprecated,
+    #[error("Missing angle brackets surrounding type")]
+    MissingAngleBrackets,
 }
 
 /// Represents a parsing error, or a parsing error in the making.
@@ -312,6 +314,10 @@ impl<'a> From<&'a ParserError> for Diagnostic {
                 }
                 ParserErrorReason::StructDefinitionDeprecated => {
                     Diagnostic::simple_warning(format!("{reason}"), String::new(), error.location())
+                }
+                ParserErrorReason::MissingAngleBrackets => {
+                    let secondary = "Types that don't start with an identifier need to be surrounded with angle brackets: `<`, `>`".to_string();
+                    Diagnostic::simple_error(format!("{reason}"), secondary, error.location())
                 }
                 other => {
                     Diagnostic::simple_error(format!("{other}"), String::new(), error.location())

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -119,7 +119,7 @@ pub enum ParserErrorReason {
     MissingParametersForFunctionDefinition,
     #[error("`StructDefinition` is deprecated. It has been renamed to `TypeDefinition`")]
     StructDefinitionDeprecated,
-    #[error("Missing angle brackets surrounding type")]
+    #[error("Missing angle brackets surrounding type in associated item path")]
     MissingAngleBrackets,
     #[error("Expected value, found built-in type `{typ}`")]
     ExpectedValueFoundBuiltInType { typ: UnresolvedType },

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Expression, IntegerBitSize, ItemVisibility};
+use crate::ast::{Expression, IntegerBitSize, ItemVisibility, UnresolvedType};
 use crate::lexer::errors::LexerErrorKind;
 use crate::lexer::token::Token;
 use crate::token::TokenKind;
@@ -121,6 +121,8 @@ pub enum ParserErrorReason {
     StructDefinitionDeprecated,
     #[error("Missing angle brackets surrounding type")]
     MissingAngleBrackets,
+    #[error("Expected value, found built-in type `{typ}`")]
+    ExpectedValueFoundBuiltInType { typ: UnresolvedType },
 }
 
 /// Represents a parsing error, or a parsing error in the making.

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -286,7 +286,7 @@ impl Parser<'_> {
     ///     | ComptimeExpression
     ///     | UnquoteExpression
     ///     | TypePathExpression
-    ///     | BracketedTypePathExpression
+    ///     | NamelessTypePathExpression
     ///     | AsTraitPath
     ///     | ResolvedExpression
     ///     | InternedExpression
@@ -354,7 +354,7 @@ impl Parser<'_> {
             return Some(kind);
         }
 
-        if let Some(kind) = self.parse_bracketed_type_path_or_as_trait_path_type_expression() {
+        if let Some(kind) = self.parse_nameless_type_path_or_as_trait_path_type_expression() {
             return Some(kind);
         }
 
@@ -373,8 +373,8 @@ impl Parser<'_> {
         None
     }
 
-    /// BracketedTypePathExpression = '<' Type '>' '::' identifier ( '::' GenericTypeArgs )?
-    fn parse_bracketed_type_path_or_as_trait_path_type_expression(
+    /// NamelessTypePathExpression = '<' Type '>' '::' identifier ( '::' GenericTypeArgs )?
+    fn parse_nameless_type_path_or_as_trait_path_type_expression(
         &mut self,
     ) -> Option<ExpressionKind> {
         if !self.eat_less() {

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -193,6 +193,14 @@ impl Parser<'_> {
 
         let typ = self.parse_type_or_error();
         self.eat_keyword_or_error(Keyword::As);
+
+        Some(self.parse_as_trait_path_for_type_after_as_keyword(typ))
+    }
+
+    pub(super) fn parse_as_trait_path_for_type_after_as_keyword(
+        &mut self,
+        typ: UnresolvedType,
+    ) -> AsTraitPath {
         let trait_path = self.parse_path_no_turbofish_or_error();
         let trait_generics = self.parse_generic_type_args();
         self.eat_or_error(Token::Greater);
@@ -204,7 +212,7 @@ impl Parser<'_> {
             Ident::new(String::new(), self.location_at_previous_token_end())
         };
 
-        Some(AsTraitPath { typ, trait_path, trait_generics, impl_item })
+        AsTraitPath { typ, trait_path, trait_generics, impl_item }
     }
 }
 

--- a/compiler/noirc_frontend/src/resolve_locations.rs
+++ b/compiler/noirc_frontend/src/resolve_locations.rs
@@ -228,13 +228,17 @@ impl NodeInterner {
 
     /// Attempts to resolve [Location] of [Type] based on [Location] of reference in code
     pub(crate) fn try_resolve_type_ref(&self, location: Location) -> Option<Location> {
+        self.try_type_ref_at_location(location).and_then(|typ| match typ {
+            Type::DataType(struct_typ, _) => Some(struct_typ.borrow().location),
+            _ => None,
+        })
+    }
+
+    pub fn try_type_ref_at_location(&self, location: Location) -> Option<Type> {
         self.type_ref_locations
             .iter()
             .find(|(_typ, type_ref_location)| type_ref_location.contains(&location))
-            .and_then(|(typ, _)| match typ {
-                Type::DataType(struct_typ, _) => Some(struct_typ.borrow().location),
-                _ => None,
-            })
+            .map(|(typ, _type_ref_location)| typ.clone())
     }
 
     fn try_resolve_type_alias(&self, location: Location) -> Option<Location> {

--- a/test_programs/compile_success_empty/type_path/src/main.nr
+++ b/test_programs/compile_success_empty/type_path/src/main.nr
@@ -10,10 +10,30 @@ fn main() {
     // whether a TypePath had generics or not, always resolved them, filling them
     // up with Type::Error, and eventually leading to an ICE.
     let _ = Field::from_be_bytes([1]);
+
+    // Make sure `<...>::name` compiles
+    let _: () = <()>::method();
+    let _: [i32; 3] = <[i32; 3]>::method();
 }
 
 pub struct Foo {}
 
 impl Foo {
     fn static() {}
+}
+
+trait Trait {
+    fn method() -> Self;
+}
+
+impl Trait for () {
+    fn method() -> () {
+        ()
+    }
+}
+
+impl Trait for [i32; 3] {
+    fn method() -> [i32; 3] {
+        [1, 2, 3]
+    }
 }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -446,6 +446,30 @@ mod completion_tests {
     }
 
     #[test]
+    async fn test_complete_type_path_for_nameless_type() {
+        let src = r#"
+          trait One {
+              fn some_method() -> Self;
+          }
+
+          impl One for () {
+              fn some_method() -> Self {
+                  1
+              }
+          }
+
+          fn main() {
+            <()>::some_meth>|<
+          }
+        "#;
+        assert_completion(
+            src,
+            vec![function_completion_item("some_method()", "some_method()", "fn()")],
+        )
+        .await;
+    }
+
+    #[test]
     async fn test_complete_function_without_arguments() {
         let src = r#"
           fn hello() { }

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -399,7 +399,17 @@ impl ChunkFormatter<'_, '_> {
     pub(super) fn format_type_path(&mut self, type_path: TypePath) -> ChunkGroup {
         let mut group = ChunkGroup::new();
         group.text(self.chunk(|formatter| {
+            let nameless = formatter.is_at(Token::Less);
+            if nameless {
+                formatter.write_token(Token::Less);
+            }
+
             formatter.format_type(type_path.typ);
+
+            if nameless {
+                formatter.write_token(Token::Greater);
+            }
+
             formatter.write_token(Token::DoubleColon);
             formatter.write_identifier(type_path.item);
             if let Some(turbofish) = type_path.turbofish {
@@ -2129,6 +2139,13 @@ global y = 1;
     fn format_type_path_with_turbofish() {
         let src = "global x = Field :: max :: < i32 > ;";
         let expected = "global x = Field::max::<i32>;\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_type_path_with_array_type() {
+        let src = "global x = < [ i32 ; 3 ] > :: max  ;";
+        let expected = "global x = <[i32; 3]>::max;\n";
         assert_format(src, expected);
     }
 


### PR DESCRIPTION
# Description

## Problem

Resolves #7767

## Summary

In addition to implementing the feature I tried to improve some parser errors. For example if you write:

```noir
fn main() {
  let _ = ()::foo();
}
```

you get this error (in addition to the one about not finding `foo`):

```
error: Missing angle brackets surrounding type in associated item path
  ┌─ src/main.nr:2:11
  │
2 │   let _ = ()::foo();
  │           -- Types that don't start with an identifier need to be surrounded with angle brackets: `<`, `>`
```

That's actually how I learned in Rust that you need to surround types with `<..>`.

For other types there's a bit of error recovery and cleanup too to make it clear that `<...>` is missing.For example for:

```noir
fn main() {
    (Field, i32)::foo()
}
```

we get:

```
error: Missing angle brackets surrounding type in associated item path
  ┌─ src/main.nr:2:5
  │
2 │     (Field, i32)::foo()
  │     ------------ Types that don't start with an identifier need to be surrounded with angle brackets: `<`, `>`
```

For this:

```noir
fn main() {
    [Field; 3]::foo()
}
```

we get this error:

```
error: Missing angle brackets surrounding type in associated item path
  ┌─ src/main.nr:2:5
  │
2 │     [Field; 3]::foo()
  │     ---------- Types that don't start with an identifier need to be surrounded with angle brackets: `<`, `>`
```

Another improvement is that previously `Field` (in an expression context, without `::` following it) would be parsed as a TypePath whose ident is empty (like `Field::`) which would then lead to a strange error saying that the method '' didn't exist for Field. Here I changed it so that it's parsed as an error, and the error says "Expected value, found built-in type `Field`" (like in Rust).

## Additional Context

We could document this though I don't know where (I couldn't find docs for this for Rust because I don't know what it's called)

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
