### PR TITLE
fix(parser): parse double `&` in type

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -262,7 +262,8 @@ impl<'interner> TokenPrettyPrinter<'interner> {
             | Token::Ampersand
             | Token::SliceStart
             | Token::ShiftLeft
-            | Token::ShiftRight => {
+            | Token::ShiftRight
+            | Token::LogicalAnd => {
                 self.last_was_op = true;
                 write!(f, " {token}")
             }

--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -26,8 +26,6 @@ pub enum LexerErrorKind {
     MalformedFuzzAttribute { location: Location },
     #[error("{:?} is not a valid inner attribute", found)]
     InvalidInnerAttribute { location: Location, found: String },
-    #[error("Logical and used instead of bitwise and")]
-    LogicalAnd { location: Location },
     #[error("Unterminated block comment")]
     UnterminatedBlockComment { location: Location },
     #[error("Unterminated string literal")]
@@ -72,7 +70,6 @@ impl LexerErrorKind {
             LexerErrorKind::MalformedTestAttribute { location, .. } => *location,
             LexerErrorKind::MalformedFuzzAttribute { location, .. } => *location,
             LexerErrorKind::InvalidInnerAttribute { location, .. } => *location,
-            LexerErrorKind::LogicalAnd { location } => *location,
             LexerErrorKind::UnterminatedBlockComment { location } => *location,
             LexerErrorKind::UnterminatedStringLiteral { location } => *location,
             LexerErrorKind::InvalidFormatString { location, .. } => *location,
@@ -134,11 +131,6 @@ impl LexerErrorKind {
             LexerErrorKind::InvalidInnerAttribute { location, found } => (
                 "Invalid inner attribute".to_string(),
                 format!(" {found} is not a valid inner attribute"),
-                *location,
-            ),
-            LexerErrorKind::LogicalAnd { location } => (
-                "Noir has no logical-and (&&) operator since short-circuiting is much less efficient when compiling to circuits".to_string(),
-                "Try `&` instead, or use `if` only if you require short-circuiting".to_string(),
                 *location,
             ),
             LexerErrorKind::UnterminatedBlockComment { location } => ("Unterminated block comment".to_string(), "Unterminated block comment".to_string(), *location),

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -102,10 +102,9 @@ impl<'a> Lexer<'a> {
 
     fn ampersand(&mut self) -> SpannedTokenResult {
         if self.peek_char_is('&') {
-            // When we issue this error the first '&' will already be consumed
-            // and the next token issued will be the next '&'.
-            let span = Span::inclusive(self.position, self.position + 1);
-            Err(LexerErrorKind::LogicalAnd { location: self.location(span) })
+            let start = self.position;
+            self.next_char();
+            Ok(Token::LogicalAnd.into_span(start, start + 1))
         } else if self.peek_char_is('[') {
             self.single_char_token(Token::SliceStart)
         } else {

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -111,6 +111,8 @@ pub enum BorrowedToken<'input> {
     DollarSign,
     /// =
     Assign,
+    /// &&
+    LogicalAnd,
     #[allow(clippy::upper_case_acronyms)]
     EOF,
 
@@ -238,6 +240,8 @@ pub enum Token {
     Assign,
     /// $
     DollarSign,
+    /// &&
+    LogicalAnd,
     #[allow(clippy::upper_case_acronyms)]
     EOF,
 
@@ -315,6 +319,7 @@ pub fn token_to_borrowed_token(token: &Token) -> BorrowedToken<'_> {
         Token::Assign => BorrowedToken::Assign,
         Token::Bang => BorrowedToken::Bang,
         Token::DollarSign => BorrowedToken::DollarSign,
+        Token::LogicalAnd => BorrowedToken::LogicalAnd,
         Token::EOF => BorrowedToken::EOF,
         Token::Invalid(c) => BorrowedToken::Invalid(*c),
         Token::Whitespace(s) => BorrowedToken::Whitespace(s),
@@ -551,6 +556,7 @@ impl fmt::Display for Token {
             Token::Assign => write!(f, "="),
             Token::Bang => write!(f, "!"),
             Token::DollarSign => write!(f, "$"),
+            Token::LogicalAnd => write!(f, "&&"),
             Token::EOF => write!(f, "end of input"),
             Token::Invalid(c) => write!(f, "{c}"),
             Token::Whitespace(ref s) => write!(f, "{s}"),

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -119,6 +119,8 @@ pub enum ParserErrorReason {
     MissingParametersForFunctionDefinition,
     #[error("`StructDefinition` is deprecated. It has been renamed to `TypeDefinition`")]
     StructDefinitionDeprecated,
+    #[error("Logical and used instead of bitwise and")]
+    LogicalAnd,
 }
 
 /// Represents a parsing error, or a parsing error in the making.
@@ -312,6 +314,13 @@ impl<'a> From<&'a ParserError> for Diagnostic {
                 }
                 ParserErrorReason::StructDefinitionDeprecated => {
                     Diagnostic::simple_warning(format!("{reason}"), String::new(), error.location())
+                }
+                ParserErrorReason::LogicalAnd => {
+                    let primary = "Noir has no logical-and (&&) operator since short-circuiting is much less efficient when compiling to circuits".to_string();
+                    let secondary =
+                        "Try `&` instead, or use `if` only if you require short-circuiting"
+                            .to_string();
+                    Diagnostic::simple_error(primary, secondary, error.location)
                 }
                 other => {
                     Diagnostic::simple_error(format!("{other}"), String::new(), error.location())

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -1739,6 +1739,21 @@ mod tests {
     }
 
     #[test]
+    fn errors_on_logical_and() {
+        let src = "
+        1 && 2
+          ^^
+        ";
+        let (src, span) = get_source_with_error_span(src);
+        let mut parser = Parser::for_str_with_dummy_file(&src);
+        let expression = parser.parse_expression_or_error();
+        assert_eq!(expression.to_string(), "(1 & 2)");
+
+        let reason = get_single_error_reason(&parser.errors, span);
+        assert!(matches!(reason, ParserErrorReason::LogicalAnd));
+    }
+
+    #[test]
     fn parses_empty_lambda() {
         let src = "|| 1";
         let expr = parse_expression_no_errors(src);

--- a/compiler/noirc_frontend/src/parser/parser/infix.rs
+++ b/compiler/noirc_frontend/src/parser/parser/infix.rs
@@ -2,6 +2,7 @@ use noirc_errors::{Located, Location};
 
 use crate::{
     ast::{BinaryOpKind, Expression, ExpressionKind, InfixExpression},
+    parser::ParserErrorReason,
     token::Token,
 };
 
@@ -48,6 +49,9 @@ impl<'a> Parser<'a> {
             if parser.next_is(Token::Assign) {
                 None
             } else if parser.eat(Token::Ampersand) {
+                Some(BinaryOpKind::And)
+            } else if parser.eat(Token::LogicalAnd) {
+                parser.push_error(ParserErrorReason::LogicalAnd, parser.previous_token_location);
                 Some(BinaryOpKind::And)
             } else {
                 None

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -628,6 +628,16 @@ mod tests {
     }
 
     #[test]
+    fn parses_double_reference_type() {
+        let src = "&&Field";
+        let typ = parse_type_no_errors(src);
+        let UnresolvedTypeData::Reference(typ, false) = typ.typ else {
+            panic!("Expected a reference type")
+        };
+        assert!(matches!(typ.typ, UnresolvedTypeData::FieldElement));
+    }
+
+    #[test]
     fn parses_named_type_no_generics() {
         let src = "foo::Bar";
         let typ = parse_type_no_errors(src);
@@ -663,6 +673,20 @@ mod tests {
     fn parses_array_type() {
         let src = "[Field; 10]";
         let typ = parse_type_no_errors(src);
+        let UnresolvedTypeData::Array(expr, typ) = typ.typ else {
+            panic!("Expected an array type")
+        };
+        assert!(matches!(typ.typ, UnresolvedTypeData::FieldElement));
+        assert_eq!(expr.to_string(), "10");
+    }
+
+    #[test]
+    fn parses_reference_to_array_type() {
+        let src = "&[Field; 10]";
+        let typ = parse_type_no_errors(src);
+        let UnresolvedTypeData::Reference(typ, false) = typ.typ else {
+            panic!("Expected a reference typ");
+        };
         let UnresolvedTypeData::Array(expr, typ) = typ.typ else {
             panic!("Expected an array type")
         };

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -59,7 +59,7 @@ impl Parser<'_> {
             return Some(typ);
         }
 
-        if let Some(typ) = self.parses_mutable_reference_type() {
+        if let Some(typ) = self.parse_reference_type() {
             return Some(typ);
         }
 
@@ -371,7 +371,7 @@ impl Parser<'_> {
         None
     }
 
-    fn parses_mutable_reference_type(&mut self) -> Option<UnresolvedTypeData> {
+    fn parse_reference_type(&mut self) -> Option<UnresolvedTypeData> {
         // The `&` may be lexed as a slice start if this is an array or slice type
         if self.eat(Token::Ampersand) || self.eat(Token::SliceStart) {
             let mutable = self.eat_keyword(Keyword::Mut);


### PR DESCRIPTION
# Description

## Problem

Resolves #7859

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
