### PR TITLE
fix: show-ssa-pass implies force-compile

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -714,6 +714,7 @@ pub fn compile_no_check(
         || options.show_brillig
         || options.force_brillig
         || options.show_ssa
+        || options.show_ssa_pass.is_some()
         || options.emit_ssa;
 
     // Hash the AST program, which is going to be used to fingerprint the compilation artifact.


### PR DESCRIPTION
# Description

## Problem

Resolves #7624

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
