### PR TITLE
feat: better error message when generic argument cannot be determined

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -7,16 +7,50 @@ use crate::{
 
 #[derive(Debug)]
 pub enum MonomorphizationError {
-    UnknownArrayLength { length: Type, err: TypeCheckError, location: Location },
-    UnknownConstant { location: Location },
-    NoDefaultType { location: Location },
-    InternalError { message: &'static str, location: Location },
+    UnknownArrayLength {
+        length: Type,
+        err: TypeCheckError,
+        location: Location,
+    },
+    UnknownConstant {
+        location: Location,
+    },
+    NoDefaultType {
+        location: Location,
+    },
+    NoDefaultTypeInItem {
+        location: Location,
+        generic_name: String,
+        item_kind: &'static str,
+        item_name: String,
+    },
+    InternalError {
+        message: &'static str,
+        location: Location,
+    },
     InterpreterError(InterpreterError),
-    ComptimeFnInRuntimeCode { name: String, location: Location },
-    ComptimeTypeInRuntimeCode { typ: String, location: Location },
-    CheckedTransmuteFailed { actual: Type, expected: Type, location: Location },
-    CheckedCastFailed { actual: Type, expected: Type, location: Location },
-    RecursiveType { typ: Type, location: Location },
+    ComptimeFnInRuntimeCode {
+        name: String,
+        location: Location,
+    },
+    ComptimeTypeInRuntimeCode {
+        typ: String,
+        location: Location,
+    },
+    CheckedTransmuteFailed {
+        actual: Type,
+        expected: Type,
+        location: Location,
+    },
+    CheckedCastFailed {
+        actual: Type,
+        expected: Type,
+        location: Location,
+    },
+    RecursiveType {
+        typ: Type,
+        location: Location,
+    },
 }
 
 impl MonomorphizationError {
@@ -30,7 +64,8 @@ impl MonomorphizationError {
             | MonomorphizationError::CheckedTransmuteFailed { location, .. }
             | MonomorphizationError::CheckedCastFailed { location, .. }
             | MonomorphizationError::RecursiveType { location, .. }
-            | MonomorphizationError::NoDefaultType { location, .. } => *location,
+            | MonomorphizationError::NoDefaultType { location, .. }
+            | MonomorphizationError::NoDefaultTypeInItem { location, .. } => *location,
             MonomorphizationError::InterpreterError(error) => error.location(),
         }
     }
@@ -54,6 +89,18 @@ impl From<MonomorphizationError> for CustomDiagnostic {
             MonomorphizationError::NoDefaultType { location } => {
                 let message = "Type annotation needed".into();
                 let secondary = "Could not determine type of generic argument".into();
+                return CustomDiagnostic::simple_error(message, secondary, *location);
+            }
+            MonomorphizationError::NoDefaultTypeInItem {
+                location,
+                generic_name,
+                item_kind,
+                item_name,
+            } => {
+                let message = "Type annotation needed".into();
+                let secondary = format!(
+                    "Could not determine the type of the generic argument `{generic_name}` declared on the {item_kind} `{item_name}`"
+                );
                 return CustomDiagnostic::simple_error(message, secondary, *location);
             }
             MonomorphizationError::InterpreterError(error) => return error.into(),

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -9,12 +9,13 @@
 //! The entry point to this pass is the `monomorphize` function which, starting from a given
 //! function, will monomorphize the entire reachable program.
 use crate::ast::{FunctionKind, IntegerBitSize, UnaryOp};
-use crate::hir::comptime::InterpreterError;
+use crate::hir::comptime::{InterpreterError, Value};
 use crate::hir::type_check::{NoMatchingImplFoundError, TypeCheckError};
 use crate::node_interner::{ExprId, GlobalValue, ImplSearchErrorKind};
 use crate::shared::{Signedness, Visibility};
 use crate::signed_field::SignedField;
 use crate::token::FmtStrFragment;
+use crate::{DataType, Shared, TypeVariableId};
 use crate::{
     Kind, Type, TypeBinding, TypeBindings,
     debug::DebugInstrumenter,
@@ -963,15 +964,20 @@ impl<'interner> Monomorphizer<'interner> {
         // Ensure all instantiation bindings are bound.
         // This ensures even unused type variables like `fn foo<T>() {}` have concrete types
         if let Some(bindings) = self.interner.try_get_instantiation_bindings(expr_id) {
-            for (_, kind, binding) in bindings.values() {
+            for (var, kind, binding) in bindings.values() {
                 match kind {
                     Kind::Any => (),
                     Kind::Normal => (),
                     Kind::Integer => (),
                     Kind::IntegerOrField => (),
-                    Kind::Numeric(typ) => Self::check_type(typ, ident.location)?,
+                    Kind::Numeric(typ) => self.check_hir_ident_type_variable_type(
+                        typ,
+                        ident.location,
+                        var.id(),
+                        &ident,
+                    )?,
                 }
-                Self::check_type(binding, ident.location)?;
+                self.check_hir_ident_type_variable_type(binding, ident.location, var.id(), &ident)?;
             }
         }
 
@@ -1226,7 +1232,9 @@ impl<'interner> Monomorphizer<'interner> {
                 // and within a larger generic type.
                 let default = match type_var_kind.default_type() {
                     Some(typ) => typ,
-                    None => return Err(MonomorphizationError::NoDefaultType { location }),
+                    None => {
+                        return Err(MonomorphizationError::NoDefaultType { location });
+                    }
                 };
 
                 let monomorphized_default =
@@ -1329,6 +1337,70 @@ impl<'interner> Monomorphizer<'interner> {
         })
     }
 
+    /// Similar to `check_type` but knowing that this is checking the type of a type variable,
+    /// while also checking a HirIdent. If this fails with `NoDefaultType` we try to find out
+    /// the name of the unbound generic argument.
+    fn check_hir_ident_type_variable_type(
+        &self,
+        typ: &HirType,
+        location: Location,
+        id: TypeVariableId,
+        ident: &HirIdent,
+    ) -> Result<(), MonomorphizationError> {
+        let result = Self::check_type(typ, location);
+        let Err(MonomorphizationError::NoDefaultType { location, .. }) = result else {
+            return result;
+        };
+
+        let definition = self.interner.definition(ident.id);
+        match &definition.kind {
+            DefinitionKind::Function(func_id) => {
+                // Try to find the type variable in the function's generic arguments
+                let meta = self.interner.function_meta(func_id);
+                for generic in &meta.direct_generics {
+                    if generic.type_var.id() == id {
+                        let item_name = self.interner.definition_name(ident.id).to_string();
+                        return Err(MonomorphizationError::NoDefaultTypeInItem {
+                            location,
+                            generic_name: generic.name.to_string(),
+                            item_kind: "function",
+                            item_name,
+                        });
+                    }
+                }
+            }
+            DefinitionKind::Global(global_id) => {
+                // Check if this global points to an enum variant, then get the enum's generics
+                // and find the type variable there.
+                let global = self.interner.get_global(*global_id);
+                let GlobalValue::Resolved(Value::Enum(_, _, Type::Forall(_, typ))) = &global.value
+                else {
+                    return result;
+                };
+
+                let typ: &Type = typ;
+                let Type::DataType(def, _) = typ else {
+                    return result;
+                };
+
+                let def = def.borrow();
+                for generic in &def.generics {
+                    if generic.type_var.id() == id {
+                        return Err(MonomorphizationError::NoDefaultTypeInItem {
+                            location,
+                            generic_name: generic.name.to_string(),
+                            item_kind: "enum",
+                            item_name: def.name.to_string(),
+                        });
+                    }
+                }
+            }
+            _ => (),
+        }
+
+        result
+    }
+
     // Similar to `convert_type` but returns an error if any type variable can't be defaulted.
     fn check_type(typ: &HirType, location: Location) -> Result<(), MonomorphizationError> {
         let typ = typ.follow_bindings_shallow();
@@ -1377,7 +1449,9 @@ impl<'interner> Monomorphizer<'interner> {
                 // and within a larger generic type.
                 let default = match type_var_kind.default_type() {
                     Some(typ) => typ,
-                    None => return Err(MonomorphizationError::NoDefaultType { location }),
+                    None => {
+                        return Err(MonomorphizationError::NoDefaultType { location });
+                    }
                 };
 
                 Self::check_type(&default, location)
@@ -2297,8 +2371,8 @@ fn unwrap_struct_type(
     match typ.follow_bindings() {
         HirType::DataType(def, args) => {
             // Some of args might not be mentioned in fields, so we need to check that they aren't unbound.
-            for arg in &args {
-                Monomorphizer::check_type(arg, location)?;
+            for (index, arg) in args.iter().enumerate() {
+                check_struct_generic_type(arg, location, &def, index)?;
             }
 
             Ok(def.borrow().get_fields(&args).unwrap())
@@ -2322,6 +2396,30 @@ fn unwrap_enum_type(
         }
         other => unreachable!("unwrap_enum_type: expected enum, found {:?}", other),
     }
+}
+
+fn check_struct_generic_type(
+    typ: &HirType,
+    location: Location,
+    def: &Shared<DataType>,
+    index: usize,
+) -> Result<(), MonomorphizationError> {
+    let result = Monomorphizer::check_type(typ, location);
+    let Err(MonomorphizationError::NoDefaultType { location, .. }) = result else {
+        return result;
+    };
+
+    let def = def.borrow();
+    if let Some(generic) = def.generics.get(index) {
+        return Err(MonomorphizationError::NoDefaultTypeInItem {
+            location,
+            generic_name: generic.name.to_string(),
+            item_kind: "struct",
+            item_name: def.name.to_string(),
+        });
+    }
+
+    result
 }
 
 pub fn perform_instantiation_bindings(bindings: &TypeBindings) {

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4251,3 +4251,54 @@ fn indexing_array_with_non_u32_on_lvalue_produces_a_warning() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn cannot_determine_type_of_generic_argument_in_function_call() {
+    let src = r#"
+    fn foo<T>() {}
+
+    fn main()
+    {
+        foo();
+        ^^^ Type annotation needed
+        ~~~ Could not determine the type of the generic argument `T` declared on the function `foo`
+    }
+
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
+fn cannot_determine_type_of_generic_argument_in_struct_constructor() {
+    let src = r#"
+    struct Foo<T> {}
+
+    fn main()
+    {
+        let _ = Foo {};
+                ^^^^^^ Type annotation needed
+                ~~~~~~ Could not determine the type of the generic argument `T` declared on the struct `Foo`
+    }
+
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
+fn cannot_determine_type_of_generic_argument_in_enum_constructor() {
+    let src = r#"
+    enum Foo<T> {
+        Bar,
+    }
+
+    fn main()
+    {
+        let _ = Foo::Bar;
+                     ^^^ Type annotation needed
+                     ~~~ Could not determine the type of the generic argument `T` declared on the enum `Foo`
+    }
+
+    "#;
+    let features = vec![UnstableFeature::Enums];
+    check_monomorphization_error_using_features(src, &features);
+}


### PR DESCRIPTION
# Description

## Problem

Not existing issue, just something I noticed.

## Summary

If you have code like this:

```noir
fn main() {
    foo();
}

fn foo<T>() {}
```

the error you get before this PR is:

```
error: Type annotation needed
  ┌─ src/main.nr:2:5
  │
2 │     foo();
  │     --- Could not determine type of generic argument
```

I think by now we probably know that it refers to a generic argument on the function `foo`, though it's not clear which generic argument it is (there could be many) and the error Rust gives is a bit clearer, so users without too much Noir experience might be confused.

With this PR, the error is now this:

```
error: Type annotation needed
  ┌─ src/main.nr:2:5
  │
2 │     foo();
  │     --- Could not determine the type of the generic argument `T` declared on the function `foo`
```

The same thing is done when a generic argument for a struct or enum cannot be determined.

## Additional Context

I think the logic for searching these generic names is okay though I'm not entirely sure, or maybe there's a more correct way to do this.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
