### PR TITLE
chore(debug): Add ownership analysis pass

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -901,11 +901,16 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 // and become usize::MAX, and then return to 1, then it will indicate
                 // an array as mutable when it probably shouldn't be.
                 if self.brillig_context.enable_debug_assertions() {
-                    let min_addr = ReservedRegisters::usize_one();
+                    let zero =
+                        SingleAddrVariable::new(self.brillig_context.allocate_register(), 32);
+
+                    self.brillig_context.const_instruction(zero, FieldElement::zero());
+
                     let condition =
                         SingleAddrVariable::new(self.brillig_context.allocate_register(), 1);
+
                     self.brillig_context.memory_op_instruction(
-                        min_addr,
+                        zero.address,
                         rc_register,
                         condition.address,
                         BrilligBinaryOp::LessThan,

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -505,6 +505,7 @@ impl FunctionBuilder {
     /// any arrays, this does nothing.
     ///
     /// Returns the ID of the array that was affected, if any.
+    #[allow(unused)]
     pub(crate) fn decrement_array_reference_count(&mut self, value: ValueId) -> Option<ValueId> {
         self.update_array_reference_count(value, false)
     }

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -505,7 +505,6 @@ impl FunctionBuilder {
     /// any arrays, this does nothing.
     ///
     /// Returns the ID of the array that was affected, if any.
-    #[allow(unused)]
     pub(crate) fn decrement_array_reference_count(&mut self, value: ValueId) -> Option<ValueId> {
         self.update_array_reference_count(value, false)
     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -24,7 +24,7 @@ use crate::ssa::ir::value::ValueId;
 
 use super::GlobalsGraph;
 use super::value::{Tree, Value, Values};
-use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use fxhash::FxHashMap as HashMap;
 
 /// The FunctionContext is the main context object for translating a
 /// function into SSA form during the SSA-gen pass.
@@ -953,65 +953,6 @@ impl<'a> FunctionContext<'a> {
                 unreachable!(
                     "assign: Expected lhs and rhs values to match but found {lhs:?} and {rhs:?}"
                 )
-            }
-        }
-    }
-
-    /// Increments the reference count of mutable reference array parameters.
-    /// Any mutable-value (`mut a: [T; N]` versus `a: &mut [T; N]`) are already incremented
-    /// by `FunctionBuilder::add_parameter_to_scope`.
-    /// Returns each array id that was incremented.
-    ///
-    /// This is done on parameters rather than call arguments so that we can optimize out
-    /// paired inc/dec instructions within brillig functions more easily.
-    ///
-    /// Returns the list of parameters incremented, together with the value ID of the arrays they refer to.
-    pub(crate) fn increment_parameter_rcs(&mut self) -> Vec<(ValueId, ValueId)> {
-        let entry = self.builder.current_function.entry_block();
-        let parameters = self.builder.current_function.dfg.block_parameters(entry).to_vec();
-
-        let mut incremented = Vec::default();
-        let mut seen_array_types = HashSet::default();
-
-        for parameter in parameters {
-            // Avoid reference counts for immutable arrays that aren't behind references.
-            let typ = self.builder.current_function.dfg.type_of_value(parameter);
-
-            if let Type::Reference(element) = typ {
-                if element.contains_an_array() {
-                    // If we have already seen this array type, the value may be possibly
-                    // aliased, so issue an inc_rc for it.
-                    if seen_array_types.insert(element.get_contained_array().clone()) {
-                        continue;
-                    }
-                    if let Some(id) = self.builder.increment_array_reference_count(parameter) {
-                        incremented.push((parameter, id));
-                    }
-                }
-            }
-        }
-
-        incremented
-    }
-
-    /// Ends a local scope of a function.
-    /// This will issue DecrementRc instructions for any arrays in the given starting scope
-    /// block's parameters. Arrays that are also used in terminator instructions for the scope are
-    /// ignored.
-    pub(crate) fn end_scope(
-        &mut self,
-        mut incremented_params: Vec<(ValueId, ValueId)>,
-        terminator_args: &[ValueId],
-    ) {
-        // TODO: This check likely leads to unsoundness.
-        // It is here to avoid decrementing the RC of a parameter we're returning but we
-        // only check the exact ValueId which can be easily circumvented by storing to and
-        // loading from a temporary reference.
-        incremented_params.retain(|(parameter, _)| !terminator_args.contains(parameter));
-
-        for (parameter, original) in incremented_params {
-            if self.builder.current_function.dfg.value_is_reference(parameter) {
-                self.builder.decrement_array_reference_count(original);
             }
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -219,7 +219,7 @@ impl<'a> FunctionContext<'a> {
             ast::Type::Unit => Tree::empty(),
             // A mutable reference wraps each element into a reference.
             // This can be multiple values if the element type is a tuple.
-            ast::Type::MutableReference(element) => {
+            ast::Type::Reference(element) => {
                 Self::map_type_helper(element, &mut |typ| f(Type::Reference(Arc::new(typ))))
             }
             ast::Type::FmtString(len, fields) => {
@@ -272,7 +272,7 @@ impl<'a> FunctionContext<'a> {
             ast::Type::Tuple(_) => panic!("convert_non_tuple_type called on a tuple: {typ}"),
             ast::Type::Function(_, _, _, _) => Type::Function,
             ast::Type::Slice(_) => panic!("convert_non_tuple_type called on a slice: {typ}"),
-            ast::Type::MutableReference(element) => {
+            ast::Type::Reference(element) => {
                 // Recursive call to panic if element is a tuple
                 let element = Self::convert_non_tuple_type(element);
                 Type::Reference(Arc::new(element))
@@ -979,7 +979,7 @@ impl<'a> FunctionContext<'a> {
 
             if let Type::Reference(element) = typ {
                 if element.contains_an_array() {
-                    // If we haven't already seen this array type, the value may be possibly
+                    // If we have already seen this array type, the value may be possibly
                     // aliased, so issue an inc_rc for it.
                     if seen_array_types.insert(element.get_contained_array().clone()) {
                         continue;

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -173,7 +173,7 @@ impl<'a> FunctionContext<'a> {
             let value = self.builder.add_parameter(typ);
             if mutable {
                 // This will wrap any `mut var: T` in a reference and increase the rc of an array if needed
-                self.new_mutable_variable(value, true)
+                self.new_mutable_variable(value)
             } else {
                 value.into()
             }
@@ -184,16 +184,8 @@ impl<'a> FunctionContext<'a> {
 
     /// Allocate a single slot of memory and store into it the given initial value of the variable.
     /// Always returns a Value::Mutable wrapping the allocate instruction.
-    pub(super) fn new_mutable_variable(
-        &mut self,
-        value_to_store: ValueId,
-        increment_array_rc: bool,
-    ) -> Value {
+    pub(super) fn new_mutable_variable(&mut self, value_to_store: ValueId) -> Value {
         let element_type = self.builder.current_function.dfg.type_of_value(value_to_store);
-
-        if increment_array_rc {
-            self.builder.increment_array_reference_count(value_to_store);
-        }
 
         let alloc = self.builder.insert_allocate(element_type);
         self.builder.insert_store(alloc, value_to_store);

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -278,17 +278,13 @@ impl FunctionContext<'_> {
     fn codegen_array_elements(
         &mut self,
         elements: &[Expression],
-    ) -> Result<Vec<(Values, bool)>, RuntimeError> {
-        try_vecmap(elements, |element| {
-            let value = self.codegen_expression(element)?;
-            Ok((value, element.is_array_or_slice_literal()))
-        })
+    ) -> Result<Vec<Values>, RuntimeError> {
+        try_vecmap(elements, |element| self.codegen_expression(element))
     }
 
     fn codegen_string(&mut self, string: &str) -> Values {
         let elements = vecmap(string.as_bytes(), |byte| {
-            let char = self.builder.numeric_constant(*byte as u128, NumericType::char());
-            (char.into(), false)
+            self.builder.numeric_constant(*byte as u128, NumericType::char()).into()
         });
         let typ = Self::convert_non_tuple_type(&ast::Type::String(elements.len() as u32));
         self.codegen_array(elements, typ)
@@ -301,7 +297,7 @@ impl FunctionContext<'_> {
     /// constant to be moved into this larger array constant.
     fn codegen_array_checked(
         &mut self,
-        elements: Vec<(Values, bool)>,
+        elements: Vec<Values>,
         typ: Type,
     ) -> Result<Values, RuntimeError> {
         if typ.is_nested_slice() {
@@ -323,22 +319,12 @@ impl FunctionContext<'_> {
     /// constant to be moved into this larger array constant.
     ///
     /// The value returned from this function is always that of the allocate instruction.
-    fn codegen_array(&mut self, elements: Vec<(Values, bool)>, typ: Type) -> Values {
+    fn codegen_array(&mut self, elements: Vec<Values>, typ: Type) -> Values {
         let mut array = im::Vector::new();
 
-        for (element, is_array_constant) in elements {
+        for element in elements {
             element.for_each(|element| {
                 let element = element.eval(self);
-
-                // If we're referencing a sub-array in a larger nested array we need to
-                // increase the reference count of the sub array. This maintains a
-                // pessimistic reference count (since some are likely moved rather than shared)
-                // which is important for Brillig's copy on write optimization. This has no
-                // effect in ACIR code.
-                if !is_array_constant {
-                    // self.builder.increment_array_reference_count(element);
-                }
-
                 array.push_back(element);
             });
         }
@@ -1030,22 +1016,12 @@ impl FunctionContext<'_> {
     fn codegen_let(&mut self, let_expr: &ast::Let) -> Result<Values, RuntimeError> {
         let mut values = self.codegen_expression(&let_expr.expression)?;
 
-        // Don't mutate the reference count if we're assigning an array literal to a Let:
-        // `let mut foo = [1, 2, 3];`
-        // we consider the array to be moved, so we should have an initial rc of just 1.
-        let should_inc_rc = !let_expr.expression.is_array_or_slice_literal();
-
         values = values.map(|value| {
             let value = value.eval(self);
 
             Tree::Leaf(if let_expr.mutable {
-                self.new_mutable_variable(value, should_inc_rc)
+                self.new_mutable_variable(value)
             } else {
-                // `new_mutable_variable` increments rcs internally so we have to
-                // handle it separately for the immutable case
-                if should_inc_rc {
-                    // self.builder.increment_array_reference_count(value);
-                }
                 value::Value::Normal(value)
             })
         });
@@ -1104,15 +1080,6 @@ impl FunctionContext<'_> {
     fn codegen_assign(&mut self, assign: &ast::Assign) -> Result<Values, RuntimeError> {
         let lhs = self.extract_current_value(&assign.lvalue)?;
         let rhs = self.codegen_expression(&assign.expression)?;
-        let should_inc_rc = !assign.expression.is_array_or_slice_literal();
-
-        rhs.clone().for_each(|value| {
-            let _value = value.eval(self);
-
-            if should_inc_rc {
-                // self.builder.increment_array_reference_count(value);
-            }
-        });
 
         self.assign_new_value(lhs, rhs);
         Ok(Self::unit_value())

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -136,10 +136,10 @@ impl FunctionContext<'_> {
     /// Codegen a function's body and set its return value to that of its last parameter.
     /// For functions returning nothing, this will be an empty list.
     fn codegen_function_body(&mut self, body: &Expression) -> Result<(), RuntimeError> {
-        let incremented_params = self.increment_parameter_rcs();
+        // let incremented_params = self.increment_parameter_rcs();
         let return_value = self.codegen_expression(body)?;
         let results = return_value.into_value_list(self);
-        self.end_scope(incremented_params, &results);
+        // self.end_scope(incremented_params, &results);
 
         self.builder.terminate_with_return(results);
         Ok(())
@@ -336,7 +336,7 @@ impl FunctionContext<'_> {
                 // which is important for Brillig's copy on write optimization. This has no
                 // effect in ACIR code.
                 if !is_array_constant {
-                    self.builder.increment_array_reference_count(element);
+                    // self.builder.increment_array_reference_count(element);
                 }
 
                 array.push_back(element);
@@ -487,7 +487,7 @@ impl FunctionContext<'_> {
             // counts when nested arrays/slices are constructed or indexed. This
             // has no effect in ACIR code.
             let result = self.builder.insert_array_get(array, offset, typ);
-            self.builder.increment_array_reference_count(result);
+            // self.builder.increment_array_reference_count(result);
             result.into()
         }))
     }
@@ -1044,7 +1044,7 @@ impl FunctionContext<'_> {
                 // `new_mutable_variable` increments rcs internally so we have to
                 // handle it separately for the immutable case
                 if should_inc_rc {
-                    self.builder.increment_array_reference_count(value);
+                    // self.builder.increment_array_reference_count(value);
                 }
                 value::Value::Normal(value)
             })
@@ -1107,10 +1107,10 @@ impl FunctionContext<'_> {
         let should_inc_rc = !assign.expression.is_array_or_slice_literal();
 
         rhs.clone().for_each(|value| {
-            let value = value.eval(self);
+            let _value = value.eval(self);
 
             if should_inc_rc {
-                self.builder.increment_array_reference_count(value);
+                // self.builder.increment_array_reference_count(value);
             }
         });
 

--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -22,6 +22,7 @@ pub mod lexer;
 pub mod locations;
 pub mod monomorphization;
 pub mod node_interner;
+pub(crate) mod ownership;
 pub mod parser;
 pub mod resolve_locations;
 pub mod shared;

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -367,6 +367,14 @@ impl Type {
             _ => f(self),
         }
     }
+
+    /// Returns the element type of this array or slice
+    pub fn array_element_type(&self) -> Option<&Type> {
+        match self {
+            Type::Array(_, elem) | Type::Slice(elem) => Some(elem),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Hash, Default)]

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -51,6 +51,7 @@ pub enum Expression {
     Assign(Assign),
     Semi(Box<Expression>),
     Clone(Box<Expression>),
+    Drop(Box<Expression>),
     Break,
     Continue,
 }

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -356,18 +356,6 @@ impl Type {
         }
     }
 
-    /// Similar to flatten but avoids allocating a new Vec
-    pub fn flatten_for_each<'a>(&'a self, mut f: impl FnMut(&'a Type)) {
-        self.flatten_for_each_helper(&mut f)
-    }
-
-    fn flatten_for_each_helper<'a>(&'a self, f: &mut impl FnMut(&'a Type)) {
-        match self {
-            Type::Tuple(fields) => fields.iter().for_each(|typ| typ.flatten_for_each_helper(f)),
-            _ => f(self),
-        }
-    }
-
     /// Returns the element type of this array or slice
     pub fn array_element_type(&self) -> Option<&Type> {
         match self {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -201,7 +201,7 @@ pub fn monomorphize_debug(
         debug_functions,
         debug_types,
     );
-    Ok(program.handle_ownership())
+    Ok(program.handle_ownership(monomorphizer.next_local_id))
 }
 
 impl<'interner> Monomorphizer<'interner> {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -201,7 +201,7 @@ pub fn monomorphize_debug(
         debug_functions,
         debug_types,
     );
-    Ok(program)
+    Ok(program.handle_ownership())
 }
 
 impl<'interner> Monomorphizer<'interner> {
@@ -1312,7 +1312,7 @@ impl<'interner> Monomorphizer<'interner> {
             // Lower both mutable & immutable references to the same reference type
             HirType::Reference(element, _mutable) => {
                 let element = Self::convert_type_helper(element, location, seen_types)?;
-                ast::Type::MutableReference(Box::new(element))
+                ast::Type::Reference(Box::new(element))
             }
 
             HirType::Forall(_, _) | HirType::Constant(..) | HirType::InfixExpr(..) => {
@@ -2131,7 +2131,7 @@ impl<'interner> Monomorphizer<'interner> {
                     typ: ast::Type::Slice(element_type.clone()),
                 }))
             }
-            ast::Type::MutableReference(element) => {
+            ast::Type::Reference(element) => {
                 use UnaryOp::Reference;
                 let rhs = Box::new(self.zeroed_value_of_type(element, location));
                 let result_type = typ.clone();

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -78,6 +78,10 @@ impl AstPrinter {
             }
             Expression::Break => write!(f, "break"),
             Expression::Continue => write!(f, "continue"),
+            Expression::Clone(expr) => {
+                self.print_expr(expr, f)?;
+                write!(f, ".clone()")
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -1,5 +1,7 @@
 //! This module implements printing of the monomorphized AST, for debugging purposes.
 
+use crate::ast::UnaryOp;
+
 use super::ast::{Definition, Expression, Function, LValue, While};
 use iter_extended::vecmap;
 use std::fmt::{Display, Formatter};
@@ -81,6 +83,10 @@ impl AstPrinter {
             Expression::Clone(expr) => {
                 self.print_expr(expr, f)?;
                 write!(f, ".clone()")
+            }
+            Expression::Drop(expr) => {
+                self.print_expr(expr, f)?;
+                write!(f, ".drop()")
             }
         }
     }
@@ -182,6 +188,9 @@ impl AstPrinter {
         f: &mut Formatter,
     ) -> Result<(), std::fmt::Error> {
         write!(f, "({}", unary.operator)?;
+        if matches!(&unary.operator, UnaryOp::Reference { mutable: true }) {
+            write!(f, " ")?;
+        }
         self.print_expr(&unary.rhs, f)?;
         write!(f, ")")
     }

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -1,0 +1,193 @@
+//! This module implements the "ownership analysis" compiler pass on the
+//! monomorphized AST. It is run after monomorphization and before SSA-gen.
+//! At this point the monomorphized AST has no polymorphic types and all functions
+//! are specialized into either constrained or unconstrained versions. This pass
+//! only operates on unconstrained functions since only Noir's unconstrained runtime Brillig
+//! has any notion of cloning a value - specifically arrays with their brillig-only reference counts.
+//!
+//! Note that this documentation may refer to cloning a value or incrementing an array's reference
+//! count. These operations are equivalent on arrays. Cloning may be applied to any value and only
+//! increments the reference counts of any arrays contained within (but not behind references or
+//! inside nested arrays). This document also focuses on arrays but all reference count operations
+//! on arrays are also performed on slices.
+//!
+//! Arrays in brillig have copy on write semantics which relies on us incrementing their
+//! reference counts when they are shared in multiple places. Note that while Noir has references,
+//! arrays can also be shared by value and we want to avoid clones when possible. This pass
+//! clones arrays (increments their reference counts) in the following situations:
+//! - Function parameters:
+//!   - Any arrays behind a mutable reference `&mut [T; N]` will have their reference count
+//!     incremented iff there was already a prior array of the same type passed into the same
+//!     function. E.g. if there are two parameters of type `&mut [Field; 3]` we increment only
+//!     the later. If there are 3 we increment the last two.
+//!     - This applies within struct & tuple types as well. If a function only takes 1 struct
+//!       parameter but that struct contains 2 or more mutable references to the same array
+//!       type, we increment the reference count of each instance of the type after the first.
+//!     - In the case of references to nested arrays, only the outer array has its reference count incremented.
+//!   - Arrays taken by mutable value are always cloned, e.g. in `mut x: [u32; 3]`, `x` will
+//!     have its reference count incremented.
+//! - Let bindings (`let _ = <expression which returns an array>;`):
+//!   - Binding an array to a let binding increments the reference count of the array unless
+//!     the expression is an array literal in which case it is considered to be moved.
+//! - Assignments (`x = <expression which returns an array>;`):
+//!   - Similarly, assigning an array to an existing variable will also increment the reference
+//!     count of the array unless it is an array literal.
+//! - Array literals:
+//!   - Arrays stored inside a nested array literal (e.g. both variables in `[array1, array2]`
+//!     have their reference count incremented).
+//!   - This does not apply to nested array literals since we know they are not referenced elsewhere.
+//! - Extracting an array from another array (`let inner: [_; _] = array[0];`):
+//!   - Extracting a nested array from its outer array will always increment the reference count
+//!     of the nested array.
+//!
+//! Additionally we currently only decrement reference counts at the end of the function when
+//! a parameter goes out of scope. These means reference counts likely trend upward over time
+//! until the array is eventually mutated and it is reset back to 1.
+use crate::{
+    ast::UnaryOp,
+    monomorphization::ast::{
+        Definition, Expression, Function, Ident, Parameters, Program, Type, Unary,
+    },
+};
+
+use fxhash::FxHashSet as HashSet;
+use noirc_errors::Location;
+
+impl Program {
+    pub(crate) fn handle_ownership(mut self) -> Self {
+        let mut context = Context {};
+
+        for function in self.functions.iter_mut() {
+            context.handle_ownership_in_function(function);
+        }
+
+        self
+    }
+}
+
+struct Context {}
+
+impl Context {
+    fn handle_ownership_in_function(&mut self, function: &mut Function) {
+        if !function.unconstrained {
+            return;
+        }
+
+        self.increment_parameter_rcs(&function.parameters);
+        self.handle_expression(&mut function.body);
+    }
+
+    fn increment_parameter_rcs(&mut self, parameters: &Parameters) {
+        let mut seen_array_types = HashSet::default();
+        let mut new_clones = Vec::new();
+
+        for (parameter_id, mutable, name, parameter_type) in parameters {
+            let parameter = Expression::Ident(Ident {
+                location: None,
+                definition: Definition::Local(*parameter_id),
+                mutable: *mutable,
+                name: name.clone(),
+                typ: parameter_type.clone(),
+            });
+            self.recur_on_parameter(
+                parameter,
+                parameter_type,
+                &mut seen_array_types,
+                &mut new_clones,
+            );
+        }
+    }
+
+    fn recur_on_parameter<'typ>(
+        &mut self,
+        parameter: Expression,
+        parameter_type: &'typ Type,
+        seen_array_types: &mut HashSet<&'typ Type>,
+        new_clones: &mut Vec<Expression>,
+    ) {
+        match parameter_type {
+            // These types never contain arrays
+            Type::Field
+            | Type::Integer(..)
+            | Type::Bool
+            | Type::Unit
+            | Type::Function(..)
+            | Type::Array(..)
+            | Type::String(_)
+            | Type::FmtString(..)
+            | Type::Slice(_) => (),
+
+            Type::Tuple(fields) => {
+                for (i, field) in fields.iter().enumerate() {
+                    let expr = Expression::ExtractTupleField(Box::new(parameter.clone()), i);
+                    self.recur_on_parameter(expr, field, seen_array_types, new_clones);
+                }
+            }
+
+            Type::Reference(element_type) => {
+                if let Some(array) = Self::inner_array_or_slice_type(&element_type) {
+                    // Check if the parameter type has been seen before
+                    if !seen_array_types.insert(array) {
+                        let expr = Expression::Unary(Unary {
+                            operator: UnaryOp::Dereference { implicitly_added: true },
+                            rhs: Box::new(parameter),
+                            result_type: element_type.as_ref().clone(),
+                            location: Location::dummy(), // TODO
+                        });
+                        new_clones.push(Expression::Clone(Box::new(expr)));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Return the inner array, slice, string, or fmtstring type if it exists.
+    fn inner_array_or_slice_type(typ: &Type) -> Option<&Type> {
+        match typ {
+            Type::Field | Type::Integer(..) | Type::Bool | Type::Function(..) | Type::Unit => None,
+
+            Type::Array(_, _) | Type::Slice(_) | Type::String(_) | Type::FmtString(..) => Some(typ),
+
+            Type::Tuple(elems) => {
+                for elem in elems {
+                    if let Some(target) = Self::inner_array_or_slice_type(elem) {
+                        return Some(target);
+                    }
+                }
+                None
+            }
+
+            // The existing SSA code still checked nested references for
+            // array types. These probably shouldn't be needed for cloning
+            // purposes but are kept for now to avoid differences with the existing code.
+            Type::Reference(element) => Self::inner_array_or_slice_type(element),
+        }
+    }
+
+    fn handle_expression(&mut self, expr: &mut Expression) {
+        match expr {
+            Expression::Ident(_) => (),
+            Expression::Literal(literal) => todo!(),
+            Expression::Block(vec) => todo!(),
+            Expression::Unary(unary) => todo!(),
+            Expression::Binary(binary) => todo!(),
+            Expression::Index(index) => todo!(),
+            Expression::Cast(cast) => todo!(),
+            Expression::For(_) => todo!(),
+            Expression::Loop(expression) => todo!(),
+            Expression::While(_) => todo!(),
+            Expression::If(_) => todo!(),
+            Expression::Match(_) => todo!(),
+            Expression::Tuple(vec) => todo!(),
+            Expression::ExtractTupleField(expression, _) => todo!(),
+            Expression::Call(call) => todo!(),
+            Expression::Let(_) => todo!(),
+            Expression::Constrain(expression, location, _) => todo!(),
+            Expression::Assign(assign) => todo!(),
+            Expression::Semi(expression) => todo!(),
+            Expression::Clone(expression) => todo!(),
+            Expression::Break => todo!(),
+            Expression::Continue => todo!(),
+        }
+    }
+}

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -100,6 +100,12 @@ fn increment_parameter_rcs(parameters: &Parameters) -> Vec<Expression> {
     new_clones
 }
 
+/// Recur on a parameter's type, digging into any struct fields, looking for references to arrays.
+/// This will build up an Expression of the current parameter access we're doing, e.g. `*foo.bar`
+/// would correspond to a parameter `foo` with struct field `bar` that is a reference to an array.
+///
+/// This function inserts a .clone() expression to any parameter arrays behind references with
+/// repeated types since these may potentially be aliased by other parameters.
 fn recur_on_parameter<'typ>(
     parameter: Expression,
     parameter_type: &'typ Type,

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -46,7 +46,7 @@
 use crate::{
     ast::UnaryOp,
     monomorphization::ast::{
-        Definition, Expression, Function, Ident, Literal, Parameters, Program, Type, Unary,
+        Definition, Expression, Function, Ident, LValue, Literal, Parameters, Program, Type, Unary,
     },
 };
 
@@ -179,29 +179,238 @@ impl Context {
     fn handle_expression(&mut self, expr: &mut Expression) {
         match expr {
             Expression::Ident(_) => (),
-            Expression::Literal(literal) => todo!(),
+            Expression::Literal(literal) => self.handle_literal(literal),
             Expression::Block(exprs) => {
                 exprs.iter_mut().for_each(|expr| self.handle_expression(expr))
             }
-            Expression::Unary(unary) => todo!(),
-            Expression::Binary(binary) => todo!(),
-            Expression::Index(index) => todo!(),
-            Expression::Cast(cast) => todo!(),
-            Expression::For(_) => todo!(),
-            Expression::Loop(expression) => todo!(),
-            Expression::While(_) => todo!(),
-            Expression::If(_) => todo!(),
-            Expression::Match(_) => todo!(),
-            Expression::Tuple(vec) => todo!(),
-            Expression::ExtractTupleField(expression, _) => todo!(),
-            Expression::Call(call) => todo!(),
-            Expression::Let(_) => todo!(),
-            Expression::Constrain(expression, location, _) => todo!(),
-            Expression::Assign(assign) => todo!(),
+            Expression::Unary(unary) => self.handle_unary(unary),
+            Expression::Binary(binary) => self.handle_binary(binary),
+            Expression::Index(_) => self.handle_index(expr),
+            Expression::Cast(cast) => self.handle_cast(cast),
+            Expression::For(for_expr) => self.handle_for(for_expr),
+            Expression::Loop(loop_expr) => self.handle_expression(loop_expr),
+            Expression::While(while_expr) => self.handle_while(while_expr),
+            Expression::If(if_expr) => self.handle_if(if_expr),
+            Expression::Match(match_expr) => self.handle_match(match_expr),
+            Expression::Tuple(elems) => self.handle_tuple(elems),
+            Expression::ExtractTupleField(tuple, _index) => self.handle_expression(tuple),
+            Expression::Call(call) => self.handle_call(call),
+            Expression::Let(let_expr) => self.handle_let(let_expr),
+            Expression::Constrain(boolean, _location, msg) => self.handle_constrain(boolean, msg),
+            Expression::Assign(assign) => self.handle_assign(assign),
             Expression::Semi(expr) => self.handle_expression(expr),
-            Expression::Clone(_) => unreachable!("Explicit clones are only inserted by this pass"),
+            // Clones are only inserted by this pass so we can assume any code they contain is
+            // already handled
+            Expression::Clone(_) => (),
             Expression::Break => (),
             Expression::Continue => (),
         }
+    }
+
+    /// - Array literals:
+    ///   - Arrays stored inside a nested array literal (e.g. both variables in `[array1, array2]`
+    ///     have their reference count incremented).
+    ///   - This does not apply to nested array literals since we know they are not referenced elsewhere.
+    fn handle_literal(&mut self, literal: &mut Literal) {
+        match literal {
+            Literal::Integer(..) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => (),
+
+            Literal::FmtStr(_, _, captures) => self.handle_expression(captures),
+
+            Literal::Array(array) | Literal::Slice(array) => {
+                let element_type = array
+                    .typ
+                    .array_element_type()
+                    .expect("Array literal should have an array type");
+                if contains_array_or_str_type(element_type) {
+                    // We have to clone nested arrays unless they are array literals
+                    for element in array.contents.iter_mut() {
+                        if !is_array_or_str_literal(element) {
+                            clone_expr(element);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_unary(&mut self, unary: &mut Unary) {
+        self.handle_expression(&mut unary.rhs);
+    }
+
+    fn handle_binary(&mut self, binary: &mut crate::monomorphization::ast::Binary) {
+        self.handle_expression(&mut binary.lhs);
+        self.handle_expression(&mut binary.rhs);
+    }
+
+    /// - Extracting an array from another array (`let inner: [_; _] = array[0];`):
+    ///   - Extracting a nested array from its outer array will always increment the reference count
+    ///     of the nested array.
+    fn handle_index(&mut self, index_expr: &mut Expression) {
+        let crate::monomorphization::ast::Expression::Index(index) = index_expr else {
+            panic!("handle_index should only be called with Index nodes");
+        };
+
+        self.handle_expression(&mut index.collection);
+        self.handle_expression(&mut index.index);
+
+        if contains_array_or_str_type(&index.element_type) {
+            clone_expr(index_expr);
+        }
+    }
+
+    fn handle_cast(&mut self, cast: &mut crate::monomorphization::ast::Cast) {
+        self.handle_expression(&mut cast.lhs);
+    }
+
+    fn handle_for(&mut self, for_expr: &mut crate::monomorphization::ast::For) {
+        self.handle_expression(&mut for_expr.start_range);
+        self.handle_expression(&mut for_expr.end_range);
+        self.handle_expression(&mut for_expr.block);
+    }
+
+    fn handle_while(&mut self, while_expr: &mut crate::monomorphization::ast::While) {
+        self.handle_expression(&mut while_expr.condition);
+        self.handle_expression(&mut while_expr.body);
+    }
+
+    fn handle_if(&mut self, if_expr: &mut crate::monomorphization::ast::If) {
+        self.handle_expression(&mut if_expr.condition);
+        self.handle_expression(&mut if_expr.consequence);
+        if let Some(alt) = &mut if_expr.alternative {
+            self.handle_expression(alt);
+        }
+    }
+
+    fn handle_match(&mut self, match_expr: &mut crate::monomorphization::ast::Match) {
+        for case in &mut match_expr.cases {
+            self.handle_expression(&mut case.branch);
+        }
+
+        if let Some(default_case) = &mut match_expr.default_case {
+            self.handle_expression(default_case);
+        }
+    }
+
+    fn handle_tuple(&mut self, elems: &mut [Expression]) {
+        for elem in elems {
+            self.handle_expression(elem);
+        }
+    }
+
+    fn handle_call(&mut self, call: &mut crate::monomorphization::ast::Call) {
+        self.handle_expression(&mut call.func);
+        for arg in &mut call.arguments {
+            self.handle_expression(arg);
+        }
+    }
+
+    /// - Let bindings (`let _ = <expression which returns an array>;`):
+    ///   - Binding an array to a let binding increments the reference count of the array unless
+    ///     the expression is an array literal in which case it is considered to be moved.
+    fn handle_let(&mut self, let_expr: &mut crate::monomorphization::ast::Let) {
+        self.handle_expression(&mut let_expr.expression);
+
+        if !is_array_or_str_literal(&let_expr.expression) {
+            clone_expr(&mut let_expr.expression);
+        }
+    }
+
+    fn handle_constrain(
+        &mut self,
+        boolean: &mut Expression,
+        msg: &mut Option<Box<(Expression, crate::hir_def::types::Type)>>,
+    ) {
+        self.handle_expression(boolean);
+
+        if let Some(msg) = msg {
+            self.handle_expression(&mut msg.0);
+        }
+    }
+
+    /// - Assignments (`x = <expression which returns an array>;`):
+    ///   - Assigning an array to an existing variable will also increment the reference
+    ///     count of the array unless it is an array literal.
+    fn handle_assign(&mut self, assign: &mut crate::monomorphization::ast::Assign) {
+        self.handle_lvalue(&mut assign.lvalue);
+        self.handle_expression(&mut assign.expression);
+
+        if !is_array_or_str_literal(&assign.expression) {
+            clone_expr(&mut assign.expression);
+        }
+    }
+
+    fn handle_lvalue(&mut self, lvalue: &mut LValue) {
+        match lvalue {
+            LValue::Ident(_) => (),
+            LValue::Index { array, index, element_type: _, location: _ } => {
+                self.handle_expression(index);
+                self.handle_lvalue(array);
+            }
+            LValue::MemberAccess { object, field_index: _ } => {
+                self.handle_lvalue(object);
+            }
+            LValue::Dereference { reference, element_type: _ } => {
+                self.handle_lvalue(reference);
+            }
+        }
+    }
+}
+
+/// Adds a `.clone()` to the given expression.
+/// Note that this method should be careful not to actually duplicate the given expression
+/// so that we do not duplicate any side-effects.
+fn clone_expr(expr: &mut Expression) {
+    let unit = Expression::Literal(Literal::Unit);
+    let old_expr = std::mem::replace(expr, unit);
+    *expr = Expression::Clone(Box::new(old_expr));
+}
+
+fn is_array_or_str_literal(expr: &Expression) -> bool {
+    match expr {
+        Expression::Literal(literal) => match literal {
+            Literal::Integer(..) | Literal::Bool(_) | Literal::Unit => false,
+
+            Literal::Array(_) | Literal::Slice(_) | Literal::Str(_) | Literal::FmtStr(..) => true,
+        },
+        Expression::Block(exprs) => {
+            if let Some(expr) = exprs.last() {
+                is_array_or_str_literal(expr)
+            } else {
+                false
+            }
+        }
+
+        Expression::Unary(_)
+        | Expression::Ident(_)
+        | Expression::Binary(_)
+        | Expression::Index(_)
+        | Expression::Cast(_)
+        | Expression::For(_)
+        | Expression::Loop(_)
+        | Expression::While(_)
+        | Expression::If(_)
+        | Expression::Match(_)
+        | Expression::Tuple(_)
+        | Expression::ExtractTupleField(_, _)
+        | Expression::Call(_)
+        | Expression::Let(_)
+        | Expression::Constrain(..)
+        | Expression::Assign(_)
+        | Expression::Semi(_)
+        | Expression::Clone(_)
+        | Expression::Break
+        | Expression::Continue => false,
+    }
+}
+
+fn contains_array_or_str_type(typ: &Type) -> bool {
+    match typ {
+        Type::Field | Type::Integer(..) | Type::Bool | Type::Unit | Type::Function(..) => false,
+
+        Type::Array(_, _) | Type::String(_) | Type::FmtString(_, _) | Type::Slice(_) => true,
+
+        Type::Tuple(elems) => elems.iter().any(contains_array_or_str_type),
+        Type::Reference(elem) => contains_array_or_str_type(elem),
     }
 }

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -134,7 +134,8 @@ fn recur_on_parameter<'typ>(
 
         Type::Array(_, element_type) | Type::Slice(element_type) => {
             seen_array_types.insert(parameter_type);
-            recur_on_parameter(parameter, &element_type, seen_array_types, new_clones);
+            // Don't clone inside arrays, but still look for more array types
+            recur_on_parameter(None, element_type, seen_array_types, new_clones);
         }
         Type::String(_) | Type::FmtString(..) => {
             seen_array_types.insert(parameter_type);

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -55,304 +55,289 @@ use noirc_errors::Location;
 
 impl Program {
     pub(crate) fn handle_ownership(mut self) -> Self {
-        let mut context = Context {};
-
         for function in self.functions.iter_mut() {
-            context.handle_ownership_in_function(function);
+            handle_ownership_in_function(function);
         }
 
         self
     }
 }
 
-struct Context {}
-
-impl Context {
-    fn handle_ownership_in_function(&mut self, function: &mut Function) {
-        if !function.unconstrained {
-            return;
-        }
-
-        let mut new_clones = self.increment_parameter_rcs(&function.parameters);
-        self.handle_expression(&mut function.body);
-
-        // Prepend new_clones to the function body
-        if !new_clones.is_empty() {
-            let unit = Expression::Literal(Literal::Unit);
-            let old_body = std::mem::replace(&mut function.body, unit);
-            new_clones.push(old_body);
-            function.body = Expression::Block(new_clones);
-        }
+fn handle_ownership_in_function(function: &mut Function) {
+    if !function.unconstrained {
+        return;
     }
 
-    /// Increment any parameter reference counts necessary. Returns a vector of new
-    /// clones to prepend to a function - if any.
-    fn increment_parameter_rcs(&mut self, parameters: &Parameters) -> Vec<Expression> {
-        let mut seen_array_types = HashSet::default();
-        let mut new_clones = Vec::new();
+    let mut new_clones = increment_parameter_rcs(&function.parameters);
+    handle_expression(&mut function.body);
 
-        for (parameter_id, mutable, name, parameter_type) in parameters {
-            let parameter = Expression::Ident(Ident {
-                location: None,
-                definition: Definition::Local(*parameter_id),
-                mutable: *mutable,
-                name: name.clone(),
-                typ: parameter_type.clone(),
-            });
-            self.recur_on_parameter(
-                parameter,
-                parameter_type,
-                &mut seen_array_types,
-                &mut new_clones,
-            );
-        }
+    // Prepend new_clones to the function body
+    if !new_clones.is_empty() {
+        let unit = Expression::Literal(Literal::Unit);
+        let old_body = std::mem::replace(&mut function.body, unit);
+        new_clones.push(old_body);
+        function.body = Expression::Block(new_clones);
+    }
+}
 
-        new_clones
+/// Increment any parameter reference counts necessary. Returns a vector of new
+/// clones to prepend to a function - if any.
+fn increment_parameter_rcs(parameters: &Parameters) -> Vec<Expression> {
+    let mut seen_array_types = HashSet::default();
+    let mut new_clones = Vec::new();
+
+    for (parameter_id, mutable, name, parameter_type) in parameters {
+        let parameter = Expression::Ident(Ident {
+            location: None,
+            definition: Definition::Local(*parameter_id),
+            mutable: *mutable,
+            name: name.clone(),
+            typ: parameter_type.clone(),
+        });
+        recur_on_parameter(parameter, parameter_type, &mut seen_array_types, &mut new_clones);
     }
 
-    fn recur_on_parameter<'typ>(
-        &mut self,
-        parameter: Expression,
-        parameter_type: &'typ Type,
-        seen_array_types: &mut HashSet<&'typ Type>,
-        new_clones: &mut Vec<Expression>,
-    ) {
-        match parameter_type {
-            // These types never contain arrays
-            Type::Field
-            | Type::Integer(..)
-            | Type::Bool
-            | Type::Unit
-            | Type::Function(..)
-            | Type::Array(..)
-            | Type::String(_)
-            | Type::FmtString(..)
-            | Type::Slice(_) => (),
+    new_clones
+}
 
-            Type::Tuple(fields) => {
-                for (i, field) in fields.iter().enumerate() {
-                    let expr = Expression::ExtractTupleField(Box::new(parameter.clone()), i);
-                    self.recur_on_parameter(expr, field, seen_array_types, new_clones);
+fn recur_on_parameter<'typ>(
+    parameter: Expression,
+    parameter_type: &'typ Type,
+    seen_array_types: &mut HashSet<&'typ Type>,
+    new_clones: &mut Vec<Expression>,
+) {
+    match parameter_type {
+        // These types never contain arrays
+        Type::Field
+        | Type::Integer(..)
+        | Type::Bool
+        | Type::Unit
+        | Type::Function(..)
+        | Type::Array(..)
+        | Type::String(_)
+        | Type::FmtString(..)
+        | Type::Slice(_) => (),
+
+        Type::Tuple(fields) => {
+            for (i, field) in fields.iter().enumerate() {
+                let expr = Expression::ExtractTupleField(Box::new(parameter.clone()), i);
+                recur_on_parameter(expr, field, seen_array_types, new_clones);
+            }
+        }
+
+        Type::Reference(element_type) => {
+            if let Some(array) = inner_array_or_slice_type(element_type) {
+                // Check if the parameter type has been seen before
+                if !seen_array_types.insert(array) {
+                    let expr = Expression::Unary(Unary {
+                        operator: UnaryOp::Dereference { implicitly_added: true },
+                        rhs: Box::new(parameter),
+                        result_type: element_type.as_ref().clone(),
+                        location: Location::dummy(), // TODO
+                    });
+                    new_clones.push(Expression::Clone(Box::new(expr)));
                 }
             }
+        }
+    }
+}
 
-            Type::Reference(element_type) => {
-                if let Some(array) = Self::inner_array_or_slice_type(&element_type) {
-                    // Check if the parameter type has been seen before
-                    if !seen_array_types.insert(array) {
-                        let expr = Expression::Unary(Unary {
-                            operator: UnaryOp::Dereference { implicitly_added: true },
-                            rhs: Box::new(parameter),
-                            result_type: element_type.as_ref().clone(),
-                            location: Location::dummy(), // TODO
-                        });
-                        new_clones.push(Expression::Clone(Box::new(expr)));
+/// Return the inner array, slice, string, or fmtstring type if it exists.
+fn inner_array_or_slice_type(typ: &Type) -> Option<&Type> {
+    match typ {
+        Type::Field | Type::Integer(..) | Type::Bool | Type::Function(..) | Type::Unit => None,
+
+        Type::Array(_, _) | Type::Slice(_) | Type::String(_) | Type::FmtString(..) => Some(typ),
+
+        Type::Tuple(elems) => {
+            for elem in elems {
+                if let Some(target) = inner_array_or_slice_type(elem) {
+                    return Some(target);
+                }
+            }
+            None
+        }
+
+        // The existing SSA code still checked nested references for
+        // array types. These probably shouldn't be needed for cloning
+        // purposes but are kept for now to avoid differences with the existing code.
+        Type::Reference(element) => inner_array_or_slice_type(element),
+    }
+}
+
+fn handle_expression(expr: &mut Expression) {
+    match expr {
+        Expression::Ident(_) => (),
+        Expression::Literal(literal) => handle_literal(literal),
+        Expression::Block(exprs) => {
+            exprs.iter_mut().for_each(handle_expression);
+        }
+        Expression::Unary(unary) => handle_unary(unary),
+        Expression::Binary(binary) => handle_binary(binary),
+        Expression::Index(_) => handle_index(expr),
+        Expression::Cast(cast) => handle_cast(cast),
+        Expression::For(for_expr) => handle_for(for_expr),
+        Expression::Loop(loop_expr) => handle_expression(loop_expr),
+        Expression::While(while_expr) => handle_while(while_expr),
+        Expression::If(if_expr) => handle_if(if_expr),
+        Expression::Match(match_expr) => handle_match(match_expr),
+        Expression::Tuple(elems) => handle_tuple(elems),
+        Expression::ExtractTupleField(tuple, _index) => handle_expression(tuple),
+        Expression::Call(call) => handle_call(call),
+        Expression::Let(let_expr) => handle_let(let_expr),
+        Expression::Constrain(boolean, _location, msg) => handle_constrain(boolean, msg),
+        Expression::Assign(assign) => handle_assign(assign),
+        Expression::Semi(expr) => handle_expression(expr),
+        // Clones are only inserted by this pass so we can assume any code they contain is
+        // already handled
+        Expression::Clone(_) => (),
+        Expression::Break => (),
+        Expression::Continue => (),
+    }
+}
+
+/// - Array literals:
+///   - Arrays stored inside a nested array literal (e.g. both variables in `[array1, array2]`
+///     have their reference count incremented).
+///   - This does not apply to nested array literals since we know they are not referenced elsewhere.
+fn handle_literal(literal: &mut Literal) {
+    match literal {
+        Literal::Integer(..) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => (),
+
+        Literal::FmtStr(_, _, captures) => handle_expression(captures),
+
+        Literal::Array(array) | Literal::Slice(array) => {
+            let element_type =
+                array.typ.array_element_type().expect("Array literal should have an array type");
+            if contains_array_or_str_type(element_type) {
+                // We have to clone nested arrays unless they are array literals
+                for element in array.contents.iter_mut() {
+                    if !is_array_or_str_literal(element) {
+                        clone_expr(element);
                     }
                 }
             }
         }
     }
+}
 
-    /// Return the inner array, slice, string, or fmtstring type if it exists.
-    fn inner_array_or_slice_type(typ: &Type) -> Option<&Type> {
-        match typ {
-            Type::Field | Type::Integer(..) | Type::Bool | Type::Function(..) | Type::Unit => None,
+fn handle_unary(unary: &mut Unary) {
+    handle_expression(&mut unary.rhs);
+}
 
-            Type::Array(_, _) | Type::Slice(_) | Type::String(_) | Type::FmtString(..) => Some(typ),
+fn handle_binary(binary: &mut crate::monomorphization::ast::Binary) {
+    handle_expression(&mut binary.lhs);
+    handle_expression(&mut binary.rhs);
+}
 
-            Type::Tuple(elems) => {
-                for elem in elems {
-                    if let Some(target) = Self::inner_array_or_slice_type(elem) {
-                        return Some(target);
-                    }
-                }
-                None
-            }
+/// - Extracting an array from another array (`let inner: [_; _] = array[0];`):
+///   - Extracting a nested array from its outer array will always increment the reference count
+///     of the nested array.
+fn handle_index(index_expr: &mut Expression) {
+    let crate::monomorphization::ast::Expression::Index(index) = index_expr else {
+        panic!("handle_index should only be called with Index nodes");
+    };
 
-            // The existing SSA code still checked nested references for
-            // array types. These probably shouldn't be needed for cloning
-            // purposes but are kept for now to avoid differences with the existing code.
-            Type::Reference(element) => Self::inner_array_or_slice_type(element),
+    handle_expression(&mut index.collection);
+    handle_expression(&mut index.index);
+
+    if contains_array_or_str_type(&index.element_type) {
+        clone_expr(index_expr);
+    }
+}
+
+fn handle_cast(cast: &mut crate::monomorphization::ast::Cast) {
+    handle_expression(&mut cast.lhs);
+}
+
+fn handle_for(for_expr: &mut crate::monomorphization::ast::For) {
+    handle_expression(&mut for_expr.start_range);
+    handle_expression(&mut for_expr.end_range);
+    handle_expression(&mut for_expr.block);
+}
+
+fn handle_while(while_expr: &mut crate::monomorphization::ast::While) {
+    handle_expression(&mut while_expr.condition);
+    handle_expression(&mut while_expr.body);
+}
+
+fn handle_if(if_expr: &mut crate::monomorphization::ast::If) {
+    handle_expression(&mut if_expr.condition);
+    handle_expression(&mut if_expr.consequence);
+    if let Some(alt) = &mut if_expr.alternative {
+        handle_expression(alt);
+    }
+}
+
+fn handle_match(match_expr: &mut crate::monomorphization::ast::Match) {
+    for case in &mut match_expr.cases {
+        handle_expression(&mut case.branch);
+    }
+
+    if let Some(default_case) = &mut match_expr.default_case {
+        handle_expression(default_case);
+    }
+}
+
+fn handle_tuple(elems: &mut [Expression]) {
+    for elem in elems {
+        handle_expression(elem);
+    }
+}
+
+fn handle_call(call: &mut crate::monomorphization::ast::Call) {
+    handle_expression(&mut call.func);
+    for arg in &mut call.arguments {
+        handle_expression(arg);
+    }
+}
+
+/// - Let bindings (`let _ = <expression which returns an array>;`):
+///   - Binding an array to a let binding increments the reference count of the array unless
+///     the expression is an array literal in which case it is considered to be moved.
+fn handle_let(let_expr: &mut crate::monomorphization::ast::Let) {
+    handle_expression(&mut let_expr.expression);
+
+    if !is_array_or_str_literal(&let_expr.expression) {
+        clone_expr(&mut let_expr.expression);
+    }
+}
+
+fn handle_constrain(
+    boolean: &mut Expression,
+    msg: &mut Option<Box<(Expression, crate::hir_def::types::Type)>>,
+) {
+    handle_expression(boolean);
+
+    if let Some(msg) = msg {
+        handle_expression(&mut msg.0);
+    }
+}
+
+/// - Assignments (`x = <expression which returns an array>;`):
+///   - Assigning an array to an existing variable will also increment the reference
+///     count of the array unless it is an array literal.
+fn handle_assign(assign: &mut crate::monomorphization::ast::Assign) {
+    handle_lvalue(&mut assign.lvalue);
+    handle_expression(&mut assign.expression);
+
+    if !is_array_or_str_literal(&assign.expression) {
+        clone_expr(&mut assign.expression);
+    }
+}
+
+fn handle_lvalue(lvalue: &mut LValue) {
+    match lvalue {
+        LValue::Ident(_) => (),
+        LValue::Index { array, index, element_type: _, location: _ } => {
+            handle_expression(index);
+            handle_lvalue(array);
         }
-    }
-
-    fn handle_expression(&mut self, expr: &mut Expression) {
-        match expr {
-            Expression::Ident(_) => (),
-            Expression::Literal(literal) => self.handle_literal(literal),
-            Expression::Block(exprs) => {
-                exprs.iter_mut().for_each(|expr| self.handle_expression(expr))
-            }
-            Expression::Unary(unary) => self.handle_unary(unary),
-            Expression::Binary(binary) => self.handle_binary(binary),
-            Expression::Index(_) => self.handle_index(expr),
-            Expression::Cast(cast) => self.handle_cast(cast),
-            Expression::For(for_expr) => self.handle_for(for_expr),
-            Expression::Loop(loop_expr) => self.handle_expression(loop_expr),
-            Expression::While(while_expr) => self.handle_while(while_expr),
-            Expression::If(if_expr) => self.handle_if(if_expr),
-            Expression::Match(match_expr) => self.handle_match(match_expr),
-            Expression::Tuple(elems) => self.handle_tuple(elems),
-            Expression::ExtractTupleField(tuple, _index) => self.handle_expression(tuple),
-            Expression::Call(call) => self.handle_call(call),
-            Expression::Let(let_expr) => self.handle_let(let_expr),
-            Expression::Constrain(boolean, _location, msg) => self.handle_constrain(boolean, msg),
-            Expression::Assign(assign) => self.handle_assign(assign),
-            Expression::Semi(expr) => self.handle_expression(expr),
-            // Clones are only inserted by this pass so we can assume any code they contain is
-            // already handled
-            Expression::Clone(_) => (),
-            Expression::Break => (),
-            Expression::Continue => (),
+        LValue::MemberAccess { object, field_index: _ } => {
+            handle_lvalue(object);
         }
-    }
-
-    /// - Array literals:
-    ///   - Arrays stored inside a nested array literal (e.g. both variables in `[array1, array2]`
-    ///     have their reference count incremented).
-    ///   - This does not apply to nested array literals since we know they are not referenced elsewhere.
-    fn handle_literal(&mut self, literal: &mut Literal) {
-        match literal {
-            Literal::Integer(..) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => (),
-
-            Literal::FmtStr(_, _, captures) => self.handle_expression(captures),
-
-            Literal::Array(array) | Literal::Slice(array) => {
-                let element_type = array
-                    .typ
-                    .array_element_type()
-                    .expect("Array literal should have an array type");
-                if contains_array_or_str_type(element_type) {
-                    // We have to clone nested arrays unless they are array literals
-                    for element in array.contents.iter_mut() {
-                        if !is_array_or_str_literal(element) {
-                            clone_expr(element);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn handle_unary(&mut self, unary: &mut Unary) {
-        self.handle_expression(&mut unary.rhs);
-    }
-
-    fn handle_binary(&mut self, binary: &mut crate::monomorphization::ast::Binary) {
-        self.handle_expression(&mut binary.lhs);
-        self.handle_expression(&mut binary.rhs);
-    }
-
-    /// - Extracting an array from another array (`let inner: [_; _] = array[0];`):
-    ///   - Extracting a nested array from its outer array will always increment the reference count
-    ///     of the nested array.
-    fn handle_index(&mut self, index_expr: &mut Expression) {
-        let crate::monomorphization::ast::Expression::Index(index) = index_expr else {
-            panic!("handle_index should only be called with Index nodes");
-        };
-
-        self.handle_expression(&mut index.collection);
-        self.handle_expression(&mut index.index);
-
-        if contains_array_or_str_type(&index.element_type) {
-            clone_expr(index_expr);
-        }
-    }
-
-    fn handle_cast(&mut self, cast: &mut crate::monomorphization::ast::Cast) {
-        self.handle_expression(&mut cast.lhs);
-    }
-
-    fn handle_for(&mut self, for_expr: &mut crate::monomorphization::ast::For) {
-        self.handle_expression(&mut for_expr.start_range);
-        self.handle_expression(&mut for_expr.end_range);
-        self.handle_expression(&mut for_expr.block);
-    }
-
-    fn handle_while(&mut self, while_expr: &mut crate::monomorphization::ast::While) {
-        self.handle_expression(&mut while_expr.condition);
-        self.handle_expression(&mut while_expr.body);
-    }
-
-    fn handle_if(&mut self, if_expr: &mut crate::monomorphization::ast::If) {
-        self.handle_expression(&mut if_expr.condition);
-        self.handle_expression(&mut if_expr.consequence);
-        if let Some(alt) = &mut if_expr.alternative {
-            self.handle_expression(alt);
-        }
-    }
-
-    fn handle_match(&mut self, match_expr: &mut crate::monomorphization::ast::Match) {
-        for case in &mut match_expr.cases {
-            self.handle_expression(&mut case.branch);
-        }
-
-        if let Some(default_case) = &mut match_expr.default_case {
-            self.handle_expression(default_case);
-        }
-    }
-
-    fn handle_tuple(&mut self, elems: &mut [Expression]) {
-        for elem in elems {
-            self.handle_expression(elem);
-        }
-    }
-
-    fn handle_call(&mut self, call: &mut crate::monomorphization::ast::Call) {
-        self.handle_expression(&mut call.func);
-        for arg in &mut call.arguments {
-            self.handle_expression(arg);
-        }
-    }
-
-    /// - Let bindings (`let _ = <expression which returns an array>;`):
-    ///   - Binding an array to a let binding increments the reference count of the array unless
-    ///     the expression is an array literal in which case it is considered to be moved.
-    fn handle_let(&mut self, let_expr: &mut crate::monomorphization::ast::Let) {
-        self.handle_expression(&mut let_expr.expression);
-
-        if !is_array_or_str_literal(&let_expr.expression) {
-            clone_expr(&mut let_expr.expression);
-        }
-    }
-
-    fn handle_constrain(
-        &mut self,
-        boolean: &mut Expression,
-        msg: &mut Option<Box<(Expression, crate::hir_def::types::Type)>>,
-    ) {
-        self.handle_expression(boolean);
-
-        if let Some(msg) = msg {
-            self.handle_expression(&mut msg.0);
-        }
-    }
-
-    /// - Assignments (`x = <expression which returns an array>;`):
-    ///   - Assigning an array to an existing variable will also increment the reference
-    ///     count of the array unless it is an array literal.
-    fn handle_assign(&mut self, assign: &mut crate::monomorphization::ast::Assign) {
-        self.handle_lvalue(&mut assign.lvalue);
-        self.handle_expression(&mut assign.expression);
-
-        if !is_array_or_str_literal(&assign.expression) {
-            clone_expr(&mut assign.expression);
-        }
-    }
-
-    fn handle_lvalue(&mut self, lvalue: &mut LValue) {
-        match lvalue {
-            LValue::Ident(_) => (),
-            LValue::Index { array, index, element_type: _, location: _ } => {
-                self.handle_expression(index);
-                self.handle_lvalue(array);
-            }
-            LValue::MemberAccess { object, field_index: _ } => {
-                self.handle_lvalue(object);
-            }
-            LValue::Dereference { reference, element_type: _ } => {
-                self.handle_lvalue(reference);
-            }
+        LValue::Dereference { reference, element_type: _ } => {
+            handle_lvalue(reference);
         }
     }
 }

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -163,15 +163,8 @@ fn increment_parameter_rcs(parameters: &Parameters) -> Vec<(String, Type, Expres
         // (by-value) Mutable parameters are always cloned. Otherwise, we have to recur on the type
         // to find a duplicate array types behind mutable references.
         let parameter = if *mutable {
-            let expr = Expression::Unary(Unary {
-                operator: UnaryOp::Dereference { implicitly_added: true },
-                rhs: Box::new(parameter),
-                result_type: parameter_type.clone(),
-                location: Location::dummy(), // TODO
-            });
-
             let name = name.clone();
-            new_bindings.push((name, parameter_type.clone(), expr));
+            new_bindings.push((name, parameter_type.clone(), parameter));
             // disable cloning in recur_on_parameter, we already cloned
             None
         } else {

--- a/test_programs/execution_success/reference_counts_inliner_0/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_0/src/main.nr
@@ -108,11 +108,9 @@ fn regression_7297() {
             "borrow_mut_two should create a fresh array and not decrease its RC",
         );
         assert_eq(refcount_1, 1, "borrow_mut_two should create a fresh array with an RC of 1");
-        // XXX: This assertion is here to demonstrate that this is happening, not because it must be like this
         assert_eq(
             refcount_2,
-            refcount_1 + 1,
-            "not ideal, but original RC permanently increased by copy_mut",
+            refcount_1,
         );
     }
 }

--- a/test_programs/execution_success/reference_counts_inliner_0/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_0/src/main.nr
@@ -108,9 +108,6 @@ fn regression_7297() {
             "borrow_mut_two should create a fresh array and not decrease its RC",
         );
         assert_eq(refcount_1, 1, "borrow_mut_two should create a fresh array with an RC of 1");
-        assert_eq(
-            refcount_2,
-            refcount_1,
-        );
+        assert_eq(refcount_2, refcount_1);
     }
 }

--- a/test_programs/execution_success/reference_counts_inliner_max/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_max/src/main.nr
@@ -108,7 +108,8 @@ fn regression_7297() {
             "borrow_mut_two should create a fresh array and not decrease its RC",
         );
 
-        assert_eq(refcount_1, 1);
+        // Difference from min & 0 inliner settings: we fail to remove an inc_rc here
+        assert_eq(refcount_1, 2);
         assert_eq(
             refcount_2,
             refcount_1,

--- a/test_programs/execution_success/reference_counts_inliner_max/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_max/src/main.nr
@@ -108,14 +108,10 @@ fn regression_7297() {
             "borrow_mut_two should create a fresh array and not decrease its RC",
         );
 
-        // Difference from other inliner cases. With inliner max we fail to remove a inc_ref
-        assert_eq(refcount_1, 2);
-
-        // XXX: This assertion is here to demonstrate that this is happening, not because it must be like this
+        assert_eq(refcount_1, 1);
         assert_eq(
             refcount_2,
-            refcount_1 + 1,
-            "not ideal, but original RC permanently increased by copy_mut",
+            refcount_1,
         );
     }
 }

--- a/test_programs/execution_success/reference_counts_inliner_max/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_max/src/main.nr
@@ -110,9 +110,6 @@ fn regression_7297() {
 
         // Difference from min & 0 inliner settings: we fail to remove an inc_rc here
         assert_eq(refcount_1, 2);
-        assert_eq(
-            refcount_2,
-            refcount_1,
-        );
+        assert_eq(refcount_2, refcount_1);
     }
 }

--- a/test_programs/execution_success/reference_counts_inliner_min/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_min/src/main.nr
@@ -109,10 +109,12 @@ fn regression_7297() {
         );
         assert_eq(refcount_1, 1, "borrow_mut_two should create a fresh array with an RC of 1");
         // XXX: This assertion is here to demonstrate that this is happening, not because it must be like this
+        println(refcount_2);
+        println(refcount_1);
+
         assert_eq(
             refcount_2,
-            refcount_1 + 1,
-            "not ideal, but original RC permanently increased by copy_mut",
+            refcount_1,
         );
     }
 }

--- a/test_programs/execution_success/reference_counts_inliner_min/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_min/src/main.nr
@@ -108,10 +108,6 @@ fn regression_7297() {
             "borrow_mut_two should create a fresh array and not decrease its RC",
         );
         assert_eq(refcount_1, 1, "borrow_mut_two should create a fresh array with an RC of 1");
-        // XXX: This assertion is here to demonstrate that this is happening, not because it must be like this
-        println(refcount_2);
-        println(refcount_1);
-
         assert_eq(
             refcount_2,
             refcount_1,

--- a/test_programs/execution_success/reference_counts_inliner_min/src/main.nr
+++ b/test_programs/execution_success/reference_counts_inliner_min/src/main.nr
@@ -108,9 +108,6 @@ fn regression_7297() {
             "borrow_mut_two should create a fresh array and not decrease its RC",
         );
         assert_eq(refcount_1, 1, "borrow_mut_two should create a fresh array with an RC of 1");
-        assert_eq(
-            refcount_2,
-            refcount_1,
-        );
+        assert_eq(refcount_2, refcount_1);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Working towards https://github.com/noir-lang/noir/issues/7321
Resolves https://github.com/noir-lang/noir/issues/7842

## Summary\*

Adds an explicit ownership pass instead of relying on ssa-gen to insert `inc_rc`s.

This pass traverses the monomorphized AST and currently only inserts a new `Clone(expr)` node exactly where SSA-gen used to insert inc_rcs. I've also documented these locations for future reference. I consider this pass to simplify things since it separates concerns a bit and lets us more easily see where clones are being inserted since `.clone()` is now printed out in each relevant location when running with `--show-monomorphized`.

In a future PR we can change the location of clones based on the `-Zownership` feature but this one aims to make as few changes as possible to start out with.

## Additional Context

The main place we can't quite replicate what SSA was doing is when inserting `dec_rc`s at the end of the function. SSA checked if we were returning the same ValueId as a parameter and did not issue it in that case. This pass does not have ValueIds and so can't do that. I think the old ssa check was unnecessary though (it can be circumvented using references as well) and have excluded it from this PR (so we currently never dec_rc). Currently waiting on CI to see performance implications of this. I'll likely re-add them but would have to always dec_rc even for returned parameters.

## Documentation\*

Check one:
- [x] No documentation needed.
  - No user-facing documentation at least
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
