### PR TITLE
fix(formatter): account lambda beginning when formatting method call

### DIFF
--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -113,6 +113,26 @@ impl Chunk {
     }
 }
 
+impl Display for Chunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Chunk::Text(text_chunk, _)
+            | Chunk::TrailingComment(text_chunk)
+            | Chunk::LeadingComment(text_chunk) => {
+                write!(f, "{}", text_chunk.string)
+            }
+            Chunk::TrailingComma => write!(f, ","),
+            Chunk::Group(chunk_group) => chunk_group.fmt(f),
+            Chunk::SpaceOrLine => write!(f, " "),
+            Chunk::Line { .. }
+            | Chunk::IncreaseIndentation
+            | Chunk::DecreaseIndentation
+            | Chunk::PushIndentation
+            | Chunk::PopIndentation => Ok(()),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ChunkGroup {
     pub(crate) chunks: Vec<Chunk>,
@@ -432,6 +452,14 @@ impl ChunkGroup {
         }
 
         false
+    }
+
+impl Display for ChunkGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for chunk in &self.chunks {
+            chunk.fmt(f)?;
+        }
+        Ok(())
     }
 }
 

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -641,7 +641,7 @@ impl<'a> Formatter<'a> {
                 let total_width = self.current_line_width() + width_until_left_paren_inclusive;
                 if total_width <= self.max_width {
                     // Check if this method call has another call or method call nested in it.
-                    // If not, it means tis is the last nested call and after it we'll need to start
+                    // If not, it means this is the last nested call and after it we'll need to start
                     // writing at least one closing parentheses. So the argument list will actually
                     // have one less character available for writing, and that's why we (temporarily) decrease
                     // max width.
@@ -709,7 +709,6 @@ impl<'a> Formatter<'a> {
             return;
         }
 
-        // if chunks.has_newlines() {
         // When formatting an expression list we have to check if the last argument is a lambda,
         // because we format that in a special way:
         // 1. to compute the group width we'll consider only the `|...| {` part of the lambda

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -1882,7 +1882,7 @@ global y = 1;
     }
 
     #[test]
-    fn format_method_call_chain() {
+    fn format_method_call_chain_1() {
         let src = "global x =  bar . baz ( 1, 2 ) . qux ( 1 , 2, 3) . one ( 5, 6)  ;";
         let expected = "global x = bar
     .baz(1, 2)

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -271,15 +271,10 @@ impl ChunkFormatter<'_, '_> {
 
         group.group(body_group);
 
-        let first_line_width = params_and_return_type_chunk_width
-            + (if block_statement_count.is_some() {
-                // 1 because we already have `|param1, param2, ..., paramN| ` (including the space)
-                // so all that's left is a `{`.
-                1
-            } else {
-                // The body is not a block so we can write it right away
-                0
-            });
+        // We assume that if we'll split the lambda into multiple lines, we'll always
+        // format the lambda expression as a block, so we add 1 to account the added `{`,
+        // so `first_line_width` is the width of `|...| {`.
+        let first_line_width = params_and_return_type_chunk_width + 1;
 
         FormattedLambda { group, first_line_width }
     }
@@ -2544,5 +2539,50 @@ global y = 1;
 }
 "#;
         assert_format_with_max_width(src, expected, 30);
+    }
+
+    #[test]
+    fn lambda_in_method_call_that_exceeds_max_width_because_of_curly_1() {
+        let src = r#"fn foo() {
+    let _ = foo.bar().x(|y| {
+        y.qux()
+    });
+}
+"#;
+        let expected = r#"fn foo() {
+    let _ = foo
+        .bar()
+        .x(|y| y.qux());
+}
+"#;
+        assert_format_with_max_width(src, expected, 28);
+    }
+
+    #[test]
+    fn lambda_in_method_call_that_exceeds_max_width_because_of_curly_2() {
+        let src = r#"fn foo() {
+    let _ = foo.bar().x(
+        |y| y.qux(),
+    );
+}
+"#;
+        let expected = r#"fn foo() {
+    let _ = foo
+        .bar()
+        .x(|y| y.qux());
+}
+"#;
+        assert_format_with_max_width(src, expected, 28);
+    }
+
+    #[test]
+    fn lambda_in_method_call_that_exceeds_max_width_because_of_curly_3() {
+        let src = r#"fn foo() {
+    let _ = foo
+        .bar()
+        .x(|y| y.qux());
+}
+"#;
+        assert_format_with_max_width(src, src, 28);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #7407

## Summary

The formatter is pretty complex when it comes to deciding how to format method calls, call chains and lambdas but I think the fix here is the "correct" one. The explanation for this change is a bit on line 642-664 of chunks.rs, then on 674-680.

The code in the issue:

```noir
comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
    let notes = NOTES.entries();
    if notes.len() > 0 {
        for i in 0..notes.len() {
            let (typ, (_, _, _, _)) = notes[i];

            let get_note_type_id = typ.get_trait_impl(NOTE_INTERFACE).unwrap().methods().filter(|m| {
                m.name() == quote { get_note_type_id }
            })[0]
                .as_typed_expr();
        }

        quote {}
    } else {
        quote {}
    }
}
```

now gets formatted like this:

```noir
comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
    let notes = NOTES.entries();
    if notes.len() > 0 {
        for i in 0..notes.len() {
            let (typ, (_, _, _, _)) = notes[i];

            let get_note_type_id = typ
                .get_trait_impl(NOTE_INTERFACE)
                .unwrap()
                .methods()
                .filter(|m| m.name() == quote { get_note_type_id })[0]
                .as_typed_expr();
        }

        quote {}
    } else {
        quote {}
    }
}
```

Note how the method call was split into multiple lines. Before this change it would check what's the width of this line:

```noir
            let get_note_type_id = typ.get_trait_impl(NOTE_INTERFACE).unwrap().methods().filter(
```

It's 96, so less than 100, so it would put all of that on one line then proceed to format the lambda. However, there's still "|m| {" in that line... it could be moved to a separate line but it would look strange. So, this PR is changed to take that piece of code into account when determining whether that first part of the call fits into a single line. In this case it doesn't anymore, so the call chain is split into multiple lines.

rustfmt formats the code in the same way (maybe they use a similar logic).

## Additional Context

I also added a couple of `Display` implementations because they are useful when debugging these things.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
