### PR TITLE
chore: allow injecting custom brillig stdlib implementations in ACIRgen

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/brillig_call.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/brillig_call.rs
@@ -13,10 +13,31 @@ use iter_extended::{try_vecmap, vecmap};
 use crate::brillig::brillig_ir::artifact::GeneratedBrillig;
 use crate::errors::{InternalError, RuntimeError};
 
-use super::generated_acir::BrilligStdlibFunc;
+use super::generated_acir::{BrilligStdlibFunc, PLACEHOLDER_BRILLIG_INDEX};
 use super::{AcirContext, AcirDynamicArray, AcirType, AcirValue, AcirVar};
 
 impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
+    /// Generates a brillig call to a handwritten section of brillig bytecode.
+    pub(crate) fn stdlib_brillig_call(
+        &mut self,
+        predicate: AcirVar,
+        brillig_stdlib_func: BrilligStdlibFunc,
+        inputs: Vec<AcirValue>,
+        outputs: Vec<AcirType>,
+        attempt_execution: bool,
+    ) -> Result<Vec<AcirValue>, RuntimeError> {
+        self.brillig_call(
+            predicate,
+            &brillig_stdlib_func.get_generated_brillig(),
+            inputs,
+            outputs,
+            attempt_execution,
+            false,
+            PLACEHOLDER_BRILLIG_INDEX,
+            Some(brillig_stdlib_func),
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn brillig_call(
         &mut self,

--- a/compiler/noirc_evaluator/src/acir/acir_context/brillig_call.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/brillig_call.rs
@@ -22,13 +22,14 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
         &mut self,
         predicate: AcirVar,
         brillig_stdlib_func: BrilligStdlibFunc,
+        stdlib_func_bytecode: &GeneratedBrillig<F>,
         inputs: Vec<AcirValue>,
         outputs: Vec<AcirType>,
         attempt_execution: bool,
     ) -> Result<Vec<AcirValue>, RuntimeError> {
         self.brillig_call(
             predicate,
-            &brillig_stdlib_func.get_generated_brillig(),
+            stdlib_func_bytecode,
             inputs,
             outputs,
             attempt_execution,

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/brillig_directive.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/brillig_directive.rs
@@ -32,6 +32,16 @@ impl<F: AcirField> Default for BrilligStdLib<F> {
     }
 }
 
+impl<F: AcirField> BrilligStdLib<F> {
+    pub(crate) fn get_code(&self, func: BrilligStdlibFunc) -> &GeneratedBrillig<F> {
+        match func {
+            BrilligStdlibFunc::Inverse => &self.invert,
+            BrilligStdlibFunc::Quotient => &self.quotient,
+            BrilligStdlibFunc::ToLeBytes => &self.to_le_bytes,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub(crate) enum BrilligStdlibFunc {
     Inverse,

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/brillig_directive.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/brillig_directive.rs
@@ -4,9 +4,40 @@ use acvm::acir::{
         BinaryFieldOp, BinaryIntOp, BitSize, HeapVector, IntegerBitSize, MemoryAddress,
         Opcode as BrilligOpcode,
     },
+    circuit::brillig::BrilligFunctionId,
 };
 
 use crate::brillig::brillig_ir::artifact::GeneratedBrillig;
+
+/// Brillig calls such as for the Brillig std lib are resolved only after code generation is finished.
+/// This index should be used when adding a Brillig call during code generation.
+/// Code generation should then keep track of that unresolved call opcode which will be resolved with the
+/// correct function index after code generation.
+pub(crate) const PLACEHOLDER_BRILLIG_INDEX: BrilligFunctionId = BrilligFunctionId(0);
+
+#[derive(Debug, Clone)]
+pub(crate) struct BrilligStdLib<F> {
+    pub(crate) invert: GeneratedBrillig<F>,
+    pub(crate) quotient: GeneratedBrillig<F>,
+    pub(crate) to_le_bytes: GeneratedBrillig<F>,
+}
+
+impl<F: AcirField> Default for BrilligStdLib<F> {
+    fn default() -> Self {
+        Self {
+            invert: directive_invert(),
+            quotient: directive_quotient(),
+            to_le_bytes: directive_to_radix(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub(crate) enum BrilligStdlibFunc {
+    Inverse,
+    Quotient,
+    ToLeBytes,
+}
 
 /// Generates brillig bytecode which computes the inverse of its input if not null, and zero else.
 pub(crate) fn directive_invert<F: AcirField>() -> GeneratedBrillig<F> {

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
@@ -31,11 +31,7 @@ use num_bigint::BigUint;
 
 mod brillig_directive;
 
-/// Brillig calls such as for the Brillig std lib are resolved only after code generation is finished.
-/// This index should be used when adding a Brillig call during code generation.
-/// Code generation should then keep track of that unresolved call opcode which will be resolved with the
-/// correct function index after code generation.
-pub(super) const PLACEHOLDER_BRILLIG_INDEX: BrilligFunctionId = BrilligFunctionId(0);
+pub(crate) use brillig_directive::{BrilligStdLib, BrilligStdlibFunc, PLACEHOLDER_BRILLIG_INDEX};
 
 #[derive(Debug, Default)]
 /// The output of the Acir-gen pass, which should only be produced for entry point Acir functions
@@ -96,23 +92,6 @@ pub(crate) type OpcodeToLocationsMap = BTreeMap<OpcodeLocation, CallStack>;
 pub(crate) type BrilligOpcodeToLocationsMap = BTreeMap<BrilligOpcodeLocation, CallStack>;
 
 pub(crate) type BrilligProcedureRangeMap = BTreeMap<ProcedureDebugId, (usize, usize)>;
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub(crate) enum BrilligStdlibFunc {
-    Inverse,
-    Quotient,
-    ToLeBytes,
-}
-
-impl BrilligStdlibFunc {
-    pub(crate) fn get_generated_brillig<F: AcirField>(&self) -> GeneratedBrillig<F> {
-        match self {
-            BrilligStdlibFunc::Inverse => brillig_directive::directive_invert(),
-            BrilligStdlibFunc::Quotient => brillig_directive::directive_quotient(),
-            BrilligStdlibFunc::ToLeBytes => brillig_directive::directive_to_radix(),
-        }
-    }
-}
 
 impl<F: AcirField> GeneratedAcir<F> {
     /// Returns the current witness index.

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -37,7 +37,6 @@ use super::{
     types::{AcirType, AcirVar},
 };
 use big_int::BigIntContext;
-use generated_acir::PLACEHOLDER_BRILLIG_INDEX;
 
 pub(crate) use generated_acir::{BrilligStdlibFunc, GeneratedAcir};
 
@@ -273,18 +272,12 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
             return Ok(inverted_var);
         }
 
-        // Compute the inverse with brillig code
-        let inverse_code = BrilligStdlibFunc::Inverse.get_generated_brillig();
-
-        let results = self.brillig_call(
+        let results = self.stdlib_brillig_call(
             predicate,
-            &inverse_code,
+            BrilligStdlibFunc::Inverse,
             vec![AcirValue::Var(var, AcirType::field())],
             vec![AcirType::field()],
             true,
-            false,
-            PLACEHOLDER_BRILLIG_INDEX,
-            Some(BrilligStdlibFunc::Inverse),
         )?;
         let inverted_var = Self::expect_one_var(results);
 
@@ -799,18 +792,15 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
         };
 
         let [q_value, r_value]: [AcirValue; 2] = self
-            .brillig_call(
+            .stdlib_brillig_call(
                 predicate,
-                &BrilligStdlibFunc::Quotient.get_generated_brillig(),
+                BrilligStdlibFunc::Quotient,
                 vec![
                     AcirValue::Var(lhs, AcirType::unsigned(bit_size)),
                     AcirValue::Var(rhs, AcirType::unsigned(bit_size)),
                 ],
                 vec![AcirType::unsigned(max_q_bits), AcirType::unsigned(max_rhs_bits)],
                 true,
-                false,
-                PLACEHOLDER_BRILLIG_INDEX,
-                Some(BrilligStdlibFunc::Quotient),
             )?
             .try_into()
             .expect("quotient only returns two values");

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -810,7 +810,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
             .stdlib_brillig_call(
                 predicate,
                 BrilligStdlibFunc::Quotient,
-                &self.brillig_stdlib.quotient.clone(),
+                &self.brillig_stdlib.get_code(BrilligStdlibFunc::Quotient).clone(),
                 vec![
                     AcirValue::Var(lhs, AcirType::unsigned(bit_size)),
                     AcirValue::Var(rhs, AcirType::unsigned(bit_size)),

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -289,7 +289,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
         let results = self.stdlib_brillig_call(
             predicate,
             BrilligStdlibFunc::Inverse,
-            &self.brillig_stdlib.invert.clone(),
+            &self.brillig_stdlib.get_code(BrilligStdlibFunc::Inverse).clone(),
             vec![AcirValue::Var(var, AcirType::field())],
             vec![AcirType::field()],
             true,

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -124,18 +124,14 @@ impl<F: AcirField> SharedContext<F> {
         {
             self.add_call_to_resolve(func_id, (opcode_location, generated_pointer));
         } else {
-            let code = match brillig_stdlib_func {
-                BrilligStdlibFunc::Inverse => self.brillig_stdlib.invert.clone(),
-                BrilligStdlibFunc::Quotient => self.brillig_stdlib.quotient.clone(),
-                BrilligStdlibFunc::ToLeBytes => self.brillig_stdlib.to_le_bytes.clone(),
-            };
+            let code = self.brillig_stdlib.get_code(*brillig_stdlib_func);
             let generated_pointer = self.new_generated_pointer();
             self.insert_generated_brillig_stdlib(
                 *brillig_stdlib_func,
                 generated_pointer,
                 func_id,
                 opcode_location,
-                code,
+                code.clone(),
             );
         }
     }

--- a/compiler/noirc_evaluator/src/acir/ssa.rs
+++ b/compiler/noirc_evaluator/src/acir/ssa.rs
@@ -12,7 +12,7 @@ use crate::{
     ssa::ssa_gen::Ssa,
 };
 
-use super::{Context, GeneratedAcir, SharedContext};
+use super::{Context, GeneratedAcir, SharedContext, acir_context::BrilligStdLib};
 
 pub(crate) type Artifacts = (
     Vec<GeneratedAcir<FieldElement>>,
@@ -29,55 +29,69 @@ impl Ssa {
         brillig_options: &BrilligOptions,
         expression_width: ExpressionWidth,
     ) -> Result<Artifacts, RuntimeError> {
-        let mut acirs = Vec::new();
-        // TODO: can we parallelize this?
-        let mut shared_context = SharedContext::default();
-
-        for function in self.functions.values() {
-            let context =
-                Context::new(&mut shared_context, expression_width, brillig, brillig_options);
-
-            if let Some(mut generated_acir) = context.convert_ssa_function(&self, function)? {
-                // We want to be able to insert Brillig stdlib functions anywhere during the ACIR generation process (e.g. such as on the `GeneratedAcir`).
-                // As we don't want a reference to the `SharedContext` on the generated ACIR itself,
-                // we instead store the opcode location at which a Brillig call to a std lib function occurred.
-                // We then defer resolving the function IDs of those Brillig functions to when we have generated Brillig
-                // for all normal Brillig calls.
-                for (opcode_location, brillig_stdlib_func) in
-                    &generated_acir.brillig_stdlib_func_locations
-                {
-                    shared_context.generate_brillig_calls_to_resolve(
-                        brillig_stdlib_func,
-                        function.id(),
-                        *opcode_location,
-                    );
-                }
-
-                // Fetch the Brillig stdlib calls to resolve for this function
-                if let Some(calls_to_resolve) =
-                    shared_context.brillig_stdlib_calls_to_resolve.get(&function.id())
-                {
-                    // Resolve the Brillig stdlib calls
-                    // We have to do a separate loop as the generated ACIR cannot be borrowed as mutable after an immutable borrow
-                    for (opcode_location, brillig_function_pointer) in calls_to_resolve {
-                        generated_acir.resolve_brillig_stdlib_call(
-                            *opcode_location,
-                            *brillig_function_pointer,
-                        );
-                    }
-                }
-
-                generated_acir.name = function.name().to_owned();
-                acirs.push(generated_acir);
-            }
-        }
-
-        let (brillig_bytecode, brillig_names) = shared_context
-            .generated_brillig
-            .into_iter()
-            .map(|brillig| (BrilligBytecode { bytecode: brillig.byte_code }, brillig.name))
-            .unzip();
-
-        Ok((acirs, brillig_bytecode, brillig_names, self.error_selector_to_type))
+        codegen_acir(self, brillig, BrilligStdLib::default(), brillig_options, expression_width)
     }
+}
+
+pub(super) fn codegen_acir(
+    ssa: Ssa,
+    brillig: &Brillig,
+    brillig_stdlib: BrilligStdLib<FieldElement>,
+    brillig_options: &BrilligOptions,
+    expression_width: ExpressionWidth,
+) -> Result<Artifacts, RuntimeError> {
+    let mut acirs = Vec::new();
+    // TODO: can we parallelize this?
+    let mut shared_context =
+        SharedContext { brillig_stdlib: brillig_stdlib.clone(), ..SharedContext::default() };
+
+    for function in ssa.functions.values() {
+        let context = Context::new(
+            &mut shared_context,
+            expression_width,
+            brillig,
+            brillig_stdlib.clone(),
+            brillig_options,
+        );
+
+        if let Some(mut generated_acir) = context.convert_ssa_function(&ssa, function)? {
+            // We want to be able to insert Brillig stdlib functions anywhere during the ACIR generation process (e.g. such as on the `GeneratedAcir`).
+            // As we don't want a reference to the `SharedContext` on the generated ACIR itself,
+            // we instead store the opcode location at which a Brillig call to a std lib function occurred.
+            // We then defer resolving the function IDs of those Brillig functions to when we have generated Brillig
+            // for all normal Brillig calls.
+            for (opcode_location, brillig_stdlib_func) in
+                &generated_acir.brillig_stdlib_func_locations
+            {
+                shared_context.generate_brillig_calls_to_resolve(
+                    brillig_stdlib_func,
+                    function.id(),
+                    *opcode_location,
+                );
+            }
+
+            // Fetch the Brillig stdlib calls to resolve for this function
+            if let Some(calls_to_resolve) =
+                shared_context.brillig_stdlib_calls_to_resolve.get(&function.id())
+            {
+                // Resolve the Brillig stdlib calls
+                // We have to do a separate loop as the generated ACIR cannot be borrowed as mutable after an immutable borrow
+                for (opcode_location, brillig_function_pointer) in calls_to_resolve {
+                    generated_acir
+                        .resolve_brillig_stdlib_call(*opcode_location, *brillig_function_pointer);
+                }
+            }
+
+            generated_acir.name = function.name().to_owned();
+            acirs.push(generated_acir);
+        }
+    }
+
+    let (brillig_bytecode, brillig_names) = shared_context
+        .generated_brillig
+        .into_iter()
+        .map(|brillig| (BrilligBytecode { bytecode: brillig.byte_code }, brillig.name))
+        .unzip();
+
+    Ok((acirs, brillig_bytecode, brillig_names, ssa.error_selector_to_type))
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -21,7 +21,7 @@ pub(crate) enum BrilligParameter {
 
 /// The result of compiling and linking brillig artifacts.
 /// This is ready to run bytecode with attached metadata.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct GeneratedBrillig<F> {
     pub(crate) byte_code: Vec<BrilligOpcode<F>>,
     pub(crate) locations: BTreeMap<OpcodeLocation, CallStack>,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR does a small refactoring to add a wrapper around stdlib brillig calls.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
