### PR TITLE
feat(opt): remove truncate after range_check

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -224,6 +224,7 @@ fn optimize_all(builder: SsaBuilder, options: &SsaEvaluatorOptions) -> Result<Ss
         .run_pass(Ssa::brillig_entry_point_analysis, "Brillig Entry Point Analysis")
         // Remove any potentially unnecessary duplication from the Brillig entry point analysis.
         .run_pass(Ssa::remove_unreachable_functions, "Removing Unreachable Functions (3rd)")
+        .run_pass(Ssa::remove_truncate_after_range_check, "Removing Truncate after RangeCheck")
         // This pass makes transformations specific to Brillig generation.
         // It must be the last pass to either alter or add new instructions before Brillig generation,
         // as other semantics in the compiler can potentially break (e.g. inserting instructions).

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -27,6 +27,7 @@ mod rc;
 mod remove_bit_shifts;
 mod remove_enable_side_effects;
 mod remove_if_else;
+mod remove_truncate_after_range_check;
 mod remove_unreachable;
 mod simplify_cfg;
 mod unrolling;

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -52,7 +52,7 @@ impl Function {
                             // we need to remove the `truncate` and all references to `v1` should now be `v0`.
                             let result =
                                 self.dfg.instruction_results(instruction_id).first().unwrap();
-                            self.dfg.set_value_from_id(*value, *result);
+                            self.dfg.set_value_from_id(*result, *value);
                             continue;
                         }
                     }

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -1,0 +1,138 @@
+use im::HashMap;
+
+use crate::ssa::{
+    ir::{function::Function, instruction::Instruction, value::ValueId},
+    ssa_gen::Ssa,
+};
+
+impl Ssa {
+    /// This SSA pass removes `truncate` instructions that happen on values that
+    /// have a `range_check` on them, where the checked range is less or equal than
+    /// the bits to truncate (the truncate isn't needed then as it won't change the
+    /// underlying value).
+    pub(crate) fn remove_truncate_after_range_check(mut self) -> Self {
+        for function in self.functions.values_mut() {
+            function.remove_truncate_after_range_check();
+        }
+        self
+    }
+}
+
+impl Function {
+    pub(crate) fn remove_truncate_after_range_check(&mut self) {
+        for block in self.reachable_blocks() {
+            // Keeps the minimum bit size a value was range-checked against
+            let mut range_checks: HashMap<ValueId, u32> = HashMap::new();
+
+            let instructions = self.dfg[block].take_instructions();
+            for instruction_id in instructions {
+                let instruction = &self.dfg[instruction_id];
+
+                // If this is a range_check instruction, associate the max bit size with the value
+                if let Instruction::RangeCheck { value, max_bit_size, .. } = instruction {
+                    range_checks
+                        .entry(*value)
+                        .and_modify(|current_max| {
+                            if *max_bit_size < *current_max {
+                                *current_max = *max_bit_size;
+                            }
+                        })
+                        .or_insert(*max_bit_size);
+                }
+
+                // If this is a truncate instruction, check if there's a range check for that same value
+                if let Instruction::Truncate { value, bit_size, .. } = instruction {
+                    if let Some(range_check_bit_size) = range_checks.get(value) {
+                        if range_check_bit_size <= bit_size {
+                            // We need to replace the truncated value with the original one. That is, in:
+                            //
+                            // range_check v0 to 32 bits
+                            // v1 = truncate v0 to 32 bits, max_bit_size: 254
+                            //
+                            // we need to remove the `truncate` and all references to `v1` should now be `v0`.
+                            let result =
+                                self.dfg.instruction_results(instruction_id).first().unwrap();
+                            self.dfg.set_value_from_id(*value, *result);
+                            continue;
+                        }
+                    }
+                }
+
+                self.dfg[block].insert_instruction(instruction_id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa};
+
+    #[test]
+    fn removes_truncate_after_range_check_with_same_bit_size() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 64 bits // This is to make sure we keep the smallest one
+            range_check v0 to 32 bits
+            v1 = truncate v0 to 32 bits, max_bit_size: 254
+            return v1
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let expected = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 64 bits
+            range_check v0 to 32 bits
+            return v0
+        }
+        ";
+
+        let ssa = ssa.remove_truncate_after_range_check();
+        assert_normalized_ssa_equals(ssa, expected);
+    }
+
+    #[test]
+    fn removes_truncate_after_range_check_with_smaller_bit_size() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 16 bits
+            v1 = truncate v0 to 32 bits, max_bit_size: 254
+            return v1
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let expected = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 16 bits
+            return v0
+        }
+        ";
+
+        let ssa = ssa.remove_truncate_after_range_check();
+        assert_normalized_ssa_equals(ssa, expected);
+    }
+
+    #[test]
+    fn does_not_remove_truncate_after_range_check_with_larger_bit_size() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 64 bits
+            v1 = truncate v0 to 32 bits, max_bit_size: 254
+            return v1
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_truncate_after_range_check();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #7828

## Summary



## Additional Context

I don't know if truncate's `max_bit_size` is relevant here (it's ignored in this PR).

## Documentation

Check one:
- [x] No documentation needed.
- [x] Documentation included in this PR.
- [x] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
