### PR TITLE
chore: more SSA refactors

### DIFF
--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -115,6 +115,31 @@ impl BlackBoxFunc {
     pub fn is_valid_black_box_func_name(op_name: &str) -> bool {
         BlackBoxFunc::lookup(op_name).is_some()
     }
+
+    pub fn has_side_effects(&self) -> bool {
+        match self {
+            BlackBoxFunc::RecursiveAggregation
+            | BlackBoxFunc::MultiScalarMul
+            | BlackBoxFunc::EmbeddedCurveAdd => true,
+            BlackBoxFunc::AES128Encrypt
+            | BlackBoxFunc::AND
+            | BlackBoxFunc::XOR
+            | BlackBoxFunc::RANGE
+            | BlackBoxFunc::Blake2s
+            | BlackBoxFunc::Blake3
+            | BlackBoxFunc::EcdsaSecp256k1
+            | BlackBoxFunc::EcdsaSecp256r1
+            | BlackBoxFunc::Keccakf1600
+            | BlackBoxFunc::BigIntAdd
+            | BlackBoxFunc::BigIntSub
+            | BlackBoxFunc::BigIntMul
+            | BlackBoxFunc::BigIntDiv
+            | BlackBoxFunc::BigIntFromLeBytes
+            | BlackBoxFunc::BigIntToLeBytes
+            | BlackBoxFunc::Poseidon2Permutation
+            | BlackBoxFunc::Sha256Compression => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -145,16 +145,6 @@ impl Intrinsic {
         }
     }
 
-    /// Intrinsics which only have a side effect due to the chance that
-    /// they can fail a constraint can be deduplicated.
-    pub(crate) fn can_be_deduplicated(&self, deduplicate_with_predicate: bool) -> bool {
-        match self.purity() {
-            Purity::Pure => true,
-            Purity::PureWithPredicate => deduplicate_with_predicate,
-            Purity::Impure => false,
-        }
-    }
-
     pub(crate) fn purity(&self) -> Purity {
         match self {
             // These apply a constraint in the form of ACIR opcodes, but they can be deduplicated

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -136,12 +136,7 @@ impl Intrinsic {
             Intrinsic::Hint(Hint::BlackBox) => true,
 
             // Some black box functions have side-effects
-            Intrinsic::BlackBox(func) => matches!(
-                func,
-                BlackBoxFunc::RecursiveAggregation
-                    | BlackBoxFunc::MultiScalarMul
-                    | BlackBoxFunc::EmbeddedCurveAdd
-            ),
+            Intrinsic::BlackBox(func) => func.has_side_effects(),
         }
     }
 
@@ -154,13 +149,8 @@ impl Intrinsic {
             // directly depend on the corresponding `enable_side_effect` instruction any more.
             // However, to conform with the expectations of `Instruction::can_be_deduplicated` and
             // `constant_folding` we only use this information if the caller shows interest in it.
-            Intrinsic::ToBits(_)
-            | Intrinsic::ToRadix(_)
-            | Intrinsic::BlackBox(
-                BlackBoxFunc::MultiScalarMul
-                | BlackBoxFunc::EmbeddedCurveAdd
-                | BlackBoxFunc::RecursiveAggregation,
-            ) => Purity::PureWithPredicate,
+            Intrinsic::ToBits(_) | Intrinsic::ToRadix(_) => Purity::PureWithPredicate,
+            Intrinsic::BlackBox(func) if func.has_side_effects() => Purity::PureWithPredicate,
 
             // Operations that remove items from a slice don't modify the slice, they just assert it's non-empty.
             Intrinsic::SlicePopBack | Intrinsic::SlicePopFront | Intrinsic::SliceRemove => {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -853,13 +853,14 @@ fn has_side_effects(instruction: &Instruction, dfg: &DataFlowGraph) -> bool {
             | BinaryOp::Shr => false,
         },
 
-        // These can have different behavior depending on the EnableSideEffectsIf context.
-        Cast(_, _)
-        | Not(_)
-        | Truncate { .. }
-        | IfElse { .. }
-        | ArrayGet { .. }
-        | ArraySet { .. } => instruction.requires_acir_gen_predicate(dfg),
+        // These don't have side effects
+        Cast(_, _) | Not(_) | Truncate { .. } | IfElse { .. } => false,
+
+        // `ArrayGet`s which read from "known good" indices from an array have no side effects
+        ArrayGet { array, index } => !dfg.is_safe_index(*index, *array),
+
+        // ArraySet has side effects
+        ArraySet { .. } => true,
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -443,9 +443,7 @@ impl<'brillig> Context<'brillig> {
         // Thus, even if the index is dynamic (meaning the array get would have side effects),
         // we can simplify the operation when we take into account the predicate.
         if let Instruction::ArraySet { index, value, .. } = &instruction {
-            let use_predicate =
-                self.use_constraint_info && instruction.requires_acir_gen_predicate(&function.dfg);
-            let predicate = use_predicate.then_some(side_effects_enabled_var);
+            let predicate = self.use_constraint_info.then_some(side_effects_enabled_var);
 
             let array_get = Instruction::ArrayGet { array: instruction_results[0], index: *index };
 

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -908,8 +908,8 @@ pub(crate) fn can_be_deduplicated(
         // removed entirely.
         Noop => true,
 
-        // Cast instructions can always be deduplicated
-        Cast(_, _) => true,
+        // These instructions can always be deduplicated
+        Cast(_, _) | Not(_) | Truncate { .. } | IfElse { .. } => true,
 
         // Arrays can be mutated in unconstrained code so code that handles this case must
         // take care to track whether the array was possibly mutated or not before
@@ -921,12 +921,7 @@ pub(crate) fn can_be_deduplicated(
         // Replacing them with a similar instruction potentially enables replacing an instruction
         // with one that was disabled. See
         // https://github.com/noir-lang/noir/pull/4716#issuecomment-2047846328.
-        Binary(_)
-        | Not(_)
-        | Truncate { .. }
-        | IfElse { .. }
-        | ArrayGet { .. }
-        | ArraySet { .. } => {
+        Binary(_) | ArrayGet { .. } | ArraySet { .. } => {
             deduplicate_with_predicate || !instruction.requires_acir_gen_predicate(&function.dfg)
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -506,7 +506,7 @@ fn can_be_hoisted(
         | DecrementRc { .. } => false,
 
         Call { func, .. } => match function.dfg[*func] {
-            Value::Intrinsic(intrinsic) => intrinsic.can_be_deduplicated(false),
+            Value::Intrinsic(intrinsic) => intrinsic.purity() == Purity::Pure,
             Value::Function(id) => match function.dfg.purity_of(id) {
                 Some(Purity::Pure) => true,
                 Some(Purity::PureWithPredicate) => false,

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -503,10 +503,7 @@ fn can_be_hoisted(
         | Load { .. }
         | Store { .. }
         | IncrementRc { .. }
-        | DecrementRc { .. }
-        | Not(_)
-        | Truncate { .. }
-        | IfElse { .. } => false,
+        | DecrementRc { .. } => false,
 
         Call { func, .. } => match function.dfg[*func] {
             Value::Intrinsic(intrinsic) => intrinsic.purity() == Purity::Pure,
@@ -531,8 +528,8 @@ fn can_be_hoisted(
         // removed entirely.
         Noop => true,
 
-        // Cast instructions can always be hoisted
-        Cast(_, _) => true,
+        // These instructions can always be hoisted
+        Cast(_, _) | Not(_) | Truncate { .. } | IfElse { .. } => true,
 
         // Arrays can be mutated in unconstrained code so code that handles this case must
         // take care to track whether the array was possibly mutated or not before

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -503,7 +503,10 @@ fn can_be_hoisted(
         | Load { .. }
         | Store { .. }
         | IncrementRc { .. }
-        | DecrementRc { .. } => false,
+        | DecrementRc { .. }
+        | Not(_)
+        | Truncate { .. }
+        | IfElse { .. } => false,
 
         Call { func, .. } => match function.dfg[*func] {
             Value::Intrinsic(intrinsic) => intrinsic.purity() == Purity::Pure,
@@ -538,12 +541,7 @@ fn can_be_hoisted(
         MakeArray { .. } => function.runtime().is_acir(),
 
         // These can have different behavior depending on the predicate.
-        Binary(_)
-        | Not(_)
-        | Truncate { .. }
-        | IfElse { .. }
-        | ArrayGet { .. }
-        | ArraySet { .. } => {
+        Binary(_) | ArrayGet { .. } | ArraySet { .. } => {
             hoist_with_predicate || !instruction.requires_acir_gen_predicate(&function.dfg)
         }
     }


### PR DESCRIPTION
# Description

## Problem

Resolves #7803

## Summary

A bunch of commits that either try to move methods closer to where they are (inlining them if that's a possibility too) or try to make match branches clearer (some branches relied on `requires_acir_gen_predicate` which always returned `true` or `false`, so I moved that boolean up to that branch). Now it's clearer that `Binary`, `ArrayGet` and `ArraySet` are the "most" side-effectful instructions.

I also introduced `BlackBoxFunc::has_side_effects` in case new black box functions are added, and also for someone to verify if any of the existing ones have side effects but are currently marked as `false`.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
