### PR TITLE
fix(debug): Fix RC underflow check

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -10,7 +10,7 @@ libraries:
     critical: true
   eddsa:
     repo: noir-lang/eddsa
-    timeout: 2
+    timeout: 3
     critical: true
   mimc:
     repo: noir-lang/mimc

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -901,11 +901,16 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 // and become usize::MAX, and then return to 1, then it will indicate
                 // an array as mutable when it probably shouldn't be.
                 if self.brillig_context.enable_debug_assertions() {
-                    let min_addr = ReservedRegisters::usize_one();
+                    let zero =
+                        SingleAddrVariable::new(self.brillig_context.allocate_register(), 32);
+
+                    self.brillig_context.const_instruction(zero, FieldElement::zero());
+
                     let condition =
                         SingleAddrVariable::new(self.brillig_context.allocate_register(), 1);
+
                     self.brillig_context.memory_op_instruction(
-                        min_addr,
+                        zero.address,
                         rc_register,
                         condition.address,
                         BrilligBinaryOp::LessThan,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -1043,13 +1043,11 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     }
 
     fn assert_rc_neq_zero(&mut self, rc_register: MemoryAddress) {
-        let zero =
-            SingleAddrVariable::new(self.brillig_context.allocate_register(), 32);
+        let zero = SingleAddrVariable::new(self.brillig_context.allocate_register(), 32);
 
         self.brillig_context.const_instruction(zero, FieldElement::zero());
 
-        let condition =
-            SingleAddrVariable::new(self.brillig_context.allocate_register(), 1);
+        let condition = SingleAddrVariable::new(self.brillig_context.allocate_register(), 1);
 
         self.brillig_context.memory_op_instruction(
             zero.address,
@@ -1058,10 +1056,8 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             BrilligBinaryOp::Equals,
         );
         self.brillig_context.not_instruction(condition, condition);
-        self.brillig_context.codegen_constrain(
-            condition,
-            Some("array ref-count underflow detected".to_owned()),
-        );
+        self.brillig_context
+            .codegen_constrain(condition, Some("array ref-count underflow detected".to_owned()));
         self.brillig_context.deallocate_single_addr(condition);
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -881,6 +881,12 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 // RC is always directly pointed by the array/vector pointer
                 self.brillig_context
                     .load_instruction(rc_register, array_or_vector.extract_register());
+
+                // Ensure we're not incrementing from 0 back to 1
+                if self.brillig_context.enable_debug_assertions() {
+                    self.assert_rc_neq_zero(rc_register);
+                }
+
                 self.brillig_context.codegen_usize_op_in_place(
                     rc_register,
                     BrilligBinaryOp::Add,
@@ -901,25 +907,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 // and become usize::MAX, and then return to 1, then it will indicate
                 // an array as mutable when it probably shouldn't be.
                 if self.brillig_context.enable_debug_assertions() {
-                    let zero =
-                        SingleAddrVariable::new(self.brillig_context.allocate_register(), 32);
-
-                    self.brillig_context.const_instruction(zero, FieldElement::zero());
-
-                    let condition =
-                        SingleAddrVariable::new(self.brillig_context.allocate_register(), 1);
-
-                    self.brillig_context.memory_op_instruction(
-                        zero.address,
-                        rc_register,
-                        condition.address,
-                        BrilligBinaryOp::LessThan,
-                    );
-                    self.brillig_context.codegen_constrain(
-                        condition,
-                        Some("array ref-count underflow detected".to_owned()),
-                    );
-                    self.brillig_context.deallocate_single_addr(condition);
+                    self.assert_rc_neq_zero(rc_register);
                 }
 
                 self.brillig_context.codegen_usize_op_in_place(
@@ -1052,6 +1040,29 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         }
 
         self.brillig_context.set_call_stack(CallStack::new());
+    }
+
+    fn assert_rc_neq_zero(&mut self, rc_register: MemoryAddress) {
+        let zero =
+            SingleAddrVariable::new(self.brillig_context.allocate_register(), 32);
+
+        self.brillig_context.const_instruction(zero, FieldElement::zero());
+
+        let condition =
+            SingleAddrVariable::new(self.brillig_context.allocate_register(), 1);
+
+        self.brillig_context.memory_op_instruction(
+            zero.address,
+            rc_register,
+            condition.address,
+            BrilligBinaryOp::Equals,
+        );
+        self.brillig_context.not_instruction(condition, condition);
+        self.brillig_context.codegen_constrain(
+            condition,
+            Some("array ref-count underflow detected".to_owned()),
+        );
+        self.brillig_context.deallocate_single_addr(condition);
     }
 
     fn convert_ssa_function_call(


### PR DESCRIPTION
# Description

## Problem\*

Breakout change from https://github.com/noir-lang/noir/pull/7837

## Summary\*

We were testing `1 < rc` when we want to allow an rc of 0 (just not for it to decrement below 0 or back up to 1).
I changed it to `0 < rc` and added another check while incrementing that we do not go from 0 back to 1.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
