### PR TITLE
feat(formatter): improved formatting of long struct patterns

### DIFF
--- a/tooling/nargo_fmt/src/formatter/pattern.rs
+++ b/tooling/nargo_fmt/src/formatter/pattern.rs
@@ -49,13 +49,19 @@ impl Formatter<'_> {
                 self.write_right_paren();
             }
             Pattern::Struct(path, fields, _span) => {
-                self.format_path(path);
-                self.write_space();
-                self.write_left_brace();
+                let mut group = ChunkGroup::new();
+
+                group.text(self.chunk_formatter().chunk(|formatter| {
+                    formatter.format_path(path);
+                    formatter.write_space();
+                    formatter.write_left_brace();
+                }));
+
                 if fields.is_empty() {
-                    self.format_empty_block_contents();
+                    if let Some(inner_group) = self.chunk_formatter().empty_block_contents_chunk() {
+                        group.group(inner_group);
+                    }
                 } else {
-                    let mut group = ChunkGroup::new();
                     self.chunk_formatter().format_items_separated_by_comma(
                         fields,
                         false, // force trailing comma,
@@ -80,10 +86,13 @@ impl Formatter<'_> {
                             }
                         },
                     );
-                    self.format_chunk_group(group);
                 }
 
-                self.write_right_brace();
+                group.text(self.chunk_formatter().chunk(|formatter| {
+                    formatter.write_right_brace();
+                }));
+
+                self.format_chunk_group(group);
             }
             Pattern::Interned(..) => {
                 unreachable!("Should not be present in the AST")
@@ -98,7 +107,7 @@ fn is_identifier_pattern(pattern: &Pattern, ident: &Ident) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::assert_format;
+    use crate::{assert_format, assert_format_with_max_width};
 
     #[test]
     fn format_identifier_pattern() {
@@ -154,5 +163,22 @@ mod tests {
         let src = "fn foo( Foo { x  , y : y } : i32) {}";
         let expected = "fn foo(Foo { x, y }: i32) {}\n";
         assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_struct_pattern_that_exceeds_max_width() {
+        let src = "
+        fn foo() {
+            let SomeStruct { one, two } = 1; 
+        }
+        ";
+        let expected = "fn foo() {
+    let SomeStruct {
+        one,
+        two,
+    } = 1;
+}
+";
+        assert_format_with_max_width(src, expected, 20);
     }
 }

--- a/tooling/nargo_fmt/src/formatter/statement.rs
+++ b/tooling/nargo_fmt/src/formatter/statement.rs
@@ -132,7 +132,9 @@ impl ChunkFormatter<'_, '_> {
             formatter.format_secondary_attributes(attributes);
             formatter.write_keyword(keyword);
             formatter.write_space();
+            formatter.increase_indentation();
             formatter.format_pattern(pattern);
+            formatter.decrease_indentation();
             if typ.typ != UnresolvedTypeData::Unspecified {
                 formatter.write_token(Token::Colon);
                 formatter.write_space();


### PR DESCRIPTION
# Description

## Problem

Resolves #7898

## Summary

Copied the logic of formatting struct constructors for formatting patterns (it can't be extracted because they are slightly different and use different types, but it's also not a lot of code).

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
