### PR TITLE
feat: add basic comptime correctness tests

### DIFF
--- a/tooling/nargo_cli/tests/common.rs
+++ b/tooling/nargo_cli/tests/common.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+
+use nargo::parse_all;
+use noirc_driver::{
+    CompilationResult, CompileOptions, CompiledProgram, CrateId, compile_main,
+    file_manager_with_stdlib, prepare_crate,
+};
+use noirc_frontend::hir::Context;
+
+/// Prepare a code snippet.
+fn prepare_snippet(source: String) -> (Context<'static, 'static>, CrateId) {
+    let root = Path::new("");
+    let file_name = Path::new("main.nr");
+    let mut file_manager = file_manager_with_stdlib(root);
+    file_manager.add_file_with_source(file_name, source).expect(
+        "Adding source buffer to file manager should never fail when file manager is empty",
+    );
+    let parsed_files = parse_all(&file_manager);
+
+    let mut context = Context::new(file_manager, parsed_files);
+    let root_crate_id = prepare_crate(&mut context, file_name);
+
+    (context, root_crate_id)
+}
+
+/// Compile the main function in a code snippet.
+///
+/// Use `force_brillig` to test it as an unconstrained function without having to change the code.
+/// This is useful for methods that use the `runtime::is_unconstrained()` method to change their behavior.
+pub fn prepare_and_compile_snippet(
+    source: String,
+    force_brillig: bool,
+) -> CompilationResult<CompiledProgram> {
+    let (mut context, root_crate_id) = prepare_snippet(source);
+    let options = CompileOptions { force_brillig, ..Default::default() };
+    // TODO: Run nargo::ops::transform_program?
+    compile_main(&mut context, root_crate_id, &options, None)
+}

--- a/tooling/nargo_cli/tests/comptime_correctness.rs
+++ b/tooling/nargo_cli/tests/comptime_correctness.rs
@@ -1,0 +1,139 @@
+mod common;
+
+use std::sync::LazyLock;
+use std::{cell::RefCell, collections::BTreeMap};
+
+use acvm::{FieldElement, acir::native_types::WitnessStack};
+use nargo::{foreign_calls::DefaultForeignCallBuilder, ops::execute_program};
+use noirc_abi::input_parser::InputValue;
+use proptest::prelude::*;
+
+static NUM_CASES: LazyLock<u32> = LazyLock::new(|| {
+    std::env::var("COMPTIME_CORRECTNESS_TEST_NUM_CASES").unwrap_or("1".into()).parse().unwrap_or(1)
+});
+
+pub(crate) fn run_snippet(source: String, force_brillig: bool) -> InputValue {
+    let program = match common::prepare_and_compile_snippet(source.clone(), force_brillig) {
+        Ok((program, _)) => program,
+        Err(e) => panic!("failed to compile program; brillig = {force_brillig}:\n{source}\n{e:?}"),
+    };
+
+    let pedantic_solving = true;
+    let blackbox_solver = bn254_blackbox_solver::Bn254BlackBoxSolver(pedantic_solving);
+    let foreign_call_executor = RefCell::new(DefaultForeignCallBuilder::default().build());
+
+    let initial_witness = program.abi.encode(&BTreeMap::new(), None).expect("failed to encode");
+    let mut foreign_call_executor = foreign_call_executor.borrow_mut();
+
+    let witness_stack: WitnessStack<FieldElement> = execute_program(
+        &program.program,
+        initial_witness,
+        &blackbox_solver,
+        &mut *foreign_call_executor,
+    )
+    .expect("failed to execute");
+
+    let main_witness = witness_stack.peek().expect("should have return value on witness stack");
+    let main_witness = &main_witness.witness;
+
+    let (_, return_value) = program.abi.decode(main_witness).expect("failed to decode");
+    return_value.expect("should decode a return value")
+}
+
+#[cfg(test)]
+fn comptime_check_field_expression(strategy: BoxedStrategy<String>, num_cases: u32) {
+    proptest!(ProptestConfig::with_cases(num_cases), |(expr in strategy)| {
+        let program = format!("
+        comptime fn comptime_code() -> Field {{
+            {expr}
+        }}
+        
+        fn runtime_code() -> Field {{
+            {expr}
+        }}
+
+        fn main() -> pub Field {{
+            assert_eq(comptime {{ comptime_code() }}, runtime_code());
+            1
+        }}");
+
+        let return_value = run_snippet(program.to_string(), true);
+        prop_assert_eq!(return_value, InputValue::Field(1u32.into()));
+    });
+}
+
+#[test]
+fn comptime_check_field_add() {
+    let strategy = any::<(u128, u128)>().prop_map(|(a, b)| format!("{a} + {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+fn comptime_check_field_sub() {
+    let strategy = any::<(u128, u128)>().prop_map(|(a, b)| format!("{a} - {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+fn comptime_check_field_div() {
+    let strategy = any::<(u32, u32)>().prop_map(|(a, b)| format!("{a} / {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+fn comptime_check_field_mul() {
+    let strategy = any::<(u32, u32)>().prop_map(|(a, b)| format!("{a} * {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+#[ignore]
+fn comptime_check_field_mod() {
+    let strategy = any::<(u32, u32)>().prop_map(|(a, b)| format!("{a} % {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+#[ignore]
+fn comptime_check_field_xor() {
+    let strategy = any::<(u32, u32)>().prop_map(|(a, b)| format!("{a} ^ {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+#[ignore]
+fn comptime_check_field_or() {
+    let strategy = any::<(u32, u32)>().prop_map(|(a, b)| format!("{a} | {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+#[ignore]
+fn comptime_check_field_and() {
+    let strategy = any::<(u32, u32)>().prop_map(|(a, b)| format!("{a} & {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+#[ignore]
+fn comptime_check_field_shl() {
+    let strategy = any::<(u32, u8)>().prop_map(|(a, b)| format!("{a} << {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}
+
+#[test]
+#[ignore]
+fn comptime_check_field_shr() {
+    let strategy = any::<(u32, u8)>().prop_map(|(a, b)| format!("{a} >> {b}")).boxed();
+
+    comptime_check_field_expression(strategy, *NUM_CASES);
+}


### PR DESCRIPTION
# Description

Adds initial basic implementation for comparison between comptime interpreter and compiled Noir results, testing arithmetic binary operations for now (a building block for future fuzzer).

## Problem\*

## Summary\*

## Additional Context

Bitwise operations tests are added but currently ignored, as they fail on compilation with the results of u32 <op> u32 literals not getting cast to Field as they probably should (maybe warrants its own issue?)

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
